### PR TITLE
✨ helm: parse chart provenance (.prov) for fetched charts

### DIFF
--- a/providers/helm/connection/connection.go
+++ b/providers/helm/connection/connection.go
@@ -21,9 +21,15 @@ var _ plugin.Connection = (*HelmConnection)(nil)
 // loaded from so the resource layer can distinguish two charts that
 // happen to share name + version (e.g., feature-branch forks of the
 // same chart in a multi-chart directory).
+//
+// ProvenanceData and ArchiveSHA256 are populated only for a chart fetched
+// from a remote source (OCI registry or HTTP repository) that ships a
+// provenance file; they stay empty for charts loaded from a local path.
 type LoadedChart struct {
-	Path  string
-	Chart *chart.Chart
+	Path           string
+	Chart          *chart.Chart
+	ProvenanceData []byte // raw .prov contents; nil when none was fetched
+	ArchiveSHA256  string // hex sha256 of the fetched archive; "" for local charts
 }
 
 type HelmConnection struct {
@@ -51,21 +57,29 @@ func NewHelmConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	// Resolve a possibly-remote chart reference (oci://, http(s) .tgz, or a
 	// chart name with --repo) to a local path. Remote refs download to a
 	// temp dir that's cleaned up once the charts are read into memory.
-	chartPath, cleanup, err := resolveChartRef(cc.Options[OptionPath], cc.Options)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	fetched, err := resolveChartRef(cc.Options[OptionPath], cc.Options)
 	if err != nil {
 		return nil, err
 	}
-	conn.path = chartPath
+	if fetched.cleanup != nil {
+		defer fetched.cleanup()
+	}
+	conn.path = fetched.localPath
 
-	charts, err := loadCharts(chartPath)
+	charts, err := loadCharts(fetched.localPath)
 	if err != nil {
 		return nil, err
 	}
 	if len(charts) == 0 {
-		return nil, errors.New("no Helm charts found at " + chartPath)
+		return nil, errors.New("no Helm charts found at " + fetched.localPath)
+	}
+
+	// A remote fetch resolves to exactly one chart archive, so its
+	// provenance and archive digest attach to that single loaded chart.
+	// Charts loaded from a local path carry no provenance.
+	if len(charts) == 1 && (fetched.provData != nil || fetched.archiveSHA256 != "") {
+		charts[0].ProvenanceData = fetched.provData
+		charts[0].ArchiveSHA256 = fetched.archiveSHA256
 	}
 	conn.charts = charts
 

--- a/providers/helm/connection/fetch.go
+++ b/providers/helm/connection/fetch.go
@@ -4,6 +4,8 @@
 package connection
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +20,18 @@ import (
 	"helm.sh/helm/v3/pkg/registry"
 )
 
+// fetchedChart is the result of resolving a (possibly remote) chart
+// reference to something loadCharts can read. For remote refs it also
+// carries the chart's provenance (.prov) bytes when the source ships one,
+// plus the sha256 of the fetched archive, so the resource layer can report
+// helm.chart.provenance without re-fetching or contacting the registry.
+type fetchedChart struct {
+	localPath     string
+	cleanup       func() // nil for local paths
+	provData      []byte // raw .prov contents; nil when no provenance was found
+	archiveSHA256 string // hex sha256 of the fetched archive; "" for local paths
+}
+
 // resolveChartRef turns a possibly-remote chart reference into a local
 // filesystem path that loadCharts can read:
 //
@@ -29,13 +43,14 @@ import (
 // For remote refs it downloads the chart archive into a temp directory and
 // returns a cleanup func that removes it; loadCharts reads the archive fully
 // into memory, so the caller can clean up immediately afterward. cleanup is
-// nil for local paths.
+// nil for local paths. Remote refs also surface the chart's provenance (when
+// the source ships a .prov) and the archive's sha256 on the returned struct.
 //
 // Fetching deliberately avoids helm's pkg/getter and pkg/repo, which pull in
 // the kube/kubectl stack (incompatible with our pinned k8s.io/api and useless
 // for static analysis). OCI uses pkg/registry directly; HTTP repositories and
 // index resolution use net/http.
-func resolveChartRef(rawPath string, opts map[string]string) (localPath string, cleanup func(), err error) {
+func resolveChartRef(rawPath string, opts map[string]string) (*fetchedChart, error) {
 	version := opts[OptionVersion]
 	username := opts[OptionUsername]
 	password := opts[OptionPassword]
@@ -44,21 +59,21 @@ func resolveChartRef(rawPath string, opts map[string]string) (localPath string, 
 	isOCI := strings.HasPrefix(rawPath, registry.OCIScheme+"://")
 	isHTTP := strings.HasPrefix(rawPath, "http://") || strings.HasPrefix(rawPath, "https://")
 
-	// Purely local chart: no fetching.
+	// Purely local chart: no fetching, no provenance.
 	if !isOCI && !isHTTP && repoURL == "" {
-		return filepath.Clean(rawPath), nil, nil
+		return &fetchedChart{localPath: filepath.Clean(rawPath)}, nil
 	}
 
-	data, err := fetchChartArchive(rawPath, repoURL, version, username, password, isOCI)
+	data, prov, err := fetchChartArchive(rawPath, repoURL, version, username, password, isOCI)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	dest, err := os.MkdirTemp("", "mql-helm-chart-*")
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-	cleanup = func() {
+	cleanup := func() {
 		if rmErr := os.RemoveAll(dest); rmErr != nil {
 			log.Warn().Err(rmErr).Str("dir", dest).Msg("failed to clean up helm chart download dir")
 		}
@@ -67,17 +82,26 @@ func resolveChartRef(rawPath string, opts map[string]string) (localPath string, 
 	archive := filepath.Join(dest, "chart.tgz")
 	if err := os.WriteFile(archive, data, 0o600); err != nil {
 		cleanup()
-		return "", nil, err
+		return nil, err
 	}
-	return archive, cleanup, nil
+
+	sum := sha256.Sum256(data)
+	return &fetchedChart{
+		localPath:     archive,
+		cleanup:       cleanup,
+		provData:      prov,
+		archiveSHA256: hex.EncodeToString(sum[:]),
+	}, nil
 }
 
-// fetchChartArchive downloads the raw .tgz bytes of a remote chart.
-func fetchChartArchive(rawPath, repoURL, version, username, password string, isOCI bool) ([]byte, error) {
+// fetchChartArchive downloads the raw .tgz bytes of a remote chart, along
+// with its provenance (.prov) bytes when the source provides one. A missing
+// provenance is not an error — prov is simply nil.
+func fetchChartArchive(rawPath, repoURL, version, username, password string, isOCI bool) (archive, prov []byte, err error) {
 	if isOCI {
 		client, err := registry.NewClient()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		ref := strings.TrimPrefix(rawPath, registry.OCIScheme+"://")
 		// Append the requested version as a tag when the ref isn't already
@@ -85,11 +109,18 @@ func fetchChartArchive(rawPath, repoURL, version, username, password string, isO
 		if version != "" && !strings.ContainsAny(lastPathSegment(ref), ":@") {
 			ref += ":" + version
 		}
-		result, err := client.Pull(ref, registry.PullOptWithChart(true))
+		result, err := client.Pull(ref,
+			registry.PullOptWithChart(true),
+			registry.PullOptWithProv(true),
+			registry.PullOptIgnoreMissingProv(true),
+		)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return result.Chart.Data, nil
+		if result.Prov != nil {
+			prov = result.Prov.Data
+		}
+		return result.Chart.Data, prov, nil
 	}
 
 	chartURL := rawPath
@@ -97,12 +128,33 @@ func fetchChartArchive(rawPath, repoURL, version, username, password string, isO
 		// Resolve "chartName" against the repository's index.yaml.
 		resolved, err := resolveChartInRepo(repoURL, rawPath, version, username, password)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		chartURL = resolved
 	}
 
-	return httpGetBytes(chartURL, username, password)
+	archive, err = httpGetBytes(chartURL, username, password)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Provenance lives next to the archive at "<url>.prov" by Helm
+	// convention. Its absence is expected for unsigned charts, so a failed
+	// fetch is swallowed rather than failing the whole connection.
+	prov = fetchProvenanceHTTP(chartURL, username, password)
+	return archive, prov, nil
+}
+
+// fetchProvenanceHTTP best-effort downloads the provenance file that sits
+// next to a chart archive at "<chartURL>.prov". It returns nil for any
+// failure (missing file, network error, oversized response) because an
+// unsigned chart simply has no provenance.
+func fetchProvenanceHTTP(chartURL, username, password string) []byte {
+	prov, err := httpGetBytes(chartURL+".prov", username, password)
+	if err != nil {
+		log.Debug().Err(err).Str("url", chartURL+".prov").Msg("no helm chart provenance found")
+		return nil
+	}
+	return prov
 }
 
 // repoIndex is the subset of a Helm repository index.yaml we need to map a

--- a/providers/helm/go.mod
+++ b/providers/helm/go.mod
@@ -5,10 +5,10 @@ go 1.26.3
 replace go.mondoo.com/mql/v13 => ../..
 
 require (
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.22.1
-	golang.org/x/crypto v0.53.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.21.1
 )
@@ -21,7 +21,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect
@@ -135,6 +134,7 @@ require (
 	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/providers/helm/go.mod
+++ b/providers/helm/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.22.1
+	golang.org/x/crypto v0.53.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.21.1
 )
@@ -134,7 +135,6 @@ require (
 	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/providers/helm/resources/helm.go
+++ b/providers/helm/resources/helm.go
@@ -44,6 +44,10 @@ func (r *mqlHelm) charts() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Provenance only exists for a chart fetched from a remote source
+		// that ships a .prov; it stays nil for local charts and subcharts.
+		mqlChart.provData = lc.ProvenanceData
+		mqlChart.archiveSHA256 = lc.ArchiveSHA256
 		mqlCharts = append(mqlCharts, mqlChart)
 	}
 	return mqlCharts, nil
@@ -60,6 +64,8 @@ type mqlHelmChartInternal struct {
 	renderedErr     error
 	resourcesOnce   sync.Once
 	cachedResources []any
+	provData        []byte // raw .prov contents; nil unless fetched with provenance
+	archiveSHA256   string // hex sha256 of the fetched archive; "" for local charts
 }
 
 // newMqlHelmChart materializes a *chart.Chart as a helm.chart resource.

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -141,6 +141,15 @@ helm.chart @defaults("name version") {
   // chart whose charts/ directory it was loaded from, enabling traversal
   // back up the dependency tree.
   parent() helm.chart
+  // Supply-chain provenance
+  //
+  // The PGP provenance Helm attaches to a signed, packaged chart (the .prov
+  // file produced by `helm package --sign`), recording the chart archive's
+  // sha256 digest and the signing key. Available only for a chart fetched
+  // from an OCI registry or an HTTP repository that ships a provenance file;
+  // null for charts loaded from a local path, for subcharts, and for fetched
+  // charts that carry no provenance. See helm.chart.provenanceRecord.
+  provenance() helm.chart.provenanceRecord
 }
 
 // Helm chart dependency
@@ -395,4 +404,38 @@ private helm.chart.lintMessage @defaults("severity message") {
   path string
   // Message text
   message string
+}
+
+// Helm chart provenance
+//
+// Examine the PGP provenance attached to a fetched chart — the .prov file
+// Helm writes with `helm package --sign`. Reports whether the chart is
+// signed, the sha256 digest the signature attests for the chart archive,
+// whether the archive actually fetched matches that digest, and the key ID
+// that produced the signature. Verification is offline: the digest is
+// recomputed locally and the issuer is read from the signature packet, so no
+// keyring and no registry round-trip are involved. Selected from a chart via
+// `helm.chart.provenance`.
+private helm.chart.provenanceRecord @defaults("signed digestMatches keyId") {
+  // Whether the provenance carries a PGP signature block
+  signed bool
+  // Digest the provenance attests for the chart archive
+  //
+  // The `sha256:...` value recorded in the signed `files:` block for the
+  // chart's .tgz. Empty when the provenance records no digest for the archive.
+  digest string
+  // Whether the fetched archive matches the attested digest
+  //
+  // True when the sha256 of the archive actually fetched equals digest. The
+  // hash is recomputed locally — no registry round-trip and no keyring — so a
+  // false value flags a tampered or stale provenance file. False when digest
+  // is empty or the archive couldn't be hashed.
+  digestMatches bool
+  // Key ID that produced the signature
+  //
+  // The 16-hexadecimal-character issuer key ID read from the signature packet
+  // (for example "1234567890ABCDEF"), identifying the signer without their
+  // public key. Empty when unsigned or the issuer can't be read. Full
+  // cryptographic verification against a keyring is out of scope.
+  keyId string
 }

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -16,18 +16,19 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceHelm                    string = "helm"
-	ResourceHelmChart               string = "helm.chart"
-	ResourceHelmDependency          string = "helm.dependency"
-	ResourceHelmOciRef              string = "helm.ociRef"
-	ResourceHelmMaintainer          string = "helm.maintainer"
-	ResourceHelmTemplate            string = "helm.template"
-	ResourceHelmDirective           string = "helm.directive"
-	ResourceHelmResource            string = "helm.resource"
-	ResourceHelmFile                string = "helm.file"
-	ResourceHelmChartDependencyLock string = "helm.chart.dependencyLock"
-	ResourceHelmChartLintResult     string = "helm.chart.lintResult"
-	ResourceHelmChartLintMessage    string = "helm.chart.lintMessage"
+	ResourceHelm                      string = "helm"
+	ResourceHelmChart                 string = "helm.chart"
+	ResourceHelmDependency            string = "helm.dependency"
+	ResourceHelmOciRef                string = "helm.ociRef"
+	ResourceHelmMaintainer            string = "helm.maintainer"
+	ResourceHelmTemplate              string = "helm.template"
+	ResourceHelmDirective             string = "helm.directive"
+	ResourceHelmResource              string = "helm.resource"
+	ResourceHelmFile                  string = "helm.file"
+	ResourceHelmChartDependencyLock   string = "helm.chart.dependencyLock"
+	ResourceHelmChartLintResult       string = "helm.chart.lintResult"
+	ResourceHelmChartLintMessage      string = "helm.chart.lintMessage"
+	ResourceHelmChartProvenanceRecord string = "helm.chart.provenanceRecord"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -81,6 +82,10 @@ func init() {
 		"helm.chart.lintMessage": {
 			// to override args, implement: initHelmChartLintMessage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createHelmChartLintMessage,
+		},
+		"helm.chart.provenanceRecord": {
+			// to override args, implement: initHelmChartProvenanceRecord(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createHelmChartProvenanceRecord,
 		},
 	}
 }
@@ -242,6 +247,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"helm.chart.parent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmChart).GetParent()).ToDataRes(types.Resource("helm.chart"))
+	},
+	"helm.chart.provenance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetProvenance()).ToDataRes(types.Resource("helm.chart.provenanceRecord"))
 	},
 	"helm.dependency.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmDependency).GetName()).ToDataRes(types.String)
@@ -405,6 +413,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"helm.chart.lintMessage.message": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmChartLintMessage).GetMessage()).ToDataRes(types.String)
 	},
+	"helm.chart.provenanceRecord.signed": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChartProvenanceRecord).GetSigned()).ToDataRes(types.Bool)
+	},
+	"helm.chart.provenanceRecord.digest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChartProvenanceRecord).GetDigest()).ToDataRes(types.String)
+	},
+	"helm.chart.provenanceRecord.digestMatches": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChartProvenanceRecord).GetDigestMatches()).ToDataRes(types.Bool)
+	},
+	"helm.chart.provenanceRecord.keyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChartProvenanceRecord).GetKeyId()).ToDataRes(types.String)
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -543,6 +563,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"helm.chart.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHelmChart).Parent, ok = plugin.RawToTValue[*mqlHelmChart](v.Value, v.Error)
+		return
+	},
+	"helm.chart.provenance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).Provenance, ok = plugin.RawToTValue[*mqlHelmChartProvenanceRecord](v.Value, v.Error)
 		return
 	},
 	"helm.dependency.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -801,6 +825,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHelmChartLintMessage).Message, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"helm.chart.provenanceRecord.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChartProvenanceRecord).__id, ok = v.Value.(string)
+		return
+	},
+	"helm.chart.provenanceRecord.signed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChartProvenanceRecord).Signed, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"helm.chart.provenanceRecord.digest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChartProvenanceRecord).Digest, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.chart.provenanceRecord.digestMatches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChartProvenanceRecord).DigestMatches, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"helm.chart.provenanceRecord.keyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChartProvenanceRecord).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 }
 
 func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
@@ -920,6 +964,7 @@ type mqlHelmChart struct {
 	Subcharts      plugin.TValue[[]any]
 	IsSubchart     plugin.TValue[bool]
 	Parent         plugin.TValue[*mqlHelmChart]
+	Provenance     plugin.TValue[*mqlHelmChartProvenanceRecord]
 }
 
 // createHelmChart creates a new instance of this resource
@@ -1212,6 +1257,22 @@ func (c *mqlHelmChart) GetParent() *plugin.TValue[*mqlHelmChart] {
 		}
 
 		return c.parent()
+	})
+}
+
+func (c *mqlHelmChart) GetProvenance() *plugin.TValue[*mqlHelmChartProvenanceRecord] {
+	return plugin.GetOrCompute[*mqlHelmChartProvenanceRecord](&c.Provenance, func() (*mqlHelmChartProvenanceRecord, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("helm.chart", c.__id, "provenance")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHelmChartProvenanceRecord), nil
+			}
+		}
+
+		return c.provenance()
 	})
 }
 
@@ -1963,4 +2024,63 @@ func (c *mqlHelmChartLintMessage) GetPath() *plugin.TValue[string] {
 
 func (c *mqlHelmChartLintMessage) GetMessage() *plugin.TValue[string] {
 	return &c.Message
+}
+
+// mqlHelmChartProvenanceRecord for the helm.chart.provenanceRecord resource
+type mqlHelmChartProvenanceRecord struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlHelmChartProvenanceRecordInternal it will be used here
+	Signed        plugin.TValue[bool]
+	Digest        plugin.TValue[string]
+	DigestMatches plugin.TValue[bool]
+	KeyId         plugin.TValue[string]
+}
+
+// createHelmChartProvenanceRecord creates a new instance of this resource
+func createHelmChartProvenanceRecord(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlHelmChartProvenanceRecord{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("helm.chart.provenanceRecord", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlHelmChartProvenanceRecord) MqlName() string {
+	return "helm.chart.provenanceRecord"
+}
+
+func (c *mqlHelmChartProvenanceRecord) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlHelmChartProvenanceRecord) GetSigned() *plugin.TValue[bool] {
+	return &c.Signed
+}
+
+func (c *mqlHelmChartProvenanceRecord) GetDigest() *plugin.TValue[string] {
+	return &c.Digest
+}
+
+func (c *mqlHelmChartProvenanceRecord) GetDigestMatches() *plugin.TValue[bool] {
+	return &c.DigestMatches
+}
+
+func (c *mqlHelmChartProvenanceRecord) GetKeyId() *plugin.TValue[string] {
+	return &c.KeyId
 }

--- a/providers/helm/resources/helm.lr.versions
+++ b/providers/helm/resources/helm.lr.versions
@@ -34,6 +34,12 @@ helm.chart.maintainers 13.0.0
 helm.chart.name 13.0.0
 helm.chart.notes 13.1.1
 helm.chart.parent 13.0.10
+helm.chart.provenance 13.2.1
+helm.chart.provenanceRecord 13.2.1
+helm.chart.provenanceRecord.digest 13.2.1
+helm.chart.provenanceRecord.digestMatches 13.2.1
+helm.chart.provenanceRecord.keyId 13.2.1
+helm.chart.provenanceRecord.signed 13.2.1
 helm.chart.renderedValues 13.1.1
 helm.chart.resources 13.0.0
 helm.chart.sources 13.0.0

--- a/providers/helm/resources/provenance.go
+++ b/providers/helm/resources/provenance.go
@@ -1,0 +1,125 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"golang.org/x/crypto/openpgp/clearsign"
+	"golang.org/x/crypto/openpgp/packet"
+	"gopkg.in/yaml.v3"
+)
+
+// provenance exposes the chart's PGP provenance (.prov), parsed offline.
+// It's populated only for a chart fetched from a remote source that ships
+// a provenance file; charts loaded from a local path and subcharts carry
+// none, so this returns null for them.
+func (c *mqlHelmChart) provenance() (*mqlHelmChartProvenanceRecord, error) {
+	if len(c.provData) == 0 {
+		c.Provenance.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	info := parseProvenance(c.provData, c.archiveSHA256)
+
+	res, err := CreateResource(c.MqlRuntime, "helm.chart.provenanceRecord", map[string]*llx.RawData{
+		"__id":          llx.StringData(c.idKey + "/provenance"),
+		"signed":        llx.BoolData(info.signed),
+		"digest":        llx.StringData(info.digest),
+		"digestMatches": llx.BoolData(info.digestMatches),
+		"keyId":         llx.StringData(info.keyId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHelmChartProvenanceRecord), nil
+}
+
+// provenanceInfo holds the fields parsed out of a .prov file.
+type provenanceInfo struct {
+	signed        bool
+	digest        string
+	digestMatches bool
+	keyId         string
+}
+
+// parseProvenance decodes a Helm .prov file. The file is a PGP clear-signed
+// message whose body is the chart's Chart.yaml followed by a "files:" block
+// mapping each packaged file to its sha256. Parsing is offline: the issuer
+// key ID comes from the signature packet, and digestMatches is computed by
+// comparing the recorded digest against the archive's locally computed
+// sha256 (no keyring, no registry).
+func parseProvenance(provData []byte, archiveSHA256 string) provenanceInfo {
+	var info provenanceInfo
+
+	block, _ := clearsign.Decode(provData)
+	if block == nil {
+		// Not a parseable clear-signed message; nothing we can report.
+		return info
+	}
+
+	info.signed = block.ArmoredSignature != nil
+	info.keyId = provenanceKeyID(block)
+	info.digest = provenanceDigest(block.Plaintext)
+	if info.digest != "" && archiveSHA256 != "" {
+		info.digestMatches = strings.EqualFold(strings.TrimPrefix(info.digest, "sha256:"), archiveSHA256)
+	}
+	return info
+}
+
+// provenanceKeyID reads the 16-hex issuer key ID from the signature packet,
+// identifying the signer without needing their public key. Empty when the
+// signature can't be parsed or carries no issuer.
+func provenanceKeyID(block *clearsign.Block) string {
+	if block.ArmoredSignature == nil {
+		return ""
+	}
+	reader := packet.NewReader(block.ArmoredSignature.Body)
+	for {
+		p, err := reader.Next()
+		if err != nil {
+			return ""
+		}
+		if sig, ok := p.(*packet.Signature); ok && sig.IssuerKeyId != nil {
+			return fmt.Sprintf("%016X", *sig.IssuerKeyId)
+		}
+	}
+}
+
+// provenanceDigest extracts the chart archive's recorded sha256 from the
+// signed "files:" block. Helm builds the signed message as the chart
+// metadata, a "\n...\n" separator, then the sums document, and parses the
+// halves separately rather than as a YAML stream — so we split on the same
+// separator and inspect each part. It returns the .tgz entry's digest,
+// falling back to the first recorded file when no .tgz entry is present.
+func provenanceDigest(plaintext []byte) string {
+	for _, part := range bytes.Split(plaintext, []byte("\n...\n")) {
+		var doc map[string]any
+		if err := yaml.Unmarshal(part, &doc); err != nil {
+			continue
+		}
+		files, ok := doc["files"].(map[string]any)
+		if !ok {
+			continue
+		}
+		var first string
+		for name, sum := range files {
+			s, _ := sum.(string)
+			if strings.HasSuffix(name, ".tgz") {
+				return s
+			}
+			if first == "" {
+				first = s
+			}
+		}
+		if first != "" {
+			return first
+		}
+	}
+	return ""
+}

--- a/providers/helm/resources/provenance.go
+++ b/providers/helm/resources/provenance.go
@@ -6,12 +6,13 @@ package resources
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"golang.org/x/crypto/openpgp/clearsign"
-	"golang.org/x/crypto/openpgp/packet"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,9 +108,16 @@ func provenanceDigest(plaintext []byte) string {
 		if !ok {
 			continue
 		}
+		// Prefer the .tgz entry; fall back to the lexicographically smallest
+		// key so the result is deterministic regardless of map iteration order.
+		names := make([]string, 0, len(files))
+		for name := range files {
+			names = append(names, name)
+		}
+		sort.Strings(names)
 		var first string
-		for name, sum := range files {
-			s, _ := sum.(string)
+		for _, name := range names {
+			s, _ := files[name].(string)
 			if strings.HasSuffix(name, ".tgz") {
 				return s
 			}

--- a/providers/helm/resources/provenance_test.go
+++ b/providers/helm/resources/provenance_test.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/clearsign"
 )
 
 // signProvenance builds a Helm-style .prov: a PGP clear-signed message whose

--- a/providers/helm/resources/provenance_test.go
+++ b/providers/helm/resources/provenance_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/clearsign"
+)
+
+// signProvenance builds a Helm-style .prov: a PGP clear-signed message whose
+// body is the chart metadata followed by a "files:" block. It returns the
+// armored bytes and the signing key's ID so tests can assert against both.
+func signProvenance(t *testing.T, body string) ([]byte, uint64) {
+	t.Helper()
+	entity, err := openpgp.NewEntity("Test User", "helm provenance test", "test@example.com", nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w, err := clearsign.Encode(&buf, entity.PrivateKey, nil)
+	require.NoError(t, err)
+	_, err = w.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return buf.Bytes(), entity.PrimaryKey.KeyId
+}
+
+func provBody(archiveSHA256 string) string {
+	return "apiVersion: v2\nname: mychart\nversion: 1.2.3\n...\n" +
+		"files:\n  mychart-1.2.3.tgz: sha256:" + archiveSHA256 + "\n"
+}
+
+func TestParseProvenance(t *testing.T) {
+	archive := []byte("fake helm chart archive bytes")
+	sum := sha256.Sum256(archive)
+	archiveHex := hex.EncodeToString(sum[:])
+
+	provData, keyID := signProvenance(t, provBody(archiveHex))
+
+	t.Run("matching archive", func(t *testing.T) {
+		info := parseProvenance(provData, archiveHex)
+		assert.True(t, info.signed)
+		assert.Equal(t, "sha256:"+archiveHex, info.digest)
+		assert.True(t, info.digestMatches)
+		assert.Equal(t, fmt.Sprintf("%016X", keyID), info.keyId)
+	})
+
+	t.Run("mismatched archive flags tampering", func(t *testing.T) {
+		info := parseProvenance(provData, "0123456789abcdef")
+		assert.True(t, info.signed)
+		assert.False(t, info.digestMatches)
+		assert.Equal(t, "sha256:"+archiveHex, info.digest)
+	})
+
+	t.Run("unknown archive hash skips comparison", func(t *testing.T) {
+		info := parseProvenance(provData, "")
+		assert.True(t, info.signed)
+		assert.False(t, info.digestMatches)
+		assert.Equal(t, "sha256:"+archiveHex, info.digest)
+	})
+
+	t.Run("not a provenance file", func(t *testing.T) {
+		info := parseProvenance([]byte("this is not a pgp message"), archiveHex)
+		assert.False(t, info.signed)
+		assert.Empty(t, info.digest)
+		assert.Empty(t, info.keyId)
+		assert.False(t, info.digestMatches)
+	})
+}
+
+func TestProvenanceDigest(t *testing.T) {
+	t.Run("prefers the .tgz entry", func(t *testing.T) {
+		plaintext := "name: c\n...\nfiles:\n  c-1.0.0.tgz: sha256:aaa\n  values.schema.json: sha256:bbb\n"
+		assert.Equal(t, "sha256:aaa", provenanceDigest([]byte(plaintext)))
+	})
+
+	t.Run("falls back to first file when no tgz", func(t *testing.T) {
+		plaintext := "name: c\n...\nfiles:\n  only.json: sha256:ccc\n"
+		assert.Equal(t, "sha256:ccc", provenanceDigest([]byte(plaintext)))
+	})
+
+	t.Run("no files block", func(t *testing.T) {
+		assert.Empty(t, provenanceDigest([]byte("name: c\nversion: 1.0.0\n")))
+	})
+}


### PR DESCRIPTION
## What

Adds a `helm.chart.provenance` accessor backed by a new private `helm.chart.provenanceRecord` resource that surfaces the PGP provenance Helm attaches to signed, packaged charts (the `.prov` file produced by `helm package --sign`).

| field | meaning |
|-------|---------|
| `signed` | a PGP signature block is present |
| `digest` | the `sha256:…` the provenance attests for the chart archive |
| `digestMatches` | whether the fetched archive's **locally recomputed** sha256 matches `digest` — a tamper / staleness check |
| `keyId` | the 16-hex issuer key ID read from the signature packet (signer identity, no public key needed) |

```ruby
helm.charts {
  name
  provenance {
    signed
    digestMatches   # false flags a tampered or stale .prov
    keyId
  }
}
```

## How

Provenance is fetched **alongside** the chart for remote sources, reusing the existing fetch path:

- **OCI** — adds `PullOptWithProv(true)` + `PullOptIgnoreMissingProv(true)` to the existing `client.Pull`, then reads `result.Prov.Data`.
- **HTTP / repo** — best-effort `GET <chart-url>.prov` after the archive download; a missing file is not an error.

The fetched archive's sha256 is computed once at fetch time and threaded onto `LoadedChart` so `digestMatches` needs no second read. Verification is **fully offline** — no keyring, no registry round-trip. Parsing mirrors Helm's own `\n...\n` message-block split (yaml.v3's stream decoder rejects the second doc) and reads the issuer from the signature packet via `golang.org/x/crypto/openpgp` (already in-tree via Helm).

`provenance()` returns **null** for charts loaded from a local path, for subcharts, and for fetched charts that ship no `.prov`.

## Schema

- New field `helm.chart.provenance` + new private resource `helm.chart.provenanceRecord`.
- Named `provenanceRecord` (not `provenance`) to avoid the field-path/resource-name collision that turns a `<parent>.<field>`-named resource into an empty husk — same convention as `lock`→`dependencyLock` and `lint`→`lintResult`.
- New `.lr.versions` entries at **13.2.1** (next patch after the shipped 13.2.0).

## Testing

- `go test ./...` green across the provider. New `provenance_test.go` signs a real `.prov` with a generated PGP keypair and asserts `signed` / `digest` / `digestMatches` (match, mismatch, unknown-hash) and `keyId`, plus `provenanceDigest` parsing variants.
- End-to-end: `mql run helm <local-chart> -c "helm.charts { provenance { … } }"` returns `provenance: null` cleanly (exercises the `StateIsNull` path, no panic).
- ⚠️ Live fetch against a signed remote chart was **not** run — the local sandbox network allowlist excludes Helm registries. The parse logic that consumes a fetched `.prov` is covered by the unit tests above with a genuinely signed blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)