### PR TITLE
✨ azure: bump armcontainerservice to v9.3.0 and model new AKS surface

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v3 v3.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -114,8 +114,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armconta
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2 v2.4.0/go.mod h1:FN0UJ15tJ7kV7JYrYAleEq44Ew1cUiyLcJrfrTxHGd0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v3 v3.0.0 h1:07oYAINVqsub90MrYYdlTSwNSwqOM4OAAg5+35OMqn0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v3 v3.0.0/go.mod h1:Qz2/GFN7OeEJ5Zw098Opbx8Veyhg8uuyLOx8njFxZjE=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.2.0 h1:dKX5PWC2kmGeTg47AuVg5dcZT7jlraP/l/eNTDu1e9s=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.2.0/go.mod h1:oUUxzEYT8sySco5ogIP6H0g558b+FtapUaKj2RVIjd0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.3.0 h1:owJIDZLIP/FYsuYI80fqXVsDlWRxS23kbXaScM+RqRA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.3.0/go.mod h1:oUUxzEYT8sySco5ogIP6H0g558b+FtapUaKj2RVIjd0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0 h1:+EhRnIOLvffCvUMUfP+MgOp6PrtN1d6xt94DZtrC3lA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0/go.mod h1:Bb7kqorvA2acMCNFac+2ldoQWi7QrcMdH+9Gg9C7fSM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0 h1:TyXI0pf9V67/vn7Vo2BebOz4B/fLj9Kt3UcrQBXMrvE=

--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -6,8 +6,10 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	clusters "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"go.mondoo.com/mql/v13/llx"
@@ -20,6 +22,17 @@ import (
 type mqlAzureSubscriptionAksServiceClusterInternal struct {
 	cacheKmsKeyId   string
 	cacheProperties *clusters.ManagedClusterProperties
+}
+
+type mqlAzureSubscriptionAksServiceClusterIdentityBindingInternal struct {
+	cacheManagedIdentityId string
+}
+
+type mqlAzureSubscriptionAksServiceClusterNodePoolInternal struct {
+	subscriptionId string
+	resourceGroup  string
+	clusterName    string
+	poolName       string
 }
 
 func (a *mqlAzureSubscriptionAksService) id() (string, error) {
@@ -248,6 +261,11 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 				powerState = (*string)(entry.Properties.PowerState.Code)
 			}
 
+			var controlPlaneMetricsEnabled *bool
+			if amp := entry.Properties.AzureMonitorProfile; amp != nil && amp.Metrics != nil && amp.Metrics.ControlPlane != nil {
+				controlPlaneMetricsEnabled = amp.Metrics.ControlPlane.Enabled
+			}
+
 			mqlAksCluster, err := CreateResource(a.MqlRuntime, "azure.subscription.aksService.cluster",
 				map[string]*llx.RawData{
 					"id":                                llx.StringDataPtr(entry.ID),
@@ -293,6 +311,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 					"nodeResourceGroupRestrictionLevel": llx.StringDataPtr(nodeResourceGroupRestrictionLevel),
 					"serviceMeshMode":                   llx.StringDataPtr(serviceMeshMode),
 					"supportPlan":                       llx.StringDataPtr((*string)(entry.Properties.SupportPlan)),
+					"controlPlaneMetricsEnabled":        llx.BoolDataPtr(controlPlaneMetricsEnabled),
 				})
 			if err != nil {
 				return nil, err
@@ -477,8 +496,129 @@ func (a *mqlAzureSubscriptionAksServiceCluster) nodePools() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, mqlPool)
+			pool := mqlPool.(*mqlAzureSubscriptionAksServiceClusterNodePool)
+			pool.subscriptionId = resourceID.SubscriptionID
+			pool.resourceGroup = resourceID.ResourceGroup
+			pool.clusterName = a.Name.Data
+			pool.poolName = convert.ToValue(entry.Name)
+			res = append(res, pool)
 		}
 	}
 	return res, nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceClusterIdentityBinding) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceCluster) identityBindings() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clusters.NewIdentityBindingsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pager := client.NewListByManagedClusterPager(resourceID.ResourceGroup, a.Name.Data, nil)
+	res := []any{}
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			// Identity bindings are a preview capability: the endpoint
+			// returns 404 on clusters/subscriptions where it is not
+			// available, and 403 when the caller lacks access. Treat
+			// both as "no bindings" rather than failing the query.
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden) {
+				return res, nil
+			}
+			return nil, err
+		}
+		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
+
+			var provisioningState, oidcIssuerUrl string
+			var managedIdentityId, managedIdentityClientId, managedIdentityObjectId, managedIdentityTenantId string
+			if props := entry.Properties; props != nil {
+				provisioningState = convert.ToValue((*string)(props.ProvisioningState))
+				if props.OidcIssuer != nil {
+					oidcIssuerUrl = convert.ToValue(props.OidcIssuer.OidcIssuerURL)
+				}
+				if mi := props.ManagedIdentity; mi != nil {
+					managedIdentityId = convert.ToValue(mi.ResourceID)
+					managedIdentityClientId = convert.ToValue(mi.ClientID)
+					managedIdentityObjectId = convert.ToValue(mi.ObjectID)
+					managedIdentityTenantId = convert.ToValue(mi.TenantID)
+				}
+			}
+
+			mqlBinding, err := CreateResource(a.MqlRuntime, "azure.subscription.aksService.cluster.identityBinding",
+				map[string]*llx.RawData{
+					"id":                      llx.StringDataPtr(entry.ID),
+					"name":                    llx.StringDataPtr(entry.Name),
+					"provisioningState":       llx.StringData(provisioningState),
+					"managedIdentityClientId": llx.StringData(managedIdentityClientId),
+					"managedIdentityObjectId": llx.StringData(managedIdentityObjectId),
+					"managedIdentityTenantId": llx.StringData(managedIdentityTenantId),
+					"oidcIssuerUrl":           llx.StringData(oidcIssuerUrl),
+				})
+			if err != nil {
+				return nil, err
+			}
+			binding := mqlBinding.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding)
+			binding.cacheManagedIdentityId = managedIdentityId
+			res = append(res, binding)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceClusterIdentityBinding) managedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	if a.cacheManagedIdentityId == "" {
+		a.ManagedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{"__id": llx.StringData(a.cacheManagedIdentityId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionManagedIdentity), nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceClusterNodePool) recentlyUsedVersions() ([]any, error) {
+	if a.poolName == "" || a.clusterName == "" {
+		return []any{}, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+
+	client, err := clusters.NewAgentPoolsClient(a.subscriptionId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	profile, err := client.GetUpgradeProfile(ctx, a.resourceGroup, a.clusterName, a.poolName, nil)
+	if err != nil {
+		return nil, err
+	}
+	if profile.Properties == nil {
+		return []any{}, nil
+	}
+	return convert.JsonToDictSlice(profile.Properties.RecentlyUsedVersions)
 }

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7085,6 +7085,10 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   aadProfile() azure.subscription.aksService.cluster.aadProfile
   // Auto-upgrade configuration for the cluster
   autoUpgradeProfile() azure.subscription.aksService.cluster.autoUpgradeProfile
+  // Whether managed Prometheus collects control-plane metrics for the cluster
+  controlPlaneMetricsEnabled bool
+  // Workload identity bindings attached to the cluster
+  identityBindings() []azure.subscription.aksService.cluster.identityBinding
 }
 
 // Azure Kubernetes Service cluster AAD profile
@@ -7121,6 +7125,34 @@ private azure.subscription.aksService.cluster.advancedNetworking @defaults("tran
   accelerationMode string
   // Whether advanced network security (FQDN-based policies) is enabled
   securityEnabled bool
+}
+
+// Azure Kubernetes Service cluster identity binding
+//
+// Examine a binding between an external workload identity and an Azure
+// user-assigned managed identity on an AKS cluster. Each binding ties a
+// federated identity — selected by the `name` field — to a managed
+// identity, letting in-cluster workloads authenticate as that identity
+// through the cluster's OIDC issuer. Surfaces the bound managed
+// identity's client, object, and tenant IDs, the OIDC issuer URL the
+// binding federates against, and the provisioning state.
+private azure.subscription.aksService.cluster.identityBinding @defaults("name provisioningState") {
+  // Resource ID of the identity binding
+  id string
+  // Name of the identity binding
+  name string
+  // Provisioning state of the identity binding
+  provisioningState string
+  // Client ID of the bound user-assigned managed identity
+  managedIdentityClientId string
+  // Object (principal) ID of the bound user-assigned managed identity
+  managedIdentityObjectId string
+  // Tenant ID of the bound user-assigned managed identity
+  managedIdentityTenantId string
+  // OIDC issuer URL the binding federates against
+  oidcIssuerUrl string
+  // Bound user-assigned managed identity
+  managedIdentity() azure.subscription.managedIdentity
 }
 
 // Azure Kubernetes Service cluster node pool (agent pool)
@@ -7211,6 +7243,11 @@ private azure.subscription.aksService.cluster.nodePool @defaults("name mode vmSi
   enableVTPM bool
   // Whether Secure Boot is enabled on nodes (Trusted Launch)
   enableSecureBoot bool
+  // Node image and Kubernetes versions recently used by the pool, available for rollback
+  //
+  // Each entry has `orchestratorVersion`, `nodeImageVersion`, and the
+  // `timestamp` when that version was last in use.
+  recentlyUsedVersions() []dict
 }
 
 // Azure Advisor

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -255,6 +255,7 @@ const (
 	ResourceAzureSubscriptionAksServiceClusterAadProfile                                         string = "azure.subscription.aksService.cluster.aadProfile"
 	ResourceAzureSubscriptionAksServiceClusterAutoUpgradeProfile                                 string = "azure.subscription.aksService.cluster.autoUpgradeProfile"
 	ResourceAzureSubscriptionAksServiceClusterAdvancedNetworking                                 string = "azure.subscription.aksService.cluster.advancedNetworking"
+	ResourceAzureSubscriptionAksServiceClusterIdentityBinding                                    string = "azure.subscription.aksService.cluster.identityBinding"
 	ResourceAzureSubscriptionAksServiceClusterNodePool                                           string = "azure.subscription.aksService.cluster.nodePool"
 	ResourceAzureSubscriptionAdvisorService                                                      string = "azure.subscription.advisorService"
 	ResourceAzureSubscriptionAdvisorServiceRecommendation                                        string = "azure.subscription.advisorService.recommendation"
@@ -1354,6 +1355,10 @@ func init() {
 		"azure.subscription.aksService.cluster.advancedNetworking": {
 			// to override args, implement: initAzureSubscriptionAksServiceClusterAdvancedNetworking(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionAksServiceClusterAdvancedNetworking,
+		},
+		"azure.subscription.aksService.cluster.identityBinding": {
+			// to override args, implement: initAzureSubscriptionAksServiceClusterIdentityBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionAksServiceClusterIdentityBinding,
 		},
 		"azure.subscription.aksService.cluster.nodePool": {
 			// to override args, implement: initAzureSubscriptionAksServiceClusterNodePool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -10111,6 +10116,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.autoUpgradeProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetAutoUpgradeProfile()).ToDataRes(types.Resource("azure.subscription.aksService.cluster.autoUpgradeProfile"))
 	},
+	"azure.subscription.aksService.cluster.controlPlaneMetricsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetControlPlaneMetricsEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.aksService.cluster.identityBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetIdentityBindings()).ToDataRes(types.Array(types.Resource("azure.subscription.aksService.cluster.identityBinding")))
+	},
 	"azure.subscription.aksService.cluster.aadProfile.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceClusterAadProfile).GetId()).ToDataRes(types.String)
 	},
@@ -10146,6 +10157,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.aksService.cluster.advancedNetworking.securityEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceClusterAdvancedNetworking).GetSecurityEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.provisioningState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityClientId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetManagedIdentityClientId()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityObjectId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetManagedIdentityObjectId()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityTenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetManagedIdentityTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.oidcIssuerUrl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetOidcIssuerUrl()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).GetManagedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
 	},
 	"azure.subscription.aksService.cluster.nodePool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceClusterNodePool).GetId()).ToDataRes(types.String)
@@ -10275,6 +10310,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.aksService.cluster.nodePool.enableSecureBoot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceClusterNodePool).GetEnableSecureBoot()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.aksService.cluster.nodePool.recentlyUsedVersions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceClusterNodePool).GetRecentlyUsedVersions()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.advisorService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAdvisorService).GetSubscriptionId()).ToDataRes(types.String)
@@ -26000,6 +26038,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAksServiceCluster).AutoUpgradeProfile, ok = plugin.RawToTValue[*mqlAzureSubscriptionAksServiceClusterAutoUpgradeProfile](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.aksService.cluster.controlPlaneMetricsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).ControlPlaneMetricsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).IdentityBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.aksService.cluster.aadProfile.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceClusterAadProfile).__id, ok = v.Value.(string)
 		return
@@ -26058,6 +26104,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.advancedNetworking.securityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceClusterAdvancedNetworking).SecurityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityClientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).ManagedIdentityClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityObjectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).ManagedIdentityObjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentityTenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).ManagedIdentityTenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.oidcIssuerUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).OidcIssuerUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.identityBinding.managedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterIdentityBinding).ManagedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.aksService.cluster.nodePool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26234,6 +26316,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.nodePool.enableSecureBoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceClusterNodePool).EnableSecureBoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.nodePool.recentlyUsedVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceClusterNodePool).RecentlyUsedVersions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.advisorService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59767,6 +59853,8 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	AdvancedNetworking                plugin.TValue[*mqlAzureSubscriptionAksServiceClusterAdvancedNetworking]
 	AadProfile                        plugin.TValue[*mqlAzureSubscriptionAksServiceClusterAadProfile]
 	AutoUpgradeProfile                plugin.TValue[*mqlAzureSubscriptionAksServiceClusterAutoUpgradeProfile]
+	ControlPlaneMetricsEnabled        plugin.TValue[bool]
+	IdentityBindings                  plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionAksServiceCluster creates a new instance of this resource
@@ -60046,6 +60134,26 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetAutoUpgradeProfile() *plugin.
 	})
 }
 
+func (c *mqlAzureSubscriptionAksServiceCluster) GetControlPlaneMetricsEnabled() *plugin.TValue[bool] {
+	return &c.ControlPlaneMetricsEnabled
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetIdentityBindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IdentityBindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "identityBindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.identityBindings()
+	})
+}
+
 // mqlAzureSubscriptionAksServiceClusterAadProfile for the azure.subscription.aksService.cluster.aadProfile resource
 type mqlAzureSubscriptionAksServiceClusterAadProfile struct {
 	MqlRuntime *plugin.Runtime
@@ -60238,11 +60346,107 @@ func (c *mqlAzureSubscriptionAksServiceClusterAdvancedNetworking) GetSecurityEna
 	return &c.SecurityEnabled
 }
 
+// mqlAzureSubscriptionAksServiceClusterIdentityBinding for the azure.subscription.aksService.cluster.identityBinding resource
+type mqlAzureSubscriptionAksServiceClusterIdentityBinding struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureSubscriptionAksServiceClusterIdentityBindingInternal
+	Id                      plugin.TValue[string]
+	Name                    plugin.TValue[string]
+	ProvisioningState       plugin.TValue[string]
+	ManagedIdentityClientId plugin.TValue[string]
+	ManagedIdentityObjectId plugin.TValue[string]
+	ManagedIdentityTenantId plugin.TValue[string]
+	OidcIssuerUrl           plugin.TValue[string]
+	ManagedIdentity         plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+}
+
+// createAzureSubscriptionAksServiceClusterIdentityBinding creates a new instance of this resource
+func createAzureSubscriptionAksServiceClusterIdentityBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionAksServiceClusterIdentityBinding{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.aksService.cluster.identityBinding", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) MqlName() string {
+	return "azure.subscription.aksService.cluster.identityBinding"
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetProvisioningState() *plugin.TValue[string] {
+	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetManagedIdentityClientId() *plugin.TValue[string] {
+	return &c.ManagedIdentityClientId
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetManagedIdentityObjectId() *plugin.TValue[string] {
+	return &c.ManagedIdentityObjectId
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetManagedIdentityTenantId() *plugin.TValue[string] {
+	return &c.ManagedIdentityTenantId
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetOidcIssuerUrl() *plugin.TValue[string] {
+	return &c.OidcIssuerUrl
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterIdentityBinding) GetManagedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.ManagedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster.identityBinding", c.__id, "managedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.managedIdentity()
+	})
+}
+
 // mqlAzureSubscriptionAksServiceClusterNodePool for the azure.subscription.aksService.cluster.nodePool resource
 type mqlAzureSubscriptionAksServiceClusterNodePool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAksServiceClusterNodePoolInternal it will be used here
+	mqlAzureSubscriptionAksServiceClusterNodePoolInternal
 	Id                               plugin.TValue[string]
 	Name                             plugin.TValue[string]
 	Mode                             plugin.TValue[string]
@@ -60286,6 +60490,7 @@ type mqlAzureSubscriptionAksServiceClusterNodePool struct {
 	SshAccess                        plugin.TValue[string]
 	EnableVTPM                       plugin.TValue[bool]
 	EnableSecureBoot                 plugin.TValue[bool]
+	RecentlyUsedVersions             plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionAksServiceClusterNodePool creates a new instance of this resource
@@ -60495,6 +60700,12 @@ func (c *mqlAzureSubscriptionAksServiceClusterNodePool) GetEnableVTPM() *plugin.
 
 func (c *mqlAzureSubscriptionAksServiceClusterNodePool) GetEnableSecureBoot() *plugin.TValue[bool] {
 	return &c.EnableSecureBoot
+}
+
+func (c *mqlAzureSubscriptionAksServiceClusterNodePool) GetRecentlyUsedVersions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RecentlyUsedVersions, func() ([]any, error) {
+		return c.recentlyUsedVersions()
+	})
 }
 
 // mqlAzureSubscriptionAdvisorService for the azure.subscription.advisorService resource

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -1333,7 +1333,7 @@ func init() {
 			Create: createAzureSubscriptionAuthorizationServiceRoleAssignment,
 		},
 		"azure.subscription.managedIdentity": {
-			// to override args, implement: initAzureSubscriptionManagedIdentity(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionManagedIdentity,
 			Create: createAzureSubscriptionManagedIdentity,
 		},
 		"azure.subscription.aksService": {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -64,6 +64,7 @@ azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel 11.4.28
 azure.subscription.aksService.cluster.azureKeyVaultKmsEnabled 11.4.28
 azure.subscription.aksService.cluster.azureKeyVaultKmsKey 13.1.8
 azure.subscription.aksService.cluster.azureKeyVaultKmsNetworkAccess 11.4.28
+azure.subscription.aksService.cluster.controlPlaneMetricsEnabled 13.15.2
 azure.subscription.aksService.cluster.createdAt 9.0.1
 azure.subscription.aksService.cluster.defenderEnabled 11.4.28
 azure.subscription.aksService.cluster.disableLocalAccounts 11.4.28
@@ -75,6 +76,16 @@ azure.subscription.aksService.cluster.fqdn 9.0.1
 azure.subscription.aksService.cluster.fqdnSubdomain 13.1.8
 azure.subscription.aksService.cluster.httpProxyConfig 9.0.1
 azure.subscription.aksService.cluster.id 9.0.1
+azure.subscription.aksService.cluster.identityBinding 13.15.2
+azure.subscription.aksService.cluster.identityBinding.id 13.15.2
+azure.subscription.aksService.cluster.identityBinding.managedIdentity 13.15.2
+azure.subscription.aksService.cluster.identityBinding.managedIdentityClientId 13.15.2
+azure.subscription.aksService.cluster.identityBinding.managedIdentityObjectId 13.15.2
+azure.subscription.aksService.cluster.identityBinding.managedIdentityTenantId 13.15.2
+azure.subscription.aksService.cluster.identityBinding.name 13.15.2
+azure.subscription.aksService.cluster.identityBinding.oidcIssuerUrl 13.15.2
+azure.subscription.aksService.cluster.identityBinding.provisioningState 13.15.2
+azure.subscription.aksService.cluster.identityBindings 13.15.2
 azure.subscription.aksService.cluster.imageCleanerEnabled 11.4.28
 azure.subscription.aksService.cluster.imageCleanerIntervalHours 11.4.28
 azure.subscription.aksService.cluster.kubernetesVersion 9.0.1
@@ -114,6 +125,7 @@ azure.subscription.aksService.cluster.nodePool.podSubnetId 13.10.2
 azure.subscription.aksService.cluster.nodePool.powerState 13.10.2
 azure.subscription.aksService.cluster.nodePool.provisioningState 13.10.2
 azure.subscription.aksService.cluster.nodePool.proximityPlacementGroupId 13.10.2
+azure.subscription.aksService.cluster.nodePool.recentlyUsedVersions 13.15.2
 azure.subscription.aksService.cluster.nodePool.scaleSetEvictionPolicy 13.10.2
 azure.subscription.aksService.cluster.nodePool.scaleSetPriority 13.10.2
 azure.subscription.aksService.cluster.nodePool.spotMaxPrice 13.10.2

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.15.1",
-  "generated_at": "2026-06-04T07:49:59-07:00",
+  "generated_at": "2026-06-04T08:11:09-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -837,7 +837,7 @@
     {
       "permission": "Microsoft.ManagedIdentity/userAssignedIdentities/read",
       "service": "Microsoft.ManagedIdentity",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "iam.go"
     },
     {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.15.1",
-  "generated_at": "2026-06-03T09:48:59-07:00",
+  "generated_at": "2026-06-04T07:49:59-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -62,6 +62,7 @@
     "Microsoft.ContainerRegistry/registries/tokens/read",
     "Microsoft.ContainerRegistry/registries/webhooks/read",
     "Microsoft.ContainerService/agentPools/read",
+    "Microsoft.ContainerService/identityBindings/read",
     "Microsoft.ContainerService/managedClusters/read",
     "Microsoft.DBforMySQL/servers/configurations/read",
     "Microsoft.DBforMySQL/servers/databases/read",
@@ -573,6 +574,12 @@
       "permission": "Microsoft.ContainerService/agentPools/read",
       "service": "Microsoft.ContainerService",
       "action": "NewListPager",
+      "source_file": "aks.go"
+    },
+    {
+      "permission": "Microsoft.ContainerService/identityBindings/read",
+      "service": "Microsoft.ContainerService",
+      "action": "NewListByManagedClusterPager",
       "source_file": "aks.go"
     },
     {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -316,6 +316,60 @@ func (a *mqlAzureSubscriptionAuthorizationService) managedIdentities() ([]any, e
 	return res, nil
 }
 
+// initAzureSubscriptionManagedIdentity resolves a managed identity that is
+// referenced only by its resource ID (e.g. from a typed cross-reference) by
+// fetching it on demand. When the identity was already listed by
+// managedIdentities(), the runtime cache short-circuits this and the init
+// never runs.
+func initAzureSubscriptionManagedIdentity(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["__id"]
+	if !ok {
+		return args, nil, nil
+	}
+	id, ok := idRaw.Value.(string)
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return args, nil, nil
+	}
+	name, err := resourceID.Component("userAssignedIdentities")
+	if err != nil {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.AzureConnection)
+	client, err := armmsi.NewUserAssignedIdentitiesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	identity, err := client.Get(context.Background(), resourceID.ResourceGroup, name, nil)
+	if err != nil {
+		// The identity may be inaccessible (deleted, cross-subscription, or
+		// access denied); fall back to the bare reference rather than
+		// failing the surrounding query.
+		return args, nil, nil
+	}
+
+	args["name"] = llx.StringDataPtr(identity.Name)
+	if identity.Properties != nil {
+		args["clientId"] = llx.StringDataPtr(identity.Properties.ClientID)
+		args["principalId"] = llx.StringDataPtr(identity.Properties.PrincipalID)
+		if identity.Properties.TenantID != nil {
+			args["tenantId"] = llx.StringData(string(*identity.Properties.TenantID))
+		}
+	}
+	return args, nil, nil
+}
+
 func newMqlManagedIdentity(runtime *plugin.Runtime, managedIdentity *armmsi.Identity) (*mqlAzureSubscriptionManagedIdentity, error) {
 	r, err := CreateResource(runtime, "azure.subscription.managedIdentity",
 		map[string]*llx.RawData{


### PR DESCRIPTION
## What

Refreshes the Azure provider's SDK deps and uses the one stable upgrade to expand the AKS resource.

### Dependency bump

Of 61 `github.com/Azure/...` deps, exactly one stable upgrade was available:

| Module | Old → New | Kind |
|---|---|---|
| `containerservice/armcontainerservice/v9` | `v9.2.0 → v9.3.0` | minor (non-breaking) |

Everything else is already current, or its next major exists **only** as a beta/pseudo-version (24 such modules — e.g. `armsql v2.0.0-beta.8`, `armservicebus v2.0.0-beta.4`, `armredis v4.0.0-beta.1`, `armresources v4.0.0-beta.1`, `armnetwork`'s next major) and was left in place per the stable-only policy. No import-path changes and no call-site breakage (minor bump).

### New AKS surface (from v9.3.0)

1. **`azure.subscription.aksService.cluster.identityBinding`** — new sub-resource backed by the new IdentityBindings API. An identity binding ties an external workload/OIDC identity to a user-assigned managed identity through the cluster's OIDC issuer. Exposes `name`, `provisioningState`, the bound identity's `managedIdentityClientId` / `managedIdentityObjectId` / `managedIdentityTenantId`, `oidcIssuerUrl`, and a typed `managedIdentity()` ref. Reached via `clusters.identityBindings`.

   IdentityBindings is a **preview** capability — the endpoint returns `404` on clusters/subscriptions where it isn't registered (and `403` without access). Both are treated as "no bindings" so they never fail the surrounding query.

2. **`azure.subscription.aksService.cluster.controlPlaneMetricsEnabled`** — whether managed Prometheus collects control-plane metrics (`azureMonitorProfile.metrics.controlPlane.enabled`).

3. **`azure.subscription.aksService.cluster.nodePool.recentlyUsedVersions`** — node image / Kubernetes versions recently used by the pool and available for rollback, read from the agent-pool upgrade profile.

## Verification

- `go build ./...`, `go vet ./resources/...`, `go test ./resources/...` — all pass
- `gofmt` clean; generated `.lr.go` / `.lr.versions` / `azure.permissions.json` regenerated (adds `Microsoft.ContainerService/identityBindings/read`)
- Live run against an AKS cluster: `controlPlaneMetricsEnabled` and `recentlyUsedVersions` resolve, and the identity-bindings `404` is swallowed (`identityBindings: []`)

New `.lr.versions` entries are at `13.15.2` (provider is at `13.15.1`). Provider `Version` not bumped — that's the release flow.