### PR TITLE
🎉 release aws 13.30.0, azure 13.15.0, google-workspace 13.1.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.29.0",
+	Version:         "13.30.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.14.0",
+	Version: "13.15.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.0.14",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Bumps the minor version of three providers:

| Provider | Old | New |
|---|---|---|
| aws | 13.29.0 | 13.30.0 |
| azure | 13.14.0 | 13.15.0 |
| google-workspace | 13.0.14 | 13.1.0 |

## What's new

### AWS (13.30.0)
- ✨ New Storage Gateway resources (gateways, file shares, volumes) — #8068
- ✨ ECS buildout: capacity providers, account settings, container security fields — #8065
- ✨ ECS container accelerators + HyperPod restricted instance groups — #8063
- ✨ ECS task ephemeral storage + Fargate encryption key — #8066
- ✨ New fields on EC2, S3, VPC, Lambda, CloudFront, DynamoDB — #8069
- 🧹 IAM Access Analyzer resource names normalized to camelCase — #8067
- 🧹 June 1 dep bump — #8079

### Azure (13.15.0)
- ✨ Machine Learning workspace discovery — #7989
- ✨ Defender assessments: attack-path graphs — #7992
- ✨ Defender assessments: risk, MITRE & metadata fields — #7988
- ✨ keyvault SDK bump: cert SANs + secret previousVersion — #8062
- 🧹 armmonitor v0.12.0 + diagnostic settings refactor — #8008
- 🧹 armpolicyinsights/armsecurity/azkeys bumps — #7986
- 🧹 permissions.json regen + deterministic GCP/Azure dedup — #8016, #7996
- 🧹 June 1 dep bump — #8079

### Google Workspace (13.1.0)
- ⚡ Cut API calls for users { usageReport } and connectedApps — #7973
