### PR TITLE
🎉 jamf-13.1.0, digitalocean-13.5.0, oci-13.9.0, vsphere-13.3.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.4.1",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/providers/jamf",
-	Version:         "13.0.2",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.8.1",
+	Version:         "13.9.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.2.4",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release bumps four providers to new **minor** versions, picking up the resource and field additions merged since their last release.

## jamf 13.0.2 → 13.1.0
- ✨ add policy, script, and restricted software resources (#8104)
- ✨ expand `jamf.package` fields and add typed `parentPackage` reference (#8101)

## digitalocean 13.4.1 → 13.5.0
- ✨ add typed cross-references for single-query traversal (#8103)
- ✨ add security scan resources (#8102)
- ✨ add GenAI (GradientAI) platform resources (#8099)
- ✨ add NAT gateways, NFS shares, reserved IPv6, and autoscale pools (#8098)
- ✨ add managed vector database resources (#8097)

## oci 13.8.1 → 13.9.0
- ✨ surface public-exposure signals (PARs, public IPs, public DB endpoints, LB IPs) (#8108)
- ✨ surface ZPR security attributes and network firewall health status (#8106)
- 🟢 shorten over-long `ipAddresses` doc-comment title (#8114)

## vsphere 13.2.4 → 13.3.0
- ✨ surface host runtime state (`bootTime`, `inMaintenanceMode`, `rebootRequired`) (#8107)

---

Generated with mql's provider versioning bot (`providers-sdk/v1/util/version`); changelog curated from the commits landed since each provider's prior release.
