### PR TITLE
🎉 ms365-13.4.0

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.3.0",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### ms365 (13.4.0)
- 🐛 ms365: populate authenticationMethodsPolicy on direct query (#8178)
- ✨ ms365: Intune group policy (admin template) configurations (#8171)
- ✨ ms365: Intune Windows Update rings and update profiles (#8169)
- ✨ ms365: typed routeMessageOutboundRequireTls on transport rule entry (#8170)
- 🐛 ms365: rename Exchange policy element resources that shadowed deprecated dict accessors (#8168)
- ✨ ms365: Intune app configuration policies (MAM and MDM) (#8167)
- ✨ ms365: typed DLP compliance rules (#8166)
- ✨ ms365: typed DLP compliance policies, deprecate the dict variant (#8165)
- ✨ ms365: Intune settings catalog configuration policies (#8164)
- ✨ ms365: Intune Mobile Threat Defense & compliance partner connectors (#8163)
- ✨ ms365: Intune assignment filters + typed policy-assignment filter ref (#8162)
- ✨ ms365: Intune app protection (MAM) policies (#8161)
- ✨ ms365: Teams and channel inventory with governance settings (#8160)
- ✨ ms365: typed per-method authentication methods policy config (#8159)
- ✨ ms365: Microsoft Entra ID Protection risk detections & sign-in risk (#8158)
- ✨ ms365: typed references for Conditional Access, Intune & PIM scopes (#8157)
- ✨ ms365: model 15 Exchange policy lists as resources, deprecate dicts (#8155)
- ✨ ms365: typed Teams client & SharePoint tenant config, deprecate dicts (#8152)