### PR TITLE
✨ openstack: expose Placement resource providers (GPU/accelerator inventory)

### DIFF
--- a/providers/openstack/connection/connection.go
+++ b/providers/openstack/connection/connection.go
@@ -51,6 +51,7 @@ type OpenstackConnection struct {
 	database         *gophercloud.ServiceClient
 	bareMetal        *gophercloud.ServiceClient
 	orchestration    *gophercloud.ServiceClient
+	placement        *gophercloud.ServiceClient
 
 	// Name->ID caches for Nova-reported references that Neutron/Compute
 	// expose only by ID. A non-nil map is the "ready" signal so we don't
@@ -370,5 +371,25 @@ func (c *OpenstackConnection) OrchestrationClient() (*gophercloud.ServiceClient,
 		return nil, fmt.Errorf("failed to initialize Heat client: %w", err)
 	}
 	c.orchestration = client
+	return client, nil
+}
+
+// placementMicroversion pins the Placement API microversion. 1.14 exposes the
+// nested-provider fields (`parent_provider_uuid`, `root_provider_uuid`) used to
+// walk provider trees; it has been available since OpenStack Rocky (2018).
+const placementMicroversion = "1.14"
+
+func (c *OpenstackConnection) PlacementClient() (*gophercloud.ServiceClient, error) {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+	if c.placement != nil {
+		return c.placement, nil
+	}
+	client, err := openstack.NewPlacementV1(c.provider, c.endpointOpts())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Placement client: %w", err)
+	}
+	client.Microversion = placementMicroversion
+	c.placement = client
 	return client, nil
 }

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -12,7 +12,8 @@ option go_package = "go.mondoo.com/mql/v13/providers/openstack/resources"
 // Keystone credentials and the service catalog (`credentials`, `trusts`,
 // `identityServices`, `identityEndpoints`, `regions`),
 // Nova compute assets (`servers`, `flavors`, `keypairs`, `serverGroups`,
-// `hypervisors`, `computeServices`, `aggregates`, `computeLimits`), Neutron
+// `hypervisors`, `computeServices`, `aggregates`, `computeLimits`), Placement
+// resource inventory (`resourceProviders`), Neutron
 // networking (`networks`, `subnets`, `routers`, `ports`, `floatingIps`,
 // `securityGroups`, `subnetPools`, `qosPolicies`, `trunks`), FWaaS v2
 // (`firewallGroups`, `firewallPolicies`, `firewallRules`), Cinder block storage
@@ -71,6 +72,8 @@ openstack {
   aggregates() []openstack.compute.aggregate
   // Per-project Nova resource limits and current usage
   computeLimits() openstack.compute.limits
+  // Placement resource providers (compute nodes, storage pools, and accelerator/GPU devices) with their inventory and traits
+  resourceProviders() []openstack.placement.resourceProvider
   // Per-project Cinder quota
   blockStorageQuotaSet() openstack.blockstorage.quotaSet
   // Per-project Neutron quota
@@ -1864,6 +1867,39 @@ private openstack.compute.limits @defaults("maxTotalInstances totalInstancesUsed
   maxPersonality int
   // Maximum personality file content size in bytes (legacy)
   maxPersonalitySize int
+}
+
+// OpenStack Placement resource provider
+//
+// Examine a Placement resource provider — a source of consumable inventory
+// such as a compute node, a shared storage pool, or an accelerator device
+// (GPU/FPGA). Select a provider by its `id` (UUID). Query `inventories` and
+// `traits` to audit accelerator capacity — for example the `VGPU` / `PGPU`
+// resource classes and `HW_GPU_*` traits — and how much of each class is
+// already allocated. Walk `parent` and `root` to traverse nested provider
+// trees, such as a compute node with child GPU providers.
+private openstack.placement.resourceProvider @defaults("id name generation") {
+  init(id? string)
+  // Resource provider ID (UUID)
+  id string
+  // Resource provider name (often the compute host name, or a device name for child providers)
+  name string
+  // Consistency-view generation marker (increments as the provider's inventory/allocations change)
+  generation int
+  // Capability traits advertised by this provider
+  //
+  // Standardized (`HW_GPU_*`, `HW_CPU_*`, `STORAGE_DISK_SSD`, ...) and operator-defined (`CUSTOM_*`) qualitative markers used by the scheduler to place workloads.
+  traits() []string
+  // Inventory lines, one per resource class
+  //
+  // Each entry has `resource_class` (for example `VCPU`, `MEMORY_MB`, `DISK_GB`, `VGPU`, `PGPU`, or a `CUSTOM_*` device class) plus `total`, `reserved`, `allocation_ratio`, `min_unit`, `max_unit`, `step_size`, and `used` (the amount of that class currently allocated against this provider).
+  inventories() []dict
+  // Placement aggregate UUIDs this provider belongs to
+  aggregates() []string
+  // Immediate parent provider in a nested tree; null for a top-level provider
+  parent() openstack.placement.resourceProvider
+  // Top-most provider in this provider's tree (itself for a top-level provider)
+  root() openstack.placement.resourceProvider
 }
 
 // OpenStack Cinder block-storage quota for the scoped project (configured maximums; usage values are not exposed by the default API path).

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -71,6 +71,7 @@ const (
 	ResourceOpenstackIdentityRegion                  string = "openstack.identity.region"
 	ResourceOpenstackComputeAggregate                string = "openstack.compute.aggregate"
 	ResourceOpenstackComputeLimits                   string = "openstack.compute.limits"
+	ResourceOpenstackPlacementResourceProvider       string = "openstack.placement.resourceProvider"
 	ResourceOpenstackBlockstorageQuotaSet            string = "openstack.blockstorage.quotaSet"
 	ResourceOpenstackNetworkQuotaSet                 string = "openstack.network.quotaSet"
 	ResourceOpenstackKeymanagerAcl                   string = "openstack.keymanager.acl"
@@ -310,6 +311,10 @@ func init() {
 			// to override args, implement: initOpenstackComputeLimits(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createOpenstackComputeLimits,
 		},
+		"openstack.placement.resourceProvider": {
+			Init:   initOpenstackPlacementResourceProvider,
+			Create: createOpenstackPlacementResourceProvider,
+		},
 		"openstack.blockstorage.quotaSet": {
 			// to override args, implement: initOpenstackBlockstorageQuotaSet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createOpenstackBlockstorageQuotaSet,
@@ -495,6 +500,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.computeLimits": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetComputeLimits()).ToDataRes(types.Resource("openstack.compute.limits"))
+	},
+	"openstack.resourceProviders": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstack).GetResourceProviders()).ToDataRes(types.Array(types.Resource("openstack.placement.resourceProvider")))
 	},
 	"openstack.blockStorageQuotaSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetBlockStorageQuotaSet()).ToDataRes(types.Resource("openstack.blockstorage.quotaSet"))
@@ -2695,6 +2703,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.compute.limits.maxPersonalitySize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeLimits).GetMaxPersonalitySize()).ToDataRes(types.Int)
 	},
+	"openstack.placement.resourceProvider.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetId()).ToDataRes(types.String)
+	},
+	"openstack.placement.resourceProvider.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetName()).ToDataRes(types.String)
+	},
+	"openstack.placement.resourceProvider.generation": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetGeneration()).ToDataRes(types.Int)
+	},
+	"openstack.placement.resourceProvider.traits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetTraits()).ToDataRes(types.Array(types.String))
+	},
+	"openstack.placement.resourceProvider.inventories": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetInventories()).ToDataRes(types.Array(types.Dict))
+	},
+	"openstack.placement.resourceProvider.aggregates": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetAggregates()).ToDataRes(types.Array(types.String))
+	},
+	"openstack.placement.resourceProvider.parent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetParent()).ToDataRes(types.Resource("openstack.placement.resourceProvider"))
+	},
+	"openstack.placement.resourceProvider.root": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPlacementResourceProvider).GetRoot()).ToDataRes(types.Resource("openstack.placement.resourceProvider"))
+	},
 	"openstack.blockstorage.quotaSet.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageQuotaSet).GetProjectId()).ToDataRes(types.String)
 	},
@@ -3396,6 +3428,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.computeLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstack).ComputeLimits, ok = plugin.RawToTValue[*mqlOpenstackComputeLimits](v.Value, v.Error)
+		return
+	},
+	"openstack.resourceProviders": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstack).ResourceProviders, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"openstack.blockStorageQuotaSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6546,6 +6582,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackComputeLimits).MaxPersonalitySize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"openstack.placement.resourceProvider.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.placement.resourceProvider.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.generation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Generation, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.traits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Traits, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.inventories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Inventories, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.aggregates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Aggregates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Parent, ok = plugin.RawToTValue[*mqlOpenstackPlacementResourceProvider](v.Value, v.Error)
+		return
+	},
+	"openstack.placement.resourceProvider.root": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPlacementResourceProvider).Root, ok = plugin.RawToTValue[*mqlOpenstackPlacementResourceProvider](v.Value, v.Error)
+		return
+	},
 	"openstack.blockstorage.quotaSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackBlockstorageQuotaSet).__id, ok = v.Value.(string)
 		return
@@ -7452,6 +7524,7 @@ type mqlOpenstack struct {
 	ComputeServices         plugin.TValue[[]any]
 	Aggregates              plugin.TValue[[]any]
 	ComputeLimits           plugin.TValue[*mqlOpenstackComputeLimits]
+	ResourceProviders       plugin.TValue[[]any]
 	BlockStorageQuotaSet    plugin.TValue[*mqlOpenstackBlockstorageQuotaSet]
 	NetworkQuotaSet         plugin.TValue[*mqlOpenstackNetworkQuotaSet]
 	Networks                plugin.TValue[[]any]
@@ -7838,6 +7911,22 @@ func (c *mqlOpenstack) GetComputeLimits() *plugin.TValue[*mqlOpenstackComputeLim
 		}
 
 		return c.computeLimits()
+	})
+}
+
+func (c *mqlOpenstack) GetResourceProviders() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ResourceProviders, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack", c.__id, "resourceProviders")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resourceProviders()
 	})
 }
 
@@ -16016,6 +16105,120 @@ func (c *mqlOpenstackComputeLimits) GetMaxPersonality() *plugin.TValue[int64] {
 
 func (c *mqlOpenstackComputeLimits) GetMaxPersonalitySize() *plugin.TValue[int64] {
 	return &c.MaxPersonalitySize
+}
+
+// mqlOpenstackPlacementResourceProvider for the openstack.placement.resourceProvider resource
+type mqlOpenstackPlacementResourceProvider struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlOpenstackPlacementResourceProviderInternal
+	Id          plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Generation  plugin.TValue[int64]
+	Traits      plugin.TValue[[]any]
+	Inventories plugin.TValue[[]any]
+	Aggregates  plugin.TValue[[]any]
+	Parent      plugin.TValue[*mqlOpenstackPlacementResourceProvider]
+	Root        plugin.TValue[*mqlOpenstackPlacementResourceProvider]
+}
+
+// createOpenstackPlacementResourceProvider creates a new instance of this resource
+func createOpenstackPlacementResourceProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackPlacementResourceProvider{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.placement.resourceProvider", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) MqlName() string {
+	return "openstack.placement.resourceProvider"
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetGeneration() *plugin.TValue[int64] {
+	return &c.Generation
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetTraits() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Traits, func() ([]any, error) {
+		return c.traits()
+	})
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetInventories() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Inventories, func() ([]any, error) {
+		return c.inventories()
+	})
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetAggregates() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Aggregates, func() ([]any, error) {
+		return c.aggregates()
+	})
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetParent() *plugin.TValue[*mqlOpenstackPlacementResourceProvider] {
+	return plugin.GetOrCompute[*mqlOpenstackPlacementResourceProvider](&c.Parent, func() (*mqlOpenstackPlacementResourceProvider, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.placement.resourceProvider", c.__id, "parent")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackPlacementResourceProvider), nil
+			}
+		}
+
+		return c.parent()
+	})
+}
+
+func (c *mqlOpenstackPlacementResourceProvider) GetRoot() *plugin.TValue[*mqlOpenstackPlacementResourceProvider] {
+	return plugin.GetOrCompute[*mqlOpenstackPlacementResourceProvider](&c.Root, func() (*mqlOpenstackPlacementResourceProvider, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.placement.resourceProvider", c.__id, "root")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackPlacementResourceProvider), nil
+			}
+		}
+
+		return c.root()
+	})
 }
 
 // mqlOpenstackBlockstorageQuotaSet for the openstack.blockstorage.quotaSet resource

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -773,6 +773,15 @@ openstack.orchestration.stack.statusReason 13.1.4
 openstack.orchestration.stack.tags 13.1.4
 openstack.orchestration.stack.timeoutMinutes 13.1.4
 openstack.orchestration.stack.updatedAt 13.1.4
+openstack.placement.resourceProvider 13.2.2
+openstack.placement.resourceProvider.aggregates 13.2.2
+openstack.placement.resourceProvider.generation 13.2.2
+openstack.placement.resourceProvider.id 13.2.2
+openstack.placement.resourceProvider.inventories 13.2.2
+openstack.placement.resourceProvider.name 13.2.2
+openstack.placement.resourceProvider.parent 13.2.2
+openstack.placement.resourceProvider.root 13.2.2
+openstack.placement.resourceProvider.traits 13.2.2
 openstack.pools 13.0.1
 openstack.port 13.0.1
 openstack.port.adminStateUp 13.0.1
@@ -820,6 +829,7 @@ openstack.qosPolicy.tags 13.0.1
 openstack.qosPolicy.updatedAt 13.0.1
 openstack.region 13.0.1
 openstack.regions 13.1.4
+openstack.resourceProviders 13.2.2
 openstack.role 13.0.1
 openstack.role.description 13.0.1
 openstack.role.domain 13.0.1

--- a/providers/openstack/resources/placement.go
+++ b/providers/openstack/resources/placement.go
@@ -1,0 +1,200 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sort"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ---- openstack.placement.resourceProvider ----
+
+type mqlOpenstackPlacementResourceProviderInternal struct {
+	cacheParentUUID string
+	cacheRootUUID   string
+}
+
+func (r *mqlOpenstackPlacementResourceProvider) id() (string, error) {
+	return "openstack.placement.resourceProvider/" + r.Id.Data, nil
+}
+
+func initOpenstackPlacementResourceProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := stringArg(args, "id")
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	list := root.(*mqlOpenstack).GetResourceProviders()
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		rp := raw.(*mqlOpenstackPlacementResourceProvider)
+		if rp.Id.Data == id {
+			return args, rp, nil
+		}
+	}
+	initSyntheticID("openstack.placement.resourceProvider", "id", args)
+	return args, nil, nil
+}
+
+func (o *mqlOpenstack) resourceProviders() ([]any, error) {
+	c := conn(o.MqlRuntime)
+	client, err := c.PlacementClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	pages, err := resourceproviders.List(client, resourceproviders.ListOpts{}).AllPages(ctx())
+	if err != nil {
+		if translateOpenstackError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, err := resourceproviders.ExtractResourceProviders(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(items))
+	for i := range items {
+		rp := &items[i]
+		res, err := CreateResource(o.MqlRuntime, "openstack.placement.resourceProvider", map[string]*llx.RawData{
+			"__id":       llx.StringData("openstack.placement.resourceProvider/" + rp.UUID),
+			"id":         llx.StringData(rp.UUID),
+			"name":       llx.StringData(rp.Name),
+			"generation": llx.IntData(int64(rp.Generation)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlRP := res.(*mqlOpenstackPlacementResourceProvider)
+		mqlRP.cacheParentUUID = rp.ParentProviderUUID
+		mqlRP.cacheRootUUID = rp.RootProviderUUID
+		out = append(out, mqlRP)
+	}
+	return out, nil
+}
+
+func (r *mqlOpenstackPlacementResourceProvider) traits() ([]any, error) {
+	client, err := conn(r.MqlRuntime).PlacementClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	res, err := resourceproviders.GetTraits(ctx(), client, r.Id.Data).Extract()
+	if err != nil {
+		if translateGetError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	return stringSlice(res.Traits), nil
+}
+
+// inventories returns one dict per resource class, joining the configured
+// inventory (total/reserved/limits) with current usage so callers can compute
+// free capacity per class (e.g. VGPU total vs used) in a single query.
+func (r *mqlOpenstackPlacementResourceProvider) inventories() ([]any, error) {
+	client, err := conn(r.MqlRuntime).PlacementClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	inv, err := resourceproviders.GetInventories(ctx(), client, r.Id.Data).Extract()
+	if err != nil {
+		if translateGetError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	// Usage is a best-effort enrichment; if it can't be read, report 0 used
+	// rather than failing the inventory query.
+	used := map[string]int{}
+	if usage, uerr := resourceproviders.GetUsages(ctx(), client, r.Id.Data).Extract(); uerr == nil {
+		used = usage.Usages
+	}
+
+	classes := make([]string, 0, len(inv.Inventories))
+	for class := range inv.Inventories {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	out := make([]any, 0, len(classes))
+	for _, class := range classes {
+		item := inv.Inventories[class]
+		out = append(out, map[string]any{
+			"resource_class":   class,
+			"total":            item.Total,
+			"reserved":         item.Reserved,
+			"allocation_ratio": float64(item.AllocationRatio),
+			"min_unit":         item.MinUnit,
+			"max_unit":         item.MaxUnit,
+			"step_size":        item.StepSize,
+			"used":             used[class],
+		})
+	}
+	return out, nil
+}
+
+func (r *mqlOpenstackPlacementResourceProvider) aggregates() ([]any, error) {
+	client, err := conn(r.MqlRuntime).PlacementClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	res, err := resourceproviders.GetAggregates(ctx(), client, r.Id.Data).Extract()
+	if err != nil {
+		if translateGetError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	return stringSlice(res.Aggregates), nil
+}
+
+func (r *mqlOpenstackPlacementResourceProvider) parent() (*mqlOpenstackPlacementResourceProvider, error) {
+	if r.cacheParentUUID == "" {
+		r.Parent.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.placement.resourceProvider", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheParentUUID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackPlacementResourceProvider), nil
+}
+
+func (r *mqlOpenstackPlacementResourceProvider) root() (*mqlOpenstackPlacementResourceProvider, error) {
+	if r.cacheRootUUID == "" {
+		r.Root.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.placement.resourceProvider", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheRootUUID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackPlacementResourceProvider), nil
+}


### PR DESCRIPTION
## Why

There's no managed AI/inference service in upstream OpenStack — it's IaaS. The AI-relevant surface is **infrastructure for AI**: accelerator capacity. **Placement** is where Nova records that — GPU resource classes (`VGPU`, `PGPU`), `HW_GPU_*` traits, and how much is allocated. (Cyborg, the actual acceleration service, has no `gophercloud` client and is rarely deployed, so it's out of scope here.)

## What

- **`openstack.resourceProviders()`** on the root resource.
- **`openstack.placement.resourceProvider`** — `id` (UUID), `name`, `generation`; lazy `traits()`, `inventories()`, `aggregates()`; typed `parent()` / `root()` to walk nested provider trees (a compute node with child GPU providers).
- **`connection.PlacementClient()`** — pinned to placement microversion `1.14` (for `parent`/`root`), graceful empty list when Placement isn't in the catalog (same pattern as Magnum/Ironic).

`inventories()` returns one `[]dict` per resource class, joining configured inventory with current usage:
`{resource_class, total, reserved, allocation_ratio, min_unit, max_unit, step_size, used}`. So:

```
openstack.resourceProviders {
  name
  inventories.where(resource_class == "VGPU") { total used }
  traits.where(_ == /HW_GPU/)
}
```

answers "which providers expose GPU and how much is allocated" in one query.

Per the schema rules, an inventory line has only a synthetic `<rp>/<class>` key and no nested typed ref, so it's modeled as `[]dict` rather than a sub-resource.

## Testing
`go build ./...`, `go vet`, `go test ./resources/...` all green; codegen run twice (Internal struct embedded); `resources.json` regenerated. New entries versioned at `13.2.2` (config is at `13.2.1`). Not yet exercised against a live OpenStack cloud with Placement.
