### PR TITLE
✨ bicep: resolve import statements to their target file and declarations

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -479,6 +479,34 @@ bicep.import @defaults("source") {
   namespace string
   // Whether this is a `* as ns` wildcard import
   wildcard bool
+
+  // Local Bicep file this import pulls from
+  //
+  // Resolves a relative `source` (for example `./shared.bicep`) against the
+  // directory of the file that declared the import and returns the matching
+  // Bicep file the scan already discovered, so you can traverse into its
+  // types, functions, and other declarations. Only scan-discovered files
+  // resolve; a bare provider import (for example `az@2.0.0`), a path that
+  // resolves outside the scanned root, or any otherwise unresolvable path
+  // returns null — the resolved path is never read directly from disk.
+  targetFile() bicep.file
+
+  // User-defined types this import brings in from the target file
+  //
+  // For a named import (`import { sku } from './shared.bicep'`) this is the
+  // subset of the target file's types whose name appears in `symbols`. For a
+  // wildcard import (`import * as shared from './shared.bicep'`) it is all of
+  // the target file's types. Empty when there is no resolvable target file.
+  resolvedTypes() []bicep.type
+
+  // User-defined functions this import brings in from the target file
+  //
+  // For a named import (`import { buildName } from './shared.bicep'`) this is
+  // the subset of the target file's functions whose name appears in
+  // `symbols`. For a wildcard import (`import * as shared from
+  // './shared.bicep'`) it is all of the target file's functions. Empty when
+  // there is no resolvable target file.
+  resolvedFunctions() []bicep.function
 }
 
 // Compiled ARM template (from ARM JSON input)

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -498,6 +498,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.import.wildcard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepImport).GetWildcard()).ToDataRes(types.Bool)
 	},
+	"bicep.import.targetFile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepImport).GetTargetFile()).ToDataRes(types.Resource("bicep.file"))
+	},
+	"bicep.import.resolvedTypes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepImport).GetResolvedTypes()).ToDataRes(types.Array(types.Resource("bicep.type")))
+	},
+	"bicep.import.resolvedFunctions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepImport).GetResolvedFunctions()).ToDataRes(types.Array(types.Resource("bicep.function")))
+	},
 	"bicep.template.schema": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplate).GetSchema()).ToDataRes(types.String)
 	},
@@ -1043,6 +1052,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.import.wildcard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepImport).Wildcard, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"bicep.import.targetFile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepImport).TargetFile, ok = plugin.RawToTValue[*mqlBicepFile](v.Value, v.Error)
+		return
+	},
+	"bicep.import.resolvedTypes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepImport).ResolvedTypes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.import.resolvedFunctions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepImport).ResolvedFunctions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.template.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2438,11 +2459,14 @@ func (c *mqlBicepFunction) GetDecorators() *plugin.TValue[[]any] {
 type mqlBicepImport struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepImportInternal it will be used here
-	Source    plugin.TValue[string]
-	Symbols   plugin.TValue[[]any]
-	Namespace plugin.TValue[string]
-	Wildcard  plugin.TValue[bool]
+	mqlBicepImportInternal
+	Source            plugin.TValue[string]
+	Symbols           plugin.TValue[[]any]
+	Namespace         plugin.TValue[string]
+	Wildcard          plugin.TValue[bool]
+	TargetFile        plugin.TValue[*mqlBicepFile]
+	ResolvedTypes     plugin.TValue[[]any]
+	ResolvedFunctions plugin.TValue[[]any]
 }
 
 // createBicepImport creates a new instance of this resource
@@ -2491,6 +2515,54 @@ func (c *mqlBicepImport) GetNamespace() *plugin.TValue[string] {
 
 func (c *mqlBicepImport) GetWildcard() *plugin.TValue[bool] {
 	return &c.Wildcard
+}
+
+func (c *mqlBicepImport) GetTargetFile() *plugin.TValue[*mqlBicepFile] {
+	return plugin.GetOrCompute[*mqlBicepFile](&c.TargetFile, func() (*mqlBicepFile, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.import", c.__id, "targetFile")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepFile), nil
+			}
+		}
+
+		return c.targetFile()
+	})
+}
+
+func (c *mqlBicepImport) GetResolvedTypes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ResolvedTypes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.import", c.__id, "resolvedTypes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resolvedTypes()
+	})
+}
+
+func (c *mqlBicepImport) GetResolvedFunctions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ResolvedFunctions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.import", c.__id, "resolvedFunctions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resolvedFunctions()
+	})
 }
 
 // mqlBicepTemplate for the bicep.template resource

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -39,8 +39,11 @@ bicep.function.parameters 13.1.2
 bicep.function.returnType 13.1.2
 bicep.import 13.1.2
 bicep.import.namespace 13.1.2
+bicep.import.resolvedFunctions 13.1.2
+bicep.import.resolvedTypes 13.1.2
 bicep.import.source 13.1.2
 bicep.import.symbols 13.1.2
+bicep.import.targetFile 13.1.2
 bicep.import.wildcard 13.1.2
 bicep.module 13.0.0
 bicep.module.condition 13.0.0

--- a/providers/bicep/resources/importres_test.go
+++ b/providers/bicep/resources/importres_test.go
@@ -1,0 +1,203 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/bicep/connection"
+)
+
+// importResRuntime builds a runtime backed by a real BicepConnection scanning
+// the importres fixture directory, plus an in-memory resource cache so
+// CreateResource/NewResource dedupe by __id.
+func importResRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	dir := filepath.Join("testdata", "importres")
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "bicep", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewBicepConnection(0, asset, asset.Connections[0])
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &mapResources{m: map[string]plugin.Resource{}},
+	}
+}
+
+// mainImports returns all materialized imports of importres/main.bicep.
+func mainImports(t *testing.T, runtime *plugin.Runtime) []*mqlBicepImport {
+	t.Helper()
+	conn := runtime.Connection.(*connection.BicepConnection)
+	for _, f := range conn.BicepFiles() {
+		if filepath.Base(f.Path) != "main.bicep" {
+			continue
+		}
+		mqlF, err := newMqlBicepFile(runtime, f)
+		require.NoError(t, err)
+		imps, err := mqlF.imports()
+		require.NoError(t, err)
+		out := make([]*mqlBicepImport, 0, len(imps))
+		for _, imp := range imps {
+			out = append(out, imp.(*mqlBicepImport))
+		}
+		return out
+	}
+	t.Fatal("main.bicep not found")
+	return nil
+}
+
+// findImport returns the first import matching the predicate.
+func findImport(t *testing.T, imps []*mqlBicepImport, match func(*mqlBicepImport) bool) *mqlBicepImport {
+	t.Helper()
+	for _, imp := range imps {
+		if match(imp) {
+			return imp
+		}
+	}
+	t.Fatal("no matching import found")
+	return nil
+}
+
+func typeNames(t *testing.T, list []any) map[string]bool {
+	t.Helper()
+	names := map[string]bool{}
+	for _, e := range list {
+		names[e.(*mqlBicepType).Name.Data] = true
+	}
+	return names
+}
+
+func funcNames(t *testing.T, list []any) map[string]bool {
+	t.Helper()
+	names := map[string]bool{}
+	for _, e := range list {
+		names[e.(*mqlBicepFunction).Name.Data] = true
+	}
+	return names
+}
+
+func TestImportNamedResolvesTypeAndFunction(t *testing.T) {
+	runtime := importResRuntime(t)
+	imps := mainImports(t, runtime)
+
+	// The named import is `import { sku, buildName } from './shared.bicep'`.
+	named := findImport(t, imps, func(i *mqlBicepImport) bool {
+		return i.Source.Data == "./shared.bicep" && !i.Wildcard.Data
+	})
+
+	target, err := named.targetFile()
+	require.NoError(t, err)
+	require.NotNil(t, target, "named import should resolve to its target file")
+	assert.Equal(t, "shared.bicep", filepath.Base(target.Path.Data))
+
+	// Only the named type is brought in (sku), not tier.
+	types, err := named.resolvedTypes()
+	require.NoError(t, err)
+	names := typeNames(t, types)
+	assert.True(t, names["sku"], "named type sku should be resolved")
+	assert.False(t, names["tier"], "unnamed type tier must not be resolved")
+	assert.Len(t, types, 1)
+
+	// Only the named function is brought in (buildName).
+	funcs, err := named.resolvedFunctions()
+	require.NoError(t, err)
+	fnames := funcNames(t, funcs)
+	assert.True(t, fnames["buildName"], "named func buildName should be resolved")
+	assert.Len(t, funcs, 1)
+}
+
+func TestImportWildcardResolvesAll(t *testing.T) {
+	runtime := importResRuntime(t)
+	imps := mainImports(t, runtime)
+
+	// The wildcard import is `import * as shared from './shared.bicep'`.
+	wild := findImport(t, imps, func(i *mqlBicepImport) bool {
+		return i.Wildcard.Data
+	})
+	assert.Equal(t, "shared", wild.Namespace.Data)
+
+	target, err := wild.targetFile()
+	require.NoError(t, err)
+	require.NotNil(t, target, "wildcard import should resolve to its target file")
+	assert.Equal(t, "shared.bicep", filepath.Base(target.Path.Data))
+
+	// A wildcard import brings in ALL exported types and functions.
+	types, err := wild.resolvedTypes()
+	require.NoError(t, err)
+	names := typeNames(t, types)
+	assert.True(t, names["sku"])
+	assert.True(t, names["tier"])
+	assert.Len(t, types, 2)
+
+	funcs, err := wild.resolvedFunctions()
+	require.NoError(t, err)
+	fnames := funcNames(t, funcs)
+	assert.True(t, fnames["buildName"])
+	assert.Len(t, funcs, 1)
+}
+
+func TestImportProviderTargetIsNull(t *testing.T) {
+	runtime := importResRuntime(t)
+	imps := mainImports(t, runtime)
+
+	// The provider import is `import 'az@2.0.0'`.
+	prov := findImport(t, imps, func(i *mqlBicepImport) bool {
+		return i.Source.Data == "az@2.0.0"
+	})
+
+	target, err := prov.targetFile()
+	require.NoError(t, err)
+	assert.Nil(t, target, "provider import target must be null")
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, prov.TargetFile.State&(plugin.StateIsSet|plugin.StateIsNull))
+
+	types, err := prov.resolvedTypes()
+	require.NoError(t, err)
+	assert.Empty(t, types)
+
+	funcs, err := prov.resolvedFunctions()
+	require.NoError(t, err)
+	assert.Empty(t, funcs)
+}
+
+// TestImportTargetOutsideRootIsNull guards against path traversal: an import
+// whose source resolves to a real, readable .bicep OUTSIDE the scanned root
+// must still resolve to null. targetFile() only returns files the scan
+// discovered and never reads an arbitrary path, so a crafted reference can't
+// disclose out-of-root file contents via bicep.file.content.
+func TestImportTargetOutsideRootIsNull(t *testing.T) {
+	runtime := importResRuntime(t)
+
+	// Precondition: the traversal target genuinely exists and is readable, so a
+	// null result proves the read was refused by policy — not just absent.
+	outside := filepath.Join("testdata", "loops.bicep")
+	_, err := os.Stat(outside)
+	require.NoError(t, err, "fixture precondition: %s must exist", outside)
+
+	imps := mainImports(t, runtime)
+	escape := findImport(t, imps, func(i *mqlBicepImport) bool {
+		return i.Source.Data == "../loops.bicep"
+	})
+
+	target, err := escape.targetFile()
+	require.NoError(t, err)
+	assert.Nil(t, target, "out-of-root import target must be null (no arbitrary file read)")
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, escape.TargetFile.State&(plugin.StateIsSet|plugin.StateIsNull))
+
+	types, err := escape.resolvedTypes()
+	require.NoError(t, err)
+	assert.Empty(t, types)
+
+	funcs, err := escape.resolvedFunctions()
+	require.NoError(t, err)
+	assert.Empty(t, funcs)
+}

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -410,6 +410,40 @@ func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
 	return expressionTreeFor(m.MqlRuntime, m.__id, "/conditionTree", m.Condition.Data, m.resolver)
 }
 
+// resolveScannedBicepFile resolves a relative `source` (e.g. './shared.bicep')
+// declared in the file at owningFilePath to the bicep.file it references,
+// returning the SAME cached bicep.file instance the scan already discovered, or
+// nil when no in-tree file matches.
+//
+// This is the shared, security-critical resolver behind both
+// bicep.module.target() and bicep.import.targetFile(). We never read an
+// arbitrary path from disk: `source` comes from the (potentially untrusted)
+// Bicep file, so an on-demand read of the resolved path would let a crafted
+// reference (e.g. '../../../../etc/passwd') disclose arbitrary file contents
+// via bicep.file.content. The scan already loads every .bicep under the root
+// recursively, so any legitimate in-tree target — including ones reached via a
+// relative '../' path — is present in conn.BicepFiles(); anything not found
+// (out-of-root or absolute references) resolves to nil. Callers are responsible
+// for setting StateIsNull on their singular field when nil is returned.
+func resolveScannedBicepFile(runtime *plugin.Runtime, owningFilePath, source string) (*mqlBicepFile, error) {
+	if source == "" || owningFilePath == "" {
+		return nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.BicepConnection)
+	if !ok {
+		return nil, nil
+	}
+
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(owningFilePath), source))
+	for _, f := range conn.BicepFiles() {
+		if filepath.Clean(f.Path) == resolved {
+			return newMqlBicepFile(runtime, f)
+		}
+	}
+	return nil, nil
+}
+
 // target resolves a local module `source` to the bicep.file it references.
 //
 // Only local sources are resolved: a registry (`br:`) or template-spec (`ts:`)
@@ -419,8 +453,8 @@ func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
 // bicep.file is returned (reusing its __id) so the runtime serves the existing
 // instance and the caller can traverse into its resources/params/outputs. A
 // path that resolves outside the scanned root — or is otherwise unresolvable —
-// returns null; target() never reads an arbitrary path from disk (see the
-// security note at the lookup below).
+// returns null; target() never reads an arbitrary path from disk (it shares the
+// scan-only resolveScannedBicepFile helper).
 func (m *mqlBicepModule) target() (*mqlBicepFile, error) {
 	source := m.Source.Data
 	// Registry and template-spec references are not local files.
@@ -430,36 +464,16 @@ func (m *mqlBicepModule) target() (*mqlBicepFile, error) {
 		m.Target.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	if source == "" || m.owningFilePath == "" {
+
+	f, err := resolveScannedBicepFile(m.MqlRuntime, m.owningFilePath, source)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
 		m.Target.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-
-	resolved := filepath.Clean(filepath.Join(filepath.Dir(m.owningFilePath), source))
-
-	conn, ok := m.MqlRuntime.Connection.(*connection.BicepConnection)
-	if !ok {
-		m.Target.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-
-	// Resolve only to a file the scan already discovered, returning the same
-	// cached bicep.file instance. We never read an arbitrary path from disk:
-	// `source` comes from the (potentially untrusted) Bicep file, so an
-	// on-demand read of the resolved path would let a crafted module
-	// reference (e.g. '../../../../etc/passwd') disclose arbitrary file
-	// contents via bicep.file.content. The scan already loads every .bicep
-	// under the root recursively, so any legitimate in-tree target — including
-	// ones reached via a relative '../' path — is present here; anything not
-	// found (out-of-root or absolute references) resolves to null.
-	for _, f := range conn.BicepFiles() {
-		if filepath.Clean(f.Path) == resolved {
-			return newMqlBicepFile(m.MqlRuntime, f)
-		}
-	}
-
-	m.Target.State = plugin.StateIsSet | plugin.StateIsNull
-	return nil, nil
+	return f, nil
 }
 
 // mqlBicepOutputInternal carries the owning file's symbol resolver so the
@@ -537,6 +551,13 @@ func createMqlFunctions(runtime *plugin.Runtime, filePath string, functions []pa
 	return mqlFunctions, nil
 }
 
+// mqlBicepImportInternal carries the path of the file that declared this
+// import; a relative `source` is resolved against its directory by the
+// targetFile() accessor.
+type mqlBicepImportInternal struct {
+	owningFilePath string
+}
+
 func createMqlImports(runtime *plugin.Runtime, filePath string, imports []parsedImport) ([]any, error) {
 	var mqlImports []any
 	for i, imp := range imports {
@@ -554,9 +575,111 @@ func createMqlImports(runtime *plugin.Runtime, filePath string, imports []parsed
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepImport).owningFilePath = filePath
 		mqlImports = append(mqlImports, res)
 	}
 	return mqlImports, nil
+}
+
+// targetFile resolves a local import `source` to the bicep.file it pulls from.
+//
+// A bare provider import (e.g. `az@2.0.0`) is not a local file: imports never
+// set isRegistry, so a provider import is detected as one whose `source` is not
+// a relative path (it has no `./`/`../` prefix and no `.bicep` extension) — it
+// resolves to null. Otherwise the relative source is resolved against the
+// declaring file's directory via the shared scan-only resolver: only a file the
+// scan already discovered is returned (the same cached bicep.file instance),
+// and an out-of-root or otherwise unresolvable path returns null. The resolved
+// path is never read directly from disk.
+func (i *mqlBicepImport) targetFile() (*mqlBicepFile, error) {
+	source := i.Source.Data
+
+	// A provider import like `az@2.0.0` is not a relative local file path.
+	isRelative := strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../")
+	if !isRelative || !strings.HasSuffix(source, ".bicep") {
+		i.TargetFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	f, err := resolveScannedBicepFile(i.MqlRuntime, i.owningFilePath, source)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		i.TargetFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return f, nil
+}
+
+// resolvedTypes returns the user-defined types this import brings in from its
+// target file: the named subset (filtered by `symbols`) for a named import, or
+// all of the target file's types for a wildcard import. Empty when there is no
+// resolvable target file.
+func (i *mqlBicepImport) resolvedTypes() ([]any, error) {
+	target, err := i.targetFile()
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return []any{}, nil
+	}
+	all, err := target.types()
+	if err != nil {
+		return nil, err
+	}
+	if i.Wildcard.Data {
+		return all, nil
+	}
+	wanted := importSymbolSet(i.Symbols.Data)
+	out := make([]any, 0, len(all))
+	for _, t := range all {
+		if wanted[t.(*mqlBicepType).Name.Data] {
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
+// resolvedFunctions returns the user-defined functions this import brings in
+// from its target file: the named subset (filtered by `symbols`) for a named
+// import, or all of the target file's functions for a wildcard import. Empty
+// when there is no resolvable target file.
+func (i *mqlBicepImport) resolvedFunctions() ([]any, error) {
+	target, err := i.targetFile()
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return []any{}, nil
+	}
+	all, err := target.functions()
+	if err != nil {
+		return nil, err
+	}
+	if i.Wildcard.Data {
+		return all, nil
+	}
+	wanted := importSymbolSet(i.Symbols.Data)
+	out := make([]any, 0, len(all))
+	for _, fn := range all {
+		if wanted[fn.(*mqlBicepFunction).Name.Data] {
+			out = append(out, fn)
+		}
+	}
+	return out, nil
+}
+
+// importSymbolSet turns the `symbols` list (an []any of strings) into a lookup
+// set for filtering a target file's types/functions on a named import.
+func importSymbolSet(symbols []any) map[string]bool {
+	set := make(map[string]bool, len(symbols))
+	for _, s := range symbols {
+		if name, ok := s.(string); ok {
+			set[name] = true
+		}
+	}
+	return set
 }
 
 // addLoopArgs sets the four flattened `for`-loop fields shared by

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -612,12 +612,24 @@ func (i *mqlBicepImport) targetFile() (*mqlBicepFile, error) {
 	return f, nil
 }
 
+// cachedTargetFile reads the resolved target file through the generated
+// GetTargetFile getter so resolvedTypes() and resolvedFunctions() share a
+// single resolution (and its connection scan) instead of each re-running
+// targetFile().
+func (i *mqlBicepImport) cachedTargetFile() (*mqlBicepFile, error) {
+	tv := i.GetTargetFile()
+	if tv.Error != nil {
+		return nil, tv.Error
+	}
+	return tv.Data, nil
+}
+
 // resolvedTypes returns the user-defined types this import brings in from its
 // target file: the named subset (filtered by `symbols`) for a named import, or
 // all of the target file's types for a wildcard import. Empty when there is no
 // resolvable target file.
 func (i *mqlBicepImport) resolvedTypes() ([]any, error) {
-	target, err := i.targetFile()
+	target, err := i.cachedTargetFile()
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +658,7 @@ func (i *mqlBicepImport) resolvedTypes() ([]any, error) {
 // import, or all of the target file's functions for a wildcard import. Empty
 // when there is no resolvable target file.
 func (i *mqlBicepImport) resolvedFunctions() ([]any, error) {
-	target, err := i.targetFile()
+	target, err := i.cachedTargetFile()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/bicep/resources/testdata/importres/main.bicep
+++ b/providers/bicep/resources/testdata/importres/main.bicep
@@ -1,0 +1,18 @@
+// Parent template exercising the three import forms.
+
+// Named import: pulls one of shared.bicep's types and its function.
+import { sku, buildName } from './shared.bicep'
+
+// Wildcard import: pulls everything shared.bicep exports under an alias.
+import * as shared from './shared.bicep'
+
+// Provider import: bare provider string, no local target file.
+import 'az@2.0.0'
+
+// Path-traversal import: points at a real, readable .bicep OUTSIDE the
+// scanned root. targetFile() must be null — the provider only resolves to
+// files the scan discovered and never reads an arbitrary path.
+import { sku as escapeSku } from '../loops.bicep'
+
+@description('Deployment location')
+param location string = 'westeurope'

--- a/providers/bicep/resources/testdata/importres/shared.bicep
+++ b/providers/bicep/resources/testdata/importres/shared.bicep
@@ -1,0 +1,10 @@
+// Shared library exporting two types and a function, imported by main.bicep.
+
+@export()
+type sku = 'Standard_LRS' | 'Premium_LRS'
+
+@export()
+type tier = 'hot' | 'cool' | 'archive'
+
+@export()
+func buildName(prefix string, suffix string) string => '${prefix}-${suffix}'


### PR DESCRIPTION
This is the final PR in the bicep "navigable graph" series. It adds the import side of the cross-file graph, mirroring the local-file module resolution already on `main`.

## What's added — on `bicep.import`

- **`targetFile() bicep.file`** — the local Bicep file the import pulls from. Resolves a relative `source` (e.g. `./shared.bicep`) against the declaring file's directory. A bare provider import (`az@2.0.0`), an out-of-root path, or any unresolvable path returns null.
- **`resolvedTypes() []bicep.type`** — the user-defined types the import brings in. For a named import, the subset of the target file's types whose name is in `symbols`; for a wildcard import (`* as ns`), all of them. Empty when there's no resolvable target.
- **`resolvedFunctions() []bicep.function`** — same logic, for the target file's functions.

## Shared safe resolution (no arbitrary reads)

The scan-only resolution is factored out of `module.target()` into a shared `resolveScannedBicepFile()` helper, now called by **both** `module.target()` and `import.targetFile()`. It resolves only to files the scan already discovered (returning the same cached `bicep.file`) and **never reads an arbitrary path from disk** — so a crafted import like `import { x } from '../../etc/passwd'` can't disclose out-of-root file contents via `bicep.file.content`. Factoring it into one helper keeps the security property from drifting between the module and import code paths.

## Tests

New `importres` fixture (`shared.bicep` exporting two `@export()` types + a function; `main.bicep` with named, wildcard, provider, and path-traversal imports) drives:
- named import resolves `targetFile` + exactly the named type/func
- wildcard import resolves all types/funcs
- provider import → null target, empty lists
- out-of-root import → null target, empty lists (security regression test, mirrors `TestModuleTargetOutsideRootIsNull`; stats the out-of-root file first to prove refusal, not absence)

Existing `moduleres` tests pass unchanged after the shared-helper refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)