### PR TITLE
🧹 gitlab: unit tests for pure resource helpers

### DIFF
--- a/providers/gitlab/resources/gitlab_governance_test.go
+++ b/providers/gitlab/resources/gitlab_governance_test.go
@@ -1,0 +1,166 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGIDInt(t *testing.T) {
+	tests := []struct {
+		name string
+		gid  string
+		want int64
+	}{
+		{"user gid", "gid://gitlab/User/123", 123},
+		{"vulnerability gid", "gid://gitlab/Vulnerability/9876543210", 9876543210},
+		{"bare number without slash", "42", 0},
+		{"empty", "", 0},
+		{"no trailing number", "gid://gitlab/User/", 0},
+		{"non-numeric tail", "gid://gitlab/User/abc", 0},
+		{"trailing slash only", "/", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseGIDInt(tt.gid))
+		})
+	}
+}
+
+func TestIsVulnerabilitiesUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []gqlGraphQLError
+		want bool
+	}{
+		{
+			name: "no errors is available",
+			errs: nil,
+			want: false,
+		},
+		{
+			name: "permission error is unavailable",
+			errs: []gqlGraphQLError{{Message: "You don't have permission to access this resource"}},
+			want: true,
+		},
+		{
+			name: "feature not available is unavailable",
+			errs: []gqlGraphQLError{{Message: "Vulnerabilities are not available on this plan"}},
+			want: true,
+		},
+		{
+			name: "schema field missing is unavailable",
+			errs: []gqlGraphQLError{{Message: "Field 'vulnerabilities' doesn't exist on type 'Project'"}},
+			want: true,
+		},
+		{
+			name: "license error is unavailable",
+			errs: []gqlGraphQLError{{Message: "This feature requires an Ultimate license"}},
+			want: true,
+		},
+		{
+			name: "case-insensitive match",
+			errs: []gqlGraphQLError{{Message: "PERMISSION DENIED"}},
+			want: true,
+		},
+		{
+			name: "genuine error is available (should surface)",
+			errs: []gqlGraphQLError{{Message: "internal server error"}},
+			want: false,
+		},
+		{
+			name: "mixed: any genuine error makes it available",
+			errs: []gqlGraphQLError{
+				{Message: "permission denied"},
+				{Message: "unexpected token in query"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isVulnerabilitiesUnavailable(tt.errs))
+		})
+	}
+}
+
+func TestParseCodeowners(t *testing.T) {
+	t.Run("empty content returns nil", func(t *testing.T) {
+		assert.Nil(t, parseCodeowners(""))
+	})
+
+	t.Run("comments and blank lines are skipped", func(t *testing.T) {
+		rules := parseCodeowners("# this is a comment\n\n   \n# another\n")
+		assert.Empty(t, rules)
+	})
+
+	t.Run("simple pattern with multiple owners", func(t *testing.T) {
+		rules := parseCodeowners("*.go @go-team @ci-bot\n")
+		require.Len(t, rules, 1)
+		r := rules[0]
+		assert.Equal(t, 1, r.LineNumber)
+		assert.Equal(t, "", r.Section)
+		assert.True(t, r.Required)
+		assert.False(t, r.Optional)
+		assert.Equal(t, 0, r.ApprovalsRequired)
+		assert.Equal(t, "*.go", r.Pattern)
+		assert.Equal(t, []string{"@go-team", "@ci-bot"}, r.Owners)
+	})
+
+	t.Run("sections, optional sections, approvals, and line numbers", func(t *testing.T) {
+		content := "# Comment line\n" + // 1
+			"*.go @go-team @ci\n" + //          2
+			"\n" + //                           3
+			"[Backend]\n" + //                  4
+			"src/ @backend\n" + //              5
+			"\n" + //                           6
+			"^[Optional][2]\n" + //             7
+			"docs/ @docs-team user@example.com" // 8 (no trailing newline)
+
+		rules := parseCodeowners(content)
+		require.Len(t, rules, 3)
+
+		// Line 2: top-level rule, no section.
+		assert.Equal(t, 2, rules[0].LineNumber)
+		assert.Equal(t, "", rules[0].Section)
+		assert.True(t, rules[0].Required)
+		assert.False(t, rules[0].Optional)
+		assert.Equal(t, "*.go", rules[0].Pattern)
+		assert.Equal(t, []string{"@go-team", "@ci"}, rules[0].Owners)
+
+		// Line 5: inside required [Backend] section.
+		assert.Equal(t, 5, rules[1].LineNumber)
+		assert.Equal(t, "Backend", rules[1].Section)
+		assert.True(t, rules[1].Required)
+		assert.False(t, rules[1].Optional)
+		assert.Equal(t, 0, rules[1].ApprovalsRequired)
+		assert.Equal(t, "src/", rules[1].Pattern)
+
+		// Line 8: inside optional ^[Optional][2] section, approvals carried over.
+		assert.Equal(t, 8, rules[2].LineNumber)
+		assert.Equal(t, "Optional", rules[2].Section)
+		assert.False(t, rules[2].Required)
+		assert.True(t, rules[2].Optional)
+		assert.Equal(t, 2, rules[2].ApprovalsRequired)
+		assert.Equal(t, "docs/", rules[2].Pattern)
+		assert.Equal(t, []string{"@docs-team", "user@example.com"}, rules[2].Owners)
+	})
+
+	t.Run("section approval count resets between sections", func(t *testing.T) {
+		content := "[A][3]\n" + //   1
+			"a/ @team-a\n" + //      2
+			"[B]\n" + //             3
+			"b/ @team-b" //          4
+
+		rules := parseCodeowners(content)
+		require.Len(t, rules, 2)
+		assert.Equal(t, "A", rules[0].Section)
+		assert.Equal(t, 3, rules[0].ApprovalsRequired)
+		assert.Equal(t, "B", rules[1].Section)
+		assert.Equal(t, 0, rules[1].ApprovalsRequired)
+	})
+}

--- a/providers/gitlab/resources/gitlab_test.go
+++ b/providers/gitlab/resources/gitlab_test.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestMapAccessLevelToRole(t *testing.T) {
+	tests := []struct {
+		accessLevel int
+		want        string
+	}{
+		{10, "Guest"},
+		{20, "Reporter"},
+		{30, "Developer"},
+		{40, "Maintainer"},
+		{50, "Owner"},
+		{0, "Unknown"},
+		{15, "Unknown"},
+		{60, "Unknown"},
+		{-1, "Unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, mapAccessLevelToRole(tt.accessLevel), "accessLevel=%d", tt.accessLevel)
+	}
+}
+
+func TestGroupsToDicts(t *testing.T) {
+	t.Run("maps fields and skips nil entries", func(t *testing.T) {
+		groups := []*gitlab.Group{
+			{
+				ID:          7,
+				Name:        "platform",
+				FullPath:    "acme/platform",
+				Visibility:  gitlab.PrivateVisibility,
+				Description: "platform team",
+			},
+			nil, // nil entries are dropped, not mapped to a zero dict
+			{
+				ID:         8,
+				Name:       "security",
+				FullPath:   "acme/security",
+				Visibility: gitlab.PublicVisibility,
+			},
+		}
+
+		out := groupsToDicts(groups)
+		require.Len(t, out, 2)
+
+		first := out[0].(map[string]any)
+		assert.Equal(t, int64(7), first["id"])
+		assert.Equal(t, "platform", first["name"])
+		assert.Equal(t, "acme/platform", first["fullPath"])
+		assert.Equal(t, "private", first["visibility"])
+		assert.Equal(t, "platform team", first["description"])
+
+		second := out[1].(map[string]any)
+		assert.Equal(t, int64(8), second["id"])
+		assert.Equal(t, "public", second["visibility"])
+		assert.Equal(t, "", second["description"])
+	})
+
+	t.Run("empty input yields empty slice", func(t *testing.T) {
+		out := groupsToDicts(nil)
+		assert.Empty(t, out)
+	})
+}
+
+func TestNamespaceArgs(t *testing.T) {
+	t.Run("nil-able fields stay unset", func(t *testing.T) {
+		ns := &gitlab.Namespace{
+			ID:       42,
+			Name:     "engineering",
+			Path:     "engineering",
+			Kind:     "group",
+			FullPath: "acme/engineering",
+			ParentID: 1,
+			WebURL:   "https://gitlab.com/groups/acme/engineering",
+			Plan:     "ultimate",
+			Trial:    false,
+			// TrialEndsOn, MaxSeatsUsed, SeatsInUse left nil
+		}
+
+		args := namespaceArgs(ns)
+
+		assert.Equal(t, int64(42), args["id"].Value)
+		assert.Equal(t, "engineering", args["name"].Value)
+		assert.Equal(t, "group", args["kind"].Value)
+		assert.Equal(t, "acme/engineering", args["fullPath"].Value)
+		assert.Equal(t, int64(1), args["parentId"].Value)
+		assert.Equal(t, "ultimate", args["plan"].Value)
+		assert.Equal(t, false, args["trial"].Value)
+		assert.Nil(t, args["trialEndsOn"].Value)
+		assert.Nil(t, args["maxSeatsUsed"].Value)
+		assert.Nil(t, args["seatsInUse"].Value)
+	})
+
+	t.Run("pointer fields are dereferenced", func(t *testing.T) {
+		trialEnd := gitlab.ISOTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+		maxSeats := int64(120)
+		seatsInUse := int64(98)
+		ns := &gitlab.Namespace{
+			ID:           5,
+			Name:         "trial-group",
+			Trial:        true,
+			TrialEndsOn:  &trialEnd,
+			MaxSeatsUsed: &maxSeats,
+			SeatsInUse:   &seatsInUse,
+		}
+
+		args := namespaceArgs(ns)
+
+		assert.Equal(t, true, args["trial"].Value)
+		require.NotNil(t, args["trialEndsOn"].Value)
+		assert.Equal(t, time.Time(trialEnd), *(args["trialEndsOn"].Value.(*time.Time)))
+		assert.Equal(t, int64(120), args["maxSeatsUsed"].Value)
+		assert.Equal(t, int64(98), args["seatsInUse"].Value)
+	})
+}


### PR DESCRIPTION
## What

Adds unit tests for the connection-free helper functions in the gitlab provider's resource layer. The gitlab resources are mostly thin wrappers around the GitLab API client (which need a live connection), but a handful of pure functions carry real logic worth pinning down with tests.

## Coverage

| Function | What's tested |
|----------|---------------|
| `mapAccessLevelToRole` | all five access-level → role mappings + unknown/boundary values |
| `groupsToDicts` | SDK group → dict field mapping, `nil`-entry skipping, visibility stringification, empty input |
| `namespaceArgs` | SDK namespace → MQL args; nil `*ISOTime`/`*int64` fields stay unset, pointer fields dereferenced |
| `parseGIDInt` | trailing-id extraction from `gid://gitlab/.../123`; empty/malformed/no-slash fallbacks |
| `isVulnerabilitiesUnavailable` | tier/permission gating (permission/license/"not available"/schema-missing → unavailable; genuine errors → surface), case-insensitivity, mixed-error precedence |
| `parseCodeowners` | CODEOWNERS parsing — comment/blank skipping, multi-owner patterns, required vs optional (`^`) sections, per-section approval counts (`[Section][2]`), approval reset between sections, 1-based line numbers |

## Notes

- These tests run unconditionally, unlike the existing `connection_test.go` which is gated behind the `debugtest` build tag and needs a live token.
- No production code was changed — only test files added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)