### PR TITLE
🧹 bicep: introduce a brace-aware statement tokenizer (no schema change)

### DIFF
--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -98,76 +98,40 @@ func parseBicep(content string) *parsedBicepFile {
 		result.targetScope = m[1]
 	}
 
-	lines := strings.Split(content, "\n")
-	i := 0
-	for i < len(lines) {
-		line := lines[i]
-		trimmed := strings.TrimSpace(line)
+	// Walk the file once into brace/bracket/string-aware statements, then
+	// dispatch each one to the construct-specific parser. Each statement's
+	// `text` is a guaranteed-complete construct (its delimiters balance), so
+	// the per-construct helpers receive the whole body rather than re-walking
+	// the raw line slice.
+	for _, stmt := range tokenizeBicep(content) {
+		// The Decl helpers still operate on a line slice indexed from the
+		// start of the statement. Because `stmt.text` is already a complete
+		// construct, splitting it and starting at index 0 yields exactly the
+		// lines the helper would have seen in the old line-walking loop.
+		stmtLines := strings.Split(stmt.text, "\n")
+		firstLine := strings.TrimSpace(stmtLines[0])
 
-		// Collect decorators. Multiline decorators (e.g. @allowed([\n...\n]))
-		// are reassembled by walking the string-aware depth scanner —
-		// paren / bracket counts inside Bicep string literals don't
-		// contribute, so `@description('contains ] bracket')` still
-		// terminates after one line.
-		var decorators []string
-		for strings.HasPrefix(trimmed, "@") {
-			decLine := trimmed
-			st := scanState{}
-			st.feed(decLine)
-			i++
-			for st.totalDepth() > 0 && i < len(lines) {
-				line = lines[i]
-				trimmed = strings.TrimSpace(line)
-				decLine += "\n" + trimmed
-				st.feed(trimmed)
-				i++
-			}
-			decorators = append(decorators, decLine)
-			if i >= len(lines) {
-				break
-			}
-			line = lines[i]
-			trimmed = strings.TrimSpace(line)
-		}
-
-		if strings.HasPrefix(trimmed, "param ") {
-			result.parameters = append(result.parameters, parseParameter(trimmed, decorators))
-			i++
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "var ") {
-			v, consumed := parseVariableDecl(lines, i, decorators)
+		switch stmt.keyword {
+		case "param":
+			result.parameters = append(result.parameters, parseParameter(firstLine, stmt.decorators))
+		case "var":
+			v, _ := parseVariableDecl(stmtLines, 0, stmt.decorators)
 			result.variables = append(result.variables, v)
-			i = consumed
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "resource ") {
-			res, consumed := parseResourceDecl(lines, i, decorators)
-			if res != nil {
+		case "resource":
+			if res, _ := parseResourceDecl(stmtLines, 0, stmt.decorators); res != nil {
 				result.resources = append(result.resources, *res)
 			}
-			i = consumed
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "module ") {
-			mod, consumed := parseModuleDecl(lines, i, decorators)
-			if mod != nil {
+		case "module":
+			if mod, _ := parseModuleDecl(stmtLines, 0, stmt.decorators); mod != nil {
 				result.modules = append(result.modules, *mod)
 			}
-			i = consumed
-			continue
+		case "output":
+			result.outputs = append(result.outputs, parseOutput(firstLine, stmt.decorators))
+		default:
+			// targetScope (already captured above) and unknown leading
+			// tokens carry no per-construct parsing here; they are retained
+			// as statements purely so the tokenizer never drops a line.
 		}
-
-		if strings.HasPrefix(trimmed, "output ") {
-			result.outputs = append(result.outputs, parseOutput(trimmed, decorators))
-			i++
-			continue
-		}
-
-		i++
 	}
 
 	return result

--- a/providers/bicep/resources/tokenizer.go
+++ b/providers/bicep/resources/tokenizer.go
@@ -1,0 +1,156 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "strings"
+
+// bicepStatement is a single top-level construct in a .bicep file —
+// a `param`, `var`, `resource`, `module`, `output`, `targetScope`, or an
+// unrecognized line — together with any leading `@decorator(...)` lines
+// that attach to it. The tokenizer yields these so the parser can dispatch
+// on a complete, brace/bracket/string-aware statement body rather than
+// re-walking raw source lines.
+type bicepStatement struct {
+	decorators []string // leading @decorators attached to this statement
+	keyword    string   // "targetScope" | "param" | "var" | "resource" | "module" | "output" | "" (unknown)
+	text       string   // the full statement source, multi-line, from keyword to the end of its body
+	startLine  int      // 1-based, for diagnostics/future use
+}
+
+// knownKeywords maps a leading token to the canonical statement keyword.
+// Anything not in this set produces a statement with an empty keyword so
+// the parser never silently drops a line and future PRs can extend the
+// classification (user-defined types, functions, imports, metadata, …).
+var knownKeywords = map[string]string{
+	"targetScope": "targetScope",
+	"param":       "param",
+	"var":         "var",
+	"resource":    "resource",
+	"module":      "module",
+	"output":      "output",
+}
+
+// tokenizeBicep walks the source once and returns its top-level statements.
+//
+// A statement begins at the first non-blank, non-comment line after any
+// leading decorators. It ends when, after consuming its first line, the
+// running bracket/brace/paren depth (tracked string-aware via scanState)
+// has returned to zero — so a single-line `param x string` ends at end of
+// line, while a `resource ... = { ... }`, a `var x = [ ... ]`, or a
+// multi-line object default keep consuming lines until their delimiters
+// balance.
+//
+// Leading `@decorator(...)` lines — themselves possibly multi-line and
+// depth-aware (e.g. `@allowed([\n ... \n])`) — attach to the next
+// statement. Blank lines and `// ...` comment-only lines between
+// statements are skipped.
+func tokenizeBicep(content string) []bicepStatement {
+	lines := strings.Split(content, "\n")
+	var statements []bicepStatement
+
+	i := 0
+	for i < len(lines) {
+		trimmed := strings.TrimSpace(lines[i])
+
+		// Skip blank lines and comment-only lines that sit between
+		// statements (decorators are handled below, so we only land here
+		// for separators).
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			i++
+			continue
+		}
+
+		// Collect leading decorators. Each decorator may span multiple
+		// lines; the string-aware scanner reassembles it so that delimiters
+		// inside string literals (e.g. `@description('contains ] bracket')`)
+		// don't keep it open past its real end.
+		var decorators []string
+		for strings.HasPrefix(trimmed, "@") {
+			decLine := trimmed
+			st := scanState{}
+			st.feed(trimmed)
+			i++
+			for st.totalDepth() > 0 && i < len(lines) {
+				t := strings.TrimSpace(lines[i])
+				decLine += "\n" + t
+				st.feed(t)
+				i++
+			}
+			decorators = append(decorators, decLine)
+
+			// Advance past any blank/comment lines between a decorator and
+			// the statement (or the next decorator) it attaches to.
+			for i < len(lines) {
+				t := strings.TrimSpace(lines[i])
+				if t == "" || strings.HasPrefix(t, "//") {
+					i++
+					continue
+				}
+				break
+			}
+			if i >= len(lines) {
+				break
+			}
+			trimmed = strings.TrimSpace(lines[i])
+		}
+
+		// If decorators ran to EOF without a following statement, still emit
+		// them as an empty-keyword statement so nothing is dropped.
+		if i >= len(lines) {
+			if len(decorators) > 0 {
+				statements = append(statements, bicepStatement{
+					decorators: decorators,
+					keyword:    "",
+					text:       "",
+					startLine:  len(lines),
+				})
+			}
+			break
+		}
+
+		// Reassemble the statement body: consume its first line, then keep
+		// pulling continuation lines until the running depth returns to zero.
+		startLine := i + 1 // 1-based
+		st := scanState{}
+		var bodyLines []string
+
+		bodyLines = append(bodyLines, lines[i])
+		st.feed(lines[i])
+		i++
+		for st.totalDepth() > 0 && i < len(lines) {
+			bodyLines = append(bodyLines, lines[i])
+			st.feed(lines[i])
+			i++
+		}
+
+		text := strings.Join(bodyLines, "\n")
+		keyword := classifyKeyword(strings.TrimSpace(bodyLines[0]))
+
+		statements = append(statements, bicepStatement{
+			decorators: decorators,
+			keyword:    keyword,
+			text:       text,
+			startLine:  startLine,
+		})
+	}
+
+	return statements
+}
+
+// classifyKeyword returns the canonical statement keyword for the leading
+// token of a (trimmed) statement line, or "" when the leading token is not
+// a recognized Bicep top-level keyword.
+func classifyKeyword(line string) string {
+	// The leading token ends at the first whitespace or `=` (covers
+	// `targetScope = '...'` with no space before `=`).
+	end := len(line)
+	for idx := 0; idx < len(line); idx++ {
+		c := line[idx]
+		if c == ' ' || c == '\t' || c == '=' {
+			end = idx
+			break
+		}
+	}
+	return knownKeywords[line[:end]]
+}

--- a/providers/bicep/resources/tokenizer_test.go
+++ b/providers/bicep/resources/tokenizer_test.go
@@ -1,0 +1,225 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenizeBicep(t *testing.T) {
+	tests := []struct {
+		name string
+		// want describes each expected statement in order.
+		want []struct {
+			keyword    string
+			decorators []string
+			// containsAll asserts substrings that must appear in the
+			// statement's reassembled text.
+			containsAll []string
+		}
+		input string
+	}{
+		{
+			name:  "simple single-line param",
+			input: `param location string = 'eastus'`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "param", containsAll: []string{"param location string = 'eastus'"}},
+			},
+		},
+		{
+			name: "multi-line param with object default",
+			input: `param config object = {
+  name: 'myService'
+  enabled: true
+}`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "param", containsAll: []string{"param config object = {", "name: 'myService'", "enabled: true", "}"}},
+			},
+		},
+		{
+			name: "resource with nested body containing brace and comment in a string",
+			input: `resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorage'
+  properties: {
+    note: 'closing brace } and // not a comment'
+  }
+}`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "resource", containsAll: []string{
+					"resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {",
+					"note: 'closing brace } and // not a comment'",
+					"properties: {",
+				}},
+			},
+		},
+		{
+			name: "var with multi-line array",
+			input: `var regions = [
+  'eastus'
+  'westus'
+]`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "var", containsAll: []string{"var regions = [", "'eastus'", "'westus'", "]"}},
+			},
+		},
+		{
+			name: "stacked multi-line decorators attach to following statement",
+			input: `@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+])
+@secure()
+param storageSku string`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{
+					keyword: "param",
+					decorators: []string{
+						"@allowed([\n'Standard_LRS'\n'Standard_GRS'\n])",
+						"@secure()",
+					},
+					containsAll: []string{"param storageSku string"},
+				},
+			},
+		},
+		{
+			name: "blank and comment lines between statements are skipped",
+			input: `param a string
+
+// a leading comment
+var b = 'x'
+
+// trailing comment block
+output c string = b`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "param", containsAll: []string{"param a string"}},
+				{keyword: "var", containsAll: []string{"var b = 'x'"}},
+				{keyword: "output", containsAll: []string{"output c string = b"}},
+			},
+		},
+		{
+			name:  "unknown leading keyword becomes empty-keyword statement",
+			input: `type myType = string`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "", containsAll: []string{"type myType = string"}},
+			},
+		},
+		{
+			name:  "targetScope is classified",
+			input: `targetScope = 'subscription'`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "targetScope", containsAll: []string{"targetScope = 'subscription'"}},
+			},
+		},
+		{
+			name: "mixed file yields all statements in order",
+			input: `targetScope = 'subscription'
+
+@description('region')
+param location string = 'eastus'
+
+var rgName = 'myRG'
+
+resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: rgName
+}
+
+module net './net.bicep' = {
+  name: 'netDeploy'
+}
+
+output rgId string = rg.id`,
+			want: []struct {
+				keyword     string
+				decorators  []string
+				containsAll []string
+			}{
+				{keyword: "targetScope"},
+				{keyword: "param", decorators: []string{"@description('region')"}},
+				{keyword: "var"},
+				{keyword: "resource"},
+				{keyword: "module"},
+				{keyword: "output"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmts := tokenizeBicep(tt.input)
+			require.Len(t, stmts, len(tt.want), "statement count")
+			for i, w := range tt.want {
+				assert.Equal(t, w.keyword, stmts[i].keyword, "statement %d keyword", i)
+				if w.decorators != nil {
+					assert.Equal(t, w.decorators, stmts[i].decorators, "statement %d decorators", i)
+				}
+				for _, sub := range w.containsAll {
+					assert.Contains(t, stmts[i].text, sub, "statement %d text", i)
+				}
+				assert.Positive(t, stmts[i].startLine, "statement %d startLine should be 1-based", i)
+			}
+		})
+	}
+}
+
+// A resource body whose string literal contains an unbalanced `}` must not
+// terminate the statement early — the tokenizer relies on scanState to ignore
+// delimiters inside strings.
+func TestTokenizeBicep_StringDelimitersDoNotCloseEarly(t *testing.T) {
+	input := `resource sa 'Type@ver' = {
+  note: '} ] )'
+  name: 'real'
+}
+
+output done string = sa.name`
+	stmts := tokenizeBicep(input)
+	require.Len(t, stmts, 2)
+	assert.Equal(t, "resource", stmts[0].keyword)
+	assert.Contains(t, stmts[0].text, "name: 'real'")
+	assert.Equal(t, "output", stmts[1].keyword)
+}
+
+// Decorators that run to end-of-file with no following statement should still
+// surface as an empty-keyword statement so nothing is silently dropped.
+func TestTokenizeBicep_TrailingDecoratorOnly(t *testing.T) {
+	input := `@description('dangling')`
+	stmts := tokenizeBicep(input)
+	require.Len(t, stmts, 1)
+	assert.Equal(t, "", stmts[0].keyword)
+	assert.Equal(t, []string{"@description('dangling')"}, stmts[0].decorators)
+}


### PR DESCRIPTION
## What

Replaces the line-anchored regex statement dispatch in `parseBicep()` with a single-pass, brace/bracket/string-aware **statement tokenizer** (`providers/bicep/resources/tokenizer.go`).

The tokenizer walks the file once and yields top-level statements:

```go
type bicepStatement struct {
    decorators []string // leading @decorators attached to this statement
    keyword    string   // "targetScope" | "param" | "var" | "resource" | "module" | "output" | "" (unknown)
    text       string   // the full statement source, multi-line, from keyword to end of body
    startLine  int      // 1-based, for diagnostics/future use
}
```

`parseBicep()` now tokenizes once and dispatches on `stmt.keyword` to the existing `parse*` helpers, handing each one a guaranteed-complete statement body instead of re-walking the raw line slice. Depth is tracked via the shared `scanState` lexer, so braces/brackets inside string literals (`'...'`, `"..."`, `'''...'''`) and after `//` comments never close a statement early. Unknown leading tokens become `keyword: ""` statements so nothing is silently dropped.

## Why

This is **PR0 of a 5-PR stack** that will add Bicep language constructs (user-defined types, functions, imports, metadata, `.bicepparam` files, for-loops, nested resources). This PR adds **no new constructs and no schema changes** — it is a pure internal refactor that pays down the parser-robustness ceiling *before* piling on more constructs, so the later PRs can reliably handle multi-line bodies, loop bodies (`[for ... : {...}]`), and indented nested resources.

## Invisible at the schema level

No changes to `bicep.lr`, `*.lr.go`, `*.lr.versions`, `*.resources.json`, `*.permissions.json`, or any field/resource. The `scanState` exported surface (shared with `expression.go`) is untouched.

## Verification

- `go vet ./resources/` — clean
- `go test ./resources/` — all existing tests pass **unchanged**, plus new `tokenizer_test.go` table-tests (single/multi-line params, nested resource bodies with delimiters inside strings, multi-line var arrays, stacked multi-line decorators, blank/comment separators, unknown keywords, trailing decorator-only, string-delimiter-aware termination)
- Built + installed the provider and ran a real query against `testdata/expressions.bicep` (`bicep.files { parameters resources variables outputs }`) — output is byte-for-byte identical to pre-refactor behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)