### PR TITLE
🐛 os: widen Windows package sanitization to publisher + installLocation

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -213,9 +213,14 @@ func ParseWindowsHotfixes(input io.Reader) ([]PowershellWinHotFix, error) {
 func HotFixesToPackages(hotfixes []PowershellWinHotFix) []Package {
 	pkgs := make([]Package, len(hotfixes))
 	for i := range hotfixes {
+		// Defense-in-depth — Get-HotFix's Description is typically a short
+		// string like "Update" / "Security Update", but it comes through the
+		// same PowerShell→JSON path as the registry packages, so apply the
+		// same sanitization so a stray control character can't corrupt the
+		// downstream SBOM projection.
 		pkgs[i] = Package{
-			Name:        hotfixes[i].HotFixId,
-			Description: hotfixes[i].Description,
+			Name:        sanitizePackageField(hotfixes[i].HotFixId),
+			Description: sanitizePackageField(hotfixes[i].Description),
 			Format:      "windows/hotfix",
 		}
 	}
@@ -806,10 +811,17 @@ func normalizeMsSqlVersion(version string) string {
 }
 
 // sanitizePackageField removes control characters (e.g. \r, \n, \t) from a
-// package name or version and trims surrounding whitespace. Windows registry
-// DisplayName/DisplayVersion values occasionally contain trailing control
-// characters, which produce invalid purls such as
-// "pkg:windows/windows/Foo%0D%0A@1.2.3" and fail to parse as URLs.
+// registry-derived string and trims surrounding whitespace. Apply it to ANY
+// REG_SZ value that ends up in the Package struct: name + version started the
+// problem (control characters there produced invalid purls \u2014 issue #7975),
+// but downstream consumers also serialize vendor/publisher and installLocation
+// into JSON projections (mondoohq/server's mondoo-sbom-internal-packages
+// bundle pulls vendor in alongside name/version/purl), and an unsanitized
+// `\r`/`\n` or unpaired quote in any of those fields produces JSON like
+// `{"name":"foo","vendor":"bar"description":...}` \u2014 JSON the server cannot
+// decode, with the downstream effect that the asset's package_scores get
+// silently emptied. The Windows packages provider is the one place that owns
+// registry-derived field plumbing, so it is the right layer to sanitize at.
 func sanitizePackageField(s string) string {
 	s = strings.Map(func(r rune) rune {
 		if unicode.IsControl(r) {
@@ -830,10 +842,15 @@ func createPackage(name, version, format, arch, publisher, installLocation strin
 	// replace non-breaking spaces with regular spaces
 	name = strings.ReplaceAll(name, "\u00a0", " ")
 	// Windows registry values can carry trailing control characters (e.g. \r\n).
-	// These break purl generation ("net/url: invalid control character in URL"),
-	// so strip control characters and surrounding whitespace from name and version.
+	// Strip them from every REG_SZ field that lands on the Package \u2014 name and
+	// version (purl correctness, #7975) and publisher and installLocation
+	// (JSON-projection correctness \u2014 these become Vendor and Files[0].Path,
+	// and an unsanitized control char in either silently corrupts the SBOM
+	// projection the server pulls them out of).
 	name = sanitizePackageField(name)
 	version = sanitizePackageField(version)
+	publisher = sanitizePackageField(publisher)
+	installLocation = sanitizePackageField(installLocation)
 	pkg := &Package{
 		Name:    name,
 		Version: version,

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -4,6 +4,7 @@
 package packages
 
 import (
+	"encoding/json"
 	"net/url"
 	"os"
 	"strings"
@@ -905,6 +906,88 @@ func TestCreatePackage(t *testing.T) {
 		assert.NotContains(t, pkg.PUrl, "%0D")
 		assert.NotContains(t, pkg.PUrl, "%0A")
 	})
+
+	t.Run("create package strips control characters from publisher", func(t *testing.T) {
+		// Defends against the JSON-projection corruption mode mondoohq/server
+		// observed: an Add/Remove entry whose Publisher carries a stray \r
+		// can produce JSON like `{"vendor":"foo"\r"description":"…"}` after
+		// PowerShell's ConvertTo-Json -Compress in some configurations,
+		// which on the server side surfaces as
+		// "invalid character 'd' after object key:value pair" inside
+		// json.Unmarshal — and silently drops the entire OS-packages list.
+		pkg := createPackage("SomeApp", "1.2.3", "windows/app", "x86_64", "Acme Corp\r\n", "", nil)
+		require.NotNil(t, pkg, "expected package to be created")
+		assert.Equal(t, "Acme Corp", pkg.Vendor,
+			"vendor must be free of control characters so it round-trips cleanly through JSON")
+		assert.NotContains(t, pkg.Vendor, "\r")
+		assert.NotContains(t, pkg.Vendor, "\n")
+	})
+
+	t.Run("create package strips control characters from installLocation", func(t *testing.T) {
+		// Same class of bug as vendor: installLocation lands on
+		// pkg.Files[0].Path and is serialized through the same SBOM
+		// projection.
+		pkg := createPackage("SomeApp", "1.2.3", "windows/app", "x86_64", "Vendor",
+			"C:\\Program Files\\Acme\r\n", nil)
+		require.NotNil(t, pkg, "expected package to be created")
+		require.Len(t, pkg.Files, 1, "installLocation must produce a Files entry")
+		assert.Equal(t, "C:\\Program Files\\Acme", pkg.Files[0].Path,
+			"installLocation path must be free of control characters")
+	})
+
+	t.Run("vendor + installLocation + name + version stay clean when ALL carry rot", func(t *testing.T) {
+		// End-to-end check: a single Add/Remove entry where every
+		// registry-derived field is dirty must still produce a clean
+		// Package whose every projected field is safe to drop into a
+		// JSON object body.
+		pkg := createPackage(
+			"SomeApp\r\n", "1.2.3\r\n", "windows/app", "x86_64",
+			"Acme Corp\r\n", "C:\\Program Files\\Acme\r\n", nil)
+		require.NotNil(t, pkg)
+		assert.Equal(t, "SomeApp", pkg.Name)
+		assert.Equal(t, "1.2.3", pkg.Version)
+		assert.Equal(t, "Acme Corp", pkg.Vendor)
+		require.Len(t, pkg.Files, 1)
+		assert.Equal(t, "C:\\Program Files\\Acme", pkg.Files[0].Path)
+
+		// Final guard: the projected fields together must serialize to a
+		// JSON object Go's encoding/json can decode back. That's the
+		// shape the server's convertPackages call would see.
+		marshalled, err := json.Marshal(map[string]string{
+			"name":            pkg.Name,
+			"version":         pkg.Version,
+			"vendor":          pkg.Vendor,
+			"installLocation": pkg.Files[0].Path,
+		})
+		require.NoError(t, err)
+		var roundtrip map[string]string
+		require.NoError(t, json.Unmarshal(marshalled, &roundtrip),
+			"the SBOM-shape JSON object must decode cleanly")
+		assert.Equal(t, "SomeApp", roundtrip["name"])
+		assert.Equal(t, "Acme Corp", roundtrip["vendor"])
+	})
+}
+
+// TestHotFixesToPackages_SanitizesFields pins the analogous fix for the
+// Get-HotFix path: Description goes through the same PowerShell→JSON
+// pipeline, so any control character there has to be stripped before it
+// reaches the Package.
+func TestHotFixesToPackages_SanitizesFields(t *testing.T) {
+	hotfixes := []PowershellWinHotFix{
+		{HotFixId: "KB5005112\r\n", Description: "Security Update\r\n"},
+		{HotFixId: "KB5023789", Description: "Update"},
+	}
+	pkgs := HotFixesToPackages(hotfixes)
+	require.Len(t, pkgs, 2)
+
+	assert.Equal(t, "KB5005112", pkgs[0].Name, "hotfix id must be sanitized")
+	assert.Equal(t, "Security Update", pkgs[0].Description, "hotfix description must be sanitized")
+	assert.NotContains(t, pkgs[0].Name, "\r")
+	assert.NotContains(t, pkgs[0].Description, "\n")
+
+	// Clean inputs must pass through unchanged.
+	assert.Equal(t, "KB5023789", pkgs[1].Name)
+	assert.Equal(t, "Update", pkgs[1].Description)
 }
 
 func TestFindAndUpdateMsExchangeSU_en(t *testing.T) {


### PR DESCRIPTION
## What

`#8002` introduced `sanitizePackageField` for `name` + `version` because trailing `\r\n` in registry `DisplayName`/`DisplayVersion` was leaking into the generated purl and producing `"net/url: invalid control character in URL"` downstream. The same class of bug applies to the other registry-derived REG_SZ fields the Package struct carries.

Downstream MQL consumers project these into a JSON object body. The SBOM bundle projection feeds the result to `encoding/json.Unmarshal`. If `vendor` (Publisher) or `installLocation` carries a stray `\r` / `\n` / unpaired quote, the per-row JSON object body comes out structurally broken (`"invalid character 'd' after object key:value pair"` is the exact production error string), and the whole packages projection fails to decode — silently dropping every OS package for that asset on the affected scan.

## How

In `providers/os/resources/packages/windows_packages.go`:

- `createPackage` sanitizes `publisher` (→ `pkg.Vendor`) and `installLocation` (→ `pkg.Files[0].Path`) the same way `name` + `version` already are.
- `HotFixesToPackages` sanitizes `HotFixId` + `Description`. Description is typically short ("Update" / "Security Update") so this is defense in depth.
- `sanitizePackageField`'s godoc now spells out the JSON-projection class of bug so future registry-derived fields are obviously in scope.

## Tests

- `TestCreatePackage` gets subtests for publisher, installLocation, the all-fields-dirty case, and a JSON round-trip guard that mirrors what the server's `convertPackages` sees.
- `TestHotFixesToPackages_SanitizesFields` pins the Get-HotFix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)