### PR TITLE
:broom: helm: fix ociref_test build after newMqlHelmChart gained a parent arg

### DIFF
--- a/providers/helm/resources/ociref_test.go
+++ b/providers/helm/resources/ociref_test.go
@@ -92,7 +92,7 @@ func TestDependencySourceClassification(t *testing.T) {
 	c, err := loader.LoadDir("../testdata/oci-deps")
 	require.NoError(t, err)
 
-	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "../testdata/oci-deps")
+	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "../testdata/oci-deps", nil)
 	require.NoError(t, err)
 
 	deps, err := mqlChart.dependencies()


### PR DESCRIPTION
## What

`newMqlHelmChart` gained a 4th parameter `parent *mqlHelmChart` in the subchart materialization work (kustomize PR #8005), but the top-level call in `providers/helm/resources/ociref_test.go` was never updated. This left the helm `resources` test package failing to compile, which fails the entire `providers/test` target in CI on `main`.

## Fix

Pass `nil` for `parent` in the test, matching the top-level call in `helm.go:33` (a top-level chart has no parent).

## Verification

```
$ go test ./resources/
ok  	go.mondoo.com/mql/v13/providers/helm/resources	0.798s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)