### PR TITLE
🎉 ms365-13.2.0, huggingface-13.1.0, gcp-13.20.0, aws-13.31.0, vsphere-13.4.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.30.0",
+	Version:         "13.31.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.19.1",
+	Version: "13.20.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "huggingface",
 	ID:              "go.mondoo.com/mql/providers/huggingface",
-	Version:         "13.0.1",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.3.0",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Bumps five providers to new minor release versions.

| Provider | Old | New |
| --- | --- | --- |
| ms365 | 13.1.0 | 13.2.0 |
| huggingface | 13.0.1 | 13.1.0 |
| gcp | 13.19.1 | 13.20.0 |
| aws | 13.30.0 | 13.31.0 |
| vsphere | 13.3.0 | 13.4.0 |

## Changes since last release

### ms365 13.2.0
- ⚡ ms365: batch per-item Graph calls via the `$batch` endpoint (#7738)
- ⚡ ms365: cut N+1 Graph calls on hot paths (#7974)
- 🧹 Update deps for mql and providers 20260601 (#8079)

### huggingface 13.1.0
- ✨ huggingface: add namespace flags and computed author/sha fields (#7966)
- 🧹 Update deps for mql and providers 20260601 (#8079)

### gcp 13.20.0
- ✨ gcp: encryption, IAM-exposure, and public-exposure fields across many services (#8109)
- ✨ gcp: security-relevant fields across compute, functions, gke, and alloydb (#8105)
- ✨ gcp: privateca CA pool CMEK key + certificate requested not-before time (#8100)
- 🟢 gcp: add `cloudfunctions.iamPolicy.get` to validated permissions list (#8113)
- 🧹 Update deps for mql and providers 20260601 (#8079)

### aws 13.31.0
- ✨ aws: typed Route 53 Resolver DNS Firewall rules + richer domain lists (#8096)

### vsphere 13.4.0
- ✨ vsphere: surface vSAN cluster, host, and disk-group configuration (#8110)
