### PR TITLE
🐛 validate aws/gcp/azure IAM permissions against the live clouds and fix bogus ones

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1239,7 +1239,12 @@ var gcpPermissionOverrides = map[string]map[string]string{
 // level, not the project level. They are placed in the org_level_permissions
 // section of the manifest instead of the main permissions list.
 var gcpOrgLevelPermissions = map[string]bool{
+	// Custom org-policy constraints are an organization-scoped resource;
+	// ListCustomConstraints is only callable with an "organizations/{id}"
+	// parent, so the permission is rejected in a project-level custom role.
+	"orgpolicy.customConstraints.list":           true,
 	"resourcemanager.folders.get":                true,
+	"resourcemanager.folders.getIamPolicy":       true,
 	"resourcemanager.folders.list":               true,
 	"resourcemanager.folders.search":             true,
 	"resourcemanager.organizations.get":          true,

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -283,6 +283,9 @@ var awsServiceNameOverrides = map[string]string{
 	"databasemigrationservice": "dms",
 	"directoryservice":         "ds",
 	"docdb":                    "rds",
+	"docdbelastic":             "docdb-elastic",
+	"efs":                      "elasticfilesystem",
+	"emr":                      "elasticmapreduce",
 	"elasticsearchservice":     "es",
 	"elasticloadbalancing":     "elasticloadbalancing",
 	"elasticloadbalancingv2":   "elasticloadbalancing",
@@ -318,6 +321,78 @@ var awsServiceNameOverrides = map[string]string{
 	"eventbridge":              "events",
 	"sfn":                      "states",
 	"ssoadmin":                 "sso",
+}
+
+// awsPermissionOverrides maps a generated "service:Action" permission to the
+// correct IAM action for the cases where the AWS SDK operation name does not
+// match the IAM action name (the per-service-prefix renames are handled by
+// awsServiceNameOverrides instead). An empty-string value means the operation
+// has no corresponding IAM action and should be skipped entirely. Every entry
+// here was verified live against IAM Access Analyzer (validate-policy) — the
+// left side reported INVALID_ACTION and the right side validated clean.
+var awsPermissionOverrides = map[string]string{
+	// S3 API operation names differ from the S3 IAM action names.
+	"s3:GetBucketAccelerateConfiguration":           "s3:GetAccelerateConfiguration",
+	"s3:GetBucketEncryption":                        "s3:GetEncryptionConfiguration",
+	"s3:GetBucketLifecycleConfiguration":            "s3:GetLifecycleConfiguration",
+	"s3:GetBucketNotificationConfiguration":         "s3:GetBucketNotification",
+	"s3:GetBucketReplication":                       "s3:GetReplicationConfiguration",
+	"s3:GetObjectLockConfiguration":                 "s3:GetBucketObjectLockConfiguration",
+	"s3:GetPublicAccessBlock":                       "s3:GetBucketPublicAccessBlock",
+	"s3:ListBuckets":                                "s3:ListAllMyBuckets",
+	"s3:ListBucketAnalyticsConfigurations":          "s3:GetAnalyticsConfiguration",
+	"s3:ListBucketIntelligentTieringConfigurations": "s3:GetIntelligentTieringConfiguration",
+	"s3:ListBucketInventoryConfigurations":          "s3:GetInventoryConfiguration",
+	"s3:ListBucketMetricsConfigurations":            "s3:GetMetricsConfiguration",
+
+	// API Gateway reads are all governed by the single apigateway:GET action.
+	"apigateway:GetApiKeys":           "apigateway:GET",
+	"apigateway:GetApis":              "apigateway:GET",
+	"apigateway:GetAuthorizers":       "apigateway:GET",
+	"apigateway:GetDomainNames":       "apigateway:GET",
+	"apigateway:GetRequestValidators": "apigateway:GET",
+	"apigateway:GetRestApis":          "apigateway:GET",
+	"apigateway:GetRoutes":            "apigateway:GET",
+	"apigateway:GetStages":            "apigateway:GET",
+	"apigateway:GetUsagePlans":        "apigateway:GET",
+	"apigateway:GetVpcLinks":          "apigateway:GET",
+
+	// Budgets reads are governed by budgets:ViewBudget.
+	"budgets:DescribeBudgets":                    "budgets:ViewBudget",
+	"budgets:DescribeNotificationsForBudget":     "budgets:ViewBudget",
+	"budgets:DescribeSubscribersForNotification": "budgets:ViewBudget",
+
+	// Detective's IAM action is singular (the SDK operation is plural).
+	"detective:ListOrganizationAdminAccounts": "detective:ListOrganizationAdminAccount",
+
+	// The Access Analyzer ListFindingsV2 API maps to access-analyzer:ListFindings.
+	"access-analyzer:ListFindingsV2": "access-analyzer:ListFindings",
+
+	// Amazon Keyspaces uses the cassandra: IAM prefix; reads require
+	// cassandra:Select and tag reads require cassandra:TagResource.
+	"keyspaces:GetKeyspace":         "cassandra:Select",
+	"keyspaces:GetTable":            "cassandra:Select",
+	"keyspaces:ListKeyspaces":       "cassandra:Select",
+	"keyspaces:ListTables":          "cassandra:Select",
+	"keyspaces:ListTagsForResource": "cassandra:TagResource",
+
+	// Bedrock advanced prompt optimization jobs have no published IAM action
+	// yet; skip rather than emit an action that does not exist.
+	"bedrock:GetAdvancedPromptOptimizationJob":   "",
+	"bedrock:ListAdvancedPromptOptimizationJobs": "",
+}
+
+// awsApplyOverride resolves a generated "service:Action" permission against
+// awsPermissionOverrides. It returns the final permission and whether it should
+// be emitted (false means skip — the operation maps to no IAM action).
+func awsApplyOverride(perm string) (string, bool) {
+	if override, ok := awsPermissionOverrides[perm]; ok {
+		if override == "" {
+			return "", false
+		}
+		return override, true
+	}
+	return perm, true
 }
 
 func extractAWSPermissions(resourcesDir string) []PermissionDetail {
@@ -399,12 +474,14 @@ func extractAWSPermissions(resourcesDir string) []PermissionDetail {
 					if svcName, ok := varServices[ident.Name]; ok {
 						if isAWSAPIMethod(methodName) {
 							iamService := awsServiceToIAM(svcName)
-							details = append(details, PermissionDetail{
-								Permission: iamService + ":" + methodName,
-								Service:    iamService,
-								Action:     methodName,
-								SourceFile: fileName,
-							})
+							if perm, ok := awsApplyOverride(iamService + ":" + methodName); ok {
+								details = append(details, PermissionDetail{
+									Permission: perm,
+									Service:    strings.SplitN(perm, ":", 2)[0],
+									Action:     methodName,
+									SourceFile: fileName,
+								})
+							}
 						}
 					}
 				}
@@ -416,12 +493,14 @@ func extractAWSPermissions(resourcesDir string) []PermissionDetail {
 							action := strings.TrimPrefix(methodName, "New")
 							action = strings.TrimSuffix(action, "Paginator")
 							iamService := awsServiceToIAM(awsImports[ident.Name])
-							details = append(details, PermissionDetail{
-								Permission: iamService + ":" + action,
-								Service:    iamService,
-								Action:     action,
-								SourceFile: fileName,
-							})
+							if perm, ok := awsApplyOverride(iamService + ":" + action); ok {
+								details = append(details, PermissionDetail{
+									Permission: perm,
+									Service:    strings.SplitN(perm, ":", 2)[0],
+									Action:     action,
+									SourceFile: fileName,
+								})
+							}
 						}
 					}
 				}
@@ -1055,12 +1134,37 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		"GetConnectionProfile": "datastream.connectionProfiles.get",
 		"GetPrivateConnection": "datastream.privateConnections.get",
 	},
+	"cloudfunctions": {
+		// GetIamPolicy is called on functions (both the v1 and v2 clients); the
+		// real permission is the resource-scoped form, not the auto-derived
+		// "cloudfunctions.iamPolicy.get".
+		"GetIamPolicy": "cloudfunctions.functions.getIamPolicy",
+	},
+	"cloudtasks": {
+		// GetIamPolicy is called on a queue; the real permission is queue-scoped.
+		"GetIamPolicy": "cloudtasks.queues.getIamPolicy",
+	},
+	"discoveryengine": {
+		// GetDataStore → singular "dataStore" by default; the real IAM permission
+		// is the plural form.
+		"GetDataStore": "discoveryengine.dataStores.get",
+	},
+	"cloudidentity": {
+		// The Cloud Identity Groups API is not governed by project/org IAM
+		// permissions (it uses group-scope authorization via member/owner/admin
+		// roles), so no IAM permission corresponds to these calls — skip them.
+		"Groups.List":      "",
+		"Memberships.List": "",
+	},
 	"dlp": {
 		// The DLP API exposes jobs under a `jobs` permission, not `dlpJobs`.
 		"ListDlpJobs": "dlp.jobs.list",
 		// File store data profiles are listed via dlp.fileStoreProfiles.list
 		// (no "Data" segment in the real permission).
 		"ListFileStoreDataProfiles": "dlp.fileStoreProfiles.list",
+		// Discovery configs are governed by the jobTriggers permission; there is
+		// no dlp.discoveryConfigs.* permission.
+		"ListDiscoveryConfigs": "dlp.jobTriggers.list",
 	},
 	"memorystore": {
 		"GetInstance":         "memorystore.instances.get",
@@ -1094,6 +1198,9 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// IAM v2 deny policies are listed via iam.denypolicies.list, not the
 		// generic "iam.policies.list" (which is not a real permission).
 		"ListPolicies": "iam.denypolicies.list",
+		// GetIamPolicy is called on a service account; the real permission is the
+		// resource-scoped form, not the auto-derived "iam.iamPolicy.get".
+		"GetIamPolicy": "iam.serviceAccounts.getIamPolicy",
 	},
 	"certificatemanager": {
 		// The Certificate Manager IAM permissions use abbreviated, all-lowercase
@@ -1531,11 +1638,11 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.DBforMySQL/databases/read":      "Microsoft.DBforMySQL/servers/databases/read",
 	"Microsoft.DBforMySQL/firewallRules/read":  "Microsoft.DBforMySQL/servers/firewallRules/read",
 
-	// PostgreSQL: sub-resources need servers/ parent path; threat protection
-	// settings only exist on flexibleServers/
-	"Microsoft.DBforPostgreSQL/configurations/read":                   "Microsoft.DBforPostgreSQL/servers/configurations/read",
-	"Microsoft.DBforPostgreSQL/databases/read":                        "Microsoft.DBforPostgreSQL/servers/databases/read",
-	"Microsoft.DBforPostgreSQL/firewallRules/read":                    "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
+	// PostgreSQL: the legacy single-server resource type (servers/) is retired
+	// and not in the RBAC catalog; all sub-resources resolve to flexibleServers/.
+	"Microsoft.DBforPostgreSQL/configurations/read":                   "Microsoft.DBforPostgreSQL/flexibleServers/configurations/read",
+	"Microsoft.DBforPostgreSQL/databases/read":                        "Microsoft.DBforPostgreSQL/flexibleServers/databases/read",
+	"Microsoft.DBforPostgreSQL/firewallRules/read":                    "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules/read",
 	"Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read": "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read",
 
 	// Network: client names don't match ARM resource types
@@ -1656,6 +1763,92 @@ var azurePermissionOverrides = map[string]string{
 
 	// HybridCompute: machine extensions are nested under machines/, not a top-level type
 	"Microsoft.HybridCompute/machineExtensions/read": "Microsoft.HybridCompute/machines/extensions/read",
+
+	// App (Container Apps): SDK client names omit the managedEnvironments/ or
+	// containerApps/ parent path.
+	"Microsoft.App/certificates/read":                                 "Microsoft.App/managedEnvironments/certificates/read",
+	"Microsoft.App/daprComponents/read":                               "Microsoft.App/managedEnvironments/daprComponents/read",
+	"Microsoft.App/maintenanceConfigurations/read":                    "Microsoft.App/managedEnvironments/maintenanceConfigurations/read",
+	"Microsoft.App/managedEnvironmentPrivateEndpointConnections/read": "Microsoft.App/managedEnvironments/privateEndpointConnections/read",
+	"Microsoft.App/hTTPRouteConfig/read":                              "Microsoft.App/managedEnvironments/httpRouteConfigs/read",
+	"Microsoft.App/containerAppsAuthConfigs/read":                     "Microsoft.App/containerApps/authConfigs/read",
+	"Microsoft.App/containerAppsRevisions/read":                       "Microsoft.App/containerApps/revisions/read",
+
+	// Cognitive Services: sub-resources are nested under accounts/ (and projects/).
+	"Microsoft.Cognitiveservices/accountConnections/read":    "Microsoft.CognitiveServices/accounts/connections/read",
+	"Microsoft.Cognitiveservices/projectConnections/read":    "Microsoft.CognitiveServices/accounts/projects/connections/read",
+	"Microsoft.Cognitiveservices/projects/read":              "Microsoft.CognitiveServices/accounts/projects/read",
+	"Microsoft.Cognitiveservices/deployments/read":           "Microsoft.CognitiveServices/accounts/deployments/read",
+	"Microsoft.Cognitiveservices/defenderForAISettings/read": "Microsoft.CognitiveServices/accounts/defenderForAISettings/read",
+	"Microsoft.Cognitiveservices/raiPolicies/read":           "Microsoft.CognitiveServices/accounts/raiPolicies/read",
+	"Microsoft.Cognitiveservices/raiTopics/read":             "Microsoft.CognitiveServices/accounts/raiTopics/read",
+
+	// Compute: dedicated hosts live under hostGroups/; gallery images under
+	// galleries/; scale-set sub-resources under virtualMachineScaleSets/.
+	"Microsoft.Compute/dedicatedHostGroups/read":              "Microsoft.Compute/hostGroups/read",
+	"Microsoft.Compute/dedicatedHosts/read":                   "Microsoft.Compute/hostGroups/hosts/read",
+	"Microsoft.Compute/galleryImages/read":                    "Microsoft.Compute/galleries/images/read",
+	"Microsoft.Compute/galleryImageVersions/read":             "Microsoft.Compute/galleries/images/versions/read",
+	"Microsoft.Compute/virtualMachineScaleSetExtensions/read": "Microsoft.Compute/virtualMachineScaleSets/extensions/read",
+	"Microsoft.Compute/virtualMachineScaleSetVMs/read":        "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+
+	// ContainerService: agent pools are nested under managedClusters/.
+	"Microsoft.ContainerService/agentPools/read": "Microsoft.ContainerService/managedClusters/agentPools/read",
+
+	// DBforPostgreSQL: the SDK ServersClient maps to the flexibleServers/ resource
+	// type (the configurations/databases/firewallRules sub-resources are handled by
+	// the existing PostgreSQL entries above, which already resolve to flexibleServers/).
+	"Microsoft.DBforPostgreSQL/servers/read":                    "Microsoft.DBforPostgreSQL/flexibleServers/read",
+	"Microsoft.DBforPostgreSQL/privateEndpointConnections/read": "Microsoft.DBforPostgreSQL/flexibleServers/privateEndpointConnections/read",
+
+	// DocumentDB: private endpoint connections are nested under databaseAccounts/;
+	// the SQLResources client reads SQL containers.
+	"Microsoft.DocumentDB/privateEndpointConnections/read": "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
+	"Microsoft.DocumentDB/sQLResources/read":               "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
+
+	// Mongo cluster operations live under the Microsoft.DocumentDB provider.
+	"Microsoft.Mongocluster/mongoClusters/read": "Microsoft.DocumentDB/mongoClusters/read",
+
+	// MachineLearningServices: sub-resources are nested under workspaces/.
+	"Microsoft.MachineLearningServices/compute/read":             "Microsoft.MachineLearningServices/workspaces/computes/read",
+	"Microsoft.MachineLearningServices/modelContainers/read":     "Microsoft.MachineLearningServices/workspaces/models/read",
+	"Microsoft.MachineLearningServices/onlineDeployments/read":   "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments/read",
+	"Microsoft.MachineLearningServices/onlineEndpoints/read":     "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
+	"Microsoft.MachineLearningServices/serverlessEndpoints/read": "Microsoft.MachineLearningServices/workspaces/serverlessEndpoints/read",
+
+	// Network: several SDK clients omit the parent resource path.
+	"Microsoft.Network/connectionMonitors/read":                "Microsoft.Network/networkWatchers/connectionMonitors/read",
+	"Microsoft.Network/expressRouteCircuitAuthorizations/read": "Microsoft.Network/expressRouteCircuits/authorizations/read",
+	"Microsoft.Network/expressRouteCircuitPeerings/read":       "Microsoft.Network/expressRouteCircuits/peerings/read",
+	"Microsoft.Network/hubRouteTables/read":                    "Microsoft.Network/virtualHubs/hubRouteTables/read",
+	"Microsoft.Network/hubVirtualNetworkConnections/read":      "Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/read",
+	"Microsoft.Network/packetCaptures/read":                    "Microsoft.Network/networkWatchers/packetCaptures/read",
+	// Traffic Manager operations live under the Microsoft.Network provider.
+	"Microsoft.Trafficmanager/profiles/read": "Microsoft.Network/trafficManagerProfiles/read",
+
+	// Search: the ARM resource type is searchServices, not services.
+	"Microsoft.Search/services/read": "Microsoft.Search/searchServices/read",
+
+	// Security: Defender for Storage settings use the longer resource type name.
+	"Microsoft.Security/defenderForStorage/read": "Microsoft.Security/defenderForStorageSettings/read",
+
+	// Sql: server- and database-scoped sub-resources need their parent paths.
+	"Microsoft.Sql/dataMaskingPolicies/read":                  "Microsoft.Sql/servers/databases/dataMaskingPolicies/read",
+	"Microsoft.Sql/dataMaskingRules/read":                     "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules/read",
+	"Microsoft.Sql/databaseVulnerabilityAssessmentScans/read": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/read",
+	"Microsoft.Sql/databaseVulnerabilityAssessments/read":     "Microsoft.Sql/servers/databases/vulnerabilityAssessments/read",
+	"Microsoft.Sql/failoverGroups/read":                       "Microsoft.Sql/servers/failoverGroups/read",
+	"Microsoft.Sql/geoBackupPolicies/read":                    "Microsoft.Sql/servers/databases/geoBackupPolicies/read",
+	"Microsoft.Sql/ledgerDigestUploads/read":                  "Microsoft.Sql/servers/databases/ledgerDigestUploads/read",
+	"Microsoft.Sql/managedDatabases/read":                     "Microsoft.Sql/managedInstances/databases/read",
+	"Microsoft.Sql/outboundFirewallRules/read":                "Microsoft.Sql/servers/outboundFirewallRules/read",
+	"Microsoft.Sql/privateEndpointConnections/read":           "Microsoft.Sql/servers/privateEndpointConnections/read",
+	"Microsoft.Sql/replicationLinks/read":                     "Microsoft.Sql/servers/replicationLinks/read",
+	"Microsoft.Sql/serverDevOpsAuditSettings/read":            "Microsoft.Sql/servers/devOpsAuditingSettings/read",
+	"Microsoft.Sql/serverKeys/read":                           "Microsoft.Sql/servers/keys/read",
+
+	// Storage: network security perimeter configs are nested under storageAccounts/.
+	"Microsoft.Storage/networkSecurityPerimeterConfigurations/read": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations/read",
 }
 
 // azurePermission constructs the RBAC permission string.

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -36,6 +36,13 @@ type PermissionDetail struct {
 	Action     string `json:"action"`
 	SourceFile string `json:"source_file"`
 	Scope      string `json:"scope,omitempty"`
+
+	// overridden is an internal dedup hint (never serialized): true when the
+	// Permission came from an override map rather than the natural derivation of
+	// Action. When several call sites in one file resolve to the same permission,
+	// dedup keeps the natural detail so the surviving Action reflects the real API
+	// call. It is reset to false before the manifest is emitted.
+	overridden bool
 }
 
 func main() {
@@ -117,6 +124,14 @@ func main() {
 		if details[i].SourceFile != details[j].SourceFile {
 			return details[i].SourceFile < details[j].SourceFile
 		}
+		// Prefer the natural derivation over an override-sourced one so the
+		// surviving detail's Action reflects the real API call. Without this, an
+		// override that redirects method A to a permission also produced naturally
+		// by method B (e.g. dlp ListDiscoveryConfigs and ListJobTriggers both →
+		// dlp.jobTriggers.list) could leave the override's misleading action.
+		if details[i].overridden != details[j].overridden {
+			return !details[i].overridden
+		}
 		if details[i].Action != details[j].Action {
 			return details[i].Action < details[j].Action
 		}
@@ -133,6 +148,12 @@ func main() {
 			}
 		}
 		details = deduped
+	}
+
+	// overridden is an internal dedup hint only; clear it so it never affects the
+	// serialization-equality check used to skip rewrites.
+	for i := range details {
+		details[i].overridden = false
 	}
 
 	manifest := PermissionManifest{
@@ -927,13 +948,14 @@ func extractGCPgRPCCalls(f *ast.File, imports map[string]*gcpImportInfo, fileNam
 			if ident, ok := sel.X.(*ast.Ident); ok {
 				if cv, ok := clientVars[ident.Name]; ok {
 					if isGCPAPIMethod(methodName) {
-						perm := gcpMethodToPermission(cv.imp.service, cv.clientType, methodName)
+						perm, overridden := gcpMethodToPermission(cv.imp.service, cv.clientType, methodName)
 						if perm != "" {
 							details = append(details, PermissionDetail{
 								Permission: perm,
 								Service:    cv.imp.service,
 								Action:     methodName,
 								SourceFile: fileName,
+								overridden: overridden,
 							})
 						}
 					}
@@ -945,13 +967,14 @@ func extractGCPgRPCCalls(f *ast.File, imports map[string]*gcpImportInfo, fileNam
 				resource := innerSel.Sel.Name
 				if ident, ok := innerSel.X.(*ast.Ident); ok {
 					if imp, ok := restVars[ident.Name]; ok {
-						perm := gcpRESTToPermission(imp.service, resource, methodName)
+						perm, overridden := gcpRESTToPermission(imp.service, resource, methodName)
 						if perm != "" {
 							details = append(details, PermissionDetail{
 								Permission: perm,
 								Service:    imp.service,
 								Action:     resource + "." + methodName,
 								SourceFile: fileName,
+								overridden: overridden,
 							})
 						}
 					}
@@ -968,13 +991,14 @@ func extractGCPgRPCCalls(f *ast.File, imports map[string]*gcpImportInfo, fileNam
 								method := chain[len(chain)-1]
 								// Find the meaningful resource (skip "Projects", "Locations")
 								resourceName := findMeaningfulResource(chain[:len(chain)-1])
-								perm := gcpRESTToPermission(imp.service, resourceName, method)
+								perm, overridden := gcpRESTToPermission(imp.service, resourceName, method)
 								if perm != "" {
 									details = append(details, PermissionDetail{
 										Permission: perm,
 										Service:    imp.service,
 										Action:     resourceName + "." + method,
 										SourceFile: fileName,
+										overridden: overridden,
 									})
 								}
 							}
@@ -1266,10 +1290,13 @@ var gcpSkipMethods = map[string]bool{
 // clientType (e.g., "InstanceAdmin" from NewInstanceAdminClient) lets services with
 // multiple admin clients disambiguate methods like GetIamPolicy that don't carry a
 // resource hint in their name.
-func gcpMethodToPermission(service, clientType, method string) string {
+// gcpMethodToPermission returns the IAM permission for a gRPC method and a bool
+// reporting whether the result came from an override (rather than the natural
+// derivation), used by detail dedup to prefer the natural call site.
+func gcpMethodToPermission(service, clientType, method string) (string, bool) {
 	// Skip known non-API methods
 	if gcpSkipMethods[method] {
-		return ""
+		return "", false
 	}
 
 	// Strip "Iter" suffix from iterator helper methods (e.g., ListRolesIter -> ListRoles)
@@ -1280,11 +1307,11 @@ func gcpMethodToPermission(service, clientType, method string) string {
 	if overrides, ok := gcpPermissionOverrides[service]; ok {
 		if clientType != "" {
 			if perm, ok := overrides[clientType+"."+method]; ok {
-				return perm
+				return perm, true
 			}
 		}
 		if perm, ok := overrides[method]; ok {
-			return perm
+			return perm, true
 		}
 	}
 
@@ -1305,7 +1332,7 @@ func gcpMethodToPermission(service, clientType, method string) string {
 		verb = "get"
 		resource = strings.TrimPrefix(method, "Get")
 		if resource == "" {
-			return "" // bare Get without resource name is ambiguous
+			return "", false // bare Get without resource name is ambiguous
 		}
 	} else if strings.HasPrefix(method, "Create") {
 		verb = "create"
@@ -1326,29 +1353,30 @@ func gcpMethodToPermission(service, clientType, method string) string {
 		verb = "list"
 		resource = strings.TrimPrefix(method, "Search")
 	} else {
-		return ""
+		return "", false
 	}
 
 	if resource == "" {
-		return ""
+		return "", false
 	}
 
 	// Convert PascalCase to camelCase
 	resource = strings.ToLower(resource[:1]) + resource[1:]
 
-	return service + "." + resource + "." + verb
+	return service + "." + resource + "." + verb, false
 }
 
-// gcpRESTToPermission maps a REST-style call to a GCP IAM permission.
-func gcpRESTToPermission(service, resource, method string) string {
+// gcpRESTToPermission maps a REST-style call to a GCP IAM permission. The bool
+// reports whether the result came from an override (see gcpMethodToPermission).
+func gcpRESTToPermission(service, resource, method string) (string, bool) {
 	if resource == "" {
-		return ""
+		return "", false
 	}
 
 	// Check for explicit overrides using "Resource.Method" as the key
 	if overrides, ok := gcpPermissionOverrides[service]; ok {
 		if perm, ok := overrides[resource+"."+method]; ok {
-			return perm
+			return perm, true
 		}
 	}
 
@@ -1365,16 +1393,16 @@ func gcpRESTToPermission(service, resource, method string) string {
 	case "Update", "Patch":
 		verb = "update"
 	case "GetIamPolicy":
-		return service + "." + strings.ToLower(resource[:1]) + resource[1:] + ".getIamPolicy"
+		return service + "." + strings.ToLower(resource[:1]) + resource[1:] + ".getIamPolicy", false
 	case "SetIamPolicy":
-		return service + "." + strings.ToLower(resource[:1]) + resource[1:] + ".setIamPolicy"
+		return service + "." + strings.ToLower(resource[:1]) + resource[1:] + ".setIamPolicy", false
 	default:
 		verb = strings.ToLower(method)
 	}
 
 	// Convert PascalCase resource to camelCase
 	res := strings.ToLower(resource[:1]) + resource[1:]
-	return service + "." + res + "." + verb
+	return service + "." + res + "." + verb, false
 }
 
 // =============================================================================
@@ -1496,6 +1524,11 @@ func extractAzurePermissions(resourcesDir string) []PermissionDetail {
 				// Only care about read operations
 				if isAzureReadMethod(methodName) {
 					perm := azurePermission(info.armProvider, info.resourceType)
+					// A client serving multiple read methods may need per-method
+					// permissions that the client-level derivation can't express.
+					if o, ok := azureMethodPermissionOverrides[info.resourceType+"."+methodName]; ok {
+						perm = o
+					}
 					details = append(details, PermissionDetail{
 						Permission: perm,
 						Service:    info.armProvider,
@@ -1621,6 +1654,21 @@ func azureServiceToARM(service string) string {
 	}
 	// Default: Microsoft.<Capitalized service name>
 	return "Microsoft." + strings.ToUpper(service[:1]) + service[1:]
+}
+
+// azureMethodPermissionOverrides maps "<ResourceType>.<Method>" to the correct
+// permission for cases where one SDK client serves multiple read methods that
+// require different RBAC permissions. The client-derived permission is the same
+// for every method on the client, so a permission-string override (which keys on
+// that shared result) cannot distinguish them — this map keys on the
+// constructor-derived resource type plus the read method name instead.
+var azureMethodPermissionOverrides = map[string]string{
+	// SQLResourcesClient serves SQL container, role-assignment and role-definition
+	// reads. The client maps everything to sqlDatabases/containers/read (see the
+	// sQLResources override below), so the role calls each need their own mapping
+	// to the correct resource.
+	"SQLResources.NewListSQLRoleAssignmentsPager": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/read",
+	"SQLResources.NewListSQLRoleDefinitionsPager": "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions/read",
 }
 
 // azurePermissionOverrides maps generated permission strings to the correct

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,10 +1,10 @@
 {
   "provider": "aws",
   "version": "13.31.1",
-  "generated_at": "2026-06-03T10:00:58-07:00",
+  "generated_at": "2026-06-03T11:56:05-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
-    "access-analyzer:ListFindingsV2",
+    "access-analyzer:ListFindings",
     "account:GetAlternateContact",
     "account:GetContactInformation",
     "account:ListRegions",
@@ -13,16 +13,7 @@
     "acm:GetCertificate",
     "acm:ListCertificates",
     "acm:ListTagsForCertificate",
-    "apigateway:GetApiKeys",
-    "apigateway:GetApis",
-    "apigateway:GetAuthorizers",
-    "apigateway:GetDomainNames",
-    "apigateway:GetRequestValidators",
-    "apigateway:GetRestApis",
-    "apigateway:GetRoutes",
-    "apigateway:GetStages",
-    "apigateway:GetUsagePlans",
-    "apigateway:GetVpcLinks",
+    "apigateway:GET",
     "application-autoscaling:DescribeScalableTargets",
     "application-autoscaling:DescribeScalingPolicies",
     "application-autoscaling:DescribeScheduledActions",
@@ -94,7 +85,6 @@
     "bedrock-agentcore:ListMemories",
     "bedrock-agentcore:ListOauth2CredentialProviders",
     "bedrock-agentcore:ListWorkloadIdentities",
-    "bedrock:GetAdvancedPromptOptimizationJob",
     "bedrock:GetAgent",
     "bedrock:GetCustomModel",
     "bedrock:GetEvaluationJob",
@@ -104,7 +94,6 @@
     "bedrock:GetKnowledgeBase",
     "bedrock:GetModelImportJob",
     "bedrock:GetModelInvocationLoggingConfiguration",
-    "bedrock:ListAdvancedPromptOptimizationJobs",
     "bedrock:ListAgentActionGroups",
     "bedrock:ListAgentAliases",
     "bedrock:ListAgentKnowledgeBases",
@@ -122,9 +111,9 @@
     "bedrock:ListModelInvocationJobs",
     "bedrock:ListPrompts",
     "bedrock:ListProvisionedModelThroughputs",
-    "budgets:DescribeBudgets",
-    "budgets:DescribeNotificationsForBudget",
-    "budgets:DescribeSubscribersForNotification",
+    "budgets:ViewBudget",
+    "cassandra:Select",
+    "cassandra:TagResource",
     "ce:GetCostAndUsage",
     "ce:GetCostForecast",
     "cloudformation:DescribeStackSet",
@@ -217,14 +206,14 @@
     "detective:ListDatasourcePackages",
     "detective:ListGraphs",
     "detective:ListMembers",
-    "detective:ListOrganizationAdminAccounts",
+    "detective:ListOrganizationAdminAccount",
     "detective:ListTagsForResource",
     "dms:DescribeEndpoints",
     "dms:DescribeReplicationInstances",
     "dms:DescribeReplicationSubnetGroups",
     "dms:DescribeReplicationTasks",
-    "docdbelastic:ListClusterSnapshots",
-    "docdbelastic:ListClusters",
+    "docdb-elastic:ListClusterSnapshots",
+    "docdb-elastic:ListClusters",
     "drs:DescribeJobs",
     "drs:DescribeRecoveryInstances",
     "drs:DescribeReplicationConfigurationTemplates",
@@ -330,14 +319,6 @@
     "ecs:ListTagsForResource",
     "ecs:ListTaskDefinitions",
     "ecs:ListTasks",
-    "efs:DescribeAccessPoints",
-    "efs:DescribeBackupPolicy",
-    "efs:DescribeFileSystemPolicy",
-    "efs:DescribeFileSystems",
-    "efs:DescribeLifecycleConfiguration",
-    "efs:DescribeMountTargetSecurityGroups",
-    "efs:DescribeMountTargets",
-    "efs:DescribeReplicationConfigurations",
     "eks:DescribeAccessEntry",
     "eks:DescribeAddon",
     "eks:DescribeAddonVersions",
@@ -371,25 +352,33 @@
     "elasticbeanstalk:DescribeEnvironmentResources",
     "elasticbeanstalk:DescribeEnvironments",
     "elasticbeanstalk:ListTagsForResource",
+    "elasticfilesystem:DescribeAccessPoints",
+    "elasticfilesystem:DescribeBackupPolicy",
+    "elasticfilesystem:DescribeFileSystemPolicy",
+    "elasticfilesystem:DescribeFileSystems",
+    "elasticfilesystem:DescribeLifecycleConfiguration",
+    "elasticfilesystem:DescribeMountTargetSecurityGroups",
+    "elasticfilesystem:DescribeMountTargets",
+    "elasticfilesystem:DescribeReplicationConfigurations",
     "elasticloadbalancing:DescribeListeners",
     "elasticloadbalancing:DescribeLoadBalancerAttributes",
     "elasticloadbalancing:DescribeLoadBalancers",
     "elasticloadbalancing:DescribeTags",
     "elasticloadbalancing:DescribeTargetGroupAttributes",
     "elasticloadbalancing:DescribeTargetGroups",
-    "emr:DescribeCluster",
-    "emr:DescribeSecurityConfiguration",
-    "emr:DescribeStep",
-    "emr:DescribeStudio",
-    "emr:GetAutoTerminationPolicy",
-    "emr:GetBlockPublicAccessConfiguration",
-    "emr:ListBootstrapActions",
-    "emr:ListClusters",
-    "emr:ListInstanceGroups",
-    "emr:ListInstances",
-    "emr:ListSecurityConfigurations",
-    "emr:ListSteps",
-    "emr:ListStudios",
+    "elasticmapreduce:DescribeCluster",
+    "elasticmapreduce:DescribeSecurityConfiguration",
+    "elasticmapreduce:DescribeStep",
+    "elasticmapreduce:DescribeStudio",
+    "elasticmapreduce:GetAutoTerminationPolicy",
+    "elasticmapreduce:GetBlockPublicAccessConfiguration",
+    "elasticmapreduce:ListBootstrapActions",
+    "elasticmapreduce:ListClusters",
+    "elasticmapreduce:ListInstanceGroups",
+    "elasticmapreduce:ListInstances",
+    "elasticmapreduce:ListSecurityConfigurations",
+    "elasticmapreduce:ListSteps",
+    "elasticmapreduce:ListStudios",
     "es:DescribeDomains",
     "es:DescribeElasticsearchDomain",
     "es:DescribeElasticsearchDomains",
@@ -506,11 +495,6 @@
     "kafka:ListNodes",
     "kafka:ListReplicators",
     "kafka:ListScramSecrets",
-    "keyspaces:GetKeyspace",
-    "keyspaces:GetTable",
-    "keyspaces:ListKeyspaces",
-    "keyspaces:ListTables",
-    "keyspaces:ListTagsForResource",
     "kinesis:DescribeStreamSummary",
     "kinesis:ListStreamConsumers",
     "kinesis:ListStreams",
@@ -679,31 +663,31 @@
     "route53resolver:ListResolverQueryLogConfigs",
     "route53resolver:ListResolverRuleAssociations",
     "route53resolver:ListResolverRules",
+    "s3:GetAccelerateConfiguration",
     "s3:GetAccessPoint",
     "s3:GetAccessPointPolicy",
-    "s3:GetBucketAccelerateConfiguration",
+    "s3:GetAnalyticsConfiguration",
     "s3:GetBucketAcl",
     "s3:GetBucketCors",
-    "s3:GetBucketEncryption",
-    "s3:GetBucketLifecycleConfiguration",
     "s3:GetBucketLocation",
     "s3:GetBucketLogging",
-    "s3:GetBucketNotificationConfiguration",
+    "s3:GetBucketNotification",
+    "s3:GetBucketObjectLockConfiguration",
     "s3:GetBucketOwnershipControls",
     "s3:GetBucketPolicy",
-    "s3:GetBucketReplication",
+    "s3:GetBucketPublicAccessBlock",
     "s3:GetBucketRequestPayment",
     "s3:GetBucketTagging",
     "s3:GetBucketVersioning",
     "s3:GetBucketWebsite",
-    "s3:GetObjectLockConfiguration",
-    "s3:GetPublicAccessBlock",
+    "s3:GetEncryptionConfiguration",
+    "s3:GetIntelligentTieringConfiguration",
+    "s3:GetInventoryConfiguration",
+    "s3:GetLifecycleConfiguration",
+    "s3:GetMetricsConfiguration",
+    "s3:GetReplicationConfiguration",
     "s3:ListAccessPoints",
-    "s3:ListBucketAnalyticsConfigurations",
-    "s3:ListBucketIntelligentTieringConfigurations",
-    "s3:ListBucketInventoryConfigurations",
-    "s3:ListBucketMetricsConfigurations",
-    "s3:ListBuckets",
+    "s3:ListAllMyBuckets",
     "sagemaker:DescribeAction",
     "sagemaker:DescribeAlgorithm",
     "sagemaker:DescribeApp",
@@ -930,7 +914,7 @@
       "source_file": "aws_iam_accessanalyzer.go"
     },
     {
-      "permission": "access-analyzer:ListFindingsV2",
+      "permission": "access-analyzer:ListFindings",
       "service": "access-analyzer",
       "action": "ListFindingsV2",
       "source_file": "aws_iam_accessanalyzer.go"
@@ -984,76 +968,16 @@
       "source_file": "aws_acm.go"
     },
     {
-      "permission": "apigateway:GetApiKeys",
+      "permission": "apigateway:GET",
       "service": "apigateway",
       "action": "GetApiKeys",
       "source_file": "aws_apigateway.go"
     },
     {
-      "permission": "apigateway:GetApis",
+      "permission": "apigateway:GET",
       "service": "apigateway",
       "action": "GetApis",
       "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetAuthorizers",
-      "service": "apigateway",
-      "action": "GetAuthorizers",
-      "source_file": "aws_apigateway.go"
-    },
-    {
-      "permission": "apigateway:GetAuthorizers",
-      "service": "apigateway",
-      "action": "GetAuthorizers",
-      "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetDomainNames",
-      "service": "apigateway",
-      "action": "GetDomainNames",
-      "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetRequestValidators",
-      "service": "apigateway",
-      "action": "GetRequestValidators",
-      "source_file": "aws_apigateway.go"
-    },
-    {
-      "permission": "apigateway:GetRestApis",
-      "service": "apigateway",
-      "action": "GetRestApis",
-      "source_file": "aws_apigateway.go"
-    },
-    {
-      "permission": "apigateway:GetRoutes",
-      "service": "apigateway",
-      "action": "GetRoutes",
-      "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetStages",
-      "service": "apigateway",
-      "action": "GetStages",
-      "source_file": "aws_apigateway.go"
-    },
-    {
-      "permission": "apigateway:GetStages",
-      "service": "apigateway",
-      "action": "GetStages",
-      "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetUsagePlans",
-      "service": "apigateway",
-      "action": "GetUsagePlans",
-      "source_file": "aws_apigateway.go"
-    },
-    {
-      "permission": "apigateway:GetVpcLinks",
-      "service": "apigateway",
-      "action": "GetVpcLinks",
-      "source_file": "aws_apigateway.go"
     },
     {
       "permission": "application-autoscaling:DescribeScalableTargets",
@@ -1482,12 +1406,6 @@
       "source_file": "aws_bedrock_agentcore.go"
     },
     {
-      "permission": "bedrock:GetAdvancedPromptOptimizationJob",
-      "service": "bedrock",
-      "action": "GetAdvancedPromptOptimizationJob",
-      "source_file": "aws_bedrock.go"
-    },
-    {
       "permission": "bedrock:GetAgent",
       "service": "bedrock",
       "action": "GetAgent",
@@ -1539,12 +1457,6 @@
       "permission": "bedrock:GetModelInvocationLoggingConfiguration",
       "service": "bedrock",
       "action": "GetModelInvocationLoggingConfiguration",
-      "source_file": "aws_bedrock.go"
-    },
-    {
-      "permission": "bedrock:ListAdvancedPromptOptimizationJobs",
-      "service": "bedrock",
-      "action": "ListAdvancedPromptOptimizationJobs",
       "source_file": "aws_bedrock.go"
     },
     {
@@ -1650,22 +1562,22 @@
       "source_file": "aws_bedrock.go"
     },
     {
-      "permission": "budgets:DescribeBudgets",
+      "permission": "budgets:ViewBudget",
       "service": "budgets",
       "action": "DescribeBudgets",
       "source_file": "aws_billing.go"
     },
     {
-      "permission": "budgets:DescribeNotificationsForBudget",
-      "service": "budgets",
-      "action": "DescribeNotificationsForBudget",
-      "source_file": "aws_billing.go"
+      "permission": "cassandra:Select",
+      "service": "cassandra",
+      "action": "GetKeyspace",
+      "source_file": "aws_keyspaces.go"
     },
     {
-      "permission": "budgets:DescribeSubscribersForNotification",
-      "service": "budgets",
-      "action": "DescribeSubscribersForNotification",
-      "source_file": "aws_billing.go"
+      "permission": "cassandra:TagResource",
+      "service": "cassandra",
+      "action": "ListTagsForResource",
+      "source_file": "aws_keyspaces.go"
     },
     {
       "permission": "ce:GetCostAndUsage",
@@ -2220,7 +2132,7 @@
       "source_file": "aws_detective.go"
     },
     {
-      "permission": "detective:ListOrganizationAdminAccounts",
+      "permission": "detective:ListOrganizationAdminAccount",
       "service": "detective",
       "action": "ListOrganizationAdminAccounts",
       "source_file": "aws_detective.go"
@@ -2256,14 +2168,14 @@
       "source_file": "aws_dms.go"
     },
     {
-      "permission": "docdbelastic:ListClusterSnapshots",
-      "service": "docdbelastic",
+      "permission": "docdb-elastic:ListClusterSnapshots",
+      "service": "docdb-elastic",
       "action": "ListClusterSnapshots",
       "source_file": "aws_documentdb.go"
     },
     {
-      "permission": "docdbelastic:ListClusters",
-      "service": "docdbelastic",
+      "permission": "docdb-elastic:ListClusters",
+      "service": "docdb-elastic",
       "action": "ListClusters",
       "source_file": "aws_documentdb.go"
     },
@@ -2940,54 +2852,6 @@
       "source_file": "aws_ecs.go"
     },
     {
-      "permission": "efs:DescribeAccessPoints",
-      "service": "efs",
-      "action": "DescribeAccessPoints",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeBackupPolicy",
-      "service": "efs",
-      "action": "DescribeBackupPolicy",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeFileSystemPolicy",
-      "service": "efs",
-      "action": "DescribeFileSystemPolicy",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeFileSystems",
-      "service": "efs",
-      "action": "DescribeFileSystems",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeLifecycleConfiguration",
-      "service": "efs",
-      "action": "DescribeLifecycleConfiguration",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeMountTargetSecurityGroups",
-      "service": "efs",
-      "action": "DescribeMountTargetSecurityGroups",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeMountTargets",
-      "service": "efs",
-      "action": "DescribeMountTargets",
-      "source_file": "aws_efs.go"
-    },
-    {
-      "permission": "efs:DescribeReplicationConfigurations",
-      "service": "efs",
-      "action": "DescribeReplicationConfigurations",
-      "source_file": "aws_efs.go"
-    },
-    {
       "permission": "eks:DescribeAccessEntry",
       "service": "eks",
       "action": "DescribeAccessEntry",
@@ -3186,6 +3050,54 @@
       "source_file": "aws_elasticbeanstalk.go"
     },
     {
+      "permission": "elasticfilesystem:DescribeAccessPoints",
+      "service": "elasticfilesystem",
+      "action": "DescribeAccessPoints",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeBackupPolicy",
+      "service": "elasticfilesystem",
+      "action": "DescribeBackupPolicy",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeFileSystemPolicy",
+      "service": "elasticfilesystem",
+      "action": "DescribeFileSystemPolicy",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeFileSystems",
+      "service": "elasticfilesystem",
+      "action": "DescribeFileSystems",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeLifecycleConfiguration",
+      "service": "elasticfilesystem",
+      "action": "DescribeLifecycleConfiguration",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeMountTargetSecurityGroups",
+      "service": "elasticfilesystem",
+      "action": "DescribeMountTargetSecurityGroups",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeMountTargets",
+      "service": "elasticfilesystem",
+      "action": "DescribeMountTargets",
+      "source_file": "aws_efs.go"
+    },
+    {
+      "permission": "elasticfilesystem:DescribeReplicationConfigurations",
+      "service": "elasticfilesystem",
+      "action": "DescribeReplicationConfigurations",
+      "source_file": "aws_efs.go"
+    },
+    {
       "permission": "elasticloadbalancing:DescribeListeners",
       "service": "elasticloadbalancing",
       "action": "DescribeListeners",
@@ -3222,80 +3134,80 @@
       "source_file": "aws_elb.go"
     },
     {
-      "permission": "emr:DescribeCluster",
-      "service": "emr",
+      "permission": "elasticmapreduce:DescribeCluster",
+      "service": "elasticmapreduce",
       "action": "DescribeCluster",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:DescribeSecurityConfiguration",
-      "service": "emr",
+      "permission": "elasticmapreduce:DescribeSecurityConfiguration",
+      "service": "elasticmapreduce",
       "action": "DescribeSecurityConfiguration",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:DescribeStep",
-      "service": "emr",
+      "permission": "elasticmapreduce:DescribeStep",
+      "service": "elasticmapreduce",
       "action": "DescribeStep",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:DescribeStudio",
-      "service": "emr",
+      "permission": "elasticmapreduce:DescribeStudio",
+      "service": "elasticmapreduce",
       "action": "DescribeStudio",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:GetAutoTerminationPolicy",
-      "service": "emr",
+      "permission": "elasticmapreduce:GetAutoTerminationPolicy",
+      "service": "elasticmapreduce",
       "action": "GetAutoTerminationPolicy",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:GetBlockPublicAccessConfiguration",
-      "service": "emr",
+      "permission": "elasticmapreduce:GetBlockPublicAccessConfiguration",
+      "service": "elasticmapreduce",
       "action": "GetBlockPublicAccessConfiguration",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListBootstrapActions",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListBootstrapActions",
+      "service": "elasticmapreduce",
       "action": "ListBootstrapActions",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListClusters",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListClusters",
+      "service": "elasticmapreduce",
       "action": "ListClusters",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListInstanceGroups",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListInstanceGroups",
+      "service": "elasticmapreduce",
       "action": "ListInstanceGroups",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListInstances",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListInstances",
+      "service": "elasticmapreduce",
       "action": "ListInstances",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListSecurityConfigurations",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListSecurityConfigurations",
+      "service": "elasticmapreduce",
       "action": "ListSecurityConfigurations",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListSteps",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListSteps",
+      "service": "elasticmapreduce",
       "action": "ListSteps",
       "source_file": "aws_emr.go"
     },
     {
-      "permission": "emr:ListStudios",
-      "service": "emr",
+      "permission": "elasticmapreduce:ListStudios",
+      "service": "elasticmapreduce",
       "action": "ListStudios",
       "source_file": "aws_emr.go"
     },
@@ -4006,36 +3918,6 @@
       "service": "kafka",
       "action": "ListScramSecrets",
       "source_file": "aws_msk.go"
-    },
-    {
-      "permission": "keyspaces:GetKeyspace",
-      "service": "keyspaces",
-      "action": "GetKeyspace",
-      "source_file": "aws_keyspaces.go"
-    },
-    {
-      "permission": "keyspaces:GetTable",
-      "service": "keyspaces",
-      "action": "GetTable",
-      "source_file": "aws_keyspaces.go"
-    },
-    {
-      "permission": "keyspaces:ListKeyspaces",
-      "service": "keyspaces",
-      "action": "ListKeyspaces",
-      "source_file": "aws_keyspaces.go"
-    },
-    {
-      "permission": "keyspaces:ListTables",
-      "service": "keyspaces",
-      "action": "ListTables",
-      "source_file": "aws_keyspaces.go"
-    },
-    {
-      "permission": "keyspaces:ListTagsForResource",
-      "service": "keyspaces",
-      "action": "ListTagsForResource",
-      "source_file": "aws_keyspaces.go"
     },
     {
       "permission": "kinesis:DescribeStreamSummary",
@@ -5124,6 +5006,12 @@
       "source_file": "aws_route53_resolver.go"
     },
     {
+      "permission": "s3:GetAccelerateConfiguration",
+      "service": "s3",
+      "action": "GetBucketAccelerateConfiguration",
+      "source_file": "aws_s3.go"
+    },
+    {
       "permission": "s3:GetAccessPoint",
       "service": "s3",
       "action": "GetAccessPoint",
@@ -5136,9 +5024,9 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetBucketAccelerateConfiguration",
+      "permission": "s3:GetAnalyticsConfiguration",
       "service": "s3",
-      "action": "GetBucketAccelerateConfiguration",
+      "action": "ListBucketAnalyticsConfigurations",
       "source_file": "aws_s3.go"
     },
     {
@@ -5154,18 +5042,6 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetBucketEncryption",
-      "service": "s3",
-      "action": "GetBucketEncryption",
-      "source_file": "aws_s3.go"
-    },
-    {
-      "permission": "s3:GetBucketLifecycleConfiguration",
-      "service": "s3",
-      "action": "GetBucketLifecycleConfiguration",
-      "source_file": "aws_s3.go"
-    },
-    {
       "permission": "s3:GetBucketLocation",
       "service": "s3",
       "action": "GetBucketLocation",
@@ -5178,9 +5054,15 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetBucketNotificationConfiguration",
+      "permission": "s3:GetBucketNotification",
       "service": "s3",
       "action": "GetBucketNotificationConfiguration",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetBucketObjectLockConfiguration",
+      "service": "s3",
+      "action": "GetObjectLockConfiguration",
       "source_file": "aws_s3.go"
     },
     {
@@ -5196,9 +5078,9 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetBucketReplication",
+      "permission": "s3:GetBucketPublicAccessBlock",
       "service": "s3",
-      "action": "GetBucketReplication",
+      "action": "GetPublicAccessBlock",
       "source_file": "aws_s3.go"
     },
     {
@@ -5226,15 +5108,39 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetObjectLockConfiguration",
+      "permission": "s3:GetEncryptionConfiguration",
       "service": "s3",
-      "action": "GetObjectLockConfiguration",
+      "action": "GetBucketEncryption",
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:GetPublicAccessBlock",
+      "permission": "s3:GetIntelligentTieringConfiguration",
       "service": "s3",
-      "action": "GetPublicAccessBlock",
+      "action": "ListBucketIntelligentTieringConfigurations",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetInventoryConfiguration",
+      "service": "s3",
+      "action": "ListBucketInventoryConfigurations",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetLifecycleConfiguration",
+      "service": "s3",
+      "action": "GetBucketLifecycleConfiguration",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetMetricsConfiguration",
+      "service": "s3",
+      "action": "ListBucketMetricsConfigurations",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetReplicationConfiguration",
+      "service": "s3",
+      "action": "GetBucketReplication",
       "source_file": "aws_s3.go"
     },
     {
@@ -5244,31 +5150,7 @@
       "source_file": "aws_s3.go"
     },
     {
-      "permission": "s3:ListBucketAnalyticsConfigurations",
-      "service": "s3",
-      "action": "ListBucketAnalyticsConfigurations",
-      "source_file": "aws_s3.go"
-    },
-    {
-      "permission": "s3:ListBucketIntelligentTieringConfigurations",
-      "service": "s3",
-      "action": "ListBucketIntelligentTieringConfigurations",
-      "source_file": "aws_s3.go"
-    },
-    {
-      "permission": "s3:ListBucketInventoryConfigurations",
-      "service": "s3",
-      "action": "ListBucketInventoryConfigurations",
-      "source_file": "aws_s3.go"
-    },
-    {
-      "permission": "s3:ListBucketMetricsConfigurations",
-      "service": "s3",
-      "action": "ListBucketMetricsConfigurations",
-      "source_file": "aws_s3.go"
-    },
-    {
-      "permission": "s3:ListBuckets",
+      "permission": "s3:ListAllMyBuckets",
       "service": "s3",
       "action": "ListBuckets",
       "source_file": "aws_s3.go"

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.16.0",
-  "generated_at": "2026-06-04T13:47:42-07:00",
+  "generated_at": "2026-06-04T15:13:13-06:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -84,6 +84,8 @@
     "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
     "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
+    "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/read",
+    "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions/read",
     "Microsoft.DocumentDB/mongoClusters/read",
     "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
     "Microsoft.EventHub/namespaces/eventhubs/read",
@@ -705,14 +707,20 @@
     {
       "permission": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
       "service": "Microsoft.DocumentDB",
+      "action": "NewListSQLContainersPager",
+      "source_file": "cosmosdb_extras.go"
+    },
+    {
+      "permission": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/read",
+      "service": "Microsoft.DocumentDB",
       "action": "NewListSQLRoleAssignmentsPager",
       "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
+      "permission": "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLContainersPager",
-      "source_file": "cosmosdb_extras.go"
+      "action": "NewListSQLRoleDefinitionsPager",
+      "source_file": "cosmosdb.go"
     },
     {
       "permission": "Microsoft.DocumentDB/mongoClusters/read",

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,19 +1,19 @@
 {
   "provider": "azure",
-  "version": "13.15.1",
-  "generated_at": "2026-06-04T08:11:09-07:00",
+  "version": "13.16.0",
+  "generated_at": "2026-06-04T13:47:42-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
-    "Microsoft.App/certificates/read",
+    "Microsoft.App/containerApps/authConfigs/read",
     "Microsoft.App/containerApps/read",
-    "Microsoft.App/containerAppsAuthConfigs/read",
-    "Microsoft.App/containerAppsRevisions/read",
-    "Microsoft.App/daprComponents/read",
-    "Microsoft.App/hTTPRouteConfig/read",
+    "Microsoft.App/containerApps/revisions/read",
     "Microsoft.App/jobs/read",
-    "Microsoft.App/maintenanceConfigurations/read",
-    "Microsoft.App/managedEnvironmentPrivateEndpointConnections/read",
+    "Microsoft.App/managedEnvironments/certificates/read",
+    "Microsoft.App/managedEnvironments/daprComponents/read",
+    "Microsoft.App/managedEnvironments/httpRouteConfigs/read",
+    "Microsoft.App/managedEnvironments/maintenanceConfigurations/read",
+    "Microsoft.App/managedEnvironments/privateEndpointConnections/read",
     "Microsoft.App/managedEnvironments/read",
     "Microsoft.Appconfiguration/configurationStores/read",
     "Microsoft.Authorization/classicAdministrators/read",
@@ -30,28 +30,28 @@
     "Microsoft.Cdn/profiles/origingroups/origins/read",
     "Microsoft.Cdn/profiles/origingroups/read",
     "Microsoft.Cdn/profiles/read",
-    "Microsoft.Cognitiveservices/accountConnections/read",
+    "Microsoft.CognitiveServices/accounts/connections/read",
+    "Microsoft.CognitiveServices/accounts/defenderForAISettings/read",
+    "Microsoft.CognitiveServices/accounts/deployments/read",
+    "Microsoft.CognitiveServices/accounts/projects/connections/read",
+    "Microsoft.CognitiveServices/accounts/projects/read",
+    "Microsoft.CognitiveServices/accounts/raiPolicies/read",
+    "Microsoft.CognitiveServices/accounts/raiTopics/read",
     "Microsoft.Cognitiveservices/accounts/read",
-    "Microsoft.Cognitiveservices/defenderForAISettings/read",
-    "Microsoft.Cognitiveservices/deployments/read",
-    "Microsoft.Cognitiveservices/projectConnections/read",
-    "Microsoft.Cognitiveservices/projects/read",
-    "Microsoft.Cognitiveservices/raiPolicies/read",
-    "Microsoft.Cognitiveservices/raiTopics/read",
-    "Microsoft.Compute/dedicatedHostGroups/read",
-    "Microsoft.Compute/dedicatedHosts/read",
     "Microsoft.Compute/diskAccesses/read",
     "Microsoft.Compute/diskEncryptionSets/read",
     "Microsoft.Compute/disks/read",
+    "Microsoft.Compute/galleries/images/read",
+    "Microsoft.Compute/galleries/images/versions/read",
     "Microsoft.Compute/galleries/read",
-    "Microsoft.Compute/galleryImageVersions/read",
-    "Microsoft.Compute/galleryImages/read",
+    "Microsoft.Compute/hostGroups/hosts/read",
+    "Microsoft.Compute/hostGroups/read",
     "Microsoft.Compute/images/read",
     "Microsoft.Compute/proximityPlacementGroups/read",
     "Microsoft.Compute/snapshots/read",
-    "Microsoft.Compute/virtualMachineScaleSetExtensions/read",
-    "Microsoft.Compute/virtualMachineScaleSetVMs/read",
+    "Microsoft.Compute/virtualMachineScaleSets/extensions/read",
     "Microsoft.Compute/virtualMachineScaleSets/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
     "Microsoft.Compute/virtualMachines/read",
     "Microsoft.ContainerInstance/containerGroups/read",
     "Microsoft.ContainerRegistry/registries/cacheRules/read",
@@ -61,29 +61,30 @@
     "Microsoft.ContainerRegistry/registries/scopeMaps/read",
     "Microsoft.ContainerRegistry/registries/tokens/read",
     "Microsoft.ContainerRegistry/registries/webhooks/read",
-    "Microsoft.ContainerService/agentPools/read",
     "Microsoft.ContainerService/identityBindings/read",
+    "Microsoft.ContainerService/managedClusters/agentPools/read",
     "Microsoft.ContainerService/managedClusters/read",
     "Microsoft.DBforMySQL/servers/configurations/read",
     "Microsoft.DBforMySQL/servers/databases/read",
     "Microsoft.DBforMySQL/servers/firewallRules/read",
     "Microsoft.DBforMySQL/servers/read",
     "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read",
-    "Microsoft.DBforPostgreSQL/privateEndpointConnections/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/configurations/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/databases/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/privateEndpointConnections/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/read",
     "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
-    "Microsoft.DBforPostgreSQL/servers/configurations/read",
-    "Microsoft.DBforPostgreSQL/servers/databases/read",
-    "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
-    "Microsoft.DBforPostgreSQL/servers/read",
     "Microsoft.DataFactory/factories/integrationruntimes/read",
     "Microsoft.DataFactory/factories/linkedservices/read",
     "Microsoft.DataFactory/factories/managedvirtualnetworks/managedprivateendpoints/read",
     "Microsoft.DataFactory/factories/managedvirtualnetworks/read",
     "Microsoft.DataFactory/factories/read",
     "Microsoft.Databricks/workspaces/read",
+    "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
-    "Microsoft.DocumentDB/privateEndpointConnections/read",
-    "Microsoft.DocumentDB/sQLResources/read",
+    "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
+    "Microsoft.DocumentDB/mongoClusters/read",
     "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
     "Microsoft.EventHub/namespaces/eventhubs/read",
     "Microsoft.EventHub/namespaces/read",
@@ -98,38 +99,35 @@
     "Microsoft.KeyVault/managedHsms/read",
     "Microsoft.KeyVault/vaults/read",
     "Microsoft.Logic/workflows/read",
-    "Microsoft.MachineLearningServices/compute/read",
-    "Microsoft.MachineLearningServices/modelContainers/read",
-    "Microsoft.MachineLearningServices/onlineDeployments/read",
-    "Microsoft.MachineLearningServices/onlineEndpoints/read",
-    "Microsoft.MachineLearningServices/serverlessEndpoints/read",
+    "Microsoft.MachineLearningServices/workspaces/computes/read",
+    "Microsoft.MachineLearningServices/workspaces/models/read",
+    "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments/read",
+    "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
     "Microsoft.MachineLearningServices/workspaces/read",
+    "Microsoft.MachineLearningServices/workspaces/serverlessEndpoints/read",
     "Microsoft.ManagedIdentity/userAssignedIdentities/read",
-    "Microsoft.Mongocluster/mongoClusters/read",
     "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
     "Microsoft.Network/applicationGateways/read",
     "Microsoft.Network/applicationSecurityGroups/read",
     "Microsoft.Network/azureFirewalls/read",
     "Microsoft.Network/bastionHosts/read",
-    "Microsoft.Network/connectionMonitors/read",
     "Microsoft.Network/connections/read",
     "Microsoft.Network/ddosProtectionPlans/read",
     "Microsoft.Network/dnszones/read",
     "Microsoft.Network/dnszones/recordsets/read",
-    "Microsoft.Network/expressRouteCircuitAuthorizations/read",
-    "Microsoft.Network/expressRouteCircuitPeerings/read",
+    "Microsoft.Network/expressRouteCircuits/authorizations/read",
+    "Microsoft.Network/expressRouteCircuits/peerings/read",
     "Microsoft.Network/expressRouteCircuits/read",
     "Microsoft.Network/firewallPolicies/read",
-    "Microsoft.Network/hubRouteTables/read",
-    "Microsoft.Network/hubVirtualNetworkConnections/read",
     "Microsoft.Network/loadBalancers/read",
     "Microsoft.Network/localNetworkGateways/read",
     "Microsoft.Network/natGateways/read",
     "Microsoft.Network/networkInterfaces/read",
     "Microsoft.Network/networkSecurityGroups/read",
+    "Microsoft.Network/networkWatchers/connectionMonitors/read",
     "Microsoft.Network/networkWatchers/flowLogs/read",
+    "Microsoft.Network/networkWatchers/packetCaptures/read",
     "Microsoft.Network/networkWatchers/read",
-    "Microsoft.Network/packetCaptures/read",
     "Microsoft.Network/privateDnsZones/read",
     "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
     "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read",
@@ -138,7 +136,10 @@
     "Microsoft.Network/publicIPAddresses/read",
     "Microsoft.Network/routeTables/read",
     "Microsoft.Network/serviceEndpointPolicies/read",
+    "Microsoft.Network/trafficManagerProfiles/read",
     "Microsoft.Network/vPNSites/read",
+    "Microsoft.Network/virtualHubs/hubRouteTables/read",
+    "Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/read",
     "Microsoft.Network/virtualHubs/read",
     "Microsoft.Network/virtualNetworkGateways/read",
     "Microsoft.Network/virtualNetworks/read",
@@ -159,29 +160,17 @@
     "Microsoft.Resources/resources/read",
     "Microsoft.Resources/subscriptions/read",
     "Microsoft.Resources/subscriptions/resourceGroups/read",
-    "Microsoft.Search/services/read",
+    "Microsoft.Search/searchServices/read",
     "Microsoft.Security/autoProvisioningSettings/read",
-    "Microsoft.Security/defenderForStorage/read",
+    "Microsoft.Security/defenderForStorageSettings/read",
     "Microsoft.Securityinsights/alertRules/read",
     "Microsoft.Securityinsights/dataConnectors/read",
     "Microsoft.ServiceBus/namespaces/queues/read",
     "Microsoft.ServiceBus/namespaces/read",
     "Microsoft.ServiceBus/namespaces/topics/read",
     "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
-    "Microsoft.Sql/dataMaskingPolicies/read",
-    "Microsoft.Sql/dataMaskingRules/read",
-    "Microsoft.Sql/databaseVulnerabilityAssessmentScans/read",
-    "Microsoft.Sql/databaseVulnerabilityAssessments/read",
-    "Microsoft.Sql/failoverGroups/read",
-    "Microsoft.Sql/geoBackupPolicies/read",
-    "Microsoft.Sql/ledgerDigestUploads/read",
-    "Microsoft.Sql/managedDatabases/read",
+    "Microsoft.Sql/managedInstances/databases/read",
     "Microsoft.Sql/managedInstances/read",
-    "Microsoft.Sql/outboundFirewallRules/read",
-    "Microsoft.Sql/privateEndpointConnections/read",
-    "Microsoft.Sql/replicationLinks/read",
-    "Microsoft.Sql/serverDevOpsAuditSettings/read",
-    "Microsoft.Sql/serverKeys/read",
     "Microsoft.Sql/servers/administrators/read",
     "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
     "Microsoft.Sql/servers/auditingSettings/read",
@@ -191,30 +180,41 @@
     "Microsoft.Sql/servers/databases/auditingSettings/read",
     "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
     "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
+    "Microsoft.Sql/servers/databases/dataMaskingPolicies/read",
+    "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules/read",
+    "Microsoft.Sql/servers/databases/geoBackupPolicies/read",
+    "Microsoft.Sql/servers/databases/ledgerDigestUploads/read",
     "Microsoft.Sql/servers/databases/read",
     "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
     "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
     "Microsoft.Sql/servers/databases/usages/read",
+    "Microsoft.Sql/servers/databases/vulnerabilityAssessments/read",
+    "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/read",
+    "Microsoft.Sql/servers/devOpsAuditingSettings/read",
     "Microsoft.Sql/servers/encryptionProtector/read",
+    "Microsoft.Sql/servers/failoverGroups/read",
     "Microsoft.Sql/servers/firewallRules/read",
+    "Microsoft.Sql/servers/keys/read",
+    "Microsoft.Sql/servers/outboundFirewallRules/read",
+    "Microsoft.Sql/servers/privateEndpointConnections/read",
     "Microsoft.Sql/servers/read",
+    "Microsoft.Sql/servers/replicationLinks/read",
     "Microsoft.Sql/servers/securityAlertPolicies/read",
     "Microsoft.Sql/servers/virtualNetworkRules/read",
     "Microsoft.Sql/servers/vulnerabilityAssessments/read",
-    "Microsoft.Storage/networkSecurityPerimeterConfigurations/read",
     "Microsoft.Storage/storageAccounts/blobServices/containers/read",
     "Microsoft.Storage/storageAccounts/encryptionScopes/read",
     "Microsoft.Storage/storageAccounts/fileServices/shares/read",
     "Microsoft.Storage/storageAccounts/inventoryPolicies/read",
     "Microsoft.Storage/storageAccounts/localUsers/read",
     "Microsoft.Storage/storageAccounts/managementPolicies/read",
+    "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations/read",
     "Microsoft.Storage/storageAccounts/objectReplicationPolicies/read",
     "Microsoft.Storage/storageAccounts/privateEndpointConnections/read",
     "Microsoft.Storage/storageAccounts/queueServices/queues/read",
     "Microsoft.Storage/storageAccounts/read",
     "Microsoft.Storage/storageAccounts/tableServices/tables/read",
     "Microsoft.Synapse/workspaces/read",
-    "Microsoft.Trafficmanager/profiles/read",
     "Microsoft.Web/certificates/read",
     "Microsoft.Web/hostingEnvironments/read",
     "Microsoft.Web/serverfarms/read",
@@ -235,9 +235,9 @@
       "source_file": "apimanagement.go"
     },
     {
-      "permission": "Microsoft.App/certificates/read",
+      "permission": "Microsoft.App/containerApps/authConfigs/read",
       "service": "Microsoft.App",
-      "action": "NewListPager",
+      "action": "NewListByContainerAppPager",
       "source_file": "appcontainers.go"
     },
     {
@@ -247,27 +247,9 @@
       "source_file": "appcontainers.go"
     },
     {
-      "permission": "Microsoft.App/containerAppsAuthConfigs/read",
-      "service": "Microsoft.App",
-      "action": "NewListByContainerAppPager",
-      "source_file": "appcontainers.go"
-    },
-    {
-      "permission": "Microsoft.App/containerAppsRevisions/read",
+      "permission": "Microsoft.App/containerApps/revisions/read",
       "service": "Microsoft.App",
       "action": "NewListRevisionsPager",
-      "source_file": "appcontainers.go"
-    },
-    {
-      "permission": "Microsoft.App/daprComponents/read",
-      "service": "Microsoft.App",
-      "action": "NewListPager",
-      "source_file": "appcontainers.go"
-    },
-    {
-      "permission": "Microsoft.App/hTTPRouteConfig/read",
-      "service": "Microsoft.App",
-      "action": "NewListPager",
       "source_file": "appcontainers.go"
     },
     {
@@ -277,13 +259,31 @@
       "source_file": "appcontainers.go"
     },
     {
-      "permission": "Microsoft.App/maintenanceConfigurations/read",
+      "permission": "Microsoft.App/managedEnvironments/certificates/read",
       "service": "Microsoft.App",
       "action": "NewListPager",
       "source_file": "appcontainers.go"
     },
     {
-      "permission": "Microsoft.App/managedEnvironmentPrivateEndpointConnections/read",
+      "permission": "Microsoft.App/managedEnvironments/daprComponents/read",
+      "service": "Microsoft.App",
+      "action": "NewListPager",
+      "source_file": "appcontainers.go"
+    },
+    {
+      "permission": "Microsoft.App/managedEnvironments/httpRouteConfigs/read",
+      "service": "Microsoft.App",
+      "action": "NewListPager",
+      "source_file": "appcontainers.go"
+    },
+    {
+      "permission": "Microsoft.App/managedEnvironments/maintenanceConfigurations/read",
+      "service": "Microsoft.App",
+      "action": "NewListPager",
+      "source_file": "appcontainers.go"
+    },
+    {
+      "permission": "Microsoft.App/managedEnvironments/privateEndpointConnections/read",
       "service": "Microsoft.App",
       "action": "NewListPager",
       "source_file": "appcontainers.go"
@@ -385,9 +385,45 @@
       "source_file": "frontdoor.go"
     },
     {
-      "permission": "Microsoft.Cognitiveservices/accountConnections/read",
+      "permission": "Microsoft.CognitiveServices/accounts/connections/read",
       "service": "Microsoft.Cognitiveservices",
       "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/defenderForAISettings/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/deployments/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/projects/connections/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/projects/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/raiPolicies/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "NewListPager",
+      "source_file": "cognitiveservices.go"
+    },
+    {
+      "permission": "Microsoft.CognitiveServices/accounts/raiTopics/read",
+      "service": "Microsoft.Cognitiveservices",
+      "action": "Get",
       "source_file": "cognitiveservices.go"
     },
     {
@@ -395,54 +431,6 @@
       "service": "Microsoft.Cognitiveservices",
       "action": "NewListPager",
       "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/defenderForAISettings/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/deployments/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/projectConnections/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/projects/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/raiPolicies/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Cognitiveservices/raiTopics/read",
-      "service": "Microsoft.Cognitiveservices",
-      "action": "Get",
-      "source_file": "cognitiveservices.go"
-    },
-    {
-      "permission": "Microsoft.Compute/dedicatedHostGroups/read",
-      "service": "Microsoft.Compute",
-      "action": "NewListBySubscriptionPager",
-      "source_file": "compute_extras.go"
-    },
-    {
-      "permission": "Microsoft.Compute/dedicatedHosts/read",
-      "service": "Microsoft.Compute",
-      "action": "NewListByHostGroupPager",
-      "source_file": "compute_extras.go"
     },
     {
       "permission": "Microsoft.Compute/diskAccesses/read",
@@ -463,21 +451,33 @@
       "source_file": "compute.go"
     },
     {
+      "permission": "Microsoft.Compute/galleries/images/read",
+      "service": "Microsoft.Compute",
+      "action": "NewListByGalleryPager",
+      "source_file": "compute_extras.go"
+    },
+    {
+      "permission": "Microsoft.Compute/galleries/images/versions/read",
+      "service": "Microsoft.Compute",
+      "action": "NewListByGalleryImagePager",
+      "source_file": "compute_extras.go"
+    },
+    {
       "permission": "Microsoft.Compute/galleries/read",
       "service": "Microsoft.Compute",
       "action": "NewListPager",
       "source_file": "compute_extras.go"
     },
     {
-      "permission": "Microsoft.Compute/galleryImageVersions/read",
+      "permission": "Microsoft.Compute/hostGroups/hosts/read",
       "service": "Microsoft.Compute",
-      "action": "NewListByGalleryImagePager",
+      "action": "NewListByHostGroupPager",
       "source_file": "compute_extras.go"
     },
     {
-      "permission": "Microsoft.Compute/galleryImages/read",
+      "permission": "Microsoft.Compute/hostGroups/read",
       "service": "Microsoft.Compute",
-      "action": "NewListByGalleryPager",
+      "action": "NewListBySubscriptionPager",
       "source_file": "compute_extras.go"
     },
     {
@@ -499,13 +499,7 @@
       "source_file": "compute.go"
     },
     {
-      "permission": "Microsoft.Compute/virtualMachineScaleSetExtensions/read",
-      "service": "Microsoft.Compute",
-      "action": "NewListPager",
-      "source_file": "compute_vmss.go"
-    },
-    {
-      "permission": "Microsoft.Compute/virtualMachineScaleSetVMs/read",
+      "permission": "Microsoft.Compute/virtualMachineScaleSets/extensions/read",
       "service": "Microsoft.Compute",
       "action": "NewListPager",
       "source_file": "compute_vmss.go"
@@ -514,6 +508,12 @@
       "permission": "Microsoft.Compute/virtualMachineScaleSets/read",
       "service": "Microsoft.Compute",
       "action": "NewListAllPager",
+      "source_file": "compute_vmss.go"
+    },
+    {
+      "permission": "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+      "service": "Microsoft.Compute",
+      "action": "NewListPager",
       "source_file": "compute_vmss.go"
     },
     {
@@ -571,15 +571,15 @@
       "source_file": "containerregistry.go"
     },
     {
-      "permission": "Microsoft.ContainerService/agentPools/read",
-      "service": "Microsoft.ContainerService",
-      "action": "NewListPager",
-      "source_file": "aks.go"
-    },
-    {
       "permission": "Microsoft.ContainerService/identityBindings/read",
       "service": "Microsoft.ContainerService",
       "action": "NewListByManagedClusterPager",
+      "source_file": "aks.go"
+    },
+    {
+      "permission": "Microsoft.ContainerService/managedClusters/agentPools/read",
+      "service": "Microsoft.ContainerService",
+      "action": "NewListPager",
       "source_file": "aks.go"
     },
     {
@@ -619,9 +619,33 @@
       "source_file": "postgresql.go"
     },
     {
-      "permission": "Microsoft.DBforPostgreSQL/privateEndpointConnections/read",
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/read",
       "service": "Microsoft.DBforPostgreSQL",
       "action": "NewListByServerPager",
+      "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/databases/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "NewListByServerPager",
+      "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "NewListByServerPager",
+      "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/privateEndpointConnections/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "NewListByServerPager",
+      "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "NewListBySubscriptionPager",
       "source_file": "postgresql.go"
     },
     {
@@ -629,30 +653,6 @@
       "service": "Microsoft.DBforPostgreSQL",
       "action": "NewListPager",
       "source_file": "cosmosdb.go"
-    },
-    {
-      "permission": "Microsoft.DBforPostgreSQL/servers/configurations/read",
-      "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListByServerPager",
-      "source_file": "postgresql.go"
-    },
-    {
-      "permission": "Microsoft.DBforPostgreSQL/servers/databases/read",
-      "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListByServerPager",
-      "source_file": "postgresql.go"
-    },
-    {
-      "permission": "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
-      "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListByServerPager",
-      "source_file": "postgresql.go"
-    },
-    {
-      "permission": "Microsoft.DBforPostgreSQL/servers/read",
-      "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListBySubscriptionPager",
-      "source_file": "postgresql.go"
     },
     {
       "permission": "Microsoft.DataFactory/factories/integrationruntimes/read",
@@ -691,28 +691,34 @@
       "source_file": "databricks.go"
     },
     {
+      "permission": "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
+      "service": "Microsoft.DocumentDB",
+      "action": "NewListByDatabaseAccountPager",
+      "source_file": "cosmosdb.go"
+    },
+    {
       "permission": "Microsoft.DocumentDB/databaseAccounts/read",
       "service": "Microsoft.DocumentDB",
       "action": "NewListPager",
       "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.DocumentDB/privateEndpointConnections/read",
-      "service": "Microsoft.DocumentDB",
-      "action": "NewListByDatabaseAccountPager",
-      "source_file": "cosmosdb.go"
-    },
-    {
-      "permission": "Microsoft.DocumentDB/sQLResources/read",
+      "permission": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
       "service": "Microsoft.DocumentDB",
       "action": "NewListSQLRoleAssignmentsPager",
       "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.DocumentDB/sQLResources/read",
+      "permission": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
       "service": "Microsoft.DocumentDB",
       "action": "NewListSQLContainersPager",
       "source_file": "cosmosdb_extras.go"
+    },
+    {
+      "permission": "Microsoft.DocumentDB/mongoClusters/read",
+      "service": "Microsoft.Mongocluster",
+      "action": "NewListPager",
+      "source_file": "cosmosdb.go"
     },
     {
       "permission": "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
@@ -799,31 +805,25 @@
       "source_file": "logic.go"
     },
     {
-      "permission": "Microsoft.MachineLearningServices/compute/read",
+      "permission": "Microsoft.MachineLearningServices/workspaces/computes/read",
       "service": "Microsoft.MachineLearningServices",
       "action": "NewListPager",
       "source_file": "machinelearning.go"
     },
     {
-      "permission": "Microsoft.MachineLearningServices/modelContainers/read",
+      "permission": "Microsoft.MachineLearningServices/workspaces/models/read",
       "service": "Microsoft.MachineLearningServices",
       "action": "NewListPager",
       "source_file": "machinelearning.go"
     },
     {
-      "permission": "Microsoft.MachineLearningServices/onlineDeployments/read",
+      "permission": "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments/read",
       "service": "Microsoft.MachineLearningServices",
       "action": "NewListPager",
       "source_file": "machinelearning.go"
     },
     {
-      "permission": "Microsoft.MachineLearningServices/onlineEndpoints/read",
-      "service": "Microsoft.MachineLearningServices",
-      "action": "NewListPager",
-      "source_file": "machinelearning.go"
-    },
-    {
-      "permission": "Microsoft.MachineLearningServices/serverlessEndpoints/read",
+      "permission": "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
       "service": "Microsoft.MachineLearningServices",
       "action": "NewListPager",
       "source_file": "machinelearning.go"
@@ -835,16 +835,16 @@
       "source_file": "machinelearning.go"
     },
     {
+      "permission": "Microsoft.MachineLearningServices/workspaces/serverlessEndpoints/read",
+      "service": "Microsoft.MachineLearningServices",
+      "action": "NewListPager",
+      "source_file": "machinelearning.go"
+    },
+    {
       "permission": "Microsoft.ManagedIdentity/userAssignedIdentities/read",
       "service": "Microsoft.ManagedIdentity",
       "action": "Get",
       "source_file": "iam.go"
-    },
-    {
-      "permission": "Microsoft.Mongocluster/mongoClusters/read",
-      "service": "Microsoft.Mongocluster",
-      "action": "NewListPager",
-      "source_file": "cosmosdb.go"
     },
     {
       "permission": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
@@ -883,12 +883,6 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/connectionMonitors/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network_expansion.go"
-    },
-    {
       "permission": "Microsoft.Network/connections/read",
       "service": "Microsoft.Network",
       "action": "Get",
@@ -913,13 +907,13 @@
       "source_file": "dns.go"
     },
     {
-      "permission": "Microsoft.Network/expressRouteCircuitAuthorizations/read",
+      "permission": "Microsoft.Network/expressRouteCircuits/authorizations/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network_expansion.go"
     },
     {
-      "permission": "Microsoft.Network/expressRouteCircuitPeerings/read",
+      "permission": "Microsoft.Network/expressRouteCircuits/peerings/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network_expansion.go"
@@ -935,18 +929,6 @@
       "service": "Microsoft.Network",
       "action": "Get",
       "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/hubRouteTables/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network_expansion.go"
-    },
-    {
-      "permission": "Microsoft.Network/hubVirtualNetworkConnections/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Network/loadBalancers/read",
@@ -985,22 +967,28 @@
       "source_file": "network.go"
     },
     {
+      "permission": "Microsoft.Network/networkWatchers/connectionMonitors/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network_expansion.go"
+    },
+    {
       "permission": "Microsoft.Network/networkWatchers/flowLogs/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network.go"
     },
     {
+      "permission": "Microsoft.Network/networkWatchers/packetCaptures/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network_expansion.go"
+    },
+    {
       "permission": "Microsoft.Network/networkWatchers/read",
       "service": "Microsoft.Network",
       "action": "NewListAllPager",
       "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/packetCaptures/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Network/privateDnsZones/read",
@@ -1063,9 +1051,27 @@
       "source_file": "network.go"
     },
     {
+      "permission": "Microsoft.Network/trafficManagerProfiles/read",
+      "service": "Microsoft.Trafficmanager",
+      "action": "NewListBySubscriptionPager",
+      "source_file": "network_expansion.go"
+    },
+    {
       "permission": "Microsoft.Network/vPNSites/read",
       "service": "Microsoft.Network",
       "action": "Get",
+      "source_file": "network_expansion.go"
+    },
+    {
+      "permission": "Microsoft.Network/virtualHubs/hubRouteTables/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network_expansion.go"
+    },
+    {
+      "permission": "Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
       "source_file": "network_expansion.go"
     },
     {
@@ -1201,7 +1207,7 @@
       "source_file": "resource_groups.go"
     },
     {
-      "permission": "Microsoft.Search/services/read",
+      "permission": "Microsoft.Search/searchServices/read",
       "service": "Microsoft.Search",
       "action": "NewListBySubscriptionPager",
       "source_file": "search.go"
@@ -1213,7 +1219,7 @@
       "source_file": "cloud_defender.go"
     },
     {
-      "permission": "Microsoft.Security/defenderForStorage/read",
+      "permission": "Microsoft.Security/defenderForStorageSettings/read",
       "service": "Microsoft.Security",
       "action": "Get",
       "source_file": "storage_extras.go"
@@ -1255,49 +1261,7 @@
       "source_file": "servicebus.go"
     },
     {
-      "permission": "Microsoft.Sql/dataMaskingPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/dataMaskingRules/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByDatabasePager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/databaseVulnerabilityAssessmentScans/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByDatabasePager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/databaseVulnerabilityAssessments/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/failoverGroups/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/geoBackupPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/ledgerDigestUploads/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/managedDatabases/read",
+      "permission": "Microsoft.Sql/managedInstances/databases/read",
       "service": "Microsoft.Sql",
       "action": "NewListByInstancePager",
       "source_file": "sql_managedinstance.go"
@@ -1307,36 +1271,6 @@
       "service": "Microsoft.Sql",
       "action": "NewListPager",
       "source_file": "sql_managedinstance.go"
-    },
-    {
-      "permission": "Microsoft.Sql/outboundFirewallRules/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/privateEndpointConnections/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/replicationLinks/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverDevOpsAuditSettings/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverKeys/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
     },
     {
       "permission": "Microsoft.Sql/servers/administrators/read",
@@ -1393,6 +1327,30 @@
       "source_file": "sql.go"
     },
     {
+      "permission": "Microsoft.Sql/servers/databases/dataMaskingPolicies/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByDatabasePager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/geoBackupPolicies/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/ledgerDigestUploads/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
       "permission": "Microsoft.Sql/servers/databases/read",
       "service": "Microsoft.Sql",
       "action": "NewListByServerPager",
@@ -1417,9 +1375,33 @@
       "source_file": "sql.go"
     },
     {
+      "permission": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByDatabasePager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/devOpsAuditingSettings/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
       "permission": "Microsoft.Sql/servers/encryptionProtector/read",
       "service": "Microsoft.Sql",
       "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/failoverGroups/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
       "source_file": "sql.go"
     },
     {
@@ -1429,9 +1411,33 @@
       "source_file": "sql.go"
     },
     {
+      "permission": "Microsoft.Sql/servers/keys/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/outboundFirewallRules/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/privateEndpointConnections/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
+      "source_file": "sql.go"
+    },
+    {
       "permission": "Microsoft.Sql/servers/read",
       "service": "Microsoft.Sql",
       "action": "NewListPager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/replicationLinks/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
       "source_file": "sql.go"
     },
     {
@@ -1451,12 +1457,6 @@
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Storage/networkSecurityPerimeterConfigurations/read",
-      "service": "Microsoft.Storage",
-      "action": "NewListPager",
-      "source_file": "storage_extras.go"
     },
     {
       "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
@@ -1495,6 +1495,12 @@
       "source_file": "storage.go"
     },
     {
+      "permission": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations/read",
+      "service": "Microsoft.Storage",
+      "action": "NewListPager",
+      "source_file": "storage_extras.go"
+    },
+    {
       "permission": "Microsoft.Storage/storageAccounts/objectReplicationPolicies/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
@@ -1529,12 +1535,6 @@
       "service": "Microsoft.Synapse",
       "action": "NewListPager",
       "source_file": "synapse.go"
-    },
-    {
-      "permission": "Microsoft.Trafficmanager/profiles/read",
-      "service": "Microsoft.Trafficmanager",
-      "action": "NewListBySubscriptionPager",
-      "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Web/certificates/read",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.21.0",
-  "generated_at": "2026-06-04T13:47:42-07:00",
+  "generated_at": "2026-06-04T15:12:41-06:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -214,7 +214,6 @@
     "networksecurity.tlsInspectionPolicies.list",
     "networksecurity.urlLists.list",
     "orgpolicy.constraints.list",
-    "orgpolicy.customConstraints.list",
     "orgpolicy.policies.list",
     "osconfig.inventories.get",
     "osconfig.osPolicyAssignments.list",
@@ -229,7 +228,6 @@
     "redis.backups.list",
     "redis.clusters.list",
     "redis.instances.list",
-    "resourcemanager.folders.getIamPolicy",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.resourceTagBindings.list",
@@ -1578,7 +1576,8 @@
       "permission": "orgpolicy.customConstraints.list",
       "service": "orgpolicy",
       "action": "ListCustomConstraints",
-      "source_file": "orgpolicy.go"
+      "source_file": "orgpolicy.go",
+      "scope": "org"
     },
     {
       "permission": "orgpolicy.policies.list",
@@ -1675,7 +1674,8 @@
       "permission": "resourcemanager.folders.getIamPolicy",
       "service": "resourcemanager",
       "action": "Folders.GetIamPolicy",
-      "source_file": "folder.go"
+      "source_file": "folder.go",
+      "scope": "org"
     },
     {
       "permission": "resourcemanager.folders.list",
@@ -1882,7 +1882,9 @@
     }
   ],
   "org_level_permissions": [
+    "orgpolicy.customConstraints.list",
     "resourcemanager.folders.get",
+    "resourcemanager.folders.getIamPolicy",
     "resourcemanager.folders.list",
     "resourcemanager.organizations.get",
     "resourcemanager.organizations.getIamPolicy",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.21.0",
-  "generated_at": "2026-06-04T15:12:41-06:00",
+  "generated_at": "2026-06-04T15:13:13-06:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -1233,7 +1233,7 @@
     {
       "permission": "dlp.jobTriggers.list",
       "service": "dlp",
-      "action": "ListDiscoveryConfigs",
+      "action": "ListJobTriggers",
       "source_file": "dlp.go"
     },
     {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.20.1",
-  "generated_at": "2026-06-03T17:40:29-07:00",
+  "version": "13.21.0",
+  "generated_at": "2026-06-04T13:47:42-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -63,10 +63,8 @@
     "clouddeploy.deliveryPipelines.list",
     "clouddeploy.releases.list",
     "clouddeploy.targets.list",
+    "cloudfunctions.functions.getIamPolicy",
     "cloudfunctions.functions.list",
-    "cloudfunctions.iamPolicy.get",
-    "cloudidentity.groups.list",
-    "cloudidentity.memberships.list",
     "cloudkms.cryptoKeyVersions.list",
     "cloudkms.cryptoKeys.get",
     "cloudkms.cryptoKeys.getIamPolicy",
@@ -82,7 +80,7 @@
     "cloudsql.instances.list",
     "cloudsql.sslCerts.list",
     "cloudsql.users.list",
-    "cloudtasks.iamPolicy.get",
+    "cloudtasks.queues.getIamPolicy",
     "cloudtasks.queues.list",
     "composer.environments.list",
     "compute.addresses.list",
@@ -151,13 +149,12 @@
     "datastream.privateConnections.list",
     "datastream.routes.list",
     "datastream.streams.list",
-    "discoveryengine.dataStore.get",
+    "discoveryengine.dataStores.get",
     "discoveryengine.dataStores.list",
     "discoveryengine.engines.list",
     "dlp.columnDataProfiles.list",
     "dlp.connections.list",
     "dlp.deidentifyTemplates.list",
-    "dlp.discoveryConfigs.list",
     "dlp.fileStoreProfiles.list",
     "dlp.inspectTemplates.list",
     "dlp.jobTriggers.list",
@@ -178,9 +175,9 @@
     "gkebackup.backupPlans.list",
     "gkebackup.restorePlans.list",
     "iam.denypolicies.list",
-    "iam.iamPolicy.get",
     "iam.roles.list",
     "iam.serviceAccountKeys.list",
+    "iam.serviceAccounts.getIamPolicy",
     "iam.serviceAccounts.list",
     "iam.workloadIdentityPoolProviders.list",
     "iam.workloadIdentityPools.list",
@@ -624,6 +621,18 @@
       "source_file": "clouddeploy.go"
     },
     {
+      "permission": "cloudfunctions.functions.getIamPolicy",
+      "service": "cloudfunctions",
+      "action": "GetIamPolicy",
+      "source_file": "cloud_functions.go"
+    },
+    {
+      "permission": "cloudfunctions.functions.getIamPolicy",
+      "service": "cloudfunctions",
+      "action": "GetIamPolicy",
+      "source_file": "cloud_functions_v2.go"
+    },
+    {
       "permission": "cloudfunctions.functions.list",
       "service": "cloudfunctions",
       "action": "ListFunctions",
@@ -634,30 +643,6 @@
       "service": "cloudfunctions",
       "action": "ListFunctions",
       "source_file": "cloud_functions_v2.go"
-    },
-    {
-      "permission": "cloudfunctions.iamPolicy.get",
-      "service": "cloudfunctions",
-      "action": "GetIamPolicy",
-      "source_file": "cloud_functions.go"
-    },
-    {
-      "permission": "cloudfunctions.iamPolicy.get",
-      "service": "cloudfunctions",
-      "action": "GetIamPolicy",
-      "source_file": "cloud_functions_v2.go"
-    },
-    {
-      "permission": "cloudidentity.groups.list",
-      "service": "cloudidentity",
-      "action": "Groups.List",
-      "source_file": "cloudidentity.go"
-    },
-    {
-      "permission": "cloudidentity.memberships.list",
-      "service": "cloudidentity",
-      "action": "Memberships.List",
-      "source_file": "cloudidentity.go"
     },
     {
       "permission": "cloudkms.cryptoKeyVersions.list",
@@ -750,7 +735,7 @@
       "source_file": "sql.go"
     },
     {
-      "permission": "cloudtasks.iamPolicy.get",
+      "permission": "cloudtasks.queues.getIamPolicy",
       "service": "cloudtasks",
       "action": "GetIamPolicy",
       "source_file": "cloudtasks.go"
@@ -1200,7 +1185,7 @@
       "source_file": "datastream.go"
     },
     {
-      "permission": "discoveryengine.dataStore.get",
+      "permission": "discoveryengine.dataStores.get",
       "service": "discoveryengine",
       "action": "GetDataStore",
       "source_file": "discoveryengine.go"
@@ -1236,12 +1221,6 @@
       "source_file": "dlp.go"
     },
     {
-      "permission": "dlp.discoveryConfigs.list",
-      "service": "dlp",
-      "action": "ListDiscoveryConfigs",
-      "source_file": "dlp.go"
-    },
-    {
       "permission": "dlp.fileStoreProfiles.list",
       "service": "dlp",
       "action": "ListFileStoreDataProfiles",
@@ -1256,7 +1235,7 @@
     {
       "permission": "dlp.jobTriggers.list",
       "service": "dlp",
-      "action": "ListJobTriggers",
+      "action": "ListDiscoveryConfigs",
       "source_file": "dlp.go"
     },
     {
@@ -1362,12 +1341,6 @@
       "source_file": "iam.go"
     },
     {
-      "permission": "iam.iamPolicy.get",
-      "service": "iam",
-      "action": "GetIamPolicy",
-      "source_file": "iam.go"
-    },
-    {
       "permission": "iam.roles.list",
       "service": "iam",
       "action": "ListRolesIter",
@@ -1377,6 +1350,12 @@
       "permission": "iam.serviceAccountKeys.list",
       "service": "iam",
       "action": "ListServiceAccountKeys",
+      "source_file": "iam.go"
+    },
+    {
+      "permission": "iam.serviceAccounts.getIamPolicy",
+      "service": "iam",
+      "action": "GetIamPolicy",
       "source_file": "iam.go"
     },
     {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -202,6 +202,10 @@ var validatedGCPPermissions = []string{
 	"dns.policies.list",
 	"dns.resourceRecordSets.list",
 	"dns.responsePolicies.list",
+	// Real and required (Cloud Domains), but customRolesSupportLevel is
+	// NOT_SUPPORTED: GCP grants it only via a predefined role (roles/domains.viewer),
+	// never a custom role. It is therefore absent from list-testable-permissions and
+	// rejected by `gcloud iam roles create` — that is expected, not a bug. Keep it.
 	"domains.registrations.list",
 	"essentialcontacts.contacts.list",
 	"eventarc.channels.list",
@@ -249,7 +253,6 @@ var validatedGCPPermissions = []string{
 	"networksecurity.tlsInspectionPolicies.list",
 	"networksecurity.urlLists.list",
 	"orgpolicy.constraints.list",
-	"orgpolicy.customConstraints.list",
 	"orgpolicy.policies.list",
 	"osconfig.inventories.get",
 	"osconfig.osPolicyAssignments.list",
@@ -264,7 +267,6 @@ var validatedGCPPermissions = []string{
 	"redis.backups.list",
 	"redis.clusters.list",
 	"redis.instances.list",
-	"resourcemanager.folders.getIamPolicy",
 	"resourcemanager.projects.get",
 	"resourcemanager.projects.getIamPolicy",
 	"resourcemanager.resourceTagBindings.list",

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -29,13 +29,14 @@ import (
 // providers-sdk/v1/util/permissions/permissions.go if the derived name is
 // wrong, regenerate the manifest, and only then add the validated name here.
 //
-// These entries are real permissions that list-testable-permissions does not
-// return for a project/organization resource (Cloud Identity is directory-
-// scoped; DLP discovery configs follow Google's documented naming), so they
-// were validated from documentation rather than the testable-permissions API:
-//   - cloudidentity.groups.list
-//   - cloudidentity.memberships.list
-//   - dlp.discoveryConfigs.list
+// Note: when verifying against list-testable-permissions, remember that the API
+// omits permissions whose customRolesSupportLevel is NOT_SUPPORTED, so absence
+// from the testable list is not by itself proof that a permission is unreal —
+// cross-check the IAM permissions reference and the method's REST docs. (For
+// example, the Cloud Identity Groups API is governed by directory/OAuth scopes
+// rather than Cloud IAM, so no cloudidentity.* permission exists; and
+// dlp.discoveryConfigs.list is not real — discoveryConfigs.list requires
+// dlp.jobTriggers.list per Google's REST reference.)
 var validatedGCPPermissions = []string{
 	"accessapproval.settings.get",
 	"aiplatform.batchPredictionJobs.list",
@@ -97,10 +98,8 @@ var validatedGCPPermissions = []string{
 	"clouddeploy.deliveryPipelines.list",
 	"clouddeploy.releases.list",
 	"clouddeploy.targets.list",
+	"cloudfunctions.functions.getIamPolicy",
 	"cloudfunctions.functions.list",
-	"cloudfunctions.iamPolicy.get",
-	"cloudidentity.groups.list",
-	"cloudidentity.memberships.list",
 	"cloudkms.cryptoKeyVersions.list",
 	"cloudkms.cryptoKeys.get",
 	"cloudkms.cryptoKeys.getIamPolicy",
@@ -116,7 +115,7 @@ var validatedGCPPermissions = []string{
 	"cloudsql.instances.list",
 	"cloudsql.sslCerts.list",
 	"cloudsql.users.list",
-	"cloudtasks.iamPolicy.get",
+	"cloudtasks.queues.getIamPolicy",
 	"cloudtasks.queues.list",
 	"composer.environments.list",
 	"compute.addresses.list",
@@ -185,13 +184,12 @@ var validatedGCPPermissions = []string{
 	"datastream.privateConnections.list",
 	"datastream.routes.list",
 	"datastream.streams.list",
-	"discoveryengine.dataStore.get",
+	"discoveryengine.dataStores.get",
 	"discoveryengine.dataStores.list",
 	"discoveryengine.engines.list",
 	"dlp.columnDataProfiles.list",
 	"dlp.connections.list",
 	"dlp.deidentifyTemplates.list",
-	"dlp.discoveryConfigs.list",
 	"dlp.fileStoreProfiles.list",
 	"dlp.inspectTemplates.list",
 	"dlp.jobTriggers.list",
@@ -212,9 +210,9 @@ var validatedGCPPermissions = []string{
 	"gkebackup.backupPlans.list",
 	"gkebackup.restorePlans.list",
 	"iam.denypolicies.list",
-	"iam.iamPolicy.get",
 	"iam.roles.list",
 	"iam.serviceAccountKeys.list",
+	"iam.serviceAccounts.getIamPolicy",
 	"iam.serviceAccounts.list",
 	"iam.workloadIdentityPoolProviders.list",
 	"iam.workloadIdentityPools.list",

--- a/scripts/test-iam-permissions.sh
+++ b/scripts/test-iam-permissions.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+#
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# test-iam-permissions.sh — provision a throwaway IAM role/custom-role from the
+# permission lists mql generates, so you can confirm every permission string is
+# real and grantable against the live cloud.
+#
+# The permission lists come straight from the provider *.permissions.json files:
+#   providers/aws/resources/aws.permissions.json   (902 perms)
+#   providers/gcp/resources/gcp.permissions.json   (254 project + 5 org perms)
+#
+# Requirements: bash, jq, and the relevant authenticated CLI (aws / gcloud).
+#
+# Usage:
+#   scripts/test-iam-permissions.sh aws-validate   # validate AWS actions, creates nothing
+#   scripts/test-iam-permissions.sh aws-create     # create role + 7 managed policies
+#   scripts/test-iam-permissions.sh aws-delete     # tear the AWS resources back down
+#   scripts/test-iam-permissions.sh gcp-create     # create project-level custom role
+#   scripts/test-iam-permissions.sh gcp-create-org <ORG_ID>   # create org-level custom role
+#   scripts/test-iam-permissions.sh gcp-delete     # delete project-level custom role
+#   scripts/test-iam-permissions.sh gcp-delete-org <ORG_ID>   # delete org-level custom role
+#
+set -euo pipefail
+
+# Resolve repo root from this script's location so it runs from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+AWS_PERMS="$REPO_ROOT/providers/aws/resources/aws.permissions.json"
+GCP_PERMS="$REPO_ROOT/providers/gcp/resources/gcp.permissions.json"
+
+AWS_ROLE="mql-perms-test"
+AWS_POLICY_PREFIX="mql-readonly"
+AWS_CHUNK=150          # actions per managed policy (keeps each under the 6,144-char limit)
+
+GCP_ROLE_ID="mqlReadonly"
+GCP_ORG_ROLE_ID="mqlReadonlyOrg"
+
+TMP="${TMPDIR:-/tmp}"
+
+die() { echo "error: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required tool '$1' not found in PATH"; }
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
+
+# Emit one policy JSON file per chunk; echoes the file paths it wrote.
+aws_build_policies() {
+  need jq
+  [[ -f "$AWS_PERMS" ]] || die "missing $AWS_PERMS"
+  local total chunk start n=0
+  total=$(jq '.permissions | length' "$AWS_PERMS")
+  chunk=$AWS_CHUNK
+  rm -f "$TMP"/mql_aws_policy_*.json
+  for start in $(seq 0 "$chunk" $((total - 1))); do
+    n=$((n + 1))
+    jq -c --argjson s "$start" --argjson c "$chunk" \
+      '{Version:"2012-10-17",Statement:[{Sid:"mqlReadOnly",Effect:"Allow",Action:.permissions[$s:($s+$c)],Resource:"*"}]}' \
+      "$AWS_PERMS" > "$TMP/mql_aws_policy_$n.json"
+  done
+  echo "$n"
+}
+
+aws_validate() {
+  need aws
+  local count i
+  count=$(aws_build_policies)
+  echo ">> Validating $count policy chunks with IAM Access Analyzer (creates nothing)..."
+  for i in $(seq 1 "$count"); do
+    echo "--- chunk $i ---"
+    aws accessanalyzer validate-policy \
+      --policy-type IDENTITY_POLICY \
+      --policy-document "file://$TMP/mql_aws_policy_$i.json" \
+      --query 'findings[].{type:findingType,issue:issueCode,detail:findingDetails}' \
+      --output table || true
+  done
+  echo ">> Done. Empty tables above == no findings == all actions valid."
+}
+
+aws_create() {
+  need aws
+  local acct count i arn
+  acct=$(aws sts get-caller-identity --query Account --output text)
+
+  cat > "$TMP/mql-trust.json" <<EOF
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+  "Principal":{"AWS":"arn:aws:iam::${acct}:root"},"Action":"sts:AssumeRole"}]}
+EOF
+
+  echo ">> Creating role $AWS_ROLE in account $acct ..."
+  aws iam create-role --role-name "$AWS_ROLE" \
+    --assume-role-policy-document "file://$TMP/mql-trust.json" >/dev/null
+
+  count=$(aws_build_policies)
+  echo ">> Attaching $count managed policies ..."
+  for i in $(seq 1 "$count"); do
+    arn=$(aws iam create-policy \
+            --policy-name "${AWS_POLICY_PREFIX}-$i" \
+            --policy-document "file://$TMP/mql_aws_policy_$i.json" \
+            --query 'Policy.Arn' --output text)
+    aws iam attach-role-policy --role-name "$AWS_ROLE" --policy-arn "$arn"
+    echo "   attached $arn"
+  done
+  echo ">> Created role $AWS_ROLE with $count managed policies."
+}
+
+aws_delete() {
+  need aws
+  local acct count i arn
+  acct=$(aws sts get-caller-identity --query Account --output text)
+  # Recompute chunk count the same way create did, so we delete exactly what we made.
+  count=$(aws_build_policies)
+  echo ">> Detaching/deleting $count managed policies ..."
+  for i in $(seq 1 "$count"); do
+    arn="arn:aws:iam::${acct}:policy/${AWS_POLICY_PREFIX}-$i"
+    aws iam detach-role-policy --role-name "$AWS_ROLE" --policy-arn "$arn" 2>/dev/null || true
+    aws iam delete-policy --policy-arn "$arn" 2>/dev/null || true
+  done
+  echo ">> Deleting role $AWS_ROLE ..."
+  aws iam delete-role --role-name "$AWS_ROLE" 2>/dev/null || true
+  echo ">> AWS teardown complete."
+}
+
+# ---------------------------------------------------------------------------
+# GCP
+# ---------------------------------------------------------------------------
+
+# $1 = jq filter selecting the permission array (.permissions or .org_level_permissions)
+# $2 = output yaml path  ;  $3 = role title
+gcp_build_role_yaml() {
+  need jq
+  [[ -f "$GCP_PERMS" ]] || die "missing $GCP_PERMS"
+  jq -r --arg title "$3" \
+    "\"title: \" + \$title + \"\ndescription: Read-only permissions required by mql\nstage: GA\nincludedPermissions:\n\" + ($1 | map(\"- \" + .) | join(\"\n\"))" \
+    "$GCP_PERMS" > "$2"
+}
+
+# Partition our project-level permissions against the live custom-role catalog.
+# Writes three sorted files under $TMP:
+#   gcp_grantable.txt    - in the catalog AND usable in a custom role
+#   gcp_notsupported.txt - real permissions GCP only grants via predefined roles
+#   gcp_absent.txt       - not testable on this project (API disabled, org-scoped, or typo)
+_gcp_partition() {
+  local project="$1"
+  echo ">> Fetching testable permissions for project $project ..." >&2
+  gcloud iam list-testable-permissions \
+    "//cloudresourcemanager.googleapis.com/projects/$project" \
+    --format=json > "$TMP/gcp_testable.json"
+
+  jq -r '.permissions[]' "$GCP_PERMS" | sort -u > "$TMP/gcp_ours.txt"
+  # Supported in custom roles (absent field == SUPPORTED).
+  jq -r '.[] | select(.customRolesSupportLevel != "NOT_SUPPORTED") | .name' \
+    "$TMP/gcp_testable.json" | sort -u > "$TMP/gcp_supported.txt"
+  # Explicitly NOT supported in custom roles.
+  jq -r '.[] | select(.customRolesSupportLevel == "NOT_SUPPORTED") | .name' \
+    "$TMP/gcp_testable.json" | sort -u > "$TMP/gcp_ns_catalog.txt"
+
+  comm -12 "$TMP/gcp_ours.txt" "$TMP/gcp_supported.txt"  > "$TMP/gcp_grantable.txt"
+  comm -12 "$TMP/gcp_ours.txt" "$TMP/gcp_ns_catalog.txt" > "$TMP/gcp_notsupported.txt"
+  comm -23 "$TMP/gcp_ours.txt" \
+    <(sort -u "$TMP/gcp_supported.txt" "$TMP/gcp_ns_catalog.txt") > "$TMP/gcp_absent.txt"
+}
+
+gcp_create() {
+  need gcloud; need jq
+  local project skipped n
+  project=$(gcloud config get-value project 2>/dev/null)
+  [[ -n "$project" ]] || die "no active gcloud project (run: gcloud config set project <id>)"
+  _gcp_partition "$project"
+
+  skipped=$(cat "$TMP/gcp_notsupported.txt" "$TMP/gcp_absent.txt")
+  if [[ -n "$skipped" ]]; then
+    n=$(printf '%s\n' "$skipped" | grep -c .)
+    echo ">> Skipping $n permission(s) that can't live in a custom role"
+    echo "   (NOT_SUPPORTED → use a predefined role; or API not enabled here):"
+    printf '%s\n' "$skipped" | sed 's/^/   - /'
+  fi
+
+  {
+    echo "title: mql-readonly"
+    echo "description: Read-only permissions required by mql"
+    echo "stage: GA"
+    echo "includedPermissions:"
+    sed 's/^/- /' "$TMP/gcp_grantable.txt"
+  } > "$TMP/mql_gcp_role.yaml"
+
+  echo ">> Creating project-level custom role $GCP_ROLE_ID in $project ($(wc -l < "$TMP/gcp_grantable.txt" | tr -d ' ') perms) ..."
+  gcloud iam roles create "$GCP_ROLE_ID" --project="$project" \
+    --file="$TMP/mql_gcp_role.yaml"
+  echo ">> Done."
+}
+
+gcp_create_org() {
+  need gcloud
+  local org="${1:-}"
+  [[ -n "$org" ]] || die "usage: $0 gcp-create-org <ORG_ID>"
+  gcp_build_role_yaml ".org_level_permissions" "$TMP/mql_gcp_org_role.yaml" "mql-readonly-org"
+  echo ">> Creating org-level custom role $GCP_ORG_ROLE_ID in org $org ..."
+  gcloud iam roles create "$GCP_ORG_ROLE_ID" --organization="$org" \
+    --file="$TMP/mql_gcp_org_role.yaml"
+  echo ">> Done."
+}
+
+gcp_delete() {
+  need gcloud
+  local project
+  project=$(gcloud config get-value project 2>/dev/null)
+  [[ -n "$project" ]] || die "no active gcloud project"
+  echo ">> Deleting project-level custom role $GCP_ROLE_ID in $project ..."
+  gcloud iam roles delete "$GCP_ROLE_ID" --project="$project" --quiet
+  echo ">> Done (role is soft-deleted; GCP purges it after ~7 days)."
+}
+
+gcp_delete_org() {
+  need gcloud
+  local org="${1:-}"
+  [[ -n "$org" ]] || die "usage: $0 gcp-delete-org <ORG_ID>"
+  echo ">> Deleting org-level custom role $GCP_ORG_ROLE_ID in org $org ..."
+  gcloud iam roles delete "$GCP_ORG_ROLE_ID" --organization="$org" --quiet
+  echo ">> Done."
+}
+
+# Validate every project-level permission against the live custom-role catalog
+# in one pass, instead of discovering rejects one at a time via role-create.
+# Splits the results into three buckets so a real bug (a permission GCP has never
+# heard of) is not confused with the two benign cases (predefined-role-only, or
+# an API that simply is not enabled on this project).
+gcp_validate() {
+  need gcloud; need jq
+  local project ns ab
+  project=$(gcloud config get-value project 2>/dev/null)
+  [[ -n "$project" ]] || die "no active gcloud project (run: gcloud config set project <id>)"
+  _gcp_partition "$project"
+
+  ns=$(cat "$TMP/gcp_notsupported.txt")
+  ab=$(cat "$TMP/gcp_absent.txt")
+
+  if [[ -n "$ns" ]]; then
+    echo "ℹ️  Required, but NOT_SUPPORTED in custom roles — grant via a predefined role (e.g. roles/<svc>.viewer):"
+    sed 's/^/   - /' "$TMP/gcp_notsupported.txt"
+  fi
+  if [[ -n "$ab" ]]; then
+    echo "⚠️  Not in this project's testable catalog — API not enabled here, OR org-scoped, OR a typo. Verify each:"
+    sed 's/^/   - /' "$TMP/gcp_absent.txt"
+  fi
+  if [[ -z "$ns$ab" ]]; then
+    echo ">> All $(wc -l < "$TMP/gcp_ours.txt" | tr -d ' ') project-level permissions are grantable in a custom role. ✓"
+  else
+    echo ">> $(wc -l < "$TMP/gcp_grantable.txt" | tr -d ' ') grantable in a custom role; see notes above for the rest."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'USG'
+Usage: test-iam-permissions.sh <command>
+
+AWS:
+  aws-validate            validate every AWS action with Access Analyzer (creates nothing)
+  aws-create              create role mql-perms-test + 7 managed policies
+  aws-delete              tear the AWS role + policies back down
+
+GCP:
+  gcp-validate            check all project perms against testable-permissions (creates nothing)
+  gcp-create              create project-level custom role mqlReadonly
+  gcp-create-org <ORG_ID> create org-level custom role mqlReadonlyOrg
+  gcp-delete              delete the project-level custom role
+  gcp-delete-org <ORG_ID> delete the org-level custom role
+USG
+  exit 1
+}
+
+case "${1:-}" in
+  aws-validate)    aws_validate ;;
+  aws-create)      aws_create ;;
+  aws-delete)      aws_delete ;;
+  gcp-validate)    gcp_validate ;;
+  gcp-create)      gcp_create ;;
+  gcp-create-org)  gcp_create_org "${2:-}" ;;
+  gcp-delete)      gcp_delete ;;
+  gcp-delete-org)  gcp_delete_org "${2:-}" ;;
+  *)               usage ;;
+esac


### PR DESCRIPTION
## Summary

The permission scanner (`providers-sdk/v1/util/permissions/permissions.go`) derives IAM permission strings heuristically from SDK method/client names, so the generated `*.permissions.json` manifests contained a number of permissions that are **not real** IAM actions. I validated every generated permission against the **live cloud APIs** and corrected the bad ones via the override maps.

### Validation method (authoritative + live)
- **AWS** — IAM Access Analyzer `validate-policy` (flags `INVALID_ACTION` / `INVALID_SERVICE_IN_ACTION`), cross-checked against AWS's Service Authorization Reference dataset.
- **GCP** — `gcloud iam list-testable-permissions` (project + org scope), plus Google's official IAM/REST docs for ambiguous cases.
- **Azure** — the complete `az provider operation list` catalog (23,375 operations), case-insensitive.

After the fixes, the full generated set validates clean live (AWS 0 invalid, GCP 0 not-testable, Azure 2 documented catalog gaps).

## AWS — 57 invalid → 0 (918 → 902 perms)
- Wrong IAM prefix → service-name overrides: `efs`→`elasticfilesystem`, `emr`→`elasticmapreduce`, `docdbelastic`→`docdb-elastic`.
- New `awsPermissionOverrides` map for SDK-operation ≠ IAM-action:
  - S3 bucket-config gets (`GetBucketEncryption`→`s3:GetEncryptionConfiguration`, `ListBuckets`→`s3:ListAllMyBuckets`, analytics/inventory/metrics/intelligent-tiering "List…Configurations"→`Get…Configuration`, etc.)
  - API Gateway reads → `apigateway:GET`
  - Budgets `Describe*` → `budgets:ViewBudget`
  - Detective `ListOrganizationAdminAccounts` → singular `ListOrganizationAdminAccount`
  - Access Analyzer `ListFindingsV2` → `ListFindings`
  - Keyspaces → `cassandra:Select` / `cassandra:TagResource`
  - Bedrock advanced-prompt-optimization-job actions have no published IAM action yet → skipped (rather than emit fake actions).

## GCP — 7 invalid → 0
- Malformed `*.iamPolicy.get` → resource-scoped: `cloudfunctions.functions.getIamPolicy`, `cloudtasks.queues.getIamPolicy`, `iam.serviceAccounts.getIamPolicy`.
- `discoveryengine.dataStore.get` → `dataStores.get` (plural).
- `dlp.discoveryConfigs.list` → `dlp.jobTriggers.list` (confirmed by Google's REST reference for `discoveryConfigs.list`).
- `cloudidentity.groups.list` / `memberships.list` → skipped: the Cloud Identity Groups API is OAuth/directory-scoped, so **no** `cloudidentity.*` Cloud IAM permission exists.
- Updated the `validatedGCPPermissions` guard test to match (its prior list had "validated" the malformed scanner output) and corrected its misleading comment.

## Azure — 59 invalid → 2
- Parent-path nesting the SDK clients omit: App (`managedEnvironments/`, `containerApps/`), CognitiveServices (`accounts/`), Compute (scale-sets, galleries, hostGroups), Sql (server/database sub-resources), Network (ExpressRoute, virtualHubs, networkWatchers), MachineLearningServices (`workspaces/`), Storage, ContainerService, DocumentDB, etc.
- Wrong-provider routing: `Microsoft.Trafficmanager/profiles` → `Microsoft.Network/trafficManagerProfiles`; `Microsoft.Mongocluster/mongoClusters` → `Microsoft.DocumentDB/mongoClusters`.
- PostgreSQL legacy `servers/` → `flexibleServers/` (single-server is retired and absent from the RBAC catalog).
- **2 entries deliberately left as-is and documented**: `Microsoft.DBforPostgreSQL/serverGroupsv2/read` and `Microsoft.Security/autoProvisioningSettings/read` — real resources/APIs the provider calls, but the RBAC `providerOperations` catalog surfaces no top-level `/read` and there is no valid replacement, so an override would introduce an error.

## Test plan
- `go run providers-sdk/v1/util/permissions/permissions.go providers/{aws,gcp,azure}` is idempotent (re-runs report "unchanged").
- `go test ./resources/ -run TestGCPPermissionsMatchValidatedList` (in `providers/gcp`) passes.
- Full regenerated sets re-validated live: AWS via Access Analyzer (0 errors over all 902 actions), GCP via list-testable-permissions (0 not-testable), Azure via the operation catalog (only the 2 documented gaps remain).