### PR TITLE
✨ ms365: typed routeMessageOutboundRequireTls on transport rule entry

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -3941,9 +3941,10 @@ private ms365.exchangeonline.retentionPolicy @defaults("name retentionPolicyTagL
 //
 // Examine a single mail flow rule returned by Get-TransportRule, selected by
 // `name`. Each rule reports its evaluation `priority` (lower numbers run
-// first), enablement `state`, operating `mode`, and administrator `comments`.
-// The full condition and action set of a rule remains available through the
-// deprecated `transportRule` dictionary.
+// first), enablement `state`, operating `mode`, administrator `comments`, and
+// whether it forces outbound TLS via `routeMessageOutboundRequireTls`. The full
+// condition and action set of a rule remains available through the deprecated
+// `transportRule` dictionary.
 private ms365.exchangeonline.transportRuleEntry @defaults("name state priority") {
   // The rule identity
   identity string
@@ -3955,6 +3956,8 @@ private ms365.exchangeonline.transportRuleEntry @defaults("name state priority")
   state string
   // Rule operating mode (Enforce, Audit, or AuditAndNotify)
   mode string
+  // Whether the rule forces matching messages to be routed outbound over TLS
+  routeMessageOutboundRequireTls bool
   // Administrator comments on the rule
   comments string
 }

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -4864,6 +4864,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.exchangeonline.transportRuleEntry.mode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineTransportRuleEntry).GetMode()).ToDataRes(types.String)
 	},
+	"ms365.exchangeonline.transportRuleEntry.routeMessageOutboundRequireTls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineTransportRuleEntry).GetRouteMessageOutboundRequireTls()).ToDataRes(types.Bool)
+	},
 	"ms365.exchangeonline.transportRuleEntry.comments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineTransportRuleEntry).GetComments()).ToDataRes(types.String)
 	},
@@ -11065,6 +11068,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.exchangeonline.transportRuleEntry.mode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365ExchangeonlineTransportRuleEntry).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.transportRuleEntry.routeMessageOutboundRequireTls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineTransportRuleEntry).RouteMessageOutboundRequireTls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"ms365.exchangeonline.transportRuleEntry.comments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26491,12 +26498,13 @@ type mqlMs365ExchangeonlineTransportRuleEntry struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMs365ExchangeonlineTransportRuleEntryInternal it will be used here
-	Identity plugin.TValue[string]
-	Name     plugin.TValue[string]
-	Priority plugin.TValue[int64]
-	State    plugin.TValue[string]
-	Mode     plugin.TValue[string]
-	Comments plugin.TValue[string]
+	Identity                       plugin.TValue[string]
+	Name                           plugin.TValue[string]
+	Priority                       plugin.TValue[int64]
+	State                          plugin.TValue[string]
+	Mode                           plugin.TValue[string]
+	RouteMessageOutboundRequireTls plugin.TValue[bool]
+	Comments                       plugin.TValue[string]
 }
 
 // createMs365ExchangeonlineTransportRuleEntry creates a new instance of this resource
@@ -26549,6 +26557,10 @@ func (c *mqlMs365ExchangeonlineTransportRuleEntry) GetState() *plugin.TValue[str
 
 func (c *mqlMs365ExchangeonlineTransportRuleEntry) GetMode() *plugin.TValue[string] {
 	return &c.Mode
+}
+
+func (c *mqlMs365ExchangeonlineTransportRuleEntry) GetRouteMessageOutboundRequireTls() *plugin.TValue[bool] {
+	return &c.RouteMessageOutboundRequireTls
 }
 
 func (c *mqlMs365ExchangeonlineTransportRuleEntry) GetComments() *plugin.TValue[string] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1410,6 +1410,7 @@ ms365.exchangeonline.transportRuleEntry.identity 13.3.1
 ms365.exchangeonline.transportRuleEntry.mode 13.3.1
 ms365.exchangeonline.transportRuleEntry.name 13.3.1
 ms365.exchangeonline.transportRuleEntry.priority 13.3.1
+ms365.exchangeonline.transportRuleEntry.routeMessageOutboundRequireTls 13.3.1
 ms365.exchangeonline.transportRuleEntry.state 13.3.1
 ms365.exchangeonline.transportRules 13.3.1
 ms365.exchangeonlineMailboxAuditBypassAssociation 11.1.43

--- a/providers/ms365/resources/ms365_exchange_policies.go
+++ b/providers/ms365/resources/ms365_exchange_policies.go
@@ -32,12 +32,13 @@ func decodeExchangeList[T any](raw any) ([]*T, error) {
 // --- Transport rules ---
 
 type ExchangeTransportRule struct {
-	Identity string `json:"Identity"`
-	Name     string `json:"Name"`
-	Priority int64  `json:"Priority"`
-	State    string `json:"State"`
-	Mode     string `json:"Mode"`
-	Comments string `json:"Comments"`
+	Identity                       string `json:"Identity"`
+	Name                           string `json:"Name"`
+	Priority                       int64  `json:"Priority"`
+	State                          string `json:"State"`
+	Mode                           string `json:"Mode"`
+	RouteMessageOutboundRequireTls bool   `json:"RouteMessageOutboundRequireTls"`
+	Comments                       string `json:"Comments"`
 }
 
 func convertTransportRules(r *mqlMs365Exchangeonline, raw any) ([]any, error) {
@@ -52,13 +53,14 @@ func convertTransportRules(r *mqlMs365Exchangeonline, raw any) ([]any, error) {
 		}
 		mql, err := CreateResource(r.MqlRuntime, "ms365.exchangeonline.transportRuleEntry",
 			map[string]*llx.RawData{
-				"__id":     llx.StringData("transportRule-" + t.Identity),
-				"identity": llx.StringData(t.Identity),
-				"name":     llx.StringData(t.Name),
-				"priority": llx.IntData(t.Priority),
-				"state":    llx.StringData(t.State),
-				"mode":     llx.StringData(t.Mode),
-				"comments": llx.StringData(t.Comments),
+				"__id":                           llx.StringData("transportRule-" + t.Identity),
+				"identity":                       llx.StringData(t.Identity),
+				"name":                           llx.StringData(t.Name),
+				"priority":                       llx.IntData(t.Priority),
+				"state":                          llx.StringData(t.State),
+				"mode":                           llx.StringData(t.Mode),
+				"routeMessageOutboundRequireTls": llx.BoolData(t.RouteMessageOutboundRequireTls),
+				"comments":                       llx.StringData(t.Comments),
 			})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Adds `routeMessageOutboundRequireTls` (bool) to the typed `ms365.exchangeonline.transportRuleEntry`. The value comes straight from the raw `Get-TransportRule` payload already serialized in the exchange report, so there is no additional API call.

## Query fixed

This field lets the cnspec content check `mondoo-m365-security-ensure-transport-rules-enforce-tls` move off the deprecated `transportRule` dict:

```diff
- ms365.exchangeonline.transportRule.any(_['state'] == "Enabled" && _['routeMessageOutboundRequireTls'] == true)
+ ms365.exchangeonline.transportRules.any(state == "Enabled" && routeMessageOutboundRequireTls == true)
```

## Changes

- `ms365.lr`: new `routeMessageOutboundRequireTls` field on `ms365.exchangeonline.transportRuleEntry` + doc comment.
- `ms365_exchange_policies.go`: field added to the `ExchangeTransportRule` struct (`json:"RouteMessageOutboundRequireTls"`) and the `CreateResource` map.
- Regenerated `ms365.lr.go` and `ms365.lr.versions`.

## Test plan

- [x] `./lr go` / `./lr versions` regenerate cleanly (single new field at 13.3.1)
- [x] `go build ./main.go` for the ms365 provider succeeds
- [x] Built provider installed locally; `cnspec policy lint` passes the migrated check with no deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)