### PR TITLE
✨ openstack: add Heat orchestration stacks

### DIFF
--- a/providers/openstack/connection/connection.go
+++ b/providers/openstack/connection/connection.go
@@ -50,6 +50,7 @@ type OpenstackConnection struct {
 	containerInfra   *gophercloud.ServiceClient
 	database         *gophercloud.ServiceClient
 	bareMetal        *gophercloud.ServiceClient
+	orchestration    *gophercloud.ServiceClient
 
 	// Name->ID caches for Nova-reported references that Neutron/Compute
 	// expose only by ID. A non-nil map is the "ready" signal so we don't
@@ -355,5 +356,19 @@ func (c *OpenstackConnection) BareMetalClient() (*gophercloud.ServiceClient, err
 	}
 	client.Microversion = bareMetalMicroversion
 	c.bareMetal = client
+	return client, nil
+}
+
+func (c *OpenstackConnection) OrchestrationClient() (*gophercloud.ServiceClient, error) {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+	if c.orchestration != nil {
+		return c.orchestration, nil
+	}
+	client, err := openstack.NewOrchestrationV1(c.provider, c.endpointOpts())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Heat client: %w", err)
+	}
+	c.orchestration = client
 	return client, nil
 }

--- a/providers/openstack/go.mod
+++ b/providers/openstack/go.mod
@@ -150,6 +150,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/providers/openstack/go.sum
+++ b/providers/openstack/go.sum
@@ -732,6 +732,7 @@ gopkg.in/ini.v1 v1.67.2/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/providers/openstack/resources/heat.go
+++ b/providers/openstack/resources/heat.go
@@ -1,0 +1,151 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/orchestration/v1/stacks"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ---- openstack.orchestration.stack ----
+
+type mqlOpenstackOrchestrationStackInternal struct {
+	detailLock           sync.Mutex
+	detailDone           bool
+	cacheDisableRollback bool
+	cacheTimeout         int
+	cacheParameters      map[string]string
+}
+
+func (r *mqlOpenstackOrchestrationStack) id() (string, error) {
+	return "openstack.orchestration.stack/" + r.Id.Data, nil
+}
+
+func initOpenstackOrchestrationStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := stringArg(args, "id")
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	list := root.(*mqlOpenstack).GetStacks()
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackOrchestrationStack)
+		if s.Id.Data == id {
+			return args, s, nil
+		}
+	}
+	initSyntheticID("openstack.orchestration.stack", "id", args)
+	return args, nil, nil
+}
+
+func (o *mqlOpenstack) stacks() ([]any, error) {
+	c := conn(o.MqlRuntime)
+	client, err := c.OrchestrationClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	pages, err := stacks.List(client, nil).AllPages(ctx())
+	if err != nil {
+		if translateOpenstackError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, err := stacks.ExtractStacks(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(items))
+	for i := range items {
+		s := &items[i]
+		res, err := CreateResource(o.MqlRuntime, "openstack.orchestration.stack", map[string]*llx.RawData{
+			"__id":         llx.StringData("openstack.orchestration.stack/" + s.ID),
+			"id":           llx.StringData(s.ID),
+			"name":         llx.StringData(s.Name),
+			"description":  llx.StringData(s.Description),
+			"status":       llx.StringData(s.Status),
+			"statusReason": llx.StringData(s.StatusReason),
+			"tags":         stringSliceData(s.Tags),
+			"createdAt":    llx.TimeDataPtr(timePtr(s.CreationTime)),
+			"updatedAt":    llx.TimeDataPtr(timePtr(s.UpdatedTime)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// fetchDetail loads the fields that only the per-stack Get returns
+// (disable_rollback, timeout, parameters), caching them so the three
+// detail accessors share a single API call. Double-checked locking guards
+// the one-time fetch.
+func (r *mqlOpenstackOrchestrationStack) fetchDetail() error {
+	if r.detailDone {
+		return nil
+	}
+	r.detailLock.Lock()
+	defer r.detailLock.Unlock()
+	if r.detailDone {
+		return nil
+	}
+
+	c := conn(r.MqlRuntime)
+	client, err := c.OrchestrationClient()
+	if err != nil {
+		if serviceMissing(err) {
+			r.detailDone = true
+			return nil
+		}
+		return err
+	}
+	stack, err := stacks.Get(ctx(), client, r.Name.Data, r.Id.Data).Extract()
+	if err != nil {
+		if translateGetError(err) == nil {
+			r.detailDone = true
+			return nil
+		}
+		return err
+	}
+	r.cacheDisableRollback = stack.DisableRollback
+	r.cacheTimeout = stack.Timeout
+	r.cacheParameters = stack.Parameters
+	r.detailDone = true
+	return nil
+}
+
+func (r *mqlOpenstackOrchestrationStack) disableRollback() (bool, error) {
+	if err := r.fetchDetail(); err != nil {
+		return false, err
+	}
+	return r.cacheDisableRollback, nil
+}
+
+func (r *mqlOpenstackOrchestrationStack) timeoutMinutes() (int64, error) {
+	if err := r.fetchDetail(); err != nil {
+		return 0, err
+	}
+	return int64(r.cacheTimeout), nil
+}
+
+func (r *mqlOpenstackOrchestrationStack) parameters() (map[string]any, error) {
+	if err := r.fetchDetail(); err != nil {
+		return nil, err
+	}
+	return stringMap(r.cacheParameters), nil
+}

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -23,9 +23,9 @@ option go_package = "go.mondoo.com/mql/v13/providers/openstack/resources"
 // Swift object storage (`objectStorageAccount`, `objectStorageContainers`),
 // Designate DNS (`dnsZones`), Manila shared file systems (`shares`,
 // `securityServices`, `shareNetworks`), Magnum container infrastructure
-// (`clusters`, `clusterTemplates`), Trove databases (`databaseInstances`), and
-// Ironic bare metal (`baremetalNodes`). `authUrl`, `projectId`, and `region`
-// identify the connection scope.
+// (`clusters`, `clusterTemplates`), Trove databases (`databaseInstances`),
+// Ironic bare metal (`baremetalNodes`), and Heat orchestration (`stacks`).
+// `authUrl`, `projectId`, and `region` identify the connection scope.
 openstack {
   // Keystone auth URL the connection is bound to
   authUrl string
@@ -153,6 +153,9 @@ openstack {
 
   // Ironic bare-metal nodes in the scoped project
   baremetalNodes() []openstack.baremetal.node
+
+  // Heat orchestration stacks in the scoped project
+  stacks() []openstack.orchestration.stack
 }
 
 // OpenStack Keystone project (formerly "tenant")
@@ -2353,4 +2356,39 @@ private openstack.baremetal.port @defaults("id address nodeUuid pxeEnabled") {
   updatedAt time
   // Node this port belongs to
   node() openstack.baremetal.node
+}
+
+// OpenStack Heat orchestration stack
+//
+// Examine a Heat stack — a set of OpenStack resources deployed and managed
+// together from a template (OpenStack's infrastructure-as-code). Select a stack
+// by its `id`. Query `status` to track deployment/drift state and
+// `disableRollback` to flag stacks that won't roll back on failure.
+private openstack.orchestration.stack @defaults("id name status") {
+  init(id? string)
+  // Stack ID (UUID)
+  id string
+  // Stack name
+  name string
+  // Description
+  description string
+  // Stack status (for example `CREATE_COMPLETE`, `UPDATE_FAILED`, or `ROLLBACK_COMPLETE`)
+  status string
+  // Human-readable reason for the current status
+  statusReason string
+  // Tags applied to the stack
+  tags []string
+  // Creation timestamp
+  createdAt time
+  // Last update timestamp
+  updatedAt time
+  // Whether rollback on failure is disabled
+  //
+  // True leaves a failed stack in place instead of rolling back; failed
+  // deployments then linger with partially created resources.
+  disableRollback() bool
+  // Stack timeout in minutes; 0 when no timeout is set
+  timeoutMinutes() int
+  // Input parameters the stack was deployed with
+  parameters() map[string]string
 }

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -83,6 +83,7 @@ const (
 	ResourceOpenstackDbInstance                      string = "openstack.db.instance"
 	ResourceOpenstackBaremetalNode                   string = "openstack.baremetal.node"
 	ResourceOpenstackBaremetalPort                   string = "openstack.baremetal.port"
+	ResourceOpenstackOrchestrationStack              string = "openstack.orchestration.stack"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -357,6 +358,10 @@ func init() {
 			// to override args, implement: initOpenstackBaremetalPort(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createOpenstackBaremetalPort,
 		},
+		"openstack.orchestration.stack": {
+			Init:   initOpenstackOrchestrationStack,
+			Create: createOpenstackOrchestrationStack,
+		},
 	}
 }
 
@@ -601,6 +606,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.baremetalNodes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetBaremetalNodes()).ToDataRes(types.Array(types.Resource("openstack.baremetal.node")))
+	},
+	"openstack.stacks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstack).GetStacks()).ToDataRes(types.Array(types.Resource("openstack.orchestration.stack")))
 	},
 	"openstack.project.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackProject).GetId()).ToDataRes(types.String)
@@ -3254,6 +3262,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.baremetal.port.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBaremetalPort).GetNode()).ToDataRes(types.Resource("openstack.baremetal.node"))
 	},
+	"openstack.orchestration.stack.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetId()).ToDataRes(types.String)
+	},
+	"openstack.orchestration.stack.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetName()).ToDataRes(types.String)
+	},
+	"openstack.orchestration.stack.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetDescription()).ToDataRes(types.String)
+	},
+	"openstack.orchestration.stack.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetStatus()).ToDataRes(types.String)
+	},
+	"openstack.orchestration.stack.statusReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetStatusReason()).ToDataRes(types.String)
+	},
+	"openstack.orchestration.stack.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetTags()).ToDataRes(types.Array(types.String))
+	},
+	"openstack.orchestration.stack.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"openstack.orchestration.stack.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"openstack.orchestration.stack.disableRollback": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetDisableRollback()).ToDataRes(types.Bool)
+	},
+	"openstack.orchestration.stack.timeoutMinutes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetTimeoutMinutes()).ToDataRes(types.Int)
+	},
+	"openstack.orchestration.stack.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOrchestrationStack).GetParameters()).ToDataRes(types.Map(types.String, types.String))
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -3500,6 +3541,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.baremetalNodes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstack).BaremetalNodes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.stacks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstack).Stacks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"openstack.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7302,6 +7347,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackBaremetalPort).Node, ok = plugin.RawToTValue[*mqlOpenstackBaremetalNode](v.Value, v.Error)
 		return
 	},
+	"openstack.orchestration.stack.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.orchestration.stack.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.statusReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).StatusReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.disableRollback": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).DisableRollback, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.timeoutMinutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).TimeoutMinutes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"openstack.orchestration.stack.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOrchestrationStack).Parameters, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 }
 
 func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
@@ -7389,6 +7482,7 @@ type mqlOpenstack struct {
 	ClusterTemplates        plugin.TValue[[]any]
 	DatabaseInstances       plugin.TValue[[]any]
 	BaremetalNodes          plugin.TValue[[]any]
+	Stacks                  plugin.TValue[[]any]
 }
 
 // createOpenstack creates a new instance of this resource
@@ -8317,6 +8411,22 @@ func (c *mqlOpenstack) GetBaremetalNodes() *plugin.TValue[[]any] {
 		}
 
 		return c.baremetalNodes()
+	})
+}
+
+func (c *mqlOpenstack) GetStacks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Stacks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack", c.__id, "stacks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.stacks()
 	})
 }
 
@@ -17471,5 +17581,110 @@ func (c *mqlOpenstackBaremetalPort) GetNode() *plugin.TValue[*mqlOpenstackBareme
 		}
 
 		return c.node()
+	})
+}
+
+// mqlOpenstackOrchestrationStack for the openstack.orchestration.stack resource
+type mqlOpenstackOrchestrationStack struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlOpenstackOrchestrationStackInternal
+	Id              plugin.TValue[string]
+	Name            plugin.TValue[string]
+	Description     plugin.TValue[string]
+	Status          plugin.TValue[string]
+	StatusReason    plugin.TValue[string]
+	Tags            plugin.TValue[[]any]
+	CreatedAt       plugin.TValue[*time.Time]
+	UpdatedAt       plugin.TValue[*time.Time]
+	DisableRollback plugin.TValue[bool]
+	TimeoutMinutes  plugin.TValue[int64]
+	Parameters      plugin.TValue[map[string]any]
+}
+
+// createOpenstackOrchestrationStack creates a new instance of this resource
+func createOpenstackOrchestrationStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackOrchestrationStack{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.orchestration.stack", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackOrchestrationStack) MqlName() string {
+	return "openstack.orchestration.stack"
+}
+
+func (c *mqlOpenstackOrchestrationStack) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetStatusReason() *plugin.TValue[string] {
+	return &c.StatusReason
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetTags() *plugin.TValue[[]any] {
+	return &c.Tags
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetDisableRollback() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableRollback, func() (bool, error) {
+		return c.disableRollback()
+	})
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetTimeoutMinutes() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.TimeoutMinutes, func() (int64, error) {
+		return c.timeoutMinutes()
+	})
+}
+
+func (c *mqlOpenstackOrchestrationStack) GetParameters() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Parameters, func() (map[string]any, error) {
+		return c.parameters()
 	})
 }

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -762,6 +762,18 @@ openstack.octavia.pool.tags 13.0.1
 openstack.octavia.pool.tlsCiphers 13.0.1
 openstack.octavia.pool.tlsEnabled 13.0.1
 openstack.octavia.pool.tlsVersions 13.0.1
+openstack.orchestration.stack 13.1.4
+openstack.orchestration.stack.createdAt 13.1.4
+openstack.orchestration.stack.description 13.1.4
+openstack.orchestration.stack.disableRollback 13.1.4
+openstack.orchestration.stack.id 13.1.4
+openstack.orchestration.stack.name 13.1.4
+openstack.orchestration.stack.parameters 13.1.4
+openstack.orchestration.stack.status 13.1.4
+openstack.orchestration.stack.statusReason 13.1.4
+openstack.orchestration.stack.tags 13.1.4
+openstack.orchestration.stack.timeoutMinutes 13.1.4
+openstack.orchestration.stack.updatedAt 13.1.4
 openstack.pools 13.0.1
 openstack.port 13.0.1
 openstack.port.adminStateUp 13.0.1
@@ -926,6 +938,7 @@ openstack.sharedfilesystem.shareNetwork.subnet 13.1.4
 openstack.sharedfilesystem.shareNetwork.updatedAt 13.1.4
 openstack.shares 13.1.4
 openstack.snapshots 13.0.1
+openstack.stacks 13.1.4
 openstack.subnet 13.0.1
 openstack.subnet.allocationPools 13.0.1
 openstack.subnet.cidr 13.0.1


### PR DESCRIPTION
## What

Adds Heat (orchestration) support — the last of the new-service additions — behind a new `OrchestrationClient()` on the connection.

| Resource | Reachable via |
|---|---|
| `openstack.orchestration.stack` | `openstack.stacks` |

## Why

Infrastructure-as-code inventory and drift state:

- `status` (`CREATE_COMPLETE` / `UPDATE_FAILED` / `ROLLBACK_COMPLETE` …) + `statusReason` — deployment/drift state.
- `name`, `description`, `tags` — inventory (from the stack list).
- `disableRollback` — flags stacks that leave failed deployments in place instead of rolling back.

`disableRollback`, `timeoutMinutes`, and `parameters` are **lazy-loaded** via a single per-stack `Get` (shared by all three via double-checked locking), so they cost nothing unless queried.

## Notes

- New `.lr.versions` entries at **13.1.4**.
- Adds `gopkg.in/yaml.v2` as an indirect dependency (required by the gophercloud `stacks` package).
- Heat-less clouds degrade to empty results (`serviceMissing`).

## Test

- `go build ./...`, `go vet ./resources/ ./connection/`, `go test ./resources/...` pass; `go mod tidy` clean; codegen stable; `make providers/build/openstack` succeeds.
- Example query (needs a Heat-enabled endpoint):
  - `openstack.stacks.where(status == /FAILED/) { name statusReason disableRollback }`

Completes the new-service set (follows #8087–#8092).