### PR TITLE
🟢 oci: shorten over-long ipAddresses doc-comment title

### DIFF
--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -1609,7 +1609,11 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   shape string
   // Whether the load balancer is private (no public IP)
   isPrivate bool
-  // Assigned IP addresses, each with an `ipAddress`, an `isPublic` flag indicating internet reachability, and a `reservedIpId` (the oci.network.publicIp OCID) when the address is backed by a reserved public IP
+  // Assigned IP addresses
+  //
+  // Each entry is a dict with an `ipAddress`, an `isPublic` flag indicating
+  // internet reachability, and a `reservedIpId` (the oci.network.publicIp
+  // OCID) when the address is backed by a reserved public IP.
   ipAddresses []dict
   // Whether delete protection is enabled
   isDeleteProtectionEnabled bool


### PR DESCRIPTION
## What

Fixes the `go-test` CI job failing on `main` (and therefore on every open PR, e.g. #8110):

```
field oci.loadBalancer.loadBalancer.ipAddresses: doc-comment title is 205 characters (line 1612), max is 150
make: *** [Makefile:260: providers/build/oci] Error 1
```

## Why

The `ipAddresses` field (added in #8108) used a single long doc-comment line. The schema generator treats line 1 of a doc-comment as the **title**, which is capped at 150 characters (`lrcore.MaxTitleLength`) and validated at parse time — so the over-long line aborts `make providers/build/oci`. Because the `go-test` job builds every provider, this fails CI on unrelated PRs too.

## Change

Split the one-liner into the required two-part doc-comment form — a short title plus the dict-shape detail in the description:

```
// Assigned IP addresses
//
// Each entry is a dict with an `ipAddress`, an `isPublic` flag indicating
// internet reachability, and a `reservedIpId` (the oci.network.publicIp
// OCID) when the address is backed by a reserved public IP.
ipAddresses []dict
```

No schema/behavior change — same field, same dict shape; only the doc-comment is reshaped to satisfy the title-length rule.

## Testing

- `./mqlr generate providers/oci/resources/oci.lr` — succeeds (previously aborted on the title check).
- `make`-equivalent provider build + `go test ./providers/oci/resources/...` — pass.