### PR TITLE
✨ bicep: expose expression trees for resource property and module param values

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -217,6 +217,19 @@ bicep.resource @defaults("type symbolicName") {
   resources() []bicep.resource
   // Resource body as dict
   properties dict
+  // Flattened expression trees of every scalar property leaf
+  //
+  // Walks the `properties` object and emits one entry per scalar leaf, each
+  // carrying the dotted/indexed `path` to the value (for example
+  // `encryption.keyVaultProperties.keyName` or `ipRules[0].action`) and a
+  // parsed `expression` tree with full symbol resolution. Use it to ask, for
+  // any property at any depth, whether a value hardcodes a literal, reads a
+  // `@secure` parameter, references another resource, or calls a Bicep
+  // function — without manually digging through the nested `properties` dict.
+  // Nested objects and arrays are descended into rather than emitted; every
+  // leaf (string, number, or boolean) becomes one entry. See
+  // `bicep.propertyExpression`.
+  propertyExpressions() []bicep.propertyExpression
   // Resource tags
   //
   // Key/value pairs from the `tags: { ... }` block in the resource body.
@@ -274,6 +287,18 @@ bicep.module @defaults("name source") {
   scopeTree() bicep.expression
   // Parameter values as dict
   params dict
+  // Flattened expression trees of every scalar param leaf
+  //
+  // Walks the `params` object passed to the module and emits one entry per
+  // scalar leaf, each carrying the dotted/indexed `path` to the value and a
+  // parsed `expression` tree with full symbol resolution. Use it to ask which
+  // arguments a module is fed — whether a param value hardcodes a literal,
+  // forwards a `@secure` parameter, references another resource, or calls a
+  // Bicep function — without manually digging through the nested `params`
+  // dict. Nested objects and arrays are descended into rather than emitted;
+  // every leaf (string, number, or boolean) becomes one entry. See
+  // `bicep.propertyExpression`.
+  paramExpressions() []bicep.propertyExpression
   // Condition expression
   condition string
   // Parsed condition expression tree
@@ -409,6 +434,32 @@ bicep.expression @defaults("kind raw") {
   // Non-null only when `referenceKind` is type; the other referenced*()
   // accessors are null in that case.
   referencedType() bicep.type
+}
+
+// Scalar leaf inside a resource's properties or a module's params
+//
+// Examine a single value buried inside a resource's `properties` object or a
+// module's `params` object, flattened out of the nested dict so it can be
+// queried directly. The `path` field is the dotted/indexed location of the
+// value within the object — for example `encryption.keyVaultProperties.keyName`
+// or `ipRules[0].action` — and `expression` is the parsed expression tree of
+// the value at that path, carrying full symbol resolution (`referenceKind`,
+// `referencedParameter`, …). Emitted by `bicep.resource.propertyExpressions`
+// and `bicep.module.paramExpressions`, one per scalar leaf, in a stable order
+// (map keys sorted, array indices preserved). See `bicep.expression`.
+private bicep.propertyExpression @defaults("path") {
+  // Dotted/indexed path to the value within the object
+  //
+  // For example `encryption.keyVaultProperties.keyName` for a nested object key
+  // or `ipRules[0].action` for an array element.
+  path string
+  // Parsed expression tree of the value at `path`
+  //
+  // Structured, queryable view of the leaf value with symbol resolution
+  // (`referenceKind` / `referencedParameter` / …). Use it to ask whether the
+  // value hardcodes a literal, reads a `@secure` parameter, references another
+  // resource, or calls a Bicep function. See `bicep.expression`.
+  expression() bicep.expression
 }
 
 // Bicep user-defined type declaration

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -15,23 +15,24 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceBicep                  string = "bicep"
-	ResourceBicepFile              string = "bicep.file"
-	ResourceBicepParamFile         string = "bicep.paramFile"
-	ResourceBicepParameter         string = "bicep.parameter"
-	ResourceBicepVariable          string = "bicep.variable"
-	ResourceBicepResource          string = "bicep.resource"
-	ResourceBicepModule            string = "bicep.module"
-	ResourceBicepOutput            string = "bicep.output"
-	ResourceBicepExpression        string = "bicep.expression"
-	ResourceBicepType              string = "bicep.type"
-	ResourceBicepFunction          string = "bicep.function"
-	ResourceBicepImport            string = "bicep.import"
-	ResourceBicepTemplate          string = "bicep.template"
-	ResourceBicepTemplateParameter string = "bicep.template.parameter"
-	ResourceBicepTemplateVariable  string = "bicep.template.variable"
-	ResourceBicepTemplateOutput    string = "bicep.template.output"
-	ResourceBicepTemplateResource  string = "bicep.template.resource"
+	ResourceBicep                   string = "bicep"
+	ResourceBicepFile               string = "bicep.file"
+	ResourceBicepParamFile          string = "bicep.paramFile"
+	ResourceBicepParameter          string = "bicep.parameter"
+	ResourceBicepVariable           string = "bicep.variable"
+	ResourceBicepResource           string = "bicep.resource"
+	ResourceBicepModule             string = "bicep.module"
+	ResourceBicepOutput             string = "bicep.output"
+	ResourceBicepExpression         string = "bicep.expression"
+	ResourceBicepPropertyExpression string = "bicep.propertyExpression"
+	ResourceBicepType               string = "bicep.type"
+	ResourceBicepFunction           string = "bicep.function"
+	ResourceBicepImport             string = "bicep.import"
+	ResourceBicepTemplate           string = "bicep.template"
+	ResourceBicepTemplateParameter  string = "bicep.template.parameter"
+	ResourceBicepTemplateVariable   string = "bicep.template.variable"
+	ResourceBicepTemplateOutput     string = "bicep.template.output"
+	ResourceBicepTemplateResource   string = "bicep.template.resource"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -73,6 +74,10 @@ func init() {
 		"bicep.expression": {
 			// to override args, implement: initBicepExpression(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createBicepExpression,
+		},
+		"bicep.propertyExpression": {
+			// to override args, implement: initBicepPropertyExpression(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createBicepPropertyExpression,
 		},
 		"bicep.type": {
 			// to override args, implement: initBicepType(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -333,6 +338,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetProperties()).ToDataRes(types.Dict)
 	},
+	"bicep.resource.propertyExpressions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetPropertyExpressions()).ToDataRes(types.Array(types.Resource("bicep.propertyExpression")))
+	},
 	"bicep.resource.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -371,6 +379,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.module.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetParams()).ToDataRes(types.Dict)
+	},
+	"bicep.module.paramExpressions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetParamExpressions()).ToDataRes(types.Array(types.Resource("bicep.propertyExpression")))
 	},
 	"bicep.module.condition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetCondition()).ToDataRes(types.String)
@@ -467,6 +478,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.expression.referencedType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepExpression).GetReferencedType()).ToDataRes(types.Resource("bicep.type"))
+	},
+	"bicep.propertyExpression.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepPropertyExpression).GetPath()).ToDataRes(types.String)
+	},
+	"bicep.propertyExpression.expression": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepPropertyExpression).GetExpression()).ToDataRes(types.Resource("bicep.expression"))
 	},
 	"bicep.type.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepType).GetName()).ToDataRes(types.String)
@@ -856,6 +873,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepResource).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"bicep.resource.propertyExpressions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).PropertyExpressions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"bicep.resource.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -910,6 +931,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.module.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepModule).Params, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"bicep.module.paramExpressions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).ParamExpressions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.module.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1046,6 +1071,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.expression.referencedType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepExpression).ReferencedType, ok = plugin.RawToTValue[*mqlBicepType](v.Value, v.Error)
+		return
+	},
+	"bicep.propertyExpression.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepPropertyExpression).__id, ok = v.Value.(string)
+		return
+	},
+	"bicep.propertyExpression.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepPropertyExpression).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.propertyExpression.expression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepPropertyExpression).Expression, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
 		return
 	},
 	"bicep.type.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1840,27 +1877,28 @@ type mqlBicepResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlBicepResourceInternal
-	SymbolicName   plugin.TValue[string]
-	Type           plugin.TValue[string]
-	ApiVersion     plugin.TValue[string]
-	Name           plugin.TValue[string]
-	NameTree       plugin.TValue[*mqlBicepExpression]
-	Location       plugin.TValue[string]
-	LocationTree   plugin.TValue[*mqlBicepExpression]
-	Existing       plugin.TValue[bool]
-	Condition      plugin.TValue[string]
-	ConditionTree  plugin.TValue[*mqlBicepExpression]
-	Parent         plugin.TValue[string]
-	Scope          plugin.TValue[string]
-	Resources      plugin.TValue[[]any]
-	Properties     plugin.TValue[any]
-	Tags           plugin.TValue[map[string]any]
-	DependsOn      plugin.TValue[[]any]
-	Decorators     plugin.TValue[[]any]
-	IsLoop         plugin.TValue[bool]
-	LoopIterator   plugin.TValue[string]
-	LoopIndexVar   plugin.TValue[string]
-	LoopExpression plugin.TValue[string]
+	SymbolicName        plugin.TValue[string]
+	Type                plugin.TValue[string]
+	ApiVersion          plugin.TValue[string]
+	Name                plugin.TValue[string]
+	NameTree            plugin.TValue[*mqlBicepExpression]
+	Location            plugin.TValue[string]
+	LocationTree        plugin.TValue[*mqlBicepExpression]
+	Existing            plugin.TValue[bool]
+	Condition           plugin.TValue[string]
+	ConditionTree       plugin.TValue[*mqlBicepExpression]
+	Parent              plugin.TValue[string]
+	Scope               plugin.TValue[string]
+	Resources           plugin.TValue[[]any]
+	Properties          plugin.TValue[any]
+	PropertyExpressions plugin.TValue[[]any]
+	Tags                plugin.TValue[map[string]any]
+	DependsOn           plugin.TValue[[]any]
+	Decorators          plugin.TValue[[]any]
+	IsLoop              plugin.TValue[bool]
+	LoopIterator        plugin.TValue[string]
+	LoopIndexVar        plugin.TValue[string]
+	LoopExpression      plugin.TValue[string]
 }
 
 // createBicepResource creates a new instance of this resource
@@ -1999,6 +2037,22 @@ func (c *mqlBicepResource) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
 }
 
+func (c *mqlBicepResource) GetPropertyExpressions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PropertyExpressions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "propertyExpressions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.propertyExpressions()
+	})
+}
+
 func (c *mqlBicepResource) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
 }
@@ -2032,22 +2086,23 @@ type mqlBicepModule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlBicepModuleInternal
-	Name           plugin.TValue[string]
-	Source         plugin.TValue[string]
-	Target         plugin.TValue[*mqlBicepFile]
-	Scope          plugin.TValue[string]
-	ScopeTree      plugin.TValue[*mqlBicepExpression]
-	Params         plugin.TValue[any]
-	Condition      plugin.TValue[string]
-	ConditionTree  plugin.TValue[*mqlBicepExpression]
-	IsRegistry     plugin.TValue[bool]
-	IsTemplateSpec plugin.TValue[bool]
-	Description    plugin.TValue[string]
-	Decorators     plugin.TValue[[]any]
-	IsLoop         plugin.TValue[bool]
-	LoopIterator   plugin.TValue[string]
-	LoopIndexVar   plugin.TValue[string]
-	LoopExpression plugin.TValue[string]
+	Name             plugin.TValue[string]
+	Source           plugin.TValue[string]
+	Target           plugin.TValue[*mqlBicepFile]
+	Scope            plugin.TValue[string]
+	ScopeTree        plugin.TValue[*mqlBicepExpression]
+	Params           plugin.TValue[any]
+	ParamExpressions plugin.TValue[[]any]
+	Condition        plugin.TValue[string]
+	ConditionTree    plugin.TValue[*mqlBicepExpression]
+	IsRegistry       plugin.TValue[bool]
+	IsTemplateSpec   plugin.TValue[bool]
+	Description      plugin.TValue[string]
+	Decorators       plugin.TValue[[]any]
+	IsLoop           plugin.TValue[bool]
+	LoopIterator     plugin.TValue[string]
+	LoopIndexVar     plugin.TValue[string]
+	LoopExpression   plugin.TValue[string]
 }
 
 // createBicepModule creates a new instance of this resource
@@ -2128,6 +2183,22 @@ func (c *mqlBicepModule) GetScopeTree() *plugin.TValue[*mqlBicepExpression] {
 
 func (c *mqlBicepModule) GetParams() *plugin.TValue[any] {
 	return &c.Params
+}
+
+func (c *mqlBicepModule) GetParamExpressions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ParamExpressions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.module", c.__id, "paramExpressions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.paramExpressions()
+	})
 }
 
 func (c *mqlBicepModule) GetCondition() *plugin.TValue[string] {
@@ -2465,6 +2536,67 @@ func (c *mqlBicepExpression) GetReferencedType() *plugin.TValue[*mqlBicepType] {
 		}
 
 		return c.referencedType()
+	})
+}
+
+// mqlBicepPropertyExpression for the bicep.propertyExpression resource
+type mqlBicepPropertyExpression struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlBicepPropertyExpressionInternal
+	Path       plugin.TValue[string]
+	Expression plugin.TValue[*mqlBicepExpression]
+}
+
+// createBicepPropertyExpression creates a new instance of this resource
+func createBicepPropertyExpression(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlBicepPropertyExpression{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("bicep.propertyExpression", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlBicepPropertyExpression) MqlName() string {
+	return "bicep.propertyExpression"
+}
+
+func (c *mqlBicepPropertyExpression) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlBicepPropertyExpression) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlBicepPropertyExpression) GetExpression() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.Expression, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.propertyExpression", c.__id, "expression")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.expression()
 	})
 }
 

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -57,6 +57,7 @@ bicep.module.loopExpression 13.1.2
 bicep.module.loopIndexVar 13.1.2
 bicep.module.loopIterator 13.1.2
 bicep.module.name 13.0.0
+bicep.module.paramExpressions 13.1.2
 bicep.module.params 13.0.0
 bicep.module.scope 13.0.0
 bicep.module.scopeTree 13.1.2
@@ -90,6 +91,9 @@ bicep.parameter.minValue 13.0.9
 bicep.parameter.name 13.0.0
 bicep.parameter.secure 13.0.0
 bicep.parameter.type 13.0.0
+bicep.propertyExpression 13.1.2
+bicep.propertyExpression.expression 13.1.2
+bicep.propertyExpression.path 13.1.2
 bicep.resource 13.0.0
 bicep.resource.apiVersion 13.0.0
 bicep.resource.condition 13.0.0
@@ -107,6 +111,7 @@ bicep.resource.name 13.0.0
 bicep.resource.nameTree 13.1.2
 bicep.resource.parent 13.0.0
 bicep.resource.properties 13.0.0
+bicep.resource.propertyExpressions 13.1.2
 bicep.resource.resources 13.1.2
 bicep.resource.scope 13.1.2
 bicep.resource.symbolicName 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -80,6 +81,11 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 type mqlBicepResourceInternal struct {
 	nested   []parsedResource
 	resolver *symbolResolver
+	// propertiesBody is the raw text of the resource's `properties: { ... }`
+	// block (between the outer braces), kept so propertyExpressions() can
+	// re-walk it with quoting intact — the parsed `properties` dict has already
+	// stripped quotes, losing the literal-vs-expression distinction.
+	propertiesBody string
 }
 
 func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource, resolver *symbolResolver) ([]any, error) {
@@ -111,9 +117,11 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 	// map rather than nil so the shape stays consistent across
 	// resources.
 	var properties any = map[string]any{}
+	propertiesBody := ""
 	if r.body != "" {
 		if raw := extractFieldBlock(r.body, "properties"); raw != "" {
 			properties = parseBicepObject(raw)
+			propertiesBody = raw
 		}
 	}
 
@@ -150,6 +158,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 	mqlRes := res.(*mqlBicepResource)
 	mqlRes.nested = r.nested
 	mqlRes.resolver = resolver
+	mqlRes.propertiesBody = propertiesBody
 	return mqlRes, nil
 }
 
@@ -178,6 +187,9 @@ func (r *mqlBicepResource) resources() ([]any, error) {
 type mqlBicepModuleInternal struct {
 	resolver       *symbolResolver
 	owningFilePath string
+	// paramsBody is the raw text of the module's `params: { ... }` block,
+	// kept so paramExpressions() can re-walk it with quoting intact.
+	paramsBody string
 }
 
 func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsedModule, resolver *symbolResolver) ([]any, error) {
@@ -187,9 +199,11 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 		// `params: { ... }` block as a structured dict so audits can
 		// pluck individual parameter values.
 		var params any = map[string]any{}
+		paramsBody := ""
 		if m.body != "" {
 			if raw := extractFieldBlock(m.body, "params"); raw != "" {
 				params = parseBicepObject(raw)
+				paramsBody = raw
 			}
 		}
 
@@ -215,6 +229,7 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 		mqlMod := res.(*mqlBicepModule)
 		mqlMod.resolver = resolver
 		mqlMod.owningFilePath = filePath
+		mqlMod.paramsBody = paramsBody
 		mqlModules = append(mqlModules, res)
 	}
 	return mqlModules, nil
@@ -408,6 +423,116 @@ func (m *mqlBicepModule) scopeTree() (*mqlBicepExpression, error) {
 
 func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
 	return expressionTreeFor(m.MqlRuntime, m.__id, "/conditionTree", m.Condition.Data, m.resolver)
+}
+
+// mqlBicepPropertyExpressionInternal carries the raw leaf value and the owning
+// file's symbol resolver so the lazy expression() accessor can parse the value
+// into a bicep.expression with symbol resolution intact (the same resolver the
+// owning resource/module's scalar expression trees thread through).
+type mqlBicepPropertyExpressionInternal struct {
+	raw      string
+	resolver *symbolResolver
+}
+
+// propertyExpressionEntry is one flattened string leaf of a properties/params
+// object: its dotted/indexed path and the raw Bicep value text at that path.
+type propertyExpressionEntry struct {
+	path string
+	raw  string
+}
+
+// flattenObjectExpressions walks the raw body text of a Bicep object (the text
+// between the outer braces, as captured by extractFieldBlock) and returns one
+// entry per scalar leaf, paired with its dotted/indexed path. It re-walks the
+// raw text rather than the already-parsed dict so the leaf value keeps its
+// original quoting: `'Hot'` (a literal), `resourceGroup().location` (a function
+// call), and `'${adminPassword}'` (an interpolation) stay distinguishable when
+// parsed into an expression. Map keys are sorted so output is deterministic;
+// array element order is preserved. Nested objects (`{`) and arrays (`[`)
+// recurse; every other value is a leaf and is emitted with its raw text intact.
+func flattenObjectExpressions(body, prefix string) []propertyExpressionEntry {
+	var out []propertyExpressionEntry
+
+	type kv struct{ key, value string }
+	var pairs []kv
+	for _, entry := range splitTopLevelEntries(body) {
+		key, value, ok := splitFirstColon(entry)
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, kv{strings.TrimSpace(key), strings.TrimSpace(value)})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+
+	for _, p := range pairs {
+		child := p.key
+		if prefix != "" {
+			child = prefix + "." + p.key
+		}
+		out = append(out, flattenValueExpressions(p.value, child)...)
+	}
+	return out
+}
+
+// flattenValueExpressions emits entries for a single value at the given path:
+// it recurses into objects and arrays and emits a leaf for everything else,
+// keeping the raw (still-quoted) value text.
+func flattenValueExpressions(value, path string) []propertyExpressionEntry {
+	if value == "" {
+		return nil
+	}
+	switch value[0] {
+	case '{':
+		return flattenObjectExpressions(stripOuter(value, '{', '}'), path)
+	case '[':
+		var out []propertyExpressionEntry
+		elems := splitTopLevelEntries(stripOuter(value, '[', ']'))
+		for i, elem := range elems {
+			out = append(out, flattenValueExpressions(strings.TrimSpace(elem), path+"["+strconv.Itoa(i)+"]")...)
+		}
+		return out
+	}
+	return []propertyExpressionEntry{{path: path, raw: value}}
+}
+
+// newMqlBicepPropertyExpressions builds the flattened []bicep.propertyExpression
+// for a properties/params object. The parentID is the owning resource/module's
+// __id; each entry gets a synthetic, parent-qualified `__id`
+// (`<parentId>/<accessor>/<path>`) and carries the raw leaf value plus the
+// resolver so its expression() resolves references the same way the scalar
+// trees do.
+func newMqlBicepPropertyExpressions(runtime *plugin.Runtime, parentID, accessor, body string, resolver *symbolResolver) ([]any, error) {
+	entries := flattenObjectExpressions(body, "")
+	out := make([]any, 0, len(entries))
+	for _, e := range entries {
+		res, err := CreateResource(runtime, "bicep.propertyExpression", map[string]*llx.RawData{
+			"__id": llx.StringData(parentID + "/" + accessor + "/" + e.path),
+			"path": llx.StringData(e.path),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlPE := res.(*mqlBicepPropertyExpression)
+		mqlPE.raw = e.raw
+		mqlPE.resolver = resolver
+		out = append(out, mqlPE)
+	}
+	return out, nil
+}
+
+func (r *mqlBicepResource) propertyExpressions() ([]any, error) {
+	return newMqlBicepPropertyExpressions(r.MqlRuntime, r.__id, "propertyExpressions", r.propertiesBody, r.resolver)
+}
+
+func (m *mqlBicepModule) paramExpressions() ([]any, error) {
+	return newMqlBicepPropertyExpressions(m.MqlRuntime, m.__id, "paramExpressions", m.paramsBody, m.resolver)
+}
+
+// expression parses this leaf's raw Bicep value into a bicep.expression,
+// threading the owning file's resolver so referenceKind / referenced*()
+// resolve property values to their same-file declarations.
+func (p *mqlBicepPropertyExpression) expression() (*mqlBicepExpression, error) {
+	return expressionTreeFor(p.MqlRuntime, p.__id, "/expr", p.raw, p.resolver)
 }
 
 // resolveScannedBicepFile resolves a relative `source` (e.g. './shared.bicep')
@@ -720,6 +845,7 @@ var (
 	_ plugin.Resource = (*mqlBicepModule)(nil)
 	_ plugin.Resource = (*mqlBicepOutput)(nil)
 	_ plugin.Resource = (*mqlBicepExpression)(nil)
+	_ plugin.Resource = (*mqlBicepPropertyExpression)(nil)
 	_ plugin.Resource = (*mqlBicepType)(nil)
 	_ plugin.Resource = (*mqlBicepFunction)(nil)
 	_ plugin.Resource = (*mqlBicepImport)(nil)

--- a/providers/bicep/resources/propexpr_test.go
+++ b/providers/bicep/resources/propexpr_test.go
@@ -1,0 +1,168 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collectPropertyExpressions runs an accessor's []any of
+// *mqlBicepPropertyExpression into a path->resource map for easy assertion.
+func collectPropertyExpressions(t *testing.T, list []any) map[string]*mqlBicepPropertyExpression {
+	t.Helper()
+	out := map[string]*mqlBicepPropertyExpression{}
+	for _, item := range list {
+		pe, ok := item.(*mqlBicepPropertyExpression)
+		require.True(t, ok)
+		out[pe.Path.Data] = pe
+	}
+	return out
+}
+
+func TestPropertyExpressions(t *testing.T) {
+	data, err := os.ReadFile("testdata/propexpr.bicep")
+	require.NoError(t, err)
+
+	parsed := parseBicep(string(data))
+	resolver := newSymbolResolver("testdata/propexpr.bicep", parsed)
+	runtime := testRuntime()
+
+	saResource := findResource(parsed, "sa")
+	require.Equal(t, "sa", saResource.symbolicName)
+
+	sa, err := newMqlBicepResource(runtime, "bicep.resource:testdata/propexpr.bicep:sa", saResource, resolver)
+	require.NoError(t, err)
+
+	list, err := sa.propertyExpressions()
+	require.NoError(t, err)
+	byPath := collectPropertyExpressions(t, list)
+
+	t.Run("walks nested object into dotted paths", func(t *testing.T) {
+		// Stable, sorted set of every string-valued leaf in properties.
+		var paths []string
+		for p := range byPath {
+			paths = append(paths, p)
+		}
+		assert.ElementsMatch(t, []string{
+			"accessTier",
+			"adminCredentials.password",
+			"derivedLocation",
+			"encryption.keyVaultProperties.keyVaultUri",
+		}, paths)
+	})
+
+	t.Run("property calling a built-in function is a functionCall", func(t *testing.T) {
+		pe := byPath["derivedLocation"]
+		require.NotNil(t, pe)
+		expr, err := pe.expression()
+		require.NoError(t, err)
+		// resourceGroup().location -> propertyAccess whose base is a functionCall.
+		require.Equal(t, exprKindPropertyAccess, expr.node.kind)
+		require.Len(t, expr.node.args, 1)
+		assert.Equal(t, exprKindFunctionCall, expr.node.args[0].kind)
+		assert.Equal(t, "resourceGroup", expr.node.args[0].functionName)
+		kind, err := expr.referenceKind()
+		require.NoError(t, err)
+		assert.Equal(t, "", kind)
+	})
+
+	t.Run("deep @secure parameter interpolation resolves to parameter", func(t *testing.T) {
+		pe := byPath["adminCredentials.password"]
+		require.NotNil(t, pe)
+		expr, err := pe.expression()
+		require.NoError(t, err)
+		require.Equal(t, exprKindInterpolation, expr.node.kind)
+		// The interpolation's embedded segment is the @secure parameter.
+		seg, err := newMqlBicepExpression(runtime, "seg", expr.node.segments[1], resolver)
+		require.NoError(t, err)
+		kind, err := seg.referenceKind()
+		require.NoError(t, err)
+		assert.Equal(t, refKindParameter, kind)
+		p, err := seg.referencedParameter()
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		assert.Equal(t, "adminPassword", p.Name.Data)
+		assert.True(t, p.Secure.Data)
+	})
+
+	t.Run("property referencing another resource resolves to resource", func(t *testing.T) {
+		pe := byPath["encryption.keyVaultProperties.keyVaultUri"]
+		require.NotNil(t, pe)
+		expr, err := pe.expression()
+		require.NoError(t, err)
+		// kv.properties.vaultUri — propertyAccess rooted at the kv resource.
+		require.Equal(t, exprKindPropertyAccess, expr.node.kind)
+		assert.Equal(t, "kv", expr.node.target)
+		kind, err := expr.referenceKind()
+		require.NoError(t, err)
+		assert.Equal(t, refKindResource, kind)
+		res, err := expr.referencedResource()
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, "kv", res.SymbolicName.Data)
+	})
+
+	t.Run("hardcoded literal property is a literal", func(t *testing.T) {
+		pe := byPath["accessTier"]
+		require.NotNil(t, pe)
+		expr, err := pe.expression()
+		require.NoError(t, err)
+		assert.Equal(t, exprKindLiteral, expr.node.kind)
+		kind, err := expr.referenceKind()
+		require.NoError(t, err)
+		assert.Equal(t, "", kind)
+	})
+}
+
+func TestParamExpressions(t *testing.T) {
+	data, err := os.ReadFile("testdata/propexpr.bicep")
+	require.NoError(t, err)
+
+	parsed := parseBicep(string(data))
+	resolver := newSymbolResolver("testdata/propexpr.bicep", parsed)
+	runtime := testRuntime()
+
+	var netModule parsedModule
+	for _, m := range parsed.modules {
+		if m.name == "net" {
+			netModule = m
+		}
+	}
+	require.Equal(t, "net", netModule.name)
+
+	mods, err := createMqlModules(runtime, "testdata/propexpr.bicep", []parsedModule{netModule}, resolver)
+	require.NoError(t, err)
+	net := mods[0].(*mqlBicepModule)
+
+	list, err := net.paramExpressions()
+	require.NoError(t, err)
+	byPath := collectPropertyExpressions(t, list)
+
+	t.Run("walks params into entries", func(t *testing.T) {
+		var paths []string
+		for p := range byPath {
+			paths = append(paths, p)
+		}
+		assert.ElementsMatch(t, []string{"region", "secret"}, paths)
+	})
+
+	t.Run("param value forwarding a parameter resolves to parameter", func(t *testing.T) {
+		pe := byPath["secret"]
+		require.NotNil(t, pe)
+		expr, err := pe.expression()
+		require.NoError(t, err)
+		require.Equal(t, exprKindSymbolicRef, expr.node.kind)
+		kind, err := expr.referenceKind()
+		require.NoError(t, err)
+		assert.Equal(t, refKindParameter, kind)
+		p, err := expr.referencedParameter()
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		assert.Equal(t, "adminPassword", p.Name.Data)
+	})
+}

--- a/providers/bicep/resources/testdata/propexpr.bicep
+++ b/providers/bicep/resources/testdata/propexpr.bicep
@@ -1,0 +1,39 @@
+// Fixture for bicep.resource.propertyExpressions and
+// bicep.module.paramExpressions. A storage account whose nested properties
+// (a) deeply interpolate a @secure parameter, (b) reference another resource
+// by symbolic name, (c) call a built-in function, and (d) hardcode a literal,
+// plus a module whose params forward a parameter.
+
+@secure()
+param adminPassword string
+
+param location string = 'eastus'
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: 'my-keyvault'
+}
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorage'
+  location: resourceGroup().location
+  properties: {
+    accessTier: 'Hot'
+    derivedLocation: resourceGroup().location
+    encryption: {
+      keyVaultProperties: {
+        keyVaultUri: kv.properties.vaultUri
+      }
+    }
+    adminCredentials: {
+      password: '${adminPassword}'
+    }
+  }
+}
+
+module net './network.bicep' = {
+  name: 'netDeploy'
+  params: {
+    secret: adminPassword
+    region: location
+  }
+}


### PR DESCRIPTION
## What

A resource's `properties` and a module's `params` were opaque `dict`s — and that's exactly where the security-relevant values live ("does this property hardcode a secret? read a `@secure` param? reference another resource?"). This PR decomposes those object values into a flat, queryable list of expression trees.

### New row type

```
private bicep.propertyExpression @defaults("path") {
  path string                    // dotted/indexed path, e.g. "encryption.keyVaultProperties.keyName" or "ipRules[0].action"
  expression() bicep.expression  // parsed tree with full symbol resolution
}
```

### New accessors

- `bicep.resource.propertyExpressions() []bicep.propertyExpression` — walks the resource's parsed `properties` object.
- `bicep.module.paramExpressions() []bicep.propertyExpression` — walks the module's `params` object.

Both carry **full symbol resolution** into nested property values: the leaf's `expression()` is parsed through the same tokenizer the existing scalar trees (`nameTree`/`locationTree`/`scopeTree`/…) use, threading the owning file's `*symbolResolver`, so `referenceKind` / `referencedParameter` / `referencedResource` / … resolve property values to their same-file declarations.

## Walk semantics

- Recurses nested objects and arrays; emits one entry per scalar leaf.
- **Stable order:** map keys sorted, array index order preserved — deterministic output/tests.
- Re-walks the **raw** properties/params block text rather than the already-parsed dict, because the dict strips string quotes and would lose the literal-vs-expression distinction (`'Hot'` literal vs `resourceGroup().location` functionCall vs `'${adminPassword}'` interpolation).
- `__id` is synthetic and parent-qualified (`<resourceId>/propertyExpressions/<path>`, `<moduleId>/paramExpressions/<path>`); no public `id` field. The type is `private` per the synthetic-keyed-leaf guidance — it's reachable only through its parent accessor.

## Tests

Fixture-driven (`testdata/propexpr.bicep`): a storage account whose nested `properties` deeply interpolate a `@secure` parameter, reference another resource (`kv.properties.vaultUri`), call a built-in (`resourceGroup().location`), and hardcode a literal; plus a module whose `params` forward a parameter. Assertions cover the emitted paths, the parameter/resource/literal/functionCall resolution, and `paramExpressions()`.

`.lr.versions` entries at `13.1.2`. `go test ./...` within the provider passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)