### PR TITLE
✨ bicep: expose expression trees on resource name/location/condition and module scope

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -181,12 +181,34 @@ bicep.resource @defaults("type symbolicName") {
   apiVersion string
   // Resource name expression
   name string
+  // Parsed name expression tree
+  //
+  // Structured, queryable view of the `name` value. Use it to ask whether a
+  // resource name is a hardcoded literal, which Bicep function builds it
+  // (`functionCall`), or which parameters an interpolated name embeds
+  // (`interpolation` / `symbolicRef`). See `bicep.expression`.
+  nameTree() bicep.expression
   // Resource location expression
   location string
+  // Parsed location expression tree
+  //
+  // Structured, queryable view of the `location` value. Use it to ask
+  // whether a location is a hardcoded literal (e.g. `'eastus'`) or derived
+  // from a function such as `resourceGroup().location` (`functionCall` /
+  // `propertyAccess`). See `bicep.expression`.
+  locationTree() bicep.expression
   // Whether this is an existing resource reference
   existing bool
   // Condition expression (empty if unconditional)
   condition string
+  // Parsed condition expression tree
+  //
+  // Structured, queryable view of the `= if (<cond>)` deployment condition.
+  // Use it to ask which symbol or parameter gates the resource
+  // (`symbolicRef` / `propertyAccess`) or which function evaluates it
+  // (`functionCall`). An unconditional resource yields an `unknown` node
+  // with empty `raw`. See `bicep.expression`.
+  conditionTree() bicep.expression
   // Parent resource symbolic name
   parent string
   // Scope expression (deploy target scope, e.g. resourceGroup(), subscription())
@@ -231,10 +253,26 @@ bicep.module @defaults("name source") {
   source string
   // Scope expression
   scope string
+  // Parsed scope expression tree
+  //
+  // Structured, queryable view of the `scope` value. Use it to ask which
+  // function or symbol sets the module deployment scope — e.g.
+  // `resourceGroup('rg-name')` or `subscription()` (`functionCall`) or a
+  // referenced resource (`symbolicRef` / `propertyAccess`). See
+  // `bicep.expression`.
+  scopeTree() bicep.expression
   // Parameter values as dict
   params dict
   // Condition expression
   condition string
+  // Parsed condition expression tree
+  //
+  // Structured, queryable view of the module's `= if (<cond>)` deployment
+  // condition. Use it to ask which symbol or parameter gates the module
+  // (`symbolicRef` / `propertyAccess`) or which function evaluates it
+  // (`functionCall`). An unconditional module yields an `unknown` node with
+  // empty `raw`. See `bicep.expression`.
+  conditionTree() bicep.expression
   // Whether this references a Bicep registry (br:)
   isRegistry bool
   // Whether this references a template spec (ts:)

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -288,14 +288,23 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetName()).ToDataRes(types.String)
 	},
+	"bicep.resource.nameTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetNameTree()).ToDataRes(types.Resource("bicep.expression"))
+	},
 	"bicep.resource.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetLocation()).ToDataRes(types.String)
+	},
+	"bicep.resource.locationTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetLocationTree()).ToDataRes(types.Resource("bicep.expression"))
 	},
 	"bicep.resource.existing": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetExisting()).ToDataRes(types.Bool)
 	},
 	"bicep.resource.condition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetCondition()).ToDataRes(types.String)
+	},
+	"bicep.resource.conditionTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetConditionTree()).ToDataRes(types.Resource("bicep.expression"))
 	},
 	"bicep.resource.parent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetParent()).ToDataRes(types.String)
@@ -339,11 +348,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.module.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetScope()).ToDataRes(types.String)
 	},
+	"bicep.module.scopeTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetScopeTree()).ToDataRes(types.Resource("bicep.expression"))
+	},
 	"bicep.module.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetParams()).ToDataRes(types.Dict)
 	},
 	"bicep.module.condition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetCondition()).ToDataRes(types.String)
+	},
+	"bicep.module.conditionTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetConditionTree()).ToDataRes(types.Resource("bicep.expression"))
 	},
 	"bicep.module.isRegistry": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetIsRegistry()).ToDataRes(types.Bool)
@@ -705,8 +720,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepResource).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.resource.nameTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).NameTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
+		return
+	},
 	"bicep.resource.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.locationTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).LocationTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
 		return
 	},
 	"bicep.resource.existing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -715,6 +738,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.resource.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.conditionTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).ConditionTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
 		return
 	},
 	"bicep.resource.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -777,12 +804,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepModule).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.module.scopeTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).ScopeTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
+		return
+	},
 	"bicep.module.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepModule).Params, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"bicep.module.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepModule).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.module.conditionTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).ConditionTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
 		return
 	},
 	"bicep.module.isRegistry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1593,9 +1628,12 @@ type mqlBicepResource struct {
 	Type           plugin.TValue[string]
 	ApiVersion     plugin.TValue[string]
 	Name           plugin.TValue[string]
+	NameTree       plugin.TValue[*mqlBicepExpression]
 	Location       plugin.TValue[string]
+	LocationTree   plugin.TValue[*mqlBicepExpression]
 	Existing       plugin.TValue[bool]
 	Condition      plugin.TValue[string]
+	ConditionTree  plugin.TValue[*mqlBicepExpression]
 	Parent         plugin.TValue[string]
 	Scope          plugin.TValue[string]
 	Resources      plugin.TValue[[]any]
@@ -1657,8 +1695,40 @@ func (c *mqlBicepResource) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
+func (c *mqlBicepResource) GetNameTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.NameTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "nameTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.nameTree()
+	})
+}
+
 func (c *mqlBicepResource) GetLocation() *plugin.TValue[string] {
 	return &c.Location
+}
+
+func (c *mqlBicepResource) GetLocationTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.LocationTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "locationTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.locationTree()
+	})
 }
 
 func (c *mqlBicepResource) GetExisting() *plugin.TValue[bool] {
@@ -1667,6 +1737,22 @@ func (c *mqlBicepResource) GetExisting() *plugin.TValue[bool] {
 
 func (c *mqlBicepResource) GetCondition() *plugin.TValue[string] {
 	return &c.Condition
+}
+
+func (c *mqlBicepResource) GetConditionTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.ConditionTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "conditionTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.conditionTree()
+	})
 }
 
 func (c *mqlBicepResource) GetParent() *plugin.TValue[string] {
@@ -1733,8 +1819,10 @@ type mqlBicepModule struct {
 	Name           plugin.TValue[string]
 	Source         plugin.TValue[string]
 	Scope          plugin.TValue[string]
+	ScopeTree      plugin.TValue[*mqlBicepExpression]
 	Params         plugin.TValue[any]
 	Condition      plugin.TValue[string]
+	ConditionTree  plugin.TValue[*mqlBicepExpression]
 	IsRegistry     plugin.TValue[bool]
 	IsTemplateSpec plugin.TValue[bool]
 	Description    plugin.TValue[string]
@@ -1789,12 +1877,44 @@ func (c *mqlBicepModule) GetScope() *plugin.TValue[string] {
 	return &c.Scope
 }
 
+func (c *mqlBicepModule) GetScopeTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.ScopeTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.module", c.__id, "scopeTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.scopeTree()
+	})
+}
+
 func (c *mqlBicepModule) GetParams() *plugin.TValue[any] {
 	return &c.Params
 }
 
 func (c *mqlBicepModule) GetCondition() *plugin.TValue[string] {
 	return &c.Condition
+}
+
+func (c *mqlBicepModule) GetConditionTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.ConditionTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.module", c.__id, "conditionTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.conditionTree()
+	})
 }
 
 func (c *mqlBicepModule) GetIsRegistry() *plugin.TValue[bool] {

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -38,6 +38,7 @@ bicep.import.symbols 13.1.2
 bicep.import.wildcard 13.1.2
 bicep.module 13.0.0
 bicep.module.condition 13.0.0
+bicep.module.conditionTree 13.1.2
 bicep.module.decorators 13.0.1
 bicep.module.description 13.0.1
 bicep.module.isLoop 13.1.2
@@ -49,6 +50,7 @@ bicep.module.loopIterator 13.1.2
 bicep.module.name 13.0.0
 bicep.module.params 13.0.0
 bicep.module.scope 13.0.0
+bicep.module.scopeTree 13.1.2
 bicep.module.source 13.0.0
 bicep.output 13.0.0
 bicep.output.description 13.0.0
@@ -81,15 +83,18 @@ bicep.parameter.type 13.0.0
 bicep.resource 13.0.0
 bicep.resource.apiVersion 13.0.0
 bicep.resource.condition 13.0.0
+bicep.resource.conditionTree 13.1.2
 bicep.resource.decorators 13.0.0
 bicep.resource.dependsOn 13.0.0
 bicep.resource.existing 13.0.0
 bicep.resource.isLoop 13.1.2
 bicep.resource.location 13.0.0
+bicep.resource.locationTree 13.1.2
 bicep.resource.loopExpression 13.1.2
 bicep.resource.loopIndexVar 13.1.2
 bicep.resource.loopIterator 13.1.2
 bicep.resource.name 13.0.0
+bicep.resource.nameTree 13.1.2
 bicep.resource.parent 13.0.0
 bicep.resource.properties 13.0.0
 bicep.resource.resources 13.1.2

--- a/providers/bicep/resources/exprtrees_test.go
+++ b/providers/bicep/resources/exprtrees_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceModuleExpressionTrees drives the resource/module expression-tree
+// accessors off a committed fixture, parsing each security-relevant raw field
+// (name, location, condition, scope) through the same tokenizer the
+// nameTree/locationTree/conditionTree/scopeTree accessors use, and asserts the
+// produced node shape.
+func TestResourceModuleExpressionTrees(t *testing.T) {
+	data, err := os.ReadFile("testdata/exprtrees.bicep")
+	require.NoError(t, err)
+
+	result := parseBicep(string(data))
+
+	resources := map[string]parsedResource{}
+	for _, r := range result.resources {
+		resources[r.symbolicName] = r
+	}
+	require.Contains(t, resources, "interpName")
+	require.Contains(t, resources, "fnLoc")
+
+	modules := map[string]parsedModule{}
+	for _, m := range result.modules {
+		modules[m.name] = m
+	}
+	require.Contains(t, modules, "net")
+
+	t.Run("interpolated name", func(t *testing.T) {
+		r := resources["interpName"]
+		node := parseExpression(r.name)
+		require.Equal(t, exprKindInterpolation, node.kind)
+		assert.Equal(t, "'${prefix}-sa'", node.raw)
+		require.Len(t, node.segments, 3)
+		assert.Equal(t, exprKindSymbolicRef, node.segments[1].kind)
+		assert.Equal(t, "prefix", node.segments[1].target)
+		assert.Equal(t, "-sa", node.segments[2].raw)
+	})
+
+	t.Run("literal location", func(t *testing.T) {
+		r := resources["interpName"]
+		node := parseExpression(r.location)
+		require.Equal(t, exprKindLiteral, node.kind)
+		assert.Equal(t, "'eastus'", node.raw)
+	})
+
+	t.Run("unconditional resource yields unknown condition tree", func(t *testing.T) {
+		r := resources["interpName"]
+		assert.Equal(t, "", r.condition)
+		node := parseExpression(r.condition)
+		require.Equal(t, exprKindUnknown, node.kind)
+		assert.Equal(t, "", node.raw)
+	})
+
+	t.Run("function-call location", func(t *testing.T) {
+		r := resources["fnLoc"]
+		node := parseExpression(r.location)
+		// resourceGroup().location parses to a propertyAccess whose base is
+		// a functionCall on resourceGroup.
+		require.Equal(t, exprKindPropertyAccess, node.kind)
+		assert.Equal(t, []string{"location"}, node.path)
+		require.Len(t, node.args, 1)
+		base := node.args[0]
+		assert.Equal(t, exprKindFunctionCall, base.kind)
+		assert.Equal(t, "resourceGroup", base.functionName)
+	})
+
+	t.Run("conditional resource condition tree", func(t *testing.T) {
+		r := resources["fnLoc"]
+		assert.Equal(t, "deployFlag", r.condition)
+		node := parseExpression(r.condition)
+		require.Equal(t, exprKindSymbolicRef, node.kind)
+		assert.Equal(t, "deployFlag", node.target)
+	})
+
+	t.Run("module scope tree", func(t *testing.T) {
+		m := modules["net"]
+		node := parseExpression(m.scope)
+		require.Equal(t, exprKindFunctionCall, node.kind)
+		assert.Equal(t, "resourceGroup", node.functionName)
+		require.Len(t, node.args, 1)
+		assert.Equal(t, exprKindLiteral, node.args[0].kind)
+		assert.Equal(t, "'rg-network'", node.args[0].raw)
+	})
+
+	t.Run("module condition tree", func(t *testing.T) {
+		m := modules["net"]
+		assert.Equal(t, "deployFlag", m.condition)
+		node := parseExpression(m.condition)
+		require.Equal(t, exprKindSymbolicRef, node.kind)
+		assert.Equal(t, "deployFlag", node.target)
+	})
+}

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -250,14 +250,43 @@ func (e *mqlBicepExpression) segments() ([]any, error) {
 	return out, nil
 }
 
+// expressionTreeFor parses a raw Bicep expression string and returns it as a
+// bicep.expression resource. The suffix is appended to the parent's __id so
+// distinct expression fields under the same parent (e.g. nameTree vs
+// locationTree on one resource) get distinct, non-colliding cache keys. An
+// empty raw string parses to an `unknown` node with empty `raw`, mirroring the
+// existing variable/output expressionTree() behavior.
+func expressionTreeFor(runtime *plugin.Runtime, parentID, suffix, raw string) (*mqlBicepExpression, error) {
+	node := parseExpression(raw)
+	return newMqlBicepExpression(runtime, parentID+suffix, node)
+}
+
 func (v *mqlBicepVariable) expressionTree() (*mqlBicepExpression, error) {
-	node := parseExpression(v.Expression.Data)
-	return newMqlBicepExpression(v.MqlRuntime, v.__id+"/expr", node)
+	return expressionTreeFor(v.MqlRuntime, v.__id, "/expr", v.Expression.Data)
 }
 
 func (o *mqlBicepOutput) expressionTree() (*mqlBicepExpression, error) {
-	node := parseExpression(o.Expression.Data)
-	return newMqlBicepExpression(o.MqlRuntime, o.__id+"/expr", node)
+	return expressionTreeFor(o.MqlRuntime, o.__id, "/expr", o.Expression.Data)
+}
+
+func (r *mqlBicepResource) nameTree() (*mqlBicepExpression, error) {
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/nameTree", r.Name.Data)
+}
+
+func (r *mqlBicepResource) locationTree() (*mqlBicepExpression, error) {
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/locationTree", r.Location.Data)
+}
+
+func (r *mqlBicepResource) conditionTree() (*mqlBicepExpression, error) {
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/conditionTree", r.Condition.Data)
+}
+
+func (m *mqlBicepModule) scopeTree() (*mqlBicepExpression, error) {
+	return expressionTreeFor(m.MqlRuntime, m.__id, "/scopeTree", m.Scope.Data)
+}
+
+func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
+	return expressionTreeFor(m.MqlRuntime, m.__id, "/conditionTree", m.Condition.Data)
 }
 
 func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput) ([]any, error) {

--- a/providers/bicep/resources/testdata/exprtrees.bicep
+++ b/providers/bicep/resources/testdata/exprtrees.bicep
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Fixture exercising the resource/module expression-tree accessors:
+// interpolated name, literal location, function-call location, a
+// conditional resource, and a module with a scope expression and a
+// condition.
+
+@description('Resource name prefix')
+param prefix string = 'demo'
+
+@description('Whether to deploy the optional account')
+param deployFlag bool = true
+
+// name interpolates a parameter, location is a hardcoded literal
+resource interpName 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: '${prefix}-sa'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+// location is derived from a function call; conditional deployment
+resource fnLoc 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployFlag) {
+  name: 'fnlocsa'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+// module with a scope expression and a deployment condition
+module net './modules/network.bicep' = if (deployFlag) {
+  name: 'networkDeploy'
+  scope: resourceGroup('rg-network')
+  params: {
+    location: 'eastus'
+  }
+}


### PR DESCRIPTION
## What

Extends the existing Bicep expression tokenizer to the security-critical expression fields on `bicep.resource` and `bicep.module`. The tokenizer (in `expression.go`, surfacing as `bicep.expression`) was already wired to `bicep.variable.expressionTree()` and `bicep.output.expressionTree()`; this PR exposes the same structured, queryable tree on the fields that IaC policies actually need to reason about — resource name/location/condition and module scope/condition — so audits can ask structural questions ("is this location a hardcoded literal?", "does this resource name interpolate a parameter?", "which symbol gates this conditional deployment?") without string-matching.

## New accessors

All return `bicep.expression`:

On `bicep.resource`:
- `nameTree()` — parsed tree of the raw `name` expression
- `locationTree()` — parsed tree of the raw `location` expression
- `conditionTree()` — parsed tree of the `= if (<cond>)` deployment condition

On `bicep.module`:
- `scopeTree()` — parsed tree of the raw `scope` expression
- `conditionTree()` — parsed tree of the `= if (<cond>)` deployment condition

## Notes

- The raw string fields (`name`, `location`, `condition`, `scope`) are unchanged — these are additive `*Tree()` accessors.
- All five reuse the same `parseExpression` tokenizer via a shared `expressionTreeFor` helper (no parse-logic duplication).
- An empty raw field (e.g. an unconditional resource/module) parses to an `unknown` node with empty `raw`, matching the existing `expressionTree()` behavior — uniform schema, no special-casing.
- Each returned node gets a parent-qualified synthetic `__id` (`<parentId>/nameTree`, `/locationTree`, `/conditionTree`, `/scopeTree`) so distinct trees under the same resource don't collide in the cache.
- New `.lr.versions` entries at `13.1.2` (provider is at `13.1.1`).

## Verification

`go test ./resources/` passes (existing + new fixture-driven tests in `exprtrees_test.go`, fixture `testdata/exprtrees.bicep`). E2E query confirms: literal location → `literal`, `resourceGroup().location` → `propertyAccess` (functionCall base), interpolated name → `interpolation`, conditional → `symbolicRef`, unconditional → `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)