### PR TITLE
🐛 ms365: populate authenticationMethodsPolicy on direct query

### DIFF
--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -558,7 +558,7 @@ func init() {
 			Create: createMicrosoftGraphAccessReviewReviewerScope,
 		},
 		"microsoft.authenticationMethodsPolicy": {
-			// to override args, implement: initMicrosoftAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftAuthenticationMethodsPolicy,
 			Create: createMicrosoftAuthenticationMethodsPolicy,
 		},
 		"microsoft.authenticationMethodConfiguration": {

--- a/providers/ms365/resources/policies_authmethods.go
+++ b/providers/ms365/resources/policies_authmethods.go
@@ -14,6 +14,26 @@ type mqlMicrosoftAuthenticationMethodsPolicyInternal struct {
 	cachePolicy models.AuthenticationMethodsPolicyable
 }
 
+// initMicrosoftAuthenticationMethodsPolicy populates the policy when it is
+// queried directly (microsoft.authenticationMethodsPolicy) rather than through
+// microsoft.policies.authenticationMethodsPolicy. Without this, a direct query
+// returns a bare resource whose cachePolicy is nil, so every per-method
+// accessor (fido2, microsoftAuthenticator, ...) resolves to null. We delegate
+// to the policies accessor, which fetches the policy and caches it.
+func initMicrosoftAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	policiesResource, err := CreateResource(runtime, ResourceMicrosoftPolicies, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policy, err := policiesResource.(*mqlMicrosoftPolicies).authenticationMethodsPolicy()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, policy, nil
+}
+
 // authMethodTargets renders the include/exclude target lists of an
 // authentication method (or the registration campaign) as dictionaries. Every
 // target type shares the id and targetType accessors.


### PR DESCRIPTION
## Problem

`microsoft.authenticationMethodsPolicy` (added in #8159) had no `init` function. Querying it **directly** — rather than via `microsoft.policies.authenticationMethodsPolicy` — produced a bare resource with a `nil` `cachePolicy`, so every per-method accessor silently resolved to `null`:

```
microsoft.authenticationMethodsPolicy {
  fido2 { state }                 # null
  microsoftAuthenticator { state } # null
  temporaryAccessPass { state }    # null
  email { state }                  # null
  voice { state }                  # null
  registrationCampaign { state }   # null
}
```

The per-method accessors read from `cachePolicy`, which is only set when the resource is built through the `microsoft.policies` accessor (`newAuthenticationMethodsPolicy`).

## Fix

Add `initMicrosoftAuthenticationMethodsPolicy`, which delegates to the policies accessor (the same pattern as `initMicrosoftExternalIdentitiesPolicy`) so the policy is fetched and `cachePolicy` is populated. The generated `Init:` wiring in `ms365.lr.go` is regenerated accordingly. No schema field added, so no `.lr.versions` change.

## Verification

Built and run against a live Microsoft 365 tenant. The direct query now returns the same populated configs as the `microsoft.policies.authenticationMethodsPolicy` path:

```
microsoft.authenticationMethodsPolicy: {
  fido2:               { state: "disabled", isAttestationEnforced: false }
  microsoftAuthenticator: { state: "disabled" }
  temporaryAccessPass: { state: "disabled", defaultLength: 8 }
  email:               { state: "enabled" }
}
```