### PR TITLE
🧪 rpm: deterministic queryformat round-trip test for #7818 regression

### DIFF
--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -631,7 +631,9 @@ func TestRpmQueryFormatRoundTrip(t *testing.T) {
 	// Cover both queryFormat() variants: EPOCHNUM + modularity (redhat/centos 7+)
 	// and EPOCH without modularity (suse).
 	platforms := []*inventory.Platform{
-		{Name: "redhat", Version: "8.10", Arch: "x86_64"},
+		// redhat with a plain-integer version >=7 takes the EPOCHNUM branch in
+		// queryFormat() (ParseInt rejects "8.10", so "8" is required to hit it).
+		{Name: "redhat", Version: "8", Arch: "x86_64"},
 		{Name: "oraclelinux", Version: "9", Arch: "x86_64"},
 		{Name: "suse", Version: "15.6", Arch: "x86_64"},
 	}

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -6,6 +6,7 @@ package packages
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -552,6 +553,108 @@ func TestModularitySupportedByPlatform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, modularitySupportedByPlatform(tt.platform))
+		})
+	}
+}
+
+// renderRpmQueryFormat models how rpm renders a --queryformat string so we can
+// check the round-trip without a real rpm binary. rpm interprets only the
+// named C escapes (\a \b \f \n \r \t \v); for ANY other backslash sequence it
+// drops the backslash and keeps the following byte(s) literally. Crucially,
+// rpm's queryformat does NOT support \NNN octal or \xNN hex escapes — `\036`
+// renders to the literal string "036", and `\x1e` to "x1e". (Confirmed against
+// rpm 4.20.1: `rpm -q --qf 'A\tB\036C\x1eD\n'` emits "A<TAB>B036Cx1eD<LF>".)
+// %{TAG} tokens contain no backslash, so escape processing leaves them intact;
+// we substitute them afterwards with literal sample values.
+func renderRpmQueryFormat(format string, fields map[string]string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] == '\\' && i+1 < len(format) {
+			switch format[i+1] {
+			case 'a':
+				b.WriteByte('\a')
+			case 'b':
+				b.WriteByte('\b')
+			case 'f':
+				b.WriteByte('\f')
+			case 'n':
+				b.WriteByte('\n')
+			case 'r':
+				b.WriteByte('\r')
+			case 't':
+				b.WriteByte('\t')
+			case 'v':
+				b.WriteByte('\v')
+			default:
+				// unknown escape (incl. \NNN and \xNN): backslash dropped, byte kept
+				b.WriteByte(format[i+1])
+			}
+			i++
+			continue
+		}
+		b.WriteByte(format[i])
+	}
+	rendered := b.String()
+	for tag, val := range fields {
+		rendered = strings.ReplaceAll(rendered, "%{"+tag+"}", val)
+	}
+	return rendered
+}
+
+// TestRpmQueryFormatRoundTrip guards the queryformat field separator against
+// the class of bug that caused the #7818 incident (reverted in #7963): the
+// separator emitted by queryFormat() must be something rpm can actually render
+// AND something RPM_REGEX can split on. #7818 switched the separator to `\036`
+// (intending ASCII RS, 0x1E), but rpm's queryformat has no octal escape, so it
+// emitted the literal "036"; RPM_REGEX expected the 0x1E byte, matched nothing,
+// and every rpm asset reported zero packages.
+//
+// This renders the real queryFormat() output exactly the way rpm does, then
+// feeds it back through ParseRpmPackages. Any separator rpm can't emit (or that
+// the regex can't split on) fails here — deterministically, with no rpm binary,
+// container, or VM.
+func TestRpmQueryFormatRoundTrip(t *testing.T) {
+	fields := map[string]string{
+		"NAME":            "glibc",
+		"EPOCH":           "0",
+		"EPOCHNUM":        "0",
+		"VERSION":         "2.34",
+		"RELEASE":         "100.el8",
+		"ARCH":            "x86_64",
+		"VENDOR":          "Red Hat, Inc.",
+		"SUMMARY":         "The GNU libc libraries",
+		"LICENSE":         "LGPLv2+",
+		"INSTALLTIME":     "1700000000",
+		"MODULARITYLABEL": "(none)", // rpm emits "(none)" for non-modular packages
+	}
+
+	// Cover both queryFormat() variants: EPOCHNUM + modularity (redhat/centos 7+)
+	// and EPOCH without modularity (suse).
+	platforms := []*inventory.Platform{
+		{Name: "redhat", Version: "8.10", Arch: "x86_64"},
+		{Name: "oraclelinux", Version: "9", Arch: "x86_64"},
+		{Name: "suse", Version: "15.6", Arch: "x86_64"},
+	}
+
+	for _, pf := range platforms {
+		t.Run(pf.Name, func(t *testing.T) {
+			mgr := &RpmPkgManager{platform: pf}
+			format := mgr.queryFormat()
+
+			output := renderRpmQueryFormat(format, fields)
+
+			pkgs := ParseRpmPackages(pf, strings.NewReader(output))
+			require.Lenf(t, pkgs, 1,
+				"queryFormat() output is not parseable by RPM_REGEX — the field separator is not something rpm emits (octal/hex escape?). format=%q rendered=%q",
+				format, output)
+
+			p := pkgs[0]
+			assert.Equal(t, "glibc", p.Name)
+			assert.Equal(t, "2.34-100.el8", p.Version)
+			assert.Equal(t, "x86_64", p.Arch)
+			assert.Equal(t, "Red Hat, Inc.", p.Vendor)
+			assert.Equal(t, "The GNU libc libraries", p.Description)
+			assert.Equal(t, "LGPLv2+", p.License)
 		})
 	}
 }

--- a/test/providers/rpm_test.go
+++ b/test/providers/rpm_test.go
@@ -13,10 +13,9 @@ import (
 	"go.mondoo.com/mql/v13/test"
 )
 
-// rpmTestImages are rpm-based images we exercise both package code paths
-// against. We deliberately use the *minimal* variants (~15-20 MB compressed)
-// to keep the pull cheap; they still ship the rpm CLI and a real rpm database,
-// which is all both code paths need.
+// rpmTestImages are rpm-based images this smoke test scans. We deliberately
+// use the *minimal* variants (~15-20 MB compressed) to keep the pull cheap;
+// they carry a real rpm database, which is what the static rpmdb path reads.
 var rpmTestImages = []string{
 	"redhat/ubi9-minimal",
 	"almalinux:9-minimal",
@@ -42,8 +41,9 @@ func requireDocker(t *testing.T) {
 }
 
 // dockerRunDetached starts a long-lived container from image and returns its
-// id. A *running* container is what routes mql to the runtime code path
-// (ContainerConnection.RunCommand -> real `rpm -qa --queryformat`).
+// id, so the scan goes through ContainerConnection rather than the image
+// snapshot connection. (Both still resolve to the static rpmdb path — see the
+// TestRpmPackages doc comment.)
 func dockerRunDetached(t *testing.T, image string) string {
 	t.Helper()
 	// Pull explicitly first: `docker run` prints image-pull progress, and if
@@ -63,17 +63,6 @@ func dockerRunDetached(t *testing.T, image string) string {
 		_ = exec.Command("docker", "rm", "-f", id).Run()
 	})
 	return id
-}
-
-// requireRpmBinary asserts the running container actually has the rpm CLI so
-// the runtime code path (`rpm -qa --queryformat`) is genuinely exercised. Some
-// minimal/micro images ship rpm-libs without /usr/bin/rpm; on those mql would
-// silently fall back to the static path, making this test pass while covering
-// nothing. Fail loudly instead so a bad image choice is obvious.
-func requireRpmBinary(t *testing.T, containerID string) {
-	t.Helper()
-	out, err := exec.Command("docker", "exec", containerID, "sh", "-c", "command -v rpm").CombinedOutput()
-	require.NoErrorf(t, err, "rpm CLI missing in container, runtime path would fall back to static: %s", string(out))
 }
 
 // queryPackages runs mql against the target and returns the parsed package
@@ -123,62 +112,65 @@ func packageNames(list []pkgInfo) []string {
 	return names
 }
 
-// assertRealRpmPackages is the core regression guard for the rpm queryformat
-// delimiter. The bug that triggered the revert (#7963 reverting #7818) made
-// the runtime path parse zero packages because rpm did not emit the assumed
-// delimiter byte. These assertions only pass against genuine rpm output.
-func assertRealRpmPackages(t *testing.T, path string, list []pkgInfo) {
+// assertRpmPackages smoke-checks that a real rpm database parsed into sane
+// packages via the static rpmdb path. It is NOT a guard for the queryformat
+// field separator — that lives on the runtime path and is covered by
+// TestRpmQueryFormatRoundTrip (see the TestRpmPackages doc comment).
+func assertRpmPackages(t *testing.T, conn string, list []pkgInfo) {
 	t.Helper()
-	// The delimiter break produced an empty list. Even a minimal image has
-	// dozens of packages, so 20 is a safe floor that still catches that failure.
-	assert.Greaterf(t, len(list), 20, "%s path returned too few packages (delimiter/parse regression?)", path)
+	// Even a minimal image has dozens of packages; 20 is a safe floor that
+	// catches a wholly broken read.
+	assert.Greaterf(t, len(list), 20, "%s: too few packages (broken rpmdb read?)", conn)
 
 	for _, p := range list {
-		assert.NotEmptyf(t, p.Name, "%s path: package with empty name", path)
-		assert.NotEmptyf(t, p.Version, "%s path: %q has empty version", path, p.Name)
+		assert.NotEmptyf(t, p.Name, "%s: package with empty name", conn)
+		assert.NotEmptyf(t, p.Version, "%s: %q has empty version", conn, p.Name)
 	}
 
 	// glibc is present on every rpm image (including minimal variants) and
-	// carries a normal arch and format, so it proves field splitting worked end
+	// carries a normal arch and format, so it proves field mapping worked end
 	// to end. We assert these on glibc rather than every package because
 	// gpg-pubkey (a GPG-key pseudo-package, not real software) has neither.
 	glibc, ok := hasPackage(list, "glibc")
-	require.Truef(t, ok, "%s path: base package glibc missing", path)
-	assert.NotEmptyf(t, glibc.Arch, "%s path: glibc has empty arch", path)
-	assert.Equalf(t, "rpm", glibc.Format, "%s path: glibc has unexpected format %q", path, glibc.Format)
+	require.Truef(t, ok, "%s: base package glibc missing", conn)
+	assert.NotEmptyf(t, glibc.Arch, "%s: glibc has empty arch", conn)
+	assert.Equalf(t, "rpm", glibc.Format, "%s: glibc has unexpected format %q", conn, glibc.Format)
 }
 
-// TestRpmPackages exercises both rpm package code paths against real rpm
-// images and cross-checks them. It deliberately requires docker rather than
-// skipping, because the whole point is to catch divergence between our
-// assumptions and what rpm actually emits.
+// TestRpmPackages is a smoke test that mql parses a real rpm database into
+// sane packages across distros, via both the running-container connection and
+// the image-snapshot connection.
+//
+// Both connections resolve to the *static* rpmdb path: rpm scans over the
+// docker transport do not reliably use the runtime `rpm -qa --queryformat`
+// path, because the exit code of `command -v rpm` is unreliable over docker,
+// so isStaticAnalysis() prefers the static read. This test therefore does NOT
+// guard the queryformat field separator — that bug (#7818, reverted in #7963)
+// lives on the runtime path and is covered deterministically by
+// TestRpmQueryFormatRoundTrip in providers/os/resources/packages.
+//
+// It requires docker rather than skipping, so a CI box without docker fails
+// loudly instead of silently covering nothing.
 func TestRpmPackages(t *testing.T) {
 	once.Do(setup)
 	requireDocker(t)
 
 	for _, image := range rpmTestImages {
 		t.Run(image, func(t *testing.T) {
-			// Runtime path: a running container routes to ContainerConnection,
-			// which runs the real `rpm -qa --queryformat '<queryFormat()>'` and
-			// parses the output with RPM_REGEX. This is the path the __ -> RS
-			// delimiter change broke and the reason mock fixtures could not.
+			// Scan via ContainerConnection (running container).
 			id := dockerRunDetached(t, image)
-			requireRpmBinary(t, id)
-			runtime := queryPackages(t, "docker", id)
-			assertRealRpmPackages(t, "runtime", runtime)
+			viaContainer := queryPackages(t, "docker", id)
+			assertRpmPackages(t, "container", viaContainer)
 
-			// Static path: the same image as an image reference routes to a
-			// snapshot connection, which reads the rpm database with the rpmdb
-			// library and never touches queryFormat/RPM_REGEX.
-			static := queryPackages(t, "docker", image)
-			assertRealRpmPackages(t, "static", static)
+			// Scan the same image as an image reference (snapshot connection).
+			viaImage := queryPackages(t, "docker", image)
+			assertRpmPackages(t, "image", viaImage)
 
-			// Both code paths enumerate the same installed rpm database, so the
-			// set of package names must match. This pins the runtime and static
-			// paths to each other and to real rpm, so neither can silently
-			// drift again.
-			assert.ElementsMatchf(t, packageNames(static), packageNames(runtime),
-				"runtime and static package sets diverge for %s", image)
+			// Both connections read the same installed rpm database, so the
+			// package name sets must match — a cross-check that the static read
+			// is consistent across connection types.
+			assert.ElementsMatchf(t, packageNames(viaImage), packageNames(viaContainer),
+				"container and image package sets diverge for %s", image)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Two related changes to make the rpm tests honest about what they guard:

1. **Adds `TestRpmQueryFormatRoundTrip`** — a fast, deterministic unit test that catches the class of bug behind the #7818 incident (reverted in #7963), with no rpm binary, container, or VM.
2. **Reframes the docker `TestRpmPackages`** (from #8046) as what it actually is — a static-path smoke test, not a runtime/delimiter guard.

## Why this exists (and why the docker test didn't catch #7818)

The rpm **runtime** path builds an `rpm -qa --queryformat '…'` string and parses the output with `RPM_REGEX`. The two must agree on a field separator that **rpm can actually emit**. #7818 switched the separator from `__` to `\036`, intending ASCII Record Separator (`0x1E`). But rpm's queryformat only interprets *named* C escapes (`\t`, `\n`, …) — it has **no octal or hex escape**. So `\036` was emitted as the literal string `036`; `RPM_REGEX` expected the `0x1E` byte, matched nothing, and every rpm-based asset reported **zero packages**.

Reproduced end-to-end on a real Fedora VM over SSH:

| rpm code | `packages.where(format == "rpm").length` |
|---|---|
| clean (`__`) | 671 |
| #7818 (`\036`) | 0 |

Confirmed rpm's escape handling directly (rpm 4.20.1):
```
$ rpm -q --qf 'A\tB\036C\x1eD\n'
A<TAB>B036Cx1eD<LF>      # \t→tab, but \036→"036" and \x1e→"x1e"
```

The docker integration test added in #8046 **did not catch this**: rpm scans over the docker transport prefer the **static** rpmdb-library path (the exit code of `command -v rpm` is unreliable over docker, per `isStaticAnalysis()`), which never runs the queryformat. So it passed even with #7818 re-applied — false confidence.

## What the unit test does

`TestRpmQueryFormatRoundTrip` renders the **real** `queryFormat()` output exactly the way rpm does (named escapes → control chars; `\NNN`/`\xNN` → backslash dropped, rest literal), substitutes sample field values, then feeds the result back through `ParseRpmPackages`. Any separator rpm can't emit — or that `RPM_REGEX` can't split on — fails the round-trip. Covers both format variants (EPOCHNUM + modularity for redhat/oracle; EPOCH without modularity for suse).

Verified: passes on `main`; fails on the exact #7818 `rpm_packages.go` with a clear message showing the literal `036` separators in the rendered output.

## Docker test reframing

`TestRpmPackages` is reframed as a **static-path smoke test** across two connection types (running container + image snapshot). The misleading `requireRpmBinary` guard (which claimed to ensure the runtime path) is removed, and the doc comment now points at `TestRpmQueryFormatRoundTrip` as the actual queryformat-delimiter guard.

## Test plan

- [x] `go test ./providers/os/resources/packages/ -run TestRpmQueryFormatRoundTrip` — passes on main
- [x] Fails on #7818 `rpm_packages.go` (verified locally)
- [x] `gofmt` / `go vet` clean
- [ ] `go-test-integration` green (docker smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)