### PR TITLE
✨ aws: new fields on EC2, S3, VPC, Lambda, CloudFront, DynamoDB

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -141,6 +141,23 @@ func (c *AwsConnection) SetAccountId(id string) {
 	}
 }
 
+// GetCachedValue returns a previously cached value for the given key. It is
+// connection-scoped and safe for concurrent use, intended for account- or
+// region-level data that multiple resources would otherwise re-fetch.
+func (c *AwsConnection) GetCachedValue(key string) (any, bool) {
+	entry, ok := c.clientcache.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return entry.Data, true
+}
+
+// SetCachedValue stores a value under the given key for the lifetime of the
+// connection. See GetCachedValue.
+func (c *AwsConnection) SetCachedValue(key string, val any) {
+	c.clientcache.Store(key, &CacheEntry{Data: val})
+}
+
 func (p *AwsConnection) AccountId() string {
 	return p.accountId
 }

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -314,8 +314,18 @@ aws.vpc @defaults("id isDefault cidrBlock region") {
   internetGateways() []aws.ec2.internetgateway
   // Security groups in this VPC
   securityGroups() []aws.ec2.securitygroup
+  // Default security group of the VPC (the group named "default")
+  defaultSecurityGroup() aws.ec2.securitygroup
   // Network ACLs in this VPC
   networkAcls() []aws.ec2.networkacl
+  // Default network ACL of the VPC
+  defaultNetworkAcl() aws.ec2.networkacl
+  // Account- and region-level VPC Block Public Access options that apply to the VPC
+  //
+  // A dict with `internetGatewayBlockMode`, `state`, `exclusionsAllowed`,
+  // `managedBy`, `reason`, and `lastUpdateTimestamp`. Empty when VPC Block
+  // Public Access has never been configured in the region.
+  blockPublicAccessOptions() dict
   // Virtual private gateways attached to the VPC
   vpnGateways() []aws.vpc.vpnGateway
   // DHCP options set associated with the VPC
@@ -9017,6 +9027,10 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   sslSupportMethod string
   // ARN of the AWS WAF web ACL associated with the distribution (empty string if none)
   webAclId string
+  // AWS WAF web ACL associated with the distribution
+  webAcl() aws.waf.acl
+  // ID of the continuous deployment policy associated with the distribution (empty string when none)
+  continuousDeploymentPolicyId() string
   // Type of geographic restriction applied to the distribution (none, whitelist, or blacklist)
   geoRestrictionType string
   // When the distribution was last modified
@@ -9788,14 +9802,59 @@ private aws.s3.bucket @defaults("name location public") {
   lifecycleRules() []aws.s3.bucket.lifecycleRule
   // Notification configuration for the bucket (Lambda, SQS, SNS, EventBridge)
   notificationConfiguration() dict
+  // Event notification targets configured on the bucket (Lambda, SQS, and SNS)
+  eventNotifications() []aws.s3.bucket.eventNotification
   // Object ownership setting: BucketOwnerEnforced, BucketOwnerPreferred, or ObjectWriter
   ownershipControls() string
+  // S3 Intelligent-Tiering configurations on the bucket
+  //
+  // Each entry is a dict with `id`, `status`, and `tierings` (the
+  // access-tier transition rules).
+  intelligentTieringConfigurations() []dict
+  // S3 Inventory configurations on the bucket
+  //
+  // Each entry is a dict with `id`, `isEnabled`, `includedObjectVersions`,
+  // `destination`, `schedule`, and `optionalFields`.
+  inventoryConfigurations() []dict
+  // S3 Analytics (storage class analysis) configurations on the bucket
+  //
+  // Each entry is a dict with `id`, `filter`, and `storageClassAnalysis`.
+  analyticsConfigurations() []dict
+  // Request payment configuration: "BucketOwner" (default) or "Requester"
+  requestPayment() string
+  // S3 Transfer Acceleration status: "Enabled", "Suspended", or empty when never configured
+  transferAcceleration() string
   // Amazon Macie coverage record for this bucket
   //
   // Reports sensitivity score, public-access summary, encryption defaults, and automated-discovery status. Null when Macie is not enabled in the bucket's region or the bucket is outside Macie's monitored set.
   macieCoverage() aws.macie.bucket
   // S3 access points attached to the bucket
   accessPoints() []aws.s3.bucket.accessPoint
+}
+
+// Amazon S3 bucket event notification
+//
+// Examine a single event-notification target configured on a bucket. The
+// `type` field distinguishes the destination — `lambda`, `queue` (SQS), or
+// `topic` (SNS) — and `events` lists the S3 event types that trigger it
+// (for example `s3:ObjectCreated:*`). The matching typed reference among
+// `lambdaFunction()`, `queue()`, and `topic()` resolves to the destination
+// resource; the other two are null.
+private aws.s3.bucket.eventNotification @defaults("id type events") {
+  // Notification configuration ID assigned to the target
+  id string
+  // Destination type, one of "lambda", "queue", or "topic"
+  type string
+  // ARN of the destination Lambda function, SQS queue, or SNS topic
+  arn string
+  // S3 event types that trigger the notification, for example s3:ObjectCreated:*
+  events []string
+  // Lambda function the notification invokes, when the destination is a Lambda function
+  lambdaFunction() aws.lambda.function
+  // SQS queue the notification sends to, when the destination is an SQS queue
+  queue() aws.sqs.queue
+  // SNS topic the notification publishes to, when the destination is an SNS topic
+  topic() aws.sns.topic
 }
 
 // Amazon S3 bucket access point
@@ -10739,6 +10798,8 @@ private aws.dynamodb.table @defaults("name region") {
   sseDescription() dict
   // Type of server-side encryption: "AES256" (AWS-owned) or "KMS" (customer-managed or AWS-managed KMS key)
   sseType() string
+  // ARN of the KMS key used for server-side encryption at rest
+  kmsMasterKeyId() string
   // KMS key used for server-side encryption at rest
   sseKmsKey() aws.kms.key
   // Provisioned throughput settings for the table
@@ -13613,6 +13674,8 @@ private aws.lambda.function @defaults("arn") {
   concurrency() int
   // Target ARN of the dead-letter queue config
   dlqTargetArn string
+  // Recursive loop detection mode, either "Allow" or "Terminate"
+  recursiveLoop() string
   // Policy for the function
   policy() dict
   // Raw VPC configuration for the Lambda function
@@ -15141,6 +15204,8 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   httpEndpoint string
   // Maximum number of hops for the instance metadata PUT response (1-64); values >1 increase SSRF risk
   httpPutResponseHopLimit int
+  // Whether IMDSv2 is required (httpTokens is "required"), enforcing session-token-authenticated metadata access
+  imdsv2Required bool
   // Whether the instance is enabled for AWS Nitro Enclaves
   enclaveEnabled bool
   // Patch state information about the instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -110029,7 +110029,7 @@ func (c *mqlAwsCloudfrontAnycastIpList) GetRegion() *plugin.TValue[string] {
 type mqlAwsCloudfrontDistribution struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsCloudfrontDistributionInternal it will be used here
+	mqlAwsCloudfrontDistributionInternal
 	Arn                          plugin.TValue[string]
 	Status                       plugin.TValue[string]
 	DomainName                   plugin.TValue[string]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -404,6 +404,7 @@ const (
 	ResourceAwsS3control                                                        string = "aws.s3control"
 	ResourceAwsS3                                                               string = "aws.s3"
 	ResourceAwsS3Bucket                                                         string = "aws.s3.bucket"
+	ResourceAwsS3BucketEventNotification                                        string = "aws.s3.bucket.eventNotification"
 	ResourceAwsS3BucketAccessPoint                                              string = "aws.s3.bucket.accessPoint"
 	ResourceAwsS3BucketGrant                                                    string = "aws.s3.bucket.grant"
 	ResourceAwsS3BucketCorsrule                                                 string = "aws.s3.bucket.corsrule"
@@ -2433,6 +2434,10 @@ func init() {
 		"aws.s3.bucket": {
 			Init:   initAwsS3Bucket,
 			Create: createAwsS3Bucket,
+		},
+		"aws.s3.bucket.eventNotification": {
+			// to override args, implement: initAwsS3BucketEventNotification(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsS3BucketEventNotification,
 		},
 		"aws.s3.bucket.accessPoint": {
 			// to override args, implement: initAwsS3BucketAccessPoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4663,8 +4668,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.vpc.defaultSecurityGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetDefaultSecurityGroup()).ToDataRes(types.Resource("aws.ec2.securitygroup"))
+	},
 	"aws.vpc.networkAcls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetNetworkAcls()).ToDataRes(types.Array(types.Resource("aws.ec2.networkacl")))
+	},
+	"aws.vpc.defaultNetworkAcl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetDefaultNetworkAcl()).ToDataRes(types.Resource("aws.ec2.networkacl"))
+	},
+	"aws.vpc.blockPublicAccessOptions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetBlockPublicAccessOptions()).ToDataRes(types.Dict)
 	},
 	"aws.vpc.vpnGateways": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetVpnGateways()).ToDataRes(types.Array(types.Resource("aws.vpc.vpnGateway")))
@@ -14479,6 +14493,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudfront.distribution.webAclId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetWebAclId()).ToDataRes(types.String)
 	},
+	"aws.cloudfront.distribution.webAcl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetWebAcl()).ToDataRes(types.Resource("aws.waf.acl"))
+	},
+	"aws.cloudfront.distribution.continuousDeploymentPolicyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetContinuousDeploymentPolicyId()).ToDataRes(types.String)
+	},
 	"aws.cloudfront.distribution.geoRestrictionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetGeoRestrictionType()).ToDataRes(types.String)
 	},
@@ -15208,14 +15228,53 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.notificationConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetNotificationConfiguration()).ToDataRes(types.Dict)
 	},
+	"aws.s3.bucket.eventNotifications": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetEventNotifications()).ToDataRes(types.Array(types.Resource("aws.s3.bucket.eventNotification")))
+	},
 	"aws.s3.bucket.ownershipControls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetOwnershipControls()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.intelligentTieringConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetIntelligentTieringConfigurations()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.s3.bucket.inventoryConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetInventoryConfigurations()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.s3.bucket.analyticsConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetAnalyticsConfigurations()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.s3.bucket.requestPayment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetRequestPayment()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.transferAcceleration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetTransferAcceleration()).ToDataRes(types.String)
 	},
 	"aws.s3.bucket.macieCoverage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetMacieCoverage()).ToDataRes(types.Resource("aws.macie.bucket"))
 	},
 	"aws.s3.bucket.accessPoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetAccessPoints()).ToDataRes(types.Array(types.Resource("aws.s3.bucket.accessPoint")))
+	},
+	"aws.s3.bucket.eventNotification.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetId()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.eventNotification.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetType()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.eventNotification.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetArn()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.eventNotification.events": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetEvents()).ToDataRes(types.Array(types.String))
+	},
+	"aws.s3.bucket.eventNotification.lambdaFunction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetLambdaFunction()).ToDataRes(types.Resource("aws.lambda.function"))
+	},
+	"aws.s3.bucket.eventNotification.queue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetQueue()).ToDataRes(types.Resource("aws.sqs.queue"))
+	},
+	"aws.s3.bucket.eventNotification.topic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketEventNotification).GetTopic()).ToDataRes(types.Resource("aws.sns.topic"))
 	},
 	"aws.s3.bucket.accessPoint.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketAccessPoint).GetArn()).ToDataRes(types.String)
@@ -16251,6 +16310,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.dynamodb.table.sseType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetSseType()).ToDataRes(types.String)
+	},
+	"aws.dynamodb.table.kmsMasterKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetKmsMasterKeyId()).ToDataRes(types.String)
 	},
 	"aws.dynamodb.table.sseKmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetSseKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
@@ -19435,6 +19497,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.dlqTargetArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetDlqTargetArn()).ToDataRes(types.String)
 	},
+	"aws.lambda.function.recursiveLoop": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetRecursiveLoop()).ToDataRes(types.String)
+	},
 	"aws.lambda.function.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetPolicy()).ToDataRes(types.Dict)
 	},
@@ -21273,6 +21338,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.instance.httpPutResponseHopLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetHttpPutResponseHopLimit()).ToDataRes(types.Int)
+	},
+	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetImdsv2Required()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetEnclaveEnabled()).ToDataRes(types.Bool)
@@ -31352,8 +31420,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpc).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.defaultSecurityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).DefaultSecurityGroup, ok = plugin.RawToTValue[*mqlAwsEc2Securitygroup](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.networkAcls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).NetworkAcls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.defaultNetworkAcl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).DefaultNetworkAcl, ok = plugin.RawToTValue[*mqlAwsEc2Networkacl](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.blockPublicAccessOptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).BlockPublicAccessOptions, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.vpnGateways": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -45836,6 +45916,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudfrontDistribution).WebAclId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.cloudfront.distribution.webAcl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).WebAcl, ok = plugin.RawToTValue[*mqlAwsWafAcl](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.continuousDeploymentPolicyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).ContinuousDeploymentPolicyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.cloudfront.distribution.geoRestrictionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudfrontDistribution).GeoRestrictionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -46924,8 +47012,32 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsS3Bucket).NotificationConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.eventNotifications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).EventNotifications, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.ownershipControls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).OwnershipControls, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.intelligentTieringConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).IntelligentTieringConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.inventoryConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).InventoryConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.analyticsConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).AnalyticsConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.requestPayment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).RequestPayment, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.transferAcceleration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).TransferAcceleration, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.s3.bucket.macieCoverage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -46934,6 +47046,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.s3.bucket.accessPoints": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).AccessPoints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.s3.bucket.eventNotification.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.events": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Events, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.lambdaFunction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).LambdaFunction, ok = plugin.RawToTValue[*mqlAwsLambdaFunction](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.queue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Queue, ok = plugin.RawToTValue[*mqlAwsSqsQueue](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.eventNotification.topic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketEventNotification).Topic, ok = plugin.RawToTValue[*mqlAwsSnsTopic](v.Value, v.Error)
 		return
 	},
 	"aws.s3.bucket.accessPoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48470,6 +48614,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.dynamodb.table.sseType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbTable).SseType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.dynamodb.table.kmsMasterKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).KmsMasterKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.dynamodb.table.sseKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -53048,6 +53196,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaFunction).DlqTargetArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.function.recursiveLoop": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).RecursiveLoop, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.function.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).Policy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -55738,6 +55890,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.httpPutResponseHopLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).HttpPutResponseHopLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).Imdsv2Required, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -70755,7 +70911,10 @@ type mqlAwsVpc struct {
 	DhcpOptionsId             plugin.TValue[string]
 	InternetGateways          plugin.TValue[[]any]
 	SecurityGroups            plugin.TValue[[]any]
+	DefaultSecurityGroup      plugin.TValue[*mqlAwsEc2Securitygroup]
 	NetworkAcls               plugin.TValue[[]any]
+	DefaultNetworkAcl         plugin.TValue[*mqlAwsEc2Networkacl]
+	BlockPublicAccessOptions  plugin.TValue[any]
 	VpnGateways               plugin.TValue[[]any]
 	DhcpOptions               plugin.TValue[*mqlAwsEc2DhcpOptions]
 	EnableDnsSupport          plugin.TValue[bool]
@@ -70989,6 +71148,22 @@ func (c *mqlAwsVpc) GetSecurityGroups() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsVpc) GetDefaultSecurityGroup() *plugin.TValue[*mqlAwsEc2Securitygroup] {
+	return plugin.GetOrCompute[*mqlAwsEc2Securitygroup](&c.DefaultSecurityGroup, func() (*mqlAwsEc2Securitygroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc", c.__id, "defaultSecurityGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Securitygroup), nil
+			}
+		}
+
+		return c.defaultSecurityGroup()
+	})
+}
+
 func (c *mqlAwsVpc) GetNetworkAcls() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.NetworkAcls, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -71002,6 +71177,28 @@ func (c *mqlAwsVpc) GetNetworkAcls() *plugin.TValue[[]any] {
 		}
 
 		return c.networkAcls()
+	})
+}
+
+func (c *mqlAwsVpc) GetDefaultNetworkAcl() *plugin.TValue[*mqlAwsEc2Networkacl] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkacl](&c.DefaultNetworkAcl, func() (*mqlAwsEc2Networkacl, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc", c.__id, "defaultNetworkAcl")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkacl), nil
+			}
+		}
+
+		return c.defaultNetworkAcl()
+	})
+}
+
+func (c *mqlAwsVpc) GetBlockPublicAccessOptions() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.BlockPublicAccessOptions, func() (any, error) {
+		return c.blockPublicAccessOptions()
 	})
 }
 
@@ -109833,27 +110030,29 @@ type mqlAwsCloudfrontDistribution struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsCloudfrontDistributionInternal it will be used here
-	Arn                    plugin.TValue[string]
-	Status                 plugin.TValue[string]
-	DomainName             plugin.TValue[string]
-	Origins                plugin.TValue[[]any]
-	DefaultCacheBehavior   plugin.TValue[any]
-	CacheBehaviors         plugin.TValue[[]any]
-	HttpVersion            plugin.TValue[string]
-	IsIPV6Enabled          plugin.TValue[bool]
-	Enabled                plugin.TValue[bool]
-	PriceClass             plugin.TValue[string]
-	Cnames                 plugin.TValue[[]any]
-	ViewerProtocolPolicy   plugin.TValue[string]
-	MinimumProtocolVersion plugin.TValue[string]
-	SslSupportMethod       plugin.TValue[string]
-	WebAclId               plugin.TValue[string]
-	GeoRestrictionType     plugin.TValue[string]
-	LastModifiedAt         plugin.TValue[*time.Time]
-	Comment                plugin.TValue[string]
-	Logging                plugin.TValue[*mqlAwsCloudfrontDistributionLoggingConfig]
-	ViewerMtlsMode         plugin.TValue[string]
-	ViewerMtlsTrustStoreId plugin.TValue[string]
+	Arn                          plugin.TValue[string]
+	Status                       plugin.TValue[string]
+	DomainName                   plugin.TValue[string]
+	Origins                      plugin.TValue[[]any]
+	DefaultCacheBehavior         plugin.TValue[any]
+	CacheBehaviors               plugin.TValue[[]any]
+	HttpVersion                  plugin.TValue[string]
+	IsIPV6Enabled                plugin.TValue[bool]
+	Enabled                      plugin.TValue[bool]
+	PriceClass                   plugin.TValue[string]
+	Cnames                       plugin.TValue[[]any]
+	ViewerProtocolPolicy         plugin.TValue[string]
+	MinimumProtocolVersion       plugin.TValue[string]
+	SslSupportMethod             plugin.TValue[string]
+	WebAclId                     plugin.TValue[string]
+	WebAcl                       plugin.TValue[*mqlAwsWafAcl]
+	ContinuousDeploymentPolicyId plugin.TValue[string]
+	GeoRestrictionType           plugin.TValue[string]
+	LastModifiedAt               plugin.TValue[*time.Time]
+	Comment                      plugin.TValue[string]
+	Logging                      plugin.TValue[*mqlAwsCloudfrontDistributionLoggingConfig]
+	ViewerMtlsMode               plugin.TValue[string]
+	ViewerMtlsTrustStoreId       plugin.TValue[string]
 }
 
 // createAwsCloudfrontDistribution creates a new instance of this resource
@@ -109951,6 +110150,28 @@ func (c *mqlAwsCloudfrontDistribution) GetSslSupportMethod() *plugin.TValue[stri
 
 func (c *mqlAwsCloudfrontDistribution) GetWebAclId() *plugin.TValue[string] {
 	return &c.WebAclId
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetWebAcl() *plugin.TValue[*mqlAwsWafAcl] {
+	return plugin.GetOrCompute[*mqlAwsWafAcl](&c.WebAcl, func() (*mqlAwsWafAcl, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudfront.distribution", c.__id, "webAcl")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsWafAcl), nil
+			}
+		}
+
+		return c.webAcl()
+	})
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetContinuousDeploymentPolicyId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ContinuousDeploymentPolicyId, func() (string, error) {
+		return c.continuousDeploymentPolicyId()
+	})
 }
 
 func (c *mqlAwsCloudfrontDistribution) GetGeoRestrictionType() *plugin.TValue[string] {
@@ -112627,34 +112848,40 @@ type mqlAwsS3Bucket struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsS3BucketInternal
-	Arn                       plugin.TValue[string]
-	Name                      plugin.TValue[string]
-	Policy                    plugin.TValue[*mqlAwsS3BucketPolicy]
-	Tags                      plugin.TValue[map[string]any]
-	Acl                       plugin.TValue[[]any]
-	Owner                     plugin.TValue[map[string]any]
-	Public                    plugin.TValue[bool]
-	Cors                      plugin.TValue[[]any]
-	Location                  plugin.TValue[string]
-	Versioning                plugin.TValue[map[string]any]
-	Logging                   plugin.TValue[map[string]any]
-	StaticWebsiteHosting      plugin.TValue[map[string]any]
-	Website                   plugin.TValue[*mqlAwsS3BucketWebsiteConfiguration]
-	DefaultLock               plugin.TValue[string]
-	Replication               plugin.TValue[any]
-	Encryption                plugin.TValue[any]
-	EncryptionRules           plugin.TValue[[]any]
-	ReplicationRules          plugin.TValue[[]any]
-	PublicAccessBlock         plugin.TValue[any]
-	ObjectLockEnabled         plugin.TValue[bool]
-	MetricsConfigurations     plugin.TValue[[]any]
-	Exists                    plugin.TValue[bool]
-	CreatedAt                 plugin.TValue[*time.Time]
-	LifecycleRules            plugin.TValue[[]any]
-	NotificationConfiguration plugin.TValue[any]
-	OwnershipControls         plugin.TValue[string]
-	MacieCoverage             plugin.TValue[*mqlAwsMacieBucket]
-	AccessPoints              plugin.TValue[[]any]
+	Arn                              plugin.TValue[string]
+	Name                             plugin.TValue[string]
+	Policy                           plugin.TValue[*mqlAwsS3BucketPolicy]
+	Tags                             plugin.TValue[map[string]any]
+	Acl                              plugin.TValue[[]any]
+	Owner                            plugin.TValue[map[string]any]
+	Public                           plugin.TValue[bool]
+	Cors                             plugin.TValue[[]any]
+	Location                         plugin.TValue[string]
+	Versioning                       plugin.TValue[map[string]any]
+	Logging                          plugin.TValue[map[string]any]
+	StaticWebsiteHosting             plugin.TValue[map[string]any]
+	Website                          plugin.TValue[*mqlAwsS3BucketWebsiteConfiguration]
+	DefaultLock                      plugin.TValue[string]
+	Replication                      plugin.TValue[any]
+	Encryption                       plugin.TValue[any]
+	EncryptionRules                  plugin.TValue[[]any]
+	ReplicationRules                 plugin.TValue[[]any]
+	PublicAccessBlock                plugin.TValue[any]
+	ObjectLockEnabled                plugin.TValue[bool]
+	MetricsConfigurations            plugin.TValue[[]any]
+	Exists                           plugin.TValue[bool]
+	CreatedAt                        plugin.TValue[*time.Time]
+	LifecycleRules                   plugin.TValue[[]any]
+	NotificationConfiguration        plugin.TValue[any]
+	EventNotifications               plugin.TValue[[]any]
+	OwnershipControls                plugin.TValue[string]
+	IntelligentTieringConfigurations plugin.TValue[[]any]
+	InventoryConfigurations          plugin.TValue[[]any]
+	AnalyticsConfigurations          plugin.TValue[[]any]
+	RequestPayment                   plugin.TValue[string]
+	TransferAcceleration             plugin.TValue[string]
+	MacieCoverage                    plugin.TValue[*mqlAwsMacieBucket]
+	AccessPoints                     plugin.TValue[[]any]
 }
 
 // createAwsS3Bucket creates a new instance of this resource
@@ -112916,9 +113143,55 @@ func (c *mqlAwsS3Bucket) GetNotificationConfiguration() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlAwsS3Bucket) GetEventNotifications() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EventNotifications, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket", c.__id, "eventNotifications")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.eventNotifications()
+	})
+}
+
 func (c *mqlAwsS3Bucket) GetOwnershipControls() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.OwnershipControls, func() (string, error) {
 		return c.ownershipControls()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetIntelligentTieringConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IntelligentTieringConfigurations, func() ([]any, error) {
+		return c.intelligentTieringConfigurations()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetInventoryConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InventoryConfigurations, func() ([]any, error) {
+		return c.inventoryConfigurations()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetAnalyticsConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AnalyticsConfigurations, func() ([]any, error) {
+		return c.analyticsConfigurations()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetRequestPayment() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RequestPayment, func() (string, error) {
+		return c.requestPayment()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetTransferAcceleration() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.TransferAcceleration, func() (string, error) {
+		return c.transferAcceleration()
 	})
 }
 
@@ -112951,6 +113224,116 @@ func (c *mqlAwsS3Bucket) GetAccessPoints() *plugin.TValue[[]any] {
 		}
 
 		return c.accessPoints()
+	})
+}
+
+// mqlAwsS3BucketEventNotification for the aws.s3.bucket.eventNotification resource
+type mqlAwsS3BucketEventNotification struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsS3BucketEventNotificationInternal it will be used here
+	Id             plugin.TValue[string]
+	Type           plugin.TValue[string]
+	Arn            plugin.TValue[string]
+	Events         plugin.TValue[[]any]
+	LambdaFunction plugin.TValue[*mqlAwsLambdaFunction]
+	Queue          plugin.TValue[*mqlAwsSqsQueue]
+	Topic          plugin.TValue[*mqlAwsSnsTopic]
+}
+
+// createAwsS3BucketEventNotification creates a new instance of this resource
+func createAwsS3BucketEventNotification(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsS3BucketEventNotification{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.s3.bucket.eventNotification", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsS3BucketEventNotification) MqlName() string {
+	return "aws.s3.bucket.eventNotification"
+}
+
+func (c *mqlAwsS3BucketEventNotification) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetEvents() *plugin.TValue[[]any] {
+	return &c.Events
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetLambdaFunction() *plugin.TValue[*mqlAwsLambdaFunction] {
+	return plugin.GetOrCompute[*mqlAwsLambdaFunction](&c.LambdaFunction, func() (*mqlAwsLambdaFunction, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket.eventNotification", c.__id, "lambdaFunction")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsLambdaFunction), nil
+			}
+		}
+
+		return c.lambdaFunction()
+	})
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetQueue() *plugin.TValue[*mqlAwsSqsQueue] {
+	return plugin.GetOrCompute[*mqlAwsSqsQueue](&c.Queue, func() (*mqlAwsSqsQueue, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket.eventNotification", c.__id, "queue")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsSqsQueue), nil
+			}
+		}
+
+		return c.queue()
+	})
+}
+
+func (c *mqlAwsS3BucketEventNotification) GetTopic() *plugin.TValue[*mqlAwsSnsTopic] {
+	return plugin.GetOrCompute[*mqlAwsSnsTopic](&c.Topic, func() (*mqlAwsSnsTopic, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket.eventNotification", c.__id, "topic")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsSnsTopic), nil
+			}
+		}
+
+		return c.topic()
 	})
 }
 
@@ -116859,6 +117242,7 @@ type mqlAwsDynamodbTable struct {
 	Backups                   plugin.TValue[[]any]
 	SseDescription            plugin.TValue[any]
 	SseType                   plugin.TValue[string]
+	KmsMasterKeyId            plugin.TValue[string]
 	SseKmsKey                 plugin.TValue[*mqlAwsKmsKey]
 	ProvisionedThroughput     plugin.TValue[any]
 	ContinuousBackups         plugin.TValue[any]
@@ -116948,6 +117332,12 @@ func (c *mqlAwsDynamodbTable) GetSseDescription() *plugin.TValue[any] {
 func (c *mqlAwsDynamodbTable) GetSseType() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.SseType, func() (string, error) {
 		return c.sseType()
+	})
+}
+
+func (c *mqlAwsDynamodbTable) GetKmsMasterKeyId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.KmsMasterKeyId, func() (string, error) {
+		return c.kmsMasterKeyId()
 	})
 }
 
@@ -127777,6 +128167,7 @@ type mqlAwsLambdaFunction struct {
 	Runtime                       plugin.TValue[string]
 	Concurrency                   plugin.TValue[int64]
 	DlqTargetArn                  plugin.TValue[string]
+	RecursiveLoop                 plugin.TValue[string]
 	Policy                        plugin.TValue[any]
 	VpcConfig                     plugin.TValue[any]
 	Vpc                           plugin.TValue[*mqlAwsVpc]
@@ -127879,6 +128270,12 @@ func (c *mqlAwsLambdaFunction) GetConcurrency() *plugin.TValue[int64] {
 
 func (c *mqlAwsLambdaFunction) GetDlqTargetArn() *plugin.TValue[string] {
 	return &c.DlqTargetArn
+}
+
+func (c *mqlAwsLambdaFunction) GetRecursiveLoop() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RecursiveLoop, func() (string, error) {
+		return c.recursiveLoop()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetPolicy() *plugin.TValue[any] {
@@ -134525,6 +134922,7 @@ type mqlAwsEc2Instance struct {
 	HttpTokens              plugin.TValue[string]
 	HttpEndpoint            plugin.TValue[string]
 	HttpPutResponseHopLimit plugin.TValue[int64]
+	Imdsv2Required          plugin.TValue[bool]
 	EnclaveEnabled          plugin.TValue[bool]
 	PatchState              plugin.TValue[any]
 	State                   plugin.TValue[string]
@@ -134658,6 +135056,10 @@ func (c *mqlAwsEc2Instance) GetHttpEndpoint() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Instance) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
 	return &c.HttpPutResponseHopLimit
+}
+
+func (c *mqlAwsEc2Instance) GetImdsv2Required() *plugin.TValue[bool] {
+	return &c.Imdsv2Required
 }
 
 func (c *mqlAwsEc2Instance) GetEnclaveEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1274,6 +1274,7 @@ aws.cloudfront.distribution.arn 11.15.2
 aws.cloudfront.distribution.cacheBehaviors 11.15.2
 aws.cloudfront.distribution.cnames 11.15.2
 aws.cloudfront.distribution.comment 11.15.2
+aws.cloudfront.distribution.continuousDeploymentPolicyId 13.29.1
 aws.cloudfront.distribution.defaultCacheBehavior 11.15.2
 aws.cloudfront.distribution.domainName 11.15.2
 aws.cloudfront.distribution.enabled 11.15.2
@@ -1305,6 +1306,7 @@ aws.cloudfront.distribution.status 11.15.2
 aws.cloudfront.distribution.viewerMtlsMode 13.25.1
 aws.cloudfront.distribution.viewerMtlsTrustStoreId 13.25.1
 aws.cloudfront.distribution.viewerProtocolPolicy 11.15.2
+aws.cloudfront.distribution.webAcl 13.29.1
 aws.cloudfront.distribution.webAclId 11.15.2
 aws.cloudfront.distributions 11.15.2
 aws.cloudfront.fieldLevelEncryptionConfig 13.26.3
@@ -2605,6 +2607,7 @@ aws.dynamodb.table.globalSecondaryIndexes 13.6.3
 aws.dynamodb.table.globalTableVersion 11.15.2
 aws.dynamodb.table.id 11.15.2
 aws.dynamodb.table.items 11.15.2
+aws.dynamodb.table.kmsMasterKeyId 13.29.1
 aws.dynamodb.table.latestStreamArn 11.15.2
 aws.dynamodb.table.latestStreamLabel 11.15.2
 aws.dynamodb.table.name 11.15.2
@@ -2782,6 +2785,7 @@ aws.ec2.instance.httpTokens 11.15.2
 aws.ec2.instance.hypervisor 11.15.2
 aws.ec2.instance.iamInstanceProfile 11.15.2
 aws.ec2.instance.image 11.15.2
+aws.ec2.instance.imdsv2Required 13.29.1
 aws.ec2.instance.instanceId 11.15.2
 aws.ec2.instance.instanceLifecycle 11.15.2
 aws.ec2.instance.instanceStatus 11.15.2
@@ -5611,6 +5615,7 @@ aws.lambda.function.provisionedConcurrencyConfig.requestedConcurrentExecutions 1
 aws.lambda.function.provisionedConcurrencyConfig.status 11.15.2
 aws.lambda.function.provisionedConcurrencyConfig.statusReason 11.15.2
 aws.lambda.function.provisionedConcurrencyConfigs 11.15.2
+aws.lambda.function.recursiveLoop 13.29.1
 aws.lambda.function.region 11.15.2
 aws.lambda.function.resolvedImageUri 13.26.2
 aws.lambda.function.role 11.15.2
@@ -7303,6 +7308,7 @@ aws.s3.bucket.accessPoint.publicAccessBlock 13.26.2
 aws.s3.bucket.accessPoint.vpc 13.26.2
 aws.s3.bucket.accessPoints 13.26.2
 aws.s3.bucket.acl 11.15.2
+aws.s3.bucket.analyticsConfigurations 13.29.1
 aws.s3.bucket.arn 11.15.2
 aws.s3.bucket.cors 11.15.2
 aws.s3.bucket.corsrule 11.15.2
@@ -7321,12 +7327,23 @@ aws.s3.bucket.encryptionRule.id 11.15.2
 aws.s3.bucket.encryptionRule.kmsMasterKeyId 11.15.2
 aws.s3.bucket.encryptionRule.sseAlgorithm 11.15.2
 aws.s3.bucket.encryptionRules 11.15.2
+aws.s3.bucket.eventNotification 13.29.1
+aws.s3.bucket.eventNotification.arn 13.29.1
+aws.s3.bucket.eventNotification.events 13.29.1
+aws.s3.bucket.eventNotification.id 13.29.1
+aws.s3.bucket.eventNotification.lambdaFunction 13.29.1
+aws.s3.bucket.eventNotification.queue 13.29.1
+aws.s3.bucket.eventNotification.topic 13.29.1
+aws.s3.bucket.eventNotification.type 13.29.1
+aws.s3.bucket.eventNotifications 13.29.1
 aws.s3.bucket.exists 11.15.2
 aws.s3.bucket.grant 11.15.2
 aws.s3.bucket.grant.grantee 11.15.2
 aws.s3.bucket.grant.id 11.15.2
 aws.s3.bucket.grant.name 11.15.2
 aws.s3.bucket.grant.permission 11.15.2
+aws.s3.bucket.intelligentTieringConfigurations 13.29.1
+aws.s3.bucket.inventoryConfigurations 13.29.1
 aws.s3.bucket.lifecycleRule 13.6.3
 aws.s3.bucket.lifecycleRule.abortIncompleteMultipartUploadDays 13.6.3
 aws.s3.bucket.lifecycleRule.expiration 13.6.3
@@ -7371,8 +7388,10 @@ aws.s3.bucket.replicationRule.priority 11.15.2
 aws.s3.bucket.replicationRule.resourceId 11.15.2
 aws.s3.bucket.replicationRule.status 11.15.2
 aws.s3.bucket.replicationRules 11.15.2
+aws.s3.bucket.requestPayment 13.29.1
 aws.s3.bucket.staticWebsiteHosting 11.15.2
 aws.s3.bucket.tags 11.15.2
+aws.s3.bucket.transferAcceleration 13.29.1
 aws.s3.bucket.versioning 11.15.2
 aws.s3.bucket.website 11.15.2
 aws.s3.bucket.websiteConfiguration 11.15.2
@@ -9031,8 +9050,11 @@ aws.verifiedaccess.trustProvider.verifiedAccessTrustProviderId 13.10.0
 aws.verifiedaccess.trustProviders 13.10.0
 aws.vpc 11.15.2
 aws.vpc.arn 11.15.2
+aws.vpc.blockPublicAccessOptions 13.29.1
 aws.vpc.cidrBlock 11.15.2
 aws.vpc.cidrBlockAssociations 13.6.3
+aws.vpc.defaultNetworkAcl 13.29.1
+aws.vpc.defaultSecurityGroup 13.29.1
 aws.vpc.dhcpOptions 13.6.3
 aws.vpc.dhcpOptionsId 11.15.2
 aws.vpc.enableDnsHostnames 13.6.3

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.29.0",
-  "generated_at": "2026-05-28T21:30:17-07:00",
+  "generated_at": "2026-05-28T22:36:52-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",
@@ -272,6 +272,7 @@
     "ec2:DescribeVerifiedAccessTrustProviders",
     "ec2:DescribeVolumes",
     "ec2:DescribeVpcAttribute",
+    "ec2:DescribeVpcBlockPublicAccessOptions",
     "ec2:DescribeVpcEndpointConnections",
     "ec2:DescribeVpcEndpointServiceConfigurations",
     "ec2:DescribeVpcEndpointServicePermissions",
@@ -513,6 +514,7 @@
     "lambda:GetFunctionCodeSigningConfig",
     "lambda:GetFunctionConcurrency",
     "lambda:GetFunctionEventInvokeConfig",
+    "lambda:GetFunctionRecursionConfig",
     "lambda:GetFunctionUrlConfig",
     "lambda:GetPolicy",
     "lambda:GetRuntimeManagementConfig",
@@ -651,6 +653,7 @@
     "route53resolver:ListResolverRules",
     "s3:GetAccessPoint",
     "s3:GetAccessPointPolicy",
+    "s3:GetBucketAccelerateConfiguration",
     "s3:GetBucketAcl",
     "s3:GetBucketCors",
     "s3:GetBucketEncryption",
@@ -661,12 +664,16 @@
     "s3:GetBucketOwnershipControls",
     "s3:GetBucketPolicy",
     "s3:GetBucketReplication",
+    "s3:GetBucketRequestPayment",
     "s3:GetBucketTagging",
     "s3:GetBucketVersioning",
     "s3:GetBucketWebsite",
     "s3:GetObjectLockConfiguration",
     "s3:GetPublicAccessBlock",
     "s3:ListAccessPoints",
+    "s3:ListBucketAnalyticsConfigurations",
+    "s3:ListBucketIntelligentTieringConfigurations",
+    "s3:ListBucketInventoryConfigurations",
     "s3:ListBucketMetricsConfigurations",
     "s3:ListBuckets",
     "sagemaker:DescribeAction",
@@ -2543,6 +2550,12 @@
       "source_file": "aws_vpc.go"
     },
     {
+      "permission": "ec2:DescribeVpcBlockPublicAccessOptions",
+      "service": "ec2",
+      "action": "DescribeVpcBlockPublicAccessOptions",
+      "source_file": "aws_vpc.go"
+    },
+    {
       "permission": "ec2:DescribeVpcEndpointConnections",
       "service": "ec2",
       "action": "DescribeVpcEndpointConnections",
@@ -4013,6 +4026,12 @@
       "source_file": "aws_lambda.go"
     },
     {
+      "permission": "lambda:GetFunctionRecursionConfig",
+      "service": "lambda",
+      "action": "GetFunctionRecursionConfig",
+      "source_file": "aws_lambda.go"
+    },
+    {
       "permission": "lambda:GetFunctionUrlConfig",
       "service": "lambda",
       "action": "GetFunctionUrlConfig",
@@ -4913,6 +4932,12 @@
       "source_file": "aws_s3.go"
     },
     {
+      "permission": "s3:GetBucketAccelerateConfiguration",
+      "service": "s3",
+      "action": "GetBucketAccelerateConfiguration",
+      "source_file": "aws_s3.go"
+    },
+    {
       "permission": "s3:GetBucketAcl",
       "service": "s3",
       "action": "GetBucketAcl",
@@ -4973,6 +4998,12 @@
       "source_file": "aws_s3.go"
     },
     {
+      "permission": "s3:GetBucketRequestPayment",
+      "service": "s3",
+      "action": "GetBucketRequestPayment",
+      "source_file": "aws_s3.go"
+    },
+    {
       "permission": "s3:GetBucketTagging",
       "service": "s3",
       "action": "GetBucketTagging",
@@ -5006,6 +5037,24 @@
       "permission": "s3:ListAccessPoints",
       "service": "s3",
       "action": "ListAccessPoints",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:ListBucketAnalyticsConfigurations",
+      "service": "s3",
+      "action": "ListBucketAnalyticsConfigurations",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:ListBucketIntelligentTieringConfigurations",
+      "service": "s3",
+      "action": "ListBucketIntelligentTieringConfigurations",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:ListBucketInventoryConfigurations",
+      "service": "s3",
+      "action": "ListBucketInventoryConfigurations",
       "source_file": "aws_s3.go"
     },
     {

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -159,6 +159,47 @@ func (a *mqlAwsCloudfrontDistributionLoggingConfig) id() (string, error) {
 	return a.__id, nil
 }
 
+func (a *mqlAwsCloudfrontDistribution) webAcl() (*mqlAwsWafAcl, error) {
+	arnVal := a.WebAclId.Data
+	// WAFv2 associations store the full ARN; WAF Classic stores a bare ID that
+	// the aws.waf.acl resource cannot resolve, so only build the ref for an ARN.
+	if !strings.HasPrefix(arnVal, "arn:") {
+		a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.waf.acl",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsWafAcl), nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) continuousDeploymentPolicyId() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Cloudfront("") // global service
+	ctx := context.Background()
+
+	parsedArn, err := arn.Parse(a.Arn.Data)
+	if err != nil {
+		return "", errors.Wrap(err, "could not parse cloudfront distribution ARN")
+	}
+	parts := strings.SplitN(parsedArn.Resource, "/", 2)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("unexpected cloudfront distribution ARN resource format: %s", parsedArn.Resource)
+	}
+	distID := parts[1]
+
+	resp, err := svc.GetDistribution(ctx, &cloudfront.GetDistributionInput{Id: &distID})
+	if err != nil {
+		return "", errors.Wrap(err, "could not get cloudfront distribution details")
+	}
+	if resp.Distribution == nil || resp.Distribution.DistributionConfig == nil {
+		return "", nil
+	}
+	return convert.ToValue(resp.Distribution.DistributionConfig.ContinuousDeploymentPolicyId), nil
+}
+
 func (a *mqlAwsCloudfrontDistribution) logging() (*mqlAwsCloudfrontDistributionLoggingConfig, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Cloudfront("") // global service

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -175,24 +176,60 @@ func (a *mqlAwsCloudfrontDistribution) webAcl() (*mqlAwsWafAcl, error) {
 	return res.(*mqlAwsWafAcl), nil
 }
 
-func (a *mqlAwsCloudfrontDistribution) continuousDeploymentPolicyId() (string, error) {
+type mqlAwsCloudfrontDistributionInternal struct {
+	detailFetched bool
+	detailErr     error
+	detailLock    sync.Mutex
+	detail        *cloudfront.GetDistributionOutput
+}
+
+// fetchDistributionDetail lazily loads the full distribution via GetDistribution
+// and caches it (double-check locking) so fields backed by the same call —
+// logging() and continuousDeploymentPolicyId() — share one API request.
+func (a *mqlAwsCloudfrontDistribution) fetchDistributionDetail() (*cloudfront.GetDistributionOutput, error) {
+	if a.detailFetched {
+		return a.detail, a.detailErr
+	}
+	a.detailLock.Lock()
+	defer a.detailLock.Unlock()
+	if a.detailFetched {
+		return a.detail, a.detailErr
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Cloudfront("") // global service
 	ctx := context.Background()
 
+	// Extract distribution ID from ARN: arn:aws:cloudfront::ACCOUNT:distribution/DIST_ID
 	parsedArn, err := arn.Parse(a.Arn.Data)
 	if err != nil {
-		return "", errors.Wrap(err, "could not parse cloudfront distribution ARN")
+		a.detailErr = errors.Wrap(err, "could not parse cloudfront distribution ARN")
+		a.detailFetched = true
+		return nil, a.detailErr
 	}
 	parts := strings.SplitN(parsedArn.Resource, "/", 2)
 	if len(parts) < 2 {
-		return "", fmt.Errorf("unexpected cloudfront distribution ARN resource format: %s", parsedArn.Resource)
+		a.detailErr = fmt.Errorf("unexpected cloudfront distribution ARN resource format: %s", parsedArn.Resource)
+		a.detailFetched = true
+		return nil, a.detailErr
 	}
 	distID := parts[1]
 
 	resp, err := svc.GetDistribution(ctx, &cloudfront.GetDistributionInput{Id: &distID})
 	if err != nil {
-		return "", errors.Wrap(err, "could not get cloudfront distribution details")
+		a.detailErr = errors.Wrap(err, "could not get cloudfront distribution details")
+		a.detailFetched = true
+		return nil, a.detailErr
+	}
+	a.detail = resp
+	a.detailFetched = true
+	return resp, nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) continuousDeploymentPolicyId() (string, error) {
+	resp, err := a.fetchDistributionDetail()
+	if err != nil {
+		return "", err
 	}
 	if resp.Distribution == nil || resp.Distribution.DistributionConfig == nil {
 		return "", nil
@@ -201,28 +238,9 @@ func (a *mqlAwsCloudfrontDistribution) continuousDeploymentPolicyId() (string, e
 }
 
 func (a *mqlAwsCloudfrontDistribution) logging() (*mqlAwsCloudfrontDistributionLoggingConfig, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Cloudfront("") // global service
-	ctx := context.Background()
-
-	// Extract distribution ID from ARN: arn:aws:cloudfront::ACCOUNT:distribution/DIST_ID
-	distArn := a.Arn.Data
-	parsedArn, err := arn.Parse(distArn)
+	resp, err := a.fetchDistributionDetail()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse cloudfront distribution ARN")
-	}
-	// Resource is "distribution/DIST_ID"
-	parts := strings.SplitN(parsedArn.Resource, "/", 2)
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("unexpected cloudfront distribution ARN resource format: %s", parsedArn.Resource)
-	}
-	distID := parts[1]
-
-	resp, err := svc.GetDistribution(ctx, &cloudfront.GetDistributionInput{
-		Id: &distID,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get cloudfront distribution details")
+		return nil, err
 	}
 
 	if resp.Distribution == nil || resp.Distribution.DistributionConfig == nil || resp.Distribution.DistributionConfig.Logging == nil {
@@ -233,7 +251,7 @@ func (a *mqlAwsCloudfrontDistribution) logging() (*mqlAwsCloudfrontDistributionL
 	logging := resp.Distribution.DistributionConfig.Logging
 	mqlLogging, err := CreateResource(a.MqlRuntime, ResourceAwsCloudfrontDistributionLoggingConfig,
 		map[string]*llx.RawData{
-			"__id":           llx.StringData(distArn + "/logging"),
+			"__id":           llx.StringData(a.Arn.Data + "/logging"),
 			"enabled":        llx.BoolDataPtr(logging.Enabled),
 			"bucket":         llx.StringDataPtr(logging.Bucket),
 			"prefix":         llx.StringDataPtr(logging.Prefix),

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -609,6 +609,7 @@ func (a *mqlAwsDynamodbTable) fetchDetail() error {
 
 	a.SseDescription = plugin.TValue[any]{Data: sseDict, State: plugin.StateIsSet}
 	a.SseType = plugin.TValue[string]{Data: sseType, State: plugin.StateIsSet}
+	a.KmsMasterKeyId = plugin.TValue[string]{Data: convert.ToValue(a.cacheSseKmsKeyArn), State: plugin.StateIsSet}
 	a.ProvisionedThroughput = plugin.TValue[any]{Data: throughputDict, State: plugin.StateIsSet}
 	a.CreatedAt = plugin.TValue[*time.Time]{Data: table.Table.CreationDateTime, State: plugin.StateIsSet}
 	a.DeletionProtectionEnabled = plugin.TValue[bool]{Data: convert.ToValue(table.Table.DeletionProtectionEnabled), State: plugin.StateIsSet}
@@ -641,6 +642,10 @@ func (a *mqlAwsDynamodbTable) sseDescription() (any, error) {
 }
 
 func (a *mqlAwsDynamodbTable) sseType() (string, error) {
+	return "", a.fetchDetail()
+}
+
+func (a *mqlAwsDynamodbTable) kmsMasterKeyId() (string, error) {
 	return "", a.fetchDetail()
 }
 

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1400,10 +1400,12 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			args["httpEndpoint"] = llx.StringData(string(instance.MetadataOptions.HttpEndpoint))
 			args["httpTokens"] = llx.StringData(string(instance.MetadataOptions.HttpTokens))
 			args["httpPutResponseHopLimit"] = llx.IntDataDefault(instance.MetadataOptions.HttpPutResponseHopLimit, 1)
+			args["imdsv2Required"] = llx.BoolData(instance.MetadataOptions.HttpTokens == ec2types.HttpTokensStateRequired)
 		} else {
 			args["httpEndpoint"] = llx.NilData
 			args["httpTokens"] = llx.NilData
 			args["httpPutResponseHopLimit"] = llx.IntData(1)
+			args["imdsv2Required"] = llx.BoolData(false)
 		}
 		// add vpc if there is one
 		if instance.VpcId != nil {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -495,6 +495,24 @@ func (a *mqlAwsLambdaFunction) securityGroups() ([]any, error) {
 	return a.newSecurityGroupResources(a.MqlRuntime)
 }
 
+func (a *mqlAwsLambdaFunction) recursiveLoop() (string, error) {
+	funcName := a.Name.Data
+	region := a.Region.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Lambda(region)
+	ctx := context.Background()
+
+	cfg, err := svc.GetFunctionRecursionConfig(ctx, &lambda.GetFunctionRecursionConfigInput{FunctionName: &funcName})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", errors.Wrap(err, "could not gather aws lambda function recursion config")
+	}
+	return string(cfg.RecursiveLoop), nil
+}
+
 func (a *mqlAwsLambdaFunction) concurrency() (int64, error) {
 	funcName := a.Name.Data
 	region := a.Region.Data

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -1493,7 +1493,7 @@ func (a *mqlAwsS3Bucket) eventNotifications() ([]any, error) {
 		}
 		return CreateResource(a.MqlRuntime, "aws.s3.bucket.eventNotification",
 			map[string]*llx.RawData{
-				"__id":   llx.StringData(fmt.Sprintf("%s/notification/%s/%s", a.Arn.Data, notifType, id+targetArn)),
+				"__id":   llx.StringData(fmt.Sprintf("%s/notification/%s/%s/%s", a.Arn.Data, notifType, id, targetArn)),
 				"id":     llx.StringData(id),
 				"type":   llx.StringData(notifType),
 				"arn":    llx.StringData(targetArn),

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -1464,6 +1464,256 @@ func (a *mqlAwsS3Bucket) notificationConfiguration() (any, error) {
 	return result, nil
 }
 
+func (a *mqlAwsS3Bucket) eventNotifications() ([]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
+	bucketname := a.Name.Data
+	region := a.Location.Data
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(region)
+	ctx := context.Background()
+
+	resp, err := svc.GetBucketNotificationConfiguration(ctx, &s3.GetBucketNotificationConfigurationInput{
+		Bucket: &bucketname,
+	})
+	if err != nil {
+		if isNotFoundForS3(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	build := func(notifType, id, targetArn string, events []s3types.Event) (any, error) {
+		eventList := make([]any, 0, len(events))
+		for _, e := range events {
+			eventList = append(eventList, string(e))
+		}
+		return CreateResource(a.MqlRuntime, "aws.s3.bucket.eventNotification",
+			map[string]*llx.RawData{
+				"__id":   llx.StringData(fmt.Sprintf("%s/notification/%s/%s", a.Arn.Data, notifType, id+targetArn)),
+				"id":     llx.StringData(id),
+				"type":   llx.StringData(notifType),
+				"arn":    llx.StringData(targetArn),
+				"events": llx.ArrayData(eventList, types.String),
+			})
+	}
+
+	res := []any{}
+	for _, lc := range resp.LambdaFunctionConfigurations {
+		mql, err := build("lambda", aws.ToString(lc.Id), aws.ToString(lc.LambdaFunctionArn), lc.Events)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mql)
+	}
+	for _, qc := range resp.QueueConfigurations {
+		mql, err := build("queue", aws.ToString(qc.Id), aws.ToString(qc.QueueArn), qc.Events)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mql)
+	}
+	for _, tc := range resp.TopicConfigurations {
+		mql, err := build("topic", aws.ToString(tc.Id), aws.ToString(tc.TopicArn), tc.Events)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mql)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsS3BucketEventNotification) lambdaFunction() (*mqlAwsLambdaFunction, error) {
+	if a.Type.Data != "lambda" || a.Arn.Data == "" {
+		a.LambdaFunction.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.lambda.function",
+		map[string]*llx.RawData{"arn": llx.StringData(a.Arn.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsLambdaFunction), nil
+}
+
+func (a *mqlAwsS3BucketEventNotification) queue() (*mqlAwsSqsQueue, error) {
+	if a.Type.Data != "queue" || a.Arn.Data == "" {
+		a.Queue.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.sqs.queue",
+		map[string]*llx.RawData{"arn": llx.StringData(a.Arn.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsSqsQueue), nil
+}
+
+func (a *mqlAwsS3BucketEventNotification) topic() (*mqlAwsSnsTopic, error) {
+	if a.Type.Data != "topic" || a.Arn.Data == "" {
+		a.Topic.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.sns.topic",
+		map[string]*llx.RawData{"arn": llx.StringData(a.Arn.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsSnsTopic), nil
+}
+
+func (a *mqlAwsS3Bucket) intelligentTieringConfigurations() ([]any, error) {
+	if !a.Exists.Data {
+		return nil, nil
+	}
+	bucketName := a.Name.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(a.Location.Data)
+	ctx := context.Background()
+
+	res := []any{}
+	var token *string
+	for {
+		resp, err := svc.ListBucketIntelligentTieringConfigurations(ctx, &s3.ListBucketIntelligentTieringConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: token,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for _, c := range resp.IntelligentTieringConfigurationList {
+			d, err := convert.JsonToDict(c)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, d)
+		}
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		token = resp.NextContinuationToken
+	}
+	return res, nil
+}
+
+func (a *mqlAwsS3Bucket) inventoryConfigurations() ([]any, error) {
+	if !a.Exists.Data {
+		return nil, nil
+	}
+	bucketName := a.Name.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(a.Location.Data)
+	ctx := context.Background()
+
+	res := []any{}
+	var token *string
+	for {
+		resp, err := svc.ListBucketInventoryConfigurations(ctx, &s3.ListBucketInventoryConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: token,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for _, c := range resp.InventoryConfigurationList {
+			d, err := convert.JsonToDict(c)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, d)
+		}
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		token = resp.NextContinuationToken
+	}
+	return res, nil
+}
+
+func (a *mqlAwsS3Bucket) analyticsConfigurations() ([]any, error) {
+	if !a.Exists.Data {
+		return nil, nil
+	}
+	bucketName := a.Name.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(a.Location.Data)
+	ctx := context.Background()
+
+	res := []any{}
+	var token *string
+	for {
+		resp, err := svc.ListBucketAnalyticsConfigurations(ctx, &s3.ListBucketAnalyticsConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: token,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for _, c := range resp.AnalyticsConfigurationList {
+			d, err := convert.JsonToDict(c)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, d)
+		}
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		token = resp.NextContinuationToken
+	}
+	return res, nil
+}
+
+func (a *mqlAwsS3Bucket) requestPayment() (string, error) {
+	if !a.Exists.Data {
+		return "", nil
+	}
+	bucketName := a.Name.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(a.Location.Data)
+	ctx := context.Background()
+
+	resp, err := svc.GetBucketRequestPayment(ctx, &s3.GetBucketRequestPaymentInput{Bucket: &bucketName})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(resp.Payer), nil
+}
+
+func (a *mqlAwsS3Bucket) transferAcceleration() (string, error) {
+	if !a.Exists.Data {
+		return "", nil
+	}
+	bucketName := a.Name.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.S3(a.Location.Data)
+	ctx := context.Background()
+
+	resp, err := svc.GetBucketAccelerateConfiguration(ctx, &s3.GetBucketAccelerateConfigurationInput{Bucket: &bucketName})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(resp.Status), nil
+}
+
 func (a *mqlAwsS3Bucket) ownershipControls() (string, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
 	if !a.Exists.Data {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1373,14 +1373,16 @@ func (a *mqlAwsVpc) blockPublicAccessOptions() (any, error) {
 	if opts.LastUpdateTimestamp != nil {
 		lastUpdate = opts.LastUpdateTimestamp.Format(time.RFC3339)
 	}
-	return map[string]any{
+	result := map[string]any{
 		"internetGatewayBlockMode": string(opts.InternetGatewayBlockMode),
 		"state":                    string(opts.State),
 		"exclusionsAllowed":        string(opts.ExclusionsAllowed),
 		"managedBy":                string(opts.ManagedBy),
 		"reason":                   convert.ToValue(opts.Reason),
 		"lastUpdateTimestamp":      lastUpdate,
-	}, nil
+	}
+	conn.SetCachedValue(cacheKey, result)
+	return result, nil
 }
 
 // VPN Gateway implementation

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1344,18 +1344,29 @@ func (a *mqlAwsVpc) defaultNetworkAcl() (*mqlAwsEc2Networkacl, error) {
 
 func (a *mqlAwsVpc) blockPublicAccessOptions() (any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Ec2(a.Region.Data)
+	region := a.Region.Data
+
+	// VPC Block Public Access is account/region-scoped, so every VPC in a
+	// region returns identical data — cache it per region on the connection.
+	cacheKey := "_vpc_bpa_" + region
+	if cached, ok := conn.GetCachedValue(cacheKey); ok {
+		return cached, nil
+	}
+
+	svc := conn.Ec2(region)
 	ctx := context.Background()
 
 	resp, err := svc.DescribeVpcBlockPublicAccessOptions(ctx, &ec2.DescribeVpcBlockPublicAccessOptionsInput{})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			conn.SetCachedValue(cacheKey, nil)
 			return nil, nil
 		}
 		return nil, err
 	}
 	opts := resp.VpcBlockPublicAccessOptions
 	if opts == nil {
+		conn.SetCachedValue(cacheKey, nil)
 		return nil, nil
 	}
 	lastUpdate := ""

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -1281,6 +1282,94 @@ func (a *mqlAwsVpc) networkAcls() ([]any, error) {
 		}
 	}
 	return acls, nil
+}
+
+func (a *mqlAwsVpc) defaultSecurityGroup() (*mqlAwsEc2Securitygroup, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(a.Region.Data)
+	ctx := context.Background()
+
+	resp, err := svc.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []vpctypes.Filter{
+			vpcFilter(a.Id.Data),
+			{Name: aws.String("group-name"), Values: []string{"default"}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.SecurityGroups) == 0 {
+		a.DefaultSecurityGroup.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	mqlSg, err := NewResource(a.MqlRuntime, ResourceAwsEc2Securitygroup,
+		map[string]*llx.RawData{
+			"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, a.Region.Data, conn.AccountId(), convert.ToValue(resp.SecurityGroups[0].GroupId))),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlSg.(*mqlAwsEc2Securitygroup), nil
+}
+
+func (a *mqlAwsVpc) defaultNetworkAcl() (*mqlAwsEc2Networkacl, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(a.Region.Data)
+	ctx := context.Background()
+
+	resp, err := svc.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		Filters: []vpctypes.Filter{
+			vpcFilter(a.Id.Data),
+			{Name: aws.String("default"), Values: []string{"true"}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.NetworkAcls) == 0 {
+		a.DefaultNetworkAcl.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	mqlAcl, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkacl,
+		map[string]*llx.RawData{
+			"arn": llx.StringData(fmt.Sprintf(networkAclArnPattern, a.Region.Data, conn.AccountId(), convert.ToValue(resp.NetworkAcls[0].NetworkAclId))),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlAcl.(*mqlAwsEc2Networkacl), nil
+}
+
+func (a *mqlAwsVpc) blockPublicAccessOptions() (any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(a.Region.Data)
+	ctx := context.Background()
+
+	resp, err := svc.DescribeVpcBlockPublicAccessOptions(ctx, &ec2.DescribeVpcBlockPublicAccessOptionsInput{})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	opts := resp.VpcBlockPublicAccessOptions
+	if opts == nil {
+		return nil, nil
+	}
+	lastUpdate := ""
+	if opts.LastUpdateTimestamp != nil {
+		lastUpdate = opts.LastUpdateTimestamp.Format(time.RFC3339)
+	}
+	return map[string]any{
+		"internetGatewayBlockMode": string(opts.InternetGatewayBlockMode),
+		"state":                    string(opts.State),
+		"exclusionsAllowed":        string(opts.ExclusionsAllowed),
+		"managedBy":                string(opts.ManagedBy),
+		"reason":                   convert.ToValue(opts.Reason),
+		"lastUpdateTimestamp":      lastUpdate,
+	}, nil
 }
 
 // VPN Gateway implementation


### PR DESCRIPTION
## What

Adds security- and posture-relevant fields to existing AWS resources.

### New fields / sub-resources

| Resource | Addition | Source |
|---|---|---|
| `aws.ec2.instance` | `imdsv2Required` bool | derived from `httpTokens == "required"` |
| `aws.s3.bucket` | `intelligentTieringConfigurations`, `inventoryConfigurations`, `analyticsConfigurations` (`[]dict`) | paginated `ListBucket*Configurations` |
| `aws.s3.bucket` | `requestPayment`, `transferAcceleration` | `GetBucketRequestPayment`, `GetBucketAccelerateConfiguration` |
| `aws.s3.bucket.eventNotification` | **new typed sub-resource** with `type`/`events`/`arn` + typed `lambdaFunction()` / `queue()` / `topic()` refs | `GetBucketNotificationConfiguration` |
| `aws.vpc` | typed `defaultSecurityGroup()`, `defaultNetworkAcl()` | filtered `DescribeSecurityGroups` / `DescribeNetworkAcls` |
| `aws.vpc` | `blockPublicAccessOptions()` dict | `DescribeVpcBlockPublicAccessOptions` |
| `aws.lambda.function` | `recursiveLoop` | `GetFunctionRecursionConfig` |
| `aws.cloudfront.distribution` | typed `webAcl()`, `continuousDeploymentPolicyId` | existing `webAclId` / lazy `GetDistribution` |
| `aws.dynamodb.table` | `kmsMasterKeyId` | `SSEDescription.KMSMasterKeyArn` (already fetched) |

### Scope note

This PR was scoped from a 15-item wishlist. On investigation, **8 of the 15 were already fully implemented on `main`** and were intentionally left untouched (renaming existing fields to match the wishlist names would be needless churn / breakage):

- **RDS** — `performanceInsightsEnabled` + `performanceInsightsKmsKey()`, `iamDatabaseAuthentication`, `deletionProtection`, `certificateAuthority`, `activityStreamStatus`
- **KMS** — `rotationPeriodInDays`, `multiRegion` + `multiRegionConfiguration`
- **EKS** — `upgradePolicy`/`supportType`, `zonalShiftConfig`, `authenticationMode`, `remoteNetworkConfig`
- **ECS** — `enableExecuteCommand`, `availabilityZoneRebalancing`
- **API Gateway** (v1 + v2) — `disableExecuteApiEndpoint`
- **ELB** — `desyncMitigationMode`, `dropInvalidHeaderFields`, `connectionLogsEnabled` (on `loadbalancer.attribute`)
- **EFS** — `availabilityZone`, `backupPolicy()`, `fileSystemProtection()`
- **SNS / SQS** — `kmsMasterKey()`/`kmsKey()`, `tracingConfig`, `signatureVersion`, `sqsManagedSseEnabled`

### Design notes

- `eventNotification` qualifies as a sub-resource because it nests typed refs to other modeled resources (Lambda/SQS/SNS). The existing `notificationConfiguration() dict` is kept for backward compatibility.
- New per-bucket S3 config lists and the VPC/CloudFront/Lambda detail calls are lazy — they only fire when the field is queried.
- Dropped the originally-listed Lambda `deadLetterTarget()` ref: the DLQ target is polymorphic (SNS or SQS) so it can't be a single clean typed ref, and a `{service, arn}` dict would just duplicate the existing `dlqTargetArn`.

## Testing

- `make providers/build/aws && make providers/install/aws` — clean; `gofmt`, `go vet`, `go mod tidy` clean (no new deps); `./mqlr generate` idempotent.
- Smoke-tested against live account `177043759486`:
  - `aws.ec2.instances` → `imdsv2Required: false` (httpTokens optional)
  - `aws.vpcs` → `defaultSecurityGroup.id`, `defaultNetworkAcl.id`, and `blockPublicAccessOptions` (state/managedBy/reason) all resolve
  - `aws.s3.buckets` → `requestPayment: "BucketOwner"`, `transferAcceleration: ""`, config lists + `eventNotifications` resolve
  - `aws.lambda.functions` → `recursiveLoop: "Terminate"`
  - `aws.dynamodb.tables` → `kmsMasterKeyId` resolves
  - CloudFront: no distributions provisioned in the account, so `webAcl()`/`continuousDeploymentPolicyId` and the `eventNotification` target refs are compile-verified and follow existing proven patterns but were not exercised against live data.

New `.lr.versions` entries (22) are all at `13.29.1` (provider at `13.29.0`). No `config.go` version bump.