### PR TITLE
✨ digitalocean: add typed cross-references for single-query traversal

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -297,6 +297,8 @@ digitalocean.database @defaults("id name engine") {
 private digitalocean.database.backup @defaults("databaseId createdAt sizeGigabytes") {
   // ID of the parent database cluster
   databaseId string
+  // Parent database cluster
+  database() digitalocean.database
   // Time the backup was created
   createdAt time
   // Backup size in gigabytes
@@ -307,6 +309,8 @@ private digitalocean.database.backup @defaults("databaseId createdAt sizeGigabyt
 private digitalocean.database.user @defaults("name role") {
   // ID of the parent database cluster
   databaseId string
+  // Parent database cluster
+  database() digitalocean.database
   // Username
   name string
   // Role (primary, normal)
@@ -317,6 +321,8 @@ private digitalocean.database.user @defaults("name role") {
 private digitalocean.database.replica @defaults("name status") {
   // ID of the parent database cluster
   databaseId string
+  // Parent database cluster
+  database() digitalocean.database
   // Replica name
   name string
   // Region slug
@@ -335,6 +341,8 @@ private digitalocean.database.replica @defaults("name status") {
 private digitalocean.database.pool @defaults("name mode") {
   // ID of the parent database cluster
   databaseId string
+  // Parent database cluster
+  databaseCluster() digitalocean.database
   // Pool name
   name string
   // Database name the pool connects to
@@ -398,6 +406,8 @@ digitalocean.vectorDatabase @defaults("id name region status") {
 private digitalocean.vectorDatabase.backup @defaults("backupId status startedAt") {
   // ID of the parent vector database cluster
   vectorDatabaseId string
+  // Parent vector database cluster
+  vectorDatabase() digitalocean.vectorDatabase
   // Backup ID
   backupId string
   // Backup status
@@ -574,6 +584,8 @@ digitalocean.vpcPeering @defaults("id name status") {
   name string
   // VPC IDs in this peering
   vpcIds []string
+  // VPCs connected by this peering
+  vpcs() []digitalocean.vpc
   // Status
   status string
   // Time the resource was created
@@ -641,6 +653,8 @@ private digitalocean.kubernetes.nodePool @defaults("id name size") {
   id string
   // Cluster ID (parent)
   clusterId string
+  // Cluster this node pool belongs to
+  cluster() digitalocean.kubernetes.cluster
   // Name
   name string
   // Droplet size slug
@@ -868,10 +882,14 @@ digitalocean.reservedIp @defaults("ip region") {
   region string
   // Project ID
   projectId string
+  // Project the IP belongs to
+  project() digitalocean.project
   // Whether the IP is locked
   locked bool
   // Droplet ID (0 if unassigned)
   dropletId int
+  // Droplet the IP is routed to; null when unassigned
+  droplet() digitalocean.droplet
 }
 
 // DigitalOcean App Platform application
@@ -967,6 +985,8 @@ digitalocean.cdn @defaults("id origin") {
   ttl int
   // TLS certificate ID
   certificateId string
+  // TLS certificate bound to the endpoint; null when none is configured
+  certificate() digitalocean.certificate
   // Custom domain
   customDomain string
   // Time the resource was created

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -715,6 +715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.database.backup.databaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseBackup).GetDatabaseId()).ToDataRes(types.String)
 	},
+	"digitalocean.database.backup.database": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDatabaseBackup).GetDatabase()).ToDataRes(types.Resource("digitalocean.database"))
+	},
 	"digitalocean.database.backup.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseBackup).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -724,6 +727,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.database.user.databaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseUser).GetDatabaseId()).ToDataRes(types.String)
 	},
+	"digitalocean.database.user.database": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDatabaseUser).GetDatabase()).ToDataRes(types.Resource("digitalocean.database"))
+	},
 	"digitalocean.database.user.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseUser).GetName()).ToDataRes(types.String)
 	},
@@ -732,6 +738,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.database.replica.databaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseReplica).GetDatabaseId()).ToDataRes(types.String)
+	},
+	"digitalocean.database.replica.database": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDatabaseReplica).GetDatabase()).ToDataRes(types.Resource("digitalocean.database"))
 	},
 	"digitalocean.database.replica.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabaseReplica).GetName()).ToDataRes(types.String)
@@ -753,6 +762,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.database.pool.databaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabasePool).GetDatabaseId()).ToDataRes(types.String)
+	},
+	"digitalocean.database.pool.databaseCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDatabasePool).GetDatabaseCluster()).ToDataRes(types.Resource("digitalocean.database"))
 	},
 	"digitalocean.database.pool.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabasePool).GetName()).ToDataRes(types.String)
@@ -816,6 +828,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.vectorDatabase.backup.vectorDatabaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVectorDatabaseBackup).GetVectorDatabaseId()).ToDataRes(types.String)
+	},
+	"digitalocean.vectorDatabase.backup.vectorDatabase": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVectorDatabaseBackup).GetVectorDatabase()).ToDataRes(types.Resource("digitalocean.vectorDatabase"))
 	},
 	"digitalocean.vectorDatabase.backup.backupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVectorDatabaseBackup).GetBackupId()).ToDataRes(types.String)
@@ -988,6 +1003,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.vpcPeering.vpcIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcPeering).GetVpcIds()).ToDataRes(types.Array(types.String))
 	},
+	"digitalocean.vpcPeering.vpcs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcPeering).GetVpcs()).ToDataRes(types.Array(types.Resource("digitalocean.vpc")))
+	},
 	"digitalocean.vpcPeering.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcPeering).GetStatus()).ToDataRes(types.String)
 	},
@@ -1062,6 +1080,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.kubernetes.nodePool.clusterId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesNodePool).GetClusterId()).ToDataRes(types.String)
+	},
+	"digitalocean.kubernetes.nodePool.cluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesNodePool).GetCluster()).ToDataRes(types.Resource("digitalocean.kubernetes.cluster"))
 	},
 	"digitalocean.kubernetes.nodePool.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesNodePool).GetName()).ToDataRes(types.String)
@@ -1273,11 +1294,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.reservedIp.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanReservedIp).GetProjectId()).ToDataRes(types.String)
 	},
+	"digitalocean.reservedIp.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanReservedIp).GetProject()).ToDataRes(types.Resource("digitalocean.project"))
+	},
 	"digitalocean.reservedIp.locked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanReservedIp).GetLocked()).ToDataRes(types.Bool)
 	},
 	"digitalocean.reservedIp.dropletId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanReservedIp).GetDropletId()).ToDataRes(types.Int)
+	},
+	"digitalocean.reservedIp.droplet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanReservedIp).GetDroplet()).ToDataRes(types.Resource("digitalocean.droplet"))
 	},
 	"digitalocean.app.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanApp).GetId()).ToDataRes(types.String)
@@ -1365,6 +1392,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.cdn.certificateId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanCdn).GetCertificateId()).ToDataRes(types.String)
+	},
+	"digitalocean.cdn.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanCdn).GetCertificate()).ToDataRes(types.Resource("digitalocean.certificate"))
 	},
 	"digitalocean.cdn.customDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanCdn).GetCustomDomain()).ToDataRes(types.String)
@@ -2880,6 +2910,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDatabaseBackup).DatabaseId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"digitalocean.database.backup.database": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDatabaseBackup).Database, ok = plugin.RawToTValue[*mqlDigitaloceanDatabase](v.Value, v.Error)
+		return
+	},
 	"digitalocean.database.backup.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabaseBackup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -2896,6 +2930,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDatabaseUser).DatabaseId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"digitalocean.database.user.database": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDatabaseUser).Database, ok = plugin.RawToTValue[*mqlDigitaloceanDatabase](v.Value, v.Error)
+		return
+	},
 	"digitalocean.database.user.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabaseUser).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2910,6 +2948,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.database.replica.databaseId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabaseReplica).DatabaseId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.database.replica.database": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDatabaseReplica).Database, ok = plugin.RawToTValue[*mqlDigitaloceanDatabase](v.Value, v.Error)
 		return
 	},
 	"digitalocean.database.replica.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2942,6 +2984,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.database.pool.databaseId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabasePool).DatabaseId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.database.pool.databaseCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDatabasePool).DatabaseCluster, ok = plugin.RawToTValue[*mqlDigitaloceanDatabase](v.Value, v.Error)
 		return
 	},
 	"digitalocean.database.pool.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3034,6 +3080,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.vectorDatabase.backup.vectorDatabaseId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVectorDatabaseBackup).VectorDatabaseId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vectorDatabase.backup.vectorDatabase": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVectorDatabaseBackup).VectorDatabase, ok = plugin.RawToTValue[*mqlDigitaloceanVectorDatabase](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vectorDatabase.backup.backupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3288,6 +3338,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanVpcPeering).VpcIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.vpcPeering.vpcs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcPeering).Vpcs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.vpcPeering.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVpcPeering).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -3394,6 +3448,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.kubernetes.nodePool.clusterId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanKubernetesNodePool).ClusterId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.kubernetes.nodePool.cluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesNodePool).Cluster, ok = plugin.RawToTValue[*mqlDigitaloceanKubernetesCluster](v.Value, v.Error)
 		return
 	},
 	"digitalocean.kubernetes.nodePool.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3712,12 +3770,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanReservedIp).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"digitalocean.reservedIp.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanReservedIp).Project, ok = plugin.RawToTValue[*mqlDigitaloceanProject](v.Value, v.Error)
+		return
+	},
 	"digitalocean.reservedIp.locked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanReservedIp).Locked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.reservedIp.dropletId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanReservedIp).DropletId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.reservedIp.droplet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanReservedIp).Droplet, ok = plugin.RawToTValue[*mqlDigitaloceanDroplet](v.Value, v.Error)
 		return
 	},
 	"digitalocean.app.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3850,6 +3916,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.cdn.certificateId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanCdn).CertificateId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.cdn.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanCdn).Certificate, ok = plugin.RawToTValue[*mqlDigitaloceanCertificate](v.Value, v.Error)
 		return
 	},
 	"digitalocean.cdn.customDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6657,6 +6727,7 @@ type mqlDigitaloceanDatabaseBackup struct {
 	__id       string
 	// optional: if you define mqlDigitaloceanDatabaseBackupInternal it will be used here
 	DatabaseId    plugin.TValue[string]
+	Database      plugin.TValue[*mqlDigitaloceanDatabase]
 	CreatedAt     plugin.TValue[*time.Time]
 	SizeGigabytes plugin.TValue[float64]
 }
@@ -6702,6 +6773,22 @@ func (c *mqlDigitaloceanDatabaseBackup) GetDatabaseId() *plugin.TValue[string] {
 	return &c.DatabaseId
 }
 
+func (c *mqlDigitaloceanDatabaseBackup) GetDatabase() *plugin.TValue[*mqlDigitaloceanDatabase] {
+	return plugin.GetOrCompute[*mqlDigitaloceanDatabase](&c.Database, func() (*mqlDigitaloceanDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.database.backup", c.__id, "database")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanDatabase), nil
+			}
+		}
+
+		return c.database()
+	})
+}
+
 func (c *mqlDigitaloceanDatabaseBackup) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
@@ -6716,6 +6803,7 @@ type mqlDigitaloceanDatabaseUser struct {
 	__id       string
 	// optional: if you define mqlDigitaloceanDatabaseUserInternal it will be used here
 	DatabaseId plugin.TValue[string]
+	Database   plugin.TValue[*mqlDigitaloceanDatabase]
 	Name       plugin.TValue[string]
 	Role       plugin.TValue[string]
 }
@@ -6761,6 +6849,22 @@ func (c *mqlDigitaloceanDatabaseUser) GetDatabaseId() *plugin.TValue[string] {
 	return &c.DatabaseId
 }
 
+func (c *mqlDigitaloceanDatabaseUser) GetDatabase() *plugin.TValue[*mqlDigitaloceanDatabase] {
+	return plugin.GetOrCompute[*mqlDigitaloceanDatabase](&c.Database, func() (*mqlDigitaloceanDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.database.user", c.__id, "database")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanDatabase), nil
+			}
+		}
+
+		return c.database()
+	})
+}
+
 func (c *mqlDigitaloceanDatabaseUser) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -6775,6 +6879,7 @@ type mqlDigitaloceanDatabaseReplica struct {
 	__id       string
 	// optional: if you define mqlDigitaloceanDatabaseReplicaInternal it will be used here
 	DatabaseId plugin.TValue[string]
+	Database   plugin.TValue[*mqlDigitaloceanDatabase]
 	Name       plugin.TValue[string]
 	Region     plugin.TValue[string]
 	Status     plugin.TValue[string]
@@ -6824,6 +6929,22 @@ func (c *mqlDigitaloceanDatabaseReplica) GetDatabaseId() *plugin.TValue[string] 
 	return &c.DatabaseId
 }
 
+func (c *mqlDigitaloceanDatabaseReplica) GetDatabase() *plugin.TValue[*mqlDigitaloceanDatabase] {
+	return plugin.GetOrCompute[*mqlDigitaloceanDatabase](&c.Database, func() (*mqlDigitaloceanDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.database.replica", c.__id, "database")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanDatabase), nil
+			}
+		}
+
+		return c.database()
+	})
+}
+
 func (c *mqlDigitaloceanDatabaseReplica) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -6853,12 +6974,13 @@ type mqlDigitaloceanDatabasePool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanDatabasePoolInternal it will be used here
-	DatabaseId plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Database   plugin.TValue[string]
-	User       plugin.TValue[string]
-	Size       plugin.TValue[int64]
-	Mode       plugin.TValue[string]
+	DatabaseId      plugin.TValue[string]
+	DatabaseCluster plugin.TValue[*mqlDigitaloceanDatabase]
+	Name            plugin.TValue[string]
+	Database        plugin.TValue[string]
+	User            plugin.TValue[string]
+	Size            plugin.TValue[int64]
+	Mode            plugin.TValue[string]
 }
 
 // createDigitaloceanDatabasePool creates a new instance of this resource
@@ -6900,6 +7022,22 @@ func (c *mqlDigitaloceanDatabasePool) MqlID() string {
 
 func (c *mqlDigitaloceanDatabasePool) GetDatabaseId() *plugin.TValue[string] {
 	return &c.DatabaseId
+}
+
+func (c *mqlDigitaloceanDatabasePool) GetDatabaseCluster() *plugin.TValue[*mqlDigitaloceanDatabase] {
+	return plugin.GetOrCompute[*mqlDigitaloceanDatabase](&c.DatabaseCluster, func() (*mqlDigitaloceanDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.database.pool", c.__id, "databaseCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanDatabase), nil
+			}
+		}
+
+		return c.databaseCluster()
+	})
 }
 
 func (c *mqlDigitaloceanDatabasePool) GetName() *plugin.TValue[string] {
@@ -7054,6 +7192,7 @@ type mqlDigitaloceanVectorDatabaseBackup struct {
 	__id       string
 	// optional: if you define mqlDigitaloceanVectorDatabaseBackupInternal it will be used here
 	VectorDatabaseId plugin.TValue[string]
+	VectorDatabase   plugin.TValue[*mqlDigitaloceanVectorDatabase]
 	BackupId         plugin.TValue[string]
 	Status           plugin.TValue[string]
 	StartedAt        plugin.TValue[*time.Time]
@@ -7099,6 +7238,22 @@ func (c *mqlDigitaloceanVectorDatabaseBackup) MqlID() string {
 
 func (c *mqlDigitaloceanVectorDatabaseBackup) GetVectorDatabaseId() *plugin.TValue[string] {
 	return &c.VectorDatabaseId
+}
+
+func (c *mqlDigitaloceanVectorDatabaseBackup) GetVectorDatabase() *plugin.TValue[*mqlDigitaloceanVectorDatabase] {
+	return plugin.GetOrCompute[*mqlDigitaloceanVectorDatabase](&c.VectorDatabase, func() (*mqlDigitaloceanVectorDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vectorDatabase.backup", c.__id, "vectorDatabase")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanVectorDatabase), nil
+			}
+		}
+
+		return c.vectorDatabase()
+	})
 }
 
 func (c *mqlDigitaloceanVectorDatabaseBackup) GetBackupId() *plugin.TValue[string] {
@@ -7643,6 +7798,7 @@ type mqlDigitaloceanVpcPeering struct {
 	Id        plugin.TValue[string]
 	Name      plugin.TValue[string]
 	VpcIds    plugin.TValue[[]any]
+	Vpcs      plugin.TValue[[]any]
 	Status    plugin.TValue[string]
 	CreatedAt plugin.TValue[*time.Time]
 }
@@ -7694,6 +7850,22 @@ func (c *mqlDigitaloceanVpcPeering) GetName() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanVpcPeering) GetVpcIds() *plugin.TValue[[]any] {
 	return &c.VpcIds
+}
+
+func (c *mqlDigitaloceanVpcPeering) GetVpcs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Vpcs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpcPeering", c.__id, "vpcs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.vpcs()
+	})
 }
 
 func (c *mqlDigitaloceanVpcPeering) GetStatus() *plugin.TValue[string] {
@@ -7884,6 +8056,7 @@ type mqlDigitaloceanKubernetesNodePool struct {
 	// optional: if you define mqlDigitaloceanKubernetesNodePoolInternal it will be used here
 	Id        plugin.TValue[string]
 	ClusterId plugin.TValue[string]
+	Cluster   plugin.TValue[*mqlDigitaloceanKubernetesCluster]
 	Name      plugin.TValue[string]
 	Size      plugin.TValue[string]
 	Count     plugin.TValue[int64]
@@ -7938,6 +8111,22 @@ func (c *mqlDigitaloceanKubernetesNodePool) GetId() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanKubernetesNodePool) GetClusterId() *plugin.TValue[string] {
 	return &c.ClusterId
+}
+
+func (c *mqlDigitaloceanKubernetesNodePool) GetCluster() *plugin.TValue[*mqlDigitaloceanKubernetesCluster] {
+	return plugin.GetOrCompute[*mqlDigitaloceanKubernetesCluster](&c.Cluster, func() (*mqlDigitaloceanKubernetesCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.kubernetes.nodePool", c.__id, "cluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanKubernetesCluster), nil
+			}
+		}
+
+		return c.cluster()
+	})
 }
 
 func (c *mqlDigitaloceanKubernetesNodePool) GetName() *plugin.TValue[string] {
@@ -8686,8 +8875,10 @@ type mqlDigitaloceanReservedIp struct {
 	Ip        plugin.TValue[string]
 	Region    plugin.TValue[string]
 	ProjectId plugin.TValue[string]
+	Project   plugin.TValue[*mqlDigitaloceanProject]
 	Locked    plugin.TValue[bool]
 	DropletId plugin.TValue[int64]
+	Droplet   plugin.TValue[*mqlDigitaloceanDroplet]
 }
 
 // createDigitaloceanReservedIp creates a new instance of this resource
@@ -8739,12 +8930,44 @@ func (c *mqlDigitaloceanReservedIp) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
 }
 
+func (c *mqlDigitaloceanReservedIp) GetProject() *plugin.TValue[*mqlDigitaloceanProject] {
+	return plugin.GetOrCompute[*mqlDigitaloceanProject](&c.Project, func() (*mqlDigitaloceanProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.reservedIp", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanProject), nil
+			}
+		}
+
+		return c.project()
+	})
+}
+
 func (c *mqlDigitaloceanReservedIp) GetLocked() *plugin.TValue[bool] {
 	return &c.Locked
 }
 
 func (c *mqlDigitaloceanReservedIp) GetDropletId() *plugin.TValue[int64] {
 	return &c.DropletId
+}
+
+func (c *mqlDigitaloceanReservedIp) GetDroplet() *plugin.TValue[*mqlDigitaloceanDroplet] {
+	return plugin.GetOrCompute[*mqlDigitaloceanDroplet](&c.Droplet, func() (*mqlDigitaloceanDroplet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.reservedIp", c.__id, "droplet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanDroplet), nil
+			}
+		}
+
+		return c.droplet()
+	})
 }
 
 // mqlDigitaloceanApp for the digitalocean.app resource
@@ -9009,6 +9232,7 @@ type mqlDigitaloceanCdn struct {
 	Endpoint      plugin.TValue[string]
 	Ttl           plugin.TValue[int64]
 	CertificateId plugin.TValue[string]
+	Certificate   plugin.TValue[*mqlDigitaloceanCertificate]
 	CustomDomain  plugin.TValue[string]
 	CreatedAt     plugin.TValue[*time.Time]
 }
@@ -9068,6 +9292,22 @@ func (c *mqlDigitaloceanCdn) GetTtl() *plugin.TValue[int64] {
 
 func (c *mqlDigitaloceanCdn) GetCertificateId() *plugin.TValue[string] {
 	return &c.CertificateId
+}
+
+func (c *mqlDigitaloceanCdn) GetCertificate() *plugin.TValue[*mqlDigitaloceanCertificate] {
+	return plugin.GetOrCompute[*mqlDigitaloceanCertificate](&c.Certificate, func() (*mqlDigitaloceanCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.cdn", c.__id, "certificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanCertificate), nil
+			}
+		}
+
+		return c.certificate()
+	})
 }
 
 func (c *mqlDigitaloceanCdn) GetCustomDomain() *plugin.TValue[string] {

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -36,6 +36,7 @@ digitalocean.app.spec 13.0.1
 digitalocean.app.updatedAt 13.0.1
 digitalocean.apps 13.0.1
 digitalocean.cdn 13.0.1
+digitalocean.cdn.certificate 13.4.2
 digitalocean.cdn.certificateId 13.0.1
 digitalocean.cdn.createdAt 13.0.1
 digitalocean.cdn.customDomain 13.0.1
@@ -57,6 +58,7 @@ digitalocean.certificates 13.0.1
 digitalocean.database 13.0.1
 digitalocean.database.backup 13.2.1
 digitalocean.database.backup.createdAt 13.2.1
+digitalocean.database.backup.database 13.4.2
 digitalocean.database.backup.databaseId 13.2.1
 digitalocean.database.backup.sizeGigabytes 13.2.1
 digitalocean.database.backupCount 13.2.1
@@ -76,6 +78,7 @@ digitalocean.database.name 13.0.1
 digitalocean.database.numNodes 13.0.1
 digitalocean.database.pool 13.0.1
 digitalocean.database.pool.database 13.0.1
+digitalocean.database.pool.databaseCluster 13.4.2
 digitalocean.database.pool.databaseId 13.0.1
 digitalocean.database.pool.mode 13.0.1
 digitalocean.database.pool.name 13.0.1
@@ -89,6 +92,7 @@ digitalocean.database.projectId 13.1.7
 digitalocean.database.region 13.0.1
 digitalocean.database.replica 13.0.1
 digitalocean.database.replica.createdAt 13.0.1
+digitalocean.database.replica.database 13.4.2
 digitalocean.database.replica.databaseId 13.0.1
 digitalocean.database.replica.name 13.0.1
 digitalocean.database.replica.region 13.0.1
@@ -101,6 +105,7 @@ digitalocean.database.status 13.0.1
 digitalocean.database.storageSizeMib 13.1.7
 digitalocean.database.tags 13.0.1
 digitalocean.database.user 13.0.1
+digitalocean.database.user.database 13.4.2
 digitalocean.database.user.databaseId 13.0.1
 digitalocean.database.user.name 13.0.1
 digitalocean.database.user.role 13.0.1
@@ -483,6 +488,7 @@ digitalocean.kubernetes.cluster.vpc 13.0.2
 digitalocean.kubernetes.cluster.vpcUuid 13.0.1
 digitalocean.kubernetes.nodePool 13.0.1
 digitalocean.kubernetes.nodePool.autoScale 13.0.1
+digitalocean.kubernetes.nodePool.cluster 13.4.2
 digitalocean.kubernetes.nodePool.clusterId 13.0.1
 digitalocean.kubernetes.nodePool.count 13.0.1
 digitalocean.kubernetes.nodePool.id 13.0.1
@@ -586,9 +592,11 @@ digitalocean.registryRepositories 13.0.1
 digitalocean.reservedIPs 13.0.1
 digitalocean.reservedIPv6s 13.4.2
 digitalocean.reservedIp 13.0.1
+digitalocean.reservedIp.droplet 13.4.2
 digitalocean.reservedIp.dropletId 13.0.1
 digitalocean.reservedIp.ip 13.0.1
 digitalocean.reservedIp.locked 13.0.1
+digitalocean.reservedIp.project 13.4.2
 digitalocean.reservedIp.projectId 13.0.1
 digitalocean.reservedIp.region 13.0.1
 digitalocean.reservedIpV6 13.4.2
@@ -673,6 +681,7 @@ digitalocean.vectorDatabase.backup.backupId 13.4.2
 digitalocean.vectorDatabase.backup.completedAt 13.4.2
 digitalocean.vectorDatabase.backup.startedAt 13.4.2
 digitalocean.vectorDatabase.backup.status 13.4.2
+digitalocean.vectorDatabase.backup.vectorDatabase 13.4.2
 digitalocean.vectorDatabase.backup.vectorDatabaseId 13.4.2
 digitalocean.vectorDatabase.backups 13.4.2
 digitalocean.vectorDatabase.createdAt 13.4.2
@@ -735,5 +744,6 @@ digitalocean.vpcPeering.id 13.0.1
 digitalocean.vpcPeering.name 13.0.1
 digitalocean.vpcPeering.status 13.0.1
 digitalocean.vpcPeering.vpcIds 13.0.1
+digitalocean.vpcPeering.vpcs 13.4.2
 digitalocean.vpcPeerings 13.0.1
 digitalocean.vpcs 13.0.1

--- a/providers/digitalocean/resources/digitalocean_crossrefs.go
+++ b/providers/digitalocean/resources/digitalocean_crossrefs.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ----- VPC peering -----
+
+func (r *mqlDigitaloceanVpcPeering) vpcs() ([]interface{}, error) {
+	uuids := make([]string, 0, len(r.VpcIds.Data))
+	for _, v := range r.VpcIds.Data {
+		if s, ok := v.(string); ok {
+			uuids = append(uuids, s)
+		}
+	}
+	return vpcRefsByUUIDs(r.MqlRuntime, uuids)
+}
+
+// ----- Kubernetes node pool -----
+
+func (r *mqlDigitaloceanKubernetesNodePool) cluster() (*mqlDigitaloceanKubernetesCluster, error) {
+	if r.ClusterId.Data == "" {
+		r.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	cluster, err := parent.kubernetesClusterByID(r.ClusterId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if cluster == nil {
+		r.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return cluster, nil
+}
+
+// ----- Reserved IP (v4) -----
+
+func (r *mqlDigitaloceanReservedIp) project() (*mqlDigitaloceanProject, error) {
+	return projectRef(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+}
+
+func (r *mqlDigitaloceanReservedIp) droplet() (*mqlDigitaloceanDroplet, error) {
+	return dropletRef(r.MqlRuntime, r.DropletId.Data, &r.Droplet)
+}
+
+// ----- CDN -----
+
+func (r *mqlDigitaloceanCdn) certificate() (*mqlDigitaloceanCertificate, error) {
+	if r.CertificateId.Data == "" {
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := parent.certificateByID(r.CertificateId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if cert == nil {
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return cert, nil
+}
+
+// ----- Database sub-resource back-references -----
+
+func databaseClusterRef(runtime *plugin.Runtime, id string, target *plugin.TValue[*mqlDigitaloceanDatabase]) (*mqlDigitaloceanDatabase, error) {
+	if id == "" {
+		target.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(runtime)
+	if err != nil {
+		return nil, err
+	}
+	db, err := parent.databaseByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if db == nil {
+		target.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return db, nil
+}
+
+func (r *mqlDigitaloceanDatabaseBackup) database() (*mqlDigitaloceanDatabase, error) {
+	return databaseClusterRef(r.MqlRuntime, r.DatabaseId.Data, &r.Database)
+}
+
+func (r *mqlDigitaloceanDatabaseUser) database() (*mqlDigitaloceanDatabase, error) {
+	return databaseClusterRef(r.MqlRuntime, r.DatabaseId.Data, &r.Database)
+}
+
+func (r *mqlDigitaloceanDatabaseReplica) database() (*mqlDigitaloceanDatabase, error) {
+	return databaseClusterRef(r.MqlRuntime, r.DatabaseId.Data, &r.Database)
+}
+
+// pool exposes the parent cluster as databaseCluster() because its
+// `database` field already names the logical database the pool connects to.
+func (r *mqlDigitaloceanDatabasePool) databaseCluster() (*mqlDigitaloceanDatabase, error) {
+	return databaseClusterRef(r.MqlRuntime, r.DatabaseId.Data, &r.DatabaseCluster)
+}
+
+// ----- Vector database backup back-reference -----
+
+func (r *mqlDigitaloceanVectorDatabaseBackup) vectorDatabase() (*mqlDigitaloceanVectorDatabase, error) {
+	if r.VectorDatabaseId.Data == "" {
+		r.VectorDatabase.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	vdb, err := parent.vectorDatabaseByID(r.VectorDatabaseId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if vdb == nil {
+		r.VectorDatabase.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return vdb, nil
+}

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -34,6 +34,18 @@ type mqlDigitaloceanInternal struct {
 	databaseIndex     map[string]*mqlDigitaloceanDatabase
 	databaseIndexErr  error
 
+	vectorDatabaseIndexOnce sync.Once
+	vectorDatabaseIndex     map[string]*mqlDigitaloceanVectorDatabase
+	vectorDatabaseIndexErr  error
+
+	certificateIndexOnce sync.Once
+	certificateIndex     map[string]*mqlDigitaloceanCertificate
+	certificateIndexErr  error
+
+	k8sClusterIndexOnce sync.Once
+	k8sClusterIndex     map[string]*mqlDigitaloceanKubernetesCluster
+	k8sClusterIndexErr  error
+
 	firewallIndexOnce sync.Once
 	firewallByDroplet map[int64][]*mqlDigitaloceanFirewall
 	firewallByTag     map[string][]*mqlDigitaloceanFirewall
@@ -106,6 +118,66 @@ func (r *mqlDigitalocean) databaseByID(id string) (*mqlDigitaloceanDatabase, err
 		return nil, r.databaseIndexErr
 	}
 	return r.databaseIndex[id], nil
+}
+
+func (r *mqlDigitalocean) vectorDatabaseByID(id string) (*mqlDigitaloceanVectorDatabase, error) {
+	r.vectorDatabaseIndexOnce.Do(func() {
+		vdbs := r.GetVectorDatabases()
+		if vdbs.Error != nil {
+			r.vectorDatabaseIndexErr = vdbs.Error
+			return
+		}
+		idx := make(map[string]*mqlDigitaloceanVectorDatabase, len(vdbs.Data))
+		for _, v := range vdbs.Data {
+			mv := v.(*mqlDigitaloceanVectorDatabase)
+			idx[mv.Id.Data] = mv
+		}
+		r.vectorDatabaseIndex = idx
+	})
+	if r.vectorDatabaseIndexErr != nil {
+		return nil, r.vectorDatabaseIndexErr
+	}
+	return r.vectorDatabaseIndex[id], nil
+}
+
+func (r *mqlDigitalocean) certificateByID(id string) (*mqlDigitaloceanCertificate, error) {
+	r.certificateIndexOnce.Do(func() {
+		certs := r.GetCertificates()
+		if certs.Error != nil {
+			r.certificateIndexErr = certs.Error
+			return
+		}
+		idx := make(map[string]*mqlDigitaloceanCertificate, len(certs.Data))
+		for _, c := range certs.Data {
+			mc := c.(*mqlDigitaloceanCertificate)
+			idx[mc.Id.Data] = mc
+		}
+		r.certificateIndex = idx
+	})
+	if r.certificateIndexErr != nil {
+		return nil, r.certificateIndexErr
+	}
+	return r.certificateIndex[id], nil
+}
+
+func (r *mqlDigitalocean) kubernetesClusterByID(id string) (*mqlDigitaloceanKubernetesCluster, error) {
+	r.k8sClusterIndexOnce.Do(func() {
+		clusters := r.GetKubernetesClusters()
+		if clusters.Error != nil {
+			r.k8sClusterIndexErr = clusters.Error
+			return
+		}
+		idx := make(map[string]*mqlDigitaloceanKubernetesCluster, len(clusters.Data))
+		for _, c := range clusters.Data {
+			mc := c.(*mqlDigitaloceanKubernetesCluster)
+			idx[mc.Id.Data] = mc
+		}
+		r.k8sClusterIndex = idx
+	})
+	if r.k8sClusterIndexErr != nil {
+		return nil, r.k8sClusterIndexErr
+	}
+	return r.k8sClusterIndex[id], nil
 }
 
 func (r *mqlDigitalocean) dropletByIDs(ids []any) ([]any, error) {


### PR DESCRIPTION
## What

Wires raw ID/UUID fields across the DigitalOcean provider to **typed resource references**, so users can traverse related resources in a single query instead of manually correlating IDs. All additive.

## Cross-references added

| From | New typed field | To |
|---|---|---|
| `vpcPeering` | `vpcs()` | `[]digitalocean.vpc` (the peered VPCs) |
| `kubernetes.nodePool` | `cluster()` | `digitalocean.kubernetes.cluster` (parent cluster) |
| `reservedIp` | `project()` | `digitalocean.project` |
| `reservedIp` | `droplet()` | `digitalocean.droplet` — parity with `reservedIpV6`, which already had it |
| `cdn` | `certificate()` | `digitalocean.certificate` (bound TLS cert) |
| `database.backup` / `.user` / `.replica` | `database()` | `digitalocean.database` (parent cluster) |
| `database.pool` | `databaseCluster()` | `digitalocean.database` — named differently because `pool.database` already names the logical DB |
| `vectorDatabase.backup` | `vectorDatabase()` | `digitalocean.vectorDatabase` (parent cluster) |

Example:
```
digitalocean.reservedIps.where(dropletId != 0) { ip droplet { name region } }
digitalocean.cdnEndpoints { origin certificate { name notAfter } }
digitalocean.vpcPeerings { name vpcs { name ipRange } }
```

## Implementation

- Adds `certificateByID`, `kubernetesClusterByID`, and `vectorDatabaseByID` index helpers, mirroring the existing `vpcByID`/`projectByID`/`databaseByID` (build-once, cached). Reuses `projectRef`/`dropletRef`/`vpcRefsByUUIDs`.
- All singular refs set `StateIsSet | StateIsNull` when the ID is empty or unresolved.
- New schema entries at `13.4.2`. No `config.go` version bump.

## Testing

- `go build ./...` (whole digitalocean provider) — clean
- `gofmt -l`, `go vet ./resources/` — clean
- `go test ./resources/` — `ok`
- Codegen idempotent
