### PR TITLE
🐛 ms365: fix panic, husks, and owner accessors found in provider audit

### DIFF
--- a/providers/ms365/resources/batch.go
+++ b/providers/ms365/resources/batch.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
@@ -77,10 +78,21 @@ func batchGet[T serialization.Parsable](
 
 	statusCodes := resp.GetStatusCodes()
 	for id, key := range idToKey {
-		if code, ok := statusCodes[id]; ok {
+		code, hasCode := statusCodes[id]
+		if hasCode {
 			out.statuses[key] = code
 		}
-		val, err := msgraphgocore.GetBatchResponseById[T](resp, id, constructor)
+		// A non-2xx sub-response carries an error body, not a T. The kiota core
+		// helper GetBatchResponseById panics trying to deserialize that body as
+		// T (e.g. a 403 when the app lacks AuditLog.Read.All for signInActivity).
+		// Skip the parse when we already know the sub-request failed...
+		if hasCode && (code < 200 || code >= 300) {
+			out.errs[key] = fmt.Errorf("batch request failed with status %d", code)
+			continue
+		}
+		// ...and recover defensively around the parse itself, since the helper
+		// can still panic on malformed/error bodies the status map does not flag.
+		val, err := safeGetBatchResponseByID[T](resp, id, constructor)
 		if err != nil {
 			out.errs[key] = transformError(err)
 			continue
@@ -88,4 +100,24 @@ func batchGet[T serialization.Parsable](
 		out.results[key] = val
 	}
 	return out, nil
+}
+
+// safeGetBatchResponseByID wraps msgraphgocore.GetBatchResponseById, which can
+// panic (rather than return an error) when a batch sub-response holds an error
+// body that does not deserialize into T -- e.g. a 403 error object parsed as a
+// User. Recovering keeps one failed sub-request from crashing the whole batched
+// query; the caller records it as a per-item error like any other failure.
+func safeGetBatchResponseByID[T serialization.Parsable](
+	resp msgraphgocore.BatchResponse,
+	id string,
+	constructor serialization.ParsableFactory,
+) (val T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var zero T
+			val = zero
+			err = fmt.Errorf("batch sub-response %q could not be parsed: %v", id, r)
+		}
+	}()
+	return msgraphgocore.GetBatchResponseById[T](resp, id, constructor)
 }

--- a/providers/ms365/resources/batch.go
+++ b/providers/ms365/resources/batch.go
@@ -10,6 +10,7 @@ import (
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	"github.com/rs/zerolog/log"
 )
 
 // batchItemRequest pairs a caller-defined key with the Graph request to issue
@@ -116,7 +117,11 @@ func safeGetBatchResponseByID[T serialization.Parsable](
 		if r := recover(); r != nil {
 			var zero T
 			val = zero
-			err = fmt.Errorf("batch sub-response %q could not be parsed: %v", id, r)
+			err = fmt.Errorf("batch sub-response %q could not be parsed (recovered panic): %v", id, r)
+			// Surface the recovered panic so it is not lost during debugging --
+			// the status-code guard handles the expected non-2xx case, so a panic
+			// reaching here means an unexpected/malformed body the SDK mishandled.
+			log.Warn().Str("id", id).Msgf("recovered panic parsing batch sub-response: %v", r)
 		}
 	}()
 	return msgraphgocore.GetBatchResponseById[T](resp, id, constructor)

--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -554,6 +554,26 @@ func convertEnumCollectionToStrings[T fmt.Stringer](enums []T) []string {
 	return result
 }
 
+// initMicrosoftConditionalAccessAuthenticationMethodsPolicy populates the
+// policy when it is queried directly
+// (microsoft.conditionalAccess.authenticationMethodsPolicy) rather than through
+// the microsoft.conditionalAccess accessor. Without this, a direct query
+// returns a bare husk with all fields null. We build it through the parent
+// accessor, which fetches and caches the policy.
+func initMicrosoftConditionalAccessAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	caResource, err := CreateResource(runtime, "microsoft.conditionalAccess", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policy, err := caResource.(*mqlMicrosoftConditionalAccess).authenticationMethodsPolicy()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, policy, nil
+}
+
 func (a *mqlMicrosoftConditionalAccess) authenticationMethodsPolicy() (*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()

--- a/providers/ms365/resources/devicemanagement_configurationpolicies.go
+++ b/providers/ms365/resources/devicemanagement_configurationpolicies.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 
+	betadm "github.com/microsoftgraph/msgraph-beta-sdk-go/devicemanagement"
 	betamodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -25,7 +26,15 @@ func (a *mqlMicrosoftDevicemanagement) configurationPolicies() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	resp, err := graphClient.DeviceManagement().ConfigurationPolicies().Get(ctx, nil)
+	// Expand assignments so isAssigned can be derived reliably: the list
+	// endpoint omits the computed isAssigned property (returns a nil *bool)
+	// unless assignments are expanded.
+	reqConfig := &betadm.ConfigurationPoliciesRequestBuilderGetRequestConfiguration{
+		QueryParameters: &betadm.ConfigurationPoliciesRequestBuilderGetQueryParameters{
+			Expand: []string{"assignments"},
+		},
+	}
+	resp, err := graphClient.DeviceManagement().ConfigurationPolicies().Get(ctx, reqConfig)
 	if err != nil {
 		return nil, transformError(err)
 	}
@@ -55,7 +64,7 @@ func (a *mqlMicrosoftDevicemanagement) configurationPolicies() ([]any, error) {
 				"description":          llx.StringDataPtr(p.GetDescription()),
 				"platforms":            llx.StringDataPtr(enumPtrString(p.GetPlatforms())),
 				"technologies":         llx.StringDataPtr(enumPtrString(p.GetTechnologies())),
-				"isAssigned":           llx.BoolDataPtr(p.GetIsAssigned()),
+				"isAssigned":           llx.BoolData(len(p.GetAssignments()) > 0),
 				"settingCount":         llx.IntDataPtr(p.GetSettingCount()),
 				"roleScopeTagIds":      llx.ArrayData(llx.TArr2Raw(p.GetRoleScopeTagIds()), types.String),
 				"templateId":           llx.StringDataPtr(templateId),

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
@@ -267,7 +268,7 @@ func (a *mqlMicrosoftGroup) owners() ([]any, error) {
 				"__id":        llx.StringDataPtr(owner.GetId()),
 				"id":          llx.StringDataPtr(owner.GetId()),
 				"displayName": llx.StringDataPtr(displayName),
-				"ownerType":   llx.StringDataPtr(owner.GetOdataType()),
+				"ownerType":   llx.StringDataPtr(normalizeOwnerType(owner.GetOdataType())),
 			})
 		if err != nil {
 			return nil, err
@@ -278,10 +279,24 @@ func (a *mqlMicrosoftGroup) owners() ([]any, error) {
 	return owners, nil
 }
 
+// normalizeOwnerType converts a raw Graph OData type (e.g.
+// "#microsoft.graph.user") to the documented short form ("user",
+// "servicePrincipal"). Returns nil for a nil input.
+func normalizeOwnerType(odataType *string) *string {
+	if odataType == nil {
+		return nil
+	}
+	short := strings.TrimPrefix(*odataType, "#microsoft.graph.")
+	return &short
+}
+
 func (a *mqlMicrosoftGroupOwner) user() (*mqlMicrosoftUser, error) {
-	ownerType := a.OwnerType.Data
-	if ownerType != "#microsoft.graph.user" {
-		return nil, errors.New("owner type is not a user")
+	if a.OwnerType.Data != "user" {
+		// This owner is a service principal (or other type); the user ref is
+		// legitimately absent. Mark it null so callers can select user() and
+		// servicePrincipal() side by side without erroring the whole query.
+		a.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	userId := a.Id.Data
@@ -296,9 +311,12 @@ func (a *mqlMicrosoftGroupOwner) user() (*mqlMicrosoftUser, error) {
 }
 
 func (a *mqlMicrosoftGroupOwner) servicePrincipal() (*mqlMicrosoftServiceprincipal, error) {
-	ownerType := a.OwnerType.Data
-	if ownerType != "#microsoft.graph.servicePrincipal" {
-		return nil, errors.New("owner type is not a service principal")
+	if a.OwnerType.Data != "servicePrincipal" {
+		// This owner is a user (or other type); the service principal ref is
+		// legitimately absent. Mark it null so callers can select user() and
+		// servicePrincipal() side by side without erroring the whole query.
+		a.ServicePrincipal.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	spId := a.Id.Data

--- a/providers/ms365/resources/groups_test.go
+++ b/providers/ms365/resources/groups_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestNormalizeOwnerType(t *testing.T) {
+	str := func(s string) *string { return &s }
+	tests := []struct {
+		name string
+		in   *string
+		want *string
+	}{
+		{"user", str("#microsoft.graph.user"), str("user")},
+		{"servicePrincipal", str("#microsoft.graph.servicePrincipal"), str("servicePrincipal")},
+		{"device", str("#microsoft.graph.device"), str("device")},
+		{"already short", str("user"), str("user")},
+		{"unknown prefix untouched", str("#custom.type"), str("#custom.type")},
+		{"nil", nil, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeOwnerType(tc.in)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.want, *got)
+		})
+	}
+}
+
+// A group owner is either a user or a service principal. Selecting both
+// accessors on a mixed list must not error: the accessor for the type the
+// owner is NOT must return (nil, nil) with the field marked null, rather than
+// returning an error that aborts the whole owners selection.
+func TestGroupOwnerAccessorsReturnNullForWrongType(t *testing.T) {
+	t.Run("user() on a service principal owner", func(t *testing.T) {
+		owner := &mqlMicrosoftGroupOwner{}
+		owner.OwnerType.Data = "servicePrincipal"
+		owner.OwnerType.State = plugin.StateIsSet
+
+		u, err := owner.user()
+		require.NoError(t, err)
+		assert.Nil(t, u)
+		assert.NotZero(t, owner.User.State&plugin.StateIsNull, "user field should be marked null")
+	})
+
+	t.Run("servicePrincipal() on a user owner", func(t *testing.T) {
+		owner := &mqlMicrosoftGroupOwner{}
+		owner.OwnerType.Data = "user"
+		owner.OwnerType.State = plugin.StateIsSet
+
+		sp, err := owner.servicePrincipal()
+		require.NoError(t, err)
+		assert.Nil(t, sp)
+		assert.NotZero(t, owner.ServicePrincipal.State&plugin.StateIsNull, "servicePrincipal field should be marked null")
+	})
+}

--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -390,6 +390,33 @@ func (a *mqlMicrosoftIdentityAndAccessIdentityAndSignIn) policies() (*mqlMicroso
 	return resource.(*mqlMicrosoftIdentityAndAccessIdentityAndSignInPolicies), nil
 }
 
+// initMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy
+// populates the policy when it is queried directly via its full dotted path
+// rather than through the parent accessor chain. Without this, the terminal
+// resource is built as a bare husk with all fields null. We rebuild the chain
+// (identityAndSignIn -> policies -> identitySecurityDefaultsEnforcementPolicy),
+// which fetches the policy.
+func initMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	signIn, err := CreateResource(runtime, "microsoft.identityAndAccess.identityAndSignIn", map[string]*llx.RawData{
+		"__id": llx.StringData("identityAndSignIn"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policies, err := signIn.(*mqlMicrosoftIdentityAndAccessIdentityAndSignIn).policies()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policy, err := policies.identitySecurityDefaultsEnforcementPolicy()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, policy, nil
+}
+
 // Implementation for the identitySecurityDefaultsEnforcementPolicy resource
 func (a *mqlMicrosoftIdentityAndAccessIdentityAndSignInPolicies) identitySecurityDefaultsEnforcementPolicy() (*mqlMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -306,7 +306,7 @@ func init() {
 			Create: createMicrosoftIdentityAndAccessIdentityAndSignInPolicies,
 		},
 		"microsoft.identityAndAccess.identityAndSignIn.policies.identitySecurityDefaultsEnforcementPolicy": {
-			// to override args, implement: initMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy,
 			Create: createMicrosoftIdentityAndAccessIdentityAndSignInPoliciesIdentitySecurityDefaultsEnforcementPolicy,
 		},
 		"microsoft.user.assignedLicense": {
@@ -326,7 +326,7 @@ func init() {
 			Create: createMicrosoftConditionalAccess,
 		},
 		"microsoft.conditionalAccess.authenticationMethodsPolicy": {
-			// to override args, implement: initMicrosoftConditionalAccessAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftConditionalAccessAuthenticationMethodsPolicy,
 			Create: createMicrosoftConditionalAccessAuthenticationMethodsPolicy,
 		},
 		"microsoft.conditionalAccess.authenticationMethodConfiguration": {


### PR DESCRIPTION
A full-provider audit of the ms365 provider against a live Microsoft 365 tenant surfaced several bugs. This fixes six of them (one per area) and adds unit tests for the two with pure, testable logic.

## Fixes

| # | Bug | Fix |
|---|---|---|
| 1 | **`microsoft.user.signInActivity` panics** — a batch sub-request returning a non-2xx body crashes the query (kiota's `GetBatchResponseById` panics instead of erroring). Latent for **any** batched field that hits a 403. | `batch.go`: skip status-flagged failures and `recover` around the parse, recording a per-item error instead. |
| 2 | **`microsoft.conditionalAccess.authenticationMethodsPolicy` husk** — direct query returns all-null because the resource had no init. | `conditional-access.go`: add `init` that builds it through the parent accessor (same pattern as #8178). |
| 3 | **`microsoft.identityAndAccess.identityAndSignIn.policies.identitySecurityDefaultsEnforcementPolicy` husk** — same defect on the dotted terminal path. | `identity_and_access.go`: add `init` that rebuilds the accessor chain. |
| 4 | **group owner `user()` / `servicePrincipal()` error on the wrong type** — selecting both on a mixed-owner list aborts the whole `owners` selection. | `groups.go`: return null (with `StateIsNull`) per the singular-accessor contract. |
| 5 | **`group.owner.ownerType` exposed the raw OData type** (`#microsoft.graph.user`) instead of the documented `user`/`servicePrincipal`. | `groups.go`: normalize via a new pure `normalizeOwnerType` helper. |
| 6 | **`configurationPolicy.isAssigned` returns null** instead of a bool — the list endpoint omits the computed property, so `.where(isAssigned == false)` silently dropped policies. | `devicemanagement_configurationpolicies.go`: `$expand=assignments` and derive `isAssigned`. |

## Tests
- `groups_test.go`: table test for `normalizeOwnerType`, and a runtime-free test asserting the group-owner accessors return `(nil, nil)` + `StateIsNull` for the wrong owner type.

## Verified
All six fixes were run against a live M365 tenant: `signInActivity` returns data across all users with **0 panics**; both husk resources populate on direct query; group owners resolve with `user()`/`servicePrincipal()` selected together (irrelevant side null, `ownerType` normalized); `isAssigned` returns `false`. The full `providers/ms365/resources` test suite passes.

## Not included (investigated)
- `ms365.sharepointonline.spoSites.owner` is empty under app-only auth. `Get-PnPTenantSite -Detailed`, including per-site `-Identity` lookups, does **not** populate `Owner` without a delegated user context — a PnP/app-only limitation, not a provider bug. Left as-is to avoid an N+1 per-site cost with no benefit; worth a separate follow-up (e.g. a Graph-based owner source).
- A **husk meta-test** (structurally asserting every singleton resource populates) would catch the #2/#3/#8178 class wholesale — proposed as a focused follow-up.