### PR TITLE
✨ azure: bump keyvault SDKs, expose cert SANs + secret previousVersion

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -59,9 +59,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/cockroachdb/errors v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -200,12 +200,12 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0/go.mod h1:IzuvA34YNVnlifc1+KhCouAKEf1VYzV439FOpyfTHzA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0 h1:e3kTG23M5ps+DjvPolK4dcgohDY8sHsXU7zrdHj1WzY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0/go.mod h1:Os5dq8Cvvz97rJauZhZJAfKHN+OEvF/0nVmHzF4aVys=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.4.0 h1:mtvR5ZXH5Ew6PSONd5lO5OXovWP1E3oAlgC8fpxor2Q=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.4.0/go.mod h1:u560+RFVfG0CBPzkXlDW43slESbBAQjgDGi3r6z+wk8=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0 h1:15MiSirdxWpIKFEHwfwfMWYieETCUnPTERPIlnytQeo=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0/go.mod h1:0AAf/fHAqhIsvD6XGKlCsDO8u+cCiYBBuro+lWS6os4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 h1:MaKvxE6D0KkjOg6Wd9M00iqP5PR0kUxCfiezes4JweM=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0/go.mod h1:i2h9fsTFKZorh8RdV2IcSUf/Qj98GlTkrTvUbX/s8as=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
-github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFOzch6ZJo4Ct9hI4A9Y2fPen5YNRTPmkSBhe5m0ZQ=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -5953,6 +5953,16 @@ private azure.subscription.keyVaultService.certificate.policy.x509CertificatePro
   keyUsage []string
   // Extended key usage OIDs
   ekus []string
+  // Subject alternative name DNS domain names
+  sanDnsNames []string
+  // Subject alternative name email addresses
+  sanEmails []string
+  // Subject alternative name user principal names (UPNs)
+  sanUpns []string
+  // Subject alternative name IP addresses (IPv4 and IPv6)
+  sanIpAddresses []string
+  // Subject alternative name URIs
+  sanUris []string
 }
 
 // Azure Key Vault secret
@@ -5981,6 +5991,10 @@ private azure.subscription.keyVaultService.secret @defaults("id secretName") {
   version() string
   // List of secret versions
   versions() []azure.subscription.keyVaultService.secret
+  // Previous version of the secret
+  //
+  // Set for certificate-backed secrets created after 2025-06-01.
+  previousVersion() azure.subscription.keyVaultService.secret
 }
 
 // Azure Monitor

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -8708,6 +8708,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.ekus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetEkus()).ToDataRes(types.Array(types.String))
 	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanDnsNames": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetSanDnsNames()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanEmails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetSanEmails()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUpns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetSanUpns()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanIpAddresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetSanIpAddresses()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUris": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).GetSanUris()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.keyVaultService.secret.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKeyVaultServiceSecret).GetId()).ToDataRes(types.String)
 	},
@@ -8743,6 +8758,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.keyVaultService.secret.versions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKeyVaultServiceSecret).GetVersions()).ToDataRes(types.Array(types.Resource("azure.subscription.keyVaultService.secret")))
+	},
+	"azure.subscription.keyVaultService.secret.previousVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceSecret).GetPreviousVersion()).ToDataRes(types.Resource("azure.subscription.keyVaultService.secret"))
 	},
 	"azure.subscription.monitorService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorService).GetSubscriptionId()).ToDataRes(types.String)
@@ -23545,6 +23563,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).Ekus, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanDnsNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).SanDnsNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanEmails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).SanEmails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUpns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).SanUpns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanIpAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).SanIpAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUris": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties).SanUris, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.keyVaultService.secret.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKeyVaultServiceSecret).__id, ok = v.Value.(string)
 		return
@@ -23595,6 +23633,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.keyVaultService.secret.versions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKeyVaultServiceSecret).Versions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.secret.previousVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceSecret).PreviousVersion, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceSecret](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -54251,6 +54293,11 @@ type mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperti
 	ValidityInMonths plugin.TValue[int64]
 	KeyUsage         plugin.TValue[[]any]
 	Ekus             plugin.TValue[[]any]
+	SanDnsNames      plugin.TValue[[]any]
+	SanEmails        plugin.TValue[[]any]
+	SanUpns          plugin.TValue[[]any]
+	SanIpAddresses   plugin.TValue[[]any]
+	SanUris          plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties creates a new instance of this resource
@@ -54306,23 +54353,44 @@ func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProp
 	return &c.Ekus
 }
 
+func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties) GetSanDnsNames() *plugin.TValue[[]any] {
+	return &c.SanDnsNames
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties) GetSanEmails() *plugin.TValue[[]any] {
+	return &c.SanEmails
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties) GetSanUpns() *plugin.TValue[[]any] {
+	return &c.SanUpns
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties) GetSanIpAddresses() *plugin.TValue[[]any] {
+	return &c.SanIpAddresses
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties) GetSanUris() *plugin.TValue[[]any] {
+	return &c.SanUris
+}
+
 // mqlAzureSubscriptionKeyVaultServiceSecret for the azure.subscription.keyVaultService.secret resource
 type mqlAzureSubscriptionKeyVaultServiceSecret struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionKeyVaultServiceSecretInternal it will be used here
-	Id          plugin.TValue[string]
-	Tags        plugin.TValue[map[string]any]
-	ContentType plugin.TValue[string]
-	Managed     plugin.TValue[bool]
-	Enabled     plugin.TValue[bool]
-	NotBefore   plugin.TValue[*time.Time]
-	Expires     plugin.TValue[*time.Time]
-	Created     plugin.TValue[*time.Time]
-	Updated     plugin.TValue[*time.Time]
-	SecretName  plugin.TValue[string]
-	Version     plugin.TValue[string]
-	Versions    plugin.TValue[[]any]
+	Id              plugin.TValue[string]
+	Tags            plugin.TValue[map[string]any]
+	ContentType     plugin.TValue[string]
+	Managed         plugin.TValue[bool]
+	Enabled         plugin.TValue[bool]
+	NotBefore       plugin.TValue[*time.Time]
+	Expires         plugin.TValue[*time.Time]
+	Created         plugin.TValue[*time.Time]
+	Updated         plugin.TValue[*time.Time]
+	SecretName      plugin.TValue[string]
+	Version         plugin.TValue[string]
+	Versions        plugin.TValue[[]any]
+	PreviousVersion plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret]
 }
 
 // createAzureSubscriptionKeyVaultServiceSecret creates a new instance of this resource
@@ -54423,6 +54491,22 @@ func (c *mqlAzureSubscriptionKeyVaultServiceSecret) GetVersions() *plugin.TValue
 		}
 
 		return c.versions()
+	})
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceSecret) GetPreviousVersion() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceSecret](&c.PreviousVersion, func() (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.keyVaultService.secret", c.__id, "previousVersion")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceSecret), nil
+			}
+		}
+
+		return c.previousVersion()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1892,6 +1892,11 @@ azure.subscription.keyVaultService.certificate.policy.keyProperties.reuseKey 11.
 azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties 11.4.26
 azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.ekus 11.4.26
 azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.keyUsage 11.4.26
+azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanDnsNames 13.14.1
+azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanEmails 13.14.1
+azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanIpAddresses 13.14.1
+azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUpns 13.14.1
+azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.sanUris 13.14.1
 azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.subject 11.4.26
 azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties.validityInMonths 11.4.26
 azure.subscription.keyVaultService.certificate.recoveryLevel 9.0.1
@@ -1953,6 +1958,7 @@ azure.subscription.keyVaultService.secret.expires 9.0.1
 azure.subscription.keyVaultService.secret.id 9.0.1
 azure.subscription.keyVaultService.secret.managed 9.0.1
 azure.subscription.keyVaultService.secret.notBefore 9.0.1
+azure.subscription.keyVaultService.secret.previousVersion 13.14.1
 azure.subscription.keyVaultService.secret.secretName 9.0.1
 azure.subscription.keyVaultService.secret.tags 9.0.1
 azure.subscription.keyVaultService.secret.updated 9.0.1

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -1103,6 +1103,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceCertificate) policy() (*mqlAzureSubs
 					"validityInMonths": llx.IntData(0),
 					"keyUsage":         llx.ArrayData([]any{}, types.String),
 					"ekus":             llx.ArrayData([]any{}, types.String),
+					"sanDnsNames":      llx.ArrayData([]any{}, types.String),
+					"sanEmails":        llx.ArrayData([]any{}, types.String),
+					"sanUpns":          llx.ArrayData([]any{}, types.String),
+					"sanIpAddresses":   llx.ArrayData([]any{}, types.String),
+					"sanUris":          llx.ArrayData([]any{}, types.String),
 				},
 			)
 			if err != nil {
@@ -1162,6 +1167,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceCertificate) policy() (*mqlAzureSubs
 	validityInMonths := int64(0)
 	keyUsage := []any{}
 	ekus := []any{}
+	sanDnsNames := []any{}
+	sanEmails := []any{}
+	sanUpns := []any{}
+	sanIpAddresses := []any{}
+	sanUris := []any{}
 
 	if policyResp.X509CertificateProperties != nil {
 		if policyResp.X509CertificateProperties.Subject != nil {
@@ -1184,6 +1194,13 @@ func (a *mqlAzureSubscriptionKeyVaultServiceCertificate) policy() (*mqlAzureSubs
 				}
 			}
 		}
+		if san := policyResp.X509CertificateProperties.SubjectAlternativeNames; san != nil {
+			sanDnsNames = convert.SliceStrPtrToInterface(san.DNSNames)
+			sanEmails = convert.SliceStrPtrToInterface(san.Emails)
+			sanUpns = convert.SliceStrPtrToInterface(san.UserPrincipalNames)
+			sanIpAddresses = convert.SliceStrPtrToInterface(san.IPAddresses)
+			sanUris = convert.SliceStrPtrToInterface(san.URIs)
+		}
 	}
 
 	// Create X.509 properties resource
@@ -1195,6 +1212,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceCertificate) policy() (*mqlAzureSubs
 			"validityInMonths": llx.IntData(validityInMonths),
 			"keyUsage":         llx.ArrayData(keyUsage, types.String),
 			"ekus":             llx.ArrayData(ekus, types.String),
+			"sanDnsNames":      llx.ArrayData(sanDnsNames, types.String),
+			"sanEmails":        llx.ArrayData(sanEmails, types.String),
+			"sanUpns":          llx.ArrayData(sanUpns, types.String),
+			"sanIpAddresses":   llx.ArrayData(sanIpAddresses, types.String),
+			"sanUris":          llx.ArrayData(sanUris, types.String),
 		},
 	)
 	if err != nil {
@@ -1411,6 +1433,61 @@ func (a *mqlAzureSubscriptionKeyVaultServiceSecret) versions() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func (a *mqlAzureSubscriptionKeyVaultServiceSecret) previousVersion() (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	id := a.Id.Data
+	kvid, err := parseKeyVaultId(id)
+	if err != nil {
+		return nil, err
+	}
+	if kvid.Type != "secrets" {
+		return nil, errors.New("only secret ids are supported")
+	}
+
+	client, err := azsecrets.NewClient(kvid.BaseUrl, conn.Token(), &azsecrets.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	resp, err := client.GetSecret(ctx, kvid.Name, kvid.Version, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.PreviousVersion == nil || *resp.PreviousVersion == "" {
+		a.PreviousVersion.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	prev, err := client.GetSecret(ctx, kvid.Name, *resp.PreviousVersion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var attrs azsecrets.SecretAttributes
+	if prev.Attributes != nil {
+		attrs = *prev.Attributes
+	}
+	mqlPrev, err := CreateResource(a.MqlRuntime, "azure.subscription.keyVaultService.secret",
+		map[string]*llx.RawData{
+			"id":          llx.StringDataPtr((*string)(prev.ID)),
+			"tags":        llx.MapData(convert.PtrMapStrToInterface(prev.Tags), types.String),
+			"contentType": llx.StringDataPtr(prev.ContentType),
+			"managed":     llx.BoolDataPtr(prev.Managed),
+			"enabled":     llx.BoolDataPtr(attrs.Enabled),
+			"created":     llx.TimeDataPtr(attrs.Created),
+			"updated":     llx.TimeDataPtr(attrs.Updated),
+			"expires":     llx.TimeDataPtr(attrs.Expires),
+			"notBefore":   llx.TimeDataPtr(attrs.NotBefore),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPrev.(*mqlAzureSubscriptionKeyVaultServiceSecret), nil
 }
 
 func initAzureSubscriptionKeyVaultServiceVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## What

Bump the two Azure Key Vault data-plane SDKs to their latest **stable** minors and surface the net-new queryable data they add.

### Dependency bumps (both within major v1 — no breaking changes per Azure SDK policy)
| Module | Old | New |
|---|---|---|
| `sdk/security/keyvault/azcertificates` | v1.4.0 | v1.5.0 |
| `sdk/security/keyvault/azsecrets` | v1.4.0 | v1.5.0 |

Every other `github.com/Azure/...` module in the provider is already on its latest stable major. The remaining new majors exist only as betas / pseudo-versions and were left in place per the stable-only policy.

### New fields

**`azure.subscription.keyVaultService.certificate.policy.x509CertificateProperties`** — subject alternative names, which were not exposed at all before:
- `sanDnsNames`, `sanEmails`, `sanUpns` (already available in the SDK)
- `sanIpAddresses`, `sanUris` (**new in azcertificates v1.5.0**, API version `2025-07-01`)

**`azure.subscription.keyVaultService.secret`** — `previousVersion`, a reference to the prior secret version (**new in azsecrets v1.5.0**). Populated for certificate-backed secrets created after 2025-06-01; resolves the full secret on demand via `GetSecret`.

## Notes
- `previousVersion` returns a fully-populated `azure.subscription.keyVaultService.secret` (not a husk) — it fetches the prior version's attributes via a lazy `GetSecret`, so you can traverse e.g. `…secret.previousVersion.expires`.
- `azure.permissions.json` unchanged — these are Key Vault data-plane calls, not ARM RBAC actions.
- New `.lr.versions` entries are at `13.14.1` (next patch after the provider's current `13.14.0`).

## Test
- `go build ./...`, `go vet ./resources/...`, `go test ./resources/...` — all pass
- `gofmt -l` clean
- `make providers/build/azure` succeeds; generated code regenerated via `mqlr generate`