### PR TITLE
🎉 release aws 13.32.0, gcp 13.21.0, azure 13.16.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.31.1",
+	Version:         "13.32.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.15.1",
+	Version: "13.16.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.20.1",
+	Version: "13.21.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
## Summary

Minor version bumps for three providers to cut a release of the changes that have accumulated since the last release (`6f112c544`).

| Provider | Old | New |
|---|---|---|
| aws | 13.31.1 | **13.32.0** |
| gcp | 13.20.1 | **13.21.0** |
| azure | 13.15.1 | **13.16.0** |

`oci` had no changes since its last release (13.10.0) and is intentionally left out.

## Changes included

### aws
- 🛑 typed cross-resource refs for new AI resources (gcp, aws) + finish openstack credential cleanup (#8148)
- ✨ add Bedrock AgentCore resources (MCP gateways, agents, identity) (#8135)
- ✨ enrich Bedrock — inference profiles, imported models, prompts, agent aliases (#8141)
- ✨ add Amazon Q Business resources (applications, indices, data sources, plugins) (#8139)

### gcp
- 🐛 correct GetEndpoint IAM permission to plural endpoints.get (#8156)
- 🐛 resolve Vertex AI model/endpoint references instead of husks (#8149)
- 🛑 typed cross-resource refs for new AI resources (gcp, aws) + finish openstack credential cleanup (#8148)
- ✨ type Vertex AI endpoint model deployments (deprecate deployedModels) (#8136)
- ✨ add Vertex AI data-movement & training job resources (#8128)
- ✨ add remaining Vertex AI collection resources (#8132)
- 🟢 update validated permissions list for Colab+reasoningEngine (#8127, #8131) (#8140)
- ✨ add Discovery Engine (AI Applications / Agentspace) resources (#8137)
- ✨ add Vertex AI Agent Engine (reasoningEngine) resource (#8127)
- ✨ add Colab Enterprise notebook resources (#8131)

### azure
- 🐛 degrade NSP config listing gracefully on access-denied (#8151)
- ✨ ML serving endpoints, compute, and registered models (#8138)
- ✨ AI Foundry projects and connections on AI Services accounts (#8133)
- ✨ model deployments on AI Services accounts (#8130)
- ✨ surface storage account Network Security Perimeter configuration (#8123)