### PR TITLE
✨ Add SendReport RPC for structured diagnostic reports

### DIFF
--- a/providers-sdk/v1/upstream/health/errors.pb.go
+++ b/providers-sdk/v1/upstream/health/errors.pb.go
@@ -12,6 +12,7 @@ package health
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -248,11 +249,138 @@ func (*SendErrorResp) Descriptor() ([]byte, []int) {
 	return file_errors_proto_rawDescGZIP(), []int{3}
 }
 
+// SendReportReq carries a free-form structured report. The envelope
+// (service_account_mrn, agent_mrn, product, tags) mirrors SendErrorReq so
+// the platform can route both through the same auth and indexing path.
+// payload is a google.protobuf.Struct so callers can ship arbitrary
+// nested JSON-shaped data without the server needing a schema bump;
+// report_type disambiguates how to interpret the payload (e.g. "health",
+// "discovery").
+type SendReportReq struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	ServiceAccountMrn string                 `protobuf:"bytes,1,opt,name=service_account_mrn,json=serviceAccountMrn,proto3" json:"service_account_mrn,omitempty"`
+	AgentMrn          string                 `protobuf:"bytes,2,opt,name=agent_mrn,json=agentMrn,proto3" json:"agent_mrn,omitempty"`
+	Product           *ProductInfo           `protobuf:"bytes,3,opt,name=product,proto3" json:"product,omitempty"`
+	ReportType        string                 `protobuf:"bytes,4,opt,name=report_type,json=reportType,proto3" json:"report_type,omitempty"`
+	Payload           *structpb.Struct       `protobuf:"bytes,5,opt,name=payload,proto3" json:"payload,omitempty"`
+	Tags              map[string]string      `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SendReportReq) Reset() {
+	*x = SendReportReq{}
+	mi := &file_errors_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendReportReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendReportReq) ProtoMessage() {}
+
+func (x *SendReportReq) ProtoReflect() protoreflect.Message {
+	mi := &file_errors_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendReportReq.ProtoReflect.Descriptor instead.
+func (*SendReportReq) Descriptor() ([]byte, []int) {
+	return file_errors_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *SendReportReq) GetServiceAccountMrn() string {
+	if x != nil {
+		return x.ServiceAccountMrn
+	}
+	return ""
+}
+
+func (x *SendReportReq) GetAgentMrn() string {
+	if x != nil {
+		return x.AgentMrn
+	}
+	return ""
+}
+
+func (x *SendReportReq) GetProduct() *ProductInfo {
+	if x != nil {
+		return x.Product
+	}
+	return nil
+}
+
+func (x *SendReportReq) GetReportType() string {
+	if x != nil {
+		return x.ReportType
+	}
+	return ""
+}
+
+func (x *SendReportReq) GetPayload() *structpb.Struct {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *SendReportReq) GetTags() map[string]string {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
+}
+
+type SendReportResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendReportResp) Reset() {
+	*x = SendReportResp{}
+	mi := &file_errors_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendReportResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendReportResp) ProtoMessage() {}
+
+func (x *SendReportResp) ProtoReflect() protoreflect.Message {
+	mi := &file_errors_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendReportResp.ProtoReflect.Descriptor instead.
+func (*SendReportResp) Descriptor() ([]byte, []int) {
+	return file_errors_proto_rawDescGZIP(), []int{5}
+}
+
 var File_errors_proto protoreflect.FileDescriptor
 
 const file_errors_proto_rawDesc = "" +
 	"\n" +
-	"\ferrors.proto\x12\x13go.mondoo.health.v1\"\xc7\x02\n" +
+	"\ferrors.proto\x12\x13go.mondoo.health.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xc7\x02\n" +
 	"\fSendErrorReq\x12.\n" +
 	"\x13service_account_mrn\x18\x01 \x01(\tR\x11serviceAccountMrn\x12\x1b\n" +
 	"\tagent_mrn\x18\x02 \x01(\tR\bagentMrn\x12:\n" +
@@ -271,9 +399,23 @@ const file_errors_proto_rawDesc = "" +
 	"\n" +
 	"stacktrace\x18\x02 \x01(\tR\n" +
 	"stacktrace\"\x0f\n" +
-	"\rSendErrorResp2d\n" +
+	"\rSendErrorResp\"\xe7\x02\n" +
+	"\rSendReportReq\x12.\n" +
+	"\x13service_account_mrn\x18\x01 \x01(\tR\x11serviceAccountMrn\x12\x1b\n" +
+	"\tagent_mrn\x18\x02 \x01(\tR\bagentMrn\x12:\n" +
+	"\aproduct\x18\x03 \x01(\v2 .go.mondoo.health.v1.ProductInfoR\aproduct\x12\x1f\n" +
+	"\vreport_type\x18\x04 \x01(\tR\n" +
+	"reportType\x121\n" +
+	"\apayload\x18\x05 \x01(\v2\x17.google.protobuf.StructR\apayload\x12@\n" +
+	"\x04tags\x18\x06 \x03(\v2,.go.mondoo.health.v1.SendReportReq.TagsEntryR\x04tags\x1a7\n" +
+	"\tTagsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x10\n" +
+	"\x0eSendReportResp2\xbb\x01\n" +
 	"\x0eErrorReporting\x12R\n" +
-	"\tSendError\x12!.go.mondoo.health.v1.SendErrorReq\x1a\".go.mondoo.health.v1.SendErrorRespB\x1dZ\x1bgo.mondoo.com/mondoo/healthb\x06proto3"
+	"\tSendError\x12!.go.mondoo.health.v1.SendErrorReq\x1a\".go.mondoo.health.v1.SendErrorResp\x12U\n" +
+	"\n" +
+	"SendReport\x12\".go.mondoo.health.v1.SendReportReq\x1a#.go.mondoo.health.v1.SendReportRespB\x1dZ\x1bgo.mondoo.com/mondoo/healthb\x06proto3"
 
 var (
 	file_errors_proto_rawDescOnce sync.Once
@@ -287,25 +429,34 @@ func file_errors_proto_rawDescGZIP() []byte {
 	return file_errors_proto_rawDescData
 }
 
-var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_errors_proto_goTypes = []any{
-	(*SendErrorReq)(nil),  // 0: go.mondoo.health.v1.SendErrorReq
-	(*ProductInfo)(nil),   // 1: go.mondoo.health.v1.ProductInfo
-	(*ErrorInfo)(nil),     // 2: go.mondoo.health.v1.ErrorInfo
-	(*SendErrorResp)(nil), // 3: go.mondoo.health.v1.SendErrorResp
-	nil,                   // 4: go.mondoo.health.v1.SendErrorReq.TagsEntry
+	(*SendErrorReq)(nil),    // 0: go.mondoo.health.v1.SendErrorReq
+	(*ProductInfo)(nil),     // 1: go.mondoo.health.v1.ProductInfo
+	(*ErrorInfo)(nil),       // 2: go.mondoo.health.v1.ErrorInfo
+	(*SendErrorResp)(nil),   // 3: go.mondoo.health.v1.SendErrorResp
+	(*SendReportReq)(nil),   // 4: go.mondoo.health.v1.SendReportReq
+	(*SendReportResp)(nil),  // 5: go.mondoo.health.v1.SendReportResp
+	nil,                     // 6: go.mondoo.health.v1.SendErrorReq.TagsEntry
+	nil,                     // 7: go.mondoo.health.v1.SendReportReq.TagsEntry
+	(*structpb.Struct)(nil), // 8: google.protobuf.Struct
 }
 var file_errors_proto_depIdxs = []int32{
 	1, // 0: go.mondoo.health.v1.SendErrorReq.product:type_name -> go.mondoo.health.v1.ProductInfo
 	2, // 1: go.mondoo.health.v1.SendErrorReq.error:type_name -> go.mondoo.health.v1.ErrorInfo
-	4, // 2: go.mondoo.health.v1.SendErrorReq.tags:type_name -> go.mondoo.health.v1.SendErrorReq.TagsEntry
-	0, // 3: go.mondoo.health.v1.ErrorReporting.SendError:input_type -> go.mondoo.health.v1.SendErrorReq
-	3, // 4: go.mondoo.health.v1.ErrorReporting.SendError:output_type -> go.mondoo.health.v1.SendErrorResp
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	6, // 2: go.mondoo.health.v1.SendErrorReq.tags:type_name -> go.mondoo.health.v1.SendErrorReq.TagsEntry
+	1, // 3: go.mondoo.health.v1.SendReportReq.product:type_name -> go.mondoo.health.v1.ProductInfo
+	8, // 4: go.mondoo.health.v1.SendReportReq.payload:type_name -> google.protobuf.Struct
+	7, // 5: go.mondoo.health.v1.SendReportReq.tags:type_name -> go.mondoo.health.v1.SendReportReq.TagsEntry
+	0, // 6: go.mondoo.health.v1.ErrorReporting.SendError:input_type -> go.mondoo.health.v1.SendErrorReq
+	4, // 7: go.mondoo.health.v1.ErrorReporting.SendReport:input_type -> go.mondoo.health.v1.SendReportReq
+	3, // 8: go.mondoo.health.v1.ErrorReporting.SendError:output_type -> go.mondoo.health.v1.SendErrorResp
+	5, // 9: go.mondoo.health.v1.ErrorReporting.SendReport:output_type -> go.mondoo.health.v1.SendReportResp
+	8, // [8:10] is the sub-list for method output_type
+	6, // [6:8] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_errors_proto_init() }
@@ -319,7 +470,7 @@ func file_errors_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_errors_proto_rawDesc), len(file_errors_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/providers-sdk/v1/upstream/health/errors.proto
+++ b/providers-sdk/v1/upstream/health/errors.proto
@@ -5,12 +5,18 @@ syntax = "proto3";
 
 package go.mondoo.health.v1;
 
+import "google/protobuf/struct.proto";
+
 option go_package = "go.mondoo.com/mondoo/health";
 
 // Error Reporting Service
 service ErrorReporting {
   // SendError sends an error to the Mondoo API
   rpc SendError(SendErrorReq) returns (SendErrorResp);
+  // SendReport sends a structured diagnostic report (e.g. health snapshot,
+  // resource discovery dump). The payload is intentionally schema-less —
+  // the report_type tells the server how to interpret it.
+  rpc SendReport(SendReportReq) returns (SendReportResp);
 }
 
 message SendErrorReq {
@@ -33,4 +39,23 @@ message ErrorInfo {
 }
 
 message SendErrorResp {
+}
+
+// SendReportReq carries a free-form structured report. The envelope
+// (service_account_mrn, agent_mrn, product, tags) mirrors SendErrorReq so
+// the platform can route both through the same auth and indexing path.
+// payload is a google.protobuf.Struct so callers can ship arbitrary
+// nested JSON-shaped data without the server needing a schema bump;
+// report_type disambiguates how to interpret the payload (e.g. "health",
+// "discovery").
+message SendReportReq {
+  string service_account_mrn = 1;
+  string agent_mrn = 2;
+  ProductInfo product = 3;
+  string report_type = 4;
+  google.protobuf.Struct payload = 5;
+  map<string, string> tags = 6;
+}
+
+message SendReportResp {
 }

--- a/providers-sdk/v1/upstream/health/errors.ranger.go
+++ b/providers-sdk/v1/upstream/health/errors.ranger.go
@@ -20,6 +20,7 @@ import (
 
 type ErrorReporting interface {
 	SendError(context.Context, *SendErrorReq) (*SendErrorResp, error)
+	SendReport(context.Context, *SendReportReq) (*SendReportResp, error)
 }
 
 // client implementation
@@ -53,6 +54,11 @@ func (c *ErrorReportingClient) SendError(ctx context.Context, in *SendErrorReq) 
 	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/SendError"}, ""), in, out)
 	return out, err
 }
+func (c *ErrorReportingClient) SendReport(ctx context.Context, in *SendReportReq) (*SendReportResp, error) {
+	out := new(SendReportResp)
+	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/SendReport"}, ""), in, out)
+	return out, err
+}
 
 // server implementation
 
@@ -76,7 +82,8 @@ func NewErrorReportingServer(handler ErrorReporting, opts ...ErrorReportingServe
 	service := ranger.Service{
 		Name: "ErrorReporting",
 		Methods: map[string]ranger.Method{
-			"SendError": srv.SendError,
+			"SendError":  srv.SendError,
+			"SendReport": srv.SendReport,
 		},
 	}
 	return ranger.NewRPCServer(&service)
@@ -110,4 +117,28 @@ func (p *ErrorReportingServer) SendError(ctx context.Context, reqBytes *[]byte) 
 		return nil, err
 	}
 	return p.handler.SendError(ctx, &req)
+}
+func (p *ErrorReportingServer) SendReport(ctx context.Context, reqBytes *[]byte) (pb.Message, error) {
+	var req SendReportReq
+	var err error
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, errors.New("could not access header")
+	}
+
+	switch md.First("Content-Type") {
+	case "application/protobuf", "application/octet-stream", "application/grpc+proto":
+		err = pb.Unmarshal(*reqBytes, &req)
+	default:
+		// handle case of empty object
+		if len(*reqBytes) > 0 {
+			err = jsonpb.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(*reqBytes, &req)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return p.handler.SendReport(ctx, &req)
 }

--- a/providers-sdk/v1/upstream/health/errors_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/health/errors_vtproto.pb.go
@@ -7,7 +7,9 @@ package health
 import (
 	fmt "fmt"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
+	structpb "github.com/planetscale/vtprotobuf/types/known/structpb"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb1 "google.golang.org/protobuf/types/known/structpb"
 	io "io"
 )
 
@@ -238,6 +240,132 @@ func (m *SendErrorResp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *SendReportReq) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SendReportReq) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SendReportReq) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Tags) > 0 {
+		for k := range m.Tags {
+			v := m.Tags[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
+	if m.Payload != nil {
+		size, err := (*structpb.Struct)(m.Payload).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.ReportType) > 0 {
+		i -= len(m.ReportType)
+		copy(dAtA[i:], m.ReportType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ReportType)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Product != nil {
+		size, err := m.Product.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AgentMrn) > 0 {
+		i -= len(m.AgentMrn)
+		copy(dAtA[i:], m.AgentMrn)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AgentMrn)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ServiceAccountMrn) > 0 {
+		i -= len(m.ServiceAccountMrn)
+		copy(dAtA[i:], m.ServiceAccountMrn)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ServiceAccountMrn)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SendReportResp) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SendReportResp) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SendReportResp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *SendErrorReq) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -313,6 +441,54 @@ func (m *ErrorInfo) SizeVT() (n int) {
 }
 
 func (m *SendErrorResp) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SendReportReq) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ServiceAccountMrn)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.AgentMrn)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Product != nil {
+		l = m.Product.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ReportType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Payload != nil {
+		l = (*structpb.Struct)(m.Payload).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Tags) > 0 {
+		for k, v := range m.Tags {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SendReportResp) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -925,6 +1101,403 @@ func (m *SendErrorResp) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SendErrorResp: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SendReportReq) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SendReportReq: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SendReportReq: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceAccountMrn", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ServiceAccountMrn = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AgentMrn", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AgentMrn = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Product", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Product == nil {
+				m.Product = &ProductInfo{}
+			}
+			if err := m.Product.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReportType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ReportType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Payload == nil {
+				m.Payload = &structpb1.Struct{}
+			}
+			if err := (*structpb.Struct)(m.Payload).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Tags == nil {
+				m.Tags = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Tags[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SendReportResp) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SendReportResp: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SendReportResp: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
## Summary

Extends the `ErrorReporting` service in \`providers-sdk/v1/upstream/health\` with a sibling RPC, \`SendReport\`. The envelope mirrors \`SendErrorReq\` (\`service_account_mrn\`, \`agent_mrn\`, \`product\`, \`tags\`) so both go through the same auth + Sentry routing on the platform side; the payload is a \`google.protobuf.Struct\` so callers can ship arbitrary nested JSON without bumping the schema, and a \`report_type\` string tells the server how to interpret it.

First consumer is an on-demand health report from \`serverless-scanner-aws\`. Server-side handler can stay a no-op until consumers materialize — this PR just registers the type so clients can start emitting.

## Test plan

- [x] \`go generate ./providers-sdk/v1/upstream/health/\` — regenerated cleanly; only \`SendReport\` additions to ranger/.pb/.vtproto.
- [x] \`go build ./...\` clean in mql.
- [ ] CI green.
- [ ] Server-side no-op handler follow-up (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)