### PR TITLE
🎉 release ms365 13.5.0, aws 13.32.1, gcp 13.21.1, azure 13.16.1

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.32.0",
+	Version:         "13.32.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.16.0",
+	Version: "13.16.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.21.0",
+	Version: "13.21.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.4.0",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Version bumps for the ms365 (minor) and aws / gcp / azure (patch) providers.

| Provider | Old | New | Bump |
|---|---|---|---|
| ms365 | 13.4.0 | **13.5.0** | minor |
| aws | 13.32.0 | **13.32.1** | patch |
| gcp | 13.21.0 | **13.21.1** | patch |
| azure | 13.16.0 | **13.16.1** | patch |

## Changes since last release

### ms365 (13.4.0 → 13.5.0)
- ⚡ ms365: eliminate per-user N+1 for microsoft.user job/contact (#8181)
- 🐛 ms365: fix panic, husks, and owner accessors found in provider audit (#8180)

### aws (13.32.0 → 13.32.1)
- 🐛 validate aws/gcp/azure IAM permissions against the live clouds and fix bogus ones (#8147)

### gcp (13.21.0 → 13.21.1)
- 🐛 validate aws/gcp/azure IAM permissions against the live clouds and fix bogus ones (#8147)

### azure (13.16.0 → 13.16.1)
- 🐛 validate aws/gcp/azure IAM permissions against the live clouds and fix bogus ones (#8147)