### PR TITLE
✨ Annotate Grafana on provider release

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -201,6 +201,33 @@ jobs:
             gsutil -m cp -c dist/${pkg}_provider.json gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/provider.json
           done
 
+      - name: "Annotate Grafana"
+        if: ${{ ! inputs.skip_publish }}
+        # Non-blocking: a Grafana failure must never fail a provider release, but
+        # we still want the step to go red so a broken token/URL is visible.
+        continue-on-error: true
+        env:
+          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+          GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
+        run: |
+          # PROVIDER/VERSION are cut from goreleaser dist filenames
+          # (name_version_os_arch.ext): a lowercase-alnum provider name and a
+          # semver, so manual JSON is safe. We avoid jq here because this job
+          # runs on the self-hosted runner where jq isn't guaranteed.
+          fail=0
+          for pkg in $(ls dist | cut -f1,2 -d_ | uniq); do
+            PROVIDER=$(echo $pkg | cut -f1 -d_)
+            VERSION=$(echo $pkg | cut -f2 -d_)
+            echo "Annotating Grafana: $PROVIDER $VERSION"
+            payload="{\"text\":\"${PROVIDER} provider ${VERSION} released\",\"tags\":[\"release\",\"provider\",\"${PROVIDER}\"]}"
+            curl -sS --fail -X POST "${GRAFANA_URL%/}/api/annotations" \
+              -H "Authorization: Bearer ${GRAFANA_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$payload" \
+              || { echo "::warning::Failed to annotate Grafana for ${PROVIDER} ${VERSION}"; fail=1; }
+          done
+          exit $fail
+
       - name: "Save Artifacts"
         if: ${{ inputs.skip_publish }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What

Emit an **org-level Grafana annotation** every time a provider is published, so provider releases show up on any Grafana dashboard.

Adds an `Annotate Grafana` step to the `provider-build` job in `.github/workflows/providers.yaml`, right after the existing GCS publish step. It reuses the same `dist`-filename loop, so each published provider gets one annotation:

- `POST ${GRAFANA_URL}/api/annotations` (no dashboardUID → organization-scoped)
- tags: `release`, `provider`, `<provider-name>`
- text: `<name> provider <version> released` (version lives in the text, not a tag)
- best-effort: a Grafana failure logs a `::warning::` and never fails the release
- gated on `! inputs.skip_publish` so dry-run dispatches don't annotate

## Why

We want a unified, org-wide timeline of what shipped when. Provider releases are not GitHub releases (they publish to `gs://releases-us.mondoo.io/...`), so the annotation hooks the publish step directly.

## Secrets (org-level, provided out of band)

- `GRAFANA_URL` — base URL, e.g. `https://mondoo.grafana.net`
- `GRAFANA_API_TOKEN` — service-account token with `annotations:write`