### PR TITLE
✨ os: ingest npm and python manifests from in-memory content (13.22.0)

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -877,11 +877,20 @@ func (c *compiler) unnamedResourceArgs(resource *resources.ResourceInfo, args []
 // values resolve to strings at runtime; the runtime init function is
 // responsible for asserting the actual element types. See `compileOperand`
 // where the value type is widened to `Any` for refs/mixed entries.
+//
+// Restricted to `want.Child() == types.String` for now — it's the only
+// case in the schema today, and broadening would let other element types
+// (e.g. `map[string]int`) pass the compile check only to fail at runtime
+// with a confusing assertion error. Extend deliberately when the need
+// arises and the runtime path can convert the value safely.
 func mapLiteralCoercibleTo(got, want types.Type) bool {
 	if !got.IsMap() || !want.IsMap() {
 		return false
 	}
 	if got.Key() != want.Key() {
+		return false
+	}
+	if want.Child() != types.String {
 		return false
 	}
 	return got.Child() == types.Any

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -870,6 +870,23 @@ func (c *compiler) unnamedResourceArgs(resource *resources.ResourceInfo, args []
 	return c.unnamedArgs("resource "+resource.Name, resource.Init, args)
 }
 
+// mapLiteralCoercibleTo reports whether a value of type `got` can be passed
+// where the resource field expects type `want` for the common case of an MQL
+// map literal whose inferred value-type was widened to `any`. Map literals
+// like `{"a": file(...).content}` come out as `map[string]any` even when all
+// values resolve to strings at runtime; the runtime init function is
+// responsible for asserting the actual element types. See `compileOperand`
+// where the value type is widened to `Any` for refs/mixed entries.
+func mapLiteralCoercibleTo(got, want types.Type) bool {
+	if !got.IsMap() || !want.IsMap() {
+		return false
+	}
+	if got.Key() != want.Key() {
+		return false
+	}
+	return got.Child() == types.Any
+}
+
 // resourceArgs turns the list of arguments for the resource into a list of
 // primitives that are used as arguments to initialize that resource
 // only works if len(args) > 0 !!
@@ -898,8 +915,14 @@ func (c *compiler) resourceArgs(resource *resources.ResourceInfo, args []*parser
 		}
 
 		ft := types.Type(field.Type)
-		if vt != ft {
-			return nil, errors.New("Wrong type for field " + arg.Name + " in resource " + resource.Name + ": expected " + ft.Label() + ", got " + vt.Label())
+		if vt != ft && ft != types.Any {
+			if !mapLiteralCoercibleTo(vt, ft) {
+				return nil, errors.New("Wrong type for field " + arg.Name + " in resource " + resource.Name + ": expected " + ft.Label() + ", got " + vt.Label())
+			}
+			// Coerce the literal map's type to match the field's expected
+			// type so downstream serialization knows the element type. The
+			// runtime init function still validates each element's type.
+			v.Type = string(ft)
 		}
 
 		res[idx*2] = llx.StringPrimitive(arg.Name)

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.21.0",
+	Version: "13.22.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/os/resources/npm.go
+++ b/providers/os/resources/npm.go
@@ -91,24 +91,37 @@ func (r *mqlNpmPackages) id() (string, error) {
 		return "", err
 	}
 
-	// fold content-map keys into the id so two instances with different
-	// inputs do not collide in the runtime resource cache
-	if contentKeys := r.contentKeys(); len(contentKeys) > 0 {
-		entries = append(entries, contentKeys...)
-		sort.Strings(entries)
+	// fold content into the id so two instances with the same filenames but
+	// different content do not collide in the runtime resource cache
+	contents := r.contentMap()
+
+	if len(entries) == 0 && len(contents) == 0 {
+		return "npm.packages", nil
+	}
+	if len(contents) == 0 && len(entries) == 1 {
+		return "npm.packages/" + entries[0], nil
 	}
 
-	if len(entries) == 0 {
-		return "npm.packages", nil
-	} else if len(entries) == 1 {
-		return "npm.packages/" + entries[0], nil
-	} else {
-		hash := sha256.New()
-		for _, entry := range entries {
-			hash.Write([]byte(entry))
-		}
-		return "npm.packages/" + hex.EncodeToString(hash.Sum(nil)), nil
+	sort.Strings(entries)
+	hash := sha256.New()
+	for _, entry := range entries {
+		hash.Write([]byte(entry))
+		hash.Write([]byte{0})
 	}
+	// stable iteration order: hash by sorted filename, with both key and
+	// value included so different content under the same key disambiguates
+	keys := make([]string, 0, len(contents))
+	for k := range contents {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		hash.Write([]byte(k))
+		hash.Write([]byte{0})
+		hash.Write([]byte(contents[k]))
+		hash.Write([]byte{0})
+	}
+	return "npm.packages/" + hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func (r *mqlNpmPackages) paths() ([]any, error) {
@@ -309,13 +322,13 @@ func npmExtractorFor(path string) languages.Extractor {
 }
 
 // collectNpmPackagesFromContents parses the supplied {path: content} map
-// directly, without touching the connection's filesystem. Lockfiles are
-// preferred over package.json when both are present so that resolved
-// versions win out.
+// directly, without touching the connection's filesystem. Lockfiles win
+// for direct/transitive dependencies (resolved versions), but the root
+// package metadata is taken from package.json when supplied — lockfiles
+// don't always carry a top-level root entry (older formats, partial
+// fixtures), and package.json is the authoritative source for project
+// name/version anyway.
 func collectNpmPackagesFromContents(contents map[string]string) (*languages.Package, []*languages.Package, []*languages.Package, []string, error) {
-	// Sort keys so output ordering is stable. Lockfiles are preferred — if
-	// any lockfile parses successfully we drop package.json results to avoid
-	// duplicates.
 	type entry struct {
 		path     string
 		isLock   bool
@@ -333,30 +346,56 @@ func collectNpmPackagesFromContents(contents map[string]string) (*languages.Pack
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
 
-	var root *languages.Package
-	var direct []*languages.Package
-	var transitive []*languages.Package
-	var files []string
-	lockfileSucceeded := false
+	var (
+		manifestRoot, lockRoot             *languages.Package
+		manifestDirect, lockDirect         []*languages.Package
+		manifestTransitive, lockTransitive []*languages.Package
+		manifestFiles, lockFiles           []string
+	)
 
 	for _, e := range entries {
-		if lockfileSucceeded && !e.isLock {
-			continue
-		}
 		bom, err := e.ext.Parse(strings.NewReader(e.contents), e.path)
 		if err != nil {
 			log.Debug().Err(err).Str("file", e.path).Msg("failed to parse npm manifest content")
 			continue
 		}
-		files = append(files, e.path)
-		if r := bom.Root(); r != nil && root == nil {
-			root = r
-		}
-		direct = append(direct, bom.Direct()...)
-		transitive = append(transitive, bom.Transitive()...)
 		if e.isLock {
-			lockfileSucceeded = true
+			lockFiles = append(lockFiles, e.path)
+			if r := bom.Root(); r != nil && lockRoot == nil {
+				lockRoot = r
+			}
+			lockDirect = append(lockDirect, bom.Direct()...)
+			lockTransitive = append(lockTransitive, bom.Transitive()...)
+		} else {
+			manifestFiles = append(manifestFiles, e.path)
+			if r := bom.Root(); r != nil && manifestRoot == nil {
+				manifestRoot = r
+			}
+			manifestDirect = append(manifestDirect, bom.Direct()...)
+			manifestTransitive = append(manifestTransitive, bom.Transitive()...)
 		}
+	}
+
+	root := manifestRoot
+	if root == nil {
+		root = lockRoot
+	}
+
+	var direct, transitive []*languages.Package
+	var files []string
+	if len(lockFiles) > 0 {
+		direct = lockDirect
+		transitive = lockTransitive
+		files = lockFiles
+		// keep the package.json in the file list when its root contributed
+		if manifestRoot != nil && root == manifestRoot {
+			files = append(files, manifestFiles...)
+			sort.Strings(files)
+		}
+	} else {
+		direct = manifestDirect
+		transitive = manifestTransitive
+		files = manifestFiles
 	}
 
 	return root, direct, transitive, files, nil

--- a/providers/os/resources/npm.go
+++ b/providers/os/resources/npm.go
@@ -70,6 +70,18 @@ func initNpmPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[strin
 			}
 		}
 	}
+
+	if x, ok := args["contents"]; ok {
+		xv, ok := x.Value.(map[string]any)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'contents' in npm.packages initialization, it must be a map of string to string")
+		}
+		for k, v := range xv {
+			if _, ok := v.(string); !ok {
+				return nil, nil, fmt.Errorf("wrong type for 'contents[%q]' in npm.packages initialization, values must be strings", k)
+			}
+		}
+	}
 	return args, nil, nil
 }
 
@@ -77,6 +89,13 @@ func (r *mqlNpmPackages) id() (string, error) {
 	entries, err := r.getPaths()
 	if err != nil {
 		return "", err
+	}
+
+	// fold content-map keys into the id so two instances with different
+	// inputs do not collide in the runtime resource cache
+	if contentKeys := r.contentKeys(); len(contentKeys) > 0 {
+		entries = append(entries, contentKeys...)
+		sort.Strings(entries)
 	}
 
 	if len(entries) == 0 {
@@ -93,6 +112,16 @@ func (r *mqlNpmPackages) id() (string, error) {
 }
 
 func (r *mqlNpmPackages) paths() ([]any, error) {
+	// when content is supplied, advertise the supplied filenames rather than
+	// the filesystem-default search paths so consumers see the actual inputs
+	if contentKeys := r.contentKeys(); len(contentKeys) > 0 {
+		res := []any{}
+		for _, k := range contentKeys {
+			res = append(res, k)
+		}
+		return res, nil
+	}
+
 	paths, err := r.getPaths()
 	if err != nil {
 		return nil, err
@@ -102,6 +131,37 @@ func (r *mqlNpmPackages) paths() ([]any, error) {
 		res = append(res, paths[i])
 	}
 	return res, nil
+}
+
+// contentKeys returns the sorted set of filenames provided through the
+// `contents` init arg, or nil if none.
+func (r *mqlNpmPackages) contentKeys() []string {
+	m := r.contentMap()
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// contentMap returns the `contents` init arg as map[string]string.
+// The MQL compiler coerces literal map values typed as `any` to `string` at
+// the resource-arg site; the init function still asserts each value's type.
+func (r *mqlNpmPackages) contentMap() map[string]string {
+	if r.Contents.Error != nil || len(r.Contents.Data) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(r.Contents.Data))
+	for k, v := range r.Contents.Data {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
 }
 
 // gatherPackagesFromSystemDefaults returns
@@ -230,6 +290,78 @@ func hasLockfile(runtime *plugin.Runtime, fs afero.Fs, path string) bool {
 	return len(filteredSearchPath) > 0
 }
 
+// npmExtractorFor returns the parser matched by the filename suffix, or nil
+// if the path does not look like a supported JS package or lock file.
+func npmExtractorFor(path string) languages.Extractor {
+	switch {
+	case strings.HasSuffix(path, "package-lock.json"):
+		return &packagelockjson.Extractor{}
+	case strings.HasSuffix(path, "pnpm-lock.yaml"):
+		return &pnpmlock.Extractor{}
+	case strings.HasSuffix(path, "yarn.lock"):
+		return &yarnlock.Extractor{}
+	case strings.HasSuffix(path, "bun.lock"):
+		return &bunlock.Extractor{}
+	case strings.HasSuffix(path, "package.json"):
+		return &packagejson.Extractor{}
+	}
+	return nil
+}
+
+// collectNpmPackagesFromContents parses the supplied {path: content} map
+// directly, without touching the connection's filesystem. Lockfiles are
+// preferred over package.json when both are present so that resolved
+// versions win out.
+func collectNpmPackagesFromContents(contents map[string]string) (*languages.Package, []*languages.Package, []*languages.Package, []string, error) {
+	// Sort keys so output ordering is stable. Lockfiles are preferred — if
+	// any lockfile parses successfully we drop package.json results to avoid
+	// duplicates.
+	type entry struct {
+		path     string
+		isLock   bool
+		ext      languages.Extractor
+		contents string
+	}
+	var entries []entry
+	for path, content := range contents {
+		ext := npmExtractorFor(path)
+		if ext == nil {
+			continue
+		}
+		isLock := !strings.HasSuffix(path, "package.json")
+		entries = append(entries, entry{path: path, isLock: isLock, ext: ext, contents: content})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+
+	var root *languages.Package
+	var direct []*languages.Package
+	var transitive []*languages.Package
+	var files []string
+	lockfileSucceeded := false
+
+	for _, e := range entries {
+		if lockfileSucceeded && !e.isLock {
+			continue
+		}
+		bom, err := e.ext.Parse(strings.NewReader(e.contents), e.path)
+		if err != nil {
+			log.Debug().Err(err).Str("file", e.path).Msg("failed to parse npm manifest content")
+			continue
+		}
+		files = append(files, e.path)
+		if r := bom.Root(); r != nil && root == nil {
+			root = r
+		}
+		direct = append(direct, bom.Direct()...)
+		transitive = append(transitive, bom.Transitive()...)
+		if e.isLock {
+			lockfileSucceeded = true
+		}
+	}
+
+	return root, direct, transitive, files, nil
+}
+
 func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (languages.Bom, error) {
 	// specific path was provided
 	afs := &afero.Afero{Fs: fs}
@@ -342,6 +474,23 @@ func (r *mqlNpmPackages) gatherData() error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	var root *languages.Package
+	var directDependencies []*languages.Package
+	var transitiveDependencies []*languages.Package
+	var filePaths []string
+
+	// content-map branch: parse provided file contents directly, without
+	// touching the os connection. Used when running on a non-os connection
+	// (for example, feeding `github.file.content` from a github repo scan).
+	if contents := r.contentMap(); len(contents) > 0 {
+		var err error
+		root, directDependencies, transitiveDependencies, filePaths, err = collectNpmPackagesFromContents(contents)
+		if err != nil {
+			return err
+		}
+		return r.finalizeData(root, directDependencies, transitiveDependencies, filePaths)
+	}
+
 	// NOTE: that we do not get paths that are an empty slice here
 	paths, err := r.getPaths()
 	if err != nil {
@@ -352,10 +501,6 @@ func (r *mqlNpmPackages) gatherData() error {
 	// if it is a directory, we check if there is a package-lock.json or package.json file
 	conn := r.MqlRuntime.Connection.(shared.Connection)
 
-	var root *languages.Package
-	var directDependencies []*languages.Package
-	var transitiveDependencies []*languages.Package
-	var filePaths []string
 	fs := conn.FileSystem()
 
 	if len(paths) > 1 {
@@ -382,6 +527,10 @@ func (r *mqlNpmPackages) gatherData() error {
 		}
 	}
 
+	return r.finalizeData(root, directDependencies, transitiveDependencies, filePaths)
+}
+
+func (r *mqlNpmPackages) finalizeData(root *languages.Package, directDependencies, transitiveDependencies []*languages.Package, filePaths []string) error {
 	// sort packages by name
 	slices.SortFunc(directDependencies, languages.SortFn)
 	slices.SortFunc(transitiveDependencies, languages.SortFn)
@@ -443,6 +592,34 @@ func (r *mqlNpmPackages) files() ([]any, error) {
 }
 
 func (r *mqlNpmPackages) scripts() (map[string]any, error) {
+	type packageJson struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+
+	// when content is supplied, parse scripts out of the package.json entry
+	// (if any) without touching the filesystem
+	if contents := r.contentMap(); len(contents) > 0 {
+		var raw string
+		for path, c := range contents {
+			if strings.HasSuffix(path, "package.json") {
+				raw = c
+				break
+			}
+		}
+		if raw == "" {
+			return map[string]any{}, nil
+		}
+		pkgInfo := packageJson{}
+		if err := json.Unmarshal([]byte(raw), &pkgInfo); err != nil {
+			return nil, err
+		}
+		res := make(map[string]any)
+		for k, v := range pkgInfo.Scripts {
+			res[k] = v
+		}
+		return res, nil
+	}
+
 	if r.Path.Error != nil {
 		return nil, r.Path.Error
 	}
@@ -455,10 +632,6 @@ func (r *mqlNpmPackages) scripts() (map[string]any, error) {
 	content := f.GetContent()
 	if content.Error != nil {
 		return nil, content.Error
-	}
-
-	type packageJson struct {
-		Scripts map[string]string `json:"scripts"`
 	}
 
 	pkgInfo := packageJson{}

--- a/providers/os/resources/npm_test.go
+++ b/providers/os/resources/npm_test.go
@@ -98,6 +98,78 @@ func (p *providerCallbacks) Collect(req *plugin.DataRes) error {
 	return nil
 }
 
+func TestCollectNpmPackagesFromContents(t *testing.T) {
+	t.Run("parses a package.json from in-memory content", func(t *testing.T) {
+		contents := map[string]string{
+			"package.json": `{
+				"name": "demo-app",
+				"version": "1.2.3",
+				"dependencies": {
+					"left-pad": "^1.3.0"
+				}
+			}`,
+		}
+		root, direct, transitive, files, err := collectNpmPackagesFromContents(contents)
+		require.NoError(t, err)
+		require.Equal(t, []string{"package.json"}, files)
+		require.NotNil(t, root)
+		require.Equal(t, "demo-app", root.Name)
+		require.Equal(t, "1.2.3", root.Version)
+		// direct + transitive shape depends on the extractor; at minimum
+		// the dependency should appear somewhere
+		names := map[string]bool{}
+		for _, p := range direct {
+			names[p.Name] = true
+		}
+		for _, p := range transitive {
+			names[p.Name] = true
+		}
+		require.True(t, names["left-pad"], "expected left-pad in parsed deps, got %v", names)
+	})
+
+	t.Run("skips package.json when a lockfile is also provided", func(t *testing.T) {
+		// A minimal v3 package-lock.json that resolves an exact version
+		// for left-pad. If the lockfile parses, the root package.json
+		// branch is suppressed.
+		contents := map[string]string{
+			"package.json": `{
+				"name": "demo-app",
+				"version": "1.2.3",
+				"dependencies": {"left-pad": "^1.3.0"}
+			}`,
+			"package-lock.json": `{
+				"name": "demo-app",
+				"version": "1.2.3",
+				"lockfileVersion": 3,
+				"packages": {
+					"": {
+						"name": "demo-app",
+						"version": "1.2.3",
+						"dependencies": {"left-pad": "^1.3.0"}
+					},
+					"node_modules/left-pad": {
+						"version": "1.3.0",
+						"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"
+					}
+				}
+			}`,
+		}
+		_, _, _, files, err := collectNpmPackagesFromContents(contents)
+		require.NoError(t, err)
+		// only the lockfile should contribute when both parsed successfully
+		require.Contains(t, files, "package-lock.json")
+		require.NotContains(t, files, "package.json", "package.json must be skipped when a lockfile is present")
+	})
+
+	t.Run("ignores unknown filenames", func(t *testing.T) {
+		_, _, _, files, err := collectNpmPackagesFromContents(map[string]string{
+			"README.md": "not a manifest",
+		})
+		require.NoError(t, err)
+		require.Empty(t, files)
+	})
+}
+
 func TestCollectNpmPackagesInPaths(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/providers/os/resources/npm_test.go
+++ b/providers/os/resources/npm_test.go
@@ -127,10 +127,12 @@ func TestCollectNpmPackagesFromContents(t *testing.T) {
 		require.True(t, names["left-pad"], "expected left-pad in parsed deps, got %v", names)
 	})
 
-	t.Run("skips package.json when a lockfile is also provided", func(t *testing.T) {
+	t.Run("uses lockfile for deps but keeps package.json root metadata", func(t *testing.T) {
 		// A minimal v3 package-lock.json that resolves an exact version
-		// for left-pad. If the lockfile parses, the root package.json
-		// branch is suppressed.
+		// for left-pad. When both files are present the lockfile wins for
+		// resolved versions, but the project's root metadata is still
+		// taken from package.json (the authoritative source for project
+		// name/version) and the package.json appears in the files list.
 		contents := map[string]string{
 			"package.json": `{
 				"name": "demo-app",
@@ -154,11 +156,13 @@ func TestCollectNpmPackagesFromContents(t *testing.T) {
 				}
 			}`,
 		}
-		_, _, _, files, err := collectNpmPackagesFromContents(contents)
+		root, _, _, files, err := collectNpmPackagesFromContents(contents)
 		require.NoError(t, err)
-		// only the lockfile should contribute when both parsed successfully
-		require.Contains(t, files, "package-lock.json")
-		require.NotContains(t, files, "package.json", "package.json must be skipped when a lockfile is present")
+		require.NotNil(t, root, "root should be populated from package.json")
+		require.Equal(t, "demo-app", root.Name)
+		require.Equal(t, "1.2.3", root.Version)
+		require.Contains(t, files, "package-lock.json", "lockfile contributes deps")
+		require.Contains(t, files, "package.json", "package.json contributes root metadata")
 	})
 
 	t.Run("ignores unknown filenames", func(t *testing.T) {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -4513,9 +4513,21 @@ kubelet {
 //
 // Examine all installed packages plus the explicitly-installed top level
 python {
-  init(path? string)
+  init(path? string, contents? map[string]string)
   // Path to a specific site-packages location to exclusively scan (empty means scan default locations)
   path string
+
+  // Optional: in-memory file contents keyed by filename
+  //
+  // Provide raw file contents (e.g., `requirements.txt`, `poetry.lock`,
+  // `Pipfile.lock`, `uv.lock`, `pdm.lock`, `setup.py`, `setup.cfg`) instead
+  // of reading from the connection's filesystem. The value must be a map
+  // from filename to string content; parser selection follows the filename
+  // suffix on each key, matching the on-disk behavior. Useful when feeding
+  // files discovered through another provider (for example,
+  // `github.file.content`) during a non-os scan. When set, both the
+  // `site-packages` walk and the on-disk manifest scan are skipped.
+  contents map[string]string
 
   // List of all discovered packages
   packages() []python.package
@@ -4566,7 +4578,7 @@ python.package @defaults("name version") {
 npm.packages {
   []npm.package
 
-  init(path? string)
+  init(path? string, contents? map[string]string)
 
   // Path to search for packages
   //
@@ -4575,6 +4587,17 @@ npm.packages {
 
   // Optional: list of paths searched for packages
   paths() []string
+
+  // Optional: in-memory file contents keyed by filename
+  //
+  // Provide raw file contents (e.g., `package.json`, `package-lock.json`,
+  // `yarn.lock`) instead of reading from the connection's filesystem. The
+  // value must be a map from filename to string content; parser selection
+  // follows the filename suffix on each key, matching the on-disk behavior.
+  // Useful when feeding files discovered through another provider (for
+  // example, `github.file.content`) during a non-os scan. When set, the
+  // filesystem walk is skipped entirely.
+  contents map[string]string
 
   // Root Package (may not exist)
   root() npm.package

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -6092,6 +6092,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"python.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPython).GetPath()).ToDataRes(types.String)
 	},
+	"python.contents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPython).GetContents()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"python.packages": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPython).GetPackages()).ToDataRes(types.Array(types.Resource("python.package")))
 	},
@@ -6142,6 +6145,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"npm.packages.paths": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNpmPackages).GetPaths()).ToDataRes(types.Array(types.String))
+	},
+	"npm.packages.contents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNpmPackages).GetContents()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"npm.packages.root": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNpmPackages).GetRoot()).ToDataRes(types.Resource("npm.package"))
@@ -15559,6 +15565,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPython).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"python.contents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPython).Contents, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"python.packages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPython).Packages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -15633,6 +15643,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"npm.packages.paths": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNpmPackages).Paths, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"npm.packages.contents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNpmPackages).Contents, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"npm.packages.root": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39906,6 +39920,7 @@ type mqlPython struct {
 	__id       string
 	// optional: if you define mqlPythonInternal it will be used here
 	Path     plugin.TValue[string]
+	Contents plugin.TValue[map[string]any]
 	Packages plugin.TValue[[]any]
 	Toplevel plugin.TValue[[]any]
 }
@@ -39949,6 +39964,10 @@ func (c *mqlPython) MqlID() string {
 
 func (c *mqlPython) GetPath() *plugin.TValue[string] {
 	return &c.Path
+}
+
+func (c *mqlPython) GetContents() *plugin.TValue[map[string]any] {
+	return &c.Contents
 }
 
 func (c *mqlPython) GetPackages() *plugin.TValue[[]any] {
@@ -40111,6 +40130,7 @@ type mqlNpmPackages struct {
 	mqlNpmPackagesInternal
 	Path               plugin.TValue[string]
 	Paths              plugin.TValue[[]any]
+	Contents           plugin.TValue[map[string]any]
 	Root               plugin.TValue[*mqlNpmPackage]
 	DirectDependencies plugin.TValue[[]any]
 	Files              plugin.TValue[[]any]
@@ -40163,6 +40183,10 @@ func (c *mqlNpmPackages) GetPaths() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Paths, func() ([]any, error) {
 		return c.paths()
 	})
+}
+
+func (c *mqlNpmPackages) GetContents() *plugin.TValue[map[string]any] {
+	return &c.Contents
 }
 
 func (c *mqlNpmPackages) GetRoot() *plugin.TValue[*mqlNpmPackage] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1738,6 +1738,7 @@ npm.package.name 10.2.1
 npm.package.purl 10.2.1
 npm.package.version 10.2.1
 npm.packages 10.2.1
+npm.packages.contents 13.22.0
 npm.packages.directDependencies 10.2.1
 npm.packages.files 10.2.1
 npm.packages.list 10.2.1
@@ -2029,6 +2030,7 @@ prolog.packages.files 13.13.1
 prolog.packages.list 13.13.1
 prolog.packages.path 13.13.1
 python 9.0.1
+python.contents 13.22.0
 python.package 9.0.1
 python.package.author 9.0.1
 python.package.authorEmail 9.0.1

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -73,22 +73,26 @@ func initPython(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 }
 
 func (r *mqlPython) id() (string, error) {
-	// when content is supplied, fold the supplied filenames into the id so
-	// two instances with different inputs do not collide in the runtime
-	// resource cache
-	if contents := r.contentMap(); len(contents) > 0 {
-		keys := make([]string, 0, len(contents))
-		for k := range contents {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		hash := sha256.New()
-		for _, k := range keys {
-			hash.Write([]byte(k))
-		}
-		return "python/" + hex.EncodeToString(hash.Sum(nil)), nil
+	// when content is supplied, fold both filenames and their content into
+	// the id so two instances with the same filenames but different content
+	// do not collide in the runtime resource cache
+	contents := r.contentMap()
+	if len(contents) == 0 {
+		return "python", nil
 	}
-	return "python", nil
+	keys := make([]string, 0, len(contents))
+	for k := range contents {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	hash := sha256.New()
+	for _, k := range keys {
+		hash.Write([]byte(k))
+		hash.Write([]byte{0})
+		hash.Write([]byte(contents[k]))
+		hash.Write([]byte{0})
+	}
+	return "python/" + hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func (r *mqlPython) packages() ([]any, error) {

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -4,10 +4,13 @@
 package resources
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -54,10 +57,37 @@ func initPython(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 		args["path"] = llx.StringData("")
 	}
 
+	if x, ok := args["contents"]; ok {
+		xv, ok := x.Value.(map[string]any)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'contents' in python initialization, it must be a map of string to string")
+		}
+		for k, v := range xv {
+			if _, ok := v.(string); !ok {
+				return nil, nil, fmt.Errorf("wrong type for 'contents[%q]' in python initialization, values must be strings", k)
+			}
+		}
+	}
+
 	return args, nil, nil
 }
 
 func (r *mqlPython) id() (string, error) {
+	// when content is supplied, fold the supplied filenames into the id so
+	// two instances with different inputs do not collide in the runtime
+	// resource cache
+	if contents := r.contentMap(); len(contents) > 0 {
+		keys := make([]string, 0, len(contents))
+		for k := range contents {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		hash := sha256.New()
+		for _, k := range keys {
+			hash.Write([]byte(k))
+		}
+		return "python/" + hex.EncodeToString(hash.Sum(nil)), nil
+	}
 	return "python", nil
 }
 
@@ -116,6 +146,13 @@ func (r *mqlPython) toplevel() ([]any, error) {
 }
 
 func (r *mqlPython) getAllPackages() ([]python.PackageDetails, error) {
+	// content-map branch: parse provided file contents directly, without
+	// touching the os connection. Used when running on a non-os connection
+	// (for example, feeding `github.file.content` from a github repo scan).
+	if contents := r.contentMap(); len(contents) > 0 {
+		return collectPythonPackagesFromContents(contents), nil
+	}
+
 	conn, ok := r.MqlRuntime.Connection.(shared.Connection)
 	if !ok {
 		return nil, fmt.Errorf("provider is not an operating system provider")
@@ -535,6 +572,117 @@ func languagePackagesToDetails(pkgs languages.Packages, file string) []python.Pa
 		})
 	}
 	return results
+}
+
+// contentMap returns the `contents` init arg as map[string]string, or nil
+// if none was supplied. The MQL compiler coerces literal map values typed
+// as `any` to `string` at the resource-arg site; the init function still
+// asserts each value's type.
+func (r *mqlPython) contentMap() map[string]string {
+	if r.Contents.Error != nil || len(r.Contents.Data) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(r.Contents.Data))
+	for k, v := range r.Contents.Data {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// collectPythonPackagesFromContents parses the supplied {path: content} map
+// directly, without touching the connection's filesystem. Lockfiles are
+// preferred over requirements.txt / setup.py to match the on-disk priority.
+// Site-packages METADATA / PKG-INFO is install-only and not handled here.
+func collectPythonPackagesFromContents(contents map[string]string) []python.PackageDetails {
+	// Sort keys so output ordering is stable.
+	keys := make([]string, 0, len(contents))
+	for k := range contents {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// First pass: lock files take priority. If any parse succeeds we return
+	// the union of all lock-file results and skip lower-priority manifests
+	// to avoid duplicates.
+	var lockResults []python.PackageDetails
+	for _, key := range keys {
+		base := filepath.Base(key)
+		for _, mf := range pythonManifestFiles {
+			if base != mf.name {
+				continue
+			}
+			bom, err := mf.extractor.Parse(strings.NewReader(contents[key]), key)
+			if err != nil {
+				log.Debug().Err(err).Str("file", key).Msg("failed to parse python manifest content")
+				continue
+			}
+			if pkgs := bom.Transitive(); len(pkgs) > 0 {
+				lockResults = append(lockResults, languagePackagesToDetails(pkgs, key)...)
+			}
+		}
+	}
+	if len(lockResults) > 0 {
+		return lockResults
+	}
+
+	// Fall back to requirements.txt entries.
+	var reqResults []python.PackageDetails
+	for _, key := range keys {
+		if filepath.Base(key) != "requirements.txt" {
+			continue
+		}
+		reqs, err := requirements.ParseRequirementsTxt(strings.NewReader(contents[key]))
+		if err != nil {
+			log.Debug().Err(err).Str("file", key).Msg("failed to parse requirements.txt content")
+			continue
+		}
+		for _, req := range reqs {
+			if req.Name == "" {
+				continue
+			}
+			reqResults = append(reqResults, python.PackageDetails{
+				Name:    req.Name,
+				Version: req.Version,
+				File:    key,
+				Purl:    python.NewPackageUrl(req.Name, req.Version),
+				Cpes:    python.NewCpes(req.Name, req.Version),
+				IsLeaf:  true,
+			})
+		}
+	}
+	if len(reqResults) > 0 {
+		return reqResults
+	}
+
+	// Final fall back: setup.py / setup.cfg.
+	var setupResults []python.PackageDetails
+	for _, key := range keys {
+		base := filepath.Base(key)
+		if base != "setup.py" && base != "setup.cfg" {
+			continue
+		}
+		reqs, err := requirements.ParseSetupPy(strings.NewReader(contents[key]))
+		if err != nil {
+			log.Debug().Err(err).Str("file", key).Msg("failed to parse setup file content")
+			continue
+		}
+		for _, req := range reqs {
+			if req.Name == "" {
+				continue
+			}
+			setupResults = append(setupResults, python.PackageDetails{
+				Name:    req.Name,
+				Version: req.Version,
+				File:    key,
+				Purl:    python.NewPackageUrl(req.Name, req.Version),
+				Cpes:    python.NewCpes(req.Name, req.Version),
+				IsLeaf:  true,
+			})
+		}
+	}
+	return setupResults
 }
 
 // mergePythonPackages merges two slices of PackageDetails, deduplicating by name.

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -314,8 +314,14 @@ func newMqlPythonPackage(runtime *plugin.Runtime, ppd python.PackageDetails) (pl
 		cpes = append(cpes, cpe)
 	}
 
+	// id has to be unique per package; multiple packages can share a File
+	// (lockfiles, requirements.txt), so disambiguate with name@version.
+	id := ppd.File
+	if ppd.Name != "" {
+		id = ppd.File + "#" + ppd.Name + "@" + ppd.Version
+	}
 	r, err := CreateResource(runtime, "python.package", map[string]*llx.RawData{
-		"id":             llx.StringData(ppd.File),
+		"id":             llx.StringData(id),
 		"name":           llx.StringData(ppd.Name),
 		"version":        llx.StringData(ppd.Version),
 		"author":         llx.StringData(ppd.Author),

--- a/providers/os/resources/python_contents_test.go
+++ b/providers/os/resources/python_contents_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectPythonPackagesFromContents(t *testing.T) {
+	t.Run("parses a requirements.txt from in-memory content", func(t *testing.T) {
+		contents := map[string]string{
+			"requirements.txt": "requests==2.31.0\nurllib3>=2.0.0\n",
+		}
+		pkgs := collectPythonPackagesFromContents(contents)
+		names := map[string]string{}
+		for _, p := range pkgs {
+			names[p.Name] = p.Version
+		}
+		require.Equal(t, "2.31.0", names["requests"])
+		require.Contains(t, names, "urllib3")
+		for _, p := range pkgs {
+			require.Equal(t, "requirements.txt", p.File)
+		}
+	})
+
+	t.Run("prefers poetry.lock over requirements.txt", func(t *testing.T) {
+		poetryLock := `[[package]]
+name = "django"
+version = "4.2.7"
+description = "A high-level Python Web framework."
+
+[metadata]
+lock-version = "2.0"
+python-versions = "^3.11"
+content-hash = "abc123"
+`
+		contents := map[string]string{
+			"poetry.lock":      poetryLock,
+			"requirements.txt": "flask==3.0.0\n",
+		}
+		pkgs := collectPythonPackagesFromContents(contents)
+		require.NotEmpty(t, pkgs)
+		for _, p := range pkgs {
+			require.Equal(t, "poetry.lock", p.File, "requirements.txt must be ignored when a lockfile is present")
+		}
+		names := map[string]bool{}
+		for _, p := range pkgs {
+			names[p.Name] = true
+		}
+		require.True(t, names["django"], "expected django from poetry.lock, got %v", names)
+		require.False(t, names["flask"], "flask must not appear when poetry.lock is present")
+	})
+
+	t.Run("ignores unknown filenames", func(t *testing.T) {
+		pkgs := collectPythonPackagesFromContents(map[string]string{
+			"README.md": "not a manifest",
+		})
+		require.Empty(t, pkgs)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds an optional `contents map[string]string` init arg to `npm.packages` and `python`. When set, both resources skip the filesystem walk and feed the supplied `{filename: content}` entries to the existing parsers (parser selection by filename suffix). Lets a query pack feed `github.file.content` straight into the parsers from a github-repo scan, without round-tripping through disk and without duplicating the parsers into the github provider.
- Small mqlc patch so a MQL map literal whose value type widened to `any` (e.g. `{"package.json": file(...).content}`) satisfies a `map[string]string` resource init field. Runtime init still asserts each value's type, so safety is preserved end-to-end. Also adds the `Any`-field special-case to the named-arg path that already existed on the unnamed-arg path.
- Drive-by fix: `python.package` was keyed in the runtime resource cache by `ppd.File`, which collided for manifest-style inputs where many packages share one file (lockfiles, requirements.txt). Disambiguate the id with `name@version`. The first commit lands this independently — the smoke test on lockfile inputs depends on it.
- Provider version: `13.21.0` → `13.22.0`.

Example query the feature unlocks:

```mql
npm.packages(contents: {
  "package.json":      githubFile1.content,
  "package-lock.json": githubFile2.content,
}) { name version purl }

python(contents: {
  "requirements.txt": githubFile3.content,
  "poetry.lock":      githubFile4.content,
}) { name version purl }
```

## Test plan

- [x] `go test ./providers/os/resources/...` — all existing tests pass.
- [x] `go test ./mqlc/...` — mqlc tests pass after the coercion patch.
- [x] New `TestCollectNpmPackagesFromContents` (3 subtests): package.json parse, lockfile preference over package.json, unknown filenames ignored.
- [x] New `TestCollectPythonPackagesFromContents` (3 subtests): requirements.txt parse, poetry.lock preference over requirements.txt, unknown filenames ignored.
- [x] End-to-end smoke against [`M-gre/test-npm`](https://github.com/M-gre/test-npm) (which now also carries `requirements.txt` + `poetry.lock` fixtures): `npm.packages` returns the 6 expected packages from `package.json`; `python` returns the 5 lockfile entries with lockfile taking priority over `requirements.txt`.
- [ ] Reviewer: rebuild + install the os provider (`make providers/build/os providers/install/os`) and try the query above against a github repo asset with `mql shell github repo --repository <owner>/<repo>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)