### PR TITLE
✨ gcp: privateca CA pool CMEK key + certificate requested not-before time

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -8108,6 +8108,8 @@ private gcp.project.certificateAuthorityService.caPool @defaults("name tier") {
   publishCaCert bool
   // Whether each CA's certificate revocation list is published and referenced in the CRL Distribution Points X.509 extension of issued certificates
   publishCrl bool
+  // Customer-managed Cloud KMS key that encrypts the Subject, Subject Alternative Names, and PEM-encoded certificate of issued certificates at rest
+  kmsKey() gcp.project.kmsService.keyring.cryptokey
   // User-defined key/value labels for organizing the resource
   labels map[string]string
   // Certificate authorities in this pool
@@ -8190,6 +8192,8 @@ private gcp.project.certificateAuthorityService.certificate @defaults("name") {
   issuerCertificateAuthority string
   // Certificate lifetime
   lifetime string
+  // Requester-pinned start of the validity period, before which the issued certificate is not valid
+  requestedNotBeforeTime time
   // Subject description
   subjectDescription dict
   // Certificate description (config)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -10353,6 +10353,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.certificateAuthorityService.caPool.publishCrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).GetPublishCrl()).ToDataRes(types.Bool)
 	},
+	"gcp.project.certificateAuthorityService.caPool.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
 	"gcp.project.certificateAuthorityService.caPool.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -10439,6 +10442,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.certificateAuthorityService.certificate.lifetime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCertificate).GetLifetime()).ToDataRes(types.String)
+	},
+	"gcp.project.certificateAuthorityService.certificate.requestedNotBeforeTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCertificateAuthorityServiceCertificate).GetRequestedNotBeforeTime()).ToDataRes(types.Time)
 	},
 	"gcp.project.certificateAuthorityService.certificate.subjectDescription": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCertificate).GetSubjectDescription()).ToDataRes(types.Dict)
@@ -27204,6 +27210,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).PublishCrl, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.certificateAuthorityService.caPool.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
 	"gcp.project.certificateAuthorityService.caPool.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -27326,6 +27336,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.certificateAuthorityService.certificate.lifetime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCertificateAuthorityServiceCertificate).Lifetime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.certificateAuthorityService.certificate.requestedNotBeforeTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCertificateAuthorityServiceCertificate).RequestedNotBeforeTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gcp.project.certificateAuthorityService.certificate.subjectDescription": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62499,7 +62513,7 @@ func (c *mqlGcpProjectCertificateAuthorityService) GetCaPools() *plugin.TValue[[
 type mqlGcpProjectCertificateAuthorityServiceCaPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCertificateAuthorityServiceCaPoolInternal it will be used here
+	mqlGcpProjectCertificateAuthorityServiceCaPoolInternal
 	ProjectId              plugin.TValue[string]
 	ResourcePath           plugin.TValue[string]
 	Name                   plugin.TValue[string]
@@ -62509,6 +62523,7 @@ type mqlGcpProjectCertificateAuthorityServiceCaPool struct {
 	PublishingOptions      plugin.TValue[any]
 	PublishCaCert          plugin.TValue[bool]
 	PublishCrl             plugin.TValue[bool]
+	KmsKey                 plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	Labels                 plugin.TValue[map[string]any]
 	CertificateAuthorities plugin.TValue[[]any]
 	Certificates           plugin.TValue[[]any]
@@ -62585,6 +62600,22 @@ func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetPublishCaCert() *plu
 
 func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetPublishCrl() *plugin.TValue[bool] {
 	return &c.PublishCrl
+}
+
+func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.KmsKey, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.certificateAuthorityService.caPool", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetLabels() *plugin.TValue[map[string]any] {
@@ -62774,6 +62805,7 @@ type mqlGcpProjectCertificateAuthorityServiceCertificate struct {
 	CaPool                     plugin.TValue[string]
 	IssuerCertificateAuthority plugin.TValue[string]
 	Lifetime                   plugin.TValue[string]
+	RequestedNotBeforeTime     plugin.TValue[*time.Time]
 	SubjectDescription         plugin.TValue[any]
 	CertDescription            plugin.TValue[any]
 	PemCertificate             plugin.TValue[string]
@@ -62847,6 +62879,10 @@ func (c *mqlGcpProjectCertificateAuthorityServiceCertificate) GetIssuerCertifica
 
 func (c *mqlGcpProjectCertificateAuthorityServiceCertificate) GetLifetime() *plugin.TValue[string] {
 	return &c.Lifetime
+}
+
+func (c *mqlGcpProjectCertificateAuthorityServiceCertificate) GetRequestedNotBeforeTime() *plugin.TValue[*time.Time] {
+	return &c.RequestedNotBeforeTime
 }
 
 func (c *mqlGcpProjectCertificateAuthorityServiceCertificate) GetSubjectDescription() *plugin.TValue[any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -738,6 +738,7 @@ gcp.project.certificateAuthorityService.caPool 11.5.1
 gcp.project.certificateAuthorityService.caPool.certificateAuthorities 11.5.1
 gcp.project.certificateAuthorityService.caPool.certificates 11.5.1
 gcp.project.certificateAuthorityService.caPool.issuancePolicy 11.5.1
+gcp.project.certificateAuthorityService.caPool.kmsKey 13.19.2
 gcp.project.certificateAuthorityService.caPool.labels 11.5.1
 gcp.project.certificateAuthorityService.caPool.location 11.5.1
 gcp.project.certificateAuthorityService.caPool.name 11.5.1
@@ -760,6 +761,7 @@ gcp.project.certificateAuthorityService.certificate.name 11.5.1
 gcp.project.certificateAuthorityService.certificate.pemCertificate 11.5.1
 gcp.project.certificateAuthorityService.certificate.pemCertificateChain 11.5.1
 gcp.project.certificateAuthorityService.certificate.projectId 11.5.1
+gcp.project.certificateAuthorityService.certificate.requestedNotBeforeTime 13.19.2
 gcp.project.certificateAuthorityService.certificate.resourcePath 11.5.1
 gcp.project.certificateAuthorityService.certificate.revocationDetails 11.5.1
 gcp.project.certificateAuthorityService.certificate.subjectDescription 11.5.1

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.18.0",
-  "generated_at": "2026-05-27T12:12:16-07:00",
+  "version": "13.19.1",
+  "generated_at": "2026-06-01T22:12:21-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.get",

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -128,10 +128,17 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		if pool.EncryptionSpec != nil {
+			mqlPool.(*mqlGcpProjectCertificateAuthorityServiceCaPool).cacheKmsKeyName = pool.EncryptionSpec.CloudKmsKey
+		}
 		res = append(res, mqlPool)
 	}
 
 	return res, nil
+}
+
+type mqlGcpProjectCertificateAuthorityServiceCaPoolInternal struct {
+	cacheKmsKeyName string
 }
 
 func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) id() (string, error) {
@@ -139,6 +146,19 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) id() (string, error) {
 		return "", g.ResourcePath.Error
 	}
 	return g.ResourcePath.Data, nil
+}
+
+func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	if g.cacheKmsKeyName == "" {
+		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey",
+		map[string]*llx.RawData{"resourcePath": llx.StringData(g.cacheKmsKeyName)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
 func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities() ([]any, error) {
@@ -328,6 +348,13 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 			updatedAt = llx.NilData
 		}
 
+		var requestedNotBeforeTime *llx.RawData
+		if cert.RequestedNotBeforeTime != nil {
+			requestedNotBeforeTime = llx.TimeData(cert.RequestedNotBeforeTime.AsTime())
+		} else {
+			requestedNotBeforeTime = llx.NilData
+		}
+
 		mqlCert, err := CreateResource(g.MqlRuntime, "gcp.project.certificateAuthorityService.certificate", map[string]*llx.RawData{
 			"projectId":                  llx.StringData(projectId),
 			"resourcePath":               llx.StringData(cert.Name),
@@ -336,6 +363,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 			"caPool":                     llx.StringData(caPoolName),
 			"issuerCertificateAuthority": llx.StringData(cert.IssuerCertificateAuthority),
 			"lifetime":                   llx.StringData(cert.Lifetime.String()),
+			"requestedNotBeforeTime":     requestedNotBeforeTime,
 			"subjectDescription":         llx.DictData(subjectDescription),
 			"certDescription":            llx.DictData(certConfig),
 			"pemCertificate":             llx.StringData(cert.PemCertificate),


### PR DESCRIPTION
## What

Adds two fields to the GCP Private CA Service resources, both surfaced by the `cloud.google.com/go/security` **v1.25.0** bump that landed in #8079:

- **`gcp.project.certificateAuthorityService.caPool.kmsKey`** — the customer-managed Cloud KMS key (`CaPool.EncryptionSpec.CloudKmsKey`, new in v1.25.0) that encrypts the `Subject`, Subject Alternative Names, and PEM-encoded certificate of issued certificates **at rest**. Exposed as a typed `gcp.project.kmsService.keyring.cryptokey` reference, following the existing `kmsKey()` pattern used across the provider (alloydb, bigquery, compute, etc.).
- **`gcp.project.certificateAuthorityService.certificate.requestedNotBeforeTime`** — the requester-pinned start of the certificate validity period (`Certificate.RequestedNotBeforeTime`, new in v1.25.0).

## Why

These are net-new security-relevant fields:
- `kmsKey` answers "is this CA pool's sensitive certificate data encrypted with a customer-managed key (CMEK)?" — a common compliance check.
- `requestedNotBeforeTime` exposes certificate backdating, which audits may want to flag.

The companion `CaPool.IssuancePolicy.AllowRequesterSpecifiedNotBeforeTime` field (also new in v1.25.0) already surfaces automatically through the existing `caPool.issuancePolicy` dict, so no schema change was needed for it.

## Notes

- New `.lr.versions` entries are at **13.19.2** (next patch after the provider's current 13.19.1).
- **No new IAM permissions** — both fields come from the existing `ListCaPools` / `ListCertificates` responses (the `gcp.permissions.json` diff is version/timestamp metadata only).
- Field values verified against the vendored `privatecapb` v1.25.0 protos.

## Testing

Provider builds, installs, and loads cleanly. The new `caPool.kmsKey` field compiles and resolves in the schema — verified the query reaches the live API (it only failed with `SERVICE_DISABLED` because the Certificate Authority API isn't enabled in the test project, not a schema/code error). Live data verification would require enabling the privateca API and provisioning CMEK-encrypted CA pools.