### PR TITLE
✨ ms365: typed references for Conditional Access, Intune & PIM scopes

### DIFF
--- a/providers/ms365/resources/conditional-access-refs.go
+++ b/providers/ms365/resources/conditional-access-refs.go
@@ -1,0 +1,68 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"regexp"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// objectIdRegex matches a Microsoft Entra directory object ID (a GUID).
+var objectIdRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// resolveDirectoryRefs turns a Conditional Access scope list into typed
+// resource references. Conditional Access mixes object IDs with special
+// tokens (`All`, `None`, `GuestsOrExternalUsers`, `ServicePrincipalsInMyTenant`,
+// …) in the same list, so anything that isn't a GUID is skipped.
+func resolveDirectoryRefs(runtime *plugin.Runtime, resource string, ids []any) ([]any, error) {
+	res := []any{}
+	for _, raw := range ids {
+		id, ok := raw.(string)
+		if !ok || !objectIdRegex.MatchString(id) {
+			continue
+		}
+		r, err := runtime.NewResource(runtime, resource, map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) includeUsersRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.user", c.IncludeUsers.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) excludeUsersRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.user", c.ExcludeUsers.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) includeGroupsRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.group", c.IncludeGroups.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) excludeGroupsRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.group", c.ExcludeGroups.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) includeRolesRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.rolemanagement.roledefinition", c.IncludeRoles.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) excludeRolesRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.rolemanagement.roledefinition", c.ExcludeRoles.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) includeServicePrincipalsRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.serviceprincipal", c.IncludeServicePrincipals.Data)
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) excludeServicePrincipalsRefs() ([]any, error) {
+	return resolveDirectoryRefs(c.MqlRuntime, "microsoft.serviceprincipal", c.ExcludeServicePrincipals.Data)
+}

--- a/providers/ms365/resources/conditional-access-refs.go
+++ b/providers/ms365/resources/conditional-access-refs.go
@@ -4,31 +4,33 @@
 package resources
 
 import (
-	"regexp"
-
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-// objectIdRegex matches a Microsoft Entra directory object ID (a GUID).
-var objectIdRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
-
 // resolveDirectoryRefs turns a Conditional Access scope list into typed
 // resource references. Conditional Access mixes object IDs with special
 // tokens (`All`, `None`, `GuestsOrExternalUsers`, `ServicePrincipalsInMyTenant`,
-// …) in the same list, so anything that isn't a GUID is skipped.
+// …) in the same list, so anything that isn't a directory object ID (a GUID)
+// is skipped. A reference that fails to resolve — e.g. a stale entry pointing
+// at an object that has since been deleted from the directory — is logged and
+// skipped rather than failing the whole list.
 func resolveDirectoryRefs(runtime *plugin.Runtime, resource string, ids []any) ([]any, error) {
 	res := []any{}
 	for _, raw := range ids {
 		id, ok := raw.(string)
-		if !ok || !objectIdRegex.MatchString(id) {
+		if !ok || uuid.Validate(id) != nil {
 			continue
 		}
 		r, err := runtime.NewResource(runtime, resource, map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})
 		if err != nil {
-			return nil, err
+			log.Warn().Err(err).Str("resource", resource).Str("id", id).
+				Msg("ms365: skipping unresolvable conditional access reference")
+			continue
 		}
 		res = append(res, r)
 	}

--- a/providers/ms365/resources/devicemanagement_devicestate.go
+++ b/providers/ms365/resources/devicemanagement_devicestate.go
@@ -17,6 +17,39 @@ func (m *mqlMicrosoftDevicemanagementPolicyAssignment) id() (string, error) {
 	return m.Id.Data, nil
 }
 
+// group resolves the Entra ID group a policy assignment targets, when the
+// assignment targets a group.
+func (m *mqlMicrosoftDevicemanagementPolicyAssignment) group() (*mqlMicrosoftGroup, error) {
+	id := m.GroupId.Data
+	if id == "" {
+		m.Group.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(m.MqlRuntime, "microsoft.group", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMicrosoftGroup), nil
+}
+
+// user resolves the Entra ID user associated with the managed device.
+func (m *mqlMicrosoftDevicemanagementManageddevice) user() (*mqlMicrosoftUser, error) {
+	id := m.UserId.Data
+	if id == "" {
+		m.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(m.MqlRuntime, "microsoft.user", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMicrosoftUser), nil
+}
+
 func (m *mqlMicrosoftDevicemanagementManageddevicePolicyState) id() (string, error) {
 	return m.Id.Data, nil
 }

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -143,32 +143,7 @@ func (a *mqlMicrosoftGroups) list() ([]any, error) {
 	}
 	res := []any{}
 	for _, grp := range grps {
-		graphGrp, err := CreateResource(a.MqlRuntime, "microsoft.group",
-			map[string]*llx.RawData{
-				"id":                            llx.StringDataPtr(grp.GetId()),
-				"displayName":                   llx.StringDataPtr(grp.GetDisplayName()),
-				"mail":                          llx.StringDataPtr(grp.GetMail()),
-				"mailEnabled":                   llx.BoolDataPtr(grp.GetMailEnabled()),
-				"mailNickname":                  llx.StringDataPtr(grp.GetMailNickname()),
-				"securityEnabled":               llx.BoolDataPtr(grp.GetSecurityEnabled()),
-				"visibility":                    llx.StringDataPtr(grp.GetVisibility()),
-				"groupTypes":                    llx.ArrayData(llx.TArr2Raw(grp.GetGroupTypes()), types.String),
-				"membershipRule":                llx.StringDataPtr(grp.GetMembershipRule()),
-				"membershipRuleProcessingState": llx.StringDataPtr(grp.GetMembershipRuleProcessingState()),
-				"createdDateTime":               llx.TimeDataPtr(grp.GetCreatedDateTime()),
-				"description":                   llx.StringDataPtr(grp.GetDescription()),
-				"expirationDateTime":            llx.TimeDataPtr(grp.GetExpirationDateTime()),
-				"isAssignableToRole":            llx.BoolDataPtr(grp.GetIsAssignableToRole()),
-				"renewedDateTime":               llx.TimeDataPtr(grp.GetRenewedDateTime()),
-				"onPremisesSyncEnabled":         llx.BoolDataPtr(grp.GetOnPremisesSyncEnabled()),
-				"onPremisesLastSyncDateTime":    llx.TimeDataPtr(grp.GetOnPremisesLastSyncDateTime()),
-				"classification":                llx.StringDataPtr(grp.GetClassification()),
-				"deletedDateTime":               llx.TimeDataPtr(grp.GetDeletedDateTime()),
-				"proxyAddresses":                llx.ArrayData(llx.TArr2Raw(grp.GetProxyAddresses()), types.String),
-				"theme":                         llx.StringDataPtr(grp.GetTheme()),
-				"preferredLanguage":             llx.StringDataPtr(grp.GetPreferredLanguage()),
-				"preferredDataLocation":         llx.StringDataPtr(grp.GetPreferredDataLocation()),
-			})
+		graphGrp, err := newMqlMicrosoftGroup(a.MqlRuntime, grp)
 		if err != nil {
 			return nil, err
 		}
@@ -176,6 +151,72 @@ func (a *mqlMicrosoftGroups) list() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// newMqlMicrosoftGroup builds a microsoft.group resource from a Graph group.
+func newMqlMicrosoftGroup(runtime *plugin.Runtime, grp models.Groupable) (*mqlMicrosoftGroup, error) {
+	graphGrp, err := CreateResource(runtime, "microsoft.group",
+		map[string]*llx.RawData{
+			"id":                            llx.StringDataPtr(grp.GetId()),
+			"displayName":                   llx.StringDataPtr(grp.GetDisplayName()),
+			"mail":                          llx.StringDataPtr(grp.GetMail()),
+			"mailEnabled":                   llx.BoolDataPtr(grp.GetMailEnabled()),
+			"mailNickname":                  llx.StringDataPtr(grp.GetMailNickname()),
+			"securityEnabled":               llx.BoolDataPtr(grp.GetSecurityEnabled()),
+			"visibility":                    llx.StringDataPtr(grp.GetVisibility()),
+			"groupTypes":                    llx.ArrayData(llx.TArr2Raw(grp.GetGroupTypes()), types.String),
+			"membershipRule":                llx.StringDataPtr(grp.GetMembershipRule()),
+			"membershipRuleProcessingState": llx.StringDataPtr(grp.GetMembershipRuleProcessingState()),
+			"createdDateTime":               llx.TimeDataPtr(grp.GetCreatedDateTime()),
+			"description":                   llx.StringDataPtr(grp.GetDescription()),
+			"expirationDateTime":            llx.TimeDataPtr(grp.GetExpirationDateTime()),
+			"isAssignableToRole":            llx.BoolDataPtr(grp.GetIsAssignableToRole()),
+			"renewedDateTime":               llx.TimeDataPtr(grp.GetRenewedDateTime()),
+			"onPremisesSyncEnabled":         llx.BoolDataPtr(grp.GetOnPremisesSyncEnabled()),
+			"onPremisesLastSyncDateTime":    llx.TimeDataPtr(grp.GetOnPremisesLastSyncDateTime()),
+			"classification":                llx.StringDataPtr(grp.GetClassification()),
+			"deletedDateTime":               llx.TimeDataPtr(grp.GetDeletedDateTime()),
+			"proxyAddresses":                llx.ArrayData(llx.TArr2Raw(grp.GetProxyAddresses()), types.String),
+			"theme":                         llx.StringDataPtr(grp.GetTheme()),
+			"preferredLanguage":             llx.StringDataPtr(grp.GetPreferredLanguage()),
+			"preferredDataLocation":         llx.StringDataPtr(grp.GetPreferredDataLocation()),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return graphGrp.(*mqlMicrosoftGroup), nil
+}
+
+// initMicrosoftGroup resolves a single group by its object ID, enabling
+// microsoft.group(id: "...") lookups and typed group references.
+func initMicrosoftGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// only resolve when handed a bare id; a fully populated group passes
+	// through untouched
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+	rawId, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := context.Background()
+	grp, err := graphClient.Groups().ByGroupId(rawId.Value.(string)).Get(ctx, nil)
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+
+	mqlGroup, err := newMqlMicrosoftGroup(runtime, grp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, mqlGroup, nil
 }
 
 func (a *mqlMicrosoftGroup) owners() ([]any, error) {

--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -352,6 +352,22 @@ func newMqlRoleEligibilityScheduleInstance(runtime *plugin.Runtime, inst models.
 	return resource.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance), nil
 }
 
+// roleDefinition resolves the role definition this eligibility grants.
+func (a *mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance) roleDefinition() (*mqlMicrosoftRolemanagementRoledefinition, error) {
+	id := a.RoleDefinitionId.Data
+	if id == "" {
+		a.RoleDefinition.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "microsoft.rolemanagement.roledefinition", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMicrosoftRolemanagementRoledefinition), nil
+}
+
 // Implementation for the new identityAndSignIn resource
 func (a *mqlMicrosoftIdentityAndAccess) identityAndSignIn() (*mqlMicrosoftIdentityAndAccessIdentityAndSignIn, error) {
 	resource, err := CreateResource(a.MqlRuntime, "microsoft.identityAndAccess.identityAndSignIn", map[string]*llx.RawData{

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -341,6 +341,8 @@ private microsoft.identityAndAccess.roleEligibilityScheduleInstance @defaults("m
   principalId string
   // The identifier of the role definition that the eligibility is for
   roleDefinitionId string
+  // Role definition the eligibility grants
+  roleDefinition() microsoft.rolemanagement.roledefinition
   // The identifier of the directory object representing the scope of the role eligibility
   directoryScopeId string
   // The identifier of the app-specific scope of the role eligibility
@@ -703,6 +705,10 @@ private microsoft.conditionalAccess.policy.conditions.clientApplications @defaul
   excludeServicePrincipals []string
   // Service principal IDs included in the policy scope, or ServicePrincipalsInMyTenant
   includeServicePrincipals []string
+  // Service principals excluded from the policy scope
+  excludeServicePrincipalsRefs() []microsoft.serviceprincipal
+  // Service principals included in the policy scope
+  includeServicePrincipalsRefs() []microsoft.serviceprincipal
 }
 
 // Platforms included in and excluded from the policy scope
@@ -737,6 +743,18 @@ private microsoft.conditionalAccess.policy.conditions.users @defaults("includeUs
   includeRoles []string
   // Role IDs excluded from scope of policy
   excludeRoles []string
+  // Users in scope of policy
+  includeUsersRefs() []microsoft.user
+  // Users excluded from scope of policy
+  excludeUsersRefs() []microsoft.user
+  // Groups in scope of policy
+  includeGroupsRefs() []microsoft.group
+  // Groups excluded from scope of policy
+  excludeGroupsRefs() []microsoft.group
+  // Roles in scope of policy
+  includeRolesRefs() []microsoft.rolemanagement.roledefinition
+  // Roles excluded from scope of policy
+  excludeRolesRefs() []microsoft.rolemanagement.roledefinition
 }
 
 // Locations included in and excluded from a Conditional Access policy
@@ -2138,6 +2156,8 @@ private microsoft.rolemanagement.roleassignment @defaults("id principalId") {
   id string
   // Role definition ID
   roleDefinitionId string
+  // Role definition assigned
+  roleDefinition() microsoft.rolemanagement.roledefinition
   // Service principal ID
   principalId string
   // Service principal
@@ -2209,6 +2229,8 @@ private microsoft.devicemanagement.manageddevice {
   id string
   // Unique identifier for the user associated with the device
   userId string
+  // User associated with the device
+  user() microsoft.user
   // Name of the device
   name string
   // Operating system of the device
@@ -2385,6 +2407,8 @@ private microsoft.devicemanagement.policyAssignment @defaults("id targetType gro
   targetType string
   // Group ID when the target is a group, empty otherwise
   groupId string
+  // Group the assignment targets, when targetType is a group
+  group() microsoft.group
   // Whether the assignment excludes the target rather than including it
   excluded bool
   // Assignment filter type (none, include, exclude)

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -334,13 +334,15 @@ microsoft.identityAndAccess.privilegedIdentityManagement.policies {
 }
 
 // Represents an instance of a role eligibility in PIM
-private microsoft.identityAndAccess.roleEligibilityScheduleInstance @defaults("memberType principalId roleDefinitionId") {
+private microsoft.identityAndAccess.roleEligibilityScheduleInstance @defaults("memberType principalId") {
   // The unique identifier of the role eligibility schedule instance
   id string
   // The identifier of the principal (user, group, or service principal) that has the role eligibility
   principalId string
   // The identifier of the role definition that the eligibility is for
-  roleDefinitionId string
+  //
+  // Deprecated in favor of roleDefinition.
+  roleDefinitionId @maturity("deprecated") string
   // Role definition the eligibility grants
   roleDefinition() microsoft.rolemanagement.roledefinition
   // The identifier of the directory object representing the scope of the role eligibility
@@ -2155,7 +2157,9 @@ private microsoft.rolemanagement.roleassignment @defaults("id principalId") {
   // Role assignment ID
   id string
   // Role definition ID
-  roleDefinitionId string
+  //
+  // Deprecated in favor of roleDefinition.
+  roleDefinitionId @maturity("deprecated") string
   // Role definition assigned
   roleDefinition() microsoft.rolemanagement.roledefinition
   // Service principal ID
@@ -2228,7 +2232,9 @@ private microsoft.devicemanagement.manageddevice {
   // Managed device ID
   id string
   // Unique identifier for the user associated with the device
-  userId string
+  //
+  // Deprecated in favor of user.
+  userId @maturity("deprecated") string
   // User associated with the device
   user() microsoft.user
   // Name of the device
@@ -2400,13 +2406,15 @@ private microsoft.devicemanagement.devicecompliancepolicy @defaults("id displayN
 // (`groupAssignmentTarget`, `exclusionGroupAssignmentTarget`,
 // `allDevicesAssignmentTarget`, `allLicensedUsersAssignmentTarget`); `groupId`
 // is populated only when the target is a group.
-private microsoft.devicemanagement.policyAssignment @defaults("id targetType groupId") {
+private microsoft.devicemanagement.policyAssignment @defaults("id targetType") {
   // Assignment ID
   id string
   // Target kind (groupAssignmentTarget, exclusionGroupAssignmentTarget, allDevicesAssignmentTarget, allLicensedUsersAssignmentTarget)
   targetType string
   // Group ID when the target is a group, empty otherwise
-  groupId string
+  //
+  // Deprecated in favor of group.
+  groupId @maturity("deprecated") string
   // Group the assignment targets, when targetType is a group
   group() microsoft.group
   // Whether the assignment excludes the target rather than including it

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -738,13 +738,21 @@ private microsoft.conditionalAccess.policy.conditions.users @defaults("includeUs
   // User IDs excluded from scope of policy and/or GuestsOrExternalUsers
   excludeUsers []string
   // Group IDs in scope of policy unless explicitly excluded
-  includeGroups []string
+  //
+  // Deprecated in favor of includeGroupsRefs.
+  includeGroups @maturity("deprecated") []string
   // Group IDs excluded from scope of policy
-  excludeGroups []string
+  //
+  // Deprecated in favor of excludeGroupsRefs.
+  excludeGroups @maturity("deprecated") []string
   // Role IDs in scope of policy unless explicitly excluded
-  includeRoles []string
+  //
+  // Deprecated in favor of includeRolesRefs.
+  includeRoles @maturity("deprecated") []string
   // Role IDs excluded from scope of policy
-  excludeRoles []string
+  //
+  // Deprecated in favor of excludeRolesRefs.
+  excludeRoles @maturity("deprecated") []string
   // Users in scope of policy
   includeUsersRefs() []microsoft.user
   // Users excluded from scope of policy

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -411,7 +411,7 @@ func init() {
 			Create: createMicrosoftUserAuthenticationMethodsUserRegistrationDetails,
 		},
 		"microsoft.group": {
-			// to override args, implement: initMicrosoftGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftGroup,
 			Create: createMicrosoftGroup,
 		},
 		"microsoft.group.owner": {
@@ -579,7 +579,7 @@ func init() {
 			Create: createMicrosoftRolemanagement,
 		},
 		"microsoft.rolemanagement.roledefinition": {
-			// to override args, implement: initMicrosoftRolemanagementRoledefinition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftRolemanagementRoledefinition,
 			Create: createMicrosoftRolemanagementRoledefinition,
 		},
 		"microsoft.rolemanagement.roleassignment": {
@@ -1147,6 +1147,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinitionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).GetRoleDefinitionId()).ToDataRes(types.String)
 	},
+	"microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).GetRoleDefinition()).ToDataRes(types.Resource("microsoft.rolemanagement.roledefinition"))
+	},
 	"microsoft.identityAndAccess.roleEligibilityScheduleInstance.directoryScopeId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).GetDirectoryScopeId()).ToDataRes(types.String)
 	},
@@ -1474,6 +1477,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.conditionalAccess.policy.conditions.clientApplications.includeServicePrincipals": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).GetIncludeServicePrincipals()).ToDataRes(types.Array(types.String))
 	},
+	"microsoft.conditionalAccess.policy.conditions.clientApplications.excludeServicePrincipalsRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).GetExcludeServicePrincipalsRefs()).ToDataRes(types.Array(types.Resource("microsoft.serviceprincipal")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.clientApplications.includeServicePrincipalsRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).GetIncludeServicePrincipalsRefs()).ToDataRes(types.Array(types.Resource("microsoft.serviceprincipal")))
+	},
 	"microsoft.conditionalAccess.policy.conditions.platforms.excludePlatforms": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsPlatforms).GetExcludePlatforms()).ToDataRes(types.Array(types.String))
 	},
@@ -1506,6 +1515,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.conditionalAccess.policy.conditions.users.excludeRoles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetExcludeRoles()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeUsersRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetIncludeUsersRefs()).ToDataRes(types.Array(types.Resource("microsoft.user")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeUsersRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetExcludeUsersRefs()).ToDataRes(types.Array(types.Resource("microsoft.user")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeGroupsRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetIncludeGroupsRefs()).ToDataRes(types.Array(types.Resource("microsoft.group")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeGroupsRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetExcludeGroupsRefs()).ToDataRes(types.Array(types.Resource("microsoft.group")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeRolesRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetIncludeRolesRefs()).ToDataRes(types.Array(types.Resource("microsoft.rolemanagement.roledefinition")))
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeRolesRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).GetExcludeRolesRefs()).ToDataRes(types.Array(types.Resource("microsoft.rolemanagement.roledefinition")))
 	},
 	"microsoft.conditionalAccess.policy.conditions.locations.includeLocations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicyConditionsLocations).GetIncludeLocations()).ToDataRes(types.Array(types.String))
@@ -2968,6 +2995,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.rolemanagement.roleassignment.roleDefinitionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetRoleDefinitionId()).ToDataRes(types.String)
 	},
+	"microsoft.rolemanagement.roleassignment.roleDefinition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetRoleDefinition()).ToDataRes(types.Resource("microsoft.rolemanagement.roledefinition"))
+	},
 	"microsoft.rolemanagement.roleassignment.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipalId()).ToDataRes(types.String)
 	},
@@ -3042,6 +3072,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.devicemanagement.manageddevice.userId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUserId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUser()).ToDataRes(types.Resource("microsoft.user"))
 	},
 	"microsoft.devicemanagement.manageddevice.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetName()).ToDataRes(types.String)
@@ -3246,6 +3279,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.devicemanagement.policyAssignment.groupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GetGroupId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.policyAssignment.group": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GetGroup()).ToDataRes(types.Resource("microsoft.group"))
 	},
 	"microsoft.devicemanagement.policyAssignment.excluded": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GetExcluded()).ToDataRes(types.Bool)
@@ -4846,6 +4882,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).RoleDefinitionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).RoleDefinition, ok = plugin.RawToTValue[*mqlMicrosoftRolemanagementRoledefinition](v.Value, v.Error)
+		return
+	},
 	"microsoft.identityAndAccess.roleEligibilityScheduleInstance.directoryScopeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance).DirectoryScopeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5382,6 +5422,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).IncludeServicePrincipals, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"microsoft.conditionalAccess.policy.conditions.clientApplications.excludeServicePrincipalsRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).ExcludeServicePrincipalsRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.clientApplications.includeServicePrincipalsRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsClientApplications).IncludeServicePrincipalsRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"microsoft.conditionalAccess.policy.conditions.platforms.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftConditionalAccessPolicyConditionsPlatforms).__id, ok = v.Value.(string)
 		return
@@ -5436,6 +5484,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.conditionalAccess.policy.conditions.users.excludeRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).ExcludeRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeUsersRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).IncludeUsersRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeUsersRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).ExcludeUsersRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeGroupsRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).IncludeGroupsRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeGroupsRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).ExcludeGroupsRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.includeRolesRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).IncludeRolesRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.conditions.users.excludeRolesRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicyConditionsUsers).ExcludeRolesRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"microsoft.conditionalAccess.policy.conditions.locations.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7610,6 +7682,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftRolemanagementRoleassignment).RoleDefinitionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.rolemanagement.roleassignment.roleDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftRolemanagementRoleassignment).RoleDefinition, ok = plugin.RawToTValue[*mqlMicrosoftRolemanagementRoledefinition](v.Value, v.Error)
+		return
+	},
 	"microsoft.rolemanagement.roleassignment.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftRolemanagementRoleassignment).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7720,6 +7796,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.devicemanagement.manageddevice.userId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagementManageddevice).UserId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).User, ok = plugin.RawToTValue[*mqlMicrosoftUser](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.manageddevice.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8004,6 +8084,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.devicemanagement.policyAssignment.groupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.policyAssignment.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementPolicyAssignment).Group, ok = plugin.RawToTValue[*mqlMicrosoftGroup](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.policyAssignment.excluded": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11230,6 +11314,7 @@ type mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance struct {
 	Id                        plugin.TValue[string]
 	PrincipalId               plugin.TValue[string]
 	RoleDefinitionId          plugin.TValue[string]
+	RoleDefinition            plugin.TValue[*mqlMicrosoftRolemanagementRoledefinition]
 	DirectoryScopeId          plugin.TValue[string]
 	AppScopeId                plugin.TValue[string]
 	StartDateTime             plugin.TValue[*time.Time]
@@ -11280,6 +11365,22 @@ func (c *mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance) GetPrinci
 
 func (c *mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance) GetRoleDefinitionId() *plugin.TValue[string] {
 	return &c.RoleDefinitionId
+}
+
+func (c *mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance) GetRoleDefinition() *plugin.TValue[*mqlMicrosoftRolemanagementRoledefinition] {
+	return plugin.GetOrCompute[*mqlMicrosoftRolemanagementRoledefinition](&c.RoleDefinition, func() (*mqlMicrosoftRolemanagementRoledefinition, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.identityAndAccess.roleEligibilityScheduleInstance", c.__id, "roleDefinition")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftRolemanagementRoledefinition), nil
+			}
+		}
+
+		return c.roleDefinition()
+	})
 }
 
 func (c *mqlMicrosoftIdentityAndAccessRoleEligibilityScheduleInstance) GetDirectoryScopeId() *plugin.TValue[string] {
@@ -12870,8 +12971,10 @@ type mqlMicrosoftConditionalAccessPolicyConditionsClientApplications struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftConditionalAccessPolicyConditionsClientApplicationsInternal it will be used here
-	ExcludeServicePrincipals plugin.TValue[[]any]
-	IncludeServicePrincipals plugin.TValue[[]any]
+	ExcludeServicePrincipals     plugin.TValue[[]any]
+	IncludeServicePrincipals     plugin.TValue[[]any]
+	ExcludeServicePrincipalsRefs plugin.TValue[[]any]
+	IncludeServicePrincipalsRefs plugin.TValue[[]any]
 }
 
 // createMicrosoftConditionalAccessPolicyConditionsClientApplications creates a new instance of this resource
@@ -12912,6 +13015,38 @@ func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) GetExc
 
 func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) GetIncludeServicePrincipals() *plugin.TValue[[]any] {
 	return &c.IncludeServicePrincipals
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) GetExcludeServicePrincipalsRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExcludeServicePrincipalsRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.clientApplications", c.__id, "excludeServicePrincipalsRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.excludeServicePrincipalsRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsClientApplications) GetIncludeServicePrincipalsRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IncludeServicePrincipalsRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.clientApplications", c.__id, "includeServicePrincipalsRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.includeServicePrincipalsRefs()
+	})
 }
 
 // mqlMicrosoftConditionalAccessPolicyConditionsPlatforms for the microsoft.conditionalAccess.policy.conditions.platforms resource
@@ -13022,12 +13157,18 @@ type mqlMicrosoftConditionalAccessPolicyConditionsUsers struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftConditionalAccessPolicyConditionsUsersInternal it will be used here
-	IncludeUsers  plugin.TValue[[]any]
-	ExcludeUsers  plugin.TValue[[]any]
-	IncludeGroups plugin.TValue[[]any]
-	ExcludeGroups plugin.TValue[[]any]
-	IncludeRoles  plugin.TValue[[]any]
-	ExcludeRoles  plugin.TValue[[]any]
+	IncludeUsers      plugin.TValue[[]any]
+	ExcludeUsers      plugin.TValue[[]any]
+	IncludeGroups     plugin.TValue[[]any]
+	ExcludeGroups     plugin.TValue[[]any]
+	IncludeRoles      plugin.TValue[[]any]
+	ExcludeRoles      plugin.TValue[[]any]
+	IncludeUsersRefs  plugin.TValue[[]any]
+	ExcludeUsersRefs  plugin.TValue[[]any]
+	IncludeGroupsRefs plugin.TValue[[]any]
+	ExcludeGroupsRefs plugin.TValue[[]any]
+	IncludeRolesRefs  plugin.TValue[[]any]
+	ExcludeRolesRefs  plugin.TValue[[]any]
 }
 
 // createMicrosoftConditionalAccessPolicyConditionsUsers creates a new instance of this resource
@@ -13084,6 +13225,102 @@ func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetIncludeRoles() *
 
 func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetExcludeRoles() *plugin.TValue[[]any] {
 	return &c.ExcludeRoles
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetIncludeUsersRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IncludeUsersRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "includeUsersRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.includeUsersRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetExcludeUsersRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExcludeUsersRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "excludeUsersRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.excludeUsersRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetIncludeGroupsRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IncludeGroupsRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "includeGroupsRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.includeGroupsRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetExcludeGroupsRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExcludeGroupsRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "excludeGroupsRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.excludeGroupsRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetIncludeRolesRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IncludeRolesRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "includeRolesRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.includeRolesRefs()
+	})
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicyConditionsUsers) GetExcludeRolesRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExcludeRolesRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess.policy.conditions.users", c.__id, "excludeRolesRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.excludeRolesRefs()
+	})
 }
 
 // mqlMicrosoftConditionalAccessPolicyConditionsLocations for the microsoft.conditionalAccess.policy.conditions.locations resource
@@ -18364,6 +18601,7 @@ type mqlMicrosoftRolemanagementRoleassignment struct {
 	// optional: if you define mqlMicrosoftRolemanagementRoleassignmentInternal it will be used here
 	Id               plugin.TValue[string]
 	RoleDefinitionId plugin.TValue[string]
+	RoleDefinition   plugin.TValue[*mqlMicrosoftRolemanagementRoledefinition]
 	PrincipalId      plugin.TValue[string]
 	Principal        plugin.TValue[any]
 }
@@ -18411,6 +18649,22 @@ func (c *mqlMicrosoftRolemanagementRoleassignment) GetId() *plugin.TValue[string
 
 func (c *mqlMicrosoftRolemanagementRoleassignment) GetRoleDefinitionId() *plugin.TValue[string] {
 	return &c.RoleDefinitionId
+}
+
+func (c *mqlMicrosoftRolemanagementRoleassignment) GetRoleDefinition() *plugin.TValue[*mqlMicrosoftRolemanagementRoledefinition] {
+	return plugin.GetOrCompute[*mqlMicrosoftRolemanagementRoledefinition](&c.RoleDefinition, func() (*mqlMicrosoftRolemanagementRoledefinition, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.rolemanagement.roleassignment", c.__id, "roleDefinition")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftRolemanagementRoledefinition), nil
+			}
+		}
+
+		return c.roleDefinition()
+	})
 }
 
 func (c *mqlMicrosoftRolemanagementRoleassignment) GetPrincipalId() *plugin.TValue[string] {
@@ -18743,6 +18997,7 @@ type mqlMicrosoftDevicemanagementManageddevice struct {
 	// optional: if you define mqlMicrosoftDevicemanagementManageddeviceInternal it will be used here
 	Id                                      plugin.TValue[string]
 	UserId                                  plugin.TValue[string]
+	User                                    plugin.TValue[*mqlMicrosoftUser]
 	Name                                    plugin.TValue[string]
 	OperatingSystem                         plugin.TValue[string]
 	JailBroken                              plugin.TValue[string]
@@ -18826,6 +19081,22 @@ func (c *mqlMicrosoftDevicemanagementManageddevice) GetId() *plugin.TValue[strin
 
 func (c *mqlMicrosoftDevicemanagementManageddevice) GetUserId() *plugin.TValue[string] {
 	return &c.UserId
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetUser() *plugin.TValue[*mqlMicrosoftUser] {
+	return plugin.GetOrCompute[*mqlMicrosoftUser](&c.User, func() (*mqlMicrosoftUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement.manageddevice", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftUser), nil
+			}
+		}
+
+		return c.user()
+	})
 }
 
 func (c *mqlMicrosoftDevicemanagementManageddevice) GetName() *plugin.TValue[string] {
@@ -19242,6 +19513,7 @@ type mqlMicrosoftDevicemanagementPolicyAssignment struct {
 	Id         plugin.TValue[string]
 	TargetType plugin.TValue[string]
 	GroupId    plugin.TValue[string]
+	Group      plugin.TValue[*mqlMicrosoftGroup]
 	Excluded   plugin.TValue[bool]
 	FilterType plugin.TValue[string]
 	FilterId   plugin.TValue[string]
@@ -19294,6 +19566,22 @@ func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetTargetType() *plugin.T
 
 func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetGroupId() *plugin.TValue[string] {
 	return &c.GroupId
+}
+
+func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetGroup() *plugin.TValue[*mqlMicrosoftGroup] {
+	return plugin.GetOrCompute[*mqlMicrosoftGroup](&c.Group, func() (*mqlMicrosoftGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement.policyAssignment", c.__id, "group")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftGroup), nil
+			}
+		}
+
+		return c.group()
+	})
 }
 
 func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetExcluded() *plugin.TValue[bool] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -113,7 +113,9 @@ microsoft.conditionalAccess.policy.conditions.authenticationFlows.transferMethod
 microsoft.conditionalAccess.policy.conditions.clientAppTypes 11.1.38
 microsoft.conditionalAccess.policy.conditions.clientApplications 11.1.38
 microsoft.conditionalAccess.policy.conditions.clientApplications.excludeServicePrincipals 11.1.38
+microsoft.conditionalAccess.policy.conditions.clientApplications.excludeServicePrincipalsRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.clientApplications.includeServicePrincipals 11.1.38
+microsoft.conditionalAccess.policy.conditions.clientApplications.includeServicePrincipalsRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.id 11.1.38
 microsoft.conditionalAccess.policy.conditions.insiderRiskLevels 11.1.38
 microsoft.conditionalAccess.policy.conditions.locations 11.1.38
@@ -127,11 +129,17 @@ microsoft.conditionalAccess.policy.conditions.signInRiskLevels 11.1.38
 microsoft.conditionalAccess.policy.conditions.userRiskLevels 11.1.38
 microsoft.conditionalAccess.policy.conditions.users 11.1.38
 microsoft.conditionalAccess.policy.conditions.users.excludeGroups 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.excludeGroupsRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.users.excludeRoles 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.excludeRolesRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.users.excludeUsers 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.excludeUsersRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.users.includeGroups 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.includeGroupsRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.users.includeRoles 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.includeRolesRefs 13.3.1
 microsoft.conditionalAccess.policy.conditions.users.includeUsers 11.1.38
+microsoft.conditionalAccess.policy.conditions.users.includeUsersRefs 13.3.1
 microsoft.conditionalAccess.policy.createdDateTime 11.1.38
 microsoft.conditionalAccess.policy.displayName 11.1.38
 microsoft.conditionalAccess.policy.grantControls 11.1.38
@@ -338,6 +346,7 @@ microsoft.devicemanagement.manageddevice.serialNumber 11.1.40
 microsoft.devicemanagement.manageddevice.subscriberCarrier 11.1.102
 microsoft.devicemanagement.manageddevice.totalStorageSpaceInBytes 11.1.102
 microsoft.devicemanagement.manageddevice.udid 11.1.40
+microsoft.devicemanagement.manageddevice.user 13.3.1
 microsoft.devicemanagement.manageddevice.userDisplayName 11.1.40
 microsoft.devicemanagement.manageddevice.userId 11.1.40
 microsoft.devicemanagement.manageddevice.userPrincipalName 11.1.40
@@ -361,6 +370,7 @@ microsoft.devicemanagement.policyAssignment 13.0.12
 microsoft.devicemanagement.policyAssignment.excluded 13.0.12
 microsoft.devicemanagement.policyAssignment.filterId 13.0.12
 microsoft.devicemanagement.policyAssignment.filterType 13.0.12
+microsoft.devicemanagement.policyAssignment.group 13.3.1
 microsoft.devicemanagement.policyAssignment.groupId 13.0.12
 microsoft.devicemanagement.policyAssignment.id 13.0.12
 microsoft.devicemanagement.policyAssignment.targetType 13.0.12
@@ -573,6 +583,7 @@ microsoft.identityAndAccess.roleEligibilityScheduleInstance.endDateTime 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.id 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.memberType 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.principalId 11.1.41
+microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinition 13.3.1
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinitionId 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleEligibilityScheduleId 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.startDateTime 11.1.41
@@ -628,6 +639,7 @@ microsoft.rolemanagement.roleassignment 9.0.0
 microsoft.rolemanagement.roleassignment.id 9.0.0
 microsoft.rolemanagement.roleassignment.principal 9.0.0
 microsoft.rolemanagement.roleassignment.principalId 9.0.0
+microsoft.rolemanagement.roleassignment.roleDefinition 13.3.1
 microsoft.rolemanagement.roleassignment.roleDefinitionId 9.0.0
 microsoft.rolemanagement.roledefinition 9.0.0
 microsoft.rolemanagement.roledefinition.assignments 9.0.0

--- a/providers/ms365/resources/rolemanagement.go
+++ b/providers/ms365/resources/rolemanagement.go
@@ -84,21 +84,7 @@ func (a *mqlMicrosoftRoles) list() ([]any, error) {
 
 	res := []any{}
 	for _, role := range roles {
-		rolePermissions, err := convert.JsonToDictSlice(newUnifiedRolePermissions(role.GetRolePermissions()))
-		if err != nil {
-			return nil, err
-		}
-		mqlResource, err := CreateResource(a.MqlRuntime, "microsoft.rolemanagement.roledefinition",
-			map[string]*llx.RawData{
-				"id":              llx.StringDataPtr(role.GetId()),
-				"description":     llx.StringDataPtr(role.GetDescription()),
-				"displayName":     llx.StringDataPtr(role.GetDisplayName()),
-				"isBuiltIn":       llx.BoolDataPtr(role.GetIsBuiltIn()),
-				"isEnabled":       llx.BoolDataPtr(role.GetIsEnabled()),
-				"rolePermissions": llx.ArrayData(rolePermissions, types.Any),
-				"templateId":      llx.StringDataPtr(role.GetTemplateId()),
-				"version":         llx.StringDataPtr(role.GetVersion()),
-			})
+		mqlResource, err := newMqlMicrosoftRoleDefinition(a.MqlRuntime, role)
 		if err != nil {
 			return nil, err
 		}
@@ -106,6 +92,68 @@ func (a *mqlMicrosoftRoles) list() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// newMqlMicrosoftRoleDefinition builds a microsoft.rolemanagement.roledefinition
+// resource from a Graph unified role definition.
+func newMqlMicrosoftRoleDefinition(runtime *plugin.Runtime, role models.UnifiedRoleDefinitionable) (*mqlMicrosoftRolemanagementRoledefinition, error) {
+	rolePermissions, err := convert.JsonToDictSlice(newUnifiedRolePermissions(role.GetRolePermissions()))
+	if err != nil {
+		return nil, err
+	}
+	mqlResource, err := CreateResource(runtime, "microsoft.rolemanagement.roledefinition",
+		map[string]*llx.RawData{
+			"id":              llx.StringDataPtr(role.GetId()),
+			"description":     llx.StringDataPtr(role.GetDescription()),
+			"displayName":     llx.StringDataPtr(role.GetDisplayName()),
+			"isBuiltIn":       llx.BoolDataPtr(role.GetIsBuiltIn()),
+			"isEnabled":       llx.BoolDataPtr(role.GetIsEnabled()),
+			"rolePermissions": llx.ArrayData(rolePermissions, types.Any),
+			"templateId":      llx.StringDataPtr(role.GetTemplateId()),
+			"version":         llx.StringDataPtr(role.GetVersion()),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlMicrosoftRolemanagementRoledefinition), nil
+}
+
+// initMicrosoftRolemanagementRoledefinition resolves a single role definition
+// by its ID, enabling typed role references from Conditional Access conditions
+// and role assignments.
+func initMicrosoftRolemanagementRoledefinition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// only resolve when handed a bare id; a fully populated role definition
+	// passes through untouched
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+	rawId, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := context.Background()
+	role, err := graphClient.
+		RoleManagement().
+		Directory().
+		RoleDefinitions().
+		ByUnifiedRoleDefinitionId(rawId.Value.(string)).
+		Get(ctx, nil)
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+
+	mqlRole, err := newMqlMicrosoftRoleDefinition(runtime, role)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, mqlRole, nil
 }
 
 func (a *mqlMicrosoft) roles() (*mqlMicrosoftRoles, error) {
@@ -134,6 +182,22 @@ func (m *mqlMicrosoftRolemanagementRoledefinition) id() (string, error) {
 // Deprecated: use mqlMicrosoft roles() instead
 func (m *mqlMicrosoftRolemanagementRoleassignment) id() (string, error) {
 	return m.Id.Data, nil
+}
+
+// roleDefinition resolves the role definition this assignment grants.
+func (m *mqlMicrosoftRolemanagementRoleassignment) roleDefinition() (*mqlMicrosoftRolemanagementRoledefinition, error) {
+	id := m.RoleDefinitionId.Data
+	if id == "" {
+		m.RoleDefinition.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(m.MqlRuntime, "microsoft.rolemanagement.roledefinition", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMicrosoftRolemanagementRoledefinition), nil
 }
 
 // Deprecated: use mqlMicrosoft roles() instead


### PR DESCRIPTION
## What

Adds typed resource accessors alongside the existing raw ID fields in the ms365 provider, so audits can traverse from a scope directly into the referenced directory object instead of re-looking up IDs by hand. This continues the dict→typed / raw-ID→typed-ref migration already in flight (#8152, #8155).

The raw ID fields are **kept** — they carry Conditional Access special tokens (`All`, `None`, `GuestsOrExternalUsers`, `ServicePrincipalsInMyTenant`) and remain stable selection keys. The new accessors are additive.

### New accessors

| Resource | New accessor(s) | Resolves to |
|---|---|---|
| `…conditionalAccess.policy.conditions.users` | `includeUsersRefs`, `excludeUsersRefs` | `[]microsoft.user` |
| | `includeGroupsRefs`, `excludeGroupsRefs` | `[]microsoft.group` |
| | `includeRolesRefs`, `excludeRolesRefs` | `[]microsoft.rolemanagement.roledefinition` |
| `…conditionalAccess.policy.conditions.clientApplications` | `includeServicePrincipalsRefs`, `excludeServicePrincipalsRefs` | `[]microsoft.serviceprincipal` |
| `microsoft.devicemanagement.manageddevice` | `user` | `microsoft.user` |
| `microsoft.devicemanagement.policyAssignment` | `group` | `microsoft.group` |
| `microsoft.rolemanagement.roleassignment` | `roleDefinition` | `microsoft.rolemanagement.roledefinition` |
| `microsoft.identityAndAccess.roleEligibilityScheduleInstance` | `roleDefinition` | `microsoft.rolemanagement.roledefinition` |

### Supporting changes

- The Conditional Access list refs resolve **only GUID entries**, skipping the special scope tokens that Graph mixes into the same lists.
- Adds by-id `init` functions for `microsoft.group` and `microsoft.rolemanagement.roledefinition`. These were required for the refs to resolve, and as a bonus enable direct `microsoft.group(id: "...")` lookups.
- Extracts `newMqlMicrosoftGroup` / `newMqlMicrosoftRoleDefinition` helpers shared by the list paths and the new inits (removes the duplicated field-mapping that would otherwise exist in both).

## Example queries

```mql
# Who/what is in scope of each Conditional Access policy
microsoft.conditionalAccess.policies {
  displayName
  conditions.users {
    includeUsersRefs { displayName userPrincipalName }
    includeGroupsRefs { displayName }
    includeRolesRefs { displayName }
  }
}

# Traverse a managed device to its owner
microsoft.devicemanagement.managedDevices { name user { displayName accountEnabled } }

# Role assignment → role definition permissions
microsoft.rolemanagement.roleAssignments { roleDefinition { displayName isBuiltIn } }
```

## Notes

- `.lr.versions` entries for the new fields land at **13.3.1** (auto-assigned next patch); `config.go` `Version` is untouched.
- `*.permissions.json` is **unchanged** — the new Graph calls (group-by-id, role-definition-by-id) reuse endpoints already covered by the existing `list` paths.
- Deliberately left raw: own-identity fields (`application.appId`, `serviceprincipal.appId`, `device.deviceId`), first-party MDM GUIDs, and the polymorphic `principalId` fields (user **or** group **or** SP — needs type-discriminated resolution; can follow up).

## Testing

- `make providers/build/ms365` compiles cleanly; codegen is up to date.
- `gofmt` clean; `go vet ./resources/` surfaces only pre-existing warnings.
- Not yet exercised against a live tenant — happy to run interactive verification if a test tenant is available.