### PR TITLE
✨ bicep: resolve expression symbol references to their declarations

### DIFF
--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -72,6 +72,9 @@ func (r *mqlBicep) template() (*mqlBicepTemplate, error) {
 type mqlBicepFileInternal struct {
 	parseOnce sync.Once
 	parsed    *parsedBicepFile
+
+	resolverOnce   sync.Once
+	cachedResolver *symbolResolver
 }
 
 func newMqlBicepFile(runtime *plugin.Runtime, f *connection.BicepFile) (*mqlBicepFile, error) {
@@ -114,13 +117,17 @@ func (f *mqlBicepFile) id() (string, error) {
 	return "bicep.file:" + f.Path.Data, nil
 }
 
-// resolver builds the per-file symbol table once and stamps it under
-// parseOnce's happens-before guarantee. The resolver lets expression-tree
-// nodes resolve a root identifier (`target`) to the declaration it names
-// within this file. It's derived purely from the already-parsed model, so
-// it's cheap to rebuild if the resource was reconstructed across gRPC.
+// resolver builds the per-file symbol table once and caches it. It's invoked
+// from variables()/resources()/modules()/outputs(), so caching avoids
+// rebuilding the index (and its maps) on each call. The resolver lets
+// expression-tree nodes resolve a root identifier (`target`) to the
+// declaration it names within this file, and is derived purely from the
+// already-parsed model.
 func (f *mqlBicepFile) resolver() *symbolResolver {
-	return newSymbolResolver(f.Path.Data, f.getParsed())
+	f.resolverOnce.Do(func() {
+		f.cachedResolver = newSymbolResolver(f.Path.Data, f.getParsed())
+	})
+	return f.cachedResolver
 }
 
 func (f *mqlBicepFile) parameters() ([]any, error) {

--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -114,24 +114,33 @@ func (f *mqlBicepFile) id() (string, error) {
 	return "bicep.file:" + f.Path.Data, nil
 }
 
+// resolver builds the per-file symbol table once and stamps it under
+// parseOnce's happens-before guarantee. The resolver lets expression-tree
+// nodes resolve a root identifier (`target`) to the declaration it names
+// within this file. It's derived purely from the already-parsed model, so
+// it's cheap to rebuild if the resource was reconstructed across gRPC.
+func (f *mqlBicepFile) resolver() *symbolResolver {
+	return newSymbolResolver(f.Path.Data, f.getParsed())
+}
+
 func (f *mqlBicepFile) parameters() ([]any, error) {
 	return createMqlParameters(f.MqlRuntime, f.Path.Data, f.getParsed().parameters)
 }
 
 func (f *mqlBicepFile) variables() ([]any, error) {
-	return createMqlVariables(f.MqlRuntime, f.Path.Data, f.getParsed().variables)
+	return createMqlVariables(f.MqlRuntime, f.Path.Data, f.getParsed().variables, f.resolver())
 }
 
 func (f *mqlBicepFile) resources() ([]any, error) {
-	return createMqlResources(f.MqlRuntime, f.Path.Data, f.getParsed().resources)
+	return createMqlResources(f.MqlRuntime, f.Path.Data, f.getParsed().resources, f.resolver())
 }
 
 func (f *mqlBicepFile) modules() ([]any, error) {
-	return createMqlModules(f.MqlRuntime, f.Path.Data, f.getParsed().modules)
+	return createMqlModules(f.MqlRuntime, f.Path.Data, f.getParsed().modules, f.resolver())
 }
 
 func (f *mqlBicepFile) outputs() ([]any, error) {
-	return createMqlOutputs(f.MqlRuntime, f.Path.Data, f.getParsed().outputs)
+	return createMqlOutputs(f.MqlRuntime, f.Path.Data, f.getParsed().outputs, f.resolver())
 }
 
 func (f *mqlBicepFile) types() ([]any, error) {

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -361,6 +361,43 @@ bicep.expression @defaults("kind raw") {
   path []string
   // Alternating literal and embedded-expression parts of an interpolation node
   segments() []bicep.expression
+  // Declaration category the root identifier resolves to
+  //
+  // One of parameter, variable, resource, module, or type — the kind of
+  // same-file declaration that `target` names — or empty when `target` is
+  // empty or doesn't match a declaration in the owning file (a built-in like
+  // `resourceGroup`, or a symbol brought in by `import`). Resolution is
+  // file-scoped; cross-file import resolution is handled elsewhere.
+  referenceKind() string
+  // Parameter the root identifier resolves to, or null
+  //
+  // Non-null only when `referenceKind` is parameter; the other referenced*()
+  // accessors are null in that case. Resolves the root identifier `target`
+  // (for example `myParam` in `'${myParam}'`) to the same-file
+  // `bicep.parameter` it names.
+  referencedParameter() bicep.parameter
+  // Variable the root identifier resolves to, or null
+  //
+  // Non-null only when `referenceKind` is variable; the other referenced*()
+  // accessors are null in that case.
+  referencedVariable() bicep.variable
+  // Resource the root identifier resolves to, or null
+  //
+  // Non-null only when `referenceKind` is resource; the other referenced*()
+  // accessors are null in that case. For a `propertyAccess` like
+  // `vnet.properties.subnets[0].id` the root identifier `vnet` resolves here,
+  // not the whole accessor chain.
+  referencedResource() bicep.resource
+  // Module the root identifier resolves to, or null
+  //
+  // Non-null only when `referenceKind` is module; the other referenced*()
+  // accessors are null in that case.
+  referencedModule() bicep.module
+  // User-defined type the root identifier resolves to, or null
+  //
+  // Non-null only when `referenceKind` is type; the other referenced*()
+  // accessors are null in that case.
+  referencedType() bicep.type
 }
 
 // Bicep user-defined type declaration

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -432,6 +432,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.expression.segments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepExpression).GetSegments()).ToDataRes(types.Array(types.Resource("bicep.expression")))
 	},
+	"bicep.expression.referenceKind": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferenceKind()).ToDataRes(types.String)
+	},
+	"bicep.expression.referencedParameter": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferencedParameter()).ToDataRes(types.Resource("bicep.parameter"))
+	},
+	"bicep.expression.referencedVariable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferencedVariable()).ToDataRes(types.Resource("bicep.variable"))
+	},
+	"bicep.expression.referencedResource": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferencedResource()).ToDataRes(types.Resource("bicep.resource"))
+	},
+	"bicep.expression.referencedModule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferencedModule()).ToDataRes(types.Resource("bicep.module"))
+	},
+	"bicep.expression.referencedType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetReferencedType()).ToDataRes(types.Resource("bicep.type"))
+	},
 	"bicep.type.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepType).GetName()).ToDataRes(types.String)
 	},
@@ -922,6 +940,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.expression.segments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepExpression).Segments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referenceKind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferenceKind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referencedParameter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferencedParameter, ok = plugin.RawToTValue[*mqlBicepParameter](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referencedVariable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferencedVariable, ok = plugin.RawToTValue[*mqlBicepVariable](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referencedResource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferencedResource, ok = plugin.RawToTValue[*mqlBicepResource](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referencedModule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferencedModule, ok = plugin.RawToTValue[*mqlBicepModule](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.referencedType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).ReferencedType, ok = plugin.RawToTValue[*mqlBicepType](v.Value, v.Error)
 		return
 	},
 	"bicep.type.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1532,7 +1574,7 @@ func (c *mqlBicepParameter) GetDecorators() *plugin.TValue[[]any] {
 type mqlBicepVariable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepVariableInternal it will be used here
+	mqlBicepVariableInternal
 	Name           plugin.TValue[string]
 	Expression     plugin.TValue[string]
 	ExpressionTree plugin.TValue[*mqlBicepExpression]
@@ -1815,7 +1857,7 @@ func (c *mqlBicepResource) GetLoopExpression() *plugin.TValue[string] {
 type mqlBicepModule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepModuleInternal it will be used here
+	mqlBicepModuleInternal
 	Name           plugin.TValue[string]
 	Source         plugin.TValue[string]
 	Scope          plugin.TValue[string]
@@ -1953,7 +1995,7 @@ func (c *mqlBicepModule) GetLoopExpression() *plugin.TValue[string] {
 type mqlBicepOutput struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepOutputInternal it will be used here
+	mqlBicepOutputInternal
 	Name           plugin.TValue[string]
 	Type           plugin.TValue[string]
 	Expression     plugin.TValue[string]
@@ -2050,13 +2092,19 @@ type mqlBicepExpression struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlBicepExpressionInternal
-	Kind         plugin.TValue[string]
-	Raw          plugin.TValue[string]
-	FunctionName plugin.TValue[string]
-	Args         plugin.TValue[[]any]
-	Target       plugin.TValue[string]
-	Path         plugin.TValue[[]any]
-	Segments     plugin.TValue[[]any]
+	Kind                plugin.TValue[string]
+	Raw                 plugin.TValue[string]
+	FunctionName        plugin.TValue[string]
+	Args                plugin.TValue[[]any]
+	Target              plugin.TValue[string]
+	Path                plugin.TValue[[]any]
+	Segments            plugin.TValue[[]any]
+	ReferenceKind       plugin.TValue[string]
+	ReferencedParameter plugin.TValue[*mqlBicepParameter]
+	ReferencedVariable  plugin.TValue[*mqlBicepVariable]
+	ReferencedResource  plugin.TValue[*mqlBicepResource]
+	ReferencedModule    plugin.TValue[*mqlBicepModule]
+	ReferencedType      plugin.TValue[*mqlBicepType]
 }
 
 // createBicepExpression creates a new instance of this resource
@@ -2140,6 +2188,92 @@ func (c *mqlBicepExpression) GetSegments() *plugin.TValue[[]any] {
 		}
 
 		return c.segments()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferenceKind() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ReferenceKind, func() (string, error) {
+		return c.referenceKind()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferencedParameter() *plugin.TValue[*mqlBicepParameter] {
+	return plugin.GetOrCompute[*mqlBicepParameter](&c.ReferencedParameter, func() (*mqlBicepParameter, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "referencedParameter")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepParameter), nil
+			}
+		}
+
+		return c.referencedParameter()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferencedVariable() *plugin.TValue[*mqlBicepVariable] {
+	return plugin.GetOrCompute[*mqlBicepVariable](&c.ReferencedVariable, func() (*mqlBicepVariable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "referencedVariable")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepVariable), nil
+			}
+		}
+
+		return c.referencedVariable()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferencedResource() *plugin.TValue[*mqlBicepResource] {
+	return plugin.GetOrCompute[*mqlBicepResource](&c.ReferencedResource, func() (*mqlBicepResource, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "referencedResource")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepResource), nil
+			}
+		}
+
+		return c.referencedResource()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferencedModule() *plugin.TValue[*mqlBicepModule] {
+	return plugin.GetOrCompute[*mqlBicepModule](&c.ReferencedModule, func() (*mqlBicepModule, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "referencedModule")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepModule), nil
+			}
+		}
+
+		return c.referencedModule()
+	})
+}
+
+func (c *mqlBicepExpression) GetReferencedType() *plugin.TValue[*mqlBicepType] {
+	return plugin.GetOrCompute[*mqlBicepType](&c.ReferencedType, func() (*mqlBicepType, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "referencedType")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepType), nil
+			}
+		}
+
+		return c.referencedType()
 	})
 }
 

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -8,6 +8,12 @@ bicep.expression.functionName 13.1.2
 bicep.expression.kind 13.1.2
 bicep.expression.path 13.1.2
 bicep.expression.raw 13.1.2
+bicep.expression.referenceKind 13.1.2
+bicep.expression.referencedModule 13.1.2
+bicep.expression.referencedParameter 13.1.2
+bicep.expression.referencedResource 13.1.2
+bicep.expression.referencedType 13.1.2
+bicep.expression.referencedVariable 13.1.2
 bicep.expression.segments 13.1.2
 bicep.expression.target 13.1.2
 bicep.file 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -39,7 +39,14 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 	return mqlParams, nil
 }
 
-func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedVariable) ([]any, error) {
+// mqlBicepVariableInternal carries the owning file's symbol resolver so the
+// lazy expressionTree() accessor can resolve the root identifiers its nodes
+// reference to same-file declarations.
+type mqlBicepVariableInternal struct {
+	resolver *symbolResolver
+}
+
+func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedVariable, resolver *symbolResolver) ([]any, error) {
 	var mqlVars []any
 	for _, v := range vars {
 		args := map[string]*llx.RawData{
@@ -53,6 +60,7 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepVariable).resolver = resolver
 		mqlVars = append(mqlVars, res)
 	}
 	return mqlVars, nil
@@ -62,14 +70,19 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 // lazy `resources()` accessor can materialize them without re-parsing. Each
 // child carries a parent-qualified `__id` (`<parentId>/<childSymbolicName>`)
 // so nested resources under different parents never collide in the cache.
+// The resolver carries the owning file's symbol table so the lazy
+// name/location/condition expression-tree accessors can resolve referenced
+// root identifiers to same-file declarations. Nested child resources inherit
+// the same resolver since symbols stay file-scoped regardless of nesting.
 type mqlBicepResourceInternal struct {
-	nested []parsedResource
+	nested   []parsedResource
+	resolver *symbolResolver
 }
 
-func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource) ([]any, error) {
+func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource, resolver *symbolResolver) ([]any, error) {
 	var mqlResources []any
 	for _, r := range resources {
-		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r)
+		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r, resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +97,7 @@ func createMqlResources(runtime *plugin.Runtime, filePath string, resources []pa
 // parent-qualified `<parentId>/<childSymbolicName>`. The parsed nested
 // declarations are cached on the Internal struct for the lazy `resources()`
 // accessor to materialize, recursively.
-func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource) (*mqlBicepResource, error) {
+func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, resolver *symbolResolver) (*mqlBicepResource, error) {
 	dependsOn := sliceToAny(r.dependsOn)
 	decorators := sliceToAny(r.decorators)
 
@@ -133,6 +146,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource) (
 	}
 	mqlRes := res.(*mqlBicepResource)
 	mqlRes.nested = r.nested
+	mqlRes.resolver = resolver
 	return mqlRes, nil
 }
 
@@ -144,7 +158,7 @@ func (r *mqlBicepResource) resources() ([]any, error) {
 	out := make([]any, 0, len(r.nested))
 	for _, child := range r.nested {
 		childID := r.__id + "/" + child.symbolicName
-		mqlChild, err := newMqlBicepResource(r.MqlRuntime, childID, child)
+		mqlChild, err := newMqlBicepResource(r.MqlRuntime, childID, child, r.resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +167,14 @@ func (r *mqlBicepResource) resources() ([]any, error) {
 	return out, nil
 }
 
-func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsedModule) ([]any, error) {
+// mqlBicepModuleInternal carries the owning file's symbol resolver so the
+// lazy scope/condition expression-tree accessors can resolve referenced root
+// identifiers to same-file declarations.
+type mqlBicepModuleInternal struct {
+	resolver *symbolResolver
+}
+
+func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsedModule, resolver *symbolResolver) ([]any, error) {
 	var mqlModules []any
 	for _, m := range modules {
 		// Same shape as bicep.resource.properties: parse the module's
@@ -185,6 +206,7 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepModule).resolver = resolver
 		mqlModules = append(mqlModules, res)
 	}
 	return mqlModules, nil
@@ -196,12 +218,21 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 // derived from its parent's id (`<exprId>/arg[<i>]`, `<exprId>/seg[<i>]`).
 type mqlBicepExpressionInternal struct {
 	node *exprNode
+	// resolver is the owning file's symbol table, threaded down from the
+	// declaration whose value this expression is. It lets referenceKind and
+	// the referenced*() accessors resolve `target` (the root identifier of a
+	// symbolicRef or propertyAccess) to the same-file declaration it names.
+	// Child nodes (args, segments) inherit the same resolver so nested refs
+	// resolve too.
+	resolver *symbolResolver
 }
 
 // newMqlBicepExpression turns a parsed exprNode into a bicep.expression
 // resource. Scalar fields are set immediately; child nodes (args, segments)
-// are cached on the Internal struct and materialized lazily.
-func newMqlBicepExpression(runtime *plugin.Runtime, parentID string, node *exprNode) (*mqlBicepExpression, error) {
+// are cached on the Internal struct and materialized lazily. The resolver is
+// the owning file's symbol table, propagated to children so symbol resolution
+// works at every depth.
+func newMqlBicepExpression(runtime *plugin.Runtime, parentID string, node *exprNode, resolver *symbolResolver) (*mqlBicepExpression, error) {
 	res, err := CreateResource(runtime, "bicep.expression", map[string]*llx.RawData{
 		"__id":         llx.StringData(parentID),
 		"kind":         llx.StringData(node.kind),
@@ -215,6 +246,7 @@ func newMqlBicepExpression(runtime *plugin.Runtime, parentID string, node *exprN
 	}
 	mqlExpr := res.(*mqlBicepExpression)
 	mqlExpr.node = node
+	mqlExpr.resolver = resolver
 	return mqlExpr, nil
 }
 
@@ -225,7 +257,7 @@ func (e *mqlBicepExpression) args() ([]any, error) {
 	out := make([]any, 0, len(e.node.args))
 	for i, child := range e.node.args {
 		childID := e.__id + "/arg[" + strconv.Itoa(i) + "]"
-		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child)
+		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child, e.resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -241,7 +273,7 @@ func (e *mqlBicepExpression) segments() ([]any, error) {
 	out := make([]any, 0, len(e.node.segments))
 	for i, child := range e.node.segments {
 		childID := e.__id + "/seg[" + strconv.Itoa(i) + "]"
-		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child)
+		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child, e.resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -250,46 +282,134 @@ func (e *mqlBicepExpression) segments() ([]any, error) {
 	return out, nil
 }
 
+// referenceKind reports which same-file declaration this node's `target` root
+// identifier names — one of "parameter", "variable", "resource", "module", or
+// "type" — or "" when `target` is empty or doesn't match a same-file
+// declaration (a built-in like `resourceGroup`, or an imported symbol, which
+// is resolved by a separate later layer). At most one referenced*() accessor
+// is non-null, matching this kind.
+func (e *mqlBicepExpression) referenceKind() (string, error) {
+	target := ""
+	if e.node != nil {
+		target = e.node.target
+	}
+	return e.resolver.kind(target), nil
+}
+
+func (e *mqlBicepExpression) target_() string {
+	if e.node != nil {
+		return e.node.target
+	}
+	return e.Target.Data
+}
+
+func (e *mqlBicepExpression) referencedParameter() (*mqlBicepParameter, error) {
+	p, err := e.resolver.parameter(e.MqlRuntime, e.target_())
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		e.ReferencedParameter.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return p, nil
+}
+
+func (e *mqlBicepExpression) referencedVariable() (*mqlBicepVariable, error) {
+	v, err := e.resolver.variable(e.MqlRuntime, e.target_())
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		e.ReferencedVariable.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (e *mqlBicepExpression) referencedResource() (*mqlBicepResource, error) {
+	r, err := e.resolver.resource(e.MqlRuntime, e.target_())
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		e.ReferencedResource.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return r, nil
+}
+
+func (e *mqlBicepExpression) referencedModule() (*mqlBicepModule, error) {
+	m, err := e.resolver.module(e.MqlRuntime, e.target_())
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		e.ReferencedModule.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return m, nil
+}
+
+func (e *mqlBicepExpression) referencedType() (*mqlBicepType, error) {
+	t, err := e.resolver.typ(e.MqlRuntime, e.target_())
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		e.ReferencedType.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return t, nil
+}
+
 // expressionTreeFor parses a raw Bicep expression string and returns it as a
 // bicep.expression resource. The suffix is appended to the parent's __id so
 // distinct expression fields under the same parent (e.g. nameTree vs
 // locationTree on one resource) get distinct, non-colliding cache keys. An
 // empty raw string parses to an `unknown` node with empty `raw`, mirroring the
 // existing variable/output expressionTree() behavior.
-func expressionTreeFor(runtime *plugin.Runtime, parentID, suffix, raw string) (*mqlBicepExpression, error) {
+func expressionTreeFor(runtime *plugin.Runtime, parentID, suffix, raw string, resolver *symbolResolver) (*mqlBicepExpression, error) {
 	node := parseExpression(raw)
-	return newMqlBicepExpression(runtime, parentID+suffix, node)
+	return newMqlBicepExpression(runtime, parentID+suffix, node, resolver)
 }
 
 func (v *mqlBicepVariable) expressionTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(v.MqlRuntime, v.__id, "/expr", v.Expression.Data)
+	return expressionTreeFor(v.MqlRuntime, v.__id, "/expr", v.Expression.Data, v.resolver)
 }
 
 func (o *mqlBicepOutput) expressionTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(o.MqlRuntime, o.__id, "/expr", o.Expression.Data)
+	return expressionTreeFor(o.MqlRuntime, o.__id, "/expr", o.Expression.Data, o.resolver)
 }
 
 func (r *mqlBicepResource) nameTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(r.MqlRuntime, r.__id, "/nameTree", r.Name.Data)
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/nameTree", r.Name.Data, r.resolver)
 }
 
 func (r *mqlBicepResource) locationTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(r.MqlRuntime, r.__id, "/locationTree", r.Location.Data)
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/locationTree", r.Location.Data, r.resolver)
 }
 
 func (r *mqlBicepResource) conditionTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(r.MqlRuntime, r.__id, "/conditionTree", r.Condition.Data)
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/conditionTree", r.Condition.Data, r.resolver)
 }
 
 func (m *mqlBicepModule) scopeTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(m.MqlRuntime, m.__id, "/scopeTree", m.Scope.Data)
+	return expressionTreeFor(m.MqlRuntime, m.__id, "/scopeTree", m.Scope.Data, m.resolver)
 }
 
 func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(m.MqlRuntime, m.__id, "/conditionTree", m.Condition.Data)
+	return expressionTreeFor(m.MqlRuntime, m.__id, "/conditionTree", m.Condition.Data, m.resolver)
 }
 
-func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput) ([]any, error) {
+// mqlBicepOutputInternal carries the owning file's symbol resolver so the
+// lazy expressionTree() accessor can resolve referenced root identifiers to
+// same-file declarations.
+type mqlBicepOutputInternal struct {
+	resolver *symbolResolver
+}
+
+func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput, resolver *symbolResolver) ([]any, error) {
 	var mqlOutputs []any
 	for _, o := range outputs {
 		args := map[string]*llx.RawData{
@@ -304,6 +424,7 @@ func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsed
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepOutput).resolver = resolver
 		mqlOutputs = append(mqlOutputs, res)
 	}
 	return mqlOutputs, nil

--- a/providers/bicep/resources/resolver.go
+++ b/providers/bicep/resources/resolver.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Reference kinds returned by symbolResolver.kind and exposed as
+// bicep.expression.referenceKind.
+const (
+	refKindParameter = "parameter"
+	refKindVariable  = "variable"
+	refKindResource  = "resource"
+	refKindModule    = "module"
+	refKindType      = "type"
+)
+
+// symbolResolver is a per-file symbol table. Bicep symbols are file-scoped:
+// a root identifier in an expression (the `target` of a symbolicRef or
+// propertyAccess) resolves to exactly one declaration in the same file among
+// the parameters, variables, resources, modules, and user-defined types.
+// The resolver indexes those declarations by the name they're referenced by
+// (parameters/variables/modules/types by name, resources by symbolic name)
+// and builds the matching typed resource on demand, reusing the same __id the
+// declaration was originally created with so the runtime returns the cached
+// instance instead of a duplicate.
+//
+// Cross-file `import` resolution is intentionally out of scope here — a target
+// that names an imported symbol (or a built-in like `resourceGroup`) simply
+// doesn't match and resolves to the empty kind.
+type symbolResolver struct {
+	filePath   string
+	parameters map[string]parsedParameter
+	variables  map[string]parsedVariable
+	resources  map[string]parsedResource
+	modules    map[string]parsedModule
+	types      map[string]parsedType
+}
+
+// newSymbolResolver builds the per-file symbol index from a parsed file. Only
+// top-level declarations participate in symbol resolution — nested child
+// resources are addressed through their parent and never referenced by a bare
+// root identifier, so they're not indexed here.
+func newSymbolResolver(filePath string, parsed *parsedBicepFile) *symbolResolver {
+	r := &symbolResolver{
+		filePath:   filePath,
+		parameters: make(map[string]parsedParameter, len(parsed.parameters)),
+		variables:  make(map[string]parsedVariable, len(parsed.variables)),
+		resources:  make(map[string]parsedResource, len(parsed.resources)),
+		modules:    make(map[string]parsedModule, len(parsed.modules)),
+		types:      make(map[string]parsedType, len(parsed.types)),
+	}
+	for _, p := range parsed.parameters {
+		r.parameters[p.name] = p
+	}
+	for _, v := range parsed.variables {
+		r.variables[v.name] = v
+	}
+	for _, res := range parsed.resources {
+		r.resources[res.symbolicName] = res
+	}
+	for _, m := range parsed.modules {
+		r.modules[m.name] = m
+	}
+	for _, t := range parsed.types {
+		r.types[t.name] = t
+	}
+	return r
+}
+
+// kind reports which declaration category `target` names within the file, or
+// the empty string when `target` is empty or doesn't match a same-file
+// declaration (e.g. a built-in like `resourceGroup` or an imported symbol).
+func (r *symbolResolver) kind(target string) string {
+	if r == nil || target == "" {
+		return ""
+	}
+	if _, ok := r.parameters[target]; ok {
+		return refKindParameter
+	}
+	if _, ok := r.variables[target]; ok {
+		return refKindVariable
+	}
+	if _, ok := r.resources[target]; ok {
+		return refKindResource
+	}
+	if _, ok := r.modules[target]; ok {
+		return refKindModule
+	}
+	if _, ok := r.types[target]; ok {
+		return refKindType
+	}
+	return ""
+}
+
+// parameter builds (or returns the cached) bicep.parameter the target names,
+// or nil when it doesn't name a parameter in this file.
+func (r *symbolResolver) parameter(runtime *plugin.Runtime, target string) (*mqlBicepParameter, error) {
+	if r == nil {
+		return nil, nil
+	}
+	p, ok := r.parameters[target]
+	if !ok {
+		return nil, nil
+	}
+	out, err := createMqlParameters(runtime, r.filePath, []parsedParameter{p})
+	if err != nil {
+		return nil, err
+	}
+	return out[0].(*mqlBicepParameter), nil
+}
+
+// variable builds (or returns the cached) bicep.variable the target names, or
+// nil when it doesn't name a variable in this file.
+func (r *symbolResolver) variable(runtime *plugin.Runtime, target string) (*mqlBicepVariable, error) {
+	if r == nil {
+		return nil, nil
+	}
+	v, ok := r.variables[target]
+	if !ok {
+		return nil, nil
+	}
+	out, err := createMqlVariables(runtime, r.filePath, []parsedVariable{v}, r)
+	if err != nil {
+		return nil, err
+	}
+	return out[0].(*mqlBicepVariable), nil
+}
+
+// resource builds (or returns the cached) bicep.resource the target names, or
+// nil when it doesn't name a resource in this file.
+func (r *symbolResolver) resource(runtime *plugin.Runtime, target string) (*mqlBicepResource, error) {
+	if r == nil {
+		return nil, nil
+	}
+	res, ok := r.resources[target]
+	if !ok {
+		return nil, nil
+	}
+	return newMqlBicepResource(runtime, "bicep.resource:"+r.filePath+":"+res.symbolicName, res, r)
+}
+
+// module builds (or returns the cached) bicep.module the target names, or nil
+// when it doesn't name a module in this file.
+func (r *symbolResolver) module(runtime *plugin.Runtime, target string) (*mqlBicepModule, error) {
+	if r == nil {
+		return nil, nil
+	}
+	m, ok := r.modules[target]
+	if !ok {
+		return nil, nil
+	}
+	out, err := createMqlModules(runtime, r.filePath, []parsedModule{m}, r)
+	if err != nil {
+		return nil, err
+	}
+	return out[0].(*mqlBicepModule), nil
+}
+
+// typ builds (or returns the cached) bicep.type the target names, or nil when
+// it doesn't name a user-defined type in this file.
+func (r *symbolResolver) typ(runtime *plugin.Runtime, target string) (*mqlBicepType, error) {
+	if r == nil {
+		return nil, nil
+	}
+	t, ok := r.types[target]
+	if !ok {
+		return nil, nil
+	}
+	out, err := createMqlTypes(runtime, r.filePath, []parsedType{t})
+	if err != nil {
+		return nil, err
+	}
+	return out[0].(*mqlBicepType), nil
+}

--- a/providers/bicep/resources/resolver_test.go
+++ b/providers/bicep/resources/resolver_test.go
@@ -1,0 +1,256 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// mapResources is a trivial in-memory implementation of the plugin resource
+// cache, enough to let CreateResource/NewResource dedupe by __id without a
+// real provider runtime.
+type mapResources struct {
+	m map[string]plugin.Resource
+}
+
+func (r *mapResources) Get(key string) (plugin.Resource, bool) {
+	v, ok := r.m[key]
+	return v, ok
+}
+
+func (r *mapResources) Set(key string, value plugin.Resource) {
+	r.m[key] = value
+}
+
+func testRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &mapResources{m: map[string]plugin.Resource{}}}
+}
+
+// exprNodeFor parses the named declaration's relevant raw expression from the
+// fixture and returns it as a wired-up bicep.expression resource carrying the
+// file's symbol resolver — mirroring exactly what the *Tree() accessors build.
+func loadResolverFixture(t *testing.T) (*plugin.Runtime, *symbolResolver, *parsedBicepFile) {
+	data, err := os.ReadFile("testdata/resolvedref.bicep")
+	require.NoError(t, err)
+	parsed := parseBicep(string(data))
+	return testRuntime(), newSymbolResolver("testdata/resolvedref.bicep", parsed), parsed
+}
+
+func findVar(parsed *parsedBicepFile, name string) parsedVariable {
+	for _, v := range parsed.variables {
+		if v.name == name {
+			return v
+		}
+	}
+	return parsedVariable{}
+}
+
+func findResource(parsed *parsedBicepFile, sym string) parsedResource {
+	for _, r := range parsed.resources {
+		if r.symbolicName == sym {
+			return r
+		}
+	}
+	return parsedResource{}
+}
+
+func findOutput(parsed *parsedBicepFile, name string) parsedOutput {
+	for _, o := range parsed.outputs {
+		if o.name == name {
+			return o
+		}
+	}
+	return parsedOutput{}
+}
+
+func findParam(parsed *parsedBicepFile, name string) parsedParameter {
+	for _, p := range parsed.parameters {
+		if p.name == name {
+			return p
+		}
+	}
+	return parsedParameter{}
+}
+
+// exprFor builds a bicep.expression resource for a raw expression string,
+// wired with the given resolver, the way expressionTreeFor does.
+func exprFor(t *testing.T, runtime *plugin.Runtime, resolver *symbolResolver, raw string) *mqlBicepExpression {
+	node := parseExpression(raw)
+	expr, err := newMqlBicepExpression(runtime, "test:"+raw, node, resolver)
+	require.NoError(t, err)
+	return expr
+}
+
+// assertOnlyKind verifies referenceKind and that exactly the matching
+// referenced*() accessor is non-null while the others resolve to null.
+func assertOnlyKind(t *testing.T, expr *mqlBicepExpression, wantKind string) {
+	t.Helper()
+
+	kind, err := expr.referenceKind()
+	require.NoError(t, err)
+	assert.Equal(t, wantKind, kind)
+
+	p, err := expr.referencedParameter()
+	require.NoError(t, err)
+	v, err := expr.referencedVariable()
+	require.NoError(t, err)
+	res, err := expr.referencedResource()
+	require.NoError(t, err)
+	m, err := expr.referencedModule()
+	require.NoError(t, err)
+	ty, err := expr.referencedType()
+	require.NoError(t, err)
+
+	switch wantKind {
+	case refKindParameter:
+		assert.NotNil(t, p)
+		assert.Nil(t, v)
+		assert.Nil(t, res)
+		assert.Nil(t, m)
+		assert.Nil(t, ty)
+	case refKindVariable:
+		assert.Nil(t, p)
+		assert.NotNil(t, v)
+		assert.Nil(t, res)
+		assert.Nil(t, m)
+		assert.Nil(t, ty)
+	case refKindResource:
+		assert.Nil(t, p)
+		assert.Nil(t, v)
+		assert.NotNil(t, res)
+		assert.Nil(t, m)
+		assert.Nil(t, ty)
+	case refKindModule:
+		assert.Nil(t, p)
+		assert.Nil(t, v)
+		assert.Nil(t, res)
+		assert.NotNil(t, m)
+		assert.Nil(t, ty)
+	case refKindType:
+		assert.Nil(t, p)
+		assert.Nil(t, v)
+		assert.Nil(t, res)
+		assert.Nil(t, m)
+		assert.NotNil(t, ty)
+	case "":
+		assert.Nil(t, p)
+		assert.Nil(t, v)
+		assert.Nil(t, res)
+		assert.Nil(t, m)
+		assert.Nil(t, ty)
+	}
+}
+
+func TestSymbolResolverKind(t *testing.T) {
+	_, resolver, _ := loadResolverFixture(t)
+
+	assert.Equal(t, refKindParameter, resolver.kind("namePrefix"))
+	assert.Equal(t, refKindParameter, resolver.kind("skuName"))
+	assert.Equal(t, refKindVariable, resolver.kind("saName"))
+	assert.Equal(t, refKindResource, resolver.kind("sa"))
+	assert.Equal(t, refKindResource, resolver.kind("lock"))
+	assert.Equal(t, refKindModule, resolver.kind("net"))
+	assert.Equal(t, refKindType, resolver.kind("storageSku"))
+	// built-in function and unknown symbols don't resolve
+	assert.Equal(t, "", resolver.kind("resourceGroup"))
+	assert.Equal(t, "", resolver.kind("nope"))
+	assert.Equal(t, "", resolver.kind(""))
+}
+
+func TestExpressionReferenceResolution(t *testing.T) {
+	runtime, resolver, parsed := loadResolverFixture(t)
+
+	t.Run("variable expression references a parameter", func(t *testing.T) {
+		// var saName = '${namePrefix}-sa' — interpolation; the embedded
+		// segment is a symbolicRef whose target is the parameter.
+		v := findVar(parsed, "saName")
+		node := parseExpression(v.expression)
+		require.Equal(t, exprKindInterpolation, node.kind)
+		seg, err := newMqlBicepExpression(runtime, "seg", node.segments[1], resolver)
+		require.NoError(t, err)
+		assertOnlyKind(t, seg, refKindParameter)
+		p, _ := seg.referencedParameter()
+		assert.Equal(t, "namePrefix", p.Name.Data)
+	})
+
+	t.Run("resource name interpolates a variable", func(t *testing.T) {
+		// resource sa { name: saName } — bare symbolicRef to the variable.
+		r := findResource(parsed, "sa")
+		expr := exprFor(t, runtime, resolver, r.name)
+		assertOnlyKind(t, expr, refKindVariable)
+		v, _ := expr.referencedVariable()
+		assert.Equal(t, "saName", v.Name.Data)
+	})
+
+	t.Run("resource location references a parameter", func(t *testing.T) {
+		// location: namePrefix — bare symbolicRef to the parameter.
+		r := findResource(parsed, "sa")
+		expr := exprFor(t, runtime, resolver, r.location)
+		assertOnlyKind(t, expr, refKindParameter)
+		p, _ := expr.referencedParameter()
+		assert.Equal(t, "namePrefix", p.Name.Data)
+	})
+
+	t.Run("propertyAccess resolves the root resource", func(t *testing.T) {
+		// output saId string = sa.id — propertyAccess, target is the resource.
+		o := findOutput(parsed, "saId")
+		expr := exprFor(t, runtime, resolver, o.expression)
+		require.Equal(t, exprKindPropertyAccess, expr.node.kind)
+		assert.Equal(t, "sa", expr.node.target)
+		assertOnlyKind(t, expr, refKindResource)
+		res, _ := expr.referencedResource()
+		assert.Equal(t, "sa", res.SymbolicName.Data)
+	})
+
+	t.Run("scope references a resource symbolically", func(t *testing.T) {
+		// resource lock { scope: sa } — bare symbolicRef to the resource.
+		r := findResource(parsed, "lock")
+		expr := exprFor(t, runtime, resolver, r.scope)
+		assertOnlyKind(t, expr, refKindResource)
+		res, _ := expr.referencedResource()
+		assert.Equal(t, "sa", res.SymbolicName.Data)
+	})
+
+	t.Run("output references a module by name", func(t *testing.T) {
+		// output netName string = net.name — propertyAccess on the module.
+		o := findOutput(parsed, "netName")
+		expr := exprFor(t, runtime, resolver, o.expression)
+		assert.Equal(t, "net", expr.node.target)
+		assertOnlyKind(t, expr, refKindModule)
+		m, _ := expr.referencedModule()
+		assert.Equal(t, "net", m.Name.Data)
+	})
+
+	t.Run("param type references a user-defined type", func(t *testing.T) {
+		// param skuName storageSku — the type name resolves to the type decl.
+		p := findParam(parsed, "skuName")
+		require.Equal(t, "storageSku", p.typ)
+		expr := exprFor(t, runtime, resolver, p.typ)
+		assertOnlyKind(t, expr, refKindType)
+		ty, _ := expr.referencedType()
+		assert.Equal(t, "storageSku", ty.Name.Data)
+	})
+
+	t.Run("built-in function call resolves to empty kind", func(t *testing.T) {
+		// output rgLoc string = resourceGroup().location — the root is the
+		// built-in resourceGroup, which is not a same-file declaration.
+		o := findOutput(parsed, "rgLoc")
+		expr := exprFor(t, runtime, resolver, o.expression)
+		// The propertyAccess base is a functionCall; its target is empty, so
+		// the node itself resolves to the empty kind.
+		assertOnlyKind(t, expr, "")
+	})
+
+	t.Run("unparented expression with nil resolver resolves to empty", func(t *testing.T) {
+		// Defensive: a node built without a resolver (e.g. reconstructed
+		// across gRPC) must not panic and resolves to the empty kind.
+		expr := exprFor(t, runtime, nil, "namePrefix")
+		assertOnlyKind(t, expr, "")
+	})
+}

--- a/providers/bicep/resources/testdata/resolvedref.bicep
+++ b/providers/bicep/resources/testdata/resolvedref.bicep
@@ -1,0 +1,35 @@
+// Fixture for symbol-resolution on bicep.expression. Exercises a variable
+// referencing a parameter, a resource whose name/location reference a
+// parameter and a variable, a property/output referencing another resource by
+// symbolic name, a module reference, a param typed by a user-defined type, and
+// a reference to a built-in (resourceGroup) that must resolve to the empty
+// reference kind.
+
+type storageSku = 'Standard_LRS' | 'Premium_LRS'
+
+param namePrefix string
+param skuName storageSku
+
+var saName = '${namePrefix}-sa'
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: saName
+  location: namePrefix
+}
+
+resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
+  name: 'sa-lock'
+  scope: sa
+  properties: {
+    level: 'CanNotDelete'
+  }
+}
+
+module net './network.bicep' = {
+  name: 'netDeploy'
+  scope: resourceGroup('rg-network')
+}
+
+output saId string = sa.id
+output rgLoc string = resourceGroup().location
+output netName string = net.name


### PR DESCRIPTION
## What

Resolves the root identifier (`target`) of a `bicep.expression` `symbolicRef` or `propertyAccess` node to the declaration it names within the same file. This turns the parsed expression tree into a navigable graph and surfaces implicit dependency edges — e.g. a resource `name` that interpolates a parameter, or an output `sa.id` that references another resource by symbolic name.

## The symbol-resolution graph

Bicep symbols are **file-scoped**: a `target` resolves to exactly one declaration in the same file among parameters, variables, resources, modules, and user-defined types. A new per-file `symbolResolver` (in `resolver.go`) indexes those declarations by the name they're referenced by and builds the matching typed resource on demand, reusing the same `__id` scheme each declaration was created with so the runtime returns the **cached instance** rather than a duplicate.

Added to `bicep.expression`:

- `referenceKind()` — one of `parameter`, `variable`, `resource`, `module`, `type`, or `""` (empty when `target` is empty or names a built-in like `resourceGroup` / an imported symbol).
- `referencedParameter() / referencedVariable() / referencedResource() / referencedModule() / referencedType()` — at most one is non-null (the one matching `referenceKind`); the rest return null.

For a `propertyAccess` like `vnet.properties.subnets[0].id`, the **root** identifier `vnet` is resolved, not the whole accessor chain.

## Same-file only

Cross-file `import` resolution is intentionally **out of scope** here and handled by a separate later layer. A target naming an imported symbol simply doesn't match and resolves to the empty kind.

## Threading the symbol table

The resolver is built once per file (`mqlBicepFile.resolver()`, derived from the already-parsed model) and threaded through the declaration resources (`variable`/`resource`/`module`/`output`, via small `*Internal` structs) → `expressionTreeFor(...)` → `newMqlBicepExpression` → down to every child node (`args()`/`segments()`), so nested references resolve at any depth.

## StateIsNull handling

Each `referenced*()` accessor that returns nil first sets `<Field>.State = plugin.StateIsSet | plugin.StateIsNull` before `return nil, nil`, per the runtime contract for singular resource accessors. A node reconstructed without a resolver (e.g. across gRPC) degrades safely to the empty kind / null accessors instead of panicking.

## Stacking

Stacks on #8021 (already merged into `main`); opened against `main`.

## Tests

Fixture-driven (`testdata/resolvedref.bicep`) covering a variable→parameter ref, a resource name/location referencing a variable and a parameter, a property/output referencing a resource (`sa.id`) and a module (`net.name`) by symbolic name, a param typed by a user-defined type, and a built-in (`resourceGroup()`) that resolves to `referenceKind == ""`. Asserts the correct accessor is non-null and the others are null in each case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)