### PR TITLE
🎉 ms365-13.3.0

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.2.1",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### ms365 (13.3.0)
- ✨ ms365: expose security-audit fields on Teams policies & SharePoint sites (#8150)
- ✨ ms365: add typed value fields to microsoft.domaindnsrecord (#8145) (#8146)