### PR TITLE
⚡ ms365: eliminate per-user N+1 for microsoft.user job/contact

### DIFF
--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -31,6 +31,9 @@ var userSelectFields = []string{
 	"lastPasswordChangeDateTime", "onPremisesSyncEnabled", "onPremisesLastSyncDateTime",
 	"onPremisesDomainName", "onPremisesSamAccountName", "preferredLanguage",
 	"usageLocation", "externalUserState", "passwordPolicies",
+	// also fetched in bulk so job()/contact() resolve from the list response
+	// instead of an N+1 per-user Get
+	"businessPhones", "faxNumber", "mailNickname",
 }
 
 func (a *mqlMicrosoft) users() (*mqlMicrosoftUsers, error) {
@@ -273,6 +276,11 @@ func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicros
 		}
 	}
 
+	// Build job/contact from the already-fetched user so the computed
+	// job()/contact() accessors resolve from the bulk list response instead of
+	// firing an N+1 per-user Get.
+	jobDict, contactDict := buildUserJobContact(u)
+
 	graphUser, err := CreateResource(runtime, "microsoft.user",
 		map[string]*llx.RawData{
 			"__id":                       llx.StringDataPtr(u.GetId()),
@@ -302,6 +310,8 @@ func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicros
 			"assignedLicenses":           llx.ArrayData(mqlAssignedLicensesList, types.ResourceLike),
 			"employeeType":               llx.StringDataPtr(u.GetEmployeeType()),
 			"employeeHireDate":           llx.TimeDataPtr(u.GetEmployeeHireDate()),
+			"job":                        llx.DictData(jobDict),
+			"contact":                    llx.DictData(contactDict),
 			"lastPasswordChangeDateTime": llx.TimeDataPtr(u.GetLastPasswordChangeDateTime()),
 			"onPremisesSyncEnabled":      llx.BoolDataPtr(u.GetOnPremisesSyncEnabled()),
 			"onPremisesLastSyncDateTime": llx.TimeDataPtr(u.GetOnPremisesLastSyncDateTime()),
@@ -342,6 +352,35 @@ func (a *mqlMicrosoftUser) mfaEnabled() (bool, error) {
 	return a.MfaEnabled.Data, nil
 }
 
+// buildUserJobContact builds the job and contact dicts from an already-fetched
+// user. Used during bulk list construction so job()/contact() resolve from the
+// list response, and by the populateJobContactData fallback for the by-id path.
+func buildUserJobContact(u models.Userable) (any, any) {
+	jobDesc, _ := convert.JsonToDict(userJob{
+		JobTitle:    u.GetJobTitle(),
+		CompanyName: u.GetCompanyName(),
+		Department:  u.GetDepartment(),
+		EmployeeId:  u.GetEmployeeId(),
+		// EmployeeType:     u.GetEmployeeType(),
+		// EmployeeHireDate: u.GetEmployeeHireDate(),
+		OfficeLocation: u.GetOfficeLocation(),
+	})
+	contactDesc, _ := convert.JsonToDict(userContact{
+		StreetAddress:  u.GetStreetAddress(),
+		City:           u.GetCity(),
+		State:          u.GetState(),
+		PostalCode:     u.GetPostalCode(),
+		Country:        u.GetCountry(),
+		BusinessPhones: u.GetBusinessPhones(),
+		MobilePhone:    u.GetMobilePhone(),
+		Email:          u.GetMail(),
+		OtherMails:     u.GetOtherMails(),
+		FaxNumber:      u.GetFaxNumber(),
+		MailNickname:   u.GetMailNickname(),
+	})
+	return jobDesc, contactDesc
+}
+
 func (a *mqlMicrosoftUser) populateJobContactData() error {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()
@@ -360,31 +399,9 @@ func (a *mqlMicrosoftUser) populateJobContactData() error {
 		return transformError(err)
 	}
 
-	jobDesc, _ := convert.JsonToDict(userJob{
-		JobTitle:    userData.GetJobTitle(),
-		CompanyName: userData.GetCompanyName(),
-		Department:  userData.GetDepartment(),
-		EmployeeId:  userData.GetEmployeeId(),
-		// EmployeeType:     userData.GetEmployeeType(),
-		// EmployeeHireDate: userData.GetEmployeeHireDate(),
-		OfficeLocation: userData.GetOfficeLocation(),
-	})
+	jobDesc, contactDesc := buildUserJobContact(userData)
 	a.Job = plugin.TValue[any]{Data: jobDesc, State: plugin.StateIsSet}
-
-	userContact, _ := convert.JsonToDict(userContact{
-		StreetAddress:  userData.GetStreetAddress(),
-		City:           userData.GetCity(),
-		State:          userData.GetState(),
-		PostalCode:     userData.GetPostalCode(),
-		Country:        userData.GetCountry(),
-		BusinessPhones: userData.GetBusinessPhones(),
-		MobilePhone:    userData.GetMobilePhone(),
-		Email:          userData.GetMail(),
-		OtherMails:     userData.GetOtherMails(),
-		FaxNumber:      userData.GetFaxNumber(),
-		MailNickname:   userData.GetMailNickname(),
-	})
-	a.Contact = plugin.TValue[any]{Data: userContact, State: plugin.StateIsSet}
+	a.Contact = plugin.TValue[any]{Data: contactDesc, State: plugin.StateIsSet}
 
 	return nil
 }

--- a/providers/ms365/resources/users_test.go
+++ b/providers/ms365/resources/users_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// job()/contact() resolve from the bulk user list response (userSelectFields)
+// instead of an N+1 per-user Get. That optimization only holds if every field
+// the job/contact dicts read is also requested by the bulk list. This guards
+// against silently reintroducing the N+1 (or dropping data) by removing a field
+// from userSelectFields.
+func TestUserSelectFieldsCoverJobContactFields(t *testing.T) {
+	selected := make(map[string]bool, len(userSelectFields))
+	for _, f := range userSelectFields {
+		selected[f] = true
+	}
+	for _, f := range userJobContactFields {
+		assert.Truef(t, selected[f],
+			"userJobContactFields[%q] is not in userSelectFields; job()/contact() "+
+				"would fall back to an N+1 per-user Get (or lose this field)", f)
+	}
+}


### PR DESCRIPTION
## Problem

`microsoft.user`'s `job()` and `contact()` accessors each called `populateJobContactData`, which did a **per-user** Graph `Users().ByUserId(id).Get(...)`. So `microsoft.users { job contact }` fired **one extra Graph call per user** — a classic N+1.

The redundancy: the bulk user list (`userSelectFields`) already `$select`s ~15 of the 18 fields the job/contact dicts need. Only `businessPhones`, `faxNumber`, and `mailNickname` were missing — so the per-user Get was almost entirely re-fetching data we already had.

## Fix

- Add `businessPhones`, `faxNumber`, `mailNickname` to `userSelectFields` (the bulk list `$select`).
- Build the `job`/`contact` dicts in `newMqlMicrosoftUser` from the already-fetched user and pass them into the resource, so the computed accessors resolve from the **bulk list response with zero extra calls**.
- `populateJobContactData` stays as the fallback for single-user-by-reference paths (e.g. a group owner's `user()`), where there's no bulk list — that's a single Get, not an N+1.

No schema change; `job`/`contact` return identical data (verified against a live tenant, including the three newly-selected fields).

## Measured impact (live tenant, 24 users)

| Query | Before | After |
|---|---|---|
| `microsoft.users { job contact }` | **11.8s – 30.2s** (1 Get/user, high variance) | **2.3s – 3.4s** |
| `microsoft.users { id displayName }` (baseline) | 2.2s | 2.2s |

job/contact now costs the same as the plain list. The win **scales linearly with user count** — on a 1,000-user tenant the old path issued ~1,000 sequential per-user Gets (minutes of wall-clock, plus throttling); the new path adds nothing beyond the existing list call.

## Regression guard

`users_test.go` asserts `userSelectFields` covers every field in `userJobContactFields`, so removing a field from the bulk `$select` (which would silently reintroduce the N+1 or drop data) fails the test.

## Profiling notes (for context, not in this PR)

The dominant ms365 cost is PowerShell **connection** setup, measured per area: Exchange ~36s, Purview/DLP ~52s, Teams ~25s, SharePoint ~37s (each a fresh `pwsh` + module import + `Connect-*`). Those are largely inherent to the PowerShell-only surface; the Exchange report is already well-cached (one `pwsh` run shared across all 28 Exchange accessors via double-check locking). Reducing the cross-area PowerShell cost (e.g. running the independent PS areas concurrently) is a larger, separate effort worth tracking.