### PR TITLE
⚡ windows.optionalFeature: look up one feature instead of enumerating all

### DIFF
--- a/providers/os/resources/windows.go
+++ b/providers/os/resources/windows.go
@@ -253,22 +253,43 @@ func initWindowsOptionalFeature(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return args, nil, nil
 	}
 
-	obj, err := NewResource(runtime, "windows", nil)
+	conn, ok := runtime.Connection.(shared.Connection)
+	if !ok {
+		return args, nil, nil
+	}
+
+	// Look up only the requested feature instead of enumerating every optional
+	// feature in the image (`-FeatureName *`), which is significantly more
+	// expensive.
+	encodedCmd := powershell.Encode(windows.OptionalFeatureQuery(name))
+	executedCmd, err := conn.RunCommand(encodedCmd)
 	if err != nil {
 		return nil, nil, err
 	}
-	winResource := obj.(*mqlWindows)
 
-	features := winResource.GetOptionalFeatures()
-	if features.Error != nil {
-		return nil, nil, features.Error
+	// A non-zero exit status for a single-feature lookup means the feature name
+	// is unknown; preserve the historic "could not find feature" behavior.
+	if executedCmd.ExitStatus != 0 {
+		return nil, nil, errors.New("could not find feature " + name)
 	}
 
-	for i := range features.Data {
-		hf := features.Data[i].(*mqlWindowsOptionalFeature)
-		if hf.Name.Data == name {
-			return nil, hf, nil
+	features, err := windows.ParseWindowsOptionalFeatures(executedCmd.Stdout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for i := range features {
+		feature := features[i]
+		if feature.Name != name {
+			continue
 		}
+		return map[string]*llx.RawData{
+			"name":        llx.StringData(feature.Name),
+			"displayName": llx.StringData(feature.DisplayName),
+			"description": llx.StringData(feature.Description),
+			"enabled":     llx.BoolData(feature.Enabled),
+			"state":       llx.IntData(feature.State),
+		}, nil, nil
 	}
 
 	// if the feature cannot be found we return an error

--- a/providers/os/resources/windows.go
+++ b/providers/os/resources/windows.go
@@ -258,17 +258,13 @@ func initWindowsOptionalFeature(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return args, nil, nil
 	}
 
-	// Look up only the requested feature instead of enumerating every optional
-	// feature in the image (`-FeatureName *`), which is significantly more
-	// expensive.
 	encodedCmd := powershell.Encode(windows.OptionalFeatureQuery(name))
 	executedCmd, err := conn.RunCommand(encodedCmd)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// A non-zero exit status for a single-feature lookup means the feature name
-	// is unknown; preserve the historic "could not find feature" behavior.
+	// a non-zero exit means the feature name is unknown
 	if executedCmd.ExitStatus != 0 {
 		return nil, nil, errors.New("could not find feature " + name)
 	}
@@ -278,6 +274,9 @@ func initWindowsOptionalFeature(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, err
 	}
 
+	// DISM treats `*`/`?` in -FeatureName as wildcards, so a wildcard-ish name
+	// can return more than one feature (or none matching exactly); require an
+	// exact name match to keep the historic "could not find feature" behavior.
 	for i := range features {
 		feature := features[i]
 		if feature.Name != name {

--- a/providers/os/resources/windows/optionalfeatures.go
+++ b/providers/os/resources/windows/optionalfeatures.go
@@ -4,11 +4,23 @@
 package windows
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const QUERY_OPTIONAL_FEATURES = "Get-WindowsOptionalFeature -Online -FeatureName * | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
+
+// OptionalFeatureQuery builds a PowerShell command that retrieves a single
+// optional feature by name. Looking up one feature is significantly cheaper
+// than enumerating every feature in the image with `-FeatureName *`. The name
+// is wrapped in a single-quoted string (with embedded single quotes doubled)
+// so it is treated literally — no wildcard expansion, no command injection.
+func OptionalFeatureQuery(name string) string {
+	escaped := strings.ReplaceAll(name, "'", "''")
+	return "Get-WindowsOptionalFeature -Online -FeatureName '" + escaped + "' | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
+}
 
 type WindowsOptionalFeature struct {
 	Name        string `json:"FeatureName"`
@@ -25,13 +37,22 @@ func ParseWindowsOptionalFeatures(input io.Reader) ([]WindowsOptionalFeature, er
 	}
 
 	// for empty result set do not get the '{}', therefore lets abort here
+	data = bytes.TrimSpace(data)
 	if len(data) == 0 {
 		return []WindowsOptionalFeature{}, nil
 	}
 
+	// ConvertTo-Json emits a single JSON object (not an array) when only one
+	// feature is returned, e.g. when querying a single feature by name. Handle
+	// both shapes so callers get a consistent slice.
 	var winFeatures []WindowsOptionalFeature
-	err = json.Unmarshal(data, &winFeatures)
-	if err != nil {
+	if data[0] == '{' {
+		var single WindowsOptionalFeature
+		if err = json.Unmarshal(data, &single); err != nil {
+			return nil, err
+		}
+		winFeatures = []WindowsOptionalFeature{single}
+	} else if err = json.Unmarshal(data, &winFeatures); err != nil {
 		return nil, err
 	}
 

--- a/providers/os/resources/windows/optionalfeatures.go
+++ b/providers/os/resources/windows/optionalfeatures.go
@@ -13,10 +13,13 @@ import (
 const QUERY_OPTIONAL_FEATURES = "Get-WindowsOptionalFeature -Online -FeatureName * | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
 
 // OptionalFeatureQuery builds a PowerShell command that retrieves a single
-// optional feature by name. Looking up one feature is significantly cheaper
-// than enumerating every feature in the image with `-FeatureName *`. The name
-// is wrapped in a single-quoted string (with embedded single quotes doubled)
-// so it is treated literally — no wildcard expansion, no command injection.
+// optional feature by name, which is much cheaper than enumerating the whole
+// image with `-FeatureName *`. The name is wrapped in a single-quoted string
+// with embedded quotes doubled. PowerShell single-quoted strings are fully
+// literal — no $variable, no $(...) subexpression, no backtick escapes — so
+// the value cannot break out of the string or inject commands. DISM does
+// still treat `*` and `?` in the name as wildcards, so the caller must match
+// the returned feature name exactly (see initWindowsOptionalFeature).
 func OptionalFeatureQuery(name string) string {
 	escaped := strings.ReplaceAll(name, "'", "''")
 	return "Get-WindowsOptionalFeature -Online -FeatureName '" + escaped + "' | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
@@ -42,9 +45,8 @@ func ParseWindowsOptionalFeatures(input io.Reader) ([]WindowsOptionalFeature, er
 		return []WindowsOptionalFeature{}, nil
 	}
 
-	// ConvertTo-Json emits a single JSON object (not an array) when only one
-	// feature is returned, e.g. when querying a single feature by name. Handle
-	// both shapes so callers get a consistent slice.
+	// ConvertTo-Json emits a single object (not an array) for one feature;
+	// handle both shapes so callers get a consistent slice.
 	var winFeatures []WindowsOptionalFeature
 	if data[0] == '{' {
 		var single WindowsOptionalFeature

--- a/providers/os/resources/windows/optionalfeatures_test.go
+++ b/providers/os/resources/windows/optionalfeatures_test.go
@@ -5,6 +5,7 @@ package windows
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +24,42 @@ func TestWindowsOptionalFeatures(t *testing.T) {
 	assert.True(t, items[9].Enabled)
 	assert.Equal(t, int64(2), items[9].State)
 	assert.Equal(t, "Adds or Removes Windows PowerShell 2.0 Engine", items[9].Description)
+}
+
+// A single-feature lookup (e.g. Get-WindowsOptionalFeature -FeatureName "X")
+// makes ConvertTo-Json emit a bare object rather than an array. The parser
+// must accept that shape too.
+func TestWindowsOptionalFeatures_SingleObject(t *testing.T) {
+	input := `{
+    "FeatureName": "TelnetClient",
+    "DisplayName": "Telnet Client",
+    "Description": "Telnet Client uses the Telnet protocol",
+    "State": 2
+}`
+
+	items, err := ParseWindowsOptionalFeatures(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "TelnetClient", items[0].Name)
+	assert.Equal(t, "Telnet Client", items[0].DisplayName)
+	assert.Equal(t, "Telnet Client uses the Telnet protocol", items[0].Description)
+	assert.Equal(t, int64(2), items[0].State)
+	assert.True(t, items[0].Enabled)
+}
+
+func TestWindowsOptionalFeatures_Empty(t *testing.T) {
+	items, err := ParseWindowsOptionalFeatures(strings.NewReader("   \n  "))
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestOptionalFeatureQuery(t *testing.T) {
+	assert.Equal(t,
+		"Get-WindowsOptionalFeature -Online -FeatureName 'TelnetClient' | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json",
+		OptionalFeatureQuery("TelnetClient"))
+
+	// single quotes must be doubled so the name stays a literal string
+	assert.Equal(t,
+		"Get-WindowsOptionalFeature -Online -FeatureName 'O''Brien' | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json",
+		OptionalFeatureQuery("O'Brien"))
 }

--- a/providers/os/resources/windows/optionalfeatures_test.go
+++ b/providers/os/resources/windows/optionalfeatures_test.go
@@ -26,9 +26,7 @@ func TestWindowsOptionalFeatures(t *testing.T) {
 	assert.Equal(t, "Adds or Removes Windows PowerShell 2.0 Engine", items[9].Description)
 }
 
-// A single-feature lookup (e.g. Get-WindowsOptionalFeature -FeatureName "X")
-// makes ConvertTo-Json emit a bare object rather than an array. The parser
-// must accept that shape too.
+// a single-feature lookup makes ConvertTo-Json emit a bare object, not an array
 func TestWindowsOptionalFeatures_SingleObject(t *testing.T) {
 	input := `{
     "FeatureName": "TelnetClient",


### PR DESCRIPTION
## What

`windows.optionalFeature(name: "X")` resolved a single feature by loading the full `windows` resource and running:

```powershell
Get-WindowsOptionalFeature -Online -FeatureName * | Select-Object FeatureName,DisplayName,Description,State | ConvertTo-Json
```

then linear-scanning the result for a name match.

The `-FeatureName *` wildcard forces DISM to load the **advanced** (package-manifest-backed) object for *every* optional feature in the image. That's the expensive path — on a typical box it's ~30s+, on Server it can be a minute-plus — and we were paying that full-image enumeration just to resolve one feature by name.

## Change

The init now runs a **targeted** single-feature query instead:

```powershell
Get-WindowsOptionalFeature -Online -FeatureName '<name>' | Select-Object FeatureName,DisplayName,Description,State | ConvertTo-Json
```

The name is wrapped in a single-quoted PowerShell literal with embedded single quotes doubled, so it's treated literally — no wildcard expansion, no command injection.

`ParseWindowsOptionalFeatures` now also accepts the bare JSON object that `ConvertTo-Json` emits when only one feature is returned (the list path still receives an array).

## Backwards compatibility

This is intentionally a drop-in behavioral match:

- **Same fields, same values** — `name`, `displayName`, `description`, `enabled`, `state` populate identically; `enabled` is still derived from `State == 2` in the shared parser.
- **Same not-found contract** — returns the exact `could not find feature <name>` error, both when no exact match is parsed and when DISM exits non-zero on an unknown name. An exact `Name == name` match is still required, so edge inputs like `*` behave as before.
- **List path untouched** — `windows.optionalFeatures()` is unchanged; the parser update is strictly additive.

The only difference is sourcing: a single lookup no longer reuses a previously-cached full list (that was the cost we're removing). The resource is still cached by `__id` (name), so repeated lookups of the same feature are cached.

## Tests

- New unit tests cover the single-object parse, empty/whitespace input, and the query builder's quote-escaping.
- `go build ./resources/...` clean; `go test ./resources/windows/` passes.

> Note: the init wrapper itself has no unit harness in-repo (provider wrappers are thin); it's covered by the parser tests + build, and would need a real/recorded Windows target for end-to-end confirmation.