### PR TITLE
🎉 os-13.22.0, ansible-13.1.0, kustomize-13.1.0

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.0.13",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.0.9",
+	Version:         "13.1.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.21.0",
+	Version: "13.22.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Minor version bump for three providers.

## Changes

### os — 13.21.0 → 13.22.0
- 🌙 docker.file: derived predicates and from.digest parser fix (#8043)

### ansible — 13.0.13 → 13.1.0
- ✨ task-level become/no_log/ignore_errors and other security attributes (#8003)

### kustomize — 13.0.9 → 13.1.0
- ✨ classify patch format and decompose JSON6902 operations (#8005)