### PR TITLE
🐛 helm: drop reserved -f shorthand; harden provider flag attach against shorthand collisions

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -291,6 +291,21 @@ func attachPFlags(base *pflag.FlagSet, nu *pflag.FlagSet) {
 }
 
 func attachFlag(flagset *pflag.FlagSet, flag plugin.Flag) {
+	// A provider must never be able to panic the whole CLI by declaring a
+	// shorthand that a global flag (e.g. -f for output-format) already owns.
+	// pflag's AddFlag panics on a duplicate shorthand, so drop the colliding
+	// shorthand here and keep the long flag usable.
+	if flag.Short != "" {
+		if found := flagset.ShorthandLookup(flag.Short); found != nil {
+			log.Warn().
+				Str("flag", flag.Long).
+				Str("shorthand", flag.Short).
+				Str("conflicts-with", found.Name).
+				Msg("provider flag shorthand already in use, ignoring shorthand")
+			flag.Short = ""
+		}
+	}
+
 	switch flag.Type {
 	case plugin.FlagType_Bool:
 		if flag.Short != "" {

--- a/cli/providers/providers_test.go
+++ b/cli/providers/providers_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// A provider flag whose shorthand collides with an already-registered flag
+// (e.g. -f for the global output-format) must not panic the CLI. The
+// colliding shorthand is dropped and the long flag stays usable.
+func TestAttachFlag_ShorthandCollisionDoesNotPanic(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.StringP("output-format", "f", "json", "global output format")
+
+	require.NotPanics(t, func() {
+		attachFlag(flags, plugin.Flag{
+			Long:  "values",
+			Short: "f",
+			Type:  plugin.FlagType_List,
+			Desc:  "provider flag that reuses -f",
+		})
+	})
+
+	// long flag is registered, shorthand still belongs to the original owner
+	assert.NotNil(t, flags.Lookup("values"), "long flag should be attached")
+	assert.Equal(t, "output-format", flags.ShorthandLookup("f").Name, "shorthand should remain with the original flag")
+}
+
+// A non-colliding shorthand is preserved.
+func TestAttachFlag_FreeShorthandPreserved(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	attachFlag(flags, plugin.Flag{
+		Long:  "namespace",
+		Short: "n",
+		Type:  plugin.FlagType_String,
+		Desc:  "release namespace",
+	})
+
+	f := flags.Lookup("namespace")
+	require.NotNil(t, f)
+	assert.Equal(t, "n", f.Shorthand, "free shorthand should be preserved")
+}

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -32,10 +32,9 @@ Examples:
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{
-					Long:  "values",
-					Short: "f",
-					Type:  plugin.FlagType_List,
-					Desc:  "Values files to merge into the chart's values before rendering (repeatable, like helm -f)",
+					Long: "values",
+					Type: plugin.FlagType_List,
+					Desc: "Values files to merge into the chart's values before rendering (repeatable, like helm --values)",
 				},
 				{
 					Long: "set",


### PR DESCRIPTION
## Problem

`cnspec scan helm --help` (and any helm invocation) panicked the entire binary:

```
unable to redefine 'f' shorthand in "set" flagset: it's already used for "output-format" flag
panic: ...
github.com/spf13/pflag.(*FlagSet).AddFlag
go.mondoo.com/mql/v13/cli/providers.attachFlag (providers.go:315)
go.mondoo.com/mql/v13/cli/providers.detectConnectorName (providers.go:113)
```

The helm provider's `values` flag declared `Short: "f"`, but `-f` is a reserved global shorthand (`output-format`). pflag's `AddFlag` panics on a duplicate shorthand, and because the offending code runs in `detectConnectorName` — before any command executes — it took down the whole CLI on *every* invocation, not just `helm`.

## Fix (two layers)

**1. Framework hardening — `cli/providers/providers.go`** (the real defect)
`attachFlag` now checks `flagset.ShorthandLookup` first; if the shorthand is already registered it logs a warning, drops just the shorthand, and keeps the long flag usable. A third-party provider plugin can no longer panic the CLI by reusing a reserved shorthand. This mirrors the dedup `attachPFlags` already does for persistent flags.

**2. Provider correctness — `providers/helm/config/config.go`**
Removed `Short: "f"` from the `values` flag (`-f`/`output-format` is reserved globally across mql and cnspec). `--values` still works; `-n` (namespace) and `-a` (api-versions) are unaffected.

## Verification

- New regression tests in `cli/providers/providers_test.go`: collision is handled without panic and the shorthand stays with the original owner; a free shorthand is preserved. Both pass.
- Rebuilt + installed the helm provider and ran `mql run helm --help` (the crashing path): renders cleanly, no panic, `--values` long-only, `-a`/`-n` intact, global `-f` no longer collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)