### PR TITLE
🐛 azure: degrade NSP config listing gracefully on access-denied

### DIFF
--- a/providers/azure/resources/loganalytics.go
+++ b/providers/azure/resources/loganalytics.go
@@ -5,10 +5,13 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2"
 	"github.com/rs/zerolog/log"
@@ -694,6 +697,11 @@ func (a *mqlAzureSubscriptionMonitorServiceWorkspace) networkSecurityPerimeterCo
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
+				log.Warn().Err(err).Msg("could not list network security perimeter configurations due to access denied")
+				return res, nil
+			}
 			return nil, err
 		}
 		for _, nsp := range page.Value {

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity"
 	storage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v4"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -340,6 +341,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) networkSecurityPerimeterConf
 			if isFeatureNotSupportedForAccountError(err) {
 				a.NetworkSecurityPerimeterConfigurations.State = plugin.StateIsNull | plugin.StateIsSet
 				return nil, nil
+			}
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
+				log.Warn().Err(err).Msg("could not list network security perimeter configurations due to access denied")
+				return res, nil
 			}
 			return nil, err
 		}


### PR DESCRIPTION
## Problem

The `networkSecurityPerimeterConfigurations()` resolvers on **storage accounts** (`storage_extras.go`) and **Log Analytics workspaces** (`loganalytics.go`) return the raw error and fail the entire query when the caller lacks NSP read permission (HTTP 403).

The sibling resolvers added in the same batch — `cognitiveservices.go` (accounts, deployments, projects, connections) and `machinelearning.go` (workspaces) — already degrade a 403 to an empty list with a warning. These two NSP resolvers were the outliers.

## Fix

On a `403 Forbidden`, log a warning and return the configurations collected so far instead of erroring, matching the established pattern:

```go
var respErr *azcore.ResponseError
if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
    log.Warn().Err(err).Msg("could not list network security perimeter configurations due to access denied")
    return res, nil
}
return nil, err
```

The storage resolver keeps its existing `FeatureNotSupportedForAccount` handling (unsupported account kind/region → no configurations).

## Notes

- No `.lr` schema change; no codegen or `.lr.versions` bump.
- `gofmt`, `go build ./resources/`, and `go vet ./resources/` clean.

## Test plan

- [ ] With a principal lacking `Microsoft.Storage/.../networkSecurityPerimeterConfigurations/read`: `mql shell azure -c "azure.subscription.storageService.accounts { networkSecurityPerimeterConfigurations { id } }"` returns empty rather than erroring.
- [ ] Same for `azure.subscription.monitorService.workspaces { networkSecurityPerimeterConfigurations { id } }`.
- [ ] With full permissions, configurations still list correctly.