### PR TITLE
✨ oci: surface ZPR security attributes and network firewall health status

### DIFF
--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciNetworkFirewall) id() (string, error) {
@@ -98,15 +99,16 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 				}
 
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.firewall", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(fw.Id),
-					"name":          llx.StringDataPtr(fw.DisplayName),
-					"compartmentID": llx.StringDataPtr(fw.CompartmentId),
-					"ipv4Address":   llx.StringDataPtr(fw.Ipv4Address),
-					"ipv6Address":   llx.StringDataPtr(fw.Ipv6Address),
-					"shape":         llx.StringDataPtr(fw.Shape),
-					"state":         llx.StringData(string(fw.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
+					"id":                 llx.StringDataPtr(fw.Id),
+					"name":               llx.StringDataPtr(fw.DisplayName),
+					"compartmentID":      llx.StringDataPtr(fw.CompartmentId),
+					"ipv4Address":        llx.StringDataPtr(fw.Ipv4Address),
+					"ipv6Address":        llx.StringDataPtr(fw.Ipv6Address),
+					"shape":              llx.StringDataPtr(fw.Shape),
+					"state":              llx.StringData(string(fw.LifecycleState)),
+					"created":            llx.TimeDataPtr(created),
+					"timeUpdated":        llx.TimeDataPtr(timeUpdated),
+					"securityAttributes": llx.MapData(definedTagsToAny(fw.SecurityAttributes), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -114,6 +116,7 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 				mqlFw := mqlInstance.(*mqlOciNetworkFirewallFirewall)
 				mqlFw.cacheSubnetId = stringValue(fw.SubnetId)
 				mqlFw.cachePolicyId = stringValue(fw.NetworkFirewallPolicyId)
+				mqlFw.region = regionResource.Id.Data
 				res = append(res, mqlFw)
 			}
 
@@ -127,10 +130,26 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 type mqlOciNetworkFirewallFirewallInternal struct {
 	cacheSubnetId string
 	cachePolicyId string
+	region        string
 }
 
 func (o *mqlOciNetworkFirewallFirewall) id() (string, error) {
 	return "oci.networkFirewall.firewall/" + o.Id.Data, nil
+}
+
+func (o *mqlOciNetworkFirewallFirewall) healthStatus() (string, error) {
+	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+	svc, err := conn.NetworkFirewallClient(o.region)
+	if err != nil {
+		return "", err
+	}
+	resp, err := svc.GetNetworkFirewallHealthStatus(context.Background(), networkfirewall.GetNetworkFirewallHealthStatusRequest{
+		NetworkFirewallId: common.String(o.Id.Data),
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Status), nil
 }
 
 func (o *mqlOciNetworkFirewallFirewall) subnet() (*mqlOciNetworkSubnet, error) {

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -1620,6 +1620,12 @@ private oci.networkFirewall.firewall @defaults("name") {
   created time
   // Last update time
   timeUpdated time
+  // Zero Trust Packet Routing security attributes enforced on the firewall
+  securityAttributes map[string]dict
+  // Overall firewall health status
+  //
+  // One of OK, WARNING, CRITICAL, or UNKNOWN.
+  healthStatus() string
 }
 
 // Oracle Cloud Infrastructure (OCI) network firewall policy
@@ -1693,6 +1699,8 @@ private oci.oke.cluster @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // Zero Trust Packet Routing security attributes on the cluster API endpoint
+  securityAttributes map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) OKE node pool

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -2424,6 +2424,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.firewall.timeUpdated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetTimeUpdated()).ToDataRes(types.Time)
 	},
+	"oci.networkFirewall.firewall.securityAttributes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetSecurityAttributes()).ToDataRes(types.Map(types.String, types.Dict))
+	},
+	"oci.networkFirewall.firewall.healthStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetHealthStatus()).ToDataRes(types.String)
+	},
 	"oci.networkFirewall.policy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -2501,6 +2507,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.oke.cluster.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
+	"oci.oke.cluster.securityAttributes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeCluster).GetSecurityAttributes()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.oke.nodePool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetId()).ToDataRes(types.String)
@@ -6794,6 +6803,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallFirewall).TimeUpdated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.networkFirewall.firewall.securityAttributes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).SecurityAttributes, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.networkFirewall.firewall.healthStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).HealthStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"oci.networkFirewall.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).__id, ok = v.Value.(string)
 		return
@@ -6908,6 +6925,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.oke.cluster.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeCluster).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.oke.cluster.securityAttributes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeCluster).SecurityAttributes, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.oke.nodePool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16505,17 +16526,19 @@ type mqlOciNetworkFirewallFirewall struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciNetworkFirewallFirewallInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Subnet        plugin.TValue[*mqlOciNetworkSubnet]
-	Policy        plugin.TValue[*mqlOciNetworkFirewallPolicy]
-	Ipv4Address   plugin.TValue[string]
-	Ipv6Address   plugin.TValue[string]
-	Shape         plugin.TValue[string]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	TimeUpdated   plugin.TValue[*time.Time]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	CompartmentID      plugin.TValue[string]
+	Subnet             plugin.TValue[*mqlOciNetworkSubnet]
+	Policy             plugin.TValue[*mqlOciNetworkFirewallPolicy]
+	Ipv4Address        plugin.TValue[string]
+	Ipv6Address        plugin.TValue[string]
+	Shape              plugin.TValue[string]
+	State              plugin.TValue[string]
+	Created            plugin.TValue[*time.Time]
+	TimeUpdated        plugin.TValue[*time.Time]
+	SecurityAttributes plugin.TValue[map[string]any]
+	HealthStatus       plugin.TValue[string]
 }
 
 // createOciNetworkFirewallFirewall creates a new instance of this resource
@@ -16621,6 +16644,16 @@ func (c *mqlOciNetworkFirewallFirewall) GetCreated() *plugin.TValue[*time.Time] 
 
 func (c *mqlOciNetworkFirewallFirewall) GetTimeUpdated() *plugin.TValue[*time.Time] {
 	return &c.TimeUpdated
+}
+
+func (c *mqlOciNetworkFirewallFirewall) GetSecurityAttributes() *plugin.TValue[map[string]any] {
+	return &c.SecurityAttributes
+}
+
+func (c *mqlOciNetworkFirewallFirewall) GetHealthStatus() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.HealthStatus, func() (string, error) {
+		return c.healthStatus()
+	})
 }
 
 // mqlOciNetworkFirewallPolicy for the oci.networkFirewall.policy resource
@@ -16790,6 +16823,7 @@ type mqlOciOkeCluster struct {
 	Created                     plugin.TValue[*time.Time]
 	FreeformTags                plugin.TValue[map[string]any]
 	DefinedTags                 plugin.TValue[map[string]any]
+	SecurityAttributes          plugin.TValue[map[string]any]
 }
 
 // createOciOkeCluster creates a new instance of this resource
@@ -16935,6 +16969,10 @@ func (c *mqlOciOkeCluster) GetFreeformTags() *plugin.TValue[map[string]any] {
 
 func (c *mqlOciOkeCluster) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciOkeCluster) GetSecurityAttributes() *plugin.TValue[map[string]any] {
+	return &c.SecurityAttributes
 }
 
 // mqlOciOkeNodePool for the oci.oke.nodePool resource

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -923,11 +923,13 @@ oci.networkFirewall 13.0.6
 oci.networkFirewall.firewall 13.0.6
 oci.networkFirewall.firewall.compartmentID 13.0.6
 oci.networkFirewall.firewall.created 13.0.6
+oci.networkFirewall.firewall.healthStatus 13.8.2
 oci.networkFirewall.firewall.id 13.0.6
 oci.networkFirewall.firewall.ipv4Address 13.0.6
 oci.networkFirewall.firewall.ipv6Address 13.0.6
 oci.networkFirewall.firewall.name 13.0.6
 oci.networkFirewall.firewall.policy 13.0.6
+oci.networkFirewall.firewall.securityAttributes 13.8.2
 oci.networkFirewall.firewall.shape 13.0.6
 oci.networkFirewall.firewall.state 13.0.6
 oci.networkFirewall.firewall.subnet 13.0.6
@@ -992,6 +994,7 @@ oci.oke.cluster.name 13.0.6
 oci.oke.cluster.nodePools 13.0.6
 oci.oke.cluster.privateEndpoint 13.0.6
 oci.oke.cluster.publicEndpoint 13.0.6
+oci.oke.cluster.securityAttributes 13.8.2
 oci.oke.cluster.state 13.0.6
 oci.oke.cluster.type 13.0.6
 oci.oke.cluster.vcn 13.0.6

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -97,8 +97,10 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 
 				// Extract endpoint config
 				var isPublicEndpointEnabled bool
+				var securityAttributes map[string]any
 				if cluster.EndpointConfig != nil {
 					isPublicEndpointEnabled = boolValue(cluster.EndpointConfig.IsPublicIpEnabled)
+					securityAttributes = definedTagsToAny(cluster.EndpointConfig.SecurityAttributes)
 				}
 
 				// Extract endpoints
@@ -151,6 +153,7 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 					"created":                     llx.TimeDataPtr(created),
 					"freeformTags":                llx.MapData(freeformTags, types.String),
 					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"securityAttributes":          llx.MapData(securityAttributes, types.Dict),
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
## What

The `oci-go-sdk/v65` **v65.116.0** bump (PR #8079) added Zero Trust Packet Routing (ZPR) security attributes and a network firewall health-status endpoint. This surfaces those on the OCI resources we already model:

| Resource | New field | Source |
|---|---|---|
| `oci.networkFirewall.firewall` | `securityAttributes map[string]dict` | `NetworkFirewallSummary.SecurityAttributes` (new in 65.116.0) |
| `oci.networkFirewall.firewall` | `healthStatus() string` | `GetNetworkFirewallHealthStatus` → `OK` / `WARNING` / `CRITICAL` / `UNKNOWN` (new API in 65.116.0) |
| `oci.oke.cluster` | `securityAttributes map[string]dict` | `ClusterEndpointConfig.SecurityAttributes` (new ZPR attrs in 65.116.0) |

## Why

ZPR security attributes are the labels that ZPR policies reference to control access to supported resources — useful audit surface for tenancies adopting Zero Trust Packet Routing. The firewall health status gives at-a-glance operational posture for next-gen firewall deployments.

## Notes

- `securityAttributes` is read straight from the list summaries — no extra API calls.
- `healthStatus()` is a computed field (one `GetNetworkFirewallHealthStatus` call per firewall, only when queried); the firewall now caches its region for the client.
- `.lr.versions` entries land at `13.8.2` (next patch after the provider's current `13.8.1`).
- The SDK additions for GoldenGate, Data Science, Cluster Placement Groups, and Exadata VM clusters target services/resources this provider doesn't model, so they're out of scope here.

## Test plan

- [x] `go build ./...` (oci provider)
- [x] `go test ./resources/...` (oci provider)
- [x] `make providers/build/oci` regenerates cleanly (no diff drift)
- [ ] Interactive verification against a live OCI tenancy with a deployed network firewall / OKE cluster