### PR TITLE
✨ bicep: model for-loop deployments on resources, modules, outputs, and variables

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -155,6 +155,14 @@ bicep.variable @defaults("name") {
   expressionTree() bicep.expression
   // Description from @description decorator
   description string
+  // Whether the value is built with a `for` loop
+  isLoop bool
+  // Loop item iteration variable (empty when not a loop)
+  loopIterator string
+  // Loop index variable in the `(item, index)` form (empty otherwise)
+  loopIndexVar string
+  // Raw collection expression the loop iterates (empty when not a loop)
+  loopExpression string
 }
 
 // Bicep resource declaration
@@ -196,6 +204,14 @@ bicep.resource @defaults("type symbolicName") {
   dependsOn []string
   // Decorators
   decorators []string
+  // Whether the resource is deployed with a `for` loop
+  isLoop bool
+  // Loop item iteration variable (empty when not a loop)
+  loopIterator string
+  // Loop index variable in the `(item, index)` form (empty otherwise)
+  loopIndexVar string
+  // Raw collection expression the loop iterates (empty when not a loop)
+  loopExpression string
 }
 
 // Bicep module reference
@@ -223,6 +239,14 @@ bicep.module @defaults("name source") {
   description string
   // All decorators as raw strings
   decorators []string
+  // Whether the module is deployed with a `for` loop
+  isLoop bool
+  // Loop item iteration variable (empty when not a loop)
+  loopIterator string
+  // Loop index variable in the `(item, index)` form (empty otherwise)
+  loopIndexVar string
+  // Raw collection expression the loop iterates (empty when not a loop)
+  loopExpression string
 }
 
 // Bicep output declaration
@@ -247,6 +271,14 @@ bicep.output @defaults("name type") {
   expressionTree() bicep.expression
   // Description from @description decorator
   description string
+  // Whether the value is built with a `for` loop
+  isLoop bool
+  // Loop item iteration variable (empty when not a loop)
+  loopIterator string
+  // Loop index variable in the `(item, index)` form (empty otherwise)
+  loopIndexVar string
+  // Raw collection expression the loop iterates (empty when not a loop)
+  loopExpression string
 }
 
 // Parsed Bicep expression

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -264,6 +264,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.variable.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepVariable).GetDescription()).ToDataRes(types.String)
 	},
+	"bicep.variable.isLoop": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetIsLoop()).ToDataRes(types.Bool)
+	},
+	"bicep.variable.loopIterator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetLoopIterator()).ToDataRes(types.String)
+	},
+	"bicep.variable.loopIndexVar": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetLoopIndexVar()).ToDataRes(types.String)
+	},
+	"bicep.variable.loopExpression": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetLoopExpression()).ToDataRes(types.String)
+	},
 	"bicep.resource.symbolicName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetSymbolicName()).ToDataRes(types.String)
 	},
@@ -300,6 +312,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.decorators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetDecorators()).ToDataRes(types.Array(types.String))
 	},
+	"bicep.resource.isLoop": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetIsLoop()).ToDataRes(types.Bool)
+	},
+	"bicep.resource.loopIterator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetLoopIterator()).ToDataRes(types.String)
+	},
+	"bicep.resource.loopIndexVar": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetLoopIndexVar()).ToDataRes(types.String)
+	},
+	"bicep.resource.loopExpression": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetLoopExpression()).ToDataRes(types.String)
+	},
 	"bicep.module.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetName()).ToDataRes(types.String)
 	},
@@ -327,6 +351,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.module.decorators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetDecorators()).ToDataRes(types.Array(types.String))
 	},
+	"bicep.module.isLoop": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetIsLoop()).ToDataRes(types.Bool)
+	},
+	"bicep.module.loopIterator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetLoopIterator()).ToDataRes(types.String)
+	},
+	"bicep.module.loopIndexVar": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetLoopIndexVar()).ToDataRes(types.String)
+	},
+	"bicep.module.loopExpression": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetLoopExpression()).ToDataRes(types.String)
+	},
 	"bicep.output.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetName()).ToDataRes(types.String)
 	},
@@ -341,6 +377,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.output.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetDescription()).ToDataRes(types.String)
+	},
+	"bicep.output.isLoop": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetIsLoop()).ToDataRes(types.Bool)
+	},
+	"bicep.output.loopIterator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetLoopIterator()).ToDataRes(types.String)
+	},
+	"bicep.output.loopIndexVar": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetLoopIndexVar()).ToDataRes(types.String)
+	},
+	"bicep.output.loopExpression": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetLoopExpression()).ToDataRes(types.String)
 	},
 	"bicep.expression.kind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepExpression).GetKind()).ToDataRes(types.String)
@@ -615,6 +663,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepVariable).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.variable.isLoop": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).IsLoop, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"bicep.variable.loopIterator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).LoopIterator, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.variable.loopIndexVar": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).LoopIndexVar, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.variable.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"bicep.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).__id, ok = v.Value.(string)
 		return
@@ -667,6 +731,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepResource).Decorators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"bicep.resource.isLoop": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).IsLoop, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.loopIterator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).LoopIterator, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.loopIndexVar": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).LoopIndexVar, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"bicep.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepModule).__id, ok = v.Value.(string)
 		return
@@ -707,6 +787,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepModule).Decorators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"bicep.module.isLoop": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).IsLoop, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"bicep.module.loopIterator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).LoopIterator, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.module.loopIndexVar": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).LoopIndexVar, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.module.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"bicep.output.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).__id, ok = v.Value.(string)
 		return
@@ -729,6 +825,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.output.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.output.isLoop": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).IsLoop, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"bicep.output.loopIterator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).LoopIterator, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.output.loopIndexVar": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).LoopIndexVar, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.output.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"bicep.expression.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1376,6 +1488,10 @@ type mqlBicepVariable struct {
 	Expression     plugin.TValue[string]
 	ExpressionTree plugin.TValue[*mqlBicepExpression]
 	Description    plugin.TValue[string]
+	IsLoop         plugin.TValue[bool]
+	LoopIterator   plugin.TValue[string]
+	LoopIndexVar   plugin.TValue[string]
+	LoopExpression plugin.TValue[string]
 }
 
 // createBicepVariable creates a new instance of this resource
@@ -1438,23 +1554,43 @@ func (c *mqlBicepVariable) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
 
+func (c *mqlBicepVariable) GetIsLoop() *plugin.TValue[bool] {
+	return &c.IsLoop
+}
+
+func (c *mqlBicepVariable) GetLoopIterator() *plugin.TValue[string] {
+	return &c.LoopIterator
+}
+
+func (c *mqlBicepVariable) GetLoopIndexVar() *plugin.TValue[string] {
+	return &c.LoopIndexVar
+}
+
+func (c *mqlBicepVariable) GetLoopExpression() *plugin.TValue[string] {
+	return &c.LoopExpression
+}
+
 // mqlBicepResource for the bicep.resource resource
 type mqlBicepResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlBicepResourceInternal it will be used here
-	SymbolicName plugin.TValue[string]
-	Type         plugin.TValue[string]
-	ApiVersion   plugin.TValue[string]
-	Name         plugin.TValue[string]
-	Location     plugin.TValue[string]
-	Existing     plugin.TValue[bool]
-	Condition    plugin.TValue[string]
-	Parent       plugin.TValue[string]
-	Properties   plugin.TValue[any]
-	Tags         plugin.TValue[map[string]any]
-	DependsOn    plugin.TValue[[]any]
-	Decorators   plugin.TValue[[]any]
+	SymbolicName   plugin.TValue[string]
+	Type           plugin.TValue[string]
+	ApiVersion     plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Location       plugin.TValue[string]
+	Existing       plugin.TValue[bool]
+	Condition      plugin.TValue[string]
+	Parent         plugin.TValue[string]
+	Properties     plugin.TValue[any]
+	Tags           plugin.TValue[map[string]any]
+	DependsOn      plugin.TValue[[]any]
+	Decorators     plugin.TValue[[]any]
+	IsLoop         plugin.TValue[bool]
+	LoopIterator   plugin.TValue[string]
+	LoopIndexVar   plugin.TValue[string]
+	LoopExpression plugin.TValue[string]
 }
 
 // createBicepResource creates a new instance of this resource
@@ -1537,6 +1673,22 @@ func (c *mqlBicepResource) GetDecorators() *plugin.TValue[[]any] {
 	return &c.Decorators
 }
 
+func (c *mqlBicepResource) GetIsLoop() *plugin.TValue[bool] {
+	return &c.IsLoop
+}
+
+func (c *mqlBicepResource) GetLoopIterator() *plugin.TValue[string] {
+	return &c.LoopIterator
+}
+
+func (c *mqlBicepResource) GetLoopIndexVar() *plugin.TValue[string] {
+	return &c.LoopIndexVar
+}
+
+func (c *mqlBicepResource) GetLoopExpression() *plugin.TValue[string] {
+	return &c.LoopExpression
+}
+
 // mqlBicepModule for the bicep.module resource
 type mqlBicepModule struct {
 	MqlRuntime *plugin.Runtime
@@ -1551,6 +1703,10 @@ type mqlBicepModule struct {
 	IsTemplateSpec plugin.TValue[bool]
 	Description    plugin.TValue[string]
 	Decorators     plugin.TValue[[]any]
+	IsLoop         plugin.TValue[bool]
+	LoopIterator   plugin.TValue[string]
+	LoopIndexVar   plugin.TValue[string]
+	LoopExpression plugin.TValue[string]
 }
 
 // createBicepModule creates a new instance of this resource
@@ -1621,6 +1777,22 @@ func (c *mqlBicepModule) GetDecorators() *plugin.TValue[[]any] {
 	return &c.Decorators
 }
 
+func (c *mqlBicepModule) GetIsLoop() *plugin.TValue[bool] {
+	return &c.IsLoop
+}
+
+func (c *mqlBicepModule) GetLoopIterator() *plugin.TValue[string] {
+	return &c.LoopIterator
+}
+
+func (c *mqlBicepModule) GetLoopIndexVar() *plugin.TValue[string] {
+	return &c.LoopIndexVar
+}
+
+func (c *mqlBicepModule) GetLoopExpression() *plugin.TValue[string] {
+	return &c.LoopExpression
+}
+
 // mqlBicepOutput for the bicep.output resource
 type mqlBicepOutput struct {
 	MqlRuntime *plugin.Runtime
@@ -1631,6 +1803,10 @@ type mqlBicepOutput struct {
 	Expression     plugin.TValue[string]
 	ExpressionTree plugin.TValue[*mqlBicepExpression]
 	Description    plugin.TValue[string]
+	IsLoop         plugin.TValue[bool]
+	LoopIterator   plugin.TValue[string]
+	LoopIndexVar   plugin.TValue[string]
+	LoopExpression plugin.TValue[string]
 }
 
 // createBicepOutput creates a new instance of this resource
@@ -1695,6 +1871,22 @@ func (c *mqlBicepOutput) GetExpressionTree() *plugin.TValue[*mqlBicepExpression]
 
 func (c *mqlBicepOutput) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+func (c *mqlBicepOutput) GetIsLoop() *plugin.TValue[bool] {
+	return &c.IsLoop
+}
+
+func (c *mqlBicepOutput) GetLoopIterator() *plugin.TValue[string] {
+	return &c.LoopIterator
+}
+
+func (c *mqlBicepOutput) GetLoopIndexVar() *plugin.TValue[string] {
+	return &c.LoopIndexVar
+}
+
+func (c *mqlBicepOutput) GetLoopExpression() *plugin.TValue[string] {
+	return &c.LoopExpression
 }
 
 // mqlBicepExpression for the bicep.expression resource

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -40,8 +40,12 @@ bicep.module 13.0.0
 bicep.module.condition 13.0.0
 bicep.module.decorators 13.0.1
 bicep.module.description 13.0.1
+bicep.module.isLoop 13.1.2
 bicep.module.isRegistry 13.0.0
 bicep.module.isTemplateSpec 13.0.0
+bicep.module.loopExpression 13.1.2
+bicep.module.loopIndexVar 13.1.2
+bicep.module.loopIterator 13.1.2
 bicep.module.name 13.0.0
 bicep.module.params 13.0.0
 bicep.module.scope 13.0.0
@@ -50,6 +54,10 @@ bicep.output 13.0.0
 bicep.output.description 13.0.0
 bicep.output.expression 13.0.0
 bicep.output.expressionTree 13.1.2
+bicep.output.isLoop 13.1.2
+bicep.output.loopExpression 13.1.2
+bicep.output.loopIndexVar 13.1.2
+bicep.output.loopIterator 13.1.2
 bicep.output.name 13.0.0
 bicep.output.type 13.0.0
 bicep.paramFile 13.1.2
@@ -76,7 +84,11 @@ bicep.resource.condition 13.0.0
 bicep.resource.decorators 13.0.0
 bicep.resource.dependsOn 13.0.0
 bicep.resource.existing 13.0.0
+bicep.resource.isLoop 13.1.2
 bicep.resource.location 13.0.0
+bicep.resource.loopExpression 13.1.2
+bicep.resource.loopIndexVar 13.1.2
+bicep.resource.loopIterator 13.1.2
 bicep.resource.name 13.0.0
 bicep.resource.parent 13.0.0
 bicep.resource.properties 13.0.0
@@ -108,4 +120,8 @@ bicep.variable 13.0.0
 bicep.variable.description 13.0.0
 bicep.variable.expression 13.0.0
 bicep.variable.expressionTree 13.1.2
+bicep.variable.isLoop 13.1.2
+bicep.variable.loopExpression 13.1.2
+bicep.variable.loopIndexVar 13.1.2
+bicep.variable.loopIterator 13.1.2
 bicep.variable.name 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -42,12 +42,14 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedVariable) ([]any, error) {
 	var mqlVars []any
 	for _, v := range vars {
-		res, err := CreateResource(runtime, "bicep.variable", map[string]*llx.RawData{
+		args := map[string]*llx.RawData{
 			"__id":        llx.StringData("bicep.variable:" + filePath + ":" + v.name),
 			"name":        llx.StringData(v.name),
 			"expression":  llx.StringData(v.expression),
 			"description": llx.StringData(v.description),
-		})
+		}
+		addLoopArgs(args, v.loop)
+		res, err := CreateResource(runtime, "bicep.variable", args)
 		if err != nil {
 			return nil, err
 		}
@@ -98,6 +100,7 @@ func createMqlResources(runtime *plugin.Runtime, filePath string, resources []pa
 			}
 			args["tags"] = llx.MapData(tags, types.String)
 		}
+		addLoopArgs(args, r.loop)
 
 		res, err := CreateResource(runtime, "bicep.resource", args)
 		if err != nil {
@@ -123,7 +126,7 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 
 		decorators := sliceToAny(m.decorators)
 
-		res, err := CreateResource(runtime, "bicep.module", map[string]*llx.RawData{
+		args := map[string]*llx.RawData{
 			"__id":           llx.StringData("bicep.module:" + filePath + ":" + m.name),
 			"name":           llx.StringData(m.name),
 			"source":         llx.StringData(m.source),
@@ -134,7 +137,9 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 			"isTemplateSpec": llx.BoolData(m.isTemplateSpec),
 			"description":    llx.StringData(m.description),
 			"decorators":     llx.ArrayData(decorators, types.String),
-		})
+		}
+		addLoopArgs(args, m.loop)
+		res, err := CreateResource(runtime, "bicep.module", args)
 		if err != nil {
 			return nil, err
 		}
@@ -216,13 +221,15 @@ func (o *mqlBicepOutput) expressionTree() (*mqlBicepExpression, error) {
 func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput) ([]any, error) {
 	var mqlOutputs []any
 	for _, o := range outputs {
-		res, err := CreateResource(runtime, "bicep.output", map[string]*llx.RawData{
+		args := map[string]*llx.RawData{
 			"__id":        llx.StringData("bicep.output:" + filePath + ":" + o.name),
 			"name":        llx.StringData(o.name),
 			"type":        llx.StringData(o.typ),
 			"expression":  llx.StringData(o.expression),
 			"description": llx.StringData(o.description),
-		})
+		}
+		addLoopArgs(args, o.loop)
+		res, err := CreateResource(runtime, "bicep.output", args)
 		if err != nil {
 			return nil, err
 		}
@@ -298,6 +305,16 @@ func createMqlImports(runtime *plugin.Runtime, filePath string, imports []parsed
 		mqlImports = append(mqlImports, res)
 	}
 	return mqlImports, nil
+}
+
+// addLoopArgs sets the four flattened `for`-loop fields shared by
+// bicep.resource, bicep.module, bicep.output, and bicep.variable. For a
+// non-loop declaration isLoop is false and the string fields are empty.
+func addLoopArgs(args map[string]*llx.RawData, loop loopInfo) {
+	args["isLoop"] = llx.BoolData(loop.isLoop)
+	args["loopIterator"] = llx.StringData(loop.iterator)
+	args["loopIndexVar"] = llx.StringData(loop.indexVar)
+	args["loopExpression"] = llx.StringData(loop.expression)
 }
 
 func sliceToAny(s []string) []any {

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -352,8 +352,10 @@ func parseVariable(line string, decorators []string) parsedVariable {
 		v.name = m[1]
 		expr := strings.TrimSpace(m[2])
 		// A looped variable (`var names = [for i in range(0, 3): 'item-${i}']`)
-		// builds an array; store the per-iteration value expression in
-		// `expression` and record the loop header.
+		// builds an array. Intentionally store the per-iteration value
+		// expression in `expression` (here `'item-${i}'`), not the raw
+		// `[for ...]` text, and record the loop header separately. This keeps
+		// `expression` describing the value each iteration produces.
 		if loop := detectLoop(expr); loop.isLoop {
 			v.loop = loop
 			v.expression = loop.body
@@ -529,8 +531,10 @@ func parseOutput(line string, decorators []string) parsedOutput {
 		o.typ = m[2]
 		expr := strings.TrimSpace(m[3])
 		// A looped output (`output ids array = [for sa in sas: sa.id]`)
-		// produces an array; store the per-iteration value expression in
-		// `expression` and record the loop header.
+		// produces an array. Intentionally store the per-iteration value
+		// expression in `expression` (here `sa.id`), not the raw `[for ...]`
+		// text, and record the loop header separately. This keeps `expression`
+		// describing the value each iteration produces.
 		if loop := detectLoop(expr); loop.isLoop {
 			o.loop = loop
 			o.expression = loop.body

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -41,6 +41,7 @@ type parsedVariable struct {
 	name        string
 	expression  string
 	description string
+	loop        loopInfo
 }
 
 type parsedResource struct {
@@ -56,6 +57,7 @@ type parsedResource struct {
 	tags         map[string]string
 	dependsOn    []string
 	decorators   []string
+	loop         loopInfo
 }
 
 type parsedModule struct {
@@ -68,6 +70,7 @@ type parsedModule struct {
 	isRegistry     bool
 	isTemplateSpec bool
 	decorators     []string
+	loop           loopInfo
 }
 
 type parsedOutput struct {
@@ -75,6 +78,22 @@ type parsedOutput struct {
 	typ         string
 	expression  string
 	description string
+	loop        loopInfo
+}
+
+// loopInfo captures a Bicep `for`-loop on a declaration. Bicep iterates
+// resources, modules, outputs, and variables with
+// `[for <iterator> in <expression>: <body>]` (or the indexed
+// `[for (<iterator>, <indexVar>) in <expression>: <body>]` form). When a
+// declaration's value is such a loop, isLoop is true and the iterator,
+// optional indexVar, and collection expression are extracted; body holds
+// the text after the header colon (the per-iteration object or expression).
+type loopInfo struct {
+	isLoop     bool
+	iterator   string
+	indexVar   string
+	expression string
+	body       string
 }
 
 type parsedType struct {
@@ -221,7 +240,14 @@ func parseBicep(content string) *parsedBicepFile {
 				result.modules = append(result.modules, *mod)
 			}
 		case "output":
-			result.outputs = append(result.outputs, parseOutput(firstLine, stmt.decorators))
+			// Reassemble multi-line output values (a looped output's
+			// `[for ... : ...]` spans lines) into a single collapsed-whitespace
+			// line so the value regex and loop detector see the whole RHS.
+			outLine := firstLine
+			if len(stmtLines) > 1 {
+				outLine = strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
+			}
+			result.outputs = append(result.outputs, parseOutput(outLine, stmt.decorators))
 		case "type":
 			if t, ok := parseTypeDecl(stmt.text, stmt.decorators); ok {
 				result.types = append(result.types, t)
@@ -324,7 +350,16 @@ func parseVariable(line string, decorators []string) parsedVariable {
 	m := varRe.FindStringSubmatch(line)
 	if len(m) >= 3 {
 		v.name = m[1]
-		v.expression = strings.TrimSpace(m[2])
+		expr := strings.TrimSpace(m[2])
+		// A looped variable (`var names = [for i in range(0, 3): 'item-${i}']`)
+		// builds an array; store the per-iteration value expression in
+		// `expression` and record the loop header.
+		if loop := detectLoop(expr); loop.isLoop {
+			v.loop = loop
+			v.expression = loop.body
+		} else {
+			v.expression = expr
+		}
 	}
 	decText := strings.Join(decorators, "\n")
 	if m := descDecRe.FindStringSubmatch(decText); len(m) > 1 {
@@ -366,6 +401,33 @@ func parseVariableDecl(lines []string, startIdx int, decorators []string) (parse
 	return parseVariable(combined, decorators), i
 }
 
+// declValueAfterEquals returns the text following the top-level `=` of a
+// declaration that spans lines[startIdx:] — i.e. everything to the right of
+// the `=` in `resource foo 'Type@ver' = <value>` or `module m 'src' = <value>`.
+// The whole statement is reassembled and the first `=` that sits outside any
+// string, paren, bracket, or brace is taken as the assignment operator (so an
+// `=` inside the resource type string or a condition expression is ignored).
+// Returns "" when no top-level `=` is found.
+func declValueAfterEquals(lines []string, startIdx int) string {
+	full := strings.Join(lines[startIdx:], "\n")
+	st := scanState{}
+	for i := 0; i < len(full); {
+		if st.inStr == 0 && !st.inMulti && full[i] == '=' &&
+			st.paren == 0 && st.bracket == 0 && st.brace == 0 {
+			// Guard against `==`/`=>` which can appear in conditions; a real
+			// assignment `=` is followed by whitespace or a value char, not
+			// another `=` or `>`.
+			if i+1 < len(full) && (full[i+1] == '=' || full[i+1] == '>') {
+				i = st.stepAt(full, i)
+				continue
+			}
+			return strings.TrimSpace(full[i+1:])
+		}
+		i = st.stepAt(full, i)
+	}
+	return ""
+}
+
 func parseResourceDecl(lines []string, startIdx int, decorators []string) (*parsedResource, int) {
 	line := strings.TrimSpace(lines[startIdx])
 	m := resourceRe.FindStringSubmatch(line)
@@ -388,15 +450,29 @@ func parseResourceDecl(lines []string, startIdx int, decorators []string) (*pars
 	}
 
 	r.existing = len(m) > 4 && strings.TrimSpace(m[4]) == "existing"
+	r.condition = extractCondition(joinDeclHeader(lines, startIdx))
 
-	// Find the body between { and }
-	body, endIdx := extractBlock(lines, startIdx)
+	// endIdx is where the next statement begins; with the tokenizer feeding a
+	// single complete statement it is the end of the slice.
+	_, endIdx := extractBlock(lines, startIdx)
+
+	// When deployed via a `for`-loop the body object lives inside
+	// `[for <hdr>: { ... }]`. Detect the loop and parse the per-iteration
+	// object body the same way a plain resource body is parsed.
+	r.loop = detectLoop(declValueAfterEquals(lines, startIdx))
+	bodyLines := lines
+	bodyStart := startIdx
+	if r.loop.isLoop {
+		bodyLines = strings.Split(r.loop.body, "\n")
+		bodyStart = 0
+	}
+
+	body, _ := extractBlock(bodyLines, bodyStart)
 	r.body = body
 
 	// Extract common fields from body
 	r.name = extractFieldValue(body, "name")
 	r.location = extractFieldValue(body, "location")
-	r.condition = extractCondition(joinDeclHeader(lines, startIdx))
 	r.parent = extractFieldValue(body, "parent")
 	r.dependsOn = extractDependsOn(body)
 	r.tags = extractTags(body)
@@ -420,7 +496,20 @@ func parseModuleDecl(lines []string, startIdx int, decorators []string) (*parsed
 	}
 
 	mod.condition = extractCondition(joinDeclHeader(lines, startIdx))
-	body, endIdx := extractBlock(lines, startIdx)
+	_, endIdx := extractBlock(lines, startIdx)
+
+	// As with resources, a looped module wraps its body object in
+	// `[for <hdr>: { ... }]`; feed the loop body to the body parser so
+	// `name`/`scope`/`params` extraction still works.
+	mod.loop = detectLoop(declValueAfterEquals(lines, startIdx))
+	bodyLines := lines
+	bodyStart := startIdx
+	if mod.loop.isLoop {
+		bodyLines = strings.Split(mod.loop.body, "\n")
+		bodyStart = 0
+	}
+
+	body, _ := extractBlock(bodyLines, bodyStart)
 	mod.body = body
 	mod.scope = extractFieldValue(body, "scope")
 
@@ -438,7 +527,16 @@ func parseOutput(line string, decorators []string) parsedOutput {
 	if len(m) >= 4 {
 		o.name = m[1]
 		o.typ = m[2]
-		o.expression = strings.TrimSpace(m[3])
+		expr := strings.TrimSpace(m[3])
+		// A looped output (`output ids array = [for sa in sas: sa.id]`)
+		// produces an array; store the per-iteration value expression in
+		// `expression` and record the loop header.
+		if loop := detectLoop(expr); loop.isLoop {
+			o.loop = loop
+			o.expression = loop.body
+		} else {
+			o.expression = expr
+		}
 	}
 	decText := strings.Join(decorators, "\n")
 	if m := descDecRe.FindStringSubmatch(decText); len(m) > 1 {
@@ -583,6 +681,80 @@ var (
 	// importProviderRe matches a bare provider import like `import 'az@2.0.0'`.
 	importProviderRe = regexp.MustCompile(`^import\s+'([^']+)'`)
 )
+
+// loopHeaderRe matches the `[for` opener of a loop value and the iteration
+// variable form that follows. Group 1 captures the indexed
+// `(item, index)` form's item, group 2 the index var, group 3 the single
+// `item` form. Only the header up to the first identifier(s) and the
+// trailing `in ` is matched; the `<expression>: <body>` tail is split out
+// depth-aware so collection expressions and bodies that contain `:`/`]`
+// inside strings, parens, or nested brackets parse correctly.
+var loopHeaderRe = regexp.MustCompile(`^\[\s*for\s+(?:\(\s*(\w+)\s*,\s*(\w+)\s*\)|(\w+))\s+in\s+`)
+
+// detectLoop inspects a declaration's value text (everything after the `=`)
+// and, when it is a `for`-loop, returns the parsed loop header plus the
+// per-iteration body. For a non-loop value it returns loopInfo{} with
+// isLoop=false, so callers can fall back to their normal parse.
+//
+// The collection expression runs from `in` up to the top-level `:` that
+// separates the loop header from its body; the body runs from that `:` to
+// the matching closing `]`. Both boundaries are found with the shared
+// string/bracket-aware scanState so a `:` or `]` inside a string literal,
+// a `range(0, 3)` call, or a nested object/array doesn't split early.
+func detectLoop(value string) loopInfo {
+	trimmed := strings.TrimSpace(value)
+	m := loopHeaderRe.FindStringSubmatchIndex(trimmed)
+	if m == nil {
+		return loopInfo{}
+	}
+
+	info := loopInfo{isLoop: true}
+	// Submatch groups: [2:3]=indexed item, [4:5]=index var, [6:7]=single item.
+	if m[2] >= 0 {
+		info.iterator = trimmed[m[2]:m[3]]
+		info.indexVar = trimmed[m[4]:m[5]]
+	} else if m[6] >= 0 {
+		info.iterator = trimmed[m[6]:m[7]]
+	}
+
+	// The collection expression starts right after the matched `... in ` prefix.
+	exprStart := m[1]
+
+	// Find the top-level `:` separating the loop header from the body, and
+	// the matching closing `]`. Seed the scanner with the leading `[`
+	// already consumed (bracket depth 1).
+	st := scanState{bracket: 1}
+	colon := -1
+	closeBracket := -1
+	for i := exprStart; i < len(trimmed); {
+		if st.inStr == 0 && !st.inMulti {
+			// The header/body separator is the first `:` at the loop's own
+			// bracket depth (1) with no open paren/brace.
+			if trimmed[i] == ':' && colon < 0 && st.bracket == 1 && st.paren == 0 && st.brace == 0 {
+				colon = i
+			}
+		}
+		prev := i
+		i = st.stepAt(trimmed, i)
+		if st.bracket == 0 {
+			closeBracket = prev
+			break
+		}
+	}
+
+	if colon < 0 {
+		// Malformed loop (no header colon found); treat as non-loop so the
+		// caller's normal parse still runs.
+		return loopInfo{}
+	}
+	if closeBracket < 0 {
+		closeBracket = len(trimmed)
+	}
+
+	info.expression = strings.TrimSpace(trimmed[exprStart:colon])
+	info.body = strings.TrimSpace(trimmed[colon+1 : closeBracket])
+	return info
+}
 
 // parseImportDecl handles the three Bicep import forms:
 //

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -1053,41 +1054,13 @@ param config = {
 }
 
 func TestParseBicepForLoops(t *testing.T) {
-	input := `param location string = 'eastus'
+	// The committed fixture is the single source of truth for the loop
+	// scenarios asserted below — read it rather than duplicating the Bicep
+	// inline, so the fixture and the test can't drift apart.
+	data, err := os.ReadFile("testdata/loops.bicep")
+	require.NoError(t, err)
 
-var storageNames = [
-  'stga'
-  'stgb'
-]
-
-var itemNames = [for i in range(0, 3): 'item-${i}']
-
-resource sas 'Microsoft.Storage/storageAccounts@2023-01-01' = [for (name, i) in storageNames: {
-  name: name
-  location: location
-  sku: {
-    name: 'Standard_LRS'
-  }
-}]
-
-resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
-  name: 'mykeyvault'
-  location: location
-}
-
-module stamps 'stamp.bicep' = [for sku in storageNames: {
-  name: 'stamp-${sku}'
-  params: {
-    skuName: sku
-  }
-}]
-
-output ids array = [for sa in sas: sa.id]
-
-output region string = location
-`
-
-	result := parseBicep(input)
+	result := parseBicep(string(data))
 
 	// --- variables ---
 	vars := map[string]parsedVariable{}

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -1051,3 +1051,132 @@ param config = {
 		assert.Equal(t, "{ name: 'example' tier: 'standard' }", params["config"])
 	})
 }
+
+func TestParseBicepForLoops(t *testing.T) {
+	input := `param location string = 'eastus'
+
+var storageNames = [
+  'stga'
+  'stgb'
+]
+
+var itemNames = [for i in range(0, 3): 'item-${i}']
+
+resource sas 'Microsoft.Storage/storageAccounts@2023-01-01' = [for (name, i) in storageNames: {
+  name: name
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+}]
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'mykeyvault'
+  location: location
+}
+
+module stamps 'stamp.bicep' = [for sku in storageNames: {
+  name: 'stamp-${sku}'
+  params: {
+    skuName: sku
+  }
+}]
+
+output ids array = [for sa in sas: sa.id]
+
+output region string = location
+`
+
+	result := parseBicep(input)
+
+	// --- variables ---
+	vars := map[string]parsedVariable{}
+	for _, v := range result.variables {
+		vars[v.name] = v
+	}
+	require.Contains(t, vars, "itemNames")
+	require.Contains(t, vars, "storageNames")
+
+	t.Run("looped variable with range", func(t *testing.T) {
+		v := vars["itemNames"]
+		assert.True(t, v.loop.isLoop)
+		assert.Equal(t, "i", v.loop.iterator)
+		assert.Equal(t, "", v.loop.indexVar)
+		assert.Equal(t, "range(0, 3)", v.loop.expression)
+		assert.Equal(t, "'item-${i}'", v.expression)
+	})
+
+	t.Run("non-looped variable", func(t *testing.T) {
+		v := vars["storageNames"]
+		assert.False(t, v.loop.isLoop)
+		assert.Equal(t, "", v.loop.iterator)
+		assert.Equal(t, "", v.loop.expression)
+	})
+
+	// --- resources ---
+	resources := map[string]parsedResource{}
+	for _, r := range result.resources {
+		resources[r.symbolicName] = r
+	}
+	require.Contains(t, resources, "sas")
+	require.Contains(t, resources, "kv")
+
+	t.Run("looped resource indexed form", func(t *testing.T) {
+		r := resources["sas"]
+		assert.True(t, r.loop.isLoop)
+		assert.Equal(t, "name", r.loop.iterator)
+		assert.Equal(t, "i", r.loop.indexVar)
+		assert.Equal(t, "storageNames", r.loop.expression)
+		// body-derived fields must still be extracted from the loop body
+		assert.Equal(t, "name", r.name)
+		assert.Equal(t, "location", r.location)
+		assert.Contains(t, r.body, "sku")
+	})
+
+	t.Run("non-looped resource", func(t *testing.T) {
+		r := resources["kv"]
+		assert.False(t, r.loop.isLoop)
+		assert.Equal(t, "", r.loop.iterator)
+		assert.Equal(t, "", r.loop.indexVar)
+		assert.Equal(t, "", r.loop.expression)
+		assert.Equal(t, "'mykeyvault'", r.name)
+	})
+
+	// --- modules ---
+	require.Len(t, result.modules, 1)
+	t.Run("looped module", func(t *testing.T) {
+		m := result.modules[0]
+		assert.Equal(t, "stamps", m.name)
+		assert.True(t, m.loop.isLoop)
+		assert.Equal(t, "sku", m.loop.iterator)
+		assert.Equal(t, "", m.loop.indexVar)
+		assert.Equal(t, "storageNames", m.loop.expression)
+		// body-derived name still extracted from the loop body
+		assert.Equal(t, "'stamp-${sku}'", extractFieldValue(m.body, "name"))
+		assert.Contains(t, m.body, "params")
+	})
+
+	// --- outputs ---
+	outputs := map[string]parsedOutput{}
+	for _, o := range result.outputs {
+		outputs[o.name] = o
+	}
+	require.Contains(t, outputs, "ids")
+	require.Contains(t, outputs, "region")
+
+	t.Run("looped output", func(t *testing.T) {
+		o := outputs["ids"]
+		assert.True(t, o.loop.isLoop)
+		assert.Equal(t, "sa", o.loop.iterator)
+		assert.Equal(t, "", o.loop.indexVar)
+		assert.Equal(t, "sas", o.loop.expression)
+		assert.Equal(t, "sa.id", o.expression)
+	})
+
+	t.Run("non-looped output", func(t *testing.T) {
+		o := outputs["region"]
+		assert.False(t, o.loop.isLoop)
+		assert.Equal(t, "", o.loop.iterator)
+		assert.Equal(t, "location", o.expression)
+	})
+}

--- a/providers/bicep/resources/testdata/loops.bicep
+++ b/providers/bicep/resources/testdata/loops.bicep
@@ -1,0 +1,39 @@
+// Test fixture for Bicep `for`-loop modeling.
+param location string = 'eastus'
+
+var storageNames = [
+  'stga'
+  'stgb'
+]
+
+// Looped variable using range(...)
+var itemNames = [for i in range(0, 3): 'item-${i}']
+
+// Looped resource using the indexed (name, i) form with an object body.
+resource sas 'Microsoft.Storage/storageAccounts@2023-01-01' = [for (name, i) in storageNames: {
+  name: name
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+}]
+
+// Non-looped resource to prove isLoop is false.
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'mykeyvault'
+  location: location
+}
+
+// Looped module.
+module stamps 'stamp.bicep' = [for sku in storageNames: {
+  name: 'stamp-${sku}'
+  params: {
+    skuName: sku
+  }
+}]
+
+// Looped output.
+output ids array = [for sa in sas: sa.id]
+
+// Non-looped output.
+output region string = location


### PR DESCRIPTION
## What

Bicep iterates resources, modules, outputs, and variables with a `for`-loop:

```bicep
resource sas 'Microsoft.Storage/storageAccounts@2023-01-01' = [for (name, i) in storageNames: {
  name: name
  location: location
}]
module stamps 'stamp.bicep' = [for sku in skus: { name: 'stamp-${sku}', params: {...} }]
output ids array = [for sa in sas: sa.id]
var names = [for i in range(0, 3): 'item-${i}']
```

This PR adds first-class modeling of those loops to the static Bicep parser. Syntax variants handled:

- `[for <item> in <collection>: <body>]`
- `[for (<item>, <index>) in <collection>: <body>]` (indexed)
- collection can be an array literal, a symbolic ref, or `range(...)`.

## How — flatten, don't add a sub-resource

Per the CLAUDE.md sub-resource bar (a single nested struct → flatten scalars onto the parent rather than create a `bicep.loop` sub-resource), loop info is exposed as four flattened fields on **each** of `bicep.resource`, `bicep.module`, `bicep.output`, and `bicep.variable`:

| field | meaning |
| --- | --- |
| `isLoop` | whether the declaration is deployed/derived via a `for` loop |
| `loopIterator` | the item iteration variable (`name`, `sku`, `i`) — empty when not a loop |
| `loopIndexVar` | the index variable in the `(item, index)` form — empty otherwise |
| `loopExpression` | the raw collection expression (`storageNames`, `range(0, 3)`) — empty when not a loop |

A depth-aware `detectLoop` helper (reusing the shared string/bracket-aware `scanState`) splits the `[for <hdr>: <body>]` value into its header and body. For resources and modules, the body object inside the loop is fed to the existing `name`/`location`/`tags`/`dependsOn`/`params` extraction, so body-derived fields keep working. For outputs and variables, the per-iteration value expression is stored in the existing `expression` field and the loop header is recorded.

New `.lr.versions` entries (16) are at `13.1.2`.

## Tests

Added `testdata/loops.bicep` and `TestParseBicepForLoops` covering an indexed-form looped resource (asserting the body-derived `name` still extracts), a looped module, a looped output, a `range(...)` looped variable, and non-looped resource/variable/output cases proving `isLoop` is false.

## Stacking

Stacks on #8011 (.bicepparam files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)