### PR TITLE
✨ bicep: decompose user-defined type structure and resolve param/output types

### DIFF
--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -131,7 +131,7 @@ func (f *mqlBicepFile) resolver() *symbolResolver {
 }
 
 func (f *mqlBicepFile) parameters() ([]any, error) {
-	return createMqlParameters(f.MqlRuntime, f.Path.Data, f.getParsed().parameters)
+	return createMqlParameters(f.MqlRuntime, f.Path.Data, f.getParsed().parameters, f.resolver())
 }
 
 func (f *mqlBicepFile) variables() ([]any, error) {

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -104,6 +104,14 @@ bicep.parameter @defaults("name type") {
   type string
   // Default value expression (empty if required)
   defaultValue string
+  // User-defined type the `type` names, or null
+  //
+  // Non-null only when `type` names a `bicep.type` declared in the same file
+  // (for example `param sku storageSku` resolves to the `storageSku` type).
+  // Null for a built-in type (`string`, `int`, `bool`, `object`, `array`,
+  // `secureString`, `secureObject`) or any name that doesn't match a
+  // same-file type declaration.
+  resolvedType() bicep.type
   // Description from @description decorator
   description string
   // Whether @secure decorator is present
@@ -337,6 +345,13 @@ bicep.output @defaults("name type") {
   name string
   // Output type
   type string
+  // User-defined type the `type` names, or null
+  //
+  // Non-null only when `type` names a `bicep.type` declared in the same file.
+  // Null for a built-in type (`string`, `int`, `bool`, `object`, `array`,
+  // `secureString`, `secureObject`) or any name that doesn't match a
+  // same-file type declaration.
+  resolvedType() bicep.type
   // Value expression
   expression string
   // Parsed expression tree
@@ -471,17 +486,57 @@ private bicep.propertyExpression @defaults("path") {
 // `@export()`ed for reuse from other files, and the full raw decorator list.
 // Select a type by its `name` — for example
 // `bicep.file.types.where(name == "sku")`.
-bicep.type @defaults("name") {
+bicep.type @defaults("name kind") {
   // Type name
   name string
   // Raw right-hand-side definition text (the part after `=`)
   definition string
+  // Classification of the definition
+  //
+  // One of "object" (a `{ ... }` body), "union" (members joined by top-level
+  // `|`), "array" (a `[]`-suffixed or `[...]` tuple type), "primitive" (a
+  // built-in like string/int/bool/object/array/secureString/secureObject), or
+  // "alias" (a bare identifier naming another type).
+  kind string
+  // Literal members of a union type
+  //
+  // For example `['Standard_LRS', 'Premium_LRS']` for the definition
+  // `'Standard_LRS' | 'Premium_LRS'`; each member is preserved exactly as
+  // written, including its quotes. Empty for non-union types.
+  unionMembers []string
+  // Properties of an object type
+  //
+  // For an object definition like `{ name: string, tier: sku }` this lists one
+  // entry per property with its name and declared type. Empty for non-object
+  // types. See `bicep.type.property`.
+  properties() []bicep.type.property
+  // Discriminator key of a tagged union
+  //
+  // The key captured from an `@discriminator('<key>')` decorator (for example
+  // `kind` for `@discriminator('kind')`); empty when the type carries no
+  // discriminator decorator.
+  discriminator string
   // Description from @description decorator
   description string
   // Whether @export() is present
   exported bool
   // All decorators as raw strings
   decorators []string
+}
+
+// Property of a Bicep object type
+//
+// Examine a single `name: type` member of an object-typed `bicep.type`
+// definition. The `type` may itself name a user-defined type. Emitted by
+// `bicep.type.properties`, one per declared property.
+private bicep.type.property @defaults("name type") {
+  // Property name
+  name string
+  // Declared type
+  //
+  // The property's declared type as written; may itself name a user-defined
+  // type (for example `sku` in `tier: sku`).
+  type string
 }
 
 // Bicep user-defined function declaration

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -26,6 +26,7 @@ const (
 	ResourceBicepExpression         string = "bicep.expression"
 	ResourceBicepPropertyExpression string = "bicep.propertyExpression"
 	ResourceBicepType               string = "bicep.type"
+	ResourceBicepTypeProperty       string = "bicep.type.property"
 	ResourceBicepFunction           string = "bicep.function"
 	ResourceBicepImport             string = "bicep.import"
 	ResourceBicepTemplate           string = "bicep.template"
@@ -82,6 +83,10 @@ func init() {
 		"bicep.type": {
 			// to override args, implement: initBicepType(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createBicepType,
+		},
+		"bicep.type.property": {
+			// to override args, implement: initBicepTypeProperty(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createBicepTypeProperty,
 		},
 		"bicep.function": {
 			// to override args, implement: initBicepFunction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -247,6 +252,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.parameter.defaultValue": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepParameter).GetDefaultValue()).ToDataRes(types.String)
+	},
+	"bicep.parameter.resolvedType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParameter).GetResolvedType()).ToDataRes(types.Resource("bicep.type"))
 	},
 	"bicep.parameter.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepParameter).GetDescription()).ToDataRes(types.String)
@@ -419,6 +427,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.output.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetType()).ToDataRes(types.String)
 	},
+	"bicep.output.resolvedType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetResolvedType()).ToDataRes(types.Resource("bicep.type"))
+	},
 	"bicep.output.expression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetExpression()).ToDataRes(types.String)
 	},
@@ -491,6 +502,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.type.definition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepType).GetDefinition()).ToDataRes(types.String)
 	},
+	"bicep.type.kind": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepType).GetKind()).ToDataRes(types.String)
+	},
+	"bicep.type.unionMembers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepType).GetUnionMembers()).ToDataRes(types.Array(types.String))
+	},
+	"bicep.type.properties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepType).GetProperties()).ToDataRes(types.Array(types.Resource("bicep.type.property")))
+	},
+	"bicep.type.discriminator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepType).GetDiscriminator()).ToDataRes(types.String)
+	},
 	"bicep.type.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepType).GetDescription()).ToDataRes(types.String)
 	},
@@ -499,6 +522,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.type.decorators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepType).GetDecorators()).ToDataRes(types.Array(types.String))
+	},
+	"bicep.type.property.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTypeProperty).GetName()).ToDataRes(types.String)
+	},
+	"bicep.type.property.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTypeProperty).GetType()).ToDataRes(types.String)
 	},
 	"bicep.function.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepFunction).GetName()).ToDataRes(types.String)
@@ -745,6 +774,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepParameter).DefaultValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.parameter.resolvedType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParameter).ResolvedType, ok = plugin.RawToTValue[*mqlBicepType](v.Value, v.Error)
+		return
+	},
 	"bicep.parameter.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepParameter).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -989,6 +1022,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepOutput).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.output.resolvedType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).ResolvedType, ok = plugin.RawToTValue[*mqlBicepType](v.Value, v.Error)
+		return
+	},
 	"bicep.output.expression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).Expression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1097,6 +1134,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepType).Definition, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.type.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepType).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.type.unionMembers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepType).UnionMembers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.type.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepType).Properties, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.type.discriminator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepType).Discriminator, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"bicep.type.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepType).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1107,6 +1160,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.type.decorators": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepType).Decorators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.type.property.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTypeProperty).__id, ok = v.Value.(string)
+		return
+	},
+	"bicep.type.property.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTypeProperty).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.type.property.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTypeProperty).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"bicep.function.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1691,10 +1756,11 @@ func (c *mqlBicepParamFile) GetContent() *plugin.TValue[string] {
 type mqlBicepParameter struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepParameterInternal it will be used here
+	mqlBicepParameterInternal
 	Name         plugin.TValue[string]
 	Type         plugin.TValue[string]
 	DefaultValue plugin.TValue[string]
+	ResolvedType plugin.TValue[*mqlBicepType]
 	Description  plugin.TValue[string]
 	Secure       plugin.TValue[bool]
 	Allowed      plugin.TValue[[]any]
@@ -1747,6 +1813,22 @@ func (c *mqlBicepParameter) GetType() *plugin.TValue[string] {
 
 func (c *mqlBicepParameter) GetDefaultValue() *plugin.TValue[string] {
 	return &c.DefaultValue
+}
+
+func (c *mqlBicepParameter) GetResolvedType() *plugin.TValue[*mqlBicepType] {
+	return plugin.GetOrCompute[*mqlBicepType](&c.ResolvedType, func() (*mqlBicepType, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.parameter", c.__id, "resolvedType")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepType), nil
+			}
+		}
+
+		return c.resolvedType()
+	})
 }
 
 func (c *mqlBicepParameter) GetDescription() *plugin.TValue[string] {
@@ -2260,6 +2342,7 @@ type mqlBicepOutput struct {
 	mqlBicepOutputInternal
 	Name           plugin.TValue[string]
 	Type           plugin.TValue[string]
+	ResolvedType   plugin.TValue[*mqlBicepType]
 	Expression     plugin.TValue[string]
 	ExpressionTree plugin.TValue[*mqlBicepExpression]
 	Description    plugin.TValue[string]
@@ -2307,6 +2390,22 @@ func (c *mqlBicepOutput) GetName() *plugin.TValue[string] {
 
 func (c *mqlBicepOutput) GetType() *plugin.TValue[string] {
 	return &c.Type
+}
+
+func (c *mqlBicepOutput) GetResolvedType() *plugin.TValue[*mqlBicepType] {
+	return plugin.GetOrCompute[*mqlBicepType](&c.ResolvedType, func() (*mqlBicepType, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.output", c.__id, "resolvedType")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepType), nil
+			}
+		}
+
+		return c.resolvedType()
+	})
 }
 
 func (c *mqlBicepOutput) GetExpression() *plugin.TValue[string] {
@@ -2604,12 +2703,16 @@ func (c *mqlBicepPropertyExpression) GetExpression() *plugin.TValue[*mqlBicepExp
 type mqlBicepType struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlBicepTypeInternal it will be used here
-	Name        plugin.TValue[string]
-	Definition  plugin.TValue[string]
-	Description plugin.TValue[string]
-	Exported    plugin.TValue[bool]
-	Decorators  plugin.TValue[[]any]
+	mqlBicepTypeInternal
+	Name          plugin.TValue[string]
+	Definition    plugin.TValue[string]
+	Kind          plugin.TValue[string]
+	UnionMembers  plugin.TValue[[]any]
+	Properties    plugin.TValue[[]any]
+	Discriminator plugin.TValue[string]
+	Description   plugin.TValue[string]
+	Exported      plugin.TValue[bool]
+	Decorators    plugin.TValue[[]any]
 }
 
 // createBicepType creates a new instance of this resource
@@ -2652,6 +2755,34 @@ func (c *mqlBicepType) GetDefinition() *plugin.TValue[string] {
 	return &c.Definition
 }
 
+func (c *mqlBicepType) GetKind() *plugin.TValue[string] {
+	return &c.Kind
+}
+
+func (c *mqlBicepType) GetUnionMembers() *plugin.TValue[[]any] {
+	return &c.UnionMembers
+}
+
+func (c *mqlBicepType) GetProperties() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Properties, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.type", c.__id, "properties")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.properties()
+	})
+}
+
+func (c *mqlBicepType) GetDiscriminator() *plugin.TValue[string] {
+	return &c.Discriminator
+}
+
 func (c *mqlBicepType) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
@@ -2662,6 +2793,55 @@ func (c *mqlBicepType) GetExported() *plugin.TValue[bool] {
 
 func (c *mqlBicepType) GetDecorators() *plugin.TValue[[]any] {
 	return &c.Decorators
+}
+
+// mqlBicepTypeProperty for the bicep.type.property resource
+type mqlBicepTypeProperty struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlBicepTypePropertyInternal it will be used here
+	Name plugin.TValue[string]
+	Type plugin.TValue[string]
+}
+
+// createBicepTypeProperty creates a new instance of this resource
+func createBicepTypeProperty(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlBicepTypeProperty{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("bicep.type.property", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlBicepTypeProperty) MqlName() string {
+	return "bicep.type.property"
+}
+
+func (c *mqlBicepTypeProperty) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlBicepTypeProperty) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlBicepTypeProperty) GetType() *plugin.TValue[string] {
+	return &c.Type
 }
 
 // mqlBicepFunction for the bicep.function resource

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -72,6 +72,7 @@ bicep.output.loopExpression 13.1.2
 bicep.output.loopIndexVar 13.1.2
 bicep.output.loopIterator 13.1.2
 bicep.output.name 13.0.0
+bicep.output.resolvedType 13.1.2
 bicep.output.type 13.0.0
 bicep.paramFile 13.1.2
 bicep.paramFile.content 13.1.2
@@ -89,6 +90,7 @@ bicep.parameter.maxValue 13.0.9
 bicep.parameter.minLength 13.0.9
 bicep.parameter.minValue 13.0.9
 bicep.parameter.name 13.0.0
+bicep.parameter.resolvedType 13.1.2
 bicep.parameter.secure 13.0.0
 bicep.parameter.type 13.0.0
 bicep.propertyExpression 13.1.2
@@ -156,8 +158,15 @@ bicep.type 13.1.2
 bicep.type.decorators 13.1.2
 bicep.type.definition 13.1.2
 bicep.type.description 13.1.2
+bicep.type.discriminator 13.1.2
 bicep.type.exported 13.1.2
+bicep.type.kind 13.1.2
 bicep.type.name 13.1.2
+bicep.type.properties 13.1.2
+bicep.type.property 13.1.2
+bicep.type.property.name 13.1.2
+bicep.type.property.type 13.1.2
+bicep.type.unionMembers 13.1.2
 bicep.variable 13.0.0
 bicep.variable.description 13.0.0
 bicep.variable.expression 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -15,7 +15,14 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
-func createMqlParameters(runtime *plugin.Runtime, filePath string, params []parsedParameter) ([]any, error) {
+// mqlBicepParameterInternal carries the owning file's symbol resolver so the
+// lazy resolvedType() accessor can resolve the declared `type` name to the
+// same-file `bicep.type` it names.
+type mqlBicepParameterInternal struct {
+	resolver *symbolResolver
+}
+
+func createMqlParameters(runtime *plugin.Runtime, filePath string, params []parsedParameter, resolver *symbolResolver) ([]any, error) {
 	var mqlParams []any
 	for _, p := range params {
 		allowed := sliceToAny(p.allowed)
@@ -38,9 +45,25 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepParameter).resolver = resolver
 		mqlParams = append(mqlParams, res)
 	}
 	return mqlParams, nil
+}
+
+// resolvedType resolves the parameter's declared `type` name to the same-file
+// `bicep.type` it references, or null for a built-in type or an unresolvable
+// name.
+func (p *mqlBicepParameter) resolvedType() (*mqlBicepType, error) {
+	t, err := p.resolver.typ(p.MqlRuntime, p.Type.Data)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		p.ResolvedType.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return t, nil
 }
 
 // mqlBicepVariableInternal carries the owning file's symbol resolver so the
@@ -629,24 +652,70 @@ func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsed
 	return mqlOutputs, nil
 }
 
+// resolvedType resolves the output's declared `type` name to the same-file
+// `bicep.type` it references, or null for a built-in type or an unresolvable
+// name.
+func (o *mqlBicepOutput) resolvedType() (*mqlBicepType, error) {
+	t, err := o.resolver.typ(o.MqlRuntime, o.Type.Data)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		o.ResolvedType.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return t, nil
+}
+
+// mqlBicepTypeInternal caches the parsed object-type properties so the lazy
+// properties() accessor can materialize them without re-parsing the raw
+// definition.
+type mqlBicepTypeInternal struct {
+	cacheProperties []parsedTypeProperty
+}
+
 func createMqlTypes(runtime *plugin.Runtime, filePath string, types_ []parsedType) ([]any, error) {
 	var mqlTypes []any
 	for _, t := range types_ {
 		decorators := sliceToAny(t.decorators)
+		unionMembers := sliceToAny(t.unionMembers)
 		res, err := CreateResource(runtime, "bicep.type", map[string]*llx.RawData{
-			"__id":        llx.StringData("bicep.type:" + filePath + ":" + t.name),
-			"name":        llx.StringData(t.name),
-			"definition":  llx.StringData(t.definition),
-			"description": llx.StringData(t.description),
-			"exported":    llx.BoolData(t.exported),
-			"decorators":  llx.ArrayData(decorators, types.String),
+			"__id":          llx.StringData("bicep.type:" + filePath + ":" + t.name),
+			"name":          llx.StringData(t.name),
+			"definition":    llx.StringData(t.definition),
+			"kind":          llx.StringData(t.kind),
+			"unionMembers":  llx.ArrayData(unionMembers, types.String),
+			"discriminator": llx.StringData(t.discriminator),
+			"description":   llx.StringData(t.description),
+			"exported":      llx.BoolData(t.exported),
+			"decorators":    llx.ArrayData(decorators, types.String),
 		})
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlBicepType).cacheProperties = t.properties
 		mqlTypes = append(mqlTypes, res)
 	}
 	return mqlTypes, nil
+}
+
+// properties materializes the object type's `name: type` members. Each gets a
+// synthetic parent-qualified `__id` (`<typeId>/properties/<name>`); the value
+// is empty for non-object types.
+func (t *mqlBicepType) properties() ([]any, error) {
+	out := make([]any, 0, len(t.cacheProperties))
+	for _, p := range t.cacheProperties {
+		res, err := CreateResource(t.MqlRuntime, "bicep.type.property", map[string]*llx.RawData{
+			"__id": llx.StringData(t.__id + "/properties/" + p.name),
+			"name": llx.StringData(p.name),
+			"type": llx.StringData(p.typ),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
 }
 
 func createMqlFunctions(runtime *plugin.Runtime, filePath string, functions []parsedFunction) ([]any, error) {
@@ -847,6 +916,7 @@ var (
 	_ plugin.Resource = (*mqlBicepExpression)(nil)
 	_ plugin.Resource = (*mqlBicepPropertyExpression)(nil)
 	_ plugin.Resource = (*mqlBicepType)(nil)
+	_ plugin.Resource = (*mqlBicepTypeProperty)(nil)
 	_ plugin.Resource = (*mqlBicepFunction)(nil)
 	_ plugin.Resource = (*mqlBicepImport)(nil)
 	_ plugin.Resource = (*mqlBicepParamFile)(nil)

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -104,6 +104,24 @@ type parsedType struct {
 	description string
 	exported    bool
 	decorators  []string
+
+	// kind classifies the definition: "object", "union", "array", "tuple"
+	// (folded into "array"), "primitive", or "alias".
+	kind string
+	// unionMembers holds the literal members of a union type, each kept
+	// exactly as written (including quotes). Empty for non-unions.
+	unionMembers []string
+	// properties holds the name/type pairs of an object type. Empty otherwise.
+	properties []parsedTypeProperty
+	// discriminator is the key captured from an `@discriminator('<key>')`
+	// decorator; empty when no such decorator is present.
+	discriminator string
+}
+
+// parsedTypeProperty is one `name: type` member of an object-typed declaration.
+type parsedTypeProperty struct {
+	name string
+	typ  string
 }
 
 type parsedFunction struct {
@@ -138,6 +156,10 @@ var (
 	minValueDecRe  = regexp.MustCompile(`@minValue\(\s*(-?\d+)\s*\)`)
 	maxValueDecRe  = regexp.MustCompile(`@maxValue\(\s*(-?\d+)\s*\)`)
 	exportDecRe    = regexp.MustCompile(`@export\(\)`)
+
+	// discriminatorDecRe captures the key argument of an
+	// `@discriminator('<key>')` decorator on a tagged-union type.
+	discriminatorDecRe = regexp.MustCompile(`@discriminator\(\s*'([^']*)'\s*\)`)
 
 	// typeRe matches the header of a `type Name = <definition>` statement.
 	// The definition (everything after the first `=`) is captured raw;
@@ -687,7 +709,132 @@ func parseTypeDecl(text string, decorators []string) (parsedType, bool) {
 		t.description = dm[1]
 	}
 	t.exported = exportDecRe.MatchString(decText)
+	if dm := discriminatorDecRe.FindStringSubmatch(decText); len(dm) > 1 {
+		t.discriminator = dm[1]
+	}
+
+	// Decompose the definition into a kind plus (for objects/unions) its
+	// structured members. Classification runs on the RAW (pre-collapse)
+	// right-hand side because object properties may be newline-separated with
+	// no commas — collapsing whitespace would merge them — and the splitter is
+	// already string/bracket-aware so newlines and nested braces are handled.
+	t.kind, t.unionMembers, t.properties = classifyTypeDefinition(m[2])
 	return t, true
+}
+
+// builtinTypeNames is the set of Bicep built-in primitive types a bare type
+// identifier may name. A definition that is exactly one of these classifies as
+// "primitive"; any other bare identifier classifies as "alias" (it names
+// another user-defined type).
+var builtinTypeNames = map[string]bool{
+	"string":       true,
+	"int":          true,
+	"bool":         true,
+	"object":       true,
+	"array":        true,
+	"secureString": true,
+	"securestring": true,
+	"secureObject": true,
+	"secureobject": true,
+}
+
+// classifyTypeDefinition inspects a type's raw right-hand-side definition and
+// returns its kind plus, for object/union types, the structured members:
+//
+//   - a trimmed `{ ... }` body  -> "object", with each `key: type` pair parsed
+//   - a top-level `|`           -> "union", with members split on that `|`
+//   - a leading `[`             -> "array" (a `[...]` tuple is folded in)
+//   - a `[]` suffix             -> "array"
+//   - a bare built-in name      -> "primitive"
+//   - any other bare identifier -> "alias"
+//
+// Splitting (object pairs, union members) is depth-aware via scanState so
+// commas/pipes inside nested `{}`/`[]`/`<>`/strings don't split early.
+func classifyTypeDefinition(def string) (string, []string, []parsedTypeProperty) {
+	trimmed := strings.TrimSpace(def)
+	if trimmed == "" {
+		return "", nil, nil
+	}
+
+	// Union type: members separated by a top-level `|`. Checked before the
+	// object case because a discriminated tagged union's first member is itself
+	// an object (`{ kind: 'circle', ... } | { kind: 'square', ... }`), so a
+	// leading `{` does not imply a plain object type. Members keep their raw
+	// form (including the surrounding whitespace collapsed to a single line).
+	if members := splitTopLevelPipes(trimmed); len(members) > 1 {
+		out := make([]string, 0, len(members))
+		for _, m := range members {
+			m = strings.Join(strings.Fields(m), " ")
+			if m != "" {
+				out = append(out, m)
+			}
+		}
+		return "union", out, nil
+	}
+
+	// Object type: `{ name: string, tier: sku }`.
+	if trimmed[0] == '{' {
+		return "object", nil, parseTypeObjectProperties(stripOuter(trimmed, '{', '}'))
+	}
+
+	// Array/tuple: a `[...]` tuple or a `<type>[]` suffix.
+	if trimmed[0] == '[' || strings.HasSuffix(trimmed, "[]") {
+		return "array", nil, nil
+	}
+
+	// A bare identifier: a built-in primitive, otherwise an alias for another
+	// type. Anything else (a function-shaped or otherwise complex definition)
+	// also falls through to "alias".
+	if builtinTypeNames[trimmed] {
+		return "primitive", nil, nil
+	}
+	return "alias", nil, nil
+}
+
+// parseTypeObjectProperties splits an object type body (the text between the
+// outer braces) into its `name: type` members. Entries are split on top-level
+// commas and newlines (string/bracket/brace-aware) so a nested object property
+// like `nested: { a: int, b: int }` stays intact; a trailing `?` optional
+// marker on a key is stripped.
+func parseTypeObjectProperties(body string) []parsedTypeProperty {
+	var props []parsedTypeProperty
+	for _, entry := range splitTopLevelEntries(body) {
+		key, value, ok := splitFirstColon(entry)
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(key)
+		name = strings.TrimSuffix(name, "?")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		props = append(props, parsedTypeProperty{
+			name: name,
+			typ:  strings.TrimSpace(value),
+		})
+	}
+	return props
+}
+
+// splitTopLevelPipes splits s on `|` characters that sit outside any string,
+// bracket, brace, or paren and outside a triple-quoted string — so a `|` inside
+// a nested object/array or a string literal doesn't split the union.
+func splitTopLevelPipes(s string) []string {
+	var parts []string
+	st := scanState{}
+	start := 0
+	for i := 0; i < len(s); {
+		if s[i] == '|' && st.inStr == 0 && !st.inMulti &&
+			st.paren == 0 && st.bracket == 0 && st.brace == 0 {
+			parts = append(parts, s[start:i])
+			i++
+			start = i
+			continue
+		}
+		i = st.stepAt(s, i)
+	}
+	return append(parts, s[start:])
 }
 
 // parseFunctionDecl handles a `func name(p1 t1, p2 t2) returnType => expr`

--- a/providers/bicep/resources/resolver.go
+++ b/providers/bicep/resources/resolver.go
@@ -105,7 +105,7 @@ func (r *symbolResolver) parameter(runtime *plugin.Runtime, target string) (*mql
 	if !ok {
 		return nil, nil
 	}
-	out, err := createMqlParameters(runtime, r.filePath, []parsedParameter{p})
+	out, err := createMqlParameters(runtime, r.filePath, []parsedParameter{p}, r)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/bicep/resources/testdata/typestruct.bicep
+++ b/providers/bicep/resources/testdata/typestruct.bicep
@@ -1,0 +1,27 @@
+// Fixture for user-defined type decomposition. Exercises a union type, an
+// object type whose property names another user-defined type, an @export()ed
+// object type, an @discriminator() tagged-union type, an alias type, plus
+// parameters and an output that name a user-defined type vs a built-in.
+
+type sku = 'Standard_LRS' | 'Premium_LRS'
+
+type cfg = {
+  name: string
+  tier: sku
+}
+
+@export()
+type exportedCfg = {
+  id: string
+  optional: bool?
+}
+
+@discriminator('kind')
+type shape = { kind: 'circle', radius: int } | { kind: 'square', side: int }
+
+type skuAlias = sku
+
+param appCfg cfg
+param appName string
+
+output usedSku sku = 'Standard_LRS'

--- a/providers/bicep/resources/typestruct_test.go
+++ b/providers/bicep/resources/typestruct_test.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// loadTypeStructFixture parses the typestruct.bicep fixture and returns a
+// runtime plus the file's symbol resolver, mirroring loadResolverFixture.
+func loadTypeStructFixture(t *testing.T) (*plugin.Runtime, *symbolResolver, *parsedBicepFile) {
+	data, err := os.ReadFile("testdata/typestruct.bicep")
+	require.NoError(t, err)
+	parsed := parseBicep(string(data))
+	return testRuntime(), newSymbolResolver("testdata/typestruct.bicep", parsed), parsed
+}
+
+func findType(parsed *parsedBicepFile, name string) parsedType {
+	for _, ty := range parsed.types {
+		if ty.name == name {
+			return ty
+		}
+	}
+	return parsedType{}
+}
+
+func TestClassifyTypeDefinition(t *testing.T) {
+	_, _, parsed := loadTypeStructFixture(t)
+
+	t.Run("union type", func(t *testing.T) {
+		ty := findType(parsed, "sku")
+		assert.Equal(t, "union", ty.kind)
+		assert.Equal(t, []string{"'Standard_LRS'", "'Premium_LRS'"}, ty.unionMembers)
+		assert.Empty(t, ty.properties)
+		assert.Empty(t, ty.discriminator)
+	})
+
+	t.Run("object type with property naming another type", func(t *testing.T) {
+		ty := findType(parsed, "cfg")
+		assert.Equal(t, "object", ty.kind)
+		assert.Empty(t, ty.unionMembers)
+		require.Len(t, ty.properties, 2)
+		assert.Equal(t, parsedTypeProperty{name: "name", typ: "string"}, ty.properties[0])
+		assert.Equal(t, parsedTypeProperty{name: "tier", typ: "sku"}, ty.properties[1])
+	})
+
+	t.Run("exported object type strips optional marker", func(t *testing.T) {
+		ty := findType(parsed, "exportedCfg")
+		assert.True(t, ty.exported)
+		assert.Equal(t, "object", ty.kind)
+		require.Len(t, ty.properties, 2)
+		assert.Equal(t, "id", ty.properties[0].name)
+		// `optional: bool?` -> the trailing `?` is stripped from the key.
+		assert.Equal(t, "optional", ty.properties[1].name)
+		assert.Equal(t, "bool?", ty.properties[1].typ)
+	})
+
+	t.Run("discriminated tagged union", func(t *testing.T) {
+		ty := findType(parsed, "shape")
+		assert.Equal(t, "union", ty.kind)
+		assert.Equal(t, "kind", ty.discriminator)
+		require.Len(t, ty.unionMembers, 2)
+		assert.Contains(t, ty.unionMembers[0], "circle")
+		assert.Contains(t, ty.unionMembers[1], "square")
+	})
+
+	t.Run("alias type", func(t *testing.T) {
+		ty := findType(parsed, "skuAlias")
+		assert.Equal(t, "alias", ty.kind)
+		assert.Equal(t, "sku", ty.definition)
+	})
+}
+
+func TestClassifyTypeDefinitionPrimitivesAndArrays(t *testing.T) {
+	cases := []struct {
+		def  string
+		kind string
+	}{
+		{"string", "primitive"},
+		{"int", "primitive"},
+		{"bool", "primitive"},
+		{"object", "primitive"},
+		{"array", "primitive"},
+		{"secureString", "primitive"},
+		{"secureObject", "primitive"},
+		{"string[]", "array"},
+		{"[string, int]", "array"},
+		{"myType", "alias"},
+	}
+	for _, c := range cases {
+		kind, _, _ := classifyTypeDefinition(c.def)
+		assert.Equal(t, c.kind, kind, "def %q", c.def)
+	}
+}
+
+func TestTypeResourceFields(t *testing.T) {
+	runtime, _, parsed := loadTypeStructFixture(t)
+
+	mqlTypes, err := createMqlTypes(runtime, "testdata/typestruct.bicep", parsed.types)
+	require.NoError(t, err)
+
+	byName := map[string]*mqlBicepType{}
+	for _, mt := range mqlTypes {
+		ty := mt.(*mqlBicepType)
+		byName[ty.Name.Data] = ty
+	}
+
+	t.Run("union members surface on the resource", func(t *testing.T) {
+		ty := byName["sku"]
+		require.NotNil(t, ty)
+		assert.Equal(t, "union", ty.Kind.Data)
+		assert.Equal(t, []any{"'Standard_LRS'", "'Premium_LRS'"}, ty.UnionMembers.Data)
+	})
+
+	t.Run("object properties materialize", func(t *testing.T) {
+		ty := byName["cfg"]
+		require.NotNil(t, ty)
+		assert.Equal(t, "object", ty.Kind.Data)
+		props, err := ty.properties()
+		require.NoError(t, err)
+		require.Len(t, props, 2)
+		p0 := props[0].(*mqlBicepTypeProperty)
+		p1 := props[1].(*mqlBicepTypeProperty)
+		assert.Equal(t, "name", p0.Name.Data)
+		assert.Equal(t, "string", p0.Type.Data)
+		assert.Equal(t, "tier", p1.Name.Data)
+		assert.Equal(t, "sku", p1.Type.Data)
+	})
+
+	t.Run("discriminator surfaces", func(t *testing.T) {
+		ty := byName["shape"]
+		require.NotNil(t, ty)
+		assert.Equal(t, "kind", ty.Discriminator.Data)
+	})
+}
+
+func TestParameterResolvedType(t *testing.T) {
+	runtime, resolver, parsed := loadTypeStructFixture(t)
+
+	mqlParams, err := createMqlParameters(runtime, "testdata/typestruct.bicep", parsed.parameters, resolver)
+	require.NoError(t, err)
+
+	byName := map[string]*mqlBicepParameter{}
+	for _, mp := range mqlParams {
+		p := mp.(*mqlBicepParameter)
+		byName[p.Name.Data] = p
+	}
+
+	t.Run("user-defined typed param resolves", func(t *testing.T) {
+		p := byName["appCfg"]
+		require.NotNil(t, p)
+		rt, err := p.resolvedType()
+		require.NoError(t, err)
+		require.NotNil(t, rt)
+		assert.Equal(t, "cfg", rt.Name.Data)
+		assert.Equal(t, "object", rt.Kind.Data)
+	})
+
+	t.Run("built-in typed param resolves to null", func(t *testing.T) {
+		p := byName["appName"]
+		require.NotNil(t, p)
+		rt, err := p.resolvedType()
+		require.NoError(t, err)
+		assert.Nil(t, rt)
+	})
+}
+
+func TestOutputResolvedType(t *testing.T) {
+	runtime, resolver, parsed := loadTypeStructFixture(t)
+
+	mqlOutputs, err := createMqlOutputs(runtime, "testdata/typestruct.bicep", parsed.outputs, resolver)
+	require.NoError(t, err)
+	require.NotEmpty(t, mqlOutputs)
+
+	o := mqlOutputs[0].(*mqlBicepOutput)
+	assert.Equal(t, "usedSku", o.Name.Data)
+	rt, err := o.resolvedType()
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	assert.Equal(t, "sku", rt.Name.Data)
+	assert.Equal(t, "union", rt.Kind.Data)
+}


### PR DESCRIPTION
## What

Decomposes the opaque `bicep.type.definition` RHS text into queryable structure, and links `bicep.parameter` / `bicep.output` declarations to the user-defined type they name.

### `bicep.type` decomposition

| field | meaning |
|---|---|
| `kind` | classifies the definition: `object`, `union`, `array`, `primitive` (a built-in like string/int), or `alias` (names another type) |
| `unionMembers []string` | literal members of a union, preserved as written — e.g. `['Standard_LRS', 'Premium_LRS']` for `'Standard_LRS' \| 'Premium_LRS'` |
| `properties() []bicep.type.property` | name/type members of an object type `{ name: string, tier: sku }` |
| `discriminator` | the key from `@discriminator('kind')` for a tagged union |

New private `bicep.type.property` sub-resource (`name`, `type`) holds one object-property row, reachable only via `bicep.type.properties()`. Its `__id` is the synthetic parent-qualified `<typeId>/properties/<name>`, so it exposes no public `id`.

Classification runs depth-aware on the raw definition via the existing `scanState` lexer. Union is detected **before** object because a discriminated tagged union's first member is itself an object (`{ kind: 'circle', ... } | { kind: 'square', ... }`). Object pairs split on top-level commas/newlines (nested `{}`/`[]`/strings are not split), and a trailing `?` optional marker is stripped from property keys.

### `resolvedType()` on parameter and output

Both `bicep.parameter` and `bicep.output` gain `resolvedType() bicep.type`. When the declared `type` string names a same-file user-defined type, it returns that `bicep.type` (reusing the `symbolResolver`'s cached instance); for a built-in type or any unresolvable name it returns null (`StateIsSet | StateIsNull`). The resolver is now threaded into `bicep.parameter` via a new `mqlBicepParameterInternal.resolver` set in `createMqlParameters` (output already carried it).

## Verification

`go test ./...` in the provider passes. Real query against a fixture shows a union type's members, an object type's properties, a discriminated type's `discriminator: "kind"`, a param resolving to its user type, a built-in-typed param with null `resolvedType`, and an output resolving to its type.

## Stacking

Originally stacked on #8029; that PR has since squash-merged into `main`, so this is rebased onto and targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)