### PR TITLE
🧹 github: unit tests for pure-logic helpers

### DIFF
--- a/providers/github/connection/platform_test.go
+++ b/providers/github/connection/platform_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGithubOrgPlatform(t *testing.T) {
+	pf := NewGithubOrgPlatform("mondoohq")
+	assert.NotNil(t, pf)
+	assert.Equal(t, []string{"saas", "github", "organization", "mondoohq", "organization"}, pf.TechnologyUrlSegments)
+	// the helper must not mutate the package-level template
+	assert.Nil(t, GithubOrgPlatform.TechnologyUrlSegments)
+}
+
+func TestNewGithubUserPlatform(t *testing.T) {
+	pf := NewGithubUserPlatform("octocat")
+	assert.NotNil(t, pf)
+	assert.Equal(t, []string{"saas", "github", "user"}, pf.TechnologyUrlSegments)
+	assert.Nil(t, GithubUserPlatform.TechnologyUrlSegments)
+}
+
+func TestNewGitHubRepoPlatform(t *testing.T) {
+	pf := NewGitHubRepoPlatform("mondoohq", "cnquery")
+	assert.NotNil(t, pf)
+	assert.Equal(t, []string{"saas", "github", "organization", "mondoohq", "repository"}, pf.TechnologyUrlSegments)
+	assert.Nil(t, GithubRepoPlatform.TechnologyUrlSegments)
+}
+
+func TestNewGithubOrgIdentifier(t *testing.T) {
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/github/organization/mondoohq",
+		NewGithubOrgIdentifier("mondoohq"),
+	)
+}
+
+func TestNewGithubUserIdentifier(t *testing.T) {
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/github/user/octocat",
+		NewGithubUserIdentifier("octocat"),
+	)
+}
+
+func TestNewGitHubRepoIdentifier(t *testing.T) {
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/github/owner/mondoohq/repository/cnquery",
+		NewGitHubRepoIdentifier("mondoohq", "cnquery"),
+	)
+}

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -44,3 +44,34 @@ func TestReposFilter_Both(t *testing.T) {
 	assert.True(t, reposFilter.skipRepo("repo2"))
 	assert.False(t, reposFilter.skipRepo("repo3"))
 }
+
+func TestHandleTargets(t *testing.T) {
+	t.Run("all expands to every discovery target", func(t *testing.T) {
+		got := handleTargets([]string{connection.DiscoveryAll})
+		assert.Equal(t, []string{
+			connection.DiscoveryRepos,
+			connection.DiscoveryUsers,
+			connection.DiscoveryTerraform,
+			connection.DiscoveryK8sManifests,
+		}, got)
+	})
+
+	t.Run("all wins even when mixed with explicit targets", func(t *testing.T) {
+		got := handleTargets([]string{connection.DiscoveryRepos, connection.DiscoveryAll})
+		assert.Equal(t, []string{
+			connection.DiscoveryRepos,
+			connection.DiscoveryUsers,
+			connection.DiscoveryTerraform,
+			connection.DiscoveryK8sManifests,
+		}, got)
+	})
+
+	t.Run("explicit targets pass through unchanged", func(t *testing.T) {
+		in := []string{connection.DiscoveryRepos, connection.DiscoveryUsers}
+		assert.Equal(t, in, handleTargets(in))
+	})
+
+	t.Run("empty stays empty", func(t *testing.T) {
+		assert.Empty(t, handleTargets([]string{}))
+	})
+}

--- a/providers/github/resources/github_actions_secrets_test.go
+++ b/providers/github/resources/github_actions_secrets_test.go
@@ -1,0 +1,107 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionsSecretID(t *testing.T) {
+	tests := []struct {
+		name                          string
+		scope, owner, repo, env, secr string
+		want                          string
+	}{
+		{
+			name: "organization scope", scope: scopeOrganization,
+			owner: "mondoohq", secr: "TOKEN",
+			want: "github.actionsSecret/org/mondoohq/TOKEN",
+		},
+		{
+			name: "repository scope", scope: scopeRepository,
+			owner: "mondoohq", repo: "cnquery", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/cnquery/TOKEN",
+		},
+		{
+			name: "environment scope", scope: scopeEnvironment,
+			owner: "mondoohq", repo: "cnquery", env: "prod", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/cnquery/env/prod/TOKEN",
+		},
+		{
+			name: "unknown scope falls back to repo", scope: "weird",
+			owner: "mondoohq", repo: "cnquery", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/cnquery/TOKEN",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, actionsSecretID(tc.scope, tc.owner, tc.repo, tc.env, tc.secr))
+		})
+	}
+}
+
+func TestActionsVariableID(t *testing.T) {
+	tests := []struct {
+		name                          string
+		scope, owner, repo, env, vari string
+		want                          string
+	}{
+		{
+			name: "organization scope", scope: scopeOrganization,
+			owner: "mondoohq", vari: "REGION",
+			want: "github.actionsVariable/org/mondoohq/REGION",
+		},
+		{
+			name: "repository scope", scope: scopeRepository,
+			owner: "mondoohq", repo: "cnquery", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/cnquery/REGION",
+		},
+		{
+			name: "environment scope", scope: scopeEnvironment,
+			owner: "mondoohq", repo: "cnquery", env: "prod", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/cnquery/env/prod/REGION",
+		},
+		{
+			name: "unknown scope falls back to repo", scope: "weird",
+			owner: "mondoohq", repo: "cnquery", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/cnquery/REGION",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, actionsVariableID(tc.scope, tc.owner, tc.repo, tc.env, tc.vari))
+		})
+	}
+}
+
+func TestHandleActionsListErr(t *testing.T) {
+	t.Run("access denied is swallowed", func(t *testing.T) {
+		res, err := handleActionsListErr(ghErrorResponse(http.StatusForbidden), "org secrets")
+		assert.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("not found is swallowed", func(t *testing.T) {
+		res, err := handleActionsListErr(ghErrorResponse(http.StatusNotFound), "org secrets")
+		assert.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("real error is propagated", func(t *testing.T) {
+		boom := errors.New("rate limited")
+		res, err := handleActionsListErr(boom, "org secrets")
+		assert.ErrorIs(t, err, boom)
+		assert.Nil(t, res)
+	})
+
+	t.Run("server error is propagated", func(t *testing.T) {
+		res, err := handleActionsListErr(ghErrorResponse(http.StatusInternalServerError), "org secrets")
+		assert.Error(t, err)
+		assert.Nil(t, res)
+	})
+}

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-github/v87/github"
@@ -146,6 +147,25 @@ func TestPermissionsFromUser(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := permissionsFromUser(tt.user)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGithubResponseStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "not found", err: ghErrorResponse(404), want: 404},
+		{name: "forbidden", err: ghErrorResponse(403), want: 403},
+		{name: "ok", err: ghErrorResponse(200), want: 200},
+		{name: "plain error has no status", err: errors.New("boom"), want: 0},
+		{name: "wrapped github error", err: errors.Join(errors.New("ctx"), ghErrorResponse(404)), want: 404},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, githubResponseStatus(tc.err))
 		})
 	}
 }

--- a/providers/github/resources/github_security_test.go
+++ b/providers/github/resources/github_security_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v87/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func ghErrorResponse(status int) error {
+	return &github.ErrorResponse{
+		Response: &http.Response{StatusCode: status},
+	}
+}
+
+func TestIsAccessDeniedOrNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "404 not found", err: ghErrorResponse(http.StatusNotFound), want: true},
+		{name: "403 forbidden", err: ghErrorResponse(http.StatusForbidden), want: true},
+		{name: "500 server error", err: ghErrorResponse(http.StatusInternalServerError), want: false},
+		{name: "200 ok", err: ghErrorResponse(http.StatusOK), want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "no available registrations fallback", err: errors.New("no available registrations"), want: true},
+		{name: "wrapped 404", err: errors.Join(errors.New("ctx"), ghErrorResponse(http.StatusNotFound)), want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAccessDeniedOrNotFound(tc.err))
+		})
+	}
+}
+
+type samlErr = struct {
+	Type       string         `json:"type"`
+	Message    string         `json:"message"`
+	Extensions map[string]any `json:"extensions"`
+}
+
+func TestIsSamlScopeOrPermissionError(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []samlErr
+		want bool
+	}{
+		{name: "no errors", errs: nil, want: false},
+		{name: "unrelated error", errs: []samlErr{{Type: "NOT_FOUND", Message: "missing"}}, want: false},
+		{name: "type INSUFFICIENT_SCOPES", errs: []samlErr{{Type: "INSUFFICIENT_SCOPES"}}, want: true},
+		{name: "type lowercase forbidden", errs: []samlErr{{Type: "forbidden"}}, want: true},
+		{name: "type unauthorized", errs: []samlErr{{Type: "UNAUTHORIZED"}}, want: true},
+		{name: "extensions code", errs: []samlErr{{Extensions: map[string]any{"code": "insufficient_scopes"}}}, want: true},
+		{name: "message contains scope", errs: []samlErr{{Message: "Your token is missing the required scope"}}, want: true},
+		{name: "message must have admin", errs: []samlErr{{Message: "You must have admin access"}}, want: true},
+		{name: "first benign, second matches", errs: []samlErr{{Type: "OTHER"}, {Type: "FORBIDDEN"}}, want: true},
+		{name: "non-string extension code ignored", errs: []samlErr{{Extensions: map[string]any{"code": 42}}}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSamlScopeOrPermissionError(tc.errs))
+		})
+	}
+}
+
+func TestKeyAgeInDays(t *testing.T) {
+	tests := []struct {
+		name      string
+		createdAt *github.Timestamp
+		want      int64
+	}{
+		{name: "nil timestamp", createdAt: nil, want: -1},
+		{name: "zero timestamp", createdAt: &github.Timestamp{}, want: -1},
+		{name: "two days old", createdAt: &github.Timestamp{Time: time.Now().Add(-48 * time.Hour)}, want: 2},
+		{name: "ten days old", createdAt: &github.Timestamp{Time: time.Now().Add(-10 * 24 * time.Hour)}, want: 10},
+		{name: "younger than a day", createdAt: &github.Timestamp{Time: time.Now().Add(-1 * time.Hour)}, want: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, keyAgeInDays(tc.createdAt))
+		})
+	}
+}
+
+func TestIsCodeownersCommentLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "empty line", line: "", want: false},
+		{name: "leading hash", line: "# comment", want: true},
+		{name: "indented hash with spaces", line: "   # comment", want: true},
+		{name: "indented hash with tab", line: "\t# comment", want: true},
+		{name: "rule line", line: "*.go @team", want: false},
+		{name: "inline hash is not a comment", line: "path/to/#special @owner", want: false},
+		{name: "whitespace only", line: "   ", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isCodeownersCommentLine(tc.line))
+		})
+	}
+}
+
+func TestParseCodeowners(t *testing.T) {
+	content := "# top comment\n" +
+		"\n" +
+		"*.go      @org/go-team @alice\n" +
+		"   # indented comment\n" +
+		"/docs/    @org/docs-team\n" +
+		"path/to/#special   @owner\r\n" +
+		"   \n" +
+		"*.js\n"
+
+	rules := parseCodeowners(content)
+
+	assert.Equal(t, []codeownersRule{
+		{pattern: "*.go", owners: []string{"@org/go-team", "@alice"}, lineNumber: 3},
+		{pattern: "/docs/", owners: []string{"@org/docs-team"}, lineNumber: 5},
+		{pattern: "path/to/#special", owners: []string{"@owner"}, lineNumber: 6},
+		{pattern: "*.js", owners: []string{}, lineNumber: 8},
+	}, rules)
+}
+
+func TestParseCodeowners_Empty(t *testing.T) {
+	assert.Empty(t, parseCodeowners(""))
+	assert.Empty(t, parseCodeowners("# only a comment\n\n   \n"))
+}


### PR DESCRIPTION
## What

Adds unit tests for **pure-logic helper functions** in the github provider that previously had no coverage. These are deterministic functions with no network/API calls or IO, so they're cheap to test directly and were the obvious coverage gap.

## Functions now covered

**`connection/platform.go`** — platform & identifier builders
- `NewGithubOrgPlatform`, `NewGithubUserPlatform`, `NewGitHubRepoPlatform` (asserts `TechnologyUrlSegments` and that the shared package-level platform templates aren't mutated)
- `NewGithubOrgIdentifier`, `NewGithubUserIdentifier`, `NewGitHubRepoIdentifier`

**`resources/github_security.go`**
- `isAccessDeniedOrNotFound` — 404/403, 500/200, plain & wrapped errors, the `no available registrations` fallback
- `isSamlScopeOrPermissionError` — type / extension-code / message-substring paths, non-string extension guard
- `keyAgeInDays` — nil, zero, and aged timestamps
- `isCodeownersCommentLine` — leading vs inline `#`, indentation
- `parseCodeowners` — comments, blanks, CRLF, inline-`#` patterns, line numbers

**`resources/github_actions_secrets.go`**
- `actionsSecretID` / `actionsVariableID` — org/repo/env/unknown-scope branches
- `handleActionsListErr` — swallows 403/404, propagates real/500 errors

**`resources/discovery.go`**
- `handleTargets` — `all` expansion, mixed input, passthrough, empty

**`resources/github_repo.go`**
- `githubResponseStatus` — status extraction from typed/wrapped errors

## Testing

Table-driven, `testify/assert`, matching the provider's existing test style. Both `./connection/` and `./resources/` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)