### PR TITLE
🎉 bicep-13.3.0

### DIFF
--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.2.1",
+	Version:         "13.3.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### bicep (13.3.0)
- bicep: simpler query ergonomics (flat resources, literal names, typed scalars) (#8183)
- bicep: expose full resource body via `bicep.resource.body` (#8182)