### PR TITLE
🧹 os: refactor container/docker scan handling

### DIFF
--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -40,6 +40,18 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
 	}
 	// ^^
+	return newImageTarConnection(id, conf, asset, img, ref, includeOciTar(conf), cleanupDirs...)
+}
+
+// newImageTarConnection extracts img's flattened filesystem to a temporary tar
+// file and wraps it in a tar.Connection. When includeOci is true and ref is
+// non-nil, it also writes a sibling OCI-format tarball alongside. The temp
+// files are removed on connection close, along with any cleanupDirs.
+func newImageTarConnection(id uint32, conf *inventory.Config, asset *inventory.Asset, img v1.Image, ref name.Reference, includeOci bool, cleanupDirs ...string) (*tar.Connection, error) {
+	if conf.Options == nil {
+		conf.Options = map[string]string{}
+	}
+
 	extractedFsTar, err := tmp.File()
 	if err != nil {
 		return nil, err
@@ -47,7 +59,7 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 	conf.Options[tar.OPTION_FILE] = extractedFsTar.Name()
 
 	var ociTar *os.File
-	if includeOciTar(conf) {
+	if includeOci && ref != nil {
 		ociTar, err = tmp.File()
 		if err != nil {
 			return nil, err
@@ -58,8 +70,7 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 	return tar.NewConnection(id, conf, asset,
 		tar.WithFetchFn(func() (string, error) {
 			log.Debug().Str("tar", extractedFsTar.Name()).Msg("tar> starting image extract to temporary file")
-			err = saveImgTarToTmp(extractedFsTar, ociTar, img, ref, includeOciTar(conf))
-			if err != nil {
+			if err := tar.StreamToTmpFile(mutate.Extract(img), extractedFsTar); err != nil {
 				log.Debug().Str("tar", extractedFsTar.Name()).Msg("tar> failed to save image tar")
 				_ = os.Remove(extractedFsTar.Name())
 				if ociTar != nil {
@@ -67,7 +78,14 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 				}
 				return "", err
 			}
-
+			if ociTar != nil {
+				log.Debug().Str("oci_tar", ociTar.Name()).Msg("tar> saving image in oci format")
+				if err := tarball.Write(ref, img, ociTar); err != nil {
+					_ = os.Remove(extractedFsTar.Name())
+					_ = os.Remove(ociTar.Name())
+					return "", err
+				}
+			}
 			log.Debug().Str("tar", extractedFsTar.Name()).Msg("tar> extracted image to temporary file")
 			return extractedFsTar.Name(), nil
 		}),
@@ -88,20 +106,6 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 			}
 		}),
 	)
-}
-
-func saveImgTarToTmp(extractedTarFile, ociTarFile *os.File, img v1.Image, ref name.Reference, includeOciTar bool) error {
-	err := tar.StreamToTmpFile(mutate.Extract(img), extractedTarFile)
-	if err != nil {
-		return err
-	}
-
-	if includeOciTar {
-		log.Debug().Str("oci_tar", ociTarFile.Name()).Msg("tar> saving image in oci format")
-		return tarball.Write(ref, img, ociTarFile)
-	}
-
-	return nil
 }
 
 func includeOciTar(conf *inventory.Config) bool {
@@ -201,59 +205,28 @@ func NewRegistryImage(id uint32, conf *inventory.Config, asset *inventory.Asset)
 	return conn, err
 }
 
+// NewFromTar opens a container-image tar file (OCI format) and exposes its
+// flattened filesystem as a tar.Connection. The input tar is re-extracted to a
+// temporary flat tar; the original file is left untouched.
 func NewFromTar(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar.Connection, error) {
 	if conf == nil || len(conf.Options[tar.OPTION_FILE]) == 0 {
 		return nil, errors.New("tar provider requires a valid tar file")
 	}
 
-	if conf.Options == nil {
-		conf.Options = map[string]string{}
-	}
-
-	filename := conf.Options[tar.OPTION_FILE]
-	var identifier string
-
-	// try to determine if the tar is a container image
-	img, iErr := tarball.ImageFromPath(filename, nil)
-	if iErr != nil {
-		return nil, iErr
-	}
-
-	hash, err := img.Digest()
-	if err != nil {
-		return nil, err
-	}
-	identifier = containerid.MondooContainerImageID(hash.String())
-
-	// we need to extract the image from the tar file and create a new tar connection
-	imageFilename := ""
-
-	f, err := tmp.File()
-	if err != nil {
-		return nil, err
-	}
-	imageFilename = f.Name()
-	conf.Options[tar.OPTION_FILE] = imageFilename
-
-	c, err := tar.NewConnection(id, conf, asset,
-		tar.WithFetchFn(func() (string, error) {
-			err = tar.StreamToTmpFile(mutate.Extract(img), f)
-			if err != nil {
-				_ = os.Remove(imageFilename)
-				return imageFilename, err
-			}
-			return imageFilename, nil
-		}),
-		tar.WithCloseFn(func() {
-			// remove temporary file on stream close
-			log.Debug().Str("tar", imageFilename).Msg("tar> remove temporary flattened image file on connection close")
-			_ = os.Remove(imageFilename)
-		}),
-	)
+	img, err := tarball.ImageFromPath(conf.Options[tar.OPTION_FILE], nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.PlatformIdentifier = identifier
-	return c, nil
+	// includeOci=false because the input *is* an OCI tar already; we don't need
+	// to emit a second one. Pass nil ref since the OCI-write path is skipped.
+	conn, err := newImageTarConnection(id, conf, asset, img, nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if hash, hErr := img.Digest(); hErr == nil {
+		conn.PlatformIdentifier = containerid.MondooContainerImageID(hash.String())
+	}
+	return conn, nil
 }

--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -218,6 +218,15 @@ func NewFromTar(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar
 		return nil, err
 	}
 
+	// Resolve the digest before creating the tar connection so a Digest()
+	// failure doesn't leak the temp file that newImageTarConnection allocates,
+	// and so the caller surfaces the same error the pre-refactor code did
+	// instead of silently ending up with an empty PlatformIdentifier.
+	hash, err := img.Digest()
+	if err != nil {
+		return nil, err
+	}
+
 	// includeOci=false because the input *is* an OCI tar already; we don't need
 	// to emit a second one. Pass nil ref since the OCI-write path is skipped.
 	conn, err := newImageTarConnection(id, conf, asset, img, nil, false)
@@ -225,8 +234,6 @@ func NewFromTar(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar
 		return nil, err
 	}
 
-	if hash, hErr := img.Digest(); hErr == nil {
-		conn.PlatformIdentifier = containerid.MondooContainerImageID(hash.String())
-	}
+	conn.PlatformIdentifier = containerid.MondooContainerImageID(hash.String())
 	return conn, nil
 }

--- a/providers/os/connection/container/registry_connection.go
+++ b/providers/os/connection/container/registry_connection.go
@@ -79,7 +79,7 @@ func (r *RegistryConnection) DiscoverImages() (*inventory.Inventory, error) {
 		return nil, err
 	}
 
-	resolver := container_registry.NewContainerRegistryResolver(opts...)
+	resolver := container_registry.NewImageLister(opts...)
 	host := r.asset.Connections[0].Host
 	assets, err := resolver.ListImages(host)
 	if err != nil {

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -253,13 +253,17 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 	// manifest digest, which is stable across architectures for multi-arch tags.
 	ded, dockerErr := dockerDiscovery.NewDockerEngineDiscovery()
 	if dockerErr != nil {
-		fillAssetFromRegistry(asset, conf)
+		if err := fillAssetFromRegistry(asset, conf); err != nil {
+			return nil, err
+		}
 		return container.NewRegistryImage(id, conf, asset)
 	}
 
 	ii, err := ded.ImageInfo(conf.Host)
 	if err != nil {
-		fillAssetFromRegistry(asset, conf)
+		if err := fillAssetFromRegistry(asset, conf); err != nil {
+			return nil, err
+		}
 		return container.NewRegistryImage(id, conf, asset)
 	}
 
@@ -335,17 +339,23 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 // fillAssetFromRegistry pre-populates asset.Name, asset.PlatformIds, and asset.Labels
 // from the registry-side view of conf.Host. The follow-up registry pull will then
 // see those fields already set and skip its own (per-architecture) values, which
-// keeps asset.Name stable across architectures for multi-arch tags. Failures are
-// intentionally swallowed — the subsequent pull will surface a real error if the
-// registry is actually unreachable.
-func fillAssetFromRegistry(asset *inventory.Asset, conf *inventory.Config) {
+// keeps asset.Name stable across architectures for multi-arch tags. Errors are
+// returned so the caller can bail out — matching the pre-refactor behavior where
+// a registry resolution failure failed the connection attempt outright instead of
+// silently falling through to a pull that would either fail with a less specific
+// error or succeed with platform-specific (non-stable) identity.
+func fillAssetFromRegistry(asset *inventory.Asset, conf *inventory.Config) error {
 	resolved, err := (&container_registry.Resolver{NoStrictValidation: true}).Resolve(context.Background(), asset, conf, nil)
-	if err != nil || len(resolved) == 0 {
-		return
+	if err != nil {
+		return err
+	}
+	if len(resolved) == 0 {
+		return errors.New("could not resolve container image: " + conf.Host)
 	}
 	asset.Name = resolved[0].Name
 	asset.PlatformIds = resolved[0].PlatformIds
 	asset.Labels = resolved[0].Labels
+	return nil
 }
 
 func getImageStoreKind() string {

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -25,6 +25,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/ssh/cat"
 	"go.mondoo.com/mql/v13/providers/os/connection/tar"
 	"go.mondoo.com/mql/v13/providers/os/id/containerid"
+	"go.mondoo.com/mql/v13/providers/os/resources/discovery/container_registry"
 	dockerDiscovery "go.mondoo.com/mql/v13/providers/os/resources/discovery/docker_engine"
 )
 
@@ -190,90 +191,76 @@ func NewDockerEngineContainer(id uint32, conf *inventory.Config, asset *inventor
 		return nil, err
 	}
 
+	platformID := containerid.MondooContainerID(ci.ID)
+	shortID := containerid.ShortContainerImageID(ci.ID)
+
+	asset.Name = ci.Name
+	asset.PlatformIds = []string{platformID}
+
 	if ci.Running {
 		log.Debug().Msg("found running container " + ci.ID)
-
-		conn, err := NewContainerConnection(id, &inventory.Config{
-			Host: ci.ID,
-		}, asset)
+		conn, err := NewContainerConnection(id, &inventory.Config{Host: ci.ID}, asset)
 		if err != nil {
 			return nil, err
 		}
-		conn.PlatformIdentifier = containerid.MondooContainerID(ci.ID)
-		conn.Metadata.Name = containerid.ShortContainerImageID(ci.ID)
+		conn.PlatformIdentifier = platformID
+		conn.Metadata.Name = shortID
 		conn.Metadata.Labels = ci.Labels
-		asset.Name = ci.Name
-		asset.PlatformIds = []string{containerid.MondooContainerID(ci.ID)}
-		return conn, nil
-	} else {
-		log.Debug().Msg("found stopped container " + ci.ID)
-		conn, err := NewSnapshotConnection(id, &inventory.Config{
-			Host: ci.ID,
-		}, asset)
-		if err != nil {
-			return nil, err
-		}
-		conn.PlatformIdentifier = containerid.MondooContainerID(ci.ID)
-		conn.Metadata.Name = containerid.ShortContainerImageID(ci.ID)
-		conn.Metadata.Labels = ci.Labels
-		// FIXME: DEPRECATED, remove in v12.0 vv
-		// The DelayDiscovery flag should always be set from v12
-		if conf.Options == nil || conf.Options[plugin.DISABLE_DELAYED_DISCOVERY_OPTION] == "" {
-			conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
-		}
-		// ^^
-		asset.Name = ci.Name
-		asset.PlatformIds = []string{containerid.MondooContainerID(ci.ID)}
 		return conn, nil
 	}
-}
 
-func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar.Connection, error) {
-	disableInmemoryCache := false
-	if _, ok := conf.Options["disable-cache"]; ok {
-		var err error
-		disableInmemoryCache, err = strconv.ParseBool(conf.Options["disable-cache"])
-		if err != nil {
-			return nil, err
-		}
+	log.Debug().Msg("found stopped container " + ci.ID)
+	conn, err := NewSnapshotConnection(id, &inventory.Config{Host: ci.ID}, asset)
+	if err != nil {
+		return nil, err
 	}
-	if conf.Options == nil {
-		conf.Options = map[string]string{}
-	}
+	conn.PlatformIdentifier = platformID
+	conn.Metadata.Name = shortID
+	conn.Metadata.Labels = ci.Labels
 	// FIXME: DEPRECATED, remove in v12.0 vv
 	// The DelayDiscovery flag should always be set from v12
 	if conf.Options == nil || conf.Options[plugin.DISABLE_DELAYED_DISCOVERY_OPTION] == "" {
 		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
 	}
 	// ^^
-	// Determine whether the image is locally present or not.
-	resolver := dockerDiscovery.Resolver{}
-	resolvedAssets, err := resolver.Resolve(context.Background(), asset, conf, nil)
-	if err != nil {
-		return nil, err
+	return conn, nil
+}
+
+func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar.Connection, error) {
+	if conf.Options == nil {
+		conf.Options = map[string]string{}
 	}
 
-	if len(resolvedAssets) > 1 {
-		return nil, errors.New("provided image name resolved to more than one container image")
+	disableInmemoryCache := false
+	if v, ok := conf.Options["disable-cache"]; ok {
+		var err error
+		disableInmemoryCache, err = strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// The requested image isn't locally available, but we can pull it from a remote registry.
-	if len(resolvedAssets) > 0 && resolvedAssets[0].Connections[0].Type == shared.Type_RegistryImage.String() {
-		asset.Name = resolvedAssets[0].Name
-		asset.PlatformIds = resolvedAssets[0].PlatformIds
-		asset.Labels = resolvedAssets[0].Labels
+	// FIXME: DEPRECATED, remove in v12.0 vv
+	// The DelayDiscovery flag should always be set from v12
+	if conf.Options[plugin.DISABLE_DELAYED_DISCOVERY_OPTION] == "" {
+		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
+	}
+	// ^^
+
+	// Try the local docker engine first. If the image isn't present (or docker isn't
+	// available), pre-populate the asset metadata from the registry and then pull
+	// from there. The registry pre-fill keeps asset.Name keyed by the top-level
+	// manifest digest, which is stable across architectures for multi-arch tags.
+	ded, dockerErr := dockerDiscovery.NewDockerEngineDiscovery()
+	if dockerErr != nil {
+		fillAssetFromRegistry(asset, conf)
 		return container.NewRegistryImage(id, conf, asset)
-	}
-
-	// could be an image id/name, container id/name or a short reference to an image in docker engine
-	ded, err := dockerDiscovery.NewDockerEngineDiscovery()
-	if err != nil {
-		return nil, err
 	}
 
 	ii, err := ded.ImageInfo(conf.Host)
 	if err != nil {
-		return nil, err
+		fillAssetFromRegistry(asset, conf)
+		return container.NewRegistryImage(id, conf, asset)
 	}
 
 	labelImageId := ii.ID
@@ -343,6 +330,22 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 	tarConn.Metadata.Name = ii.Name
 	tarConn.Metadata.Labels = ii.Labels
 	return tarConn, nil
+}
+
+// fillAssetFromRegistry pre-populates asset.Name, asset.PlatformIds, and asset.Labels
+// from the registry-side view of conf.Host. The follow-up registry pull will then
+// see those fields already set and skip its own (per-architecture) values, which
+// keeps asset.Name stable across architectures for multi-arch tags. Failures are
+// intentionally swallowed — the subsequent pull will surface a real error if the
+// registry is actually unreachable.
+func fillAssetFromRegistry(asset *inventory.Asset, conf *inventory.Config) {
+	resolved, err := (&container_registry.Resolver{NoStrictValidation: true}).Resolve(context.Background(), asset, conf, nil)
+	if err != nil || len(resolved) == 0 {
+		return
+	}
+	asset.Name = resolved[0].Name
+	asset.PlatformIds = resolved[0].PlatformIds
+	asset.Labels = resolved[0].Labels
 }
 
 func getImageStoreKind() string {

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -89,23 +90,13 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Type = shared.Type_Vagrant.String()
 	case "docker":
 		if len(req.Args) > 1 {
-			switch req.Args[0] {
-			case "image":
-				conf.Type = shared.Type_DockerImage.String()
-				conf.Host = req.Args[1]
-			case "registry":
-				conf.Type = shared.Type_DockerRegistry.String()
-				conf.Host = req.Args[1]
-				conf.DelayDiscovery = true
-			case "tar":
-				conf.Type = shared.Type_DockerSnapshot.String()
-				conf.Path = req.Args[1]
-			case "container":
-				conf.Type = shared.Type_DockerContainer.String()
-				conf.Host = req.Args[1]
-			case "file":
+			// `docker file <path>` is docker-only because a Dockerfile is a
+			// docker-specific build recipe, not a runnable container.
+			if req.Args[0] == "file" {
 				conf.Type = shared.Type_DockerFile.String()
 				conf.Path = req.Args[1]
+			} else {
+				parseContainerSubcommand(req.Args[0], req.Args[1], conf)
 			}
 		} else {
 			connType, err := docker.FindDockerObjectConnectionType(req.Args[0])
@@ -119,27 +110,17 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		}
 	case "container":
 		if len(req.Args) > 1 {
-			switch req.Args[0] {
-			case "image":
-				conf.Type = shared.Type_DockerImage.String()
-				conf.Host = req.Args[1]
-			case "registry":
-				conf.Type = shared.Type_DockerRegistry.String()
-				conf.Host = req.Args[1]
-				conf.DelayDiscovery = true
-			case "tar":
-				conf.Type = shared.Type_DockerSnapshot.String()
-				conf.Path = req.Args[1]
-			case "container":
-				conf.Type = shared.Type_DockerContainer.String()
-				conf.Host = req.Args[1]
-			}
+			parseContainerSubcommand(req.Args[0], req.Args[1], conf)
 		} else {
-			connType := identifyContainerType(req.Args[0])
-			conf.Type = connType
-			containerID := req.Args[0]
-			conf.Host = containerID
-			assetName = containerID
+			// Unlike `docker`, the `container` connector does not probe a runtime,
+			// so a bare argument can only be an image reference. Use explicit
+			// `container container <id>` to scan a specific running container.
+			if _, err := name.ParseReference(req.Args[0], name.WeakValidation); err != nil {
+				return nil, errors.New("`container " + req.Args[0] + "` is not a valid image reference; use `container container <id>` for a running container or `container image <ref>` for an image")
+			}
+			conf.Type = shared.Type_DockerImage.String()
+			conf.Host = req.Args[0]
+			assetName = req.Args[0]
 		}
 	case "filesystem", "fs":
 		conf.Type = shared.Type_FileSystem.String()
@@ -643,10 +624,24 @@ func (s *Service) discoverLocalContainers(conf *inventory.Config) (*inventory.In
 	return inventory, nil
 }
 
-func identifyContainerType(s string) string {
-	if strings.Contains(s, ":") || strings.Contains(s, "/") {
-		return "docker-image"
-	} else {
-		return "docker-container"
+// parseContainerSubcommand translates one of the shared `image|registry|tar|container`
+// subcommands (used by both the `docker` and `container` connectors) into the
+// matching conf.Type plus host/path assignment. Unknown subcommands are a no-op
+// so the caller can layer connector-specific subcommands (e.g. `docker file`).
+func parseContainerSubcommand(subcommand, target string, conf *inventory.Config) {
+	switch subcommand {
+	case "image":
+		conf.Type = shared.Type_DockerImage.String()
+		conf.Host = target
+	case "registry":
+		conf.Type = shared.Type_DockerRegistry.String()
+		conf.Host = target
+		conf.DelayDiscovery = true
+	case "tar":
+		conf.Type = shared.Type_DockerSnapshot.String()
+		conf.Path = target
+	case "container":
+		conf.Type = shared.Type_DockerContainer.String()
+		conf.Host = target
 	}
 }

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -103,26 +102,6 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 	shutdownconnectResp, err := srv.Shutdown(&plugin.ShutdownReq{})
 	require.NoError(t, err)
 	require.NotNil(t, shutdownconnectResp)
-}
-
-func TestIdentifyDockerString(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"ubuntu:latest", "docker-image"},
-		{"docker.io/pmuench/dvwa-container-escape", "docker-image"},
-		{"registry.example.com:5000/myimage:latest", "docker-image"},
-		{"4e2474c968d6", "docker-container"},
-		{"my_container", "docker-container"},
-		{"anotherContainer123", "docker-container"},
-	}
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s,%s", tt.input, tt.want), func(t *testing.T) {
-			result := identifyContainerType(tt.input)
-			assert.Equal(t, tt.want, result, "Mismatch for input: %s", tt.input)
-		})
-	}
 }
 
 func TestService_ParseCLI(t *testing.T) {

--- a/providers/os/resources/discovery/container_registry/registry.go
+++ b/providers/os/resources/discovery/container_registry/registry.go
@@ -58,18 +58,22 @@ func RemoteOptionsFromConfigOptions(cfg *inventory.Config) ([]remote.Option, err
 	return opts, nil
 }
 
-func NewContainerRegistryResolver(opts ...remote.Option) *DockerRegistryImages {
-	return &DockerRegistryImages{
+// NewImageLister returns a helper that enumerates images and repositories in a
+// container registry. It is not a Resolver in the sense of [Resolver.Resolve] —
+// it lists what's there, it does not pick a connection type for a target.
+func NewImageLister(opts ...remote.Option) *ImageLister {
+	return &ImageLister{
 		opts: opts,
 	}
 }
 
-type DockerRegistryImages struct {
+// ImageLister enumerates images and repositories in a container registry.
+type ImageLister struct {
 	opts     []remote.Option
 	Insecure bool
 }
 
-func (a *DockerRegistryImages) remoteOptions(name string) []remote.Option {
+func (a *ImageLister) remoteOptions(name string) []remote.Option {
 	// either use the provided options or the default options
 	if len(a.opts) > 0 {
 		return a.opts
@@ -78,7 +82,7 @@ func (a *DockerRegistryImages) remoteOptions(name string) []remote.Option {
 	return auth.DefaultOpts(name, a.Insecure)
 }
 
-func (a *DockerRegistryImages) Repositories(reg name.Registry) ([]string, error) {
+func (a *ImageLister) Repositories(reg name.Registry) ([]string, error) {
 	n := 100
 	last := ""
 	var res []string
@@ -104,7 +108,7 @@ func (a *DockerRegistryImages) Repositories(reg name.Registry) ([]string, error)
 
 // ListRegistry tries to iterate over all repositories in one registry
 // eg. 1234567.dkr.ecr.us-east-1.amazonaws.com
-func (a *DockerRegistryImages) ListRegistry(registry string) ([]*inventory.Asset, error) {
+func (a *ImageLister) ListRegistry(registry string) ([]*inventory.Asset, error) {
 	reg, err := name.NewRegistry(registry)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolve registry")
@@ -136,7 +140,7 @@ func (a *DockerRegistryImages) ListRegistry(registry string) ([]*inventory.Asset
 // index.docker.io/mondoo/client
 // harbor.lunalectric.com/library
 // harbor.lunalectric.com/library/ubuntu
-func (a *DockerRegistryImages) ListRepository(repoName string) ([]*inventory.Asset, error) {
+func (a *ImageLister) ListRepository(repoName string) ([]*inventory.Asset, error) {
 	assets := []*inventory.Asset{}
 
 	repo, err := name.NewRepository(repoName)
@@ -181,7 +185,7 @@ func (a *DockerRegistryImages) ListRepository(repoName string) ([]*inventory.Ass
 }
 
 // ListImages either takes a registry or a repository and tries to fetch as many images as possible
-func (a *DockerRegistryImages) ListImages(repoName string) ([]*inventory.Asset, error) {
+func (a *ImageLister) ListImages(repoName string) ([]*inventory.Asset, error) {
 	url, err := url.Parse("//" + repoName)
 	if err != nil {
 		return nil, fmt.Errorf("registries must be valid RFC 3986 URI authorities: %s", repoName)
@@ -196,11 +200,11 @@ func (a *DockerRegistryImages) ListImages(repoName string) ([]*inventory.Asset, 
 	}
 }
 
-func (a *DockerRegistryImages) GetImage(ref name.Reference, creds []*vault.Credential, opts ...remote.Option) (*inventory.Asset, error) {
+func (a *ImageLister) GetImage(ref name.Reference, creds []*vault.Credential, opts ...remote.Option) (*inventory.Asset, error) {
 	return a.toAsset(ref, creds, opts...)
 }
 
-func (a *DockerRegistryImages) toAsset(ref name.Reference, creds []*vault.Credential, opts ...remote.Option) (*inventory.Asset, error) {
+func (a *ImageLister) toAsset(ref name.Reference, creds []*vault.Credential, opts ...remote.Option) (*inventory.Asset, error) {
 	desc, err := image.GetImageDescriptor(ref, opts...)
 	if err != nil {
 		return nil, handleUnauthorizedError(err, ref.Name())

--- a/providers/os/resources/discovery/container_registry/registry_test.go
+++ b/providers/os/resources/discovery/container_registry/registry_test.go
@@ -26,7 +26,7 @@ func TestDockerRegistry(t *testing.T) {
 		// t.Fatal(fmt.Errorf("registries must be valid RFC 3986 URI authorities: %s", name))
 	}
 
-	// r := docker.NewContainerRegistryResolver()
+	// r := docker.NewImageLister()
 	// assets, err := r.List(name)
 	// require.NoError(t, err)
 	// assert.True(t, len(assets) > 0)
@@ -45,7 +45,7 @@ func TestHarbor(t *testing.T) {
 		require.NoError(t, err, url)
 		assert.NotNil(t, ref, url)
 
-		dri := DockerRegistryImages{}
+		dri := ImageLister{}
 		a, err := dri.toAsset(ref, nil)
 		require.NoError(t, err, url)
 

--- a/providers/os/resources/discovery/container_registry/resolver.go
+++ b/providers/os/resources/discovery/container_registry/resolver.go
@@ -29,7 +29,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *inventory.Asset, conf *inv
 		return nil, err
 	}
 
-	imageFetcher := NewContainerRegistryResolver(opts...)
+	imageFetcher := NewImageLister(opts...)
 
 	// check if the reference is an image
 	// NOTE: we use strict validation here otherwise urls like cr://index.docker.io/mondoo/client are converted


### PR DESCRIPTION
## Summary

Cleans up the duplication and drift between the `docker` and `container` connectors in the OS provider. Both still exist as user-facing connectors; the intentional differences (`docker file <path>`, `docker <bare-name>` probing the local engine) are preserved. Internals are slimmer and easier to follow.

## What changed

- **Rename**: `DockerRegistryImages` → `ImageLister`, `NewContainerRegistryResolver` → `NewImageLister`. The type enumerates images in a registry; it was never a Resolver.
- **`NewContainerImageConnection`**: dropped the `dockerDiscovery.Resolver{}.Resolve` oracle pattern. Now does a direct `ded.ImageInfo(host)` to choose local-engine vs. remote-registry. A small `fillAssetFromRegistry` helper preserves the manifest-list digest as `asset.Name` so multi-arch tags stay stable across architectures.
- **`NewFromTar`**: shrank from ~50 lines to ~22 by funneling through a new private `newImageTarConnection` helper that `NewImageConnection` also uses. The tar-scaffold duplication is gone.
- **Shared CLI subcommand parser**: added `parseContainerSubcommand(subcommand, target, conf)` used by both `docker` and `container` ParseCLI cases. `docker file` is layered on top as docker-only.
- **`container <bare-name>`** behavior fix: previously a string heuristic silently picked `docker-container` for names without `:`/`/`. Now the arg must be a valid image reference (`name.ParseReference`); otherwise we return a clear error pointing users to `container container <id>` or `container image <ref>`. The old `identifyContainerType` helper and its test are deleted.
- **`NewDockerEngineContainer`**: hoisted `asset.Name` / `asset.PlatformIds` out of the running/stopped if/else and flattened the branch into early-return style.

## Why

The two connectors had grown copy-paste implementations of the same tar-extract-and-stream scaffolding plus subtly different CLI parsing. The `Resolver{}.Resolve` call inside `NewContainerImageConnection` was a four-layer indirection used only to decide local vs. remote. And the `container <bare-name>` heuristic was a footgun — typing `container alpine` silently tried to attach to a container named `alpine` instead of pulling the image.

## What I deliberately did not do

- No new `Resolver` interface or `resolver/` package — over-engineered for the two existing callers.
- No `scan.Connect` dispatcher — the existing switch in `provider.go` is already clean enough.
- `NewSnapshotConnection` was left alone — it uses `ContainerExport` (flat-fs tar) rather than `v1.Image`, so it legitimately doesn't fit the shared image-tar path.

## Behavior change to call out

- `container <bare-name>` no longer silently maps to a container ID. Users get an error message telling them to use the explicit subcommand. `docker <bare-name>` is unchanged (still probes the local engine via `FindDockerObjectConnectionType`).

## Test plan

- [x] `gofmt -w` clean on all changed files
- [x] `go build ./providers/os/...`
- [x] `go test ./providers/os/connection/...`, `./providers/os/resources/discovery/...`, `./providers/os/provider/...`
- [x] `make providers/build/os`
- [x] `go.mod` / `go.sum` unchanged
- [ ] Manual: `mql shell container image alpine:3.19`
- [ ] Manual: `mql shell container container <running-id>`
- [ ] Manual: `mql shell container alpine` → error message
- [ ] Manual: `mql shell docker file ./Dockerfile`
- [ ] Manual: `mql shell docker <local-image-tag>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)