### PR TITLE
✨ bicep: model nested child resources and the resource scope keyword

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -189,6 +189,10 @@ bicep.resource @defaults("type symbolicName") {
   condition string
   // Parent resource symbolic name
   parent string
+  // Scope expression (deploy target scope, e.g. resourceGroup(), subscription())
+  scope string
+  // Nested child resources declared inside this resource
+  resources() []bicep.resource
   // Resource body as dict
   properties dict
   // Resource tags

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -300,6 +300,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.parent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetParent()).ToDataRes(types.String)
 	},
+	"bicep.resource.scope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetScope()).ToDataRes(types.String)
+	},
+	"bicep.resource.resources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetResources()).ToDataRes(types.Array(types.Resource("bicep.resource")))
+	},
 	"bicep.resource.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetProperties()).ToDataRes(types.Dict)
 	},
@@ -713,6 +719,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.resource.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).Parent, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.resources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.resource.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1574,7 +1588,7 @@ func (c *mqlBicepVariable) GetLoopExpression() *plugin.TValue[string] {
 type mqlBicepResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepResourceInternal it will be used here
+	mqlBicepResourceInternal
 	SymbolicName   plugin.TValue[string]
 	Type           plugin.TValue[string]
 	ApiVersion     plugin.TValue[string]
@@ -1583,6 +1597,8 @@ type mqlBicepResource struct {
 	Existing       plugin.TValue[bool]
 	Condition      plugin.TValue[string]
 	Parent         plugin.TValue[string]
+	Scope          plugin.TValue[string]
+	Resources      plugin.TValue[[]any]
 	Properties     plugin.TValue[any]
 	Tags           plugin.TValue[map[string]any]
 	DependsOn      plugin.TValue[[]any]
@@ -1655,6 +1671,26 @@ func (c *mqlBicepResource) GetCondition() *plugin.TValue[string] {
 
 func (c *mqlBicepResource) GetParent() *plugin.TValue[string] {
 	return &c.Parent
+}
+
+func (c *mqlBicepResource) GetScope() *plugin.TValue[string] {
+	return &c.Scope
+}
+
+func (c *mqlBicepResource) GetResources() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Resources, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "resources")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resources()
+	})
 }
 
 func (c *mqlBicepResource) GetProperties() *plugin.TValue[any] {

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -92,6 +92,8 @@ bicep.resource.loopIterator 13.1.2
 bicep.resource.name 13.0.0
 bicep.resource.parent 13.0.0
 bicep.resource.properties 13.0.0
+bicep.resource.resources 13.1.2
+bicep.resource.scope 13.1.2
 bicep.resource.symbolicName 13.0.0
 bicep.resource.tags 13.0.9
 bicep.resource.type 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -58,57 +58,99 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 	return mqlVars, nil
 }
 
+// mqlBicepResourceInternal caches the parsed nested child resources so the
+// lazy `resources()` accessor can materialize them without re-parsing. Each
+// child carries a parent-qualified `__id` (`<parentId>/<childSymbolicName>`)
+// so nested resources under different parents never collide in the cache.
+type mqlBicepResourceInternal struct {
+	nested []parsedResource
+}
+
 func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource) ([]any, error) {
 	var mqlResources []any
 	for _, r := range resources {
-		dependsOn := sliceToAny(r.dependsOn)
-		decorators := sliceToAny(r.decorators)
-
-		// Surface the resource's `properties: { ... }` sub-block as a
-		// structured dict so audits can query individual keys directly
-		// (e.g., `bicepResource.properties["accessTier"]`). When the
-		// resource has no `properties` block the field is an empty
-		// map rather than nil so the shape stays consistent across
-		// resources.
-		var properties any = map[string]any{}
-		if r.body != "" {
-			if raw := extractFieldBlock(r.body, "properties"); raw != "" {
-				properties = parseBicepObject(raw)
-			}
-		}
-
-		args := map[string]*llx.RawData{
-			"__id":         llx.StringData("bicep.resource:" + filePath + ":" + r.symbolicName),
-			"symbolicName": llx.StringData(r.symbolicName),
-			"type":         llx.StringData(r.typ),
-			"apiVersion":   llx.StringData(r.apiVersion),
-			"name":         llx.StringData(r.name),
-			"location":     llx.StringData(r.location),
-			"existing":     llx.BoolData(r.existing),
-			"condition":    llx.StringData(r.condition),
-			"parent":       llx.StringData(r.parent),
-			"properties":   llx.DictData(properties),
-			"dependsOn":    llx.ArrayData(dependsOn, types.String),
-			"decorators":   llx.ArrayData(decorators, types.String),
-		}
-		if r.tags == nil {
-			args["tags"] = llx.NilData
-		} else {
-			tags := make(map[string]any, len(r.tags))
-			for k, v := range r.tags {
-				tags[k] = v
-			}
-			args["tags"] = llx.MapData(tags, types.String)
-		}
-		addLoopArgs(args, r.loop)
-
-		res, err := CreateResource(runtime, "bicep.resource", args)
+		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r)
 		if err != nil {
 			return nil, err
 		}
 		mqlResources = append(mqlResources, res)
 	}
 	return mqlResources, nil
+}
+
+// newMqlBicepResource builds a single bicep.resource from a parsedResource.
+// The id is supplied by the caller: top-level resources use
+// `bicep.resource:<file>:<symbolicName>`, while nested resources use a
+// parent-qualified `<parentId>/<childSymbolicName>`. The parsed nested
+// declarations are cached on the Internal struct for the lazy `resources()`
+// accessor to materialize, recursively.
+func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource) (*mqlBicepResource, error) {
+	dependsOn := sliceToAny(r.dependsOn)
+	decorators := sliceToAny(r.decorators)
+
+	// Surface the resource's `properties: { ... }` sub-block as a
+	// structured dict so audits can query individual keys directly
+	// (e.g., `bicepResource.properties["accessTier"]`). When the
+	// resource has no `properties` block the field is an empty
+	// map rather than nil so the shape stays consistent across
+	// resources.
+	var properties any = map[string]any{}
+	if r.body != "" {
+		if raw := extractFieldBlock(r.body, "properties"); raw != "" {
+			properties = parseBicepObject(raw)
+		}
+	}
+
+	args := map[string]*llx.RawData{
+		"__id":         llx.StringData(id),
+		"symbolicName": llx.StringData(r.symbolicName),
+		"type":         llx.StringData(r.typ),
+		"apiVersion":   llx.StringData(r.apiVersion),
+		"name":         llx.StringData(r.name),
+		"location":     llx.StringData(r.location),
+		"existing":     llx.BoolData(r.existing),
+		"condition":    llx.StringData(r.condition),
+		"parent":       llx.StringData(r.parent),
+		"scope":        llx.StringData(r.scope),
+		"properties":   llx.DictData(properties),
+		"dependsOn":    llx.ArrayData(dependsOn, types.String),
+		"decorators":   llx.ArrayData(decorators, types.String),
+	}
+	if r.tags == nil {
+		args["tags"] = llx.NilData
+	} else {
+		tags := make(map[string]any, len(r.tags))
+		for k, v := range r.tags {
+			tags[k] = v
+		}
+		args["tags"] = llx.MapData(tags, types.String)
+	}
+	addLoopArgs(args, r.loop)
+
+	res, err := CreateResource(runtime, "bicep.resource", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlRes := res.(*mqlBicepResource)
+	mqlRes.nested = r.nested
+	return mqlRes, nil
+}
+
+// resources materializes this resource's nested child resources. Each child
+// gets a parent-qualified `__id` so nested resources under different parents
+// don't collide; children may themselves declare further nested resources,
+// resolved recursively by the same accessor.
+func (r *mqlBicepResource) resources() ([]any, error) {
+	out := make([]any, 0, len(r.nested))
+	for _, child := range r.nested {
+		childID := r.__id + "/" + child.symbolicName
+		mqlChild, err := newMqlBicepResource(r.MqlRuntime, childID, child)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mqlChild)
+	}
+	return out, nil
 }
 
 func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsedModule) ([]any, error) {

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -53,11 +53,13 @@ type parsedResource struct {
 	existing     bool
 	condition    string
 	parent       string
+	scope        string
 	body         string
 	tags         map[string]string
 	dependsOn    []string
 	decorators   []string
 	loop         loopInfo
+	nested       []parsedResource
 }
 
 type parsedModule struct {
@@ -476,10 +478,125 @@ func parseResourceDecl(lines []string, startIdx int, decorators []string) (*pars
 	r.name = extractFieldValue(body, "name")
 	r.location = extractFieldValue(body, "location")
 	r.parent = extractFieldValue(body, "parent")
+	r.scope = extractFieldValue(body, "scope")
 	r.dependsOn = extractDependsOn(body)
 	r.tags = extractTags(body)
 
+	// A resource may declare child resources inside its body. Each nested
+	// declaration is parsed with the same logic as a top-level resource and
+	// has its `parent` set to this resource's symbolic name.
+	r.nested = extractNestedResources(body, r.symbolicName)
+
 	return r, endIdx
+}
+
+// extractNestedResources finds `resource <sym> '<type>'( existing)? =`
+// declarations that sit at the top level of the parent's body (one brace
+// deep, relative to the parent's outer braces) and parses each one
+// recursively with the same logic as a top-level resource. The body text
+// passed in is the parent's full `{ ... }` block including its outer braces,
+// so child declarations live at brace depth 1. The parent's symbolic name is
+// recorded on each child's `parent` field.
+func extractNestedResources(body, parentSymbolic string) []parsedResource {
+	var nested []parsedResource
+	st := scanState{}
+	for i := 0; i < len(body); {
+		// We only consider a `resource` keyword when it begins a statement at
+		// brace depth 1 (directly inside the parent body) and outside any
+		// string/paren/bracket. depthBefore is captured before stepping.
+		if st.inStr == 0 && !st.inMulti && st.brace == 1 && st.paren == 0 && st.bracket == 0 &&
+			isStatementStart(body, i) && hasKeywordAt(body, i, "resource") {
+			// Reassemble the nested declaration from here until its delimiters
+			// balance again, then hand the statement text to the recursive
+			// resource parser.
+			stmtEnd := scanStatementEnd(body[i:]) + i
+			stmt := body[i:stmtEnd]
+			stmtLines := strings.Split(stmt, "\n")
+			if child, _ := parseResourceDecl(stmtLines, 0, nil); child != nil {
+				child.parent = parentSymbolic
+				nested = append(nested, *child)
+			}
+			// Resume scanning after the consumed statement, keeping the depth
+			// state consistent by feeding the skipped text.
+			for j := i; j < stmtEnd; {
+				j = st.stepAt(body, j)
+			}
+			i = stmtEnd
+			continue
+		}
+		i = st.stepAt(body, i)
+	}
+	return nested
+}
+
+// isStatementStart reports whether position i in s begins a token — i.e. the
+// preceding non-ignored byte is a newline, brace, or the start of input. This
+// keeps `extractNestedResources` from matching a `resource` substring that is
+// part of a larger identifier or appears mid-line (e.g. an expression).
+func isStatementStart(s string, i int) bool {
+	for j := i - 1; j >= 0; j-- {
+		c := s[j]
+		if c == ' ' || c == '\t' || c == '\r' {
+			continue
+		}
+		return c == '\n' || c == '{' || c == '}'
+	}
+	return true
+}
+
+// hasKeywordAt reports whether the identifier starting at i in s is exactly
+// `kw` (followed by whitespace, not more identifier characters).
+func hasKeywordAt(s string, i int, kw string) bool {
+	if i+len(kw) > len(s) {
+		return false
+	}
+	if s[i:i+len(kw)] != kw {
+		return false
+	}
+	next := i + len(kw)
+	if next >= len(s) {
+		return false
+	}
+	c := s[next]
+	return c == ' ' || c == '\t'
+}
+
+// scanStatementEnd returns the index just past the end of the statement at the
+// start of s. It mirrors the tokenizer: consume the first line, then keep
+// pulling continuation lines until the running depth (string-aware) returns to
+// zero. This way a `= if (cond) { ... }` header whose parens close before the
+// body brace opens doesn't terminate the statement early, and a multi-line
+// `= { ... }` body is consumed whole.
+func scanStatementEnd(s string) int {
+	st := scanState{}
+	// Consume the first line.
+	nl := strings.IndexByte(s, '\n')
+	if nl < 0 {
+		return len(s)
+	}
+	st.feed(s[:nl])
+	pos := nl + 1
+	if st.totalDepth() <= 0 {
+		return nl
+	}
+	for pos < len(s) {
+		next := strings.IndexByte(s[pos:], '\n')
+		var line string
+		if next < 0 {
+			line = s[pos:]
+		} else {
+			line = s[pos : pos+next]
+		}
+		st.feed(line)
+		if next < 0 {
+			return len(s)
+		}
+		pos += next + 1
+		if st.totalDepth() <= 0 {
+			return pos - 1
+		}
+	}
+	return len(s)
 }
 
 func parseModuleDecl(lines []string, startIdx int, decorators []string) (*parsedModule, int) {

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -1153,3 +1153,67 @@ func TestParseBicepForLoops(t *testing.T) {
 		assert.Equal(t, "location", o.expression)
 	})
 }
+
+func TestParseBicepNestedResources(t *testing.T) {
+	// The committed fixture is the single source of truth for the nested /
+	// scope scenarios asserted below — read it rather than duplicating the
+	// Bicep inline, so the fixture and the test can't drift apart.
+	data, err := os.ReadFile("testdata/nested.bicep")
+	require.NoError(t, err)
+
+	result := parseBicep(string(data))
+
+	top := map[string]parsedResource{}
+	for _, r := range result.resources {
+		top[r.symbolicName] = r
+	}
+
+	t.Run("top-level list excludes nested resources", func(t *testing.T) {
+		require.Len(t, result.resources, 3)
+		require.Contains(t, top, "sa")
+		require.Contains(t, top, "lock")
+		require.Contains(t, top, "kv")
+		// nested resources must NOT appear at the top level
+		assert.NotContains(t, top, "blob")
+		assert.NotContains(t, top, "container")
+	})
+
+	t.Run("parent exposes its nested child", func(t *testing.T) {
+		sa := top["sa"]
+		assert.Empty(t, sa.parent)
+		require.Len(t, sa.nested, 1)
+		blob := sa.nested[0]
+		assert.Equal(t, "blob", blob.symbolicName)
+		assert.Equal(t, "blobServices", blob.typ)
+		// relative child type inherits no apiVersion when omitted
+		assert.Equal(t, "", blob.apiVersion)
+		assert.Equal(t, "'default'", blob.name)
+		assert.Equal(t, "sa", blob.parent)
+	})
+
+	t.Run("child exposes its grandchild", func(t *testing.T) {
+		blob := top["sa"].nested[0]
+		require.Len(t, blob.nested, 1)
+		container := blob.nested[0]
+		assert.Equal(t, "container", container.symbolicName)
+		assert.Equal(t, "containers", container.typ)
+		assert.Equal(t, "2023-01-01", container.apiVersion)
+		assert.Equal(t, "'data'", container.name)
+		assert.Equal(t, "blob", container.parent)
+		// grandchild has no further nesting
+		assert.Empty(t, container.nested)
+	})
+
+	t.Run("scope keyword is captured", func(t *testing.T) {
+		lock := top["lock"]
+		assert.Equal(t, "sa", lock.scope)
+		assert.Empty(t, lock.nested)
+	})
+
+	t.Run("flat resource has no scope and no nesting", func(t *testing.T) {
+		kv := top["kv"]
+		assert.Equal(t, "", kv.scope)
+		assert.Empty(t, kv.nested)
+		assert.Empty(t, kv.parent)
+	})
+}

--- a/providers/bicep/resources/testdata/nested.bicep
+++ b/providers/bicep/resources/testdata/nested.bicep
@@ -1,0 +1,36 @@
+// A storage account with a nested blobServices child and a deeper
+// containers grandchild (two levels of nesting).
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorage'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  resource blob 'blobServices' = {
+    name: 'default'
+    properties: {
+      isVersioningEnabled: true
+    }
+    resource container 'containers@2023-01-01' = {
+      name: 'data'
+      properties: {
+        publicAccess: 'None'
+      }
+    }
+  }
+}
+
+// A management lock that targets a different scope via the `scope` keyword.
+resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
+  name: 'no-delete'
+  scope: sa
+  properties: {
+    level: 'CanNotDelete'
+  }
+}
+
+// A normal flat resource with no nesting and no scope.
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'mykeyvault'
+  location: 'westus'
+}


### PR DESCRIPTION
This is the final PR (PR4 of 5) in the Bicep language-construct series. It adds the last two constructs: **nested/child resources** and the resource **`scope` keyword**.

## Resource `scope` keyword

A resource can target a different deployment scope:

```bicep
resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
  name: 'no-delete'
  scope: storageAccount   // or resourceGroup('other'), subscription(), etc.
}
```

`bicep.resource` gains a `scope string` field holding the raw `scope:` expression from the body (empty when absent). It's extracted exactly the way module `scope` is.

## Nested / child resources

A resource can declare child resources inside its body, arbitrarily deep:

```bicep
resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
  name: 'mystorage'
  resource blob 'blobServices' = {              // relative child type
    name: 'default'
    resource container 'containers@2023-01-01' = {
      name: 'data'
    }
  }
}
```

`bicep.resource` gains `resources() []bicep.resource`, modeling child resources **self-referentially and recursively** — each child is itself a `bicep.resource` that may have its own `resources()`. Each nested resource is parsed with the same logic as a top-level resource (symbolic name, type/apiVersion, name, properties, `existing`, condition, decorators, tags, dependsOn, scope, and loop fields — nested resources can be looped or `existing` too), and has its `parent` field set to the **enclosing** resource's symbolic name.

### Parent-qualified `__id`

Each nested resource gets a parent-qualified `__id` (`<parentId>/<childSymbolicName>`) so nested resources under different parents never collide in the resource cache.

### Excluded from the top-level list

Because the tokenizer hands a top-level `resource` declaration over as one complete statement (its full `{ ... }` body included), nested declarations live inside the parent statement. The file-level walk only extracts top-level `resource` statements, and nested ones are extracted depth-aware (brace depth 1) from within each parent body — so nested resources appear **only** under their parent's `resources()` and never in `bicep.file.resources()`.

## Verification

`go test ./resources/` passes (existing tests unchanged + new fixture-driven `TestParseBicepNestedResources`). Real query against `testdata/nested.bicep`:

```
bicep.files { resources { symbolicName type scope parent resources { symbolicName type parent resources { symbolicName parent } } } }
```

shows the parent→child→grandchild nesting (`sa` → `blob` parent `sa` → `container` parent `blob`), the `lock` resource with `scope: "sa"`, the flat `kv` with empty scope, and the nested `blob`/`container` absent from the top-level list.

This completes the Bicep language-construct series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)