### PR TITLE
🐛 github: fix org.repositories truncating on GHE / GitHub App auth

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.4.1",
+	Version:         "13.4.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/mql/v13/internal/workerpool"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -380,7 +378,7 @@ func (g *mqlGithubOrganization) repositories() ([]any, error) {
 		return nil, g.Login.Error
 	}
 	orgLogin := g.Login.Data
-	listOpts := github.RepositoryListByOrgOptions{
+	listOpts := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{
 			PerPage: paginationPerPage,
 			Page:    1,
@@ -388,76 +386,43 @@ func (g *mqlGithubOrganization) repositories() ([]any, error) {
 		Type: "all",
 	}
 
-	repoCount := g.TotalPrivateRepos.Data + g.TotalPublicRepos.Data
-	expectedPages := int(repoCount)/paginationPerPage + 1
-	workerCount := int(repoCount)/paginationPerPage + 1
-	workerPool := workerpool.New[[]*github.Repository](workerCount)
-	workerPool.Start()
-	defer workerPool.Close()
-
 	log.Debug().
-		Int("workers", workerCount).
-		Int64("total-repos", repoCount).
 		Str("organization", g.Name.Data).
 		Msg("list repositories")
 
+	// Paginate via resp.NextPage rather than the org's total_private_repos +
+	// public_repos counters. Those counters are unreliable on GitHub Enterprise
+	// and with GitHub App / fine-grained PAT auth, and trusting them caused
+	// scans to silently truncate at one page (see provider regression from #6244).
+	var allRepos []*github.Repository
 	for {
-		// exit as soon as we collect all repositories
-		reposLen := len(slices.Concat(workerPool.GetValues()...))
-		if reposLen >= int(repoCount) {
-			break
-		}
-
-		// failsafe: when total count is correct but some repos aren't returned from ListByOrg
-		// (e.g., due to permission issues), we stop after enough pages have been requested
-		// plus the number of pending workers to account for concurrency
-		if listOpts.Page > (int(workerPool.PendingRequests()) + expectedPages) {
-			log.Warn().
-				Int("found-repos", reposLen).
-				Int64("total-repos", repoCount).
-				Int("page", listOpts.Page).
-				Int("per-page", listOpts.PerPage).
-				Msg("Failsafe triggered, no more repos are returned")
-			break
-		}
-
-		// send requests to workers
-		opts := listOpts
-		workerPool.Submit(func() ([]*github.Repository, error) {
-			repos, _, err := conn.Client().Repositories.ListByOrg(conn.Context(), orgLogin, &opts)
-			return repos, err
-		})
-
-		// next page
-		listOpts.Page++
-
-		// check if any request failed
-		if errs := workerPool.GetErrors(); len(errs) != 0 {
-			if err := errors.Join(errs...); err != nil {
-				if strings.Contains(err.Error(), "404") {
-					return nil, nil
-				}
-				return nil, err
+		repos, resp, err := conn.Client().Repositories.ListByOrg(conn.Context(), orgLogin, listOpts)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				return nil, nil
 			}
+			return nil, err
 		}
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		listOpts.Page = resp.NextPage
 	}
 
 	if g.repoCacheMap == nil {
 		g.repoCacheMap = make(map[string]*mqlGithubRepository)
 	}
 
-	res := []any{}
-	for _, repos := range workerPool.GetValues() {
-		for i := range repos {
-			repo := repos[i]
-
-			r, err := newMqlGithubRepository(g.MqlRuntime, repo)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, r)
-			g.repoCacheMap[repo.GetName()] = r
+	res := make([]any, 0, len(allRepos))
+	for i := range allRepos {
+		repo := allRepos[i]
+		r, err := newMqlGithubRepository(g.MqlRuntime, repo)
+		if err != nil {
+			return nil, err
 		}
+		res = append(res, r)
+		g.repoCacheMap[repo.GetName()] = r
 	}
 
 	return res, nil


### PR DESCRIPTION
Fixes https://github.com/mondoo-community/customer-issues/issues/205

## Summary

`mqlGithubOrganization.repositories()` was exiting pagination as soon as the running count reached `total_private_repos + public_repos` from the org endpoint. Those counters are unreliable on GitHub Enterprise and with GitHub App / fine-grained PAT auth — they can return `0` or a permission-scoped subset while `ListByOrg` returns every repo the token can actually see. Customers on GHE saw scans silently capped at one page (exactly 100 repos out of 185 in the reported case).

The dynamic worker count and page-limit failsafe added in #6244 removed the old `workers=10` over-fetch safety net, which had been masking the latent counter-trust bug. Since `discovery.go` iterates the same `org.GetRepositories()`, the missing repos were never enqueued as assets — no error, no surfaced warning, just under-scanned orgs.

This PR drops the counter-driven loop in favour of the canonical `resp.NextPage` pagination that `user.repositories()` and every other paginated listing in this provider already use.

## Changes

- `providers/github/resources/github_org.go`: replace counter+worker-pool loop with sequential `NextPage` pagination; drop the unused `slices` and `workerpool` imports.
- `providers/github/config/config.go`: bump to `13.4.2`.

Counter fields (`totalPrivateRepos`, `totalPublicRepos`, `ownedPrivateRepos`) are still exposed on the org resource — they're just no longer used to decide when to stop paginating.

## Test plan

- [x] `make providers/build/github && make providers/install/github`
- [x] `mql run github org <gh.com org> -c 'github.organization.repositories.length'` matches expected count
- [x] `mql run github org <GHE org with >100 repos> -c 'github.organization.repositories.length'` returns the full count (was previously capped at 100)
- [x] `mql shell github org <org> --discover repos` enqueues every repo as a separate asset
- [ ] `make test/go/plain` and `make test/lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)