### PR TITLE
✨ ms365: typed DLP compliance policies, deprecate the dict variant

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -3295,8 +3295,49 @@ private ms365.exchangeonlineMailboxAuditBypassAssociation @defaults("name auditB
 
 // Microsoft 365 Exchange Online Security and Compliance
 private ms365.exchangeonline.securityAndCompliance {
-  // List of Data Loss Prevention (DLP) compliance policies
-  dlpCompliancePolicies() []dict
+  // Data Loss Prevention (DLP) compliance policies as raw dictionaries
+  //
+  // Deprecated in favor of dlpPolicies, which models the same policies as
+  // typed resources.
+  dlpCompliancePolicies() @maturity("deprecated") []dict
+  // Data Loss Prevention (DLP) compliance policies
+  dlpPolicies() []ms365.exchangeonline.dlpCompliancePolicy
+}
+
+// Microsoft 365 Data Loss Prevention compliance policy
+//
+// Examine a Data Loss Prevention (DLP) compliance policy, selected by its
+// `name`. `mode` reports the enforcement level (Enable, TestWithNotifications,
+// TestWithoutNotifications, or Disable) and `enabled` whether it is on. The
+// `workload` lists which services it covers — Exchange, SharePoint,
+// OneDriveForBusiness, Teams, or EndpointDevices — and `priority` orders policy
+// evaluation. `distributionStatus` reports whether the policy has rolled out to
+// the workloads, and `whenCreated` / `whenChanged` frame its history.
+private ms365.exchangeonline.dlpCompliancePolicy @defaults("name mode enabled workload") {
+  // Policy name
+  name string
+  // Policy GUID
+  guid string
+  // Enforcement mode (Enable, TestWithNotifications, TestWithoutNotifications, Disable, PendingDeletion)
+  mode string
+  // Whether the policy is enabled
+  enabled bool
+  // Workloads the policy applies to (for example Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices)
+  workload string
+  // Policy priority; lower numbers are evaluated first
+  priority int
+  // Administrator comment
+  comment string
+  // Account that created the policy
+  createdBy string
+  // Whether the policy is valid
+  isValid bool
+  // Distribution status of the policy across its workloads
+  distributionStatus string
+  // Date and time the policy was created
+  whenCreated time
+  // Date and time the policy was last changed
+  whenChanged time
 }
 
 // Teams Protection Policy configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -149,6 +149,7 @@ const (
 	ResourceMs365Exchangeonline                                                                          string = "ms365.exchangeonline"
 	ResourceMs365ExchangeonlineMailboxAuditBypassAssociation                                             string = "ms365.exchangeonlineMailboxAuditBypassAssociation"
 	ResourceMs365ExchangeonlineSecurityAndCompliance                                                     string = "ms365.exchangeonline.securityAndCompliance"
+	ResourceMs365ExchangeonlineDlpCompliancePolicy                                                       string = "ms365.exchangeonline.dlpCompliancePolicy"
 	ResourceMs365ExchangeonlineTeamsProtectionPolicy                                                     string = "ms365.exchangeonline.teamsProtectionPolicy"
 	ResourceMs365ExchangeonlineReportSubmissionPolicy                                                    string = "ms365.exchangeonline.reportSubmissionPolicy"
 	ResourceMs365ExchangeonlineJournalRule                                                               string = "ms365.exchangeonline.journalRule"
@@ -719,6 +720,10 @@ func init() {
 		"ms365.exchangeonline.securityAndCompliance": {
 			// to override args, implement: initMs365ExchangeonlineSecurityAndCompliance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMs365ExchangeonlineSecurityAndCompliance,
+		},
+		"ms365.exchangeonline.dlpCompliancePolicy": {
+			// to override args, implement: initMs365ExchangeonlineDlpCompliancePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMs365ExchangeonlineDlpCompliancePolicy,
 		},
 		"ms365.exchangeonline.teamsProtectionPolicy": {
 			// to override args, implement: initMs365ExchangeonlineTeamsProtectionPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4174,6 +4179,45 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ms365.exchangeonline.securityAndCompliance.dlpCompliancePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineSecurityAndCompliance).GetDlpCompliancePolicies()).ToDataRes(types.Array(types.Dict))
+	},
+	"ms365.exchangeonline.securityAndCompliance.dlpPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineSecurityAndCompliance).GetDlpPolicies()).ToDataRes(types.Array(types.Resource("ms365.exchangeonline.dlpCompliancePolicy")))
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetName()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.guid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetGuid()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.mode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetMode()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.workload": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetWorkload()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.priority": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetPriority()).ToDataRes(types.Int)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.comment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetComment()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.createdBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetCreatedBy()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.isValid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetIsValid()).ToDataRes(types.Bool)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.distributionStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetDistributionStatus()).ToDataRes(types.String)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.whenCreated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetWhenCreated()).ToDataRes(types.Time)
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.whenChanged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetWhenChanged()).ToDataRes(types.Time)
 	},
 	"ms365.exchangeonline.teamsProtectionPolicy.zapEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineTeamsProtectionPolicy).GetZapEnabled()).ToDataRes(types.Bool)
@@ -9917,6 +9961,62 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.exchangeonline.securityAndCompliance.dlpCompliancePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365ExchangeonlineSecurityAndCompliance).DlpCompliancePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.securityAndCompliance.dlpPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineSecurityAndCompliance).DlpPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.guid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Guid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.mode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.workload": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Workload, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.priority": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Priority, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.comment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Comment, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.createdBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).CreatedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.isValid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).IsValid, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.distributionStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).DistributionStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.whenCreated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).WhenCreated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.whenChanged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).WhenChanged, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"ms365.exchangeonline.teamsProtectionPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23889,6 +23989,7 @@ type mqlMs365ExchangeonlineSecurityAndCompliance struct {
 	__id       string
 	mqlMs365ExchangeonlineSecurityAndComplianceInternal
 	DlpCompliancePolicies plugin.TValue[[]any]
+	DlpPolicies           plugin.TValue[[]any]
 }
 
 // createMs365ExchangeonlineSecurityAndCompliance creates a new instance of this resource
@@ -23927,6 +24028,121 @@ func (c *mqlMs365ExchangeonlineSecurityAndCompliance) GetDlpCompliancePolicies()
 	return plugin.GetOrCompute[[]any](&c.DlpCompliancePolicies, func() ([]any, error) {
 		return c.dlpCompliancePolicies()
 	})
+}
+
+func (c *mqlMs365ExchangeonlineSecurityAndCompliance) GetDlpPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DlpPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("ms365.exchangeonline.securityAndCompliance", c.__id, "dlpPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.dlpPolicies()
+	})
+}
+
+// mqlMs365ExchangeonlineDlpCompliancePolicy for the ms365.exchangeonline.dlpCompliancePolicy resource
+type mqlMs365ExchangeonlineDlpCompliancePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMs365ExchangeonlineDlpCompliancePolicyInternal it will be used here
+	Name               plugin.TValue[string]
+	Guid               plugin.TValue[string]
+	Mode               plugin.TValue[string]
+	Enabled            plugin.TValue[bool]
+	Workload           plugin.TValue[string]
+	Priority           plugin.TValue[int64]
+	Comment            plugin.TValue[string]
+	CreatedBy          plugin.TValue[string]
+	IsValid            plugin.TValue[bool]
+	DistributionStatus plugin.TValue[string]
+	WhenCreated        plugin.TValue[*time.Time]
+	WhenChanged        plugin.TValue[*time.Time]
+}
+
+// createMs365ExchangeonlineDlpCompliancePolicy creates a new instance of this resource
+func createMs365ExchangeonlineDlpCompliancePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMs365ExchangeonlineDlpCompliancePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("ms365.exchangeonline.dlpCompliancePolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) MqlName() string {
+	return "ms365.exchangeonline.dlpCompliancePolicy"
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetGuid() *plugin.TValue[string] {
+	return &c.Guid
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetMode() *plugin.TValue[string] {
+	return &c.Mode
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetWorkload() *plugin.TValue[string] {
+	return &c.Workload
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetPriority() *plugin.TValue[int64] {
+	return &c.Priority
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetComment() *plugin.TValue[string] {
+	return &c.Comment
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetCreatedBy() *plugin.TValue[string] {
+	return &c.CreatedBy
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetIsValid() *plugin.TValue[bool] {
+	return &c.IsValid
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetDistributionStatus() *plugin.TValue[string] {
+	return &c.DistributionStatus
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetWhenCreated() *plugin.TValue[*time.Time] {
+	return &c.WhenCreated
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetWhenChanged() *plugin.TValue[*time.Time] {
+	return &c.WhenChanged
 }
 
 // mqlMs365ExchangeonlineTeamsProtectionPolicy for the ms365.exchangeonline.teamsProtectionPolicy resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1171,6 +1171,19 @@ ms365.exchangeonline.dkimSigningConfig.enabled 13.3.1
 ms365.exchangeonline.dkimSigningConfig.identity 13.3.1
 ms365.exchangeonline.dkimSigningConfig.status 13.3.1
 ms365.exchangeonline.dkimSigningConfigs 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.comment 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.createdBy 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.distributionStatus 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.enabled 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.guid 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.isValid 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.mode 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.name 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.priority 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.whenChanged 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.whenCreated 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.workload 13.3.1
 ms365.exchangeonline.exoMailbox 9.2.14
 ms365.exchangeonline.exoMailbox.externalDirectoryObjectId 9.2.14
 ms365.exchangeonline.exoMailbox.identity 9.2.14
@@ -1324,6 +1337,7 @@ ms365.exchangeonline.safeLinksPolicy.scanUrls 13.3.1
 ms365.exchangeonline.safeLinksPolicy.trackClicks 13.3.1
 ms365.exchangeonline.securityAndCompliance 11.1.41
 ms365.exchangeonline.securityAndCompliance.dlpCompliancePolicies 11.1.41
+ms365.exchangeonline.securityAndCompliance.dlpPolicies 13.3.1
 ms365.exchangeonline.sharedMailboxes 9.0.0
 ms365.exchangeonline.sharingPolicies 13.3.1
 ms365.exchangeonline.sharingPolicy 9.0.0

--- a/providers/ms365/resources/ms365_securitycompliance_dlp.go
+++ b/providers/ms365/resources/ms365_securitycompliance_dlp.go
@@ -1,0 +1,135 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// dlpPolicies returns the Data Loss Prevention compliance policies as typed
+// resources. The underlying data comes from the Security & Compliance
+// PowerShell report, whose JSON shape varies by module version, so each field
+// is extracted defensively rather than struct-decoded.
+func (r *mqlMs365ExchangeonlineSecurityAndCompliance) dlpPolicies() ([]any, error) {
+	report, err := r.getSecurityAndComplianceReport()
+	if err != nil {
+		return nil, err
+	}
+	return convertDlpCompliancePolicies(r.MqlRuntime, report.DlpCompliancePolicy)
+}
+
+func convertDlpCompliancePolicies(runtime *plugin.Runtime, raw []any) ([]any, error) {
+	result := []any{}
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		guid := dlpString(m, "Guid")
+		id := guid
+		if id == "" {
+			id = dlpString(m, "Name")
+		}
+
+		mql, err := CreateResource(runtime, "ms365.exchangeonline.dlpCompliancePolicy",
+			map[string]*llx.RawData{
+				"__id":               llx.StringData("dlpCompliancePolicy-" + id),
+				"name":               llx.StringData(dlpString(m, "Name")),
+				"guid":               llx.StringData(guid),
+				"mode":               llx.StringData(dlpString(m, "Mode")),
+				"enabled":            llx.BoolData(dlpBool(m, "Enabled")),
+				"workload":           llx.StringData(dlpWorkload(m)),
+				"priority":           llx.IntData(dlpInt(m, "Priority")),
+				"comment":            llx.StringData(dlpString(m, "Comment")),
+				"createdBy":          llx.StringData(dlpString(m, "CreatedBy")),
+				"isValid":            llx.BoolData(dlpBool(m, "IsValid")),
+				"distributionStatus": llx.StringData(dlpString(m, "DistributionStatus")),
+				"whenCreated":        llx.TimeDataPtr(dlpTime(m, "WhenCreated")),
+				"whenChanged":        llx.TimeDataPtr(dlpTime(m, "WhenChanged")),
+			})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, mql)
+	}
+	return result, nil
+}
+
+func dlpString(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func dlpBool(m map[string]any, key string) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return false
+}
+
+func dlpInt(m map[string]any, key string) int64 {
+	switch v := m[key].(type) {
+	case float64:
+		return int64(v)
+	case string:
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+// dlpWorkload coerces the Workload property, which may serialize as a single
+// string, a list of workload names, or (for a numeric enum) be unreadable.
+func dlpWorkload(m map[string]any) string {
+	switch v := m["Workload"].(type) {
+	case string:
+		return v
+	case []any:
+		parts := []string{}
+		for _, p := range v {
+			if s, ok := p.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, ", ")
+	}
+	return ""
+}
+
+// dlpTime parses a timestamp that PowerShell may emit either as an ISO 8601
+// string or as the legacy "/Date(milliseconds)/" form.
+func dlpTime(m map[string]any, key string) *time.Time {
+	s, ok := m[key].(string)
+	if !ok || s == "" {
+		return nil
+	}
+
+	if strings.HasPrefix(s, "/Date(") && strings.HasSuffix(s, ")/") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(s, "/Date("), ")/")
+		if idx := strings.IndexAny(inner, "+-"); idx > 0 {
+			inner = inner[:idx]
+		}
+		if ms, err := strconv.ParseInt(inner, 10, 64); err == nil {
+			t := time.UnixMilli(ms).UTC()
+			return &t
+		}
+		return nil
+	}
+
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return &t
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Models **Data Loss Prevention (DLP) compliance policies** as typed resources instead of the raw `[]dict`, continuing the dict→typed migration (#8152, #8155, …) and opening the Purview/compliance surface.

### `ms365.exchangeonline.securityAndCompliance.dlpPolicies()` → `dlpCompliancePolicy`

`name`, `guid`, `mode` (enforcement level — Enable / TestWithNotifications / TestWithoutNotifications / Disable), `enabled`, `workload` (Exchange / SharePoint / OneDriveForBusiness / Teams / EndpointDevices), `priority`, `comment`, `createdBy`, `isValid`, `distributionStatus`, `whenCreated`, `whenChanged`.

The existing `dlpCompliancePolicies() []dict` accessor is kept and marked `@maturity("deprecated")` in favor of `dlpPolicies`.

## Example queries

```mql
# DLP policies not in enforce mode
ms365.exchangeonline.securityAndCompliance.dlpPolicies.where(mode != "Enable") { name mode enabled workload }

# Which workloads are covered
ms365.exchangeonline.securityAndCompliance.dlpPolicies { name workload priority }
```

## Notes

- Data source is the Security & Compliance PowerShell report (`Get-DlpCompliancePolicy`), same as the existing dict accessor. Because that JSON's shape varies by module version (the `Workload` enum may serialize as a string or a list; timestamps as ISO 8601 or the legacy `/Date(ms)/` form), each field is **extracted defensively from the decoded map** rather than struct-unmarshaled — a malformed field degrades to a zero value instead of failing the whole list.
- Naming: the existing released accessor already held the plural `dlpCompliancePolicies` (for the dict), so the typed list takes `dlpPolicies` rather than colliding.
- `.lr.versions` auto-assigned to the next patch (`13.3.1`); deprecation keeps the dict accessor's version. `config.go` untouched.
- **Deferred:** per-policy location detail (Exchange/SharePoint/OneDrive/Teams location arrays) — the `workload` summary covers the "which services" audit; the detailed location objects are a fragile follow-up. DLP *rules* (`Get-DlpComplianceRule`) are a separate follow-up.

## Testing

- `make providers/build/ms365` compiles cleanly; codegen up to date; `gofmt` / `go vet` clean (only pre-existing warnings).
- Not yet run against a live tenant — happy to run `mql shell ms365` verification (DLP needs the Security & Compliance PowerShell connection) if a test tenant is available.