### PR TITLE
🏇 guard against potential race condition after #8078

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -308,10 +308,10 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 		}
 	}
 
-	if provider.Schema == nil {
-		if err := provider.LoadResources(); err != nil {
-			return nil, errors.Wrap(err, "failed to load provider "+id+" resources info")
-		}
+	// LoadResources is idempotent and safe under concurrent calls; it
+	// also synchronizes the Schema read below via Provider.schemaMu.
+	if err := provider.LoadResources(); err != nil {
+		return nil, errors.Wrap(err, "failed to load provider "+id+" resources info")
 	}
 
 	// crashLog tees the plugin subprocess's stderr to logger.LogOutputWriter
@@ -439,10 +439,10 @@ func (c *coordinator) LoadSchema(name string) (resources.ResourcesSchema, error)
 		return nil, errors.New("cannot find provider '" + name + "'")
 	}
 
-	if provider.Schema == nil {
-		if err := provider.LoadResources(); err != nil {
-			return nil, errors.Wrap(err, "failed to load provider '"+name+"' resources info")
-		}
+	// LoadResources is idempotent and safe under concurrent calls; it
+	// also synchronizes the Schema read below via Provider.schemaMu.
+	if err := provider.LoadResources(); err != nil {
+		return nil, errors.Wrap(err, "failed to load provider '"+name+"' resources info")
 	}
 
 	return provider.Schema, nil

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -167,6 +168,13 @@ func (p Providers) Add(nu *Provider) {
 
 type Provider struct {
 	*plugin.Provider
+	// schemaMu serializes lazy loads of Schema. Schema is read by many
+	// callers (often concurrently, e.g. multiple assets connecting at once
+	// via Runtime.AddConnection -> EnsureProvider -> installDependencies)
+	// while the first reader is still populating it. Every access to
+	// Schema must be preceded by a successful LoadResources call so the
+	// reader synchronizes with the (single) writer through this mutex.
+	schemaMu  sync.Mutex
 	Schema    resources.ResourcesSchema
 	Path      string
 	HasBinary bool
@@ -471,18 +479,19 @@ func installVersion(ctx context.Context, name string, version string) (*Provider
 
 // installDependencies ensures all dependencies of a provider are installed
 func installDependencies(provider *Provider, existing Providers) error {
-	if provider.Schema == nil {
-		// Schemas are loaded lazily (see readProviderDir / ListAll), so most
-		// providers reach this point without one. Load just this provider's
-		// schema on demand to inspect its dependencies — builtins have no path
-		// and legitimately carry no file-backed schema, so skip those.
-		if provider.Path == "" {
-			return nil
-		}
+	// Builtins have no file-backed schema; their Schema is set at init time
+	// in builtinProviders and never mutated again, so reading it is safe.
+	// File-backed providers (Path != "") load their schema lazily — call
+	// LoadResources unconditionally so the (racy-without-it) Schema read
+	// below is synchronized through Provider.schemaMu.
+	if provider.Path != "" {
 		if err := provider.LoadResources(); err != nil {
 			log.Error().Err(err).Str("provider", provider.Name).Msg("failed to load provider schema, unable to look up dependencies")
 			return nil
 		}
+	}
+	if provider.Schema == nil {
+		return nil
 	}
 
 	for _, dependency := range provider.Schema.AllDependencies() {
@@ -961,7 +970,18 @@ func (p *Provider) LoadJSON() error {
 	return nil
 }
 
+// LoadResources reads and parses the provider's resource schema from disk
+// into p.Schema. Safe to call concurrently and idempotent: the first
+// successful call populates Schema; subsequent calls return immediately.
+// Callers that need to read Schema must call LoadResources first so the
+// read synchronizes-after the write via schemaMu.
 func (p *Provider) LoadResources() error {
+	p.schemaMu.Lock()
+	defer p.schemaMu.Unlock()
+	if p.Schema != nil {
+		return nil
+	}
+
 	path := filepath.Join(p.Path, p.Name+".resources.json")
 	res, err := afero.ReadFile(config.AppFs, path)
 	if err != nil {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -5,12 +5,16 @@ package providers
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
@@ -61,6 +65,59 @@ func TestProviderShutdown(t *testing.T) {
 	err = s.Shutdown()
 	require.NoError(t, err)
 	require.True(t, s.isCloseOrShutdown())
+}
+
+// TestProvider_LoadResources_ConcurrentIsRaceFree exercises the lazy
+// schema load path that callers like installDependencies and the
+// coordinator now share. Run with -race to verify the per-Provider mutex
+// inside LoadResources serializes the write to p.Schema and the reads
+// after the call observe a single consistent schema value.
+func TestProvider_LoadResources_ConcurrentIsRaceFree(t *testing.T) {
+	origFs := config.AppFs
+	config.AppFs = afero.NewMemMapFs()
+	t.Cleanup(func() { config.AppFs = origFs })
+
+	const providerDir = "/providers/test"
+	const providerName = "test"
+	const resourcesJSON = `{"resources":{"test.foo":{"id":"test.foo","name":"test.foo","fields":{}}}}`
+	require.NoError(t, afero.WriteFile(
+		config.AppFs,
+		providerDir+"/"+providerName+".resources.json",
+		[]byte(resourcesJSON),
+		0o644,
+	))
+
+	p := &Provider{
+		Provider: &plugin.Provider{Name: providerName},
+		Path:     providerDir,
+	}
+
+	const goroutines = 32
+	var (
+		wg       sync.WaitGroup
+		start    = make(chan struct{})
+		errCount atomic.Int32
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := p.LoadResources(); err != nil {
+				errCount.Add(1)
+				t.Errorf("LoadResources: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Zero(t, errCount.Load(), "no goroutine should fail")
+	require.NotNil(t, p.Schema, "Schema must be populated after LoadResources")
+	// AllResources is one of the methods callers invoke on the loaded
+	// schema; calling it here lets the race detector flag any read that
+	// isn't synchronized-after the (single) write inside the lock.
+	require.NotEmpty(t, p.Schema.AllResources(), "schema resources must be parsed")
 }
 
 func TestOsRetry_RetryableError(t *testing.T) {


### PR DESCRIPTION
since LoadResources() writes p.Schema without a lock but doesn't run serially anymore.