### PR TITLE
✨ ms365: Intune assignment filters + typed policy-assignment filter ref

### DIFF
--- a/providers/ms365/resources/devicemanagement_assignmentfilters.go
+++ b/providers/ms365/resources/devicemanagement_assignmentfilters.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+
+	betamodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/ms365/connection"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// assignmentFilters lists the Intune assignment filters used to scope policy
+// and app assignments. Uses the beta Graph SDK because v1 does not expose
+// /deviceManagement/assignmentFilters.
+// requires DeviceManagementConfiguration.Read.All permission
+func (a *mqlMicrosoftDevicemanagement) assignmentFilters() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.BetaGraphClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	resp, err := graphClient.DeviceManagement().AssignmentFilters().Get(ctx, nil)
+	if err != nil {
+		return nil, transformError(err)
+	}
+	filters, err := iterate[betamodels.DeviceAndAppManagementAssignmentFilterable](ctx, resp, graphClient.GetAdapter(), betamodels.CreateDeviceAndAppManagementAssignmentFilterCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for _, f := range filters {
+		mqlFilter, err := newMqlAssignmentFilter(a.MqlRuntime, f)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlFilter)
+	}
+	return res, nil
+}
+
+func newMqlAssignmentFilter(runtime *plugin.Runtime, f betamodels.DeviceAndAppManagementAssignmentFilterable) (plugin.Resource, error) {
+	return CreateResource(runtime, "microsoft.devicemanagement.assignmentFilter",
+		map[string]*llx.RawData{
+			"__id":                           llx.StringDataPtr(f.GetId()),
+			"id":                             llx.StringDataPtr(f.GetId()),
+			"displayName":                    llx.StringDataPtr(f.GetDisplayName()),
+			"description":                    llx.StringDataPtr(f.GetDescription()),
+			"platform":                       llx.StringDataPtr(enumPtrString(f.GetPlatform())),
+			"rule":                           llx.StringDataPtr(f.GetRule()),
+			"assignmentFilterManagementType": llx.StringDataPtr(enumPtrString(f.GetAssignmentFilterManagementType())),
+			"roleScopeTags":                  llx.ArrayData(llx.TArr2Raw(f.GetRoleScopeTags()), types.String),
+			"createdDateTime":                llx.TimeDataPtr(f.GetCreatedDateTime()),
+			"lastModifiedDateTime":           llx.TimeDataPtr(f.GetLastModifiedDateTime()),
+		})
+}
+
+// initMicrosoftDevicemanagementAssignmentFilter resolves a single assignment
+// filter by its ID, enabling the typed policyAssignment.filter reference.
+func initMicrosoftDevicemanagementAssignmentFilter(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+	rawId, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.BetaGraphClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	f, err := graphClient.DeviceManagement().AssignmentFilters().
+		ByDeviceAndAppManagementAssignmentFilterId(rawId.Value.(string)).
+		Get(context.Background(), nil)
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+	mqlFilter, err := newMqlAssignmentFilter(runtime, f)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, mqlFilter, nil
+}
+
+// filter resolves the assignment filter applied to the target, when one is set.
+func (m *mqlMicrosoftDevicemanagementPolicyAssignment) filter() (*mqlMicrosoftDevicemanagementAssignmentFilter, error) {
+	id := m.FilterId.Data
+	if id == "" {
+		m.Filter.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(m.MqlRuntime, "microsoft.devicemanagement.assignmentFilter", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMicrosoftDevicemanagementAssignmentFilter), nil
+}

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -2425,6 +2425,40 @@ microsoft.devicemanagement {
   roleScopeTags() []microsoft.devicemanagement.roleScopeTag
   // App protection (MAM) policies for iOS and Android
   appProtectionPolicies() []microsoft.devicemanagement.appProtectionPolicy
+  // Assignment filters used to scope policy and app assignments
+  assignmentFilters() []microsoft.devicemanagement.assignmentFilter
+}
+
+// Microsoft Intune assignment filter
+//
+// Examine an assignment filter used to narrow which devices a policy or app
+// assignment targets, selected by its `id`. The `rule` holds the filter
+// expression evaluated against device properties, `platform` reports the
+// device platform it applies to, and `assignmentFilterManagementType`
+// distinguishes device filters from managed-app filters. A policy assignment
+// references a filter through `microsoft.devicemanagement.policyAssignment.filter`.
+private microsoft.devicemanagement.assignmentFilter @defaults("displayName platform") {
+  // Filter ID
+  id string
+  // Filter display name
+  displayName string
+  // Filter description
+  description string
+  // Device platform the filter applies to
+  //
+  // For example android, androidForWork, iOS, macOS, windowsPhone81,
+  // windows81AndLater, windows10AndLater, or androidWorkProfile.
+  platform string
+  // Filter rule expression evaluated against device properties
+  rule string
+  // What the filter manages (devices, apps)
+  assignmentFilterManagementType string
+  // Role scope tags assigned to the filter
+  roleScopeTags []string
+  // Date and time the filter was created
+  createdDateTime time
+  // Date and time the filter was last modified
+  lastModifiedDateTime time
 }
 
 // Microsoft Intune app protection (MAM) policy
@@ -2731,7 +2765,11 @@ private microsoft.devicemanagement.policyAssignment @defaults("id targetType") {
   // Assignment filter type (none, include, exclude)
   filterType string
   // Assignment filter ID when a filter is applied, empty otherwise
-  filterId string
+  //
+  // Deprecated in favor of filter.
+  filterId @maturity("deprecated") string
+  // Assignment filter applied to the target, when one is set
+  filter() microsoft.devicemanagement.assignmentFilter
 }
 
 // Evaluation state of a single Intune policy on a managed device

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -127,6 +127,7 @@ const (
 	ResourceMicrosoftRolemanagementRoledefinition                                                        string = "microsoft.rolemanagement.roledefinition"
 	ResourceMicrosoftRolemanagementRoleassignment                                                        string = "microsoft.rolemanagement.roleassignment"
 	ResourceMicrosoftDevicemanagement                                                                    string = "microsoft.devicemanagement"
+	ResourceMicrosoftDevicemanagementAssignmentFilter                                                    string = "microsoft.devicemanagement.assignmentFilter"
 	ResourceMicrosoftDevicemanagementAppProtectionPolicy                                                 string = "microsoft.devicemanagement.appProtectionPolicy"
 	ResourceMicrosoftDevicemanagementDeviceEnrollmentConfiguration                                       string = "microsoft.devicemanagement.deviceEnrollmentConfiguration"
 	ResourceMicrosoftDevicemanagementManageddevice                                                       string = "microsoft.devicemanagement.manageddevice"
@@ -627,6 +628,10 @@ func init() {
 		"microsoft.devicemanagement": {
 			// to override args, implement: initMicrosoftDevicemanagement(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftDevicemanagement,
+		},
+		"microsoft.devicemanagement.assignmentFilter": {
+			Init:   initMicrosoftDevicemanagementAssignmentFilter,
+			Create: createMicrosoftDevicemanagementAssignmentFilter,
 		},
 		"microsoft.devicemanagement.appProtectionPolicy": {
 			// to override args, implement: initMicrosoftDevicemanagementAppProtectionPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3297,6 +3302,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.devicemanagement.appProtectionPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagement).GetAppProtectionPolicies()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.appProtectionPolicy")))
 	},
+	"microsoft.devicemanagement.assignmentFilters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagement).GetAssignmentFilters()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.assignmentFilter")))
+	},
+	"microsoft.devicemanagement.assignmentFilter.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.platform": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetPlatform()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.rule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetRule()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.assignmentFilterManagementType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetAssignmentFilterManagementType()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.assignmentFilter.roleScopeTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetRoleScopeTags()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.devicemanagement.assignmentFilter.createdDateTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetCreatedDateTime()).ToDataRes(types.Time)
+	},
+	"microsoft.devicemanagement.assignmentFilter.lastModifiedDateTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementAssignmentFilter).GetLastModifiedDateTime()).ToDataRes(types.Time)
+	},
 	"microsoft.devicemanagement.appProtectionPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementAppProtectionPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -3647,6 +3682,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.devicemanagement.policyAssignment.filterId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GetFilterId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.policyAssignment.filter": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementPolicyAssignment).GetFilter()).ToDataRes(types.Resource("microsoft.devicemanagement.assignmentFilter"))
 	},
 	"microsoft.devicemanagement.manageddevice.policyState.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementManageddevicePolicyState).GetId()).ToDataRes(types.String)
@@ -8514,6 +8552,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftDevicemanagement).AppProtectionPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"microsoft.devicemanagement.assignmentFilters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagement).AssignmentFilters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.platform": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).Platform, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.rule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).Rule, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.assignmentFilterManagementType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).AssignmentFilterManagementType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.roleScopeTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).RoleScopeTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.createdDateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).CreatedDateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.assignmentFilter.lastModifiedDateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementAssignmentFilter).LastModifiedDateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"microsoft.devicemanagement.appProtectionPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagementAppProtectionPolicy).__id, ok = v.Value.(string)
 		return
@@ -9004,6 +9086,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.devicemanagement.policyAssignment.filterId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagementPolicyAssignment).FilterId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.policyAssignment.filter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementPolicyAssignment).Filter, ok = plugin.RawToTValue[*mqlMicrosoftDevicemanagementAssignmentFilter](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.manageddevice.policyState.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20462,6 +20548,7 @@ type mqlMicrosoftDevicemanagement struct {
 	RoleAssignments                    plugin.TValue[[]any]
 	RoleScopeTags                      plugin.TValue[[]any]
 	AppProtectionPolicies              plugin.TValue[[]any]
+	AssignmentFilters                  plugin.TValue[[]any]
 }
 
 // createMicrosoftDevicemanagement creates a new instance of this resource
@@ -20686,6 +20773,106 @@ func (c *mqlMicrosoftDevicemanagement) GetAppProtectionPolicies() *plugin.TValue
 
 		return c.appProtectionPolicies()
 	})
+}
+
+func (c *mqlMicrosoftDevicemanagement) GetAssignmentFilters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AssignmentFilters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement", c.__id, "assignmentFilters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.assignmentFilters()
+	})
+}
+
+// mqlMicrosoftDevicemanagementAssignmentFilter for the microsoft.devicemanagement.assignmentFilter resource
+type mqlMicrosoftDevicemanagementAssignmentFilter struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDevicemanagementAssignmentFilterInternal it will be used here
+	Id                             plugin.TValue[string]
+	DisplayName                    plugin.TValue[string]
+	Description                    plugin.TValue[string]
+	Platform                       plugin.TValue[string]
+	Rule                           plugin.TValue[string]
+	AssignmentFilterManagementType plugin.TValue[string]
+	RoleScopeTags                  plugin.TValue[[]any]
+	CreatedDateTime                plugin.TValue[*time.Time]
+	LastModifiedDateTime           plugin.TValue[*time.Time]
+}
+
+// createMicrosoftDevicemanagementAssignmentFilter creates a new instance of this resource
+func createMicrosoftDevicemanagementAssignmentFilter(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDevicemanagementAssignmentFilter{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.devicemanagement.assignmentFilter", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) MqlName() string {
+	return "microsoft.devicemanagement.assignmentFilter"
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetPlatform() *plugin.TValue[string] {
+	return &c.Platform
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetRule() *plugin.TValue[string] {
+	return &c.Rule
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetAssignmentFilterManagementType() *plugin.TValue[string] {
+	return &c.AssignmentFilterManagementType
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetRoleScopeTags() *plugin.TValue[[]any] {
+	return &c.RoleScopeTags
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetCreatedDateTime() *plugin.TValue[*time.Time] {
+	return &c.CreatedDateTime
+}
+
+func (c *mqlMicrosoftDevicemanagementAssignmentFilter) GetLastModifiedDateTime() *plugin.TValue[*time.Time] {
+	return &c.LastModifiedDateTime
 }
 
 // mqlMicrosoftDevicemanagementAppProtectionPolicy for the microsoft.devicemanagement.appProtectionPolicy resource
@@ -21503,6 +21690,7 @@ type mqlMicrosoftDevicemanagementPolicyAssignment struct {
 	Excluded   plugin.TValue[bool]
 	FilterType plugin.TValue[string]
 	FilterId   plugin.TValue[string]
+	Filter     plugin.TValue[*mqlMicrosoftDevicemanagementAssignmentFilter]
 }
 
 // createMicrosoftDevicemanagementPolicyAssignment creates a new instance of this resource
@@ -21580,6 +21768,22 @@ func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetFilterType() *plugin.T
 
 func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetFilterId() *plugin.TValue[string] {
 	return &c.FilterId
+}
+
+func (c *mqlMicrosoftDevicemanagementPolicyAssignment) GetFilter() *plugin.TValue[*mqlMicrosoftDevicemanagementAssignmentFilter] {
+	return plugin.GetOrCompute[*mqlMicrosoftDevicemanagementAssignmentFilter](&c.Filter, func() (*mqlMicrosoftDevicemanagementAssignmentFilter, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement.policyAssignment", c.__id, "filter")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftDevicemanagementAssignmentFilter), nil
+			}
+		}
+
+		return c.filter()
+	})
 }
 
 // mqlMicrosoftDevicemanagementManageddevicePolicyState for the microsoft.devicemanagement.manageddevice.policyState resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -306,6 +306,17 @@ microsoft.devicemanagement.appProtectionPolicy.printBlocked 13.3.1
 microsoft.devicemanagement.appProtectionPolicy.saveAsBlocked 13.3.1
 microsoft.devicemanagement.appProtectionPolicy.simplePinBlocked 13.3.1
 microsoft.devicemanagement.appProtectionPolicy.version 13.3.1
+microsoft.devicemanagement.assignmentFilter 13.3.1
+microsoft.devicemanagement.assignmentFilter.assignmentFilterManagementType 13.3.1
+microsoft.devicemanagement.assignmentFilter.createdDateTime 13.3.1
+microsoft.devicemanagement.assignmentFilter.description 13.3.1
+microsoft.devicemanagement.assignmentFilter.displayName 13.3.1
+microsoft.devicemanagement.assignmentFilter.id 13.3.1
+microsoft.devicemanagement.assignmentFilter.lastModifiedDateTime 13.3.1
+microsoft.devicemanagement.assignmentFilter.platform 13.3.1
+microsoft.devicemanagement.assignmentFilter.roleScopeTags 13.3.1
+microsoft.devicemanagement.assignmentFilter.rule 13.3.1
+microsoft.devicemanagement.assignmentFilters 13.3.1
 microsoft.devicemanagement.detectedApps 13.0.12
 microsoft.devicemanagement.detectedapp 13.0.12
 microsoft.devicemanagement.detectedapp.deviceCount 13.0.12
@@ -442,6 +453,7 @@ microsoft.devicemanagement.mobileapp.publisher 13.0.12
 microsoft.devicemanagement.mobileapp.publishingState 13.0.12
 microsoft.devicemanagement.policyAssignment 13.0.12
 microsoft.devicemanagement.policyAssignment.excluded 13.0.12
+microsoft.devicemanagement.policyAssignment.filter 13.3.1
 microsoft.devicemanagement.policyAssignment.filterId 13.0.12
 microsoft.devicemanagement.policyAssignment.filterType 13.0.12
 microsoft.devicemanagement.policyAssignment.group 13.3.1


### PR DESCRIPTION
## What

Adds `microsoft.devicemanagement.assignmentFilters()` — the Intune **assignment filters** used to narrow which devices a policy or app assignment targets — and wires the existing dangling `policyAssignment.filterId` to a typed `filter()` reference.

### `microsoft.devicemanagement.assignmentFilter`

`id`, `displayName`, `description`, `platform`, `rule` (the filter expression evaluated against device properties), `assignmentFilterManagementType` (devices vs apps), `roleScopeTags`, `createdDateTime`, `lastModifiedDateTime`.

### `policyAssignment.filter()`

Every policy/app assignment already exposed a raw `filterId` (+ `filterType`). This adds `filter()` → the typed `assignmentFilter`, and **deprecates `filterId`** in favor of it — the same pattern as the `group()` / deprecated `groupId` already on the resource (the typed ref carries the same id, so the raw scalar is a pure duplicate). `filterType` (none/include/exclude) stays — it's semantics, not an ID. A by-id init makes both `assignmentFilter(id:)` and the reference resolve.

## Example queries

```mql
# All assignment filters and their rules
microsoft.devicemanagement.assignmentFilters { displayName platform rule }

# Resolve the filter applied to each compliance-policy assignment
microsoft.devicemanagement.deviceCompliancePolicies {
  displayName
  assignments { filterType filter { displayName rule platform } }
}
```

## Notes

- Beta Graph SDK (v1 doesn't expose `/deviceManagement/assignmentFilters`), via the existing `conn.BetaGraphClient()` — same approach as `detectedApps` / Autopilot.
- `.lr.versions` auto-assigned to the next patch (`13.3.1`); deprecation of `filterId` keeps its original version. `config.go` untouched.
- Required scope (`DeviceManagementConfiguration.Read.All`) documented on the accessor.

## Testing

- `make providers/build/ms365` compiles cleanly; codegen up to date; `gofmt` / `go vet` clean (only pre-existing warnings).
- Not yet run against a live tenant — happy to run `mql shell ms365` verification if a test tenant is available.

---

#2 of the Intune set (App Protection ✓ → **Assignment filters** → MTD connectors → Settings catalog).