### PR TITLE
🎉 aws-13.29.0, gcp-13.19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 /lr
 /mql
 mqlr

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.28.0",
+	Version:         "13.29.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.18.0",
+	Version: "13.19.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Minor version bump for the **aws** and **gcp** providers, plus a small repo housekeeping change.

## Changes
- Bump `aws` provider `13.28.0` → `13.29.0` (minor)
- Bump `gcp` provider `13.18.0` → `13.19.0` (minor)
- Add `*.swp` to `.gitignore` (vim swap files)

## Changelog

### aws 13.28.0 → 13.29.0
- ✨ aws: expose AWS Backup malware scan jobs and rule scan actions (#8020)
- Update AWS provider deps to the latest (#8018)
- ✨ aws: discover Lake Formation settings, permissions, and resources (#7994)
- ✨ aws: discover CloudHSM clusters, HSMs, and backups (#7990)
- ✨ aws: discover SES email identities and configuration sets (#7987)

### gcp 13.18.0 → 13.19.0
- ✨ gcp: round-2 security resources & fields (liens, tags, DNS response policies, GKE/secret hardening) (#8024)
- ✨ gcp: expose additional security-relevant fields across the provider (#8012)
- ✨ gcp: discover cloud domains registrations (#7993)
- 🧹 permissions: make GCP/Azure manifest dedup deterministic (#7996)
- ✨ gcp: discover workflows (#7995)
- ✨ gcp: discover dataplex lakes, zones & assets (#7991)

🤖 Generated with [Claude Code](https://claude.com/claude-code)