### PR TITLE
✨ gcp: type Vertex AI endpoint model deployments (deprecate deployedModels)

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1075,6 +1075,9 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// JobClient.GetCustomJob → singular "customJob" by default; the real
 		// IAM permission is the plural form.
 		"GetCustomJob": "aiplatform.customJobs.get",
+		// ModelClient.GetModel → singular "model" by default; the real IAM
+		// permission is the plural form (matching aiplatform.models.list).
+		"GetModel": "aiplatform.models.get",
 	},
 	"pubsub": {
 		// SchemaClient.GetSchema → singular "schema" by default; real IAM

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -10903,7 +10903,13 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   // Human-readable description of the resource
   description string
   // Deployed models
-  deployedModels []dict
+  //
+  // Deprecated in favor of deployments, which exposes each model deployment
+  // as a queryable gcp.project.vertexaiService.endpoint.deployment with a
+  // model() reference.
+  deployedModels @maturity("deprecated") []dict
+  // Models deployed to this endpoint
+  deployments []gcp.project.vertexaiService.endpoint.deployment
   // Encryption spec (CMEK)
   encryptionSpec dict
   // Customer-managed Cloud KMS key used to encrypt this resource at rest
@@ -10922,6 +10928,36 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   createdAt time
   // Last update time
   updatedAt time
+}
+
+// Google Cloud (GCP) Vertex AI model deployment
+//
+// Examine a single model deployment on a Vertex AI endpoint. `model()`
+// resolves to the deployed Vertex AI model, `serviceAccount()` resolves the
+// identity the deployment runs as, and `disableContainerLogging` /
+// `enableAccessLogging` report the prediction-logging posture. The `id`
+// selects the deployment within its endpoint. Use these fields to audit
+// which models serve traffic and the identity and logging configuration of
+// each deployment.
+private gcp.project.vertexaiService.endpoint.deployment @defaults("id displayName") {
+  // ID of the deployment within the endpoint
+  id string
+  // Display name
+  displayName string
+  // Version ID of the deployed model
+  modelVersionId string
+  // Deployed Vertex AI model
+  model() gcp.project.vertexaiService.model
+  // Service account email the deployment runs as
+  serviceAccountEmail string
+  // Service account the deployment runs as
+  serviceAccount() gcp.project.iamService.serviceAccount
+  // Whether container request/response logging is disabled
+  disableContainerLogging bool
+  // Whether access logging is enabled
+  enableAccessLogging bool
+  // Time the model was deployed
+  createdAt time
 }
 
 // Google Cloud (GCP) Vertex AI pipeline job

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -345,6 +345,7 @@ const (
 	ResourceGcpProjectVertexaiServiceMetadataStore                                     string = "gcp.project.vertexaiService.metadataStore"
 	ResourceGcpProjectVertexaiServiceModel                                             string = "gcp.project.vertexaiService.model"
 	ResourceGcpProjectVertexaiServiceEndpoint                                          string = "gcp.project.vertexaiService.endpoint"
+	ResourceGcpProjectVertexaiServiceEndpointDeployment                                string = "gcp.project.vertexaiService.endpoint.deployment"
 	ResourceGcpProjectVertexaiServicePipelineJob                                       string = "gcp.project.vertexaiService.pipelineJob"
 	ResourceGcpProjectVertexaiServiceDataset                                           string = "gcp.project.vertexaiService.dataset"
 	ResourceGcpProjectVertexaiServiceFeatureOnlineStore                                string = "gcp.project.vertexaiService.featureOnlineStore"
@@ -1776,6 +1777,10 @@ func init() {
 		"gcp.project.vertexaiService.endpoint": {
 			// to override args, implement: initGcpProjectVertexaiServiceEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectVertexaiServiceEndpoint,
+		},
+		"gcp.project.vertexaiService.endpoint.deployment": {
+			// to override args, implement: initGcpProjectVertexaiServiceEndpointDeployment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectVertexaiServiceEndpointDeployment,
 		},
 		"gcp.project.vertexaiService.pipelineJob": {
 			// to override args, implement: initGcpProjectVertexaiServicePipelineJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -13265,6 +13270,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.endpoint.deployedModels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetDeployedModels()).ToDataRes(types.Array(types.Dict))
 	},
+	"gcp.project.vertexaiService.endpoint.deployments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetDeployments()).ToDataRes(types.Array(types.Resource("gcp.project.vertexaiService.endpoint.deployment")))
+	},
 	"gcp.project.vertexaiService.endpoint.encryptionSpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetEncryptionSpec()).ToDataRes(types.Dict)
 	},
@@ -13291,6 +13299,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.endpoint.updatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetDisplayName()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.modelVersionId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetModelVersionId()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.model": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetModel()).ToDataRes(types.Resource("gcp.project.vertexaiService.model"))
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.serviceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetServiceAccountEmail()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.disableContainerLogging": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetDisableContainerLogging()).ToDataRes(types.Bool)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.enableAccessLogging": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetEnableAccessLogging()).ToDataRes(types.Bool)
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"gcp.project.vertexaiService.pipelineJob.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetName()).ToDataRes(types.String)
@@ -32259,6 +32294,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).DeployedModels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.vertexaiService.endpoint.deployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpoint).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.vertexaiService.endpoint.encryptionSpec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).EncryptionSpec, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -32293,6 +32332,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.endpoint.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.modelVersionId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).ModelVersionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.model": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).Model, ok = plugin.RawToTValue[*mqlGcpProjectVertexaiServiceModel](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.serviceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).ServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.disableContainerLogging": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).DisableContainerLogging, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.enableAccessLogging": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).EnableAccessLogging, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.endpoint.deployment.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpointDeployment).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.pipelineJob.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -74672,6 +74751,7 @@ type mqlGcpProjectVertexaiServiceEndpoint struct {
 	DisplayName                 plugin.TValue[string]
 	Description                 plugin.TValue[string]
 	DeployedModels              plugin.TValue[[]any]
+	Deployments                 plugin.TValue[[]any]
 	EncryptionSpec              plugin.TValue[any]
 	KmsKey                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	Network                     plugin.TValue[string]
@@ -74736,6 +74816,10 @@ func (c *mqlGcpProjectVertexaiServiceEndpoint) GetDeployedModels() *plugin.TValu
 	return &c.DeployedModels
 }
 
+func (c *mqlGcpProjectVertexaiServiceEndpoint) GetDeployments() *plugin.TValue[[]any] {
+	return &c.Deployments
+}
+
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetEncryptionSpec() *plugin.TValue[any] {
 	return &c.EncryptionSpec
 }
@@ -74782,6 +74866,114 @@ func (c *mqlGcpProjectVertexaiServiceEndpoint) GetCreatedAt() *plugin.TValue[*ti
 
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.UpdatedAt
+}
+
+// mqlGcpProjectVertexaiServiceEndpointDeployment for the gcp.project.vertexaiService.endpoint.deployment resource
+type mqlGcpProjectVertexaiServiceEndpointDeployment struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlGcpProjectVertexaiServiceEndpointDeploymentInternal
+	Id                      plugin.TValue[string]
+	DisplayName             plugin.TValue[string]
+	ModelVersionId          plugin.TValue[string]
+	Model                   plugin.TValue[*mqlGcpProjectVertexaiServiceModel]
+	ServiceAccountEmail     plugin.TValue[string]
+	ServiceAccount          plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	DisableContainerLogging plugin.TValue[bool]
+	EnableAccessLogging     plugin.TValue[bool]
+	CreatedAt               plugin.TValue[*time.Time]
+}
+
+// createGcpProjectVertexaiServiceEndpointDeployment creates a new instance of this resource
+func createGcpProjectVertexaiServiceEndpointDeployment(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectVertexaiServiceEndpointDeployment{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.vertexaiService.endpoint.deployment", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) MqlName() string {
+	return "gcp.project.vertexaiService.endpoint.deployment"
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetModelVersionId() *plugin.TValue[string] {
+	return &c.ModelVersionId
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetModel() *plugin.TValue[*mqlGcpProjectVertexaiServiceModel] {
+	return plugin.GetOrCompute[*mqlGcpProjectVertexaiServiceModel](&c.Model, func() (*mqlGcpProjectVertexaiServiceModel, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.endpoint.deployment", c.__id, "model")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectVertexaiServiceModel), nil
+			}
+		}
+
+		return c.model()
+	})
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetServiceAccountEmail() *plugin.TValue[string] {
+	return &c.ServiceAccountEmail
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.endpoint.deployment", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetDisableContainerLogging() *plugin.TValue[bool] {
+	return &c.DisableContainerLogging
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetEnableAccessLogging() *plugin.TValue[bool] {
+	return &c.EnableAccessLogging
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpointDeployment) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlGcpProjectVertexaiServicePipelineJob for the gcp.project.vertexaiService.pipelineJob resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4574,6 +4574,17 @@ gcp.project.vertexaiService.deploymentResourcePools 13.20.2
 gcp.project.vertexaiService.endpoint 13.1.2
 gcp.project.vertexaiService.endpoint.createdAt 13.1.2
 gcp.project.vertexaiService.endpoint.deployedModels 13.1.2
+gcp.project.vertexaiService.endpoint.deployment 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.createdAt 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.disableContainerLogging 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.displayName 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.enableAccessLogging 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.id 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.model 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.modelVersionId 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.serviceAccount 13.20.2
+gcp.project.vertexaiService.endpoint.deployment.serviceAccountEmail 13.20.2
+gcp.project.vertexaiService.endpoint.deployments 13.20.2
 gcp.project.vertexaiService.endpoint.description 13.1.2
 gcp.project.vertexaiService.endpoint.displayName 13.1.2
 gcp.project.vertexaiService.endpoint.enablePrivateServiceConnect 13.1.2

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.20.1",
-  "generated_at": "2026-06-03T10:20:26-07:00",
+  "generated_at": "2026-06-03T11:35:17-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -18,6 +18,7 @@
     "aiplatform.indexes.list",
     "aiplatform.metadataStores.list",
     "aiplatform.modelDeploymentMonitoringJobs.list",
+    "aiplatform.models.get",
     "aiplatform.models.list",
     "aiplatform.notebookExecutionJobs.list",
     "aiplatform.notebookRuntimeTemplates.list",
@@ -349,6 +350,12 @@
       "permission": "aiplatform.modelDeploymentMonitoringJobs.list",
       "service": "aiplatform",
       "action": "ListModelDeploymentMonitoringJobs",
+      "source_file": "vertexai.go"
+    },
+    {
+      "permission": "aiplatform.models.get",
+      "service": "aiplatform",
+      "action": "GetModel",
       "source_file": "vertexai.go"
     },
     {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -52,6 +52,7 @@ var validatedGCPPermissions = []string{
 	"aiplatform.indexes.list",
 	"aiplatform.metadataStores.list",
 	"aiplatform.modelDeploymentMonitoringJobs.list",
+	"aiplatform.models.get",
 	"aiplatform.models.list",
 	"aiplatform.notebookExecutionJobs.list",
 	"aiplatform.notebookRuntimeTemplates.list",

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -237,52 +237,63 @@ func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
 				return nil, false, err
 			}
 
-			modelSourceInfo, err := protoToDict(model.ModelSourceInfo)
+			mqlModel, err := newMqlVertexaiModel(g.MqlRuntime, model)
 			if err != nil {
 				return nil, false, err
 			}
-			containerSpec, err := protoToDict(model.ContainerSpec)
-			if err != nil {
-				return nil, false, err
-			}
-			encryptionSpec, err := protoToDict(model.EncryptionSpec)
-			if err != nil {
-				return nil, false, err
-			}
-
-			deploymentTypes := make([]any, 0, len(model.SupportedDeploymentResourcesTypes))
-			for _, dt := range model.SupportedDeploymentResourcesTypes {
-				deploymentTypes = append(deploymentTypes, dt.String())
-			}
-
-			mqlModel, err := CreateResource(g.MqlRuntime, "gcp.project.vertexaiService.model", map[string]*llx.RawData{
-				"name":                              llx.StringData(model.Name),
-				"displayName":                       llx.StringData(model.DisplayName),
-				"description":                       llx.StringData(model.Description),
-				"versionId":                         llx.StringData(model.VersionId),
-				"versionAliases":                    llx.ArrayData(convert.SliceAnyToInterface(model.VersionAliases), types.String),
-				"versionDescription":                llx.StringData(model.VersionDescription),
-				"modelSourceInfo":                   llx.DictData(modelSourceInfo),
-				"containerSpec":                     llx.DictData(containerSpec),
-				"supportedDeploymentResourcesTypes": llx.ArrayData(deploymentTypes, types.String),
-				"supportedInputStorageFormats":      llx.ArrayData(convert.SliceAnyToInterface(model.SupportedInputStorageFormats), types.String),
-				"supportedOutputStorageFormats":     llx.ArrayData(convert.SliceAnyToInterface(model.SupportedOutputStorageFormats), types.String),
-				"trainingPipeline":                  llx.StringData(model.TrainingPipeline),
-				"artifactUri":                       llx.StringData(model.ArtifactUri),
-				"encryptionSpec":                    llx.DictData(encryptionSpec),
-				"labels":                            llx.MapData(convert.MapToInterfaceMap(model.Labels), types.String),
-				"etag":                              llx.StringData(model.Etag),
-				"createdAt":                         llx.TimeDataPtr(timestampAsTimePtr(model.CreateTime)),
-				"updatedAt":                         llx.TimeDataPtr(timestampAsTimePtr(model.UpdateTime)),
-			})
-			if err != nil {
-				return nil, false, err
-			}
-			mqlModel.(*mqlGcpProjectVertexaiServiceModel).cacheKmsKeyName = model.GetEncryptionSpec().GetKmsKeyName()
 			items = append(items, mqlModel)
 		}
 		return items, false, nil
 	})
+}
+
+// newMqlVertexaiModel maps a Vertex AI Model proto into an MQL resource. It is
+// shared by the models() lister and the deployment.model() reference.
+func newMqlVertexaiModel(runtime *plugin.Runtime, model *aiplatformpb.Model) (*mqlGcpProjectVertexaiServiceModel, error) {
+	modelSourceInfo, err := protoToDict(model.ModelSourceInfo)
+	if err != nil {
+		return nil, err
+	}
+	containerSpec, err := protoToDict(model.ContainerSpec)
+	if err != nil {
+		return nil, err
+	}
+	encryptionSpec, err := protoToDict(model.EncryptionSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentTypes := make([]any, 0, len(model.SupportedDeploymentResourcesTypes))
+	for _, dt := range model.SupportedDeploymentResourcesTypes {
+		deploymentTypes = append(deploymentTypes, dt.String())
+	}
+
+	mqlModel, err := CreateResource(runtime, "gcp.project.vertexaiService.model", map[string]*llx.RawData{
+		"name":                              llx.StringData(model.Name),
+		"displayName":                       llx.StringData(model.DisplayName),
+		"description":                       llx.StringData(model.Description),
+		"versionId":                         llx.StringData(model.VersionId),
+		"versionAliases":                    llx.ArrayData(convert.SliceAnyToInterface(model.VersionAliases), types.String),
+		"versionDescription":                llx.StringData(model.VersionDescription),
+		"modelSourceInfo":                   llx.DictData(modelSourceInfo),
+		"containerSpec":                     llx.DictData(containerSpec),
+		"supportedDeploymentResourcesTypes": llx.ArrayData(deploymentTypes, types.String),
+		"supportedInputStorageFormats":      llx.ArrayData(convert.SliceAnyToInterface(model.SupportedInputStorageFormats), types.String),
+		"supportedOutputStorageFormats":     llx.ArrayData(convert.SliceAnyToInterface(model.SupportedOutputStorageFormats), types.String),
+		"trainingPipeline":                  llx.StringData(model.TrainingPipeline),
+		"artifactUri":                       llx.StringData(model.ArtifactUri),
+		"encryptionSpec":                    llx.DictData(encryptionSpec),
+		"labels":                            llx.MapData(convert.MapToInterfaceMap(model.Labels), types.String),
+		"etag":                              llx.StringData(model.Etag),
+		"createdAt":                         llx.TimeDataPtr(timestampAsTimePtr(model.CreateTime)),
+		"updatedAt":                         llx.TimeDataPtr(timestampAsTimePtr(model.UpdateTime)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := mqlModel.(*mqlGcpProjectVertexaiServiceModel)
+	res.cacheKmsKeyName = model.GetEncryptionSpec().GetKmsKeyName()
+	return res, nil
 }
 
 func (g *mqlGcpProjectVertexaiServiceModel) id() (string, error) {
@@ -329,12 +340,31 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 			}
 
 			deployedModels := make([]any, 0, len(ep.DeployedModels))
+			deployments := make([]any, 0, len(ep.DeployedModels))
 			for _, dm := range ep.DeployedModels {
 				d, err := protoToDict(dm)
 				if err != nil {
 					return nil, false, err
 				}
 				deployedModels = append(deployedModels, d)
+
+				mqlDeployment, err := CreateResource(g.MqlRuntime, "gcp.project.vertexaiService.endpoint.deployment", map[string]*llx.RawData{
+					"__id":                    llx.StringData(fmt.Sprintf("%s/deployment/%s", ep.Name, dm.Id)),
+					"id":                      llx.StringData(dm.Id),
+					"displayName":             llx.StringData(dm.DisplayName),
+					"modelVersionId":          llx.StringData(dm.ModelVersionId),
+					"serviceAccountEmail":     llx.StringData(dm.ServiceAccount),
+					"disableContainerLogging": llx.BoolData(dm.DisableContainerLogging),
+					"enableAccessLogging":     llx.BoolData(dm.EnableAccessLogging),
+					"createdAt":               llx.TimeDataPtr(timestampAsTimePtr(dm.CreateTime)),
+				})
+				if err != nil {
+					return nil, false, err
+				}
+				mqlDeploymentRes := mqlDeployment.(*mqlGcpProjectVertexaiServiceEndpointDeployment)
+				mqlDeploymentRes.cacheModelName = dm.Model
+				mqlDeploymentRes.cacheProjectId = projectId
+				deployments = append(deployments, mqlDeployment)
 			}
 			encryptionSpec, err := protoToDict(ep.EncryptionSpec)
 			if err != nil {
@@ -351,6 +381,7 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 				"displayName":                 llx.StringData(ep.DisplayName),
 				"description":                 llx.StringData(ep.Description),
 				"deployedModels":              llx.ArrayData(deployedModels, types.Dict),
+				"deployments":                 llx.ArrayData(deployments, types.Resource("gcp.project.vertexaiService.endpoint.deployment")),
 				"encryptionSpec":              llx.DictData(encryptionSpec),
 				"network":                     llx.StringData(ep.Network),
 				"enablePrivateServiceConnect": llx.BoolData(ep.EnablePrivateServiceConnect),
@@ -372,6 +403,77 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 
 func (g *mqlGcpProjectVertexaiServiceEndpoint) id() (string, error) {
 	return g.Name.Data, g.Name.Error
+}
+
+type mqlGcpProjectVertexaiServiceEndpointDeploymentInternal struct {
+	cacheModelName string
+	cacheProjectId string
+}
+
+// vertexaiRegionFromName extracts the location from a Vertex AI resource name
+// of the form projects/{project}/locations/{location}/....
+func vertexaiRegionFromName(name string) string {
+	parts := strings.Split(name, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "locations" {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+func (d *mqlGcpProjectVertexaiServiceEndpointDeployment) model() (*mqlGcpProjectVertexaiServiceModel, error) {
+	region := vertexaiRegionFromName(d.cacheModelName)
+	if d.cacheModelName == "" || region == "" {
+		d.Model.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	conn := d.MqlRuntime.Connection.(*connection.GcpConnection)
+	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client, err := aiplatform.NewModelClient(ctx,
+		option.WithCredentials(creds),
+		option.WithEndpoint(vertexaiEndpoint(region)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	m, err := client.GetModel(ctx, &aiplatformpb.GetModelRequest{Name: d.cacheModelName})
+	if err != nil {
+		if isVertexAIRegionSkippable(err) {
+			d.Model.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	return newMqlVertexaiModel(d.MqlRuntime, m)
+}
+
+func (d *mqlGcpProjectVertexaiServiceEndpointDeployment) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if d.ServiceAccountEmail.Error != nil {
+		return nil, d.ServiceAccountEmail.Error
+	}
+	email := d.ServiceAccountEmail.Data
+	if email == "" || d.cacheProjectId == "" {
+		d.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	res, err := NewResource(d.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
+		"projectId": llx.StringData(d.cacheProjectId),
+		"email":     llx.StringData(email),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
 func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {


### PR DESCRIPTION
## What

Adds a typed `deployments []gcp.project.vertexaiService.endpoint.deployment` collection to `gcp.project.vertexaiService.endpoint`, exposing each model deployment as a queryable sub-resource. The existing `deployedModels []dict` field is **kept and deprecated** (`@maturity("deprecated")`) — it is still populated, so existing queries keep working.

This is the backwards-compatible version of the original change, which retyped `deployedModels` in place (a breaking change).

## Why

The deployed models on an endpoint are the link between *an endpoint serving traffic* and *the model behind it* — a core audit traversal. As a `[]dict` it was opaque; typed, it becomes queryable and the `model()` reference lets you hop straight to the model.

## New `deployment` sub-resource

`id`, `displayName`, `modelVersionId`, `serviceAccountEmail`, `disableContainerLogging`, `enableAccessLogging`, `createdAt`, plus two references:

- `model()` → the deployed `gcp.project.vertexaiService.model` (fetched on demand via `GetModel`, region parsed from the model resource name)
- `serviceAccount()` → the `gcp.project.iamService.serviceAccount` the deployment runs as

The model-mapping logic is factored into a shared `newMqlVertexaiModel` helper used by both `models()` and the `model()` reference.

## Backwards compatibility

`deployedModels` (`[]dict`) is unchanged and still populated; it is marked `@maturity("deprecated")` with a description pointing at `deployments`. No existing query breaks — queries that index it as a dict (e.g. `deployedModels[0]["id"]`) continue to work. New audits should use `deployments`.

Adds the `aiplatform.models.get` permission for the `model()` reference.

## Example

```mql
gcp.project.vertexai.endpoints {
  displayName
  deployments {
    displayName
    serviceAccount { email }
    model { displayName artifactUri }
  }
}
```

## Testing

Generated (`./mqlr generate` + versions), built, and installed the gcp provider locally; the GCP permissions test passes. No live-cloud verification in this PR (build + generate only, per scope).

> New `.lr.versions` entries (`deployment`, `deployments`) are at `13.20.2`. The deprecated `deployedModels` keeps its original `13.1.2` entry.
