### PR TITLE
🐛 gcp: fix Cloud Tasks queue listing and Vertex AI RAG region skipping

### DIFF
--- a/providers/gcp/resources/cloudtasks.go
+++ b/providers/gcp/resources/cloudtasks.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	locationpb "google.golang.org/genproto/googleapis/cloud/location"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -59,48 +60,79 @@ func (g *mqlGcpProjectCloudTasksService) queues() ([]any, error) {
 	}
 	defer client.Close()
 
-	it := client.ListQueues(ctx, &cloudtaskspb.ListQueuesRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/-", projectId),
-	})
+	// The Cloud Tasks ListQueues API rejects the "projects/<p>/locations/-"
+	// wildcard, so we enumerate the available locations first and list
+	// queues in each one.
+	locations, err := listCloudTasksLocations(ctx, client, projectId)
+	if err != nil {
+		return nil, err
+	}
 
 	var res []any
+	for _, location := range locations {
+		it := client.ListQueues(ctx, &cloudtaskspb.ListQueuesRequest{
+			Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, location),
+		})
+
+		for {
+			queue, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			rateLimits, err := cloudTasksConvertRateLimits(queue.RateLimits)
+			if err != nil {
+				return nil, err
+			}
+			retryConfig, err := cloudTasksRetryConfig(g.MqlRuntime, queue.Name, queue.RetryConfig)
+			if err != nil {
+				return nil, err
+			}
+			appEngineRouting, err := cloudTasksConvertAppEngineRouting(queue.AppEngineRoutingOverride)
+			if err != nil {
+				return nil, err
+			}
+
+			mqlQueue, err := CreateResource(g.MqlRuntime, "gcp.project.cloudTasksService.queue", map[string]*llx.RawData{
+				"projectId":                llx.StringData(projectId),
+				"name":                     llx.StringData(queue.Name),
+				"state":                    llx.StringData(queue.State.String()),
+				"rateLimits":               llx.DictData(rateLimits),
+				"retryConfig":              llx.ResourceData(retryConfig, "gcp.retryConfig"),
+				"appEngineRoutingOverride": llx.DictData(appEngineRouting),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlQueue)
+		}
+	}
+
+	return res, nil
+}
+
+// listCloudTasksLocations returns the location IDs where Cloud Tasks is
+// available for the project. The Cloud Tasks ListQueues API rejects the
+// "-" location wildcard, so queues must be listed per location.
+func listCloudTasksLocations(ctx context.Context, client *cloudtasks.Client, projectId string) ([]string, error) {
+	it := client.ListLocations(ctx, &locationpb.ListLocationsRequest{
+		Name: fmt.Sprintf("projects/%s", projectId),
+	})
+	var locations []string
 	for {
-		queue, err := it.Next()
+		l, err := it.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
-
-		rateLimits, err := cloudTasksConvertRateLimits(queue.RateLimits)
-		if err != nil {
-			return nil, err
-		}
-		retryConfig, err := cloudTasksRetryConfig(g.MqlRuntime, queue.Name, queue.RetryConfig)
-		if err != nil {
-			return nil, err
-		}
-		appEngineRouting, err := cloudTasksConvertAppEngineRouting(queue.AppEngineRoutingOverride)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlQueue, err := CreateResource(g.MqlRuntime, "gcp.project.cloudTasksService.queue", map[string]*llx.RawData{
-			"projectId":                llx.StringData(projectId),
-			"name":                     llx.StringData(queue.Name),
-			"state":                    llx.StringData(queue.State.String()),
-			"rateLimits":               llx.DictData(rateLimits),
-			"retryConfig":              llx.ResourceData(retryConfig, "gcp.retryConfig"),
-			"appEngineRoutingOverride": llx.DictData(appEngineRouting),
-		})
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, mqlQueue)
+		locations = append(locations, l.LocationId)
 	}
-
-	return res, nil
+	return locations, nil
 }
 
 func (g *mqlGcpProjectCloudTasksServiceQueue) id() (string, error) {

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -80,6 +80,11 @@ func isVertexAIRegionSkippable(err error) bool {
 		case codes.InvalidArgument, codes.NotFound:
 			// "not enabled" and "is not supported" surface as these codes
 			return true
+		case codes.FailedPrecondition:
+			// some sub-services (e.g. the RAG data service) report
+			// "<service> is not supported in region <region>" as
+			// FailedPrecondition rather than InvalidArgument
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## What

Two GCP listing bugs found while verifying recent provider additions (#8109, #8127–#8137 area) against **real infrastructure**.

### 1. Cloud Tasks `queues()` — invalid location wildcard
`cloudtasks.go` listed queues with parent `projects/<p>/locations/-`. Cloud Tasks `ListQueues` does **not** accept the `-` location wildcard and returns:

```
rpc error: InvalidArgument: Location '-' is not a valid location. Use ListLocations to list valid locations.
```

So `gcp.project.cloudTasks.queues` always errored — and the **newly added `queue.iamPolicy()`** field was unreachable as a result. Fixed by enumerating locations via `ListLocations` first and listing queues per location (same pattern already used in `artifactregistry.go`).

### 2. Vertex AI `ragCorpora()` — region not skipped
`ragCorpora()` iterates all Vertex AI regions and relies on `isVertexAIRegionSkippable` to skip regions where the sub-service is unavailable. The RAG data service reports:

```
rpc error: FailedPrecondition: Vertex AI Rag Service is not supported in region us-west2
```

`FailedPrecondition` wasn't in the skippable set, so one unsupported region failed the entire call. Added `codes.FailedPrecondition` to the helper — this also hardens every other vertexai resource that shares it.

## Verification

Both confirmed against live infrastructure (provider built from this branch):

| Query | Before | After |
|---|---|---|
| `gcp.project.cloudTasks.queues { name state iamPolicy { … } }` | `InvalidArgument: Location '-' …` | lists `mql-verify-queue` (RUNNING), `iamPolicy` resolves |
| `gcp.project.vertexai.ragCorpora { name }` | `FailedPrecondition: … not supported in region us-west2` | `[]` |

## Notes
- No schema change — no `.lr.versions` bump; `gcp.permissions.json` unchanged (258 perms).
- `gofmt` clean.