### PR TITLE
✨ aws: expose ECS task ephemeral storage + Fargate encryption key

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -6852,6 +6852,10 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   startedAt time
   // Time when the task was stopped
   stoppedAt time
+  // Size (in GiB) of ephemeral storage allocated to the task
+  ephemeralStorageSizeInGiB int
+  // KMS key encrypting the task's Fargate ephemeral storage (Fargate launch type)
+  fargateEphemeralStorageKmsKey() aws.kms.key
 }
 
 // Amazon ECS container

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -6853,6 +6853,10 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   // Time when the task was stopped
   stoppedAt time
   // Size (in GiB) of ephemeral storage allocated to the task
+  //
+  // Null when the API does not report a value (for example EC2-launch tasks
+  // that use the default ephemeral storage); a number when ephemeral storage
+  // is explicitly configured.
   ephemeralStorageSizeInGiB int
   // KMS key encrypting the task's Fargate ephemeral storage (Fargate launch type)
   fargateEphemeralStorageKmsKey() aws.kms.key

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12184,6 +12184,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.task.stoppedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTask).GetStoppedAt()).ToDataRes(types.Time)
 	},
+	"aws.ecs.task.ephemeralStorageSizeInGiB": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTask).GetEphemeralStorageSizeInGiB()).ToDataRes(types.Int)
+	},
+	"aws.ecs.task.fargateEphemeralStorageKmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTask).GetFargateEphemeralStorageKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.ecs.container.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsContainer).GetName()).ToDataRes(types.String)
 	},
@@ -42388,6 +42394,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecs.task.stoppedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsTask).StoppedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.task.ephemeralStorageSizeInGiB": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTask).EphemeralStorageSizeInGiB, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.task.fargateEphemeralStorageKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTask).FargateEphemeralStorageKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.container.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -99918,28 +99932,30 @@ type mqlAwsEcsTask struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEcsTaskInternal
-	Arn                  plugin.TValue[string]
-	ClusterName          plugin.TValue[string]
-	Connectivity         plugin.TValue[any]
-	LastStatus           plugin.TValue[string]
-	PlatformFamily       plugin.TValue[string]
-	PlatformVersion      plugin.TValue[string]
-	Tags                 plugin.TValue[map[string]any]
-	Region               plugin.TValue[string]
-	Containers           plugin.TValue[[]any]
-	TaskDefinition       plugin.TValue[*mqlAwsEcsTaskDefinition]
-	ContainerInstanceArn plugin.TValue[string]
-	Cpu                  plugin.TValue[string]
-	Memory               plugin.TValue[string]
-	HealthStatus         plugin.TValue[string]
-	LaunchType           plugin.TValue[string]
-	CapacityProviderName plugin.TValue[string]
-	Group                plugin.TValue[string]
-	EnableExecuteCommand plugin.TValue[bool]
-	StopCode             plugin.TValue[string]
-	StoppedReason        plugin.TValue[string]
-	StartedAt            plugin.TValue[*time.Time]
-	StoppedAt            plugin.TValue[*time.Time]
+	Arn                           plugin.TValue[string]
+	ClusterName                   plugin.TValue[string]
+	Connectivity                  plugin.TValue[any]
+	LastStatus                    plugin.TValue[string]
+	PlatformFamily                plugin.TValue[string]
+	PlatformVersion               plugin.TValue[string]
+	Tags                          plugin.TValue[map[string]any]
+	Region                        plugin.TValue[string]
+	Containers                    plugin.TValue[[]any]
+	TaskDefinition                plugin.TValue[*mqlAwsEcsTaskDefinition]
+	ContainerInstanceArn          plugin.TValue[string]
+	Cpu                           plugin.TValue[string]
+	Memory                        plugin.TValue[string]
+	HealthStatus                  plugin.TValue[string]
+	LaunchType                    plugin.TValue[string]
+	CapacityProviderName          plugin.TValue[string]
+	Group                         plugin.TValue[string]
+	EnableExecuteCommand          plugin.TValue[bool]
+	StopCode                      plugin.TValue[string]
+	StoppedReason                 plugin.TValue[string]
+	StartedAt                     plugin.TValue[*time.Time]
+	StoppedAt                     plugin.TValue[*time.Time]
+	EphemeralStorageSizeInGiB     plugin.TValue[int64]
+	FargateEphemeralStorageKmsKey plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsEcsTask creates a new instance of this resource
@@ -100089,6 +100105,26 @@ func (c *mqlAwsEcsTask) GetStartedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsEcsTask) GetStoppedAt() *plugin.TValue[*time.Time] {
 	return &c.StoppedAt
+}
+
+func (c *mqlAwsEcsTask) GetEphemeralStorageSizeInGiB() *plugin.TValue[int64] {
+	return &c.EphemeralStorageSizeInGiB
+}
+
+func (c *mqlAwsEcsTask) GetFargateEphemeralStorageKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.FargateEphemeralStorageKmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.task", c.__id, "fargateEphemeralStorageKmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.fargateEphemeralStorageKmsKey()
+	})
 }
 
 // mqlAwsEcsContainer for the aws.ecs.container resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3437,6 +3437,8 @@ aws.ecs.task.containerInstanceArn 13.29.1
 aws.ecs.task.containers 11.15.2
 aws.ecs.task.cpu 13.29.1
 aws.ecs.task.enableExecuteCommand 13.29.1
+aws.ecs.task.ephemeralStorageSizeInGiB 13.29.1
+aws.ecs.task.fargateEphemeralStorageKmsKey 13.29.1
 aws.ecs.task.group 13.29.1
 aws.ecs.task.healthStatus 13.29.1
 aws.ecs.task.lastStatus 11.15.2

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -480,6 +480,17 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	args["stoppedReason"] = llx.StringData(convert.ToValue(t.StoppedReason))
 	args["startedAt"] = llx.TimeDataPtr(t.StartedAt)
 	args["stoppedAt"] = llx.TimeDataPtr(t.StoppedAt)
+
+	// Ephemeral storage size: prefer the Fargate-specific value (which also
+	// carries the encryption key), otherwise the generic task ephemeral storage.
+	var ephemeralStorageSize int64
+	if t.FargateEphemeralStorage != nil {
+		ephemeralStorageSize = int64(t.FargateEphemeralStorage.SizeInGiB)
+	} else if t.EphemeralStorage != nil {
+		ephemeralStorageSize = int64(t.EphemeralStorage.SizeInGiB)
+	}
+	args["ephemeralStorageSizeInGiB"] = llx.IntData(ephemeralStorageSize)
+
 	res, err := CreateResource(runtime, "aws.ecs.task", args)
 	if err != nil {
 		return args, nil, err
@@ -489,16 +500,33 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	res.(*mqlAwsEcsTask).attachments = t.Attachments
 	res.(*mqlAwsEcsTask).clusterName = clusterName
 	res.(*mqlAwsEcsTask).taskDefArn = t.TaskDefinitionArn
+	if t.FargateEphemeralStorage != nil {
+		res.(*mqlAwsEcsTask).fargateEphemeralStorageKmsKeyId = t.FargateEphemeralStorage.KmsKeyId
+	}
 
 	return args, res, nil
 }
 
 type mqlAwsEcsTaskInternal struct {
-	cacheContainers []ecstypes.Container
-	region          string
-	attachments     []ecstypes.Attachment
-	clusterName     string
-	taskDefArn      *string
+	cacheContainers                 []ecstypes.Container
+	region                          string
+	attachments                     []ecstypes.Attachment
+	clusterName                     string
+	taskDefArn                      *string
+	fargateEphemeralStorageKmsKeyId *string
+}
+
+func (t *mqlAwsEcsTask) fargateEphemeralStorageKmsKey() (*mqlAwsKmsKey, error) {
+	if t.fargateEphemeralStorageKmsKeyId == nil || *t.fargateEphemeralStorageKmsKeyId == "" {
+		t.FargateEphemeralStorageKmsKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	mqlKey, err := NewResource(t.MqlRuntime, ResourceAwsKmsKey,
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(t.fargateEphemeralStorageKmsKeyId)})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
 func (a *mqlAwsEcsTask) taskDefinition() (*mqlAwsEcsTaskDefinition, error) {

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -482,14 +482,17 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	args["stoppedAt"] = llx.TimeDataPtr(t.StoppedAt)
 
 	// Ephemeral storage size: prefer the Fargate-specific value (which also
-	// carries the encryption key), otherwise the generic task ephemeral storage.
-	var ephemeralStorageSize int64
-	if t.FargateEphemeralStorage != nil {
-		ephemeralStorageSize = int64(t.FargateEphemeralStorage.SizeInGiB)
-	} else if t.EphemeralStorage != nil {
-		ephemeralStorageSize = int64(t.EphemeralStorage.SizeInGiB)
+	// carries the encryption key), otherwise the generic task ephemeral
+	// storage. The API only reports these when explicitly configured, so leave
+	// the field null otherwise rather than implying 0 GiB is allocated.
+	switch {
+	case t.FargateEphemeralStorage != nil:
+		args["ephemeralStorageSizeInGiB"] = llx.IntData(int64(t.FargateEphemeralStorage.SizeInGiB))
+	case t.EphemeralStorage != nil:
+		args["ephemeralStorageSizeInGiB"] = llx.IntData(int64(t.EphemeralStorage.SizeInGiB))
+	default:
+		args["ephemeralStorageSizeInGiB"] = llx.NilData
 	}
-	args["ephemeralStorageSizeInGiB"] = llx.IntData(ephemeralStorageSize)
 
 	res, err := CreateResource(runtime, "aws.ecs.task", args)
 	if err != nil {


### PR DESCRIPTION
## What

Adds two fields to `aws.ecs.task`, both read from the `DescribeTasks` response already fetched in `initAwsEcsTask` — **no new API call, no new IAM permission**:

- `ephemeralStorageSizeInGiB` — size of the task's ephemeral storage (Fargate value preferred, falling back to the generic task ephemeral storage)
- `fargateEphemeralStorageKmsKey() aws.kms.key` — the KMS key encrypting the task's Fargate ephemeral storage

## Why

This is the only place the **per-task** Fargate ephemeral-storage encryption key is exposed. We previously modeled only the cluster-level *default* (`aws.ecs.cluster.fargateEphemeralStorageKmsKey`), so an auditor couldn't see the key actually in effect for a given running task. Closes the one Fargate gap found while building out the ECS resources.

## Notes

- New `.lr.versions` entries stamped `13.29.1`.
- `permissions.json` unchanged (no new API call).
- Touches the `aws.ecs.task` block, which is also expanded in #8065 — expect a trivial merge conflict in `aws.lr` / `aws.lr.versions` depending on merge order; both are adjacent field additions.

## Verification

`go build ./...`, `go vet ./resources/`, and code generation pass. Provider installs and the query
`aws.ecs.clusters { tasks { ephemeralStorageSizeInGiB fargateEphemeralStorageKmsKey.arn } }`
runs cleanly against a live account. The test account had no running tasks, so the field values weren't exercised with live data, but the schema resolves and the typed KMS ref traverses without error.