### PR TITLE
🎉 openstack-13.2.0

### DIFF
--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.1.3",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### openstack (13.2.0)
- 🛑 openstack: make region fields typed identity.region references (#8092)
- ✨ openstack: add Heat orchestration stacks (#8093)
- ✨ openstack: add Ironic bare-metal nodes (#8091)
- ✨ openstack: add Trove managed database instances (#8090)
- ✨ openstack: add Magnum container infrastructure (#8089)
- ✨ openstack: add Manila shared file systems (#8088)
- ✨ openstack: add Keystone credentials, trusts, and service catalog (#8087)
- ⚡ openstack: dedupe security-group list on server.securityGroups path (#8086)
- 🧹 Update deps for mql and providers 20260601 (#8079)