### PR TITLE
🌙 docker.file: derived predicates and from.digest parser fix

### DIFF
--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -92,6 +92,9 @@ func (p *mqlDockerFile) parse(file *mqlFile) error {
 		p.Instructions.Error = err
 		p.Stages.Error = err
 		p.Directives.Error = err
+		p.MultiStage.Error = err
+		p.UsesBuildkit.Error = err
+		p.FinalStage.Error = err
 		return err
 	}
 
@@ -146,7 +149,7 @@ func (p *mqlDockerFile) parse(file *mqlFile) error {
 	stages := make([]any, len(parsedStages))
 	var stagesErr error
 	for i := range parsedStages {
-		stages[i], err = p.stage2resource(parsedStages[i])
+		stages[i], err = p.stage2resource(parsedStages[i], i == len(parsedStages)-1)
 		if err != nil {
 			stagesErr = multierr.Wrap(err, "failed to parse stage in dockerfile "+file.Path.Data)
 			break
@@ -158,28 +161,46 @@ func (p *mqlDockerFile) parse(file *mqlFile) error {
 		State: plugin.StateIsSet,
 	}
 
+	p.MultiStage = plugin.TValue[bool]{
+		Data:  len(stages) > 1,
+		Error: stagesErr,
+		State: plugin.StateIsSet,
+	}
+	_, hasSyntax := directives["syntax"]
+	p.UsesBuildkit = plugin.TValue[bool]{
+		Data:  hasSyntax,
+		State: plugin.StateIsSet,
+	}
+	if stagesErr == nil && len(stages) > 0 {
+		p.FinalStage = plugin.TValue[*mqlDockerFileStage]{
+			Data:  stages[len(stages)-1].(*mqlDockerFileStage),
+			State: plugin.StateIsSet,
+		}
+	} else {
+		p.FinalStage = plugin.TValue[*mqlDockerFileStage]{
+			Error: stagesErr,
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+	}
+
 	// FIXME: add meta data
 	_ = meta
 
 	return nil
 }
 
-func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFileStage, error) {
-	var image string
-	var tag string
-	var digest string
-	if idx := strings.Index(stage.BaseName, ":"); idx != -1 {
-		image = stage.BaseName[:idx]
-		if len(stage.BaseName) > idx+1 {
-			tag = stage.BaseName[idx+1:]
-		}
-	} else if idx := strings.Index(stage.BaseName, "@"); idx != -1 {
-		image = stage.BaseName[:idx]
-		if len(stage.BaseName) > idx+1 {
-			tag = stage.BaseName[idx+1:]
-		}
+func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (*mqlDockerFileStage, error) {
+	var image, tag, digest string
+	rest := stage.BaseName
+	if before, after, ok := strings.Cut(rest, "@"); ok {
+		rest = before
+		digest = after
+	}
+	if before, after, ok := strings.Cut(rest, ":"); ok {
+		image = before
+		tag = after
 	} else {
-		image = stage.BaseName
+		image = rest
 	}
 
 	stageID := p.locationID(stage.Location)
@@ -252,12 +273,17 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 			if err != nil {
 				return nil, err
 			}
+			mountsSecret, mountsSsh := mountTypeFlags(mounts)
 			runResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
-				"__id":     llx.StringData(p.locationID(v.Location())),
-				"script":   llx.StringData(script),
-				"mounts":   llx.ArrayData(mounts, types.Resource(ResourceDockerFileRunMount)),
-				"network":  llx.StringData(runFlagValue(v, "network")),
-				"security": llx.StringData(runFlagValue(v, "security")),
+				"__id":         llx.StringData(p.locationID(v.Location())),
+				"script":       llx.StringData(script),
+				"mounts":       llx.ArrayData(mounts, types.Resource(ResourceDockerFileRunMount)),
+				"network":      llx.StringData(runFlagValue(v, "network")),
+				"security":     llx.StringData(runFlagValue(v, "security")),
+				"isShellForm":  llx.BoolData(v.PrependShell),
+				"isExecForm":   llx.BoolData(!v.PrependShell),
+				"mountsSecret": llx.BoolData(mountsSecret),
+				"mountsSsh":    llx.BoolData(mountsSsh),
 			})
 			if err != nil {
 				return nil, err
@@ -389,20 +415,30 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 		log.Debug().Strs("commands", slices.Compact(unsupported)).Msg("unsupported dockerfile commands")
 	}
 
+	var userValue string
+	if userRaw != nil {
+		if parts := strings.SplitN(userRaw.User, ":", 2); len(parts) > 0 {
+			userValue = parts[0]
+		}
+	}
+
 	args := map[string]*llx.RawData{
-		"__id":    llx.StringData(stageID),
-		"from":    llx.ResourceData(rawFrom, ResourceDockerFileFrom),
-		"file":    llx.ResourceData(p, ResourceDockerFile),
-		"env":     llx.ArrayData(env, types.Resource(ResourceDockerFileEnv)),
-		"arg":     llx.ArrayData(arg, types.Resource(ResourceDockerFileArg)),
-		"labels":  llx.MapData(llx.TMap2Raw(labels), types.String),
-		"run":     llx.ArrayData(runs, types.Resource(ResourceDockerFileRun)),
-		"add":     llx.ArrayData(add, types.Resource(ResourceDockerFileAdd)),
-		"copy":    llx.ArrayData(copy, types.Resource(ResourceDockerFileCopy)),
-		"expose":  llx.ArrayData(expose, types.Resource(ResourceDockerFileExpose)),
-		"volumes": llx.ArrayData(volumes, types.Resource(ResourceDockerFileVolume)),
-		"workdir": llx.ArrayData(workdir, types.Resource(ResourceDockerFileWorkdir)),
-		"onbuild": llx.ArrayData(onbuild, types.Resource(ResourceDockerFileOnbuild)),
+		"__id":           llx.StringData(stageID),
+		"from":           llx.ResourceData(rawFrom, ResourceDockerFileFrom),
+		"file":           llx.ResourceData(p, ResourceDockerFile),
+		"env":            llx.ArrayData(env, types.Resource(ResourceDockerFileEnv)),
+		"arg":            llx.ArrayData(arg, types.Resource(ResourceDockerFileArg)),
+		"labels":         llx.MapData(llx.TMap2Raw(labels), types.String),
+		"run":            llx.ArrayData(runs, types.Resource(ResourceDockerFileRun)),
+		"add":            llx.ArrayData(add, types.Resource(ResourceDockerFileAdd)),
+		"copy":           llx.ArrayData(copy, types.Resource(ResourceDockerFileCopy)),
+		"expose":         llx.ArrayData(expose, types.Resource(ResourceDockerFileExpose)),
+		"volumes":        llx.ArrayData(volumes, types.Resource(ResourceDockerFileVolume)),
+		"workdir":        llx.ArrayData(workdir, types.Resource(ResourceDockerFileWorkdir)),
+		"onbuild":        llx.ArrayData(onbuild, types.Resource(ResourceDockerFileOnbuild)),
+		"runsAsRoot":     llx.BoolData(userRaw == nil || isRootUser(userValue)),
+		"hasHealthcheck": llx.BoolData(healthcheckRaw != nil),
+		"final":          llx.BoolData(isFinal),
 	}
 
 	if stopsignalRaw != nil {
@@ -421,11 +457,15 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 	if entrypointRaw != nil {
 		script := strings.Join(entrypointRaw.CmdLine, "\n")
 		runResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
-			"__id":     llx.StringData(p.locationID(entrypointRaw.Location())),
-			"script":   llx.StringData(script),
-			"mounts":   llx.ArrayData(nil, types.Resource(ResourceDockerFileRunMount)),
-			"network":  llx.StringData(""),
-			"security": llx.StringData(""),
+			"__id":         llx.StringData(p.locationID(entrypointRaw.Location())),
+			"script":       llx.StringData(script),
+			"mounts":       llx.ArrayData(nil, types.Resource(ResourceDockerFileRunMount)),
+			"network":      llx.StringData(""),
+			"security":     llx.StringData(""),
+			"isShellForm":  llx.BoolData(entrypointRaw.PrependShell),
+			"isExecForm":   llx.BoolData(!entrypointRaw.PrependShell),
+			"mountsSecret": llx.BoolData(false),
+			"mountsSsh":    llx.BoolData(false),
 		})
 		if err != nil {
 			return nil, err
@@ -438,11 +478,15 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 	if cmdRaw != nil {
 		script := strings.Join(cmdRaw.CmdLine, "\n")
 		cmdResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
-			"__id":     llx.StringData(p.locationID(cmdRaw.Location())),
-			"script":   llx.StringData(script),
-			"mounts":   llx.ArrayData(nil, types.Resource(ResourceDockerFileRunMount)),
-			"network":  llx.StringData(""),
-			"security": llx.StringData(""),
+			"__id":         llx.StringData(p.locationID(cmdRaw.Location())),
+			"script":       llx.StringData(script),
+			"mounts":       llx.ArrayData(nil, types.Resource(ResourceDockerFileRunMount)),
+			"network":      llx.StringData(""),
+			"security":     llx.StringData(""),
+			"isShellForm":  llx.BoolData(cmdRaw.PrependShell),
+			"isExecForm":   llx.BoolData(!cmdRaw.PrependShell),
+			"mountsSecret": llx.BoolData(false),
+			"mountsSsh":    llx.BoolData(false),
 		})
 		if err != nil {
 			return nil, err
@@ -464,9 +508,10 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 			group = arr[1]
 		}
 		userResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileUser, map[string]*llx.RawData{
-			"__id":  llx.StringData(p.locationID(userRaw.Location())),
-			"user":  llx.StringData(user),
-			"group": llx.StringData(group),
+			"__id":   llx.StringData(p.locationID(userRaw.Location())),
+			"user":   llx.StringData(user),
+			"group":  llx.StringData(group),
+			"isRoot": llx.BoolData(isRootUser(user)),
 		})
 		if err != nil {
 			return nil, err
@@ -546,6 +591,42 @@ func (p *mqlDockerFile) stages(file *mqlFile) ([]any, error) {
 
 func (p *mqlDockerFile) directives(file *mqlFile) (map[string]any, error) {
 	return nil, p.parse(file)
+}
+
+func (p *mqlDockerFile) multiStage(file *mqlFile) (bool, error) {
+	return false, p.parse(file)
+}
+
+func (p *mqlDockerFile) usesBuildkit(file *mqlFile) (bool, error) {
+	return false, p.parse(file)
+}
+
+func (p *mqlDockerFile) finalStage(file *mqlFile) (*mqlDockerFileStage, error) {
+	return nil, p.parse(file)
+}
+
+// isRootUser reports whether the USER value resolves to root. Only the user
+// portion is considered — the group is ignored.
+func isRootUser(user string) bool {
+	return user == "0" || user == "root"
+}
+
+// mountTypeFlags scans the parsed `--mount=...` entries on a RUN and reports
+// whether any of them expose a build-time secret or ssh socket.
+func mountTypeFlags(mounts []any) (secret bool, ssh bool) {
+	for _, m := range mounts {
+		rm, ok := m.(*mqlDockerFileRunMount)
+		if !ok {
+			continue
+		}
+		switch rm.Type.Data {
+		case "secret":
+			secret = true
+		case "ssh":
+			ssh = true
+		}
+	}
+	return
 }
 
 // runFlagValue returns the parsed BuildKit value for `--network=...` or

--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -93,7 +93,7 @@ func (p *mqlDockerFile) parse(file *mqlFile) error {
 		p.Stages.Error = err
 		p.Directives.Error = err
 		p.MultiStage.Error = err
-		p.UsesBuildkit.Error = err
+		p.HasSyntaxDirective.Error = err
 		p.FinalStage.Error = err
 		return err
 	}
@@ -167,7 +167,7 @@ func (p *mqlDockerFile) parse(file *mqlFile) error {
 		State: plugin.StateIsSet,
 	}
 	_, hasSyntax := directives["syntax"]
-	p.UsesBuildkit = plugin.TValue[bool]{
+	p.HasSyntaxDirective = plugin.TValue[bool]{
 		Data:  hasSyntax,
 		State: plugin.StateIsSet,
 	}
@@ -415,10 +415,14 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 		log.Debug().Strs("commands", slices.Compact(unsupported)).Msg("unsupported dockerfile commands")
 	}
 
-	var userValue string
+	var userValue, groupValue string
 	if userRaw != nil {
-		if parts := strings.SplitN(userRaw.User, ":", 2); len(parts) > 0 {
+		parts := strings.SplitN(userRaw.User, ":", 2)
+		if len(parts) > 0 && parts[0] != "" {
 			userValue = parts[0]
+		}
+		if len(parts) > 1 && parts[1] != "" {
+			groupValue = parts[1]
 		}
 	}
 
@@ -497,21 +501,11 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 	}
 
 	if userRaw != nil {
-		arr := strings.Split(userRaw.User, ":")
-		var user string
-		var group string
-		if len(arr) != 0 && arr[0] != "" {
-			user = arr[0]
-		}
-
-		if len(arr) > 1 && arr[1] != "" {
-			group = arr[1]
-		}
 		userResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileUser, map[string]*llx.RawData{
 			"__id":   llx.StringData(p.locationID(userRaw.Location())),
-			"user":   llx.StringData(user),
-			"group":  llx.StringData(group),
-			"isRoot": llx.BoolData(isRootUser(user)),
+			"user":   llx.StringData(userValue),
+			"group":  llx.StringData(groupValue),
+			"isRoot": llx.BoolData(isRootUser(userValue)),
 		})
 		if err != nil {
 			return nil, err
@@ -597,7 +591,7 @@ func (p *mqlDockerFile) multiStage(file *mqlFile) (bool, error) {
 	return false, p.parse(file)
 }
 
-func (p *mqlDockerFile) usesBuildkit(file *mqlFile) (bool, error) {
+func (p *mqlDockerFile) hasSyntaxDirective(file *mqlFile) (bool, error) {
 	return false, p.parse(file)
 }
 

--- a/providers/os/resources/docker_file_test.go
+++ b/providers/os/resources/docker_file_test.go
@@ -489,3 +489,258 @@ COPY --parents --exclude=*.log src/ /dest/
 	require.True(t, cp1.Parents.Data)
 	require.Equal(t, []any{"*.log"}, cp1.Excludes.Data)
 }
+
+func TestParseDockerfile_FromDigest(t *testing.T) {
+	cases := []struct {
+		baseName       string
+		expectedImage  string
+		expectedTag    string
+		expectedDigest string
+	}{
+		{"alpine", "alpine", "", ""},
+		{"alpine:3.18", "alpine", "3.18", ""},
+		{"alpine@sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc04d", "alpine", "", "sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc04d"},
+		{"alpine:3.18@sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc04d", "alpine", "3.18", "sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc04d"},
+	}
+	for _, kase := range cases {
+		t.Run(kase.baseName, func(t *testing.T) {
+			r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+			src := "FROM " + kase.baseName + "\n"
+			file := &mqlFile{
+				Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+				Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			df := mqlDockerFile{
+				File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			require.NoError(t, df.parse(file))
+
+			from := df.Stages.Data[0].(*mqlDockerFileStage).From.Data
+			require.Equal(t, kase.expectedImage, from.Image.Data, "image")
+			require.Equal(t, kase.expectedTag, from.Tag.Data, "tag")
+			require.Equal(t, kase.expectedDigest, from.Digest.Data, "digest")
+		})
+	}
+}
+
+func TestParseDockerfile_FilePredicates(t *testing.T) {
+	cases := []struct {
+		purpose              string
+		src                  string
+		expectedMultiStage   bool
+		expectedUsesBuildkit bool
+		expectedFinalImage   string
+	}{
+		{
+			purpose:              "single stage without syntax directive",
+			src:                  "FROM alpine\nRUN echo hi\n",
+			expectedMultiStage:   false,
+			expectedUsesBuildkit: false,
+			expectedFinalImage:   "alpine",
+		},
+		{
+			purpose: "multi-stage with syntax directive",
+			src: `# syntax=docker/dockerfile:1.7
+FROM golang AS builder
+RUN go build
+FROM scratch
+COPY --from=builder /out /out
+`,
+			expectedMultiStage:   true,
+			expectedUsesBuildkit: true,
+			expectedFinalImage:   "scratch",
+		},
+	}
+	for _, kase := range cases {
+		t.Run(kase.purpose, func(t *testing.T) {
+			r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+			file := &mqlFile{
+				Content:    plugin.TValue[string]{Data: kase.src, State: plugin.StateIsSet},
+				Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			df := mqlDockerFile{
+				File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			require.NoError(t, df.parse(file))
+
+			require.Equal(t, kase.expectedMultiStage, df.MultiStage.Data, "multiStage")
+			require.Equal(t, kase.expectedUsesBuildkit, df.UsesBuildkit.Data, "usesBuildkit")
+			require.NotNil(t, df.FinalStage.Data, "finalStage populated")
+			require.Equal(t, kase.expectedFinalImage, df.FinalStage.Data.From.Data.Image.Data, "finalStage.from.image")
+		})
+	}
+}
+
+func TestParseDockerfile_StagePredicates(t *testing.T) {
+	src := `
+FROM alpine AS builder
+RUN echo build
+
+FROM alpine
+USER 1001
+HEALTHCHECK CMD curl -f http://localhost/ || exit 1
+`
+	r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	file := &mqlFile{
+		Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+		Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	df := mqlDockerFile{
+		File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	require.NoError(t, df.parse(file))
+	require.Equal(t, 2, len(df.Stages.Data))
+
+	builder := df.Stages.Data[0].(*mqlDockerFileStage)
+	require.True(t, builder.RunsAsRoot.Data, "builder has no USER → assumed root")
+	require.False(t, builder.HasHealthcheck.Data, "builder has no HEALTHCHECK")
+	require.False(t, builder.Final.Data, "builder is not final")
+
+	finalStage := df.Stages.Data[1].(*mqlDockerFileStage)
+	require.False(t, finalStage.RunsAsRoot.Data, "final stage USER=1001 is non-root")
+	require.True(t, finalStage.HasHealthcheck.Data, "final stage declares HEALTHCHECK")
+	require.True(t, finalStage.Final.Data, "last stage is final")
+}
+
+func TestParseDockerfile_SingleStageFinal(t *testing.T) {
+	src := "FROM alpine\nRUN echo hi\n"
+	r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	file := &mqlFile{
+		Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+		Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	df := mqlDockerFile{
+		File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	require.NoError(t, df.parse(file))
+
+	require.False(t, df.MultiStage.Data, "single stage → multiStage false")
+	require.Equal(t, 1, len(df.Stages.Data))
+	stage := df.Stages.Data[0].(*mqlDockerFileStage)
+	require.True(t, stage.Final.Data, "the only stage is also the final stage")
+	require.Equal(t, stage, df.FinalStage.Data, "finalStage points at the single stage")
+}
+
+func TestParseDockerfile_HealthcheckNoneIsHealthcheck(t *testing.T) {
+	src := "FROM alpine\nHEALTHCHECK NONE\n"
+	r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	file := &mqlFile{
+		Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+		Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	df := mqlDockerFile{
+		File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	require.NoError(t, df.parse(file))
+
+	stage := df.Stages.Data[0].(*mqlDockerFileStage)
+	require.True(t, stage.HasHealthcheck.Data, "HEALTHCHECK NONE still counts as declared")
+	require.NotNil(t, stage.Healthcheck.Data)
+	require.True(t, stage.Healthcheck.Data.None.Data, "and the inner healthcheck is the NONE form")
+}
+
+func TestParseDockerfile_StageRunsAsRoot(t *testing.T) {
+	cases := []struct {
+		user     string
+		expected bool
+	}{
+		{"", true},      // no USER
+		{"0", true},     // root by UID
+		{"root", true},  // root by name
+		{"0:0", true},   // root with group
+		{"1001", false}, // non-root UID
+		{"app", false},  // non-root name
+	}
+	for _, kase := range cases {
+		name := kase.user
+		if name == "" {
+			name = "(no USER)"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+			src := "FROM alpine\n"
+			if kase.user != "" {
+				src += "USER " + kase.user + "\n"
+			}
+			file := &mqlFile{
+				Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+				Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			df := mqlDockerFile{
+				File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+				MqlRuntime: r,
+			}
+			require.NoError(t, df.parse(file))
+
+			stage := df.Stages.Data[0].(*mqlDockerFileStage)
+			require.Equal(t, kase.expected, stage.RunsAsRoot.Data)
+			if kase.user != "" {
+				require.NotNil(t, stage.User.Data)
+				require.Equal(t, kase.expected, stage.User.Data.IsRoot.Data)
+			}
+		})
+	}
+}
+
+func TestParseDockerfile_RunFormAndMountPredicates(t *testing.T) {
+	src := `
+FROM alpine
+RUN echo shell-form
+RUN ["echo", "exec-form"]
+RUN --mount=type=secret,id=npm_token,target=/run/secrets/npm npm install
+RUN --mount=type=ssh ssh-add -l
+CMD ["echo", "hello"]
+ENTRYPOINT /entry.sh
+`
+	r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	file := &mqlFile{
+		Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+		Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	df := mqlDockerFile{
+		File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	require.NoError(t, df.parse(file))
+
+	stage := df.Stages.Data[0].(*mqlDockerFileStage)
+	require.Equal(t, 4, len(stage.Run.Data))
+
+	shellRun := stage.Run.Data[0].(*mqlDockerFileRun)
+	require.True(t, shellRun.IsShellForm.Data, "RUN echo ... is shell form")
+	require.False(t, shellRun.IsExecForm.Data)
+	require.False(t, shellRun.MountsSecret.Data)
+	require.False(t, shellRun.MountsSsh.Data)
+
+	execRun := stage.Run.Data[1].(*mqlDockerFileRun)
+	require.False(t, execRun.IsShellForm.Data)
+	require.True(t, execRun.IsExecForm.Data, `RUN ["echo", ...] is exec form`)
+
+	secretRun := stage.Run.Data[2].(*mqlDockerFileRun)
+	require.True(t, secretRun.MountsSecret.Data, "RUN with --mount=type=secret")
+	require.False(t, secretRun.MountsSsh.Data)
+
+	sshRun := stage.Run.Data[3].(*mqlDockerFileRun)
+	require.True(t, sshRun.MountsSsh.Data, "RUN with --mount=type=ssh")
+	require.False(t, sshRun.MountsSecret.Data)
+
+	require.NotNil(t, stage.Cmd.Data)
+	require.True(t, stage.Cmd.Data.IsExecForm.Data, `CMD ["echo", ...] is exec form`)
+	require.False(t, stage.Cmd.Data.IsShellForm.Data)
+
+	require.NotNil(t, stage.Entrypoint.Data)
+	require.True(t, stage.Entrypoint.Data.IsShellForm.Data, `ENTRYPOINT /entry.sh is shell form`)
+	require.False(t, stage.Entrypoint.Data.IsExecForm.Data)
+}

--- a/providers/os/resources/docker_file_test.go
+++ b/providers/os/resources/docker_file_test.go
@@ -527,18 +527,18 @@ func TestParseDockerfile_FromDigest(t *testing.T) {
 
 func TestParseDockerfile_FilePredicates(t *testing.T) {
 	cases := []struct {
-		purpose              string
-		src                  string
-		expectedMultiStage   bool
-		expectedUsesBuildkit bool
-		expectedFinalImage   string
+		purpose                    string
+		src                        string
+		expectedMultiStage         bool
+		expectedHasSyntaxDirective bool
+		expectedFinalImage         string
 	}{
 		{
-			purpose:              "single stage without syntax directive",
-			src:                  "FROM alpine\nRUN echo hi\n",
-			expectedMultiStage:   false,
-			expectedUsesBuildkit: false,
-			expectedFinalImage:   "alpine",
+			purpose:                    "single stage without syntax directive",
+			src:                        "FROM alpine\nRUN echo hi\n",
+			expectedMultiStage:         false,
+			expectedHasSyntaxDirective: false,
+			expectedFinalImage:         "alpine",
 		},
 		{
 			purpose: "multi-stage with syntax directive",
@@ -548,9 +548,9 @@ RUN go build
 FROM scratch
 COPY --from=builder /out /out
 `,
-			expectedMultiStage:   true,
-			expectedUsesBuildkit: true,
-			expectedFinalImage:   "scratch",
+			expectedMultiStage:         true,
+			expectedHasSyntaxDirective: true,
+			expectedFinalImage:         "scratch",
 		},
 	}
 	for _, kase := range cases {
@@ -568,7 +568,7 @@ COPY --from=builder /out /out
 			require.NoError(t, df.parse(file))
 
 			require.Equal(t, kase.expectedMultiStage, df.MultiStage.Data, "multiStage")
-			require.Equal(t, kase.expectedUsesBuildkit, df.UsesBuildkit.Data, "usesBuildkit")
+			require.Equal(t, kase.expectedHasSyntaxDirective, df.HasSyntaxDirective.Data, "hasSyntaxDirective")
 			require.NotNil(t, df.FinalStage.Data, "finalStage populated")
 			require.Equal(t, kase.expectedFinalImage, df.FinalStage.Data.From.Data.Image.Data, "finalStage.from.image")
 		})

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2668,6 +2668,15 @@ docker.file @defaults("file.path instructions.length stages.length") {
   // `escape` (line-continuation token, default `\`), and `check` (Buildkit
   // build-check toggles).
   directives(file) map[string]string
+  // Whether the Dockerfile defines more than one stage
+  multiStage(file) bool
+  // Whether a BuildKit frontend is pinned via the `syntax` parser directive
+  usesBuildkit(file) bool
+  // Final stage in this Dockerfile
+  //
+  // Shortcut to the last `docker.file.stage`, which is the one that produces
+  // the image when the build runs without `--target`. Null for an empty file.
+  finalStage(file) docker.file.stage
 }
 
 // Dockerfile stages
@@ -2711,6 +2720,23 @@ private docker.file.stage @defaults("from.name") {
   // ONBUILD instructions are deferred and run when an image built from this
   // Dockerfile is itself used as the base image of a downstream build.
   onbuild []docker.file.onbuild
+  // Whether this stage runs as root
+  //
+  // True when no `USER` instruction is present in the stage or when the
+  // declared user resolves to UID 0 (`0` or `root`). Inherited `USER` from
+  // the base image is not considered, because it is not visible from the
+  // Dockerfile alone.
+  runsAsRoot bool
+  // Whether this stage declares a HEALTHCHECK
+  //
+  // True for any `HEALTHCHECK` line, including `HEALTHCHECK NONE` (which
+  // explicitly disables an inherited check).
+  hasHealthcheck bool
+  // Whether this stage is the final stage in the Dockerfile
+  //
+  // Only the final stage produces the image when the Dockerfile is built
+  // without `--target`.
+  final bool
 }
 
 // Dockerfile ARG instructions
@@ -2739,6 +2765,10 @@ private docker.file.user @defaults("user") {
   user string
   // Set the user group or GID (optional)
   group string
+  // Whether the declared user is root
+  //
+  // True when `user` is `0` or `root`. The group is not considered.
+  isRoot bool
 }
 
 // Dockerfile EXPOSE instruction
@@ -2777,6 +2807,21 @@ private docker.file.run @defaults("script") {
   // `insecure` runs the step with elevated privileges and is commonly
   // flagged by security policies.
   security string
+  // Whether the instruction is written in shell form
+  //
+  // Shell form (`RUN echo hi`) wraps the command in the stage `SHELL`
+  // (default `/bin/sh -c`), allowing shell expansion, pipes, and
+  // variable substitution.
+  isShellForm bool
+  // Whether the instruction is written in exec form
+  //
+  // Exec form (`RUN ["echo", "hi"]`) executes the program directly without
+  // a shell, so pipes, redirects, and `${VAR}` expansion are not interpreted.
+  isExecForm bool
+  // Whether the instruction declares a `--mount=type=secret`
+  mountsSecret bool
+  // Whether the instruction declares a `--mount=type=ssh`
+  mountsSsh bool
 }
 
 // Dockerfile RUN --mount flag

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2670,8 +2670,14 @@ docker.file @defaults("file.path instructions.length stages.length") {
   directives(file) map[string]string
   // Whether the Dockerfile defines more than one stage
   multiStage(file) bool
-  // Whether a BuildKit frontend is pinned via the `syntax` parser directive
-  usesBuildkit(file) bool
+  // Whether the Dockerfile pins a frontend via the `syntax` parser directive
+  //
+  // Set when the file begins with `# syntax=<image>` (e.g.
+  // `# syntax=docker/dockerfile:1.7`). The directive selects a specific
+  // BuildKit frontend version. Note that BuildKit-only features such as
+  // `RUN --mount=type=secret` work without this directive too, so `false`
+  // does not mean BuildKit is unused.
+  hasSyntaxDirective(file) bool
   // Final stage in this Dockerfile
   //
   // Shortcut to the last `docker.file.stage`, which is the one that produces

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4448,8 +4448,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.file.multiStage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFile).GetMultiStage()).ToDataRes(types.Bool)
 	},
-	"docker.file.usesBuildkit": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDockerFile).GetUsesBuildkit()).ToDataRes(types.Bool)
+	"docker.file.hasSyntaxDirective": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetHasSyntaxDirective()).ToDataRes(types.Bool)
 	},
 	"docker.file.finalStage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFile).GetFinalStage()).ToDataRes(types.Resource("docker.file.stage"))
@@ -12967,8 +12967,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDockerFile).MultiStage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"docker.file.usesBuildkit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDockerFile).UsesBuildkit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"docker.file.hasSyntaxDirective": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).HasSyntaxDirective, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"docker.file.finalStage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31626,13 +31626,13 @@ type mqlDockerFile struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDockerFileInternal
-	File         plugin.TValue[*mqlFile]
-	Instructions plugin.TValue[any]
-	Stages       plugin.TValue[[]any]
-	Directives   plugin.TValue[map[string]any]
-	MultiStage   plugin.TValue[bool]
-	UsesBuildkit plugin.TValue[bool]
-	FinalStage   plugin.TValue[*mqlDockerFileStage]
+	File               plugin.TValue[*mqlFile]
+	Instructions       plugin.TValue[any]
+	Stages             plugin.TValue[[]any]
+	Directives         plugin.TValue[map[string]any]
+	MultiStage         plugin.TValue[bool]
+	HasSyntaxDirective plugin.TValue[bool]
+	FinalStage         plugin.TValue[*mqlDockerFileStage]
 }
 
 // createDockerFile creates a new instance of this resource
@@ -31742,14 +31742,14 @@ func (c *mqlDockerFile) GetMultiStage() *plugin.TValue[bool] {
 	})
 }
 
-func (c *mqlDockerFile) GetUsesBuildkit() *plugin.TValue[bool] {
-	return plugin.GetOrCompute[bool](&c.UsesBuildkit, func() (bool, error) {
+func (c *mqlDockerFile) GetHasSyntaxDirective() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSyntaxDirective, func() (bool, error) {
 		vargFile := c.GetFile()
 		if vargFile.Error != nil {
 			return false, vargFile.Error
 		}
 
-		return c.usesBuildkit(vargFile.Data)
+		return c.hasSyntaxDirective(vargFile.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4445,6 +4445,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.file.directives": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFile).GetDirectives()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"docker.file.multiStage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetMultiStage()).ToDataRes(types.Bool)
+	},
+	"docker.file.usesBuildkit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetUsesBuildkit()).ToDataRes(types.Bool)
+	},
+	"docker.file.finalStage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetFinalStage()).ToDataRes(types.Resource("docker.file.stage"))
+	},
 	"docker.file.stage.from": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileStage).GetFrom()).ToDataRes(types.Resource("docker.file.from"))
 	},
@@ -4499,6 +4508,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.file.stage.onbuild": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileStage).GetOnbuild()).ToDataRes(types.Array(types.Resource("docker.file.onbuild")))
 	},
+	"docker.file.stage.runsAsRoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetRunsAsRoot()).ToDataRes(types.Bool)
+	},
+	"docker.file.stage.hasHealthcheck": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetHasHealthcheck()).ToDataRes(types.Bool)
+	},
+	"docker.file.stage.final": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetFinal()).ToDataRes(types.Bool)
+	},
 	"docker.file.arg.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileArg).GetName()).ToDataRes(types.String)
 	},
@@ -4516,6 +4534,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"docker.file.user.group": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileUser).GetGroup()).ToDataRes(types.String)
+	},
+	"docker.file.user.isRoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileUser).GetIsRoot()).ToDataRes(types.Bool)
 	},
 	"docker.file.expose.port": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileExpose).GetPort()).ToDataRes(types.Int)
@@ -4549,6 +4570,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"docker.file.run.security": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileRun).GetSecurity()).ToDataRes(types.String)
+	},
+	"docker.file.run.isShellForm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRun).GetIsShellForm()).ToDataRes(types.Bool)
+	},
+	"docker.file.run.isExecForm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRun).GetIsExecForm()).ToDataRes(types.Bool)
+	},
+	"docker.file.run.mountsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRun).GetMountsSecret()).ToDataRes(types.Bool)
+	},
+	"docker.file.run.mountsSsh": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRun).GetMountsSsh()).ToDataRes(types.Bool)
 	},
 	"docker.file.run.mount.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileRunMount).GetType()).ToDataRes(types.String)
@@ -12930,6 +12963,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDockerFile).Directives, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"docker.file.multiStage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).MultiStage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.usesBuildkit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).UsesBuildkit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.finalStage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).FinalStage, ok = plugin.RawToTValue[*mqlDockerFileStage](v.Value, v.Error)
+		return
+	},
 	"docker.file.stage.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileStage).__id, ok = v.Value.(string)
 		return
@@ -13006,6 +13051,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDockerFileStage).Onbuild, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"docker.file.stage.runsAsRoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).RunsAsRoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.stage.hasHealthcheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).HasHealthcheck, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.stage.final": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).Final, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"docker.file.arg.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileArg).__id, ok = v.Value.(string)
 		return
@@ -13040,6 +13097,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.file.user.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileUser).Group, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.user.isRoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileUser).IsRoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"docker.file.expose.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13096,6 +13157,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.file.run.security": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileRun).Security, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.isShellForm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRun).IsShellForm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.isExecForm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRun).IsExecForm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.mountsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRun).MountsSecret, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.mountsSsh": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRun).MountsSsh, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"docker.file.run.mount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31553,6 +31630,9 @@ type mqlDockerFile struct {
 	Instructions plugin.TValue[any]
 	Stages       plugin.TValue[[]any]
 	Directives   plugin.TValue[map[string]any]
+	MultiStage   plugin.TValue[bool]
+	UsesBuildkit plugin.TValue[bool]
+	FinalStage   plugin.TValue[*mqlDockerFileStage]
 }
 
 // createDockerFile creates a new instance of this resource
@@ -31651,29 +31731,75 @@ func (c *mqlDockerFile) GetDirectives() *plugin.TValue[map[string]any] {
 	})
 }
 
+func (c *mqlDockerFile) GetMultiStage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MultiStage, func() (bool, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return false, vargFile.Error
+		}
+
+		return c.multiStage(vargFile.Data)
+	})
+}
+
+func (c *mqlDockerFile) GetUsesBuildkit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesBuildkit, func() (bool, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return false, vargFile.Error
+		}
+
+		return c.usesBuildkit(vargFile.Data)
+	})
+}
+
+func (c *mqlDockerFile) GetFinalStage() *plugin.TValue[*mqlDockerFileStage] {
+	return plugin.GetOrCompute[*mqlDockerFileStage](&c.FinalStage, func() (*mqlDockerFileStage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("docker.file", c.__id, "finalStage")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDockerFileStage), nil
+			}
+		}
+
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.finalStage(vargFile.Data)
+	})
+}
+
 // mqlDockerFileStage for the docker.file.stage resource
 type mqlDockerFileStage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDockerFileStageInternal it will be used here
-	From        plugin.TValue[*mqlDockerFileFrom]
-	File        plugin.TValue[*mqlDockerFile]
-	Env         plugin.TValue[[]any]
-	Arg         plugin.TValue[[]any]
-	Labels      plugin.TValue[map[string]any]
-	Run         plugin.TValue[[]any]
-	Cmd         plugin.TValue[*mqlDockerFileRun]
-	User        plugin.TValue[*mqlDockerFileUser]
-	Entrypoint  plugin.TValue[*mqlDockerFileRun]
-	Add         plugin.TValue[[]any]
-	Copy        plugin.TValue[[]any]
-	Expose      plugin.TValue[[]any]
-	Healthcheck plugin.TValue[*mqlDockerFileHealthcheck]
-	Volumes     plugin.TValue[[]any]
-	Shell       plugin.TValue[*mqlDockerFileShell]
-	Workdir     plugin.TValue[[]any]
-	Stopsignal  plugin.TValue[*mqlDockerFileStopsignal]
-	Onbuild     plugin.TValue[[]any]
+	From           plugin.TValue[*mqlDockerFileFrom]
+	File           plugin.TValue[*mqlDockerFile]
+	Env            plugin.TValue[[]any]
+	Arg            plugin.TValue[[]any]
+	Labels         plugin.TValue[map[string]any]
+	Run            plugin.TValue[[]any]
+	Cmd            plugin.TValue[*mqlDockerFileRun]
+	User           plugin.TValue[*mqlDockerFileUser]
+	Entrypoint     plugin.TValue[*mqlDockerFileRun]
+	Add            plugin.TValue[[]any]
+	Copy           plugin.TValue[[]any]
+	Expose         plugin.TValue[[]any]
+	Healthcheck    plugin.TValue[*mqlDockerFileHealthcheck]
+	Volumes        plugin.TValue[[]any]
+	Shell          plugin.TValue[*mqlDockerFileShell]
+	Workdir        plugin.TValue[[]any]
+	Stopsignal     plugin.TValue[*mqlDockerFileStopsignal]
+	Onbuild        plugin.TValue[[]any]
+	RunsAsRoot     plugin.TValue[bool]
+	HasHealthcheck plugin.TValue[bool]
+	Final          plugin.TValue[bool]
 }
 
 // createDockerFileStage creates a new instance of this resource
@@ -31780,6 +31906,18 @@ func (c *mqlDockerFileStage) GetOnbuild() *plugin.TValue[[]any] {
 	return &c.Onbuild
 }
 
+func (c *mqlDockerFileStage) GetRunsAsRoot() *plugin.TValue[bool] {
+	return &c.RunsAsRoot
+}
+
+func (c *mqlDockerFileStage) GetHasHealthcheck() *plugin.TValue[bool] {
+	return &c.HasHealthcheck
+}
+
+func (c *mqlDockerFileStage) GetFinal() *plugin.TValue[bool] {
+	return &c.Final
+}
+
 // mqlDockerFileArg for the docker.file.arg resource
 type mqlDockerFileArg struct {
 	MqlRuntime *plugin.Runtime
@@ -31883,8 +32021,9 @@ type mqlDockerFileUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDockerFileUserInternal it will be used here
-	User  plugin.TValue[string]
-	Group plugin.TValue[string]
+	User   plugin.TValue[string]
+	Group  plugin.TValue[string]
+	IsRoot plugin.TValue[bool]
 }
 
 // createDockerFileUser creates a new instance of this resource
@@ -31925,6 +32064,10 @@ func (c *mqlDockerFileUser) GetUser() *plugin.TValue[string] {
 
 func (c *mqlDockerFileUser) GetGroup() *plugin.TValue[string] {
 	return &c.Group
+}
+
+func (c *mqlDockerFileUser) GetIsRoot() *plugin.TValue[bool] {
+	return &c.IsRoot
 }
 
 // mqlDockerFileExpose for the docker.file.expose resource
@@ -32045,10 +32188,14 @@ type mqlDockerFileRun struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDockerFileRunInternal it will be used here
-	Script   plugin.TValue[string]
-	Mounts   plugin.TValue[[]any]
-	Network  plugin.TValue[string]
-	Security plugin.TValue[string]
+	Script       plugin.TValue[string]
+	Mounts       plugin.TValue[[]any]
+	Network      plugin.TValue[string]
+	Security     plugin.TValue[string]
+	IsShellForm  plugin.TValue[bool]
+	IsExecForm   plugin.TValue[bool]
+	MountsSecret plugin.TValue[bool]
+	MountsSsh    plugin.TValue[bool]
 }
 
 // createDockerFileRun creates a new instance of this resource
@@ -32097,6 +32244,22 @@ func (c *mqlDockerFileRun) GetNetwork() *plugin.TValue[string] {
 
 func (c *mqlDockerFileRun) GetSecurity() *plugin.TValue[string] {
 	return &c.Security
+}
+
+func (c *mqlDockerFileRun) GetIsShellForm() *plugin.TValue[bool] {
+	return &c.IsShellForm
+}
+
+func (c *mqlDockerFileRun) GetIsExecForm() *plugin.TValue[bool] {
+	return &c.IsExecForm
+}
+
+func (c *mqlDockerFileRun) GetMountsSecret() *plugin.TValue[bool] {
+	return &c.MountsSecret
+}
+
+func (c *mqlDockerFileRun) GetMountsSsh() *plugin.TValue[bool] {
+	return &c.MountsSsh
 }
 
 // mqlDockerFileRunMount for the docker.file.run.mount resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -445,6 +445,7 @@ docker.file.expose 11.0.3
 docker.file.expose.port 11.0.3
 docker.file.expose.protocol 11.0.3
 docker.file.file 11.0.2
+docker.file.finalStage 13.21.1
 docker.file.from 11.0.2
 docker.file.from.digest 11.0.2
 docker.file.from.image 11.0.2
@@ -460,9 +461,12 @@ docker.file.healthcheck.startPeriod 11.8.14
 docker.file.healthcheck.test 11.8.14
 docker.file.healthcheck.timeout 11.8.14
 docker.file.instructions 11.0.2
+docker.file.multiStage 13.21.1
 docker.file.onbuild 13.16.10
 docker.file.onbuild.expression 13.16.10
 docker.file.run 11.0.2
+docker.file.run.isExecForm 13.21.1
+docker.file.run.isShellForm 13.21.1
 docker.file.run.mount 13.16.10
 docker.file.run.mount.env 13.16.10
 docker.file.run.mount.from 13.16.10
@@ -478,6 +482,8 @@ docker.file.run.mount.target 13.16.10
 docker.file.run.mount.type 13.16.10
 docker.file.run.mount.uid 13.16.10
 docker.file.run.mounts 13.16.10
+docker.file.run.mountsSecret 13.21.1
+docker.file.run.mountsSsh 13.21.1
 docker.file.run.network 13.16.10
 docker.file.run.script 11.0.2
 docker.file.run.security 13.16.10
@@ -492,11 +498,14 @@ docker.file.stage.entrypoint 11.0.2
 docker.file.stage.env 11.4.86
 docker.file.stage.expose 11.0.2
 docker.file.stage.file 11.0.2
+docker.file.stage.final 13.21.1
 docker.file.stage.from 11.0.2
+docker.file.stage.hasHealthcheck 13.21.1
 docker.file.stage.healthcheck 11.8.14
 docker.file.stage.labels 11.0.2
 docker.file.stage.onbuild 13.16.10
 docker.file.stage.run 11.0.2
+docker.file.stage.runsAsRoot 13.21.1
 docker.file.stage.shell 11.8.15
 docker.file.stage.stopsignal 13.16.10
 docker.file.stage.user 11.0.2
@@ -507,7 +516,9 @@ docker.file.stopsignal 13.16.10
 docker.file.stopsignal.signal 13.16.10
 docker.file.user 11.1.3
 docker.file.user.group 11.1.3
+docker.file.user.isRoot 13.21.1
 docker.file.user.user 11.1.3
+docker.file.usesBuildkit 13.21.1
 docker.file.volume 11.8.14
 docker.file.volume.path 11.8.14
 docker.file.workdir 11.8.15

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -452,6 +452,7 @@ docker.file.from.image 11.0.2
 docker.file.from.name 11.0.2
 docker.file.from.platform 11.0.2
 docker.file.from.tag 11.0.2
+docker.file.hasSyntaxDirective 13.21.1
 docker.file.healthcheck 11.8.14
 docker.file.healthcheck.interval 11.8.14
 docker.file.healthcheck.none 11.8.14
@@ -518,7 +519,6 @@ docker.file.user 11.1.3
 docker.file.user.group 11.1.3
 docker.file.user.isRoot 13.21.1
 docker.file.user.user 11.1.3
-docker.file.usesBuildkit 13.21.1
 docker.file.volume 11.8.14
 docker.file.volume.path 11.8.14
 docker.file.workdir 11.8.15


### PR DESCRIPTION
## Summary

- Adds 11 derived predicates on the `docker.file` schema so audits can
  express common hadolint-style checks without re-parsing strings.
- Fixes `docker.file.from.digest`, which has been declared since 11.0.2
  but was never populated — the parser indexed the first `:` in
  `alpine@sha256:…` and dumped the digest into `tag`. Now splits on `@`
  first, so `alpine@sha256:…` and `alpine:3.18@sha256:…` both resolve
  image / tag / digest correctly.
- Pure additions on the schema side; no existing field semantics change.

## New fields

| Resource | Field | Meaning |
| --- | --- | --- |
| `docker.file` | `multiStage` | `stages.length > 1` |
| `docker.file` | `usesBuildkit` | `directives[\"syntax\"]` is set |
| `docker.file` | `finalStage` | shortcut to `stages.last` |
| `docker.file.stage` | `runsAsRoot` | no `USER`, or USER resolves to `0`/`root` |
| `docker.file.stage` | `hasHealthcheck` | any `HEALTHCHECK`, including `HEALTHCHECK NONE` |
| `docker.file.stage` | `final` | true only on the last stage |
| `docker.file.run` | `isShellForm` | `RUN echo …` form (via BuildKit `PrependShell`) |
| `docker.file.run` | `isExecForm` | `RUN [\"echo\", …]` form |
| `docker.file.run` | `mountsSecret` | declares `--mount=type=secret` |
| `docker.file.run` | `mountsSsh` | declares `--mount=type=ssh` |
| `docker.file.user` | `isRoot` | user is `0` or `root` (group ignored) |

Two adjacent suggestions were dropped because they already exist:
`copy.fromStage` is the existing `copy.from string`; `healthcheck.disabled`
is the existing `healthcheck.none bool`.

## Test plan

- [x] `go test ./providers/os/resources/ -run TestParseDockerfile` — all 30 sub-cases pass
- [x] `go vet ./providers/os/resources/...` clean
- [x] `gofmt -l` clean
- [x] Generated code regenerated via `./mqlr generate providers/os/resources/os.lr --dist providers/os/resources`
- [x] `.lr.versions` entries added at `13.21.1`
- [x] New tests cover each predicate (true and false paths), plus the digest fix across four `BaseName` shapes, plus the \"HEALTHCHECK NONE still counts\" and single-stage-final edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)