### PR TITLE
✨ vsphere: surface host runtime state (bootTime, inMaintenanceMode, rebootRequired)

### DIFF
--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -86,6 +86,9 @@ type stagedHost struct {
 	firewallIncomingBlocked bool
 	firewallOutgoingBlocked bool
 	secureBootEnabled       bool
+	bootTime                *time.Time
+	inMaintenanceMode       bool
+	rebootRequired          bool
 	vendor                  string
 	model                   string
 	cpuMhz                  int64
@@ -129,6 +132,7 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 				s.tags = extractTagKeys(hostInfo.Tag)
 			}
 			s.lockdownMode, s.firewallIncomingBlocked, s.firewallOutgoingBlocked, s.secureBootEnabled = hostHardeningArgs(hostInfo)
+			s.bootTime, s.inMaintenanceMode, s.rebootRequired = hostRuntimeArgs(hostInfo)
 			if hostInfo != nil {
 				hw := hostInfo.Summary.Hardware
 				if hw != nil {
@@ -160,6 +164,9 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 			"firewallIncomingBlocked": llx.BoolData(s.firewallIncomingBlocked),
 			"firewallOutgoingBlocked": llx.BoolData(s.firewallOutgoingBlocked),
 			"secureBootEnabled":       llx.BoolData(s.secureBootEnabled),
+			"bootTime":                llx.TimeDataPtr(s.bootTime),
+			"inMaintenanceMode":       llx.BoolData(s.inMaintenanceMode),
+			"rebootRequired":          llx.BoolData(s.rebootRequired),
 			"vendor":                  llx.StringData(s.vendor),
 			"model":                   llx.StringData(s.model),
 			"cpuMhz":                  llx.IntData(s.cpuMhz),

--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -68,6 +68,19 @@ func hostHardeningArgs(hostInfo *mo.HostSystem) (lockdownMode string, firewallIn
 	return
 }
 
+// hostRuntimeArgs extracts operational state from mo.HostSystem: the last-boot
+// timestamp and maintenance-mode flag from HostRuntimeInfo, and the pending-reboot
+// flag from the host summary (set when a staged patch or VIB install needs a reboot).
+func hostRuntimeArgs(hostInfo *mo.HostSystem) (bootTime *time.Time, inMaintenanceMode, rebootRequired bool) {
+	if hostInfo == nil {
+		return
+	}
+	bootTime = hostInfo.Runtime.BootTime
+	inMaintenanceMode = hostInfo.Runtime.InMaintenanceMode
+	rebootRequired = hostInfo.Summary.RebootRequired
+	return
+}
+
 func initVsphereHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil
@@ -90,6 +103,7 @@ func initVsphereHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	lockdownMode, firewallIncomingBlocked, firewallOutgoingBlocked, secureBootEnabled := hostHardeningArgs(hostInfo)
+	bootTime, inMaintenanceMode, rebootRequired := hostRuntimeArgs(hostInfo)
 
 	args["moid"] = llx.StringData(h.Reference().Encode())
 	args["name"] = llx.StringData(name)
@@ -99,6 +113,9 @@ func initVsphereHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["firewallIncomingBlocked"] = llx.BoolData(firewallIncomingBlocked)
 	args["firewallOutgoingBlocked"] = llx.BoolData(firewallOutgoingBlocked)
 	args["secureBootEnabled"] = llx.BoolData(secureBootEnabled)
+	args["bootTime"] = llx.TimeDataPtr(bootTime)
+	args["inMaintenanceMode"] = llx.BoolData(inMaintenanceMode)
+	args["rebootRequired"] = llx.BoolData(rebootRequired)
 
 	return args, nil, nil
 }

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -455,6 +455,12 @@ private vsphere.host @defaults("moid name") {
   firewallOutgoingBlocked bool
   // Whether the host firmware reports UEFI Secure Boot was used during system boot (requires vSphere 8.0.3 or later)
   secureBootEnabled bool
+  // Last time the host booted; zero time if vCenter has never observed a boot
+  bootTime time
+  // Whether the host is currently in maintenance mode
+  inMaintenanceMode bool
+  // Whether the host needs a reboot to finish a pending configuration change (e.g. a staged patch or VIB install)
+  rebootRequired bool
   // Host SSL/TLS certificate
   certificate() vsphere.host.certificate
   // Hardware vendor (as reported by SMBIOS)

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -801,6 +801,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.host.secureBootEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetSecureBootEnabled()).ToDataRes(types.Bool)
 	},
+	"vsphere.host.bootTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetBootTime()).ToDataRes(types.Time)
+	},
+	"vsphere.host.inMaintenanceMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetInMaintenanceMode()).ToDataRes(types.Bool)
+	},
+	"vsphere.host.rebootRequired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetRebootRequired()).ToDataRes(types.Bool)
+	},
 	"vsphere.host.certificate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetCertificate()).ToDataRes(types.Resource("vsphere.host.certificate"))
 	},
@@ -2417,6 +2426,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.secureBootEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).SecureBootEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.bootTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).BootTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.inMaintenanceMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).InMaintenanceMode, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.rebootRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).RebootRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"vsphere.host.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5530,6 +5551,9 @@ type mqlVsphereHost struct {
 	FirewallIncomingBlocked plugin.TValue[bool]
 	FirewallOutgoingBlocked plugin.TValue[bool]
 	SecureBootEnabled       plugin.TValue[bool]
+	BootTime                plugin.TValue[*time.Time]
+	InMaintenanceMode       plugin.TValue[bool]
+	RebootRequired          plugin.TValue[bool]
 	Certificate             plugin.TValue[*mqlVsphereHostCertificate]
 	Vendor                  plugin.TValue[string]
 	Model                   plugin.TValue[string]
@@ -5778,6 +5802,18 @@ func (c *mqlVsphereHost) GetFirewallOutgoingBlocked() *plugin.TValue[bool] {
 
 func (c *mqlVsphereHost) GetSecureBootEnabled() *plugin.TValue[bool] {
 	return &c.SecureBootEnabled
+}
+
+func (c *mqlVsphereHost) GetBootTime() *plugin.TValue[*time.Time] {
+	return &c.BootTime
+}
+
+func (c *mqlVsphereHost) GetInMaintenanceMode() *plugin.TValue[bool] {
+	return &c.InMaintenanceMode
+}
+
+func (c *mqlVsphereHost) GetRebootRequired() *plugin.TValue[bool] {
+	return &c.RebootRequired
 }
 
 func (c *mqlVsphereHost) GetCertificate() *plugin.TValue[*mqlVsphereHostCertificate] {

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -146,6 +146,7 @@ vsphere.host.bootInfo.biosVersion 13.1.1
 vsphere.host.bootInfo.bootTime 13.1.1
 vsphere.host.bootInfo.firmwareMajorRelease 13.1.1
 vsphere.host.bootInfo.firmwareMinorRelease 13.1.1
+vsphere.host.bootTime 13.2.5
 vsphere.host.certificate 13.0.12
 vsphere.host.certificate.id 13.1.1
 vsphere.host.certificate.issuer 13.1.1
@@ -191,6 +192,7 @@ vsphere.host.firewallRuleset.required 13.1.1
 vsphere.host.firewallRuleset.rules 13.1.1
 vsphere.host.firewallRuleset.service 13.1.1
 vsphere.host.firewallRulesets 13.0.12
+vsphere.host.inMaintenanceMode 13.2.5
 vsphere.host.inventoryPath 9.0.0
 vsphere.host.ipRouteConfig 13.1.1
 vsphere.host.ipRouteConfig.defaultGateway 13.1.1
@@ -232,6 +234,7 @@ vsphere.host.ntpConfig.server 13.1.1
 vsphere.host.numCpuCores 13.0.12
 vsphere.host.packages 9.0.0
 vsphere.host.properties 9.0.0
+vsphere.host.rebootRequired 13.2.5
 vsphere.host.secureBootEnabled 13.0.10
 vsphere.host.service 13.1.1
 vsphere.host.service.key 13.1.1


### PR DESCRIPTION
## What

Adds three operational-state fields to `vsphere.host`:

| Field | Type | Source |
|---|---|---|
| `bootTime` | `time` | `HostSystem.Runtime.BootTime` — last host power-on |
| `inMaintenanceMode` | `bool` | `HostSystem.Runtime.InMaintenanceMode` |
| `rebootRequired` | `bool` | `HostSystem.Summary.RebootRequired` — staged patch/VIB install pending a reboot |

## Why

`vsphere.host` previously exposed hardware, security, and network state but no operational/runtime state. These three let audits:

- scope queries to connected, non-maintenance hosts,
- flag hosts that have a pending reboot (e.g. a staged patch awaiting completion),
- report last-boot time directly on the host (previously only reachable via the lazy `vsphere.host.bootInfo` sub-resource).

## Implementation

- New `hostRuntimeArgs` helper in `host.go` extracts the three values from `*mo.HostSystem`, mirroring the existing `hostHardeningArgs` pattern.
- Wired into **both** host creation paths: direct ESXi connect (`initVsphereHost`) and vCenter discovery (`newVsphereHostResources`, via the `stagedHost` struct).
- No new API calls — the data already comes back in the existing `HostInfo` property fetch, so `permissions.json` is unchanged.
- `.lr.versions` entries added at `13.2.5`.

## Testing

- `./mqlr generate` is clean; provider module builds.
- Verification against a live vCenter/ESXi target still pending (no test target wired into this environment) — e.g. `cnspec shell vsphere -c "vsphere.datacenters{ hosts { name bootTime inMaintenanceMode rebootRequired } }"`.