### PR TITLE
bicep: expose full resource body via `bicep.resource.body`

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -223,8 +223,22 @@ bicep.resource @defaults("type symbolicName") {
   scope string
   // Nested child resources declared inside this resource
   resources() []bicep.resource
-  // Resource body as dict
+  // The resource's `properties: { ... }` sub-block as a dict
   properties dict
+  // The full resource body as a dict
+  //
+  // Every top-level field of the resource declaration — not just the
+  // `properties: { ... }` sub-block — parsed into a dict: `properties`,
+  // `identity`, `sku`, `kind`, `zones`, and so on. Use it to reach controls
+  // that live on the resource itself rather than inside `properties` (for
+  // example a managed `identity` block), and to inspect Microsoft Graph
+  // resources (`Microsoft.Graph/...`), whose configuration — `displayName`,
+  // `state`, `conditions`, `grantControls` — is declared at the top level with
+  // no `properties:` wrapper. Scalar values are stringified the same way as in
+  // `properties` (`true` becomes `"true"`); nested `resource` declarations are
+  // not included here (reach them through `resources`). Empty only when the
+  // resource has no body.
+  body dict
   // Flattened expression trees of every scalar property leaf
   //
   // Walks the `properties` object and emits one entry per scalar leaf, each

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -346,6 +346,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetProperties()).ToDataRes(types.Dict)
 	},
+	"bicep.resource.body": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetBody()).ToDataRes(types.Dict)
+	},
 	"bicep.resource.propertyExpressions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetPropertyExpressions()).ToDataRes(types.Array(types.Resource("bicep.propertyExpression")))
 	},
@@ -904,6 +907,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.resource.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepResource).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"bicep.resource.body": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).Body, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"bicep.resource.propertyExpressions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1973,6 +1980,7 @@ type mqlBicepResource struct {
 	Scope               plugin.TValue[string]
 	Resources           plugin.TValue[[]any]
 	Properties          plugin.TValue[any]
+	Body                plugin.TValue[any]
 	PropertyExpressions plugin.TValue[[]any]
 	Tags                plugin.TValue[map[string]any]
 	DependsOn           plugin.TValue[[]any]
@@ -2117,6 +2125,10 @@ func (c *mqlBicepResource) GetResources() *plugin.TValue[[]any] {
 
 func (c *mqlBicepResource) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlBicepResource) GetBody() *plugin.TValue[any] {
+	return &c.Body
 }
 
 func (c *mqlBicepResource) GetPropertyExpressions() *plugin.TValue[[]any] {

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -98,6 +98,7 @@ bicep.propertyExpression.expression 13.1.2
 bicep.propertyExpression.path 13.1.2
 bicep.resource 13.0.0
 bicep.resource.apiVersion 13.0.0
+bicep.resource.body 13.2.2
 bicep.resource.condition 13.0.0
 bicep.resource.conditionTree 13.1.2
 bicep.resource.decorators 13.0.0

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -123,6 +123,23 @@ func createMqlResources(runtime *plugin.Runtime, filePath string, resources []pa
 	return mqlResources, nil
 }
 
+// resourceBodyInner returns the content between a resource declaration's outer
+// braces. `parsedResource.body` is the full `resource <name> '<type>' = { ... }`
+// text (braces included), so this drops everything up to and including the
+// first `{` and the final `}`, leaving the top-level field block that
+// parseBicepObject expects. Returns "" when no braces are present.
+func resourceBodyInner(body string) string {
+	open := strings.IndexByte(body, '{')
+	if open < 0 {
+		return ""
+	}
+	inner := body[open+1:]
+	if close := strings.LastIndexByte(inner, '}'); close >= 0 {
+		inner = inner[:close]
+	}
+	return inner
+}
+
 // newMqlBicepResource builds a single bicep.resource from a parsedResource.
 // The id is supplied by the caller: top-level resources use
 // `bicep.resource:<file>:<symbolicName>`, while nested resources use a
@@ -148,6 +165,20 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 		}
 	}
 
+	// Surface the entire resource body as a dict so audits can reach
+	// top-level fields the `properties` sub-block doesn't carry — `identity`,
+	// `sku`, `kind`, … — and Microsoft Graph resources, whose config lives at
+	// the top level with no `properties:` wrapper. `r.body` is the full
+	// `resource <name> '<type>' = { ... }` declaration, so strip the header up
+	// to the opening brace and the trailing close brace before parsing the
+	// top-level fields. Nested `resource` declarations carry no top-level
+	// `key: value` colon and are skipped by parseBicepObject; reach them
+	// through `resources` instead.
+	var body any = map[string]any{}
+	if inner := resourceBodyInner(r.body); inner != "" {
+		body = parseBicepObject(inner)
+	}
+
 	args := map[string]*llx.RawData{
 		"__id":         llx.StringData(id),
 		"symbolicName": llx.StringData(r.symbolicName),
@@ -160,6 +191,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 		"parent":       llx.StringData(r.parent),
 		"scope":        llx.StringData(r.scope),
 		"properties":   llx.DictData(properties),
+		"body":         llx.DictData(body),
 		"dependsOn":    llx.ArrayData(dependsOn, types.String),
 		"decorators":   llx.ArrayData(decorators, types.String),
 	}

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -336,6 +336,76 @@ func TestParseResourceDecl(t *testing.T) {
 	})
 }
 
+func TestResourceBodyInner(t *testing.T) {
+	t.Run("exposes top-level fields beyond properties", func(t *testing.T) {
+		body := `resource webApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: 'example-webapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  kind: 'app'
+  properties: {
+    httpsOnly: true
+  }
+}`
+		obj := parseBicepObject(resourceBodyInner(body))
+		identity, ok := obj["identity"].(map[string]any)
+		require.True(t, ok, "identity should be a top-level field")
+		assert.Equal(t, "SystemAssigned", identity["type"])
+		assert.Equal(t, "app", obj["kind"])
+		props, ok := obj["properties"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "true", props["httpsOnly"])
+	})
+
+	t.Run("skips nested resource declarations", func(t *testing.T) {
+		body := `resource pg 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+  name: 'pg'
+  properties: {
+    version: '16'
+  }
+  resource cfg 'configurations@2024-08-01' = {
+    name: 'require_secure_transport'
+    properties: {
+      value: 'ON'
+    }
+  }
+}`
+		obj := parseBicepObject(resourceBodyInner(body))
+		assert.Equal(t, "pg", obj["name"])
+		_, hasProps := obj["properties"].(map[string]any)
+		assert.True(t, hasProps)
+		// the nested `resource cfg ...` block carries no top-level colon and
+		// must not leak in as a key; reach nested resources via `resources`.
+		for k := range obj {
+			assert.NotContains(t, k, "resource cfg")
+		}
+	})
+
+	t.Run("microsoft graph resource (no properties wrapper)", func(t *testing.T) {
+		body := `resource ca 'Microsoft.Graph/conditionalAccessPolicies@v1.0' = {
+  displayName: 'Block legacy'
+  state: 'enabled'
+  grantControls: {
+    builtInControls: ['block']
+  }
+}`
+		obj := parseBicepObject(resourceBodyInner(body))
+		assert.Equal(t, "enabled", obj["state"])
+		assert.Equal(t, "Block legacy", obj["displayName"])
+		gc, ok := obj["grantControls"].(map[string]any)
+		require.True(t, ok)
+		controls, ok := gc["builtInControls"].([]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"block"}, controls)
+	})
+
+	t.Run("no braces returns empty", func(t *testing.T) {
+		assert.Equal(t, "", resourceBodyInner("resource x 'T' = "))
+		assert.Empty(t, parseBicepObject(resourceBodyInner("")))
+	})
+}
+
 func TestParseModuleDecl(t *testing.T) {
 	t.Run("local module", func(t *testing.T) {
 		input := `module network './modules/network.bicep' = {


### PR DESCRIPTION
## Problem

`bicep.resource.properties` only surfaces the resource's `properties: { ... }` sub-block. That hides two things policies need to assert on:

1. **Top-level resource fields** — `identity`, `sku`, `kind`, `zones`, … live as siblings of `properties:`, so a managed-identity check (`identity.type`) has nothing to read.
2. **Microsoft Graph resources** — `Microsoft.Graph/...` (e.g. `conditionalAccessPolicies`) declare their entire configuration at the top level with **no** `properties:` wrapper, so `properties` comes back empty and the resource is effectively opaque.

## Change

Adds a **`body dict`** field to `bicep.resource` that parses *every* top-level field of the resource declaration into a dict — `properties`, `identity`, `sku`, `kind`, and, for Graph resources, `displayName` / `state` / `conditions` / `grantControls`. Scalars are stringified the same way as in `properties` (`true` → `"true"`), so existing query idioms carry over.

`parsedResource.body` is the full `resource <name> '<type>' = { ... }` text, so a small `resourceBodyInner` helper strips the declaration header up to the opening brace and the trailing close brace before parsing. Nested `resource` declarations carry no top-level `key: value` colon and are skipped by the object parser, so they don't leak into `body` — they stay reachable through `resources`.

`properties` is unchanged and remains the convenient accessor for the common case.

## Example

```bicep
resource ca 'Microsoft.Graph/conditionalAccessPolicies@v1.0' = {
  displayName: 'Block legacy authentication'
  state: 'enabled'
  conditions: { clientAppTypes: ['exchangeActiveSync', 'other'] }
  grantControls: { operator: 'OR', builtInControls: ['block'] }
}
```

```mql
bicep.files.any(
  resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
    body["state"] == "enabled" &&
    body["conditions"]["clientAppTypes"] != empty &&
    body["grantControls"]["builtInControls"].any(_ == "block")
  )
)
```

## Tests

`TestResourceBodyInner` covers top-level field exposure, nested-resource skipping, the Microsoft Graph (no-`properties`) shape, and the empty/no-brace edge cases. Full `go test ./...` for the bicep provider passes.

## Motivation

Unblocks IaC policy variants in cnspec that assert on resource-level identity blocks (App Service / Function App / Data Factory managed identity) and on Microsoft Graph Conditional Access / Identity Protection policies — previously inexpressible from Bicep source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)