### PR TITLE
⚡ openstack: dedupe security-group list on server.securityGroups path

### DIFF
--- a/providers/openstack/resources/compute.go
+++ b/providers/openstack/resources/compute.go
@@ -250,15 +250,9 @@ func (r *mqlOpenstackComputeServer) securityGroups() ([]any, error) {
 		return []any{}, nil
 	}
 
-	c := conn(r.MqlRuntime)
-	client, err := c.NetworkClient()
-	if err != nil {
-		return nil, err
-	}
-
 	out := make([]any, 0, len(r.cacheSecurityGroupSGs))
 	for _, name := range r.cacheSecurityGroupSGs {
-		id, err := lookupSecurityGroupIDByName(c, client, name)
+		id, err := lookupSecurityGroupIDByName(r.MqlRuntime, name)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
@@ -18,7 +17,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/openstack/connection"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -750,14 +748,10 @@ func (o *mqlOpenstack) securityGroups() ([]any, error) {
 	}
 
 	// Prime the per-connection name->ID cache from this list call so that
-	// Nova security-group-by-name lookups (lookupSecurityGroupIDByName)
-	// reuse it instead of re-listing Neutron. First-writer-wins: whichever
-	// path populates the cache first (this accessor or
-	// lookupSecurityGroupIDByName) sets the canonical name->ID map for the
-	// connection's lifetime. Both paths list with default scope, so the
-	// result sets are equivalent; if scoping ever diverges, the second
-	// caller's data is silently ignored — at which point the cache should
-	// move into the lookup function itself.
+	// Nova security-group-by-name lookups (lookupSecurityGroupIDByName) reuse
+	// it instead of issuing a second Neutron list. This accessor is the sole
+	// source of the cache: lookupSecurityGroupIDByName routes through here via
+	// GetSecurityGroups rather than listing groups itself.
 	c.SGNameCacheLock.Lock()
 	if c.SGNameCache == nil {
 		cache := make(map[string]string, len(items))
@@ -865,32 +859,46 @@ func (r *mqlOpenstackSecurityGroupRule) remoteGroup() (*mqlOpenstackSecurityGrou
 
 // lookupSecurityGroupIDByName resolves a security-group name to an ID using a
 // per-connection cache. Nova reports server security groups by name, but
-// Neutron is the source of truth for IDs, so each connection lists groups
-// once and consults its cache thereafter. The lock single-flights the first
-// fetch; on success or auth-translated failure the cache map is non-nil and
-// subsequent callers fast-path. Real errors leave the cache nil so the next
-// call retries instead of inheriting a stale error.
-func lookupSecurityGroupIDByName(c *connection.OpenstackConnection, client *gophercloud.ServiceClient, name string) (string, error) {
+// Neutron is the source of truth for IDs. Rather than issue its own
+// groups.List, this primes the cache from the root securityGroups list
+// (memoized once per scan via GetSecurityGroups) — o.securityGroups() sets
+// SGNameCache as a side effect, so resolving a server's groups by name no
+// longer costs a second Neutron list. A non-nil cache map is the "ready"
+// signal; the lock single-flights the first fetch and concurrent callers wait.
+func lookupSecurityGroupIDByName(runtime *plugin.Runtime, name string) (string, error) {
+	c := conn(runtime)
+
+	c.SGNameCacheLock.Lock()
+	cached := c.SGNameCache
+	c.SGNameCacheLock.Unlock()
+	if cached != nil {
+		return cached[name], nil
+	}
+
+	// GetSecurityGroups() runs o.securityGroups(), which lists Neutron groups
+	// once and primes SGNameCache. Don't hold SGNameCacheLock across this call:
+	// o.securityGroups() takes the same lock to prime the cache, so holding it
+	// here would deadlock.
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return "", err
+	}
+	list := root.(*mqlOpenstack).GetSecurityGroups()
+	if list.Error != nil {
+		return "", list.Error
+	}
+
 	c.SGNameCacheLock.Lock()
 	defer c.SGNameCacheLock.Unlock()
-	if c.SGNameCache != nil {
-		return c.SGNameCache[name], nil
-	}
-	pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
-	if err != nil {
-		if translateOpenstackError(err) == nil {
-			c.SGNameCache = map[string]string{}
-			return "", nil
+	if c.SGNameCache == nil {
+		// Defensive: build the map from the resource list if priming didn't
+		// occur (e.g. the list came back via a path that left the cache unset).
+		cache := make(map[string]string, len(list.Data))
+		for _, raw := range list.Data {
+			sg := raw.(*mqlOpenstackSecurityGroup)
+			cache[sg.Name.Data] = sg.Id.Data
 		}
-		return "", err
-	}
-	items, err := groups.ExtractGroups(pages)
-	if err != nil {
-		return "", err
-	}
-	c.SGNameCache = make(map[string]string, len(items))
-	for _, sg := range items {
-		c.SGNameCache[sg.Name] = sg.ID
+		c.SGNameCache = cache
 	}
 	return c.SGNameCache[name], nil
 }


### PR DESCRIPTION
## What

On the `openstack.compute.servers { securityGroups { ... } }` path, the provider was issuing **two** full Neutron `groups.List` calls per scan instead of one.

Nova reports a server's security groups by *name*, but Neutron keys them by *ID*, so `server.securityGroups()` resolves each name to an ID via `lookupSecurityGroupIDByName`. That function issued its own `groups.List` into a separate per-connection name→ID cache (`SGNameCache`). The resolved IDs were then materialized into `openstack.securityGroup` resources through the root `GetSecurityGroups()` list — a **second, independent** `groups.List`.

When a scan touched server security groups *without* also querying the top-level `openstack.securityGroups` list, both lists ran. They populated separate caches and only collapsed to a single call when the root list happened to run first — i.e. query-order dependent.

## Change

`lookupSecurityGroupIDByName` now routes through the root `GetSecurityGroups()` list (memoized once per scan via `GetOrCompute`) and reuses the `SGNameCache` that `o.securityGroups()` already primes as a side effect. The list accessor is now the sole source of the cache, so the name lookup costs **zero** extra API calls — a single `groups.List` regardless of query order.

- `network.go`: rewrite `lookupSecurityGroupIDByName(runtime, name)` to derive the name→ID map from the cached root list; drop the now-unused `gophercloud/v2` and `connection` imports; refresh stale comments.
- `compute.go`: simplify the caller (no more manual `NetworkClient()` plumbing).

## Semantics preserved

- **Access denied (401/403/404):** `o.securityGroups()` already translates these to an empty list, so the lookup still returns `("", nil)` and caches an empty (non-nil) map → fast-path retained.
- **Real errors:** propagate, leaving `SGNameCache` nil so the next call retries.
- **No deadlock:** the lock is released before calling `GetSecurityGroups()`, which re-acquires it to prime the cache; `GetOrCompute` single-flights the underlying list under concurrent per-server access.

## Context

Came out of a broader API-call audit of the openstack provider. The provider is otherwise already well-optimized (lazy fields, `AllPages` pagination everywhere, list memoization, lazy cross-refs); this duplicate list was the one genuinely redundant call. The remaining per-item N+1s (image members, swift headers/objects, keymanager ACLs, volume encryption, DNS recordsets, keystone per-user role assignments) have no bulk API alternative.

## Test

- `go build ./...`, `go vet ./resources/`, `go test ./resources/...` all pass.
- `lookupSecurityGroupIDByName` requires a live OpenStack endpoint, so it remains covered by interactive testing rather than a unit test (consistent with the provider's existing tests).