### PR TITLE
✨ bicep: model ARM resource condition, copy loops, and linked deployments

### DIFF
--- a/providers/bicep/resources/arm_template.go
+++ b/providers/bicep/resources/arm_template.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -251,11 +252,23 @@ func (t *mqlBicepTemplate) resources() ([]any, error) {
 	return mqlResources, nil
 }
 
+// mqlBicepTemplateResourceInternal caches what the lazy linkedTemplate()
+// accessor needs: the inline nested ARM template parsed from a
+// `Microsoft.Resources/deployments` resource's `properties.template`, plus the
+// synthetic id used to build a non-colliding `bicep.template` for it. Both are
+// nil/empty for resources that carry no inline nested template (ordinary
+// resources, or deployments that use an external `templateLink`).
+type mqlBicepTemplateResourceInternal struct {
+	linkedTmpl   *connection.ARMTemplate
+	linkedTmplID string
+}
+
 func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, index int, obj map[string]any) (*mqlBicepTemplateResource, error) {
 	typ, _ := obj["type"].(string)
 	apiVersion, _ := obj["apiVersion"].(string)
 	name, _ := obj["name"].(string)
 	location, _ := obj["location"].(string)
+	condition, _ := obj["condition"].(string)
 
 	var dependsOn []any
 	if deps, ok := obj["dependsOn"].([]any); ok {
@@ -263,6 +276,23 @@ func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, i
 			if s, ok := d.(string); ok {
 				dependsOn = append(dependsOn, s)
 			}
+		}
+	}
+
+	// ARM `copy` iteration block: { name, count, mode, batchSize }. count may
+	// be an int or an ARM expression string, so it's surfaced as a dict.
+	var copyName, copyMode string
+	var copyCount any
+	var copyBatchSize *int64
+	if copy, ok := obj["copy"].(map[string]any); ok {
+		copyName, _ = copy["name"].(string)
+		copyMode, _ = copy["mode"].(string)
+		// count is already a decoded JSON value (a float64 for a literal int
+		// or a string for an ARM expression); surface it as-is in the dict.
+		copyCount = copy["count"]
+		if bs, ok := copy["batchSize"].(float64); ok {
+			v := int64(bs)
+			copyBatchSize = &v
 		}
 	}
 
@@ -276,20 +306,76 @@ func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, i
 	}
 
 	id := "bicep.template.resource:" + templatePath + ":" + typ + ":" + name + ":" + strconv.Itoa(index)
+
+	// Extract an inline nested deployment template, if any. Only a
+	// `Microsoft.Resources/deployments` resource whose `properties.template`
+	// is an inline ARM template is resolvable offline; an external
+	// `templateLink` is not.
+	linkedTmpl := extractInlineTemplate(typ, obj)
+
 	res, err := CreateResource(runtime, "bicep.template.resource", map[string]*llx.RawData{
-		"__id":       llx.StringData(id),
-		"type":       llx.StringData(typ),
-		"apiVersion": llx.StringData(apiVersion),
-		"name":       llx.StringData(name),
-		"location":   llx.StringData(location),
-		"properties": llx.DictData(properties),
-		"dependsOn":  llx.ArrayData(dependsOn, types.String),
-		"manifest":   llx.DictData(manifest),
+		"__id":          llx.StringData(id),
+		"type":          llx.StringData(typ),
+		"apiVersion":    llx.StringData(apiVersion),
+		"name":          llx.StringData(name),
+		"location":      llx.StringData(location),
+		"condition":     llx.StringData(condition),
+		"copyName":      llx.StringData(copyName),
+		"copyCount":     llx.DictData(copyCount),
+		"copyMode":      llx.StringData(copyMode),
+		"copyBatchSize": llx.IntDataPtr(copyBatchSize),
+		"properties":    llx.DictData(properties),
+		"dependsOn":     llx.ArrayData(dependsOn, types.String),
+		"manifest":      llx.DictData(manifest),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlBicepTemplateResource), nil
+	mqlRes := res.(*mqlBicepTemplateResource)
+	mqlRes.linkedTmpl = linkedTmpl
+	mqlRes.linkedTmplID = id + "/linkedTemplate"
+	return mqlRes, nil
+}
+
+// extractInlineTemplate returns the inline nested ARM template carried by a
+// `Microsoft.Resources/deployments` resource's `properties.template`, or nil
+// for non-deployment resources, external `templateLink` deployments, and
+// deployments with no inline template.
+func extractInlineTemplate(typ string, obj map[string]any) *connection.ARMTemplate {
+	if !strings.EqualFold(typ, "Microsoft.Resources/deployments") {
+		return nil
+	}
+	props, ok := obj["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	inline, ok := props["template"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, err := json.Marshal(inline)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to re-marshal inline nested ARM template")
+		return nil
+	}
+	var tmpl connection.ARMTemplate
+	if err := json.Unmarshal(raw, &tmpl); err != nil {
+		log.Warn().Err(err).Msg("failed to unmarshal inline nested ARM template")
+		return nil
+	}
+	return &tmpl
+}
+
+// linkedTemplate resolves an inline nested deployment template into a
+// bicep.template so its parameters/variables/resources/outputs can be
+// traversed. It is null for an external templateLink deployment, a
+// non-deployment resource, and a deployment with no inline template.
+func (a *mqlBicepTemplateResource) linkedTemplate() (*mqlBicepTemplate, error) {
+	if a.linkedTmpl == nil {
+		a.LinkedTemplate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return newMqlBicepTemplate(a.MqlRuntime, a.linkedTmplID, a.linkedTmpl)
 }
 
 // sortedKeys returns the keys of a raw-message map in ascending order so

--- a/providers/bicep/resources/armtemplate_test.go
+++ b/providers/bicep/resources/armtemplate_test.go
@@ -100,6 +100,99 @@ func TestARMTemplateResources(t *testing.T) {
 
 	resources, err := tmpl.resources()
 	require.NoError(t, err)
-	require.Len(t, resources, 1)
+	require.Len(t, resources, 5)
 	assert.Equal(t, "Microsoft.Storage/storageAccounts", resources[0].(*mqlBicepTemplateResource).Type.Data)
+}
+
+// armResourceByName indexes the materialized template resources by their
+// (resolved) name so each construct-specific assertion can fetch the one it
+// cares about regardless of slice order.
+func armResourceByName(t *testing.T, runtime *plugin.Runtime) map[string]*mqlBicepTemplateResource {
+	t.Helper()
+	tmpl := armTemplate(t, runtime)
+	resources, err := tmpl.resources()
+	require.NoError(t, err)
+	byName := make(map[string]*mqlBicepTemplateResource, len(resources))
+	for _, r := range resources {
+		res := r.(*mqlBicepTemplateResource)
+		byName[res.Name.Data] = res
+	}
+	return byName
+}
+
+func TestARMTemplateResourceCondition(t *testing.T) {
+	runtime := armTemplateRuntime(t)
+	byName := armResourceByName(t, runtime)
+
+	cond := byName["conditionalPip"]
+	require.NotNil(t, cond)
+	assert.Equal(t, "[greater(parameters('instanceCount'), 0)]", cond.Condition.Data)
+
+	// An ordinary resource carries no condition.
+	assert.Empty(t, byName["[variables('storageName')]"].Condition.Data)
+}
+
+func TestARMTemplateResourceCopy(t *testing.T) {
+	runtime := armTemplateRuntime(t)
+	byName := armResourceByName(t, runtime)
+
+	// The copy resource's name resolves at deploy time, so look it up by the
+	// raw concat expression.
+	var copyRes *mqlBicepTemplateResource
+	for _, r := range byName {
+		if r.CopyName.Data == "nicLoop" {
+			copyRes = r
+			break
+		}
+	}
+	require.NotNil(t, copyRes)
+	assert.Equal(t, "nicLoop", copyRes.CopyName.Data)
+	assert.Equal(t, "[parameters('instanceCount')]", copyRes.CopyCount.Data)
+	assert.Equal(t, "Serial", copyRes.CopyMode.Data)
+	assert.Equal(t, int64(2), copyRes.CopyBatchSize.Data)
+
+	// A non-copy resource has empty/null copy fields.
+	ordinary := byName["[variables('storageName')]"]
+	assert.Empty(t, ordinary.CopyName.Data)
+	assert.Empty(t, ordinary.CopyMode.Data)
+	assert.Nil(t, ordinary.CopyCount.Data)
+	assert.Equal(t, int64(0), ordinary.CopyBatchSize.Data)
+	assert.True(t, ordinary.CopyBatchSize.State&plugin.StateIsNull != 0, "absent batchSize must be null")
+}
+
+func TestARMTemplateResourceLinkedTemplate(t *testing.T) {
+	runtime := armTemplateRuntime(t)
+	byName := armResourceByName(t, runtime)
+
+	// Inline nested deployment resolves to a traversable bicep.template.
+	inline := byName["inlineNested"]
+	require.NotNil(t, inline)
+	linked, err := inline.linkedTemplate()
+	require.NoError(t, err)
+	require.NotNil(t, linked)
+
+	params, err := linked.parameters()
+	require.NoError(t, err)
+	require.Len(t, params, 1)
+	assert.Equal(t, "nestedName", params[0].(*mqlBicepTemplateParameter).Name.Data)
+
+	nestedResources, err := linked.resources()
+	require.NoError(t, err)
+	require.Len(t, nestedResources, 1)
+	assert.Equal(t, "Microsoft.Storage/storageAccounts", nestedResources[0].(*mqlBicepTemplateResource).Type.Data)
+
+	// External templateLink deployment is not resolvable offline -> null.
+	external := byName["externalLinked"]
+	require.NotNil(t, external)
+	linkedExt, err := external.linkedTemplate()
+	require.NoError(t, err)
+	assert.Nil(t, linkedExt)
+	assert.True(t, external.LinkedTemplate.State&plugin.StateIsNull != 0, "templateLink linkedTemplate must be null")
+
+	// An ordinary (non-deployment) resource has a null linkedTemplate.
+	ordinary := byName["[variables('storageName')]"]
+	linkedOrd, err := ordinary.linkedTemplate()
+	require.NoError(t, err)
+	assert.Nil(t, linkedOrd)
+	assert.True(t, ordinary.LinkedTemplate.State&plugin.StateIsNull != 0)
 }

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -604,6 +604,24 @@ bicep.template.resource @defaults("type name") {
   properties dict
   // Dependencies
   dependsOn []string
+  // ARM deployment condition expression; empty when the resource is unconditional
+  condition string
+  // Name of the ARM `copy` iteration block; empty when the resource is not copied
+  copyName string
+  // Iteration count of the ARM `copy` block (an int or an ARM expression); null when not a copy loop
+  copyCount dict
+  // Iteration mode of the ARM `copy` block: "Serial" or "Parallel"; empty when not a copy loop or unspecified
+  copyMode string
+  // Batch size for a Serial `copy` loop; null when not set
+  copyBatchSize int
+  // Inline nested deployment template
+  //
+  // For a `Microsoft.Resources/deployments` resource whose `properties.template`
+  // is an inline ARM template, returns that template as a `bicep.template` so you
+  // can traverse its parameters/variables/resources/outputs. Null for an external
+  // `templateLink` deployment (not resolvable offline) and for non-deployment
+  // resources.
+  linkedTemplate() bicep.template
   // Full manifest
   manifest dict
 }

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -591,6 +591,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.template.resource.dependsOn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetDependsOn()).ToDataRes(types.Array(types.String))
 	},
+	"bicep.template.resource.condition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetCondition()).ToDataRes(types.String)
+	},
+	"bicep.template.resource.copyName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetCopyName()).ToDataRes(types.String)
+	},
+	"bicep.template.resource.copyCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetCopyCount()).ToDataRes(types.Dict)
+	},
+	"bicep.template.resource.copyMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetCopyMode()).ToDataRes(types.String)
+	},
+	"bicep.template.resource.copyBatchSize": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetCopyBatchSize()).ToDataRes(types.Int)
+	},
+	"bicep.template.resource.linkedTemplate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetLinkedTemplate()).ToDataRes(types.Resource("bicep.template"))
+	},
 	"bicep.template.resource.manifest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetManifest()).ToDataRes(types.Dict)
 	},
@@ -1224,6 +1242,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.template.resource.dependsOn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepTemplateResource).DependsOn, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.copyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).CopyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.copyCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).CopyCount, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.copyMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).CopyMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.copyBatchSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).CopyBatchSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.linkedTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).LinkedTemplate, ok = plugin.RawToTValue[*mqlBicepTemplate](v.Value, v.Error)
 		return
 	},
 	"bicep.template.resource.manifest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2971,14 +3013,20 @@ func (c *mqlBicepTemplateOutput) GetValue() *plugin.TValue[any] {
 type mqlBicepTemplateResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepTemplateResourceInternal it will be used here
-	Type       plugin.TValue[string]
-	ApiVersion plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Location   plugin.TValue[string]
-	Properties plugin.TValue[any]
-	DependsOn  plugin.TValue[[]any]
-	Manifest   plugin.TValue[any]
+	mqlBicepTemplateResourceInternal
+	Type           plugin.TValue[string]
+	ApiVersion     plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Location       plugin.TValue[string]
+	Properties     plugin.TValue[any]
+	DependsOn      plugin.TValue[[]any]
+	Condition      plugin.TValue[string]
+	CopyName       plugin.TValue[string]
+	CopyCount      plugin.TValue[any]
+	CopyMode       plugin.TValue[string]
+	CopyBatchSize  plugin.TValue[int64]
+	LinkedTemplate plugin.TValue[*mqlBicepTemplate]
+	Manifest       plugin.TValue[any]
 }
 
 // createBicepTemplateResource creates a new instance of this resource
@@ -3035,6 +3083,42 @@ func (c *mqlBicepTemplateResource) GetProperties() *plugin.TValue[any] {
 
 func (c *mqlBicepTemplateResource) GetDependsOn() *plugin.TValue[[]any] {
 	return &c.DependsOn
+}
+
+func (c *mqlBicepTemplateResource) GetCondition() *plugin.TValue[string] {
+	return &c.Condition
+}
+
+func (c *mqlBicepTemplateResource) GetCopyName() *plugin.TValue[string] {
+	return &c.CopyName
+}
+
+func (c *mqlBicepTemplateResource) GetCopyCount() *plugin.TValue[any] {
+	return &c.CopyCount
+}
+
+func (c *mqlBicepTemplateResource) GetCopyMode() *plugin.TValue[string] {
+	return &c.CopyMode
+}
+
+func (c *mqlBicepTemplateResource) GetCopyBatchSize() *plugin.TValue[int64] {
+	return &c.CopyBatchSize
+}
+
+func (c *mqlBicepTemplateResource) GetLinkedTemplate() *plugin.TValue[*mqlBicepTemplate] {
+	return plugin.GetOrCompute[*mqlBicepTemplate](&c.LinkedTemplate, func() (*mqlBicepTemplate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.template.resource", c.__id, "linkedTemplate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepTemplate), nil
+			}
+		}
+
+		return c.linkedTemplate()
+	})
 }
 
 func (c *mqlBicepTemplateResource) GetManifest() *plugin.TValue[any] {

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -129,7 +129,13 @@ bicep.template.parameter.type 13.1.2
 bicep.template.parameters 13.0.0
 bicep.template.resource 13.0.0
 bicep.template.resource.apiVersion 13.0.0
+bicep.template.resource.condition 13.1.2
+bicep.template.resource.copyBatchSize 13.1.2
+bicep.template.resource.copyCount 13.1.2
+bicep.template.resource.copyMode 13.1.2
+bicep.template.resource.copyName 13.1.2
 bicep.template.resource.dependsOn 13.0.0
+bicep.template.resource.linkedTemplate 13.1.2
 bicep.template.resource.location 13.0.0
 bicep.template.resource.manifest 13.0.0
 bicep.template.resource.name 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -727,4 +727,5 @@ var (
 	_ plugin.Resource = (*mqlBicepTemplateParameter)(nil)
 	_ plugin.Resource = (*mqlBicepTemplateVariable)(nil)
 	_ plugin.Resource = (*mqlBicepTemplateOutput)(nil)
+	_ plugin.Resource = (*mqlBicepTemplateResource)(nil)
 )

--- a/providers/bicep/resources/testdata/armtemplate/azuredeploy.json
+++ b/providers/bicep/resources/testdata/armtemplate/azuredeploy.json
@@ -31,6 +31,64 @@
       },
       "kind": "StorageV2",
       "properties": {}
+    },
+    {
+      "condition": "[greater(parameters('instanceCount'), 0)]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2023-05-01",
+      "name": "conditionalPip",
+      "location": "eastus",
+      "properties": {}
+    },
+    {
+      "copy": {
+        "name": "nicLoop",
+        "count": "[parameters('instanceCount')]",
+        "mode": "Serial",
+        "batchSize": 2
+      },
+      "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2023-05-01",
+      "name": "[concat('nic-', copyIndex())]",
+      "location": "eastus",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "inlineNested",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "nestedName": {
+              "type": "string"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-01-01",
+              "name": "[parameters('nestedName')]",
+              "location": "eastus",
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "externalLinked",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "https://example.com/nested/azuredeploy.json"
+        }
+      }
     }
   ],
   "outputs": {


### PR DESCRIPTION
Enriches `bicep.template.resource` (a resource in the compiled ARM JSON) with the ARM-level constructs it was previously missing. All fields are additive.

## Three constructs

- **`condition`** — the per-resource deployment `condition` expression; empty when the resource is unconditional.
- **ARM `copy` iteration block** — `copyName`, `copyCount`, `copyMode`, `copyBatchSize`. `copyCount` is a `dict` because ARM allows an int **or** an expression string; `copyBatchSize` is a nullable int (absent → null, not `0`).
- **`linkedTemplate()`** — for a `Microsoft.Resources/deployments` resource whose `properties.template` is an **inline** ARM template, returns that template as a `bicep.template` so its parameters/variables/resources/outputs can be traversed. It resolves **inline nested templates only**: an external `templateLink` deployment is not resolvable offline and returns null, as do non-deployment resources and deployments with no inline template.

The inline nested template is unmarshaled into the same `connection.ARMTemplate` struct the top-level template uses and built via `newMqlBicepTemplate` with a parent-qualified synthetic `__id` (`<resourceId>/linkedTemplate`).

## Stacking

This is PR B2 of "deepen the compiled-ARM model". It stacks on #8026 (B1, retyped template params/vars/outputs), which squash-merged into `main` before this branch was pushed — so this branch was rebased onto `main` and targets `main`.

## Tests

The ARM fixture (`testdata/armtemplate/azuredeploy.json`) gains: a resource with a `condition`; a `copy` resource (name + count + mode + batchSize); an inline `Microsoft.Resources/deployments` with a minimal nested template (one parameter + one resource); and an external `templateLink` deployment. New fixture-driven tests assert each construct is captured, that `linkedTemplate()` resolves the inline template (reaching its `parameters()`/`resources()`), and that it is null for the templateLink and ordinary resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)