### PR TITLE
🟢 gcp: add cloudfunctions.iamPolicy.get to validated permissions list

### DIFF
--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -81,6 +81,7 @@ var validatedGCPPermissions = []string{
 	"clouddeploy.releases.list",
 	"clouddeploy.targets.list",
 	"cloudfunctions.functions.list",
+	"cloudfunctions.iamPolicy.get",
 	"cloudidentity.groups.list",
 	"cloudidentity.memberships.list",
 	"cloudkms.cryptoKeyVersions.list",


### PR DESCRIPTION
## What

Fixes the failing `TestGCPPermissionsMatchValidatedList` on `main` (also fails on every open PR's CI as a result).

## Why

The cloud functions `iamPolicy()` accessors call `GetIamPolicy`:
- `providers/gcp/resources/cloud_functions.go:271`
- `providers/gcp/resources/cloud_functions_v2.go:185`

so `cloudfunctions.iamPolicy.get` is legitimately emitted into the generated `gcp.permissions.json` manifest. The hand-maintained `validatedGCPPermissions` list in `permissions_test.go` was never updated to include it, so the test — which asserts the manifest exactly matches the validated list — fails:

```
--- FAIL: TestGCPPermissionsMatchValidatedList
    permissions_test.go:318: unexpected permissions in manifest (not in validated list):
    permissions_test.go:320:   - cloudfunctions.iamPolicy.get
```

This looks like fallout from #8105 (gcp functions fields), which added/relied on the IAM-policy call without syncing the validated list.

## Change

Add `cloudfunctions.iamPolicy.get` to `validatedGCPPermissions` (alphabetical position, right after `cloudfunctions.functions.list`).

## Testing

```
go test ./resources/ -run TestGCPPermissionsMatchValidatedList   # ok
```
Reproduced the failure before the change and confirmed it passes after.