### PR TITLE
bicep: simpler query ergonomics (flat resources, literal names, typed scalars)

### DIFF
--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -31,6 +31,24 @@ func (r *mqlBicep) files() ([]any, error) {
 	return mqlFiles, nil
 }
 
+// resources flattens every file's top-level resources into a single list so
+// policies can query `bicep.resources` directly, mirroring `terraform.resources`.
+func (r *mqlBicep) resources() ([]any, error) {
+	files, err := r.files()
+	if err != nil {
+		return nil, err
+	}
+	var out []any
+	for _, f := range files {
+		rs, err := f.(*mqlBicepFile).resources()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rs...)
+	}
+	return out, nil
+}
+
 func (r *mqlBicep) paramFiles() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.BicepConnection)
 	paramFiles := conn.BicepParamFiles()

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -14,6 +14,15 @@ option go_package = "go.mondoo.com/mql/v13/providers/bicep/resources"
 bicep {
   // All Bicep source files found
   files() []bicep.file
+  // All top-level resources across every Bicep source file
+  //
+  // The combined list of every source file's resource declarations, so a query
+  // can reach resources directly — for example
+  // `bicep.resources.where(type == "Microsoft.Storage/storageAccounts")` —
+  // instead of iterating the files first. Only top-level resource declarations
+  // are included; nested child resources remain available through
+  // `bicep.resource.resources`.
+  resources() []bicep.resource
   // All Bicep parameter (.bicepparam) files found
   paramFiles() []bicep.paramFile
   // Compiled ARM template (if available via JSON or bicep build)

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -190,6 +190,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicep).GetFiles()).ToDataRes(types.Array(types.Resource("bicep.file")))
 	},
+	"bicep.resources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicep).GetResources()).ToDataRes(types.Array(types.Resource("bicep.resource")))
+	},
 	"bicep.paramFiles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicep).GetParamFiles()).ToDataRes(types.Array(types.Resource("bicep.paramFile")))
 	},
@@ -679,6 +682,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicep).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.resources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicep).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.paramFiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1411,6 +1418,7 @@ type mqlBicep struct {
 	__id       string
 	// optional: if you define mqlBicepInternal it will be used here
 	Files      plugin.TValue[[]any]
+	Resources  plugin.TValue[[]any]
 	ParamFiles plugin.TValue[[]any]
 	Template   plugin.TValue[*mqlBicepTemplate]
 }
@@ -1465,6 +1473,22 @@ func (c *mqlBicep) GetFiles() *plugin.TValue[[]any] {
 		}
 
 		return c.files()
+	})
+}
+
+func (c *mqlBicep) GetResources() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Resources, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep", c.__id, "resources")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resources()
 	})
 }
 

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -120,6 +120,7 @@ bicep.resource.scope 13.1.2
 bicep.resource.symbolicName 13.0.0
 bicep.resource.tags 13.0.9
 bicep.resource.type 13.0.0
+bicep.resources 13.2.2
 bicep.template 13.0.0
 bicep.template.contentVersion 13.0.0
 bicep.template.output 13.1.2

--- a/providers/bicep/resources/ergonomics_test.go
+++ b/providers/bicep/resources/ergonomics_test.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/bicep/connection"
+)
+
+func TestParseBicepValueTyped(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want any
+	}{
+		{"bool true", "true", true},
+		{"bool false", "false", false},
+		{"integer", "90", float64(90)},
+		{"negative integer", "-5", float64(-5)},
+		{"float", "1.5", 1.5},
+		{"zero", "0", float64(0)},
+		{"empty", "", ""},
+		{"single-quoted string", "'Standard_LRS'", "Standard_LRS"},
+		{"quoted number stays a string", "'22'", "22"},
+		{"quoted bool stays a string", "'true'", "true"},
+		{"expression stays raw", "resourceGroup().location", "resourceGroup().location"},
+		{"bare identifier stays raw", "myParam", "myParam"},
+		{"object value", "{ enabled: true }", map[string]any{"enabled": true}},
+		{"array of numbers", "[1, 2, 3]", []any{float64(1), float64(2), float64(3)}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, parseBicepValue(c.in))
+		})
+	}
+}
+
+func TestParseBicepNumber(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+		ok   bool
+	}{
+		{"90", 90, true},
+		{"-5", -5, true},
+		{"1.5", 1.5, true},
+		{"0", 0, true},
+		{"", 0, false},
+		{"90abc", 0, false},
+		{"resourceGroup()", 0, false},
+		{"1.2.3", 0, false},
+		{"TLS1_2", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseBicepNumber(c.in)
+		assert.Equal(t, c.ok, ok, c.in)
+		if c.ok {
+			assert.Equal(t, c.want, got, c.in)
+		}
+	}
+}
+
+func TestStripLiteralQuotes(t *testing.T) {
+	assert.Equal(t, "VirtualMachines", stripLiteralQuotes("'VirtualMachines'"))
+	assert.Equal(t, "default", stripLiteralQuotes("'default'"))
+	assert.Equal(t, "", stripLiteralQuotes("''"))
+	// interpolated literal: the outer quotes are stripped, content kept
+	assert.Equal(t, "${env}-sa", stripLiteralQuotes("'${env}-sa'"))
+	// unquoted expressions and identifiers are left untouched
+	assert.Equal(t, "resourceGroup().name", stripLiteralQuotes("resourceGroup().name"))
+	assert.Equal(t, "storageName", stripLiteralQuotes("storageName"))
+	assert.Equal(t, "", stripLiteralQuotes(""))
+	assert.Equal(t, "'", stripLiteralQuotes("'")) // too short to be a quoted pair
+}
+
+func TestResourceNameQuoteStripping(t *testing.T) {
+	src := `resource pricing 'Microsoft.Security/pricings@2024-01-01' = {
+  name: 'VirtualMachines'
+}
+resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageName
+}`
+	parsed := parseBicep(src)
+	resolver := newSymbolResolver("inline.bicep", parsed)
+	runtime := testRuntime()
+
+	pricing, err := newMqlBicepResource(runtime, "bicep.resource:inline:pricing", findResource(parsed, "pricing"), resolver)
+	require.NoError(t, err)
+	// a literal name has its surrounding quotes stripped, so `name == "VirtualMachines"` matches
+	assert.Equal(t, "VirtualMachines", pricing.Name.Data)
+	// nameTree still classifies it as a literal — it reads the raw, quoted form
+	nt, err := pricing.nameTree()
+	require.NoError(t, err)
+	assert.Equal(t, exprKindLiteral, nt.node.kind)
+
+	sa, err := newMqlBicepResource(runtime, "bicep.resource:inline:sa", findResource(parsed, "sa"), resolver)
+	require.NoError(t, err)
+	// an expression-valued name is left untouched
+	assert.Equal(t, "storageName", sa.Name.Data)
+}
+
+func TestBicepResourcesFlatten(t *testing.T) {
+	dir := filepath.Join("testdata", "flatten")
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "bicep", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewBicepConnection(0, asset, asset.Connections[0])
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &mapResources{m: map[string]plugin.Resource{}},
+	}
+	b := &mqlBicep{MqlRuntime: runtime}
+
+	list, err := b.resources()
+	require.NoError(t, err)
+
+	types := map[string]bool{}
+	for _, r := range list {
+		types[r.(*mqlBicepResource).Type.Data] = true
+	}
+	// resources from both files appear in the single flattened list
+	assert.True(t, types["Microsoft.Storage/storageAccounts"], "expected the resource from a.bicep")
+	assert.True(t, types["Microsoft.Network/networkSecurityGroups"], "expected the resource from b.bicep")
+	assert.Len(t, list, 2)
+}

--- a/providers/bicep/resources/ergonomics_test.go
+++ b/providers/bicep/resources/ergonomics_test.go
@@ -57,6 +57,11 @@ func TestParseBicepNumber(t *testing.T) {
 		{"resourceGroup()", 0, false},
 		{"1.2.3", 0, false},
 		{"TLS1_2", 0, false},
+		// special float forms strconv.ParseFloat would otherwise accept
+		{"Inf", 0, false},
+		{"+Inf", 0, false},
+		{"-Inf", 0, false},
+		{"NaN", 0, false},
 	}
 	for _, c := range cases {
 		got, ok := parseBicepNumber(c.in)

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -109,6 +109,10 @@ type mqlBicepResourceInternal struct {
 	// re-walk it with quoting intact — the parsed `properties` dict has already
 	// stripped quotes, losing the literal-vs-expression distinction.
 	propertiesBody string
+	// rawName is the resource's name expression with quotes intact, kept so
+	// nameTree() can classify it (literal vs interpolation vs functionCall)
+	// even though the public `name` field strips surrounding literal quotes.
+	rawName string
 }
 
 func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource, resolver *symbolResolver) ([]any, error) {
@@ -184,7 +188,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 		"symbolicName": llx.StringData(r.symbolicName),
 		"type":         llx.StringData(r.typ),
 		"apiVersion":   llx.StringData(r.apiVersion),
-		"name":         llx.StringData(r.name),
+		"name":         llx.StringData(stripLiteralQuotes(r.name)),
 		"location":     llx.StringData(r.location),
 		"existing":     llx.BoolData(r.existing),
 		"condition":    llx.StringData(r.condition),
@@ -214,6 +218,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 	mqlRes.nested = r.nested
 	mqlRes.resolver = resolver
 	mqlRes.propertiesBody = propertiesBody
+	mqlRes.rawName = r.name
 	return mqlRes, nil
 }
 
@@ -461,7 +466,7 @@ func (o *mqlBicepOutput) expressionTree() (*mqlBicepExpression, error) {
 }
 
 func (r *mqlBicepResource) nameTree() (*mqlBicepExpression, error) {
-	return expressionTreeFor(r.MqlRuntime, r.__id, "/nameTree", r.Name.Data, r.resolver)
+	return expressionTreeFor(r.MqlRuntime, r.__id, "/nameTree", r.rawName, r.resolver)
 }
 
 func (r *mqlBicepResource) locationTree() (*mqlBicepExpression, error) {

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -1393,9 +1393,22 @@ func parseBicepValue(v string) any {
 
 // parseBicepNumber parses a bare integer or float literal into a float64 (the
 // shape MQL uses for numbers inside a dict). Returns false for anything that
-// isn't a plain numeric literal — including expressions that merely start with
-// a digit-like token — so expressions are preserved as raw strings.
+// isn't a plain decimal literal so expressions — and the special float forms
+// `Inf`/`NaN` that `strconv.ParseFloat` would otherwise accept — stay raw
+// strings.
 func parseBicepNumber(v string) (float64, bool) {
+	if v == "" {
+		return 0, false
+	}
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		switch {
+		case c >= '0' && c <= '9', c == '.':
+		case (c == '-' || c == '+') && i == 0:
+		default:
+			return 0, false
+		}
+	}
 	if f, err := strconv.ParseFloat(v, 64); err == nil {
 		return f, true
 	}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -1375,7 +1375,42 @@ func parseBicepValue(v string) any {
 			return v[1 : len(v)-1]
 		}
 	}
+	// Bare `true`/`false` and numeric literals become typed values so policies
+	// can compare them naturally (`== true`, `>= 30`) instead of against the
+	// stringified form. Anything else (an expression like `resourceGroup().id`,
+	// a bare symbol) is returned as-is.
+	switch v {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	if n, ok := parseBicepNumber(v); ok {
+		return n
+	}
 	return v
+}
+
+// parseBicepNumber parses a bare integer or float literal into a float64 (the
+// shape MQL uses for numbers inside a dict). Returns false for anything that
+// isn't a plain numeric literal — including expressions that merely start with
+// a digit-like token — so expressions are preserved as raw strings.
+func parseBicepNumber(v string) (float64, bool) {
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return f, true
+	}
+	return 0, false
+}
+
+// stripLiteralQuotes removes the surrounding single quotes from a Bicep string
+// literal (`'eastus'` -> `eastus`), leaving unquoted expressions
+// (`resourceGroup().location`) untouched. Mirrors how parameter default values
+// are unquoted, so equality checks like `name == "eastus"` work directly.
+func stripLiteralQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 func parseBicepArray(body string) []any {

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -355,7 +355,7 @@ func TestResourceBodyInner(t *testing.T) {
 		assert.Equal(t, "app", obj["kind"])
 		props, ok := obj["properties"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "true", props["httpsOnly"])
+		assert.Equal(t, true, props["httpsOnly"])
 	})
 
 	t.Run("skips nested resource declarations", func(t *testing.T) {
@@ -800,7 +800,7 @@ func TestParseBicepObject(t *testing.T) {
 `
 		obj := parseBicepObject(body)
 		assert.Equal(t, "Hot", obj["accessTier"])
-		assert.Equal(t, "true", obj["supportsHttpsTrafficOnly"])
+		assert.Equal(t, true, obj["supportsHttpsTrafficOnly"])
 		assert.Equal(t, "TLS1_2", obj["minimumTlsVersion"])
 
 		nested, ok := obj["networkAcls"].(map[string]any)
@@ -821,8 +821,8 @@ func TestParseBicepObject(t *testing.T) {
   count: 3
 `
 		obj := parseBicepObject(body)
-		assert.Equal(t, "true", obj["enabled"])
-		assert.Equal(t, "3", obj["count"])
+		assert.Equal(t, true, obj["enabled"])
+		assert.Equal(t, float64(3), obj["count"])
 		_, present := obj["inline"]
 		assert.False(t, present)
 	})
@@ -928,7 +928,7 @@ hello { world }
 		// We don't unquote `'''` strings (the surrounding quotes are
 		// part of the value form), but the scanner has to walk past
 		// them without splitting the entry — `enabled` must survive.
-		assert.Equal(t, "true", obj["enabled"])
+		assert.Equal(t, true, obj["enabled"])
 		_, present := obj["script"]
 		assert.True(t, present, "triple-quoted entry should still be captured")
 	})

--- a/providers/bicep/resources/testdata/flatten/a.bicep
+++ b/providers/bicep/resources/testdata/flatten/a.bicep
@@ -1,0 +1,7 @@
+resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'examplestorage'
+  location: 'eastus'
+  properties: {
+    supportsHttpsTrafficOnly: true
+  }
+}

--- a/providers/bicep/resources/testdata/flatten/b.bicep
+++ b/providers/bicep/resources/testdata/flatten/b.bicep
@@ -1,0 +1,4 @@
+resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: 'examplensg'
+  location: 'eastus'
+}


### PR DESCRIPTION
Three changes that make IaC policy queries against Bicep source shorter and less error-prone. Motivated by writing ~254 Bicep policy variants in cnspec (mondoohq/cnspec#2708); these remove the most common boilerplate and one real footgun. Follows #8182 (the `bicep.resource.body` accessor).

## 1. `bicep.resources` — flattened resource list

A top-level accessor that unions every source file's resources, so a query reaches resources directly instead of iterating files:

```mql
# before
bicep.files.all(resources.where(type == "Microsoft.Storage/storageAccounts").all(
  properties["supportsHttpsTrafficOnly"] == true))
# after
bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
  properties["supportsHttpsTrafficOnly"] == true)
```

Only top-level declarations are flattened; nested children stay under `bicep.resource.resources`.

## 2. Literal `name` is unquoted

`bicep.resource.name` kept its surrounding quotes (`"'VirtualMachines'"`), so `name == "VirtualMachines"` silently matched nothing and an `.all()` over the empty result **vacuously passed** — a real correctness footgun. Now a string literal is unquoted (`VirtualMachines`), matching how `parameter.defaultValue` already behaves:

```mql
# before
bicep.resources.where(type == "Microsoft.Security/pricings" && name == /^'VirtualMachines'$/)
# after
bicep.resources.where(type == "Microsoft.Security/pricings" && name == "VirtualMachines")
```

`nameTree` still classifies the original form (literal / interpolation / functionCall) — it reads a stored raw name, so structured access is unchanged.

## 3. Typed scalars in `properties` / `body`

Bare `true`/`false` and numeric literals now parse to typed values instead of strings:

```mql
# before
properties["securityProfile"]["encryptionAtHost"] == "true"
properties["retentionDays"] >= 30   # string-compared
# after
properties["securityProfile"]["encryptionAtHost"] == true
properties["retentionDays"] >= 30   # numeric
```

Quoted values (`'22'`, `'true'`) stay strings; expressions stay raw. This is a **behavior change** to existing `properties` values — the cnspec content that consumes them is updated in the same change set (mondoohq/cnspec#2708).

## Tests

New `ergonomics_test.go` covers `parseBicepValue` typed scalars, `parseBicepNumber`, `stripLiteralQuotes`, the literal-name stripping (asserting `nameTree` still classifies the raw form), and `bicep.resources` flattening across two files. Existing parser tests updated for the typed-scalar behavior. Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)