### PR TITLE
🛑 openstack: make region fields typed identity.region references

### DIFF
--- a/providers/openstack/resources/keystone_catalog.go
+++ b/providers/openstack/resources/keystone_catalog.go
@@ -331,6 +331,10 @@ func (o *mqlOpenstack) identityServices() ([]any, error) {
 
 // ---- openstack.identity.endpoint ----
 
+type mqlOpenstackIdentityEndpointInternal struct {
+	cacheRegion string
+}
+
 func (r *mqlOpenstackIdentityEndpoint) id() (string, error) {
 	return "openstack.identity.endpoint/" + r.Id.Data, nil
 }
@@ -383,7 +387,6 @@ func (o *mqlOpenstack) identityEndpoints() ([]any, error) {
 			"id":          llx.StringData(e.ID),
 			"interface":   llx.StringData(string(e.Availability)),
 			"name":        llx.StringData(e.Name),
-			"region":      llx.StringData(e.Region),
 			"serviceId":   llx.StringData(e.ServiceID),
 			"url":         llx.StringData(e.URL),
 			"enabled":     llx.BoolData(e.Enabled),
@@ -392,9 +395,24 @@ func (o *mqlOpenstack) identityEndpoints() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlOpenstackIdentityEndpoint).cacheRegion = e.Region
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+func (r *mqlOpenstackIdentityEndpoint) region() (*mqlOpenstackIdentityRegion, error) {
+	if r.cacheRegion == "" {
+		r.Region.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.identity.region", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackIdentityRegion), nil
 }
 
 func (r *mqlOpenstackIdentityEndpoint) service() (*mqlOpenstackIdentityService, error) {
@@ -409,20 +427,6 @@ func (r *mqlOpenstackIdentityEndpoint) service() (*mqlOpenstackIdentityService, 
 		return nil, err
 	}
 	return res.(*mqlOpenstackIdentityService), nil
-}
-
-func (r *mqlOpenstackIdentityEndpoint) regionRef() (*mqlOpenstackIdentityRegion, error) {
-	if r.Region.Data == "" {
-		r.RegionRef.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(r.MqlRuntime, "openstack.identity.region", map[string]*llx.RawData{
-		"id": llx.StringData(r.Region.Data),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOpenstackIdentityRegion), nil
 }
 
 // ---- openstack.identity.region ----

--- a/providers/openstack/resources/openstack.go
+++ b/providers/openstack/resources/openstack.go
@@ -24,8 +24,24 @@ func initOpenstack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 	if _, ok := args["projectId"]; !ok {
 		args["projectId"] = llx.StringData(c.ProjectID())
 	}
-	if _, ok := args["region"]; !ok {
-		args["region"] = llx.StringData(c.Region())
-	}
 	return args, nil, nil
+}
+
+// region resolves the connection's target region to a typed Keystone region
+// reference. The raw region id remains available via `region.id` even when the
+// region list can't be read (e.g. a non-admin token), since it is the cache
+// key. Null when the connection is not bound to a region.
+func (r *mqlOpenstack) region() (*mqlOpenstackIdentityRegion, error) {
+	name := conn(r.MqlRuntime).Region()
+	if name == "" {
+		r.Region.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.identity.region", map[string]*llx.RawData{
+		"id": llx.StringData(name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackIdentityRegion), nil
 }

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -32,7 +32,7 @@ openstack {
   // Scoped project ID
   projectId string
   // Region the connection is targeting
-  region string
+  region() openstack.identity.region
 
   // Keystone projects visible to the authenticated user (admin scope returns all)
   projects() []openstack.project
@@ -1750,7 +1750,7 @@ private openstack.identity.service @defaults("id name type enabled") {
 // (public, internal, or admin) in one region. Select an endpoint by its `id`.
 // Auditing which services expose `public` endpoints, and on which URLs, is the
 // primary use.
-private openstack.identity.endpoint @defaults("id interface url region") {
+private openstack.identity.endpoint @defaults("id interface url") {
   init(id? string)
   // Endpoint ID (UUID)
   id string
@@ -1760,8 +1760,6 @@ private openstack.identity.endpoint @defaults("id interface url region") {
   interface string
   // Endpoint name
   name string
-  // Region ID the endpoint is located in
-  region string
   // ID of the service this endpoint exposes
   serviceId string
   // Endpoint URL
@@ -1772,8 +1770,8 @@ private openstack.identity.endpoint @defaults("id interface url region") {
   description string
   // Service this endpoint exposes
   service() openstack.identity.service
-  // Region the endpoint is located in
-  regionRef() openstack.identity.region
+  // Region the endpoint is located in; null when the endpoint has no region or the region is not listed
+  region() openstack.identity.region
 }
 
 // OpenStack Keystone region

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -440,7 +440,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlOpenstack).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.region": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstack).GetRegion()).ToDataRes(types.String)
+		return (r.(*mqlOpenstack).GetRegion()).ToDataRes(types.Resource("openstack.identity.region"))
 	},
 	"openstack.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetProjects()).ToDataRes(types.Array(types.Resource("openstack.project")))
@@ -2572,9 +2572,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.identity.endpoint.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityEndpoint).GetName()).ToDataRes(types.String)
 	},
-	"openstack.identity.endpoint.region": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackIdentityEndpoint).GetRegion()).ToDataRes(types.String)
-	},
 	"openstack.identity.endpoint.serviceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityEndpoint).GetServiceId()).ToDataRes(types.String)
 	},
@@ -2590,8 +2587,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.identity.endpoint.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityEndpoint).GetService()).ToDataRes(types.Resource("openstack.identity.service"))
 	},
-	"openstack.identity.endpoint.regionRef": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackIdentityEndpoint).GetRegionRef()).ToDataRes(types.Resource("openstack.identity.region"))
+	"openstack.identity.endpoint.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackIdentityEndpoint).GetRegion()).ToDataRes(types.Resource("openstack.identity.region"))
 	},
 	"openstack.identity.region.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityRegion).GetId()).ToDataRes(types.String)
@@ -3320,7 +3317,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"openstack.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstack).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlOpenstack).Region, ok = plugin.RawToTValue[*mqlOpenstackIdentityRegion](v.Value, v.Error)
 		return
 	},
 	"openstack.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6367,10 +6364,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackIdentityEndpoint).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"openstack.identity.endpoint.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackIdentityEndpoint).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.identity.endpoint.serviceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackIdentityEndpoint).ServiceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6391,8 +6384,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackIdentityEndpoint).Service, ok = plugin.RawToTValue[*mqlOpenstackIdentityService](v.Value, v.Error)
 		return
 	},
-	"openstack.identity.endpoint.regionRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackIdentityEndpoint).RegionRef, ok = plugin.RawToTValue[*mqlOpenstackIdentityRegion](v.Value, v.Error)
+	"openstack.identity.endpoint.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackIdentityEndpoint).Region, ok = plugin.RawToTValue[*mqlOpenstackIdentityRegion](v.Value, v.Error)
 		return
 	},
 	"openstack.identity.region.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7426,7 +7419,7 @@ type mqlOpenstack struct {
 	// optional: if you define mqlOpenstackInternal it will be used here
 	AuthUrl                 plugin.TValue[string]
 	ProjectId               plugin.TValue[string]
-	Region                  plugin.TValue[string]
+	Region                  plugin.TValue[*mqlOpenstackIdentityRegion]
 	Projects                plugin.TValue[[]any]
 	Users                   plugin.TValue[[]any]
 	Roles                   plugin.TValue[[]any]
@@ -7530,8 +7523,20 @@ func (c *mqlOpenstack) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
 }
 
-func (c *mqlOpenstack) GetRegion() *plugin.TValue[string] {
-	return &c.Region
+func (c *mqlOpenstack) GetRegion() *plugin.TValue[*mqlOpenstackIdentityRegion] {
+	return plugin.GetOrCompute[*mqlOpenstackIdentityRegion](&c.Region, func() (*mqlOpenstackIdentityRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackIdentityRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlOpenstack) GetProjects() *plugin.TValue[[]any] {
@@ -15391,17 +15396,16 @@ func (c *mqlOpenstackIdentityService) GetEnabled() *plugin.TValue[bool] {
 type mqlOpenstackIdentityEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackIdentityEndpointInternal it will be used here
+	mqlOpenstackIdentityEndpointInternal
 	Id          plugin.TValue[string]
 	Interface   plugin.TValue[string]
 	Name        plugin.TValue[string]
-	Region      plugin.TValue[string]
 	ServiceId   plugin.TValue[string]
 	Url         plugin.TValue[string]
 	Enabled     plugin.TValue[bool]
 	Description plugin.TValue[string]
 	Service     plugin.TValue[*mqlOpenstackIdentityService]
-	RegionRef   plugin.TValue[*mqlOpenstackIdentityRegion]
+	Region      plugin.TValue[*mqlOpenstackIdentityRegion]
 }
 
 // createOpenstackIdentityEndpoint creates a new instance of this resource
@@ -15453,10 +15457,6 @@ func (c *mqlOpenstackIdentityEndpoint) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOpenstackIdentityEndpoint) GetRegion() *plugin.TValue[string] {
-	return &c.Region
-}
-
 func (c *mqlOpenstackIdentityEndpoint) GetServiceId() *plugin.TValue[string] {
 	return &c.ServiceId
 }
@@ -15489,10 +15489,10 @@ func (c *mqlOpenstackIdentityEndpoint) GetService() *plugin.TValue[*mqlOpenstack
 	})
 }
 
-func (c *mqlOpenstackIdentityEndpoint) GetRegionRef() *plugin.TValue[*mqlOpenstackIdentityRegion] {
-	return plugin.GetOrCompute[*mqlOpenstackIdentityRegion](&c.RegionRef, func() (*mqlOpenstackIdentityRegion, error) {
+func (c *mqlOpenstackIdentityEndpoint) GetRegion() *plugin.TValue[*mqlOpenstackIdentityRegion] {
+	return plugin.GetOrCompute[*mqlOpenstackIdentityRegion](&c.Region, func() (*mqlOpenstackIdentityRegion, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.identity.endpoint", c.__id, "regionRef")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.identity.endpoint", c.__id, "region")
 			if err != nil {
 				return nil, err
 			}
@@ -15501,7 +15501,7 @@ func (c *mqlOpenstackIdentityEndpoint) GetRegionRef() *plugin.TValue[*mqlOpensta
 			}
 		}
 
-		return c.regionRef()
+		return c.region()
 	})
 }
 

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -459,7 +459,6 @@ openstack.identity.endpoint.id 13.1.4
 openstack.identity.endpoint.interface 13.1.4
 openstack.identity.endpoint.name 13.1.4
 openstack.identity.endpoint.region 13.1.4
-openstack.identity.endpoint.regionRef 13.1.4
 openstack.identity.endpoint.service 13.1.4
 openstack.identity.endpoint.serviceId 13.1.4
 openstack.identity.endpoint.url 13.1.4


### PR DESCRIPTION
## What

Converts the remaining raw `region` string fields to typed `openstack.identity.region` references, superseding the short-lived `regionRef()` accessor added in #8087.

| Field | Before | After |
|---|---|---|
| `openstack.identity.endpoint.region` | `string` | `region() openstack.identity.region` |
| `openstack.region` (root resource) | `string` | `region() openstack.identity.region` |

The raw region id stays available via **`region.id`** — it's the resource cache key, so it resolves even for non-admin tokens that can't list regions (richer fields like `description` are null in that case).

The `*Id`-suffixed companions (`serviceId`, `parentRegionId`) are intentionally kept as raw fields, matching the existing `serviceId` + `service()` pattern.

## ⚠️ Breaking

`openstack.region` was a `string` on the root resource. Expressions like `openstack.region == "RegionOne"` must become `openstack.region.id == "RegionOne"`. No built-in content/policies reference it, but external MQL/policies might.

## Test

- `go build ./...`, `go vet`, `go test ./resources/...` pass; codegen stable; `make providers/build/openstack` succeeds.