### PR TITLE
:bug: gcp: skip discovery targets on permission denied or API not enabled

### DIFF
--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -195,20 +196,29 @@ func isDiscoverySkippableErr(err error) bool {
 		strings.Contains(msg, "is not enabled")
 }
 
+// gcpAPIServiceRe matches a GCP service-disabled error message of the form
+// "<service> API has not been used in project ...". The captured group is
+// the human-readable service name (e.g. "Memorystore",
+// "Cloud Memorystore for Memcached", "Cloud KMS").
+var gcpAPIServiceRe = regexp.MustCompile(`([A-Z][A-Za-z0-9 &.,/-]*?) API has not been used`)
+
 // runDiscoveryStep runs fn for a single discovery target. A permission /
-// API-not-enabled error is logged and swallowed so the rest of discovery
-// can continue; any other error is propagated unchanged.
+// API-not-enabled error is logged on one line and swallowed so the rest
+// of discovery can continue; any other error is propagated unchanged.
 func runDiscoveryStep(target string, fn func() error) error {
 	err := fn()
 	if err == nil {
 		return nil
 	}
-	if isDiscoverySkippableErr(err) {
-		log.Warn().Err(err).Str("target", target).
-			Msg("gcp.discovery> skipping target, no access or service not enabled")
-		return nil
+	if !isDiscoverySkippableErr(err) {
+		return err
 	}
-	return err
+	if m := gcpAPIServiceRe.FindStringSubmatch(err.Error()); len(m) == 2 {
+		log.Warn().Str("target", target).Msgf("%s API not available", m[1])
+	} else {
+		log.Warn().Str("target", target).Msg("permission denied, skipping")
+	}
+	return nil
 }
 
 func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -171,6 +171,46 @@ func getDiscoveryTargets(config *inventory.Config) []string {
 	return stringx.DedupStringArray(res)
 }
 
+// isDiscoverySkippableErr returns true when a per-service discovery error
+// indicates we lack access or the API is not enabled in this project. Both
+// classes mean "we cannot see anything here" rather than "the system is
+// broken", so callers should log and move on to the next discovery target.
+func isDiscoverySkippableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isHTTPSkippable(err) || isGRPCSkippable(err) {
+		return true
+	}
+	// Some resource fetches rewrap the original error as a plain string
+	// before returning (for example organization.go translates a 403 into
+	// errors.New("403: permission denied")). Match the common signatures
+	// so those rewrapped forms still skip cleanly.
+	msg := err.Error()
+	return strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "Error 403") ||
+		strings.Contains(msg, "403:") ||
+		strings.Contains(msg, "has not been used") ||
+		strings.Contains(msg, "API not enabled") ||
+		strings.Contains(msg, "is not enabled")
+}
+
+// runDiscoveryStep runs fn for a single discovery target. A permission /
+// API-not-enabled error is logged and swallowed so the rest of discovery
+// can continue; any other error is propagated unchanged.
+func runDiscoveryStep(target string, fn func() error) error {
+	err := fn()
+	if err == nil {
+		return nil
+	}
+	if isDiscoverySkippableErr(err) {
+		log.Warn().Err(err).Str("target", target).
+			Msg("gcp.discovery> skipping target, no access or service not enabled")
+		return nil
+	}
+	return err
+}
+
 func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -419,1054 +459,1214 @@ func discoverFolder(conn *connection.GcpConnection, gcpFolder *mqlGcpFolder, dis
 func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, discoveryTargets []string) ([]*inventory.Asset, error) {
 	assetList := []*inventory.Asset{}
 	if stringx.Contains(discoveryTargets, DiscoveryComputeInstances) {
-		compute := gcpProject.GetCompute()
-		if compute.Error != nil {
-			return nil, compute.Error
-		}
-		instances := compute.Data.GetInstances()
-		if instances.Error != nil {
-			return nil, instances.Error
-		}
-
-		for i := range instances.Data {
-			instance := instances.Data[i].(*mqlGcpProjectComputeServiceInstance)
-			status := instance.GetStatus()
-			if status.Data != "RUNNING" {
-				continue
+		if err := runDiscoveryStep(DiscoveryComputeInstances, func() error {
+			compute := gcpProject.GetCompute()
+			if compute.Error != nil {
+				return compute.Error
+			}
+			instances := compute.Data.GetInstances()
+			if instances.Error != nil {
+				return instances.Error
 			}
 
-			labels := map[string]string{}
-			labels["mondoo.com/instance"] = instance.Id.Data
-			instancelabels := instance.GetLabels()
-			for k, v := range instancelabels.Data {
-				labels[k] = v.(string)
-			}
+			for i := range instances.Data {
+				instance := instances.Data[i].(*mqlGcpProjectComputeServiceInstance)
+				status := instance.GetStatus()
+				if status.Data != "RUNNING" {
+					continue
+				}
 
-			zone := instance.GetZone()
-			if zone.Error != nil {
-				return nil, zone.Error
-			}
+				labels := map[string]string{}
+				labels["mondoo.com/instance"] = instance.Id.Data
+				instancelabels := instance.GetLabels()
+				for k, v := range instancelabels.Data {
+					labels[k] = v.(string)
+				}
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("compute", gcpProject.Id.Data, zone.Data.Name.Data, "instance", instance.Name.Data),
-				},
-				Name: instance.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-compute-instance",
-					Title:                 "GCP Compute Instance",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, zone.Data.Name.Data, "instance", instance.Name.Data),
-				},
-				Labels: labels,
-				// TODO: the current connection handling does not work well for instances
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+				zone := instance.GetZone()
+				if zone.Error != nil {
+					return zone.Error
+				}
+
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, zone.Data.Name.Data, "instance", instance.Name.Data),
+					},
+					Name: instance.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-compute-instance",
+						Title:                 "GCP Compute Instance",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, zone.Data.Name.Data, "instance", instance.Name.Data),
+					},
+					Labels: labels,
+					// TODO: the current connection handling does not work well for instances
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.Contains(discoveryTargets, DiscoveryComputeImages) {
-		compute := gcpProject.GetCompute()
-		if compute.Error != nil {
-			return nil, compute.Error
-		}
-		images := compute.Data.GetImages()
-		if images.Error != nil {
-			return nil, images.Error
-		}
-
-		for i := range images.Data {
-			image := images.Data[i].(*mqlGcpProjectComputeServiceImage)
-			labels := map[string]string{}
-			for k, v := range image.GetLabels().Data {
-				labels[k] = v.(string)
+		if err := runDiscoveryStep(DiscoveryComputeImages, func() error {
+			compute := gcpProject.GetCompute()
+			if compute.Error != nil {
+				return compute.Error
 			}
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "image", image.Name.Data),
-				},
-				Name: image.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-compute-image",
-					Title:                 "GCP Compute Image",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "image", image.Name.Data),
-				},
-				Labels:      labels,
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+			images := compute.Data.GetImages()
+			if images.Error != nil {
+				return images.Error
+			}
+
+			for i := range images.Data {
+				image := images.Data[i].(*mqlGcpProjectComputeServiceImage)
+				labels := map[string]string{}
+				for k, v := range image.GetLabels().Data {
+					labels[k] = v.(string)
+				}
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "image", image.Name.Data),
+					},
+					Name: image.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-compute-image",
+						Title:                 "GCP Compute Image",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "image", image.Name.Data),
+					},
+					Labels:      labels,
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.Contains(discoveryTargets, DiscoverCloudKMSKeyrings) {
-		kmsservice := gcpProject.GetKms()
-		if kmsservice.Error != nil {
-			return nil, kmsservice.Error
-		}
-		keyrings := kmsservice.Data.GetKeyrings()
-		if keyrings.Error != nil {
-			return nil, keyrings.Error
-		}
+		if err := runDiscoveryStep(DiscoverCloudKMSKeyrings, func() error {
+			kmsservice := gcpProject.GetKms()
+			if kmsservice.Error != nil {
+				return kmsservice.Error
+			}
+			keyrings := kmsservice.Data.GetKeyrings()
+			if keyrings.Error != nil {
+				return keyrings.Error
+			}
 
-		for i := range keyrings.Data {
-			keyring := keyrings.Data[i].(*mqlGcpProjectKmsServiceKeyring)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloud-kms", gcpProject.Id.Data, keyring.Location.Data, "keyring", keyring.Name.Data),
-				},
-				Name: keyring.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-kms-keyring",
-					Title:                 "GCP Cloud KMS Keyring",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-kms", gcpProject.Id.Data, keyring.Location.Data, "keyring", keyring.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+			for i := range keyrings.Data {
+				keyring := keyrings.Data[i].(*mqlGcpProjectKmsServiceKeyring)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloud-kms", gcpProject.Id.Data, keyring.Location.Data, "keyring", keyring.Name.Data),
+					},
+					Name: keyring.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-kms-keyring",
+						Title:                 "GCP Cloud KMS Keyring",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-kms", gcpProject.Id.Data, keyring.Location.Data, "keyring", keyring.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.Contains(discoveryTargets, DiscoverCloudDNSZones) {
-		dnsservice := gcpProject.GetDns()
-		if dnsservice.Error != nil {
-			return nil, dnsservice.Error
-		}
-		managedzones := dnsservice.Data.GetManagedZones()
-		if managedzones.Error != nil {
-			return nil, managedzones.Error
-		}
+		if err := runDiscoveryStep(DiscoverCloudDNSZones, func() error {
+			dnsservice := gcpProject.GetDns()
+			if dnsservice.Error != nil {
+				return dnsservice.Error
+			}
+			managedzones := dnsservice.Data.GetManagedZones()
+			if managedzones.Error != nil {
+				return managedzones.Error
+			}
 
-		for i := range managedzones.Data {
-			managedzone := managedzones.Data[i].(*mqlGcpProjectDnsServiceManagedzone)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloud-dns", gcpProject.Id.Data, "global", "zone", managedzone.Id.Data),
-				},
-				Name: managedzone.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-dns-zone",
-					Title:                 "GCP Cloud DNS Zone",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-dns", gcpProject.Id.Data, "global", "zone", managedzone.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+			for i := range managedzones.Data {
+				managedzone := managedzones.Data[i].(*mqlGcpProjectDnsServiceManagedzone)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloud-dns", gcpProject.Id.Data, "global", "zone", managedzone.Id.Data),
+					},
+					Name: managedzone.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-dns-zone",
+						Title:                 "GCP Cloud DNS Zone",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-dns", gcpProject.Id.Data, "global", "zone", managedzone.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	// all Cloud SQL discovery flags/types
 	if stringx.ContainsAnyOf(discoveryTargets, AllCloudSQLTypes...) {
-		sqlservice := gcpProject.GetSql()
-		if sqlservice.Error != nil {
-			return nil, sqlservice.Error
-		}
-		sqlinstances := sqlservice.Data.GetInstances()
-		if sqlinstances.Error != nil {
-			return nil, sqlinstances.Error
-		}
-
-		for i := range sqlinstances.Data {
-			var (
-				sqlinstance    = sqlinstances.Data[i].(*mqlGcpProjectSqlServiceInstance)
-				sqlTypeVersion = strings.Split(sqlinstance.DatabaseInstalledVersion.Data, "_")
-				sqlType        = connection.ParseCloudSQLType(sqlTypeVersion[0])
-				platformName   = fmt.Sprintf("gcp-sql-%s", sqlType)
-			)
-
-			if !slices.Contains(discoveryTargets, fmt.Sprintf("cloud-sql-%s", sqlType)) {
-				log.Debug().
-					Str("sql_type", sqlType).
-					Msg("gcp.discovery> skipping cloud sql instance")
-				continue // only discover known sql types
+		if err := runDiscoveryStep("cloud-sql", func() error {
+			sqlservice := gcpProject.GetSql()
+			if sqlservice.Error != nil {
+				return sqlservice.Error
+			}
+			sqlinstances := sqlservice.Data.GetInstances()
+			if sqlinstances.Error != nil {
+				return sqlinstances.Error
 			}
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloud-sql", gcpProject.Id.Data, sqlinstance.Region.Data, sqlType, sqlinstance.Name.Data),
-				},
-				Name: sqlinstance.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  platformName,
-					Title:                 connection.GetTitleForPlatformName(platformName),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-sql", gcpProject.Id.Data, sqlinstance.Region.Data, sqlType, sqlinstance.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+			for i := range sqlinstances.Data {
+				var (
+					sqlinstance    = sqlinstances.Data[i].(*mqlGcpProjectSqlServiceInstance)
+					sqlTypeVersion = strings.Split(sqlinstance.DatabaseInstalledVersion.Data, "_")
+					sqlType        = connection.ParseCloudSQLType(sqlTypeVersion[0])
+					platformName   = fmt.Sprintf("gcp-sql-%s", sqlType)
+				)
+
+				if !slices.Contains(discoveryTargets, fmt.Sprintf("cloud-sql-%s", sqlType)) {
+					log.Debug().
+						Str("sql_type", sqlType).
+						Msg("gcp.discovery> skipping cloud sql instance")
+					continue // only discover known sql types
+				}
+
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloud-sql", gcpProject.Id.Data, sqlinstance.Region.Data, sqlType, sqlinstance.Name.Data),
+					},
+					Name: sqlinstance.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  platformName,
+						Title:                 connection.GetTitleForPlatformName(platformName),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-sql", gcpProject.Id.Data, sqlinstance.Region.Data, sqlType, sqlinstance.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemorystoreRedis) {
-		redisService := gcpProject.GetRedis()
-		if redisService.Error != nil {
-			return nil, redisService.Error
-		}
-		redisInstances := redisService.Data.GetInstances()
-		if redisInstances.Error != nil {
-			return nil, redisInstances.Error
-		}
+		if err := runDiscoveryStep(DiscoverMemorystoreRedis, func() error {
+			redisService := gcpProject.GetRedis()
+			if redisService.Error != nil {
+				return redisService.Error
+			}
+			redisInstances := redisService.Data.GetInstances()
+			if redisInstances.Error != nil {
+				return redisInstances.Error
+			}
 
-		for i := range redisInstances.Data {
-			redisInstance := redisInstances.Data[i].(*mqlGcpProjectRedisServiceInstance)
+			for i := range redisInstances.Data {
+				redisInstance := redisInstances.Data[i].(*mqlGcpProjectRedisServiceInstance)
 
-			// Extract instance name from full resource path
-			// (projects/{project}/locations/{location}/instances/{instance_id})
-			nameParts := strings.Split(redisInstance.Name.Data, "/")
-			instanceName := nameParts[len(nameParts)-1]
+				// Extract instance name from full resource path
+				// (projects/{project}/locations/{location}/instances/{instance_id})
+				nameParts := strings.Split(redisInstance.Name.Data, "/")
+				instanceName := nameParts[len(nameParts)-1]
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, redisInstance.LocationId.Data, "redis", instanceName),
-				},
-				Name: instanceName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-memorystore-redis",
-					Title:                 connection.GetTitleForPlatformName("gcp-memorystore-redis"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, redisInstance.LocationId.Data, "redis", instanceName),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, redisInstance.LocationId.Data, "redis", instanceName),
+					},
+					Name: instanceName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-memorystore-redis",
+						Title:                 connection.GetTitleForPlatformName("gcp-memorystore-redis"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, redisInstance.LocationId.Data, "redis", instanceName),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemorystoreRedisCluster) {
-		redisService := gcpProject.GetRedis()
-		if redisService.Error != nil {
-			return nil, redisService.Error
-		}
-		redisClusters := redisService.Data.GetClusters()
-		if redisClusters.Error != nil {
-			return nil, redisClusters.Error
-		}
-
-		for i := range redisClusters.Data {
-			redisCluster := redisClusters.Data[i].(*mqlGcpProjectRedisServiceCluster)
-
-			// Extract cluster name and location from full resource path
-			// (projects/{project}/locations/{location}/clusters/{cluster_id})
-			nameParts := strings.Split(redisCluster.Name.Data, "/")
-			clusterName := nameParts[len(nameParts)-1]
-			var location string
-			if len(nameParts) >= 4 {
-				location = nameParts[3]
+		if err := runDiscoveryStep(DiscoverMemorystoreRedisCluster, func() error {
+			redisService := gcpProject.GetRedis()
+			if redisService.Error != nil {
+				return redisService.Error
+			}
+			redisClusters := redisService.Data.GetClusters()
+			if redisClusters.Error != nil {
+				return redisClusters.Error
 			}
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "rediscluster", clusterName),
-				},
-				Name: clusterName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-memorystore-rediscluster",
-					Title:                 connection.GetTitleForPlatformName("gcp-memorystore-rediscluster"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "rediscluster", clusterName),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+			for i := range redisClusters.Data {
+				redisCluster := redisClusters.Data[i].(*mqlGcpProjectRedisServiceCluster)
+
+				// Extract cluster name and location from full resource path
+				// (projects/{project}/locations/{location}/clusters/{cluster_id})
+				nameParts := strings.Split(redisCluster.Name.Data, "/")
+				clusterName := nameParts[len(nameParts)-1]
+				var location string
+				if len(nameParts) >= 4 {
+					location = nameParts[3]
+				}
+
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "rediscluster", clusterName),
+					},
+					Name: clusterName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-memorystore-rediscluster",
+						Title:                 connection.GetTitleForPlatformName("gcp-memorystore-rediscluster"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "rediscluster", clusterName),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemorystoreInstances) {
-		memorystoreService := gcpProject.GetMemorystore()
-		if memorystoreService.Error != nil {
-			return nil, memorystoreService.Error
-		}
-		instances := memorystoreService.Data.GetInstances()
-		if instances.Error != nil {
-			return nil, instances.Error
-		}
-		for i := range instances.Data {
-			instance := instances.Data[i].(*mqlGcpProjectMemorystoreServiceInstance)
-			// Memorystore instance name is the full resource path:
-			// projects/{project}/locations/{location}/instances/{instance}
-			instanceName := parseResourceName(instance.Name.Data)
-			location := parseLocationFromPath(instance.Name.Data)
+		if err := runDiscoveryStep(DiscoverMemorystoreInstances, func() error {
+			memorystoreService := gcpProject.GetMemorystore()
+			if memorystoreService.Error != nil {
+				return memorystoreService.Error
+			}
+			instances := memorystoreService.Data.GetInstances()
+			if instances.Error != nil {
+				return instances.Error
+			}
+			for i := range instances.Data {
+				instance := instances.Data[i].(*mqlGcpProjectMemorystoreServiceInstance)
+				// Memorystore instance name is the full resource path:
+				// projects/{project}/locations/{location}/instances/{instance}
+				instanceName := parseResourceName(instance.Name.Data)
+				location := parseLocationFromPath(instance.Name.Data)
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				// Short instance names are scoped per-location, so disambiguate
-				// the asset display name with the location.
-				Name: fmt.Sprintf("%s/%s", location, instanceName),
-				Platform: &inventory.Platform{
-					Name:                  "gcp-memorystore-instance",
-					Title:                 connection.GetTitleForPlatformName("gcp-memorystore-instance"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					// Short instance names are scoped per-location, so disambiguate
+					// the asset display name with the location.
+					Name: fmt.Sprintf("%s/%s", location, instanceName),
+					Platform: &inventory.Platform{
+						Name:                  "gcp-memorystore-instance",
+						Title:                 connection.GetTitleForPlatformName("gcp-memorystore-instance"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverArtifactRegistryRepos) {
-		artifactSvc := gcpProject.GetArtifactRegistry()
-		if artifactSvc.Error != nil {
-			return nil, artifactSvc.Error
-		}
-		repos := artifactSvc.Data.GetRepositories()
-		if repos.Error != nil {
-			return nil, repos.Error
-		}
-		for i := range repos.Data {
-			repo := repos.Data[i].(*mqlGcpProjectArtifactRegistryServiceRepository)
-			repoName := repo.Name.Data
-			location := repo.Location.Data
-			if location == "" {
-				location = "global"
+		if err := runDiscoveryStep(DiscoverArtifactRegistryRepos, func() error {
+			artifactSvc := gcpProject.GetArtifactRegistry()
+			if artifactSvc.Error != nil {
+				return artifactSvc.Error
 			}
+			repos := artifactSvc.Data.GetRepositories()
+			if repos.Error != nil {
+				return repos.Error
+			}
+			for i := range repos.Data {
+				repo := repos.Data[i].(*mqlGcpProjectArtifactRegistryServiceRepository)
+				repoName := repo.Name.Data
+				location := repo.Location.Data
+				if location == "" {
+					location = "global"
+				}
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
-				},
-				// Repository names are scoped per-location, so disambiguate the
-				// asset display name with the location.
-				Name: fmt.Sprintf("%s/%s", location, repoName),
-				Platform: &inventory.Platform{
-					Name:                  "gcp-artifactregistry-repository",
-					Title:                 connection.GetTitleForPlatformName("gcp-artifactregistry-repository"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(repo.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
+					},
+					// Repository names are scoped per-location, so disambiguate the
+					// asset display name with the location.
+					Name: fmt.Sprintf("%s/%s", location, repoName),
+					Platform: &inventory.Platform{
+						Name:                  "gcp-artifactregistry-repository",
+						Title:                 connection.GetTitleForPlatformName("gcp-artifactregistry-repository"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(repo.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemcacheInstances) {
-		memcacheService := gcpProject.GetMemcache()
-		if memcacheService.Error != nil {
-			return nil, memcacheService.Error
-		}
-		instances := memcacheService.Data.GetInstances()
-		if instances.Error != nil {
-			return nil, instances.Error
-		}
-		for i := range instances.Data {
-			instance := instances.Data[i].(*mqlGcpProjectMemcacheServiceInstance)
-			// Memcache instance name is the full resource path:
-			// projects/{project}/locations/{location}/instances/{instance}
-			instanceName := parseResourceName(instance.Name.Data)
-			location := parseLocationFromPath(instance.Name.Data)
+		if err := runDiscoveryStep(DiscoverMemcacheInstances, func() error {
+			memcacheService := gcpProject.GetMemcache()
+			if memcacheService.Error != nil {
+				return memcacheService.Error
+			}
+			instances := memcacheService.Data.GetInstances()
+			if instances.Error != nil {
+				return instances.Error
+			}
+			for i := range instances.Data {
+				instance := instances.Data[i].(*mqlGcpProjectMemcacheServiceInstance)
+				// Memcache instance name is the full resource path:
+				// projects/{project}/locations/{location}/instances/{instance}
+				instanceName := parseResourceName(instance.Name.Data)
+				location := parseLocationFromPath(instance.Name.Data)
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("memcache", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				// Short instance names are scoped per-location, so disambiguate
-				// the asset display name with the location.
-				Name: fmt.Sprintf("%s/%s", location, instanceName),
-				Platform: &inventory.Platform{
-					Name:                  "gcp-memcache-instance",
-					Title:                 connection.GetTitleForPlatformName("gcp-memcache-instance"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memcache", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("memcache", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					// Short instance names are scoped per-location, so disambiguate
+					// the asset display name with the location.
+					Name: fmt.Sprintf("%s/%s", location, instanceName),
+					Platform: &inventory.Platform{
+						Name:                  "gcp-memcache-instance",
+						Title:                 connection.GetTitleForPlatformName("gcp-memcache-instance"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("memcache", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverVertexAIJobs) {
-		vertexaiService := gcpProject.GetVertexai()
-		if vertexaiService.Error != nil {
-			return nil, vertexaiService.Error
-		}
-		jobs := vertexaiService.Data.GetCustomJobs()
-		if jobs.Error != nil {
-			return nil, jobs.Error
-		}
-		for i := range jobs.Data {
-			job := jobs.Data[i].(*mqlGcpProjectVertexaiServiceCustomJob)
-			// Custom job name is the full resource path:
-			// projects/{project}/locations/{location}/customJobs/{job}
-			jobName := parseResourceName(job.Name.Data)
-			location := parseLocationFromPath(job.Name.Data)
+		if err := runDiscoveryStep(DiscoverVertexAIJobs, func() error {
+			vertexaiService := gcpProject.GetVertexai()
+			if vertexaiService.Error != nil {
+				return vertexaiService.Error
+			}
+			jobs := vertexaiService.Data.GetCustomJobs()
+			if jobs.Error != nil {
+				return jobs.Error
+			}
+			for i := range jobs.Data {
+				job := jobs.Data[i].(*mqlGcpProjectVertexaiServiceCustomJob)
+				// Custom job name is the full resource path:
+				// projects/{project}/locations/{location}/customJobs/{job}
+				jobName := parseResourceName(job.Name.Data)
+				location := parseLocationFromPath(job.Name.Data)
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("vertexai", gcpProject.Id.Data, location, "job", jobName),
-				},
-				// Custom job names are scoped per-region, so disambiguate the
-				// asset display name with the region.
-				Name: fmt.Sprintf("%s/%s", location, jobName),
-				Platform: &inventory.Platform{
-					Name:                  "gcp-vertexai-job",
-					Title:                 connection.GetTitleForPlatformName("gcp-vertexai-job"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("vertexai", gcpProject.Id.Data, location, "job", jobName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(job.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("vertexai", gcpProject.Id.Data, location, "job", jobName),
+					},
+					// Custom job names are scoped per-region, so disambiguate the
+					// asset display name with the region.
+					Name: fmt.Sprintf("%s/%s", location, jobName),
+					Platform: &inventory.Platform{
+						Name:                  "gcp-vertexai-job",
+						Title:                 connection.GetTitleForPlatformName("gcp-vertexai-job"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("vertexai", gcpProject.Id.Data, location, "job", jobName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(job.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryComputeNetworks) {
-		compute := gcpProject.GetCompute()
-		if compute.Error != nil {
-			return nil, compute.Error
-		}
-		networks := compute.Data.GetNetworks()
-		if networks.Error != nil {
-			return nil, networks.Error
-		}
-		for i := range networks.Data {
-			network := networks.Data[i].(*mqlGcpProjectComputeServiceNetwork)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "network", network.Name.Data),
-				},
-				Name: network.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-compute-network",
-					Title:                 "GCP Compute Network",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "network", network.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+		if err := runDiscoveryStep(DiscoveryComputeNetworks, func() error {
+			compute := gcpProject.GetCompute()
+			if compute.Error != nil {
+				return compute.Error
+			}
+			networks := compute.Data.GetNetworks()
+			if networks.Error != nil {
+				return networks.Error
+			}
+			for i := range networks.Data {
+				network := networks.Data[i].(*mqlGcpProjectComputeServiceNetwork)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "network", network.Name.Data),
+					},
+					Name: network.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-compute-network",
+						Title:                 "GCP Compute Network",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "network", network.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryComputeSubnetworks) {
-		compute := gcpProject.GetCompute()
-		if compute.Error != nil {
-			return nil, compute.Error
-		}
-		networks := compute.Data.GetSubnetworks()
-		if networks.Error != nil {
-			return nil, networks.Error
-		}
-		for i := range networks.Data {
-			network := networks.Data[i].(*mqlGcpProjectComputeServiceSubnetwork)
-			region := network.GetRegionUrl()
-			if region.Error != nil {
-				return nil, region.Error
+		if err := runDiscoveryStep(DiscoveryComputeSubnetworks, func() error {
+			compute := gcpProject.GetCompute()
+			if compute.Error != nil {
+				return compute.Error
 			}
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
-				},
-				Name: network.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-compute-subnetwork",
-					Title:                 "GCP Compute Subnetwork",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+			networks := compute.Data.GetSubnetworks()
+			if networks.Error != nil {
+				return networks.Error
+			}
+			for i := range networks.Data {
+				network := networks.Data[i].(*mqlGcpProjectComputeServiceSubnetwork)
+				region := network.GetRegionUrl()
+				if region.Error != nil {
+					return region.Error
+				}
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
+					},
+					Name: network.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-compute-subnetwork",
+						Title:                 "GCP Compute Subnetwork",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryComputeFirewalls) {
-		compute := gcpProject.GetCompute()
-		if compute.Error != nil {
-			return nil, compute.Error
-		}
-		firewalls := compute.Data.GetFirewalls()
-		if firewalls.Error != nil {
-			return nil, firewalls.Error
-		}
-		for i := range firewalls.Data {
-			firewall := firewalls.Data[i].(*mqlGcpProjectComputeServiceFirewall)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "firewall", firewall.Name.Data),
-				},
-				Name: firewall.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-compute-firewall",
-					Title:                 "GCP Compute Firewall",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "firewall", firewall.Name.Data),
-				},
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+		if err := runDiscoveryStep(DiscoveryComputeFirewalls, func() error {
+			compute := gcpProject.GetCompute()
+			if compute.Error != nil {
+				return compute.Error
+			}
+			firewalls := compute.Data.GetFirewalls()
+			if firewalls.Error != nil {
+				return firewalls.Error
+			}
+			for i := range firewalls.Data {
+				firewall := firewalls.Data[i].(*mqlGcpProjectComputeServiceFirewall)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, "global", "firewall", firewall.Name.Data),
+					},
+					Name: firewall.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-compute-firewall",
+						Title:                 "GCP Compute Firewall",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, "global", "firewall", firewall.Name.Data),
+					},
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryGkeClusters) {
-		gke := gcpProject.GetGke()
-		if gke.Error != nil {
-			return nil, gke.Error
-		}
-		clusters := gke.Data.GetClusters()
-		if clusters.Error != nil {
-			return nil, clusters.Error
-		}
-		for i := range clusters.Data {
-			cluster := clusters.Data[i].(*mqlGcpProjectGkeServiceCluster)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("gke", gcpProject.Id.Data, cluster.GetLocation().Data, "cluster", cluster.Name.Data),
-				},
-				Name: cluster.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-gke-cluster",
-					Title:                 "GCP GKE Cluster",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("gke", gcpProject.Id.Data, cluster.GetLocation().Data, "cluster", cluster.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(cluster.GetResourceLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+		if err := runDiscoveryStep(DiscoveryGkeClusters, func() error {
+			gke := gcpProject.GetGke()
+			if gke.Error != nil {
+				return gke.Error
+			}
+			clusters := gke.Data.GetClusters()
+			if clusters.Error != nil {
+				return clusters.Error
+			}
+			for i := range clusters.Data {
+				cluster := clusters.Data[i].(*mqlGcpProjectGkeServiceCluster)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("gke", gcpProject.Id.Data, cluster.GetLocation().Data, "cluster", cluster.Name.Data),
+					},
+					Name: cluster.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-gke-cluster",
+						Title:                 "GCP GKE Cluster",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("gke", gcpProject.Id.Data, cluster.GetLocation().Data, "cluster", cluster.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(cluster.GetResourceLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryStorageBuckets) {
-		storage := gcpProject.GetStorage()
-		if storage.Error != nil {
-			return nil, storage.Error
-		}
-		buckets := storage.Data.GetBuckets()
-		if buckets == nil {
-			return nil, buckets.Error
-		}
-		for i := range buckets.Data {
-			bucket := buckets.Data[i].(*mqlGcpProjectStorageServiceBucket)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("storage", gcpProject.Id.Data, bucket.GetLocation().Data, "bucket", bucket.Name.Data),
-				},
-				Name: bucket.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-storage-bucket",
-					Title:                 "GCP Storage Bucket",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("storage", gcpProject.Id.Data, bucket.GetLocation().Data, "bucket", bucket.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(bucket.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+		if err := runDiscoveryStep(DiscoveryStorageBuckets, func() error {
+			storage := gcpProject.GetStorage()
+			if storage.Error != nil {
+				return storage.Error
+			}
+			buckets := storage.Data.GetBuckets()
+			if buckets == nil {
+				return buckets.Error
+			}
+			for i := range buckets.Data {
+				bucket := buckets.Data[i].(*mqlGcpProjectStorageServiceBucket)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("storage", gcpProject.Id.Data, bucket.GetLocation().Data, "bucket", bucket.Name.Data),
+					},
+					Name: bucket.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-storage-bucket",
+						Title:                 "GCP Storage Bucket",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("storage", gcpProject.Id.Data, bucket.GetLocation().Data, "bucket", bucket.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(bucket.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoveryBigQueryDatasets) {
-		bq := gcpProject.GetBigquery()
-		if bq.Error != nil {
-			return nil, bq.Error
-		}
-		datasets := bq.Data.GetDatasets()
-		if datasets.Error != nil {
-			return nil, datasets.Error
-		}
-		for i := range datasets.Data {
-			dataset := datasets.Data[i].(*mqlGcpProjectBigqueryServiceDataset)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("bigquery", gcpProject.Id.Data, dataset.GetLocation().Data, "dataset", dataset.Id.Data),
-				},
-				Name: dataset.Id.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-bigquery-dataset",
-					Title:                 "GCP BigQuery Dataset",
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("bigquery", gcpProject.Id.Data, dataset.GetLocation().Data, "dataset", dataset.Id.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(dataset.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
-			})
+		if err := runDiscoveryStep(DiscoveryBigQueryDatasets, func() error {
+			bq := gcpProject.GetBigquery()
+			if bq.Error != nil {
+				return bq.Error
+			}
+			datasets := bq.Data.GetDatasets()
+			if datasets.Error != nil {
+				return datasets.Error
+			}
+			for i := range datasets.Data {
+				dataset := datasets.Data[i].(*mqlGcpProjectBigqueryServiceDataset)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("bigquery", gcpProject.Id.Data, dataset.GetLocation().Data, "dataset", dataset.Id.Data),
+					},
+					Name: dataset.Id.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-bigquery-dataset",
+						Title:                 "GCP BigQuery Dataset",
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("bigquery", gcpProject.Id.Data, dataset.GetLocation().Data, "dataset", dataset.Id.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(dataset.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverSecretManager) {
-		secretmanagerService := gcpProject.GetSecretmanager()
-		if secretmanagerService.Error != nil {
-			return nil, secretmanagerService.Error
-		}
-		secrets := secretmanagerService.Data.GetSecrets()
-		if secrets.Error != nil {
-			return nil, secrets.Error
-		}
-		for i := range secrets.Data {
-			secret := secrets.Data[i].(*mqlGcpProjectSecretmanagerServiceSecret)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("secretmanager", gcpProject.Id.Data, "global", "secret", secret.Name.Data),
-				},
-				Name: secret.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-secretmanager-secret",
-					Title:                 connection.GetTitleForPlatformName("gcp-secretmanager-secret"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("secretmanager", gcpProject.Id.Data, "global", "secret", secret.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(secret.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverSecretManager, func() error {
+			secretmanagerService := gcpProject.GetSecretmanager()
+			if secretmanagerService.Error != nil {
+				return secretmanagerService.Error
+			}
+			secrets := secretmanagerService.Data.GetSecrets()
+			if secrets.Error != nil {
+				return secrets.Error
+			}
+			for i := range secrets.Data {
+				secret := secrets.Data[i].(*mqlGcpProjectSecretmanagerServiceSecret)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("secretmanager", gcpProject.Id.Data, "global", "secret", secret.Name.Data),
+					},
+					Name: secret.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-secretmanager-secret",
+						Title:                 connection.GetTitleForPlatformName("gcp-secretmanager-secret"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("secretmanager", gcpProject.Id.Data, "global", "secret", secret.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(secret.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverPubSubTopics) {
-		pubsubService := gcpProject.GetPubsub()
-		if pubsubService.Error != nil {
-			return nil, pubsubService.Error
-		}
-		topics := pubsubService.Data.GetTopics()
-		if topics.Error != nil {
-			return nil, topics.Error
-		}
-		for i := range topics.Data {
-			topic := topics.Data[i].(*mqlGcpProjectPubsubServiceTopic)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "topic", topic.Name.Data),
-				},
-				Name: topic.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-pubsub-topic",
-					Title:                 connection.GetTitleForPlatformName("gcp-pubsub-topic"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "topic", topic.Name.Data),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverPubSubTopics, func() error {
+			pubsubService := gcpProject.GetPubsub()
+			if pubsubService.Error != nil {
+				return pubsubService.Error
+			}
+			topics := pubsubService.Data.GetTopics()
+			if topics.Error != nil {
+				return topics.Error
+			}
+			for i := range topics.Data {
+				topic := topics.Data[i].(*mqlGcpProjectPubsubServiceTopic)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "topic", topic.Name.Data),
+					},
+					Name: topic.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-pubsub-topic",
+						Title:                 connection.GetTitleForPlatformName("gcp-pubsub-topic"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "topic", topic.Name.Data),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverPubSubSubscriptions) {
-		pubsubService := gcpProject.GetPubsub()
-		if pubsubService.Error != nil {
-			return nil, pubsubService.Error
-		}
-		subscriptions := pubsubService.Data.GetSubscriptions()
-		if subscriptions.Error != nil {
-			return nil, subscriptions.Error
-		}
-		for i := range subscriptions.Data {
-			sub := subscriptions.Data[i].(*mqlGcpProjectPubsubServiceSubscription)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "subscription", sub.Name.Data),
-				},
-				Name: sub.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-pubsub-subscription",
-					Title:                 connection.GetTitleForPlatformName("gcp-pubsub-subscription"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "subscription", sub.Name.Data),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverPubSubSubscriptions, func() error {
+			pubsubService := gcpProject.GetPubsub()
+			if pubsubService.Error != nil {
+				return pubsubService.Error
+			}
+			subscriptions := pubsubService.Data.GetSubscriptions()
+			if subscriptions.Error != nil {
+				return subscriptions.Error
+			}
+			for i := range subscriptions.Data {
+				sub := subscriptions.Data[i].(*mqlGcpProjectPubsubServiceSubscription)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "subscription", sub.Name.Data),
+					},
+					Name: sub.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-pubsub-subscription",
+						Title:                 connection.GetTitleForPlatformName("gcp-pubsub-subscription"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "subscription", sub.Name.Data),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverPubSubSnapshots) {
-		pubsubService := gcpProject.GetPubsub()
-		if pubsubService.Error != nil {
-			return nil, pubsubService.Error
-		}
-		snapshots := pubsubService.Data.GetSnapshots()
-		if snapshots.Error != nil {
-			return nil, snapshots.Error
-		}
-		for i := range snapshots.Data {
-			snap := snapshots.Data[i].(*mqlGcpProjectPubsubServiceSnapshot)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "snapshot", snap.Name.Data),
-				},
-				Name: snap.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-pubsub-snapshot",
-					Title:                 connection.GetTitleForPlatformName("gcp-pubsub-snapshot"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "snapshot", snap.Name.Data),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverPubSubSnapshots, func() error {
+			pubsubService := gcpProject.GetPubsub()
+			if pubsubService.Error != nil {
+				return pubsubService.Error
+			}
+			snapshots := pubsubService.Data.GetSnapshots()
+			if snapshots.Error != nil {
+				return snapshots.Error
+			}
+			for i := range snapshots.Data {
+				snap := snapshots.Data[i].(*mqlGcpProjectPubsubServiceSnapshot)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("pubsub", gcpProject.Id.Data, "global", "snapshot", snap.Name.Data),
+					},
+					Name: snap.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-pubsub-snapshot",
+						Title:                 connection.GetTitleForPlatformName("gcp-pubsub-snapshot"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("pubsub", gcpProject.Id.Data, "global", "snapshot", snap.Name.Data),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverCloudRunServices) {
-		cloudRunService := gcpProject.GetCloudRun()
-		if cloudRunService.Error != nil {
-			return nil, cloudRunService.Error
-		}
-		services := cloudRunService.Data.GetServices()
-		if services.Error != nil {
-			return nil, services.Error
-		}
-		for i := range services.Data {
-			svc := services.Data[i].(*mqlGcpProjectCloudRunServiceService)
-			region := svc.Region.Data
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloudrun", gcpProject.Id.Data, region, "service", svc.Name.Data),
-				},
-				Name: svc.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-cloudrun-service",
-					Title:                 connection.GetTitleForPlatformName("gcp-cloudrun-service"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloudrun", gcpProject.Id.Data, region, "service", svc.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(svc.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverCloudRunServices, func() error {
+			cloudRunService := gcpProject.GetCloudRun()
+			if cloudRunService.Error != nil {
+				return cloudRunService.Error
+			}
+			services := cloudRunService.Data.GetServices()
+			if services.Error != nil {
+				return services.Error
+			}
+			for i := range services.Data {
+				svc := services.Data[i].(*mqlGcpProjectCloudRunServiceService)
+				region := svc.Region.Data
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloudrun", gcpProject.Id.Data, region, "service", svc.Name.Data),
+					},
+					Name: svc.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-cloudrun-service",
+						Title:                 connection.GetTitleForPlatformName("gcp-cloudrun-service"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloudrun", gcpProject.Id.Data, region, "service", svc.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(svc.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverCloudRunJobs) {
-		cloudRunService := gcpProject.GetCloudRun()
-		if cloudRunService.Error != nil {
-			return nil, cloudRunService.Error
-		}
-		jobs := cloudRunService.Data.GetJobs()
-		if jobs.Error != nil {
-			return nil, jobs.Error
-		}
-		for i := range jobs.Data {
-			job := jobs.Data[i].(*mqlGcpProjectCloudRunServiceJob)
-			region := job.Region.Data
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloudrun", gcpProject.Id.Data, region, "job", job.Name.Data),
-				},
-				Name: job.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-cloudrun-job",
-					Title:                 connection.GetTitleForPlatformName("gcp-cloudrun-job"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloudrun", gcpProject.Id.Data, region, "job", job.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(job.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverCloudRunJobs, func() error {
+			cloudRunService := gcpProject.GetCloudRun()
+			if cloudRunService.Error != nil {
+				return cloudRunService.Error
+			}
+			jobs := cloudRunService.Data.GetJobs()
+			if jobs.Error != nil {
+				return jobs.Error
+			}
+			for i := range jobs.Data {
+				job := jobs.Data[i].(*mqlGcpProjectCloudRunServiceJob)
+				region := job.Region.Data
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloudrun", gcpProject.Id.Data, region, "job", job.Name.Data),
+					},
+					Name: job.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-cloudrun-job",
+						Title:                 connection.GetTitleForPlatformName("gcp-cloudrun-job"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloudrun", gcpProject.Id.Data, region, "job", job.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(job.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverCloudFunctions) {
-		funcs := gcpProject.GetCloudFunctions()
-		if funcs.Error != nil {
-			return nil, funcs.Error
-		}
-		for i := range funcs.Data {
-			fn := funcs.Data[i].(*mqlGcpProjectCloudFunction)
-			location := fn.Location.Data
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("cloud-functions", gcpProject.Id.Data, location, "function", fn.Name.Data),
-				},
-				Name: fn.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-cloud-function",
-					Title:                 connection.GetTitleForPlatformName("gcp-cloud-function"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-functions", gcpProject.Id.Data, location, "function", fn.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(fn.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverCloudFunctions, func() error {
+			funcs := gcpProject.GetCloudFunctions()
+			if funcs.Error != nil {
+				return funcs.Error
+			}
+			for i := range funcs.Data {
+				fn := funcs.Data[i].(*mqlGcpProjectCloudFunction)
+				location := fn.Location.Data
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("cloud-functions", gcpProject.Id.Data, location, "function", fn.Name.Data),
+					},
+					Name: fn.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-cloud-function",
+						Title:                 connection.GetTitleForPlatformName("gcp-cloud-function"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("cloud-functions", gcpProject.Id.Data, location, "function", fn.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(fn.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverDataprocClusters) {
-		dataprocService := gcpProject.GetDataproc()
-		if dataprocService.Error != nil {
-			return nil, dataprocService.Error
-		}
-		clusters := dataprocService.Data.GetClusters()
-		if clusters.Error != nil {
-			return nil, clusters.Error
-		}
-		for i := range clusters.Data {
-			cluster := clusters.Data[i].(*mqlGcpProjectDataprocServiceCluster)
-			location := cluster.Location.Data
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("dataproc", gcpProject.Id.Data, location, "cluster", cluster.Name.Data),
-				},
-				Name: cluster.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-dataproc-cluster",
-					Title:                 connection.GetTitleForPlatformName("gcp-dataproc-cluster"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("dataproc", gcpProject.Id.Data, location, "cluster", cluster.Name.Data),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverDataprocClusters, func() error {
+			dataprocService := gcpProject.GetDataproc()
+			if dataprocService.Error != nil {
+				return dataprocService.Error
+			}
+			clusters := dataprocService.Data.GetClusters()
+			if clusters.Error != nil {
+				return clusters.Error
+			}
+			for i := range clusters.Data {
+				cluster := clusters.Data[i].(*mqlGcpProjectDataprocServiceCluster)
+				location := cluster.Location.Data
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("dataproc", gcpProject.Id.Data, location, "cluster", cluster.Name.Data),
+					},
+					Name: cluster.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-dataproc-cluster",
+						Title:                 connection.GetTitleForPlatformName("gcp-dataproc-cluster"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("dataproc", gcpProject.Id.Data, location, "cluster", cluster.Name.Data),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverAlloyDBClusters) {
-		alloydbService := gcpProject.GetAlloydb()
-		if alloydbService.Error != nil {
-			return nil, alloydbService.Error
-		}
-		clusters := alloydbService.Data.GetClusters()
-		if clusters.Error != nil {
-			return nil, clusters.Error
-		}
-		for i := range clusters.Data {
-			cluster := clusters.Data[i].(*mqlGcpProjectAlloydbServiceCluster)
-			nameParts := strings.Split(cluster.Name.Data, "/")
-			clusterName := nameParts[len(nameParts)-1]
-			location := cluster.Location.Data
+		if err := runDiscoveryStep(DiscoverAlloyDBClusters, func() error {
+			alloydbService := gcpProject.GetAlloydb()
+			if alloydbService.Error != nil {
+				return alloydbService.Error
+			}
+			clusters := alloydbService.Data.GetClusters()
+			if clusters.Error != nil {
+				return clusters.Error
+			}
+			for i := range clusters.Data {
+				cluster := clusters.Data[i].(*mqlGcpProjectAlloydbServiceCluster)
+				nameParts := strings.Split(cluster.Name.Data, "/")
+				clusterName := nameParts[len(nameParts)-1]
+				location := cluster.Location.Data
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
-				},
-				Name: clusterName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-alloydb-cluster",
-					Title:                 connection.GetTitleForPlatformName("gcp-alloydb-cluster"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
+					},
+					Name: clusterName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-alloydb-cluster",
+						Title:                 connection.GetTitleForPlatformName("gcp-alloydb-cluster"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverSpannerInstances) {
-		spannerService := gcpProject.GetSpanner()
-		if spannerService.Error != nil {
-			return nil, spannerService.Error
-		}
-		instances := spannerService.Data.GetInstances()
-		if instances.Error != nil {
-			return nil, instances.Error
-		}
-		for i := range instances.Data {
-			instance := instances.Data[i].(*mqlGcpProjectSpannerServiceInstance)
-			// Spanner instance names are global within a project (no location
-			// segment); the regional placement is expressed by the instance's
-			// config. Use "global" here to match the platform-id scheme used
-			// by other non-regional resources (e.g. API keys, IAM).
-			instanceName := parseResourceName(instance.Name.Data)
-			location := "global"
+		if err := runDiscoveryStep(DiscoverSpannerInstances, func() error {
+			spannerService := gcpProject.GetSpanner()
+			if spannerService.Error != nil {
+				return spannerService.Error
+			}
+			instances := spannerService.Data.GetInstances()
+			if instances.Error != nil {
+				return instances.Error
+			}
+			for i := range instances.Data {
+				instance := instances.Data[i].(*mqlGcpProjectSpannerServiceInstance)
+				// Spanner instance names are global within a project (no location
+				// segment); the regional placement is expressed by the instance's
+				// config. Use "global" here to match the platform-id scheme used
+				// by other non-regional resources (e.g. API keys, IAM).
+				instanceName := parseResourceName(instance.Name.Data)
+				location := "global"
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("spanner", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Name: instanceName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-spanner-instance",
-					Title:                 connection.GetTitleForPlatformName("gcp-spanner-instance"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("spanner", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("spanner", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Name: instanceName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-spanner-instance",
+						Title:                 connection.GetTitleForPlatformName("gcp-spanner-instance"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("spanner", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverFirestoreDatabases) {
-		firestoreService := gcpProject.GetFirestore()
-		if firestoreService.Error != nil {
-			return nil, firestoreService.Error
-		}
-		databases := firestoreService.Data.GetDatabases()
-		if databases.Error != nil {
-			return nil, databases.Error
-		}
-		for i := range databases.Data {
-			database := databases.Data[i].(*mqlGcpProjectFirestoreServiceDatabase)
-			dbName := parseResourceName(database.Name.Data)
-			location := database.LocationId.Data
-			if location == "" {
-				location = "global"
+		if err := runDiscoveryStep(DiscoverFirestoreDatabases, func() error {
+			firestoreService := gcpProject.GetFirestore()
+			if firestoreService.Error != nil {
+				return firestoreService.Error
 			}
+			databases := firestoreService.Data.GetDatabases()
+			if databases.Error != nil {
+				return databases.Error
+			}
+			for i := range databases.Data {
+				database := databases.Data[i].(*mqlGcpProjectFirestoreServiceDatabase)
+				dbName := parseResourceName(database.Name.Data)
+				location := database.LocationId.Data
+				if location == "" {
+					location = "global"
+				}
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("firestore", gcpProject.Id.Data, location, "database", dbName),
-				},
-				Name: dbName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-firestore-database",
-					Title:                 connection.GetTitleForPlatformName("gcp-firestore-database"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("firestore", gcpProject.Id.Data, location, "database", dbName),
-				},
-				// Firestore's adminpb.Database has Tags but no Labels field;
-				// emit an empty map for consistency with other GCP assets.
-				Labels:      map[string]string{},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("firestore", gcpProject.Id.Data, location, "database", dbName),
+					},
+					Name: dbName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-firestore-database",
+						Title:                 connection.GetTitleForPlatformName("gcp-firestore-database"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("firestore", gcpProject.Id.Data, location, "database", dbName),
+					},
+					// Firestore's adminpb.Database has Tags but no Labels field;
+					// emit an empty map for consistency with other GCP assets.
+					Labels:      map[string]string{},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverBigtableInstances) {
-		bigtableService := gcpProject.GetBigtable()
-		if bigtableService.Error != nil {
-			return nil, bigtableService.Error
-		}
-		instances := bigtableService.Data.GetInstances()
-		if instances.Error != nil {
-			return nil, instances.Error
-		}
-		for i := range instances.Data {
-			instance := instances.Data[i].(*mqlGcpProjectBigtableServiceInstance)
-			// Bigtable instances are themselves location-independent; their
-			// placement is per-cluster. Use "global" here to match the
-			// project-scoped platform-id scheme used by API keys and IAM.
-			instanceName := parseResourceName(instance.Name.Data)
-			location := "global"
+		if err := runDiscoveryStep(DiscoverBigtableInstances, func() error {
+			bigtableService := gcpProject.GetBigtable()
+			if bigtableService.Error != nil {
+				return bigtableService.Error
+			}
+			instances := bigtableService.Data.GetInstances()
+			if instances.Error != nil {
+				return instances.Error
+			}
+			for i := range instances.Data {
+				instance := instances.Data[i].(*mqlGcpProjectBigtableServiceInstance)
+				// Bigtable instances are themselves location-independent; their
+				// placement is per-cluster. Use "global" here to match the
+				// project-scoped platform-id scheme used by API keys and IAM.
+				instanceName := parseResourceName(instance.Name.Data)
+				location := "global"
 
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Name: instanceName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-bigtable-instance",
-					Title:                 connection.GetTitleForPlatformName("gcp-bigtable-instance"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
-				},
-				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Name: instanceName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-bigtable-instance",
+						Title:                 connection.GetTitleForPlatformName("gcp-bigtable-instance"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverLoggingBuckets) {
-		loggingService := gcpProject.GetLogging()
-		if loggingService.Error != nil {
-			return nil, loggingService.Error
-		}
-		buckets := loggingService.Data.GetBuckets()
-		if buckets.Error != nil {
-			return nil, buckets.Error
-		}
-		for i := range buckets.Data {
-			bucket := buckets.Data[i].(*mqlGcpProjectLoggingserviceBucket)
-			bucketName := parseResourceName(bucket.Name.Data)
-			location := bucket.Location.Data
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("logging", gcpProject.Id.Data, location, "bucket", bucketName),
-				},
-				Name: bucketName,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-logging-bucket",
-					Title:                 connection.GetTitleForPlatformName("gcp-logging-bucket"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("logging", gcpProject.Id.Data, location, "bucket", bucketName),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverLoggingBuckets, func() error {
+			loggingService := gcpProject.GetLogging()
+			if loggingService.Error != nil {
+				return loggingService.Error
+			}
+			buckets := loggingService.Data.GetBuckets()
+			if buckets.Error != nil {
+				return buckets.Error
+			}
+			for i := range buckets.Data {
+				bucket := buckets.Data[i].(*mqlGcpProjectLoggingserviceBucket)
+				bucketName := parseResourceName(bucket.Name.Data)
+				location := bucket.Location.Data
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("logging", gcpProject.Id.Data, location, "bucket", bucketName),
+					},
+					Name: bucketName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-logging-bucket",
+						Title:                 connection.GetTitleForPlatformName("gcp-logging-bucket"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("logging", gcpProject.Id.Data, location, "bucket", bucketName),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverApiKeys) {
-		keys := gcpProject.GetApiKeys()
-		if keys.Error != nil {
-			return nil, keys.Error
-		}
-		for i := range keys.Data {
-			key := keys.Data[i].(*mqlGcpProjectApiKey)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("apikeys", gcpProject.Id.Data, "global", "key", key.Id.Data),
-				},
-				Name: key.Name.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-apikey",
-					Title:                 connection.GetTitleForPlatformName("gcp-apikey"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("apikeys", gcpProject.Id.Data, "global", "key", key.Id.Data),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverApiKeys, func() error {
+			keys := gcpProject.GetApiKeys()
+			if keys.Error != nil {
+				return keys.Error
+			}
+			for i := range keys.Data {
+				key := keys.Data[i].(*mqlGcpProjectApiKey)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("apikeys", gcpProject.Id.Data, "global", "key", key.Id.Data),
+					},
+					Name: key.Name.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-apikey",
+						Title:                 connection.GetTitleForPlatformName("gcp-apikey"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("apikeys", gcpProject.Id.Data, "global", "key", key.Id.Data),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	if stringx.ContainsAnyOf(discoveryTargets, DiscoverIamServiceAccounts) {
-		iamSvc := gcpProject.GetIam()
-		if iamSvc.Error != nil {
-			return nil, iamSvc.Error
-		}
-		sas := iamSvc.Data.GetServiceAccounts()
-		if sas.Error != nil {
-			return nil, sas.Error
-		}
-		for i := range sas.Data {
-			sa := sas.Data[i].(*mqlGcpProjectIamServiceServiceAccount)
-			assetList = append(assetList, &inventory.Asset{
-				PlatformIds: []string{
-					connection.NewResourcePlatformID("iam", gcpProject.Id.Data, "global", "service-account", sa.UniqueId.Data),
-				},
-				Name: sa.Email.Data,
-				Platform: &inventory.Platform{
-					Name:                  "gcp-iam-service-account",
-					Title:                 connection.GetTitleForPlatformName("gcp-iam-service-account"),
-					Runtime:               "gcp",
-					Kind:                  "gcp-object",
-					Family:                []string{"google"},
-					TechnologyUrlSegments: connection.ResourceTechnologyUrl("iam", gcpProject.Id.Data, "global", "service-account", sa.UniqueId.Data),
-				},
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
-			})
+		if err := runDiscoveryStep(DiscoverIamServiceAccounts, func() error {
+			iamSvc := gcpProject.GetIam()
+			if iamSvc.Error != nil {
+				return iamSvc.Error
+			}
+			sas := iamSvc.Data.GetServiceAccounts()
+			if sas.Error != nil {
+				return sas.Error
+			}
+			for i := range sas.Data {
+				sa := sas.Data[i].(*mqlGcpProjectIamServiceServiceAccount)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("iam", gcpProject.Id.Data, "global", "service-account", sa.UniqueId.Data),
+					},
+					Name: sa.Email.Data,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-iam-service-account",
+						Title:                 connection.GetTitleForPlatformName("gcp-iam-service-account"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("iam", gcpProject.Id.Data, "global", "service-account", sa.UniqueId.Data),
+					},
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -214,9 +214,9 @@ func runDiscoveryStep(target string, fn func() error) error {
 		return err
 	}
 	if m := gcpAPIServiceRe.FindStringSubmatch(err.Error()); len(m) == 2 {
-		log.Warn().Str("target", target).Msgf("%s API not available", m[1])
+		log.Warn().Msgf("%s API not available. Skipping %s discovery", m[1], target)
 	} else {
-		log.Warn().Str("target", target).Msg("permission denied, skipping")
+		log.Warn().Msgf("Permission denied. Skipping %s discovery", target)
 	}
 	return nil
 }

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -4,10 +4,13 @@
 package resources
 
 import (
+	"bytes"
 	"errors"
 	"slices"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	inventoryv1 "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"google.golang.org/api/googleapi"
@@ -224,4 +227,69 @@ func TestRunDiscoveryStep(t *testing.T) {
 		})
 		require.ErrorIs(t, err, orig)
 	})
+
+	t.Run("emits a one-line API-name message", func(t *testing.T) {
+		// Capture zerolog output into a buffer for inspection.
+		var buf bytes.Buffer
+		origLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = origLogger }()
+
+		err := runDiscoveryStep("memorystore-instances", func() error {
+			return &googleapi.Error{
+				Code:    403,
+				Message: "Memorystore API has not been used in project luna-common before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/memorystore.googleapis.com/overview?project=luna-common then retry.",
+			}
+		})
+		require.NoError(t, err)
+
+		out := buf.String()
+		require.Contains(t, out, `"message":"Memorystore API not available"`,
+			"log message should be the short, API-name form")
+		require.Contains(t, out, `"target":"memorystore-instances"`,
+			"log should carry the discovery target name")
+		require.NotContains(t, out, "console.developers.google.com",
+			"log line should not embed the full wrapped GCP error blob")
+	})
+}
+
+func TestGCPAPIServiceRe(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want string // captured group, "" means no match
+	}{
+		{
+			name: "googleapi 403, single-word service",
+			msg:  "googleapi: Error 403: Memorystore API has not been used in project luna-common before or it is disabled",
+			want: "Memorystore",
+		},
+		{
+			name: "gRPC PermissionDenied, multi-word service",
+			msg:  "rpc error: code = PermissionDenied desc = Cloud Memorystore for Memcached API has not been used in project luna-common before",
+			want: "Cloud Memorystore for Memcached",
+		},
+		{
+			name: "two-word service",
+			msg:  "googleapi: Error 403: Cloud KMS API has not been used in project foo",
+			want: "Cloud KMS",
+		},
+		{
+			name: "no match on plain permission denied",
+			msg:  "rpc error: code = PermissionDenied desc = caller does not have permission",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := gcpAPIServiceRe.FindStringSubmatch(tc.msg)
+			if tc.want == "" {
+				require.Len(t, m, 0)
+				return
+			}
+			require.Len(t, m, 2)
+			require.Equal(t, tc.want, m[1])
+		})
+	}
 }

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -244,10 +244,9 @@ func TestRunDiscoveryStep(t *testing.T) {
 		require.NoError(t, err)
 
 		out := buf.String()
-		require.Contains(t, out, `"message":"Memorystore API not available"`,
-			"log message should be the short, API-name form")
-		require.Contains(t, out, `"target":"memorystore-instances"`,
-			"log should carry the discovery target name")
+		require.Contains(t, out,
+			`"message":"Memorystore API not available. Skipping memorystore-instances discovery"`,
+			"log message should embed both the API name and the target")
 		require.NotContains(t, out, "console.developers.google.com",
 			"log line should not embed the full wrapped GCP error blob")
 	})

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -4,11 +4,15 @@
 package resources
 
 import (
+	"errors"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	inventoryv1 "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAllResolvedResources(t *testing.T) {
@@ -142,8 +146,8 @@ func TestGetDiscoveryTargets(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := &inventory.Config{
-				Discover: &inventory.Discovery{
+			config := &inventoryv1.Config{
+				Discover: &inventoryv1.Discovery{
 					Targets: tc.targets,
 				},
 			}
@@ -151,4 +155,73 @@ func TestGetDiscoveryTargets(t *testing.T) {
 			require.ElementsMatch(t, tc.want, got)
 		})
 	}
+}
+
+func TestIsDiscoverySkippableErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "googleapi 403", err: &googleapi.Error{Code: 403, Message: "permission denied"}, want: true},
+		{name: "googleapi 404", err: &googleapi.Error{Code: 404, Message: "not found"}, want: true},
+		{name: "googleapi 500", err: &googleapi.Error{Code: 500, Message: "server error"}, want: false},
+		{name: "googleapi service-disabled message", err: &googleapi.Error{Code: 400, Message: "API has not been used in project 123 before or it is disabled"}, want: true},
+		{name: "gRPC permission denied", err: status.Error(codes.PermissionDenied, "no access"), want: true},
+		{name: "gRPC not found", err: status.Error(codes.NotFound, "missing"), want: true},
+		{name: "gRPC unimplemented", err: status.Error(codes.Unimplemented, "not implemented"), want: true},
+		{name: "gRPC internal", err: status.Error(codes.Internal, "boom"), want: false},
+		{name: "rewrapped 403 string", err: errors.New("403: permission denied"), want: true},
+		{name: "googleapi error stringified", err: errors.New("googleapi: Error 403: permission denied"), want: true},
+		{name: "api-not-enabled phrasing", err: errors.New("Cloud KMS API has not been used in project foo"), want: true},
+		{name: "plain unrelated error", err: errors.New("connection reset by peer"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isDiscoverySkippableErr(tc.err))
+		})
+	}
+}
+
+func TestRunDiscoveryStep(t *testing.T) {
+	t.Run("returns nil and runs fn on success", func(t *testing.T) {
+		called := false
+		err := runDiscoveryStep("compute-instances", func() error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+
+	t.Run("swallows skippable errors (403)", func(t *testing.T) {
+		err := runDiscoveryStep("cloud-kms-keyrings", func() error {
+			return &googleapi.Error{Code: 403, Message: "permission denied"}
+		})
+		require.NoError(t, err, "skippable errors must not fail the whole discovery")
+	})
+
+	t.Run("swallows skippable errors (gRPC PermissionDenied)", func(t *testing.T) {
+		err := runDiscoveryStep("pubsub-topics", func() error {
+			return status.Error(codes.PermissionDenied, "no access")
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("swallows API-not-enabled errors", func(t *testing.T) {
+		err := runDiscoveryStep("dataproc-clusters", func() error {
+			return &googleapi.Error{Code: 403, Message: "Cloud Dataproc API has not been used in project foo before"}
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("propagates non-skippable errors", func(t *testing.T) {
+		orig := errors.New("connection reset")
+		err := runDiscoveryStep("compute-instances", func() error {
+			return orig
+		})
+		require.ErrorIs(t, err, orig)
+	})
 }


### PR DESCRIPTION
## Summary
- GCP discovery used to bail the entire run on the first per-service error (compute, kms, pubsub, …). When a user lacks permission on one service or the service isn't enabled in the project, discovery now logs a single-line warning and continues to the next target instead.
- Adds two helpers in `providers/gcp/resources/discovery.go`:
  - `isDiscoverySkippableErr(err)` — treats 403, 404, gRPC PermissionDenied/NotFound/Unimplemented, and the stringified "API has not been used"/"403:"/"Error 403" / "is not enabled" forms as skippable. Reuses the existing `isHTTPSkippable`/`isGRPCSkippable` helpers from `common.go` and adds a string-fallback layer for cases where the original typed error has been rewrapped (e.g. `organization.go` returning `errors.New("403: permission denied")`).
  - `runDiscoveryStep(target, fn)` — runs the per-target closure; on a skippable error it extracts the GCP service name from the underlying message via `gcpAPIServiceRe` and emits one clean sentence, then returns `nil` so the rest of discovery continues. Non-skippable errors propagate unchanged.
- Wraps all 30 per-service sections inside `discoverProject` (Compute Instances/Images/Networks/Subnetworks/Firewalls, KMS, DNS, Cloud SQL, Memorystore Redis/Cluster/Instances, Artifact Registry, Memcache, VertexAI, GKE, Storage, BigQuery, Secret Manager, PubSub Topics/Subs/Snapshots, Cloud Run Services/Jobs, Cloud Functions, Dataproc, AlloyDB, Spanner, Firestore, Bigtable, Logging, API Keys, IAM SAs).
- Top-level project/folder enumeration in `discoverOrganization` / `discoverFolder` is intentionally left as fail-hard — if we can't list projects under an org, there's nothing left to skip into.

### Log output

Before — one bail on the first 403, dragging the entire wrapped error onto a single (very long) line:

```
! gcp.discovery> skipping target, no access or service not enabled error="googleapi: Error 403: Memorystore API has not been used in project luna-common before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/memorystore.googleapis.com/overview?project=luna-common then retry. … error details: name = ErrorInfo reason = SERVICE_DISABLED …" target=memorystore-instances
```

After — one short sentence per skipped target, with the service name extracted from the GCP message and the target embedded in the sentence:

```
! Memorystore API not available. Skipping memorystore-instances discovery
! Cloud Memorystore for Memcached API not available. Skipping memcache-instances discovery
```

If we can't extract a service name from the error (e.g. a raw permission-denied without the "has not been used" phrasing), the fallback is equally terse:

```
! Permission denied. Skipping <target> discovery
```

## Test plan
- [x] `go test ./providers/gcp/resources/ -run "TestIsDiscoverySkippableErr|TestRunDiscoveryStep|TestGCPAPIServiceRe"`
  - `TestIsDiscoverySkippableErr` — 13 cases: nil, googleapi 403/404/500, googleapi service-disabled message, gRPC PermissionDenied/NotFound/Unimplemented/Internal, rewrapped "403: permission denied", stringified `googleapi: Error 403:`, "Cloud KMS API has not been used", unrelated connection error.
  - `TestGCPAPIServiceRe` — table covering googleapi 403 (single-word), gRPC PermissionDenied (multi-word "Cloud Memorystore for Memcached"), two-word "Cloud KMS", and plain permission-denied non-match.
  - `TestRunDiscoveryStep` — success path, 403 swallow, gRPC PermissionDenied swallow, API-not-enabled swallow, non-skippable error propagated via `errors.Is`, and a subtest that captures zerolog output to assert the new message form ("Memorystore API not available. Skipping memorystore-instances discovery") and that the activation-URL blob is not leaked.
- [x] `go build ./providers/gcp/resources/` and `go vet ./providers/gcp/resources/` are clean
- [x] Verified end-to-end with `cnspec scan gcp project …` against a project missing the Memorystore + Memcached APIs — scan continues past the disabled services instead of bailing, and the two skip lines render as full sentences