### PR TITLE
✨ bicep: discover and parse .bicepparam parameter files

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -53,6 +53,7 @@ atlassian
 autoaccept
 automattic
 bfc
+bicepparam
 bumpable
 bwawxf
 cafd

--- a/providers/bicep/connection/connection.go
+++ b/providers/bicep/connection/connection.go
@@ -19,15 +19,22 @@ var _ plugin.Connection = (*BicepConnection)(nil)
 
 type BicepConnection struct {
 	plugin.Connection
-	Conf        *inventory.Config
-	asset       *inventory.Asset
-	path        string
-	bicepFiles  []*BicepFile
-	armTemplate *ARMTemplate
+	Conf            *inventory.Config
+	asset           *inventory.Asset
+	path            string
+	bicepFiles      []*BicepFile
+	bicepParamFiles []*BicepParamFile
+	armTemplate     *ARMTemplate
 }
 
 // BicepFile holds a Bicep source file path and its raw content.
 type BicepFile struct {
+	Path    string
+	Content string
+}
+
+// BicepParamFile holds a `.bicepparam` parameter file path and its raw content.
+type BicepParamFile struct {
 	Path    string
 	Content string
 }
@@ -68,10 +75,15 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 			return nil, err
 		}
 		conn.bicepFiles = files
+		paramFiles, err := loadBicepParamFiles(bicepPath)
+		if err != nil {
+			return nil, err
+		}
+		conn.bicepParamFiles = paramFiles
 		// Check for ARM template JSON in the directory
 		conn.armTemplate = findARMTemplate(bicepPath)
-		if len(files) == 0 && conn.armTemplate == nil {
-			return nil, errors.New("no .bicep or ARM template JSON files found at " + bicepPath)
+		if len(files) == 0 && len(paramFiles) == 0 && conn.armTemplate == nil {
+			return nil, errors.New("no .bicep, .bicepparam, or ARM template JSON files found at " + bicepPath)
 		}
 	} else if strings.HasSuffix(bicepPath, ".json") {
 		// Direct ARM template JSON
@@ -80,6 +92,13 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 			return nil, err
 		}
 		conn.armTemplate = tmpl
+	} else if strings.HasSuffix(bicepPath, ".bicepparam") {
+		// Single .bicepparam parameter file
+		content, err := os.ReadFile(bicepPath)
+		if err != nil {
+			return nil, err
+		}
+		conn.bicepParamFiles = []*BicepParamFile{{Path: bicepPath, Content: string(content)}}
 	} else {
 		// Single .bicep file
 		content, err := os.ReadFile(bicepPath)
@@ -102,6 +121,10 @@ func (c *BicepConnection) Asset() *inventory.Asset {
 
 func (c *BicepConnection) BicepFiles() []*BicepFile {
 	return c.bicepFiles
+}
+
+func (c *BicepConnection) BicepParamFiles() []*BicepParamFile {
+	return c.bicepParamFiles
 }
 
 func (c *BicepConnection) ARMTemplate() *ARMTemplate {
@@ -129,6 +152,33 @@ func loadBicepFiles(dir string) ([]*BicepFile, error) {
 				return nil
 			}
 			files = append(files, &BicepFile{Path: path, Content: string(content)})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func loadBicepParamFiles(dir string) ([]*BicepParamFile, error) {
+	var files []*BicepParamFile
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".bicepparam") {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				log.Warn().Err(err).Str("path", path).Msg("failed to read bicepparam file")
+				return nil
+			}
+			files = append(files, &BicepParamFile{Path: path, Content: string(content)})
 		}
 		return nil
 	})

--- a/providers/bicep/connection/connection_test.go
+++ b/providers/bicep/connection/connection_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func newTestConnection(t *testing.T, path string) (*BicepConnection, error) {
+	t.Helper()
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{
+				Type:    "bicep",
+				Options: map[string]string{"path": path},
+			},
+		},
+	}
+	return NewBicepConnection(0, asset, asset.Connections[0])
+}
+
+func TestDiscoverBicepParamFilesInDirectory(t *testing.T) {
+	dir := filepath.Join("..", "resources", "testdata", "paramfiles")
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	// The directory holds both a .bicep and a .bicepparam file; each must land
+	// in its own bucket. A .bicepparam ends in "param", not ".bicep", so the
+	// .bicep walker never picks it up.
+	require.Len(t, conn.BicepParamFiles(), 1)
+	assert.True(t, filepath.Base(conn.BicepParamFiles()[0].Path) == "prod.bicepparam")
+	assert.Contains(t, conn.BicepParamFiles()[0].Content, "using './main.bicep'")
+
+	require.Len(t, conn.BicepFiles(), 1)
+	assert.Equal(t, "main.bicep", filepath.Base(conn.BicepFiles()[0].Path))
+}
+
+func TestDiscoverSingleBicepParamFile(t *testing.T) {
+	path := filepath.Join("..", "resources", "testdata", "paramfiles", "prod.bicepparam")
+	conn, err := newTestConnection(t, path)
+	require.NoError(t, err)
+
+	require.Len(t, conn.BicepParamFiles(), 1)
+	assert.Equal(t, path, conn.BicepParamFiles()[0].Path)
+	assert.Empty(t, conn.BicepFiles())
+}

--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -31,6 +31,34 @@ func (r *mqlBicep) files() ([]any, error) {
 	return mqlFiles, nil
 }
 
+func (r *mqlBicep) paramFiles() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.BicepConnection)
+	paramFiles := conn.BicepParamFiles()
+
+	var mqlFiles []any
+	for _, f := range paramFiles {
+		using, params := parseBicepParam(f.Content)
+
+		mqlParams := make(map[string]any, len(params))
+		for k, v := range params {
+			mqlParams[k] = v
+		}
+
+		res, err := CreateResource(r.MqlRuntime, "bicep.paramFile", map[string]*llx.RawData{
+			"__id":    llx.StringData(f.Path),
+			"path":    llx.StringData(f.Path),
+			"using":   llx.StringData(using),
+			"params":  llx.MapData(mqlParams, types.String),
+			"content": llx.StringData(f.Content),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, res)
+	}
+	return mqlFiles, nil
+}
+
 func (r *mqlBicep) template() (*mqlBicepTemplate, error) {
 	conn := r.MqlRuntime.Connection.(*connection.BicepConnection)
 	armTmpl := conn.ARMTemplate()

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -14,6 +14,8 @@ option go_package = "go.mondoo.com/mql/v13/providers/bicep/resources"
 bicep {
   // All Bicep source files found
   files() []bicep.file
+  // All Bicep parameter (.bicepparam) files found
+  paramFiles() []bicep.paramFile
   // Compiled ARM template (if available via JSON or bicep build)
   template() bicep.template
 }
@@ -53,6 +55,38 @@ bicep.file @defaults("path") {
   // `bicep.resource.tags` skips expression-valued tags. Most real-world
   // metadata is `description = '...'`.
   metadata map[string]string
+  // Raw file content
+  content string
+}
+
+// Bicep parameter file
+//
+// Examine a `.bicepparam` parameter file — the file that carries the actual
+// parameter values used for a deployment. The `using` field names the
+// template the values target (`'./main.bicep'`, `'none'`, or a
+// registry/template-spec ref like `'br:...'`); `params` maps each
+// `param <name> = <value>` assignment to its right-hand-side value text.
+// Select a file by its `path` — for example
+// `bicep.paramFiles.where(path == "prod.bicepparam")`.
+bicep.paramFile @defaults("path") {
+  // File path
+  path string
+  // Target template referenced by the `using` statement
+  //
+  // The value of `using '<target>'` — `'./main.bicep'`, `'none'`, or a
+  // registry/template-spec ref like `'br:...'`. Empty when no `using`
+  // statement is present.
+  using string
+  // Parameter assignments as a name-to-value map
+  //
+  // Maps each `param <name> = <value>` to its right-hand-side value text,
+  // stored EXACTLY as written and NOT quote-stripped: a literal stays quoted
+  // (`'Standard_LRS'`) while an expression stays bare
+  // (`resourceGroup().location`, `readEnvironmentVariable('ADMIN_PW')`).
+  // This preserves the literal-vs-expression distinction that audits care
+  // about, and intentionally differs from `bicep.parameter.defaultValue`,
+  // which strips the surrounding quotes from literal values.
+  params map[string]string
   // Raw file content
   content string
 }

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -17,6 +17,7 @@ import (
 const (
 	ResourceBicep                 string = "bicep"
 	ResourceBicepFile             string = "bicep.file"
+	ResourceBicepParamFile        string = "bicep.paramFile"
 	ResourceBicepParameter        string = "bicep.parameter"
 	ResourceBicepVariable         string = "bicep.variable"
 	ResourceBicepResource         string = "bicep.resource"
@@ -41,6 +42,10 @@ func init() {
 		"bicep.file": {
 			// to override args, implement: initBicepFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createBicepFile,
+		},
+		"bicep.paramFile": {
+			// to override args, implement: initBicepParamFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createBicepParamFile,
 		},
 		"bicep.parameter": {
 			// to override args, implement: initBicepParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -160,6 +165,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicep).GetFiles()).ToDataRes(types.Array(types.Resource("bicep.file")))
 	},
+	"bicep.paramFiles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicep).GetParamFiles()).ToDataRes(types.Array(types.Resource("bicep.paramFile")))
+	},
 	"bicep.template": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicep).GetTemplate()).ToDataRes(types.Resource("bicep.template"))
 	},
@@ -198,6 +206,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.file.content": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepFile).GetContent()).ToDataRes(types.String)
+	},
+	"bicep.paramFile.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParamFile).GetPath()).ToDataRes(types.String)
+	},
+	"bicep.paramFile.using": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParamFile).GetUsing()).ToDataRes(types.String)
+	},
+	"bicep.paramFile.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParamFile).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"bicep.paramFile.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParamFile).GetContent()).ToDataRes(types.String)
 	},
 	"bicep.parameter.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepParameter).GetName()).ToDataRes(types.String)
@@ -447,6 +467,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicep).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"bicep.paramFiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicep).ParamFiles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"bicep.template": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicep).Template, ok = plugin.RawToTValue[*mqlBicepTemplate](v.Value, v.Error)
 		return
@@ -501,6 +525,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.file.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepFile).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.paramFile.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParamFile).__id, ok = v.Value.(string)
+		return
+	},
+	"bicep.paramFile.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParamFile).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.paramFile.using": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParamFile).Using, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.paramFile.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParamFile).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"bicep.paramFile.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParamFile).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"bicep.parameter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -880,8 +924,9 @@ type mqlBicep struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlBicepInternal it will be used here
-	Files    plugin.TValue[[]any]
-	Template plugin.TValue[*mqlBicepTemplate]
+	Files      plugin.TValue[[]any]
+	ParamFiles plugin.TValue[[]any]
+	Template   plugin.TValue[*mqlBicepTemplate]
 }
 
 // createBicep creates a new instance of this resource
@@ -934,6 +979,22 @@ func (c *mqlBicep) GetFiles() *plugin.TValue[[]any] {
 		}
 
 		return c.files()
+	})
+}
+
+func (c *mqlBicep) GetParamFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ParamFiles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep", c.__id, "paramFiles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.paramFiles()
 	})
 }
 
@@ -1150,6 +1211,65 @@ func (c *mqlBicepFile) GetMetadata() *plugin.TValue[map[string]any] {
 }
 
 func (c *mqlBicepFile) GetContent() *plugin.TValue[string] {
+	return &c.Content
+}
+
+// mqlBicepParamFile for the bicep.paramFile resource
+type mqlBicepParamFile struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlBicepParamFileInternal it will be used here
+	Path    plugin.TValue[string]
+	Using   plugin.TValue[string]
+	Params  plugin.TValue[map[string]any]
+	Content plugin.TValue[string]
+}
+
+// createBicepParamFile creates a new instance of this resource
+func createBicepParamFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlBicepParamFile{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("bicep.paramFile", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlBicepParamFile) MqlName() string {
+	return "bicep.paramFile"
+}
+
+func (c *mqlBicepParamFile) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlBicepParamFile) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlBicepParamFile) GetUsing() *plugin.TValue[string] {
+	return &c.Using
+}
+
+func (c *mqlBicepParamFile) GetParams() *plugin.TValue[map[string]any] {
+	return &c.Params
+}
+
+func (c *mqlBicepParamFile) GetContent() *plugin.TValue[string] {
 	return &c.Content
 }
 

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -52,6 +52,12 @@ bicep.output.expression 13.0.0
 bicep.output.expressionTree 13.1.2
 bicep.output.name 13.0.0
 bicep.output.type 13.0.0
+bicep.paramFile 13.1.2
+bicep.paramFile.content 13.1.2
+bicep.paramFile.params 13.1.2
+bicep.paramFile.path 13.1.2
+bicep.paramFile.using 13.1.2
+bicep.paramFiles 13.1.2
 bicep.parameter 13.0.0
 bicep.parameter.allowed 13.0.0
 bicep.parameter.decorators 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -319,4 +319,5 @@ var (
 	_ plugin.Resource = (*mqlBicepType)(nil)
 	_ plugin.Resource = (*mqlBicepFunction)(nil)
 	_ plugin.Resource = (*mqlBicepImport)(nil)
+	_ plugin.Resource = (*mqlBicepParamFile)(nil)
 )

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -134,7 +134,56 @@ var (
 	// literal single-quoted values are captured; expression-/object-valued
 	// metadata is skipped (mirrors the tag-extraction behavior).
 	metadataRe = regexp.MustCompile(`(?m)^metadata\s+(\w+)\s*=\s*'([^']*)'\s*$`)
+
+	// usingRe matches the `using '<target>'` statement at the head of a
+	// `.bicepparam` file. The target is the referenced template
+	// ('./main.bicep', 'none', or a registry/template-spec ref like 'br:...').
+	usingRe = regexp.MustCompile(`(?m)^\s*using\s+'([^']*)'`)
+
+	// paramAssignRe matches a `.bicepparam` parameter assignment
+	// `param <name> = <value>`. Unlike a `.bicep` `param` declaration there
+	// is no type between the name and `=`, so this deliberately does not reuse
+	// paramRe. The right-hand side is captured raw (everything after `=`).
+	paramAssignRe = regexp.MustCompile(`^param\s+(\w+)\s*=\s*(.+)$`)
 )
+
+// parseBicepParam parses a `.bicepparam` parameter file into the `using`
+// target and a name->value map. The right-hand-side value text is stored
+// EXACTLY as written, NOT quote-stripped: a literal stays quoted
+// (`'Standard_LRS'`) and an expression stays bare
+// (`resourceGroup().location`, `readEnvironmentVariable('ADMIN_PW')`). This
+// preserves the literal-vs-expression distinction audits care about, and
+// intentionally differs from `bicep.parameter.defaultValue`, which strips
+// quotes.
+//
+// The tokenizer keys off the leading keyword of each statement, so `using`
+// and `param` assignments are dispatched the same brace/string-aware way as
+// `.bicep` constructs; multi-line object/array values are reassembled into a
+// single collapsed-whitespace value.
+func parseBicepParam(content string) (string, map[string]string) {
+	var using string
+	if m := usingRe.FindStringSubmatch(content); len(m) > 1 {
+		using = m[1]
+	}
+
+	params := map[string]string{}
+	for _, stmt := range tokenizeBicep(content) {
+		if stmt.keyword != "param" {
+			continue
+		}
+		stmtLines := strings.Split(stmt.text, "\n")
+		// Reassemble multi-line values (object/array RHS) into one line with
+		// runs of whitespace collapsed, mirroring parseVariableDecl.
+		combined := strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
+		m := paramAssignRe.FindStringSubmatch(strings.TrimSpace(combined))
+		if len(m) < 3 {
+			continue
+		}
+		params[m[1]] = strings.TrimSpace(m[2])
+	}
+
+	return using, params
+}
 
 func parseBicep(content string) *parsedBicepFile {
 	result := &parsedBicepFile{}

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -996,3 +996,58 @@ func TestParseResourceTags(t *testing.T) {
 		assert.Nil(t, result.resources[0].tags)
 	})
 }
+
+func TestParseBicepParam(t *testing.T) {
+	t.Run("using target plus literal and expression params", func(t *testing.T) {
+		input := `using './main.bicep'
+
+param storageSku = 'Standard_LRS'
+param location = resourceGroup().location
+param adminPassword = readEnvironmentVariable('ADMIN_PW')
+`
+		using, params := parseBicepParam(input)
+		assert.Equal(t, "./main.bicep", using)
+		assert.Equal(t, map[string]string{
+			// Literal stays quoted; expressions stay bare. The raw RHS text is
+			// preserved verbatim so audits can tell a literal from an expression.
+			"storageSku":    "'Standard_LRS'",
+			"location":      "resourceGroup().location",
+			"adminPassword": "readEnvironmentVariable('ADMIN_PW')",
+		}, params)
+	})
+
+	t.Run("using none", func(t *testing.T) {
+		input := `using 'none'
+param foo = 'bar'
+`
+		using, params := parseBicepParam(input)
+		assert.Equal(t, "none", using)
+		assert.Equal(t, map[string]string{"foo": "'bar'"}, params)
+	})
+
+	t.Run("registry using ref", func(t *testing.T) {
+		input := `using 'br:example.azurecr.io/bicep/modules/storage:v1'
+param env = 'prod'
+`
+		using, _ := parseBicepParam(input)
+		assert.Equal(t, "br:example.azurecr.io/bicep/modules/storage:v1", using)
+	})
+
+	t.Run("no using statement", func(t *testing.T) {
+		input := `param foo = 'bar'`
+		using, params := parseBicepParam(input)
+		assert.Equal(t, "", using)
+		assert.Equal(t, map[string]string{"foo": "'bar'"}, params)
+	})
+
+	t.Run("multi-line object value", func(t *testing.T) {
+		input := `using './main.bicep'
+param config = {
+  name: 'example'
+  tier: 'standard'
+}
+`
+		_, params := parseBicepParam(input)
+		assert.Equal(t, "{ name: 'example' tier: 'standard' }", params["config"])
+	})
+}

--- a/providers/bicep/resources/testdata/paramfiles/main.bicep
+++ b/providers/bicep/resources/testdata/paramfiles/main.bicep
@@ -1,0 +1,19 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+@description('Storage account SKU')
+param storageSku string = 'Standard_LRS'
+
+@description('Deployment location')
+param location string = resourceGroup().location
+
+@secure()
+param adminPassword string
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'examplestorage'
+  location: location
+  sku: {
+    name: storageSku
+  }
+}

--- a/providers/bicep/resources/testdata/paramfiles/prod.bicepparam
+++ b/providers/bicep/resources/testdata/paramfiles/prod.bicepparam
@@ -1,0 +1,8 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+using './main.bicep'
+
+param storageSku = 'Standard_LRS'
+param location = resourceGroup().location
+param adminPassword = readEnvironmentVariable('ADMIN_PW')


### PR DESCRIPTION
## What

Adds support for **`.bicepparam` parameter files** — the file type that carries the actual parameter VALUES used for a deployment, which is exactly what compliance audits need.

A `.bicepparam` file looks like:

```bicep
using './main.bicep'
param storageSku = 'Standard_LRS'
param location = resourceGroup().location
param adminPassword = readEnvironmentVariable('ADMIN_PW')
```

- A `using` statement names the target template (`'./main.bicep'`, `'none'`, or a registry/template-spec ref like `'br:...'`).
- Each `param name = value` assigns a value. Unlike a `.bicep` `param` declaration, there is **no type** between the name and `=`.

## Changes

- **Connection discovery** for `.bicepparam` files in both the directory walk and when a `foo.bicepparam` path is passed directly. A `.bicepparam` ends in `"param"`, not `".bicep"`, so the existing `.bicep` walker never matched it — a dedicated walker/branch was needed.
- **Dedicated parser** `parseBicepParam(content) (using, params)`. The type-less `param x = value` form doesn't fit the existing `.bicep` `paramRe`, so a small purpose-built parser keys off the statement tokenizer.
- **Schema**: `bicep.paramFiles() []bicep.paramFile` on the root resource, and the new `bicep.paramFile` resource (`path`, `using`, `params`, `content`). `params` is a `map[string]string` per the sub-resource bar (name/value pair list → map). New `.lr.versions` entries at `13.1.2`.

## Raw-value rationale

The `params` map stores the right-hand-side value text **exactly as written, NOT quote-stripped**: a literal stays quoted (`'Standard_LRS'`) while an expression stays bare (`resourceGroup().location`, `readEnvironmentVariable('ADMIN_PW')`). This preserves the literal-vs-expression distinction audits care about, and intentionally differs from `bicep.parameter.defaultValue`, which strips quotes.

## Verification

End-to-end query against the testdata fixture:

```
$ mql run bicep providers/bicep/resources/testdata/paramfiles -c "bicep.paramFiles { path using params }"
bicep.paramFiles: [
  0: {
    using: "./main.bicep"
    path: "...testdata/paramfiles/prod.bicepparam"
    params: {
      adminPassword: "readEnvironmentVariable('ADMIN_PW')"
      location: "resourceGroup().location"
      storageSku: "'Standard_LRS'"
    }
  }
]
```

Literal kept quoted, expressions kept bare. Parser-level and connection-discovery Go tests added; `go test ./...` passes for the provider.

This **stacks on #8010**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)