### PR TITLE
🎉 oci-13.10.0

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.9.1",
+	Version:         "13.10.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.10.0)
- ✨ oci: add Generative AI resources (oci.ai.generativeAi) (#8143)
- ✨ oci: add Data Science resources (oci.ai.dataScience) (#8142)
- ✨ oci: add Generative AI Agents resources (oci.ai.agents) (#8129)