### PR TITLE
🧹 llx: enrich executor panics with ref/expression context

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -465,12 +465,10 @@ func blockV2(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error
 	if len(f.Args) != 1 {
 		return nil, 0, errors.New("Called block with " + strconv.Itoa(len(f.Args)) + " arguments, expected 1")
 	}
-	panic("NOT YET BLOCK CALL")
-	// res, dref, err := c.resolveValue(f.Args[0], ref)
-	// if res != nil && res.Type[0] != types.Bool {
-	// 	return nil, 0, errors.New("called expect body with wrong type, it should be a boolean (type mismatch)")
-	// }
-	// return res, dref, err
+	// This handler is registered for "{}" but was never implemented. Return a
+	// contextual error instead of panicking so a query that reaches it fails
+	// gracefully and identifiably rather than crashing the executor.
+	return nil, 0, errors.New("block call is not implemented: " + e.refContext(ref))
 }
 
 func returnCallV2(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error) {

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -780,19 +780,33 @@ func (p *Primitive) RawData() *RawData {
 
 func (b *blockExecutor) lookupValue(ref uint64) (*RawData, uint64, error) {
 	if b == nil {
-		panic("value not computed")
+		// Unreachable in practice: callers check parent != nil before
+		// recursing and panic with full context there. Kept as a last-resort
+		// guard so we never nil-deref silently if a new caller is added.
+		panic("value not computed (ref=" + strconv.FormatUint(ref, 10) + ", no block executor)")
 	}
 
 	res, ok := b.cache.Load(ref)
-	if !ok {
-		return b.parent.lookupValue(ref)
+	if ok {
+		return res.Result, 0, res.Result.Error
 	}
-	return res.Result, 0, res.Result.Error
+
+	if b.parent == nil {
+		// We walked the whole parent chain without finding the value. This is
+		// the "value not computed" case: a ref points to something that should
+		// have been computed before this point but wasn't. Panic here, while we
+		// still hold a valid executor, so the report can identify the ref.
+		panic("value not computed: " + b.refContext(ref))
+	}
+	return b.parent.lookupValue(ref)
 }
 
 func (b *blockExecutor) resolveRef(srcRef uint64, ref uint64) (*RawData, uint64, error) {
 	if !b.isInMyBlock(srcRef) {
 		// the value is provided by a parent
+		if b.parent == nil {
+			panic("value not computed: " + b.refContext(srcRef))
+		}
 		return b.parent.lookupValue(srcRef)
 	} else {
 		// check if the reference exists; if not connect it
@@ -802,6 +816,70 @@ func (b *blockExecutor) resolveRef(srcRef uint64, ref uint64) (*RawData, uint64,
 		}
 		return res.Result, 0, res.Result.Error
 	}
+}
+
+// refContext builds a human-readable description of a ref for panic and error
+// reporting. Reports like "value not computed" are otherwise opaque: this adds
+// the block/chunk coordinates, the code checksum, and a compact, source-like
+// reconstruction of the expression (e.g. "aws.ec2.instances.where.==") so the
+// failing query can be identified from a crash report alone.
+//
+// It is deliberately defensive: a corrupt or out-of-range ref must never turn a
+// useful panic into a second index/nil-deref panic, so all chunk lookups run
+// under a recover. It intentionally never renders primitive values, only chunk
+// IDs and types, to avoid leaking query literals into upstream crash reports.
+func (b *blockExecutor) refContext(ref uint64) (desc string) {
+	desc = fmt.Sprintf("ref=%d:%d", ref>>32, uint32(ref))
+
+	defer func() {
+		if r := recover(); r != nil {
+			desc += fmt.Sprintf(" (further context unavailable: %v)", r)
+		}
+	}()
+
+	if b.ctx != nil && b.ctx.code != nil {
+		if b.ctx.code.Id != "" {
+			desc += " codeID=" + b.ctx.code.Id
+		}
+		if cs := b.ctx.code.Checksums[ref]; cs != "" {
+			desc += " checksum=" + cs
+		}
+		desc += " expr=" + b.describeRef(ref, 8)
+	}
+	desc += " executor=" + b.id
+	return desc
+}
+
+// describeRef reconstructs a compact, source-like description of a ref by
+// walking its function binding chain (most-bound first, e.g.
+// "aws.ec2.instances.where.=="). Best-effort and bounded by maxDepth. Callers
+// must run this under a recover (see refContext) since chunk lookups can index
+// out of range for a malformed ref.
+func (b *blockExecutor) describeRef(ref uint64, maxDepth int) string {
+	if ref == 0 {
+		return ""
+	}
+	if maxDepth <= 0 {
+		return "…"
+	}
+
+	chunk := b.ctx.code.Chunk(ref)
+	if chunk == nil {
+		return "?"
+	}
+
+	name := chunk.Id
+	if name == "" {
+		// A primitive (or unnamed) chunk; never render its value.
+		name = "<" + chunk.Type().Label() + ">"
+	}
+
+	if chunk.Function != nil && chunk.Function.Binding != 0 {
+		if prefix := b.describeRef(chunk.Function.Binding, maxDepth-1); prefix != "" {
+			return prefix + "." + name
+		}
+	}
+	return name
 }
 
 // returns the resolved argument if it's a ref; otherwise just the argument

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -313,10 +313,10 @@ func (b *blockExecutor) isInMyBlock(ref uint64) bool {
 func (b *blockExecutor) mustLookup(ref uint64) *RawData {
 	d, _, err := b.parent.lookupValue(ref)
 	if err != nil {
-		panic(err)
+		panic("datapoint lookup failed: " + b.refContext(ref) + ": " + err.Error())
 	}
 	if d == nil {
-		panic("did not lookup datapoint")
+		panic("did not lookup datapoint: " + b.refContext(ref))
 	}
 	return d
 }
@@ -575,7 +575,8 @@ func (b *blockExecutor) runFunctionBlock(args []*RawData, blockRef uint64, cb Re
 	b.ctx.addBlockExecutor(executor)
 
 	if len(args) < int(executor.block.Parameters) {
-		panic("not enough arguments")
+		panic("not enough arguments for block " + strconv.FormatUint(blockRef>>32, 10) +
+			": got " + strconv.Itoa(len(args)) + ", want " + strconv.Itoa(int(executor.block.Parameters)))
 	}
 
 	for i := int32(0); i < executor.block.Parameters; i++ {
@@ -760,7 +761,7 @@ func (b *blockExecutor) runGlobalFunction(chunk *Chunk, f *Function, ref uint64)
 // connect references, calling `dst` if `src` is updated
 func (b *blockExecutor) connectRef(src uint64, dst uint64) (*RawData, uint64, error) {
 	if !b.isInMyBlock(src) || !b.isInMyBlock(dst) {
-		panic("cannot connect refs across block boundaries")
+		panic("cannot connect refs across block boundaries: src=(" + b.refContext(src) + ") dst=(" + b.refContext(dst) + ")")
 	}
 	// connect the ref. If it is already connected, someone else already made this
 	// call, so we don't have to follow up anymore
@@ -951,7 +952,7 @@ func (e *blockExecutor) triggerChain(ref uint64, data *RawData) {
 	nxt, ok := e.calls.Load(ref)
 	if ok {
 		if len(nxt) == 0 {
-			panic("internal state error: cannot trigger next call on chain because it points to a zero ref")
+			panic("internal state error: cannot trigger next call on chain because it points to a zero ref: " + e.refContext(ref))
 		}
 		for i := range nxt {
 			e.runChain(nxt[i])
@@ -992,7 +993,7 @@ func (e *blockExecutor) triggerChainError(ref uint64, err error) {
 			remaining = remaining[1:]
 		}
 		if len(nxt) == 0 {
-			panic("internal state error: cannot trigger next call on chain because it points to a zero ref")
+			panic("internal state error: cannot trigger next call on chain because it points to a zero ref: " + e.refContext(cur))
 		}
 		cur = nxt[0]
 		remaining = append(remaining, nxt[1:]...)

--- a/llx/refcontext_test.go
+++ b/llx/refcontext_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/v13/types"
+)
+
+// ref builds an absolute ref from a 1-based block and chunk index.
+func ref(block, chunk uint32) uint64 {
+	return (uint64(block) << 32) | uint64(chunk)
+}
+
+func testExecutor() *blockExecutor {
+	code := &CodeV2{
+		Id: "testcode",
+		Blocks: []*Block{
+			{Chunks: []*Chunk{
+				{Call: Chunk_FUNCTION, Id: "aws.ec2.instances", Function: &Function{Type: string(types.Array(types.Resource("aws.ec2.instance")))}},
+				{Call: Chunk_FUNCTION, Id: "where", Function: &Function{Type: string(types.Array(types.Resource("aws.ec2.instance"))), Binding: ref(1, 1)}},
+				{Call: Chunk_FUNCTION, Id: "==", Function: &Function{Type: string(types.Bool), Binding: ref(1, 2)}},
+			}},
+		},
+		Checksums: map[uint64]string{
+			ref(1, 3): "abc123",
+		},
+	}
+	exec := &MQLExecutorV2{id: "exec-id", code: code}
+	return &blockExecutor{id: "exec-id/1", blockRef: ref(1, 0), ctx: exec}
+}
+
+func TestRefContext(t *testing.T) {
+	b := testExecutor()
+	got := b.refContext(ref(1, 3))
+
+	for _, want := range []string{
+		"ref=1:3",
+		"codeID=testcode",
+		"checksum=abc123",
+		"expr=aws.ec2.instances.where.==",
+		"executor=exec-id/1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("refContext() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestRefContextDefensive(t *testing.T) {
+	b := testExecutor()
+	// A ref pointing at a block that doesn't exist must not panic; it should
+	// still return the coordinates plus a graceful note.
+	got := b.refContext(ref(9, 9))
+
+	if !strings.Contains(got, "ref=9:9") {
+		t.Errorf("refContext() = %q, missing coordinates", got)
+	}
+	if !strings.Contains(got, "further context unavailable") {
+		t.Errorf("refContext() = %q, expected graceful recovery note", got)
+	}
+}
+
+func TestDescribeRefDepthBound(t *testing.T) {
+	b := testExecutor()
+	// maxDepth of 1 should stop before resolving the full chain.
+	got := b.describeRef(ref(1, 3), 1)
+	if !strings.Contains(got, "==") || !strings.Contains(got, "…") {
+		t.Errorf("describeRef(depth=1) = %q, expected truncated chain ending in '=='", got)
+	}
+}


### PR DESCRIPTION
## What

LLX executor panics were reported with opaque messages (e.g. `value not computed`) that gave no hint of which ref, chunk, or query expression caused them. This adds context to those panics so crash reports are actionable.

- New `refContext(ref)` / `describeRef` helpers on `blockExecutor` decode a ref into block/chunk coordinates, the code checksum, and a compact source-like expression (e.g. `aws.ec2.instances.where.==`).
- Helpers are defensive: all chunk lookups run under a `recover` so a malformed ref can't cause a second panic, and primitive values are never rendered (no query literals leak into upstream crash reports).
- Wired into the runtime panics that hold an executor + ref:
  - `lookupValue` / `resolveRef` (`value not computed`) — the exhausted-parent case is now detected *before* recursing into a nil executor, where context was otherwise lost.
  - `mustLookup` (`did not lookup datapoint` / propagated errors)
  - `connectRef` (`cannot connect refs across block boundaries`, now reports src + dst)
  - `triggerChain` / `triggerChainError` (`internal state error … zero ref`)
- `runFunctionBlock` now reports `got N, want M` argument counts.
- The registered-but-unimplemented `{}` block handler (`blockV2`) returned a panic (`NOT YET BLOCK CALL`); it now returns a contextual error so a query reaching it fails gracefully instead of crashing the executor.
- Added `llx/refcontext_test.go` covering the description, the defensive recover on an out-of-range ref, and depth bounding.

## Why

Most executor panics reported to us contain no useful information about what caused them. Enriching the panic value (which `health.ReportPanic` already serializes) with the failing ref/expression makes these reports diagnosable from the report alone.

## Test

`go build ./llx/`, `gofmt -l` clean, `go test ./llx/` passes (incl. new tests).