### PR TITLE
🐛 gcp: correct GetEndpoint IAM permission to plural endpoints.get

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1078,6 +1078,9 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// ModelClient.GetModel → singular "model" by default; the real IAM
 		// permission is the plural form (matching aiplatform.models.list).
 		"GetModel": "aiplatform.models.get",
+		// EndpointClient.GetEndpoint → singular "endpoint" by default; the real
+		// IAM permission is the plural form (matching aiplatform.endpoints.list).
+		"GetEndpoint": "aiplatform.endpoints.get",
 	},
 	"pubsub": {
 		// SchemaClient.GetSchema → singular "schema" by default; real IAM

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.20.1",
-  "generated_at": "2026-06-03T11:35:17-07:00",
+  "generated_at": "2026-06-03T17:40:29-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -10,6 +10,7 @@
     "aiplatform.customJobs.list",
     "aiplatform.datasets.list",
     "aiplatform.deploymentResourcePools.list",
+    "aiplatform.endpoints.get",
     "aiplatform.endpoints.list",
     "aiplatform.featureGroups.list",
     "aiplatform.featureOnlineStores.list",
@@ -302,6 +303,12 @@
       "permission": "aiplatform.deploymentResourcePools.list",
       "service": "aiplatform",
       "action": "ListDeploymentResourcePools",
+      "source_file": "vertexai.go"
+    },
+    {
+      "permission": "aiplatform.endpoints.get",
+      "service": "aiplatform",
+      "action": "GetEndpoint",
       "source_file": "vertexai.go"
     },
     {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -44,6 +44,7 @@ var validatedGCPPermissions = []string{
 	"aiplatform.customJobs.list",
 	"aiplatform.datasets.list",
 	"aiplatform.deploymentResourcePools.list",
+	"aiplatform.endpoints.get",
 	"aiplatform.endpoints.list",
 	"aiplatform.featureGroups.list",
 	"aiplatform.featureOnlineStores.list",


### PR DESCRIPTION
## Problem

`TestGCPPermissionsMatchValidatedList` fails in CI (e.g. [this run](https://github.com/mondoohq/mql/actions/runs/26921402005/job/79422449447?pr=8154)) with:

```
unexpected permissions in manifest (not in validated list):
  - aiplatform.endpoint.get
```

The permissions extractor derives the IAM permission for the Vertex AI `GetEndpoint` call (in `vertexai.go`) by stripping `Get` and lowercasing → `aiplatform.endpoint.get`. That **singular** form is not a real GCP IAM permission — the correct one is the **plural** `aiplatform.endpoints.get` (matching the already-present `aiplatform.endpoints.list`).

The committed `gcp.permissions.json` had been hand-trimmed to omit the bad permission, so the checked-in test passed — but any job that **regenerates** the manifest re-adds `aiplatform.endpoint.get`, then the test sees it as unexpected and fails. The manifest was effectively drifting from the code on every build.

## Fix

Root-cause fix in the extractor, mirroring the existing `GetCustomJob` / `GetModel` overrides in the same `aiplatform` block:

```go
// EndpointClient.GetEndpoint → singular "endpoint" by default; the real
// IAM permission is the plural form (matching aiplatform.endpoints.list).
"GetEndpoint": "aiplatform.endpoints.get",
```

Then:
- Regenerated `gcp.permissions.json` (now contains `aiplatform.endpoints.get`; the only permission change).
- Added `aiplatform.endpoints.get` to the validated list in `permissions_test.go`.

Now generation is idempotent and the manifest, the validated list, and the code all agree.

## Verification

```
$ go test ./resources/ -run TestGCPPermissionsMatchValidatedList
ok  	go.mondoo.com/mql/v13/providers/gcp/resources
```

Regenerating the manifest produces no further drift.