### PR TITLE
providers: register bicep, helm, and kustomize in DefaultProviders

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -132,6 +132,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"bicep": {
+		Provider: &plugin.Provider{
+			Name:            "bicep",
+			ID:              "go.mondoo.com/mql/v13/providers/bicep",
+			ConnectionTypes: []string{"bicep"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "bicep",
+					Use:   "bicep PATH",
+					Short: "a Bicep file, directory, or ARM template JSON",
+				},
+			},
+		},
+	},
+
 	"claude": {
 		Provider: &plugin.Provider{
 			Name:            "claude",
@@ -336,6 +351,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"helm": {
+		Provider: &plugin.Provider{
+			Name:            "helm",
+			ID:              "go.mondoo.com/mql/v13/providers/helm",
+			ConnectionTypes: []string{"helm"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "helm",
+					Use:   "helm PATH",
+					Short: "a Helm chart directory or .tgz archive",
+				},
+			},
+		},
+	},
+
 	"hetzner": {
 		Provider: &plugin.Provider{
 			Name:            "hetzner",
@@ -421,6 +451,21 @@ var DefaultProviders Providers = map[string]*Provider{
 					Name:  "k8s",
 					Use:   "k8s (optional MANIFEST path)",
 					Short: "a Kubernetes cluster or local manifest file(s)",
+				},
+			},
+		},
+	},
+
+	"kustomize": {
+		Provider: &plugin.Provider{
+			Name:            "kustomize",
+			ID:              "go.mondoo.com/mql/v13/providers/kustomize",
+			ConnectionTypes: []string{"kustomize"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "kustomize",
+					Use:   "kustomize PATH",
+					Short: "a Kustomize overlay directory",
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

`bicep`, `helm`, and `kustomize` exist under `providers/` (and publish fine — e.g. `bicep-13.3.0`), but they're absent from the generated `DefaultProviders` map in `providers/defaults.go`.

When a provider isn't already installed, `EnsureProvider` resolves it via `DefaultProviders`:

```go
upstream := DefaultProviders.Lookup(search)
if upstream == nil {
    return nil, &ProviderNotFoundError{lookup: search}  // "cannot find provider for ..."
}
...
nu, err := Install(upstream.Name, "")  // only reached if it's in the map
```

So a miss never even attempts an install. Anything that requests these providers by name fails — including a policy bundle that declares `require: - provider: bicep`, which is what surfaced this (cnspec policy lint failing with `cannot find provider for provider=bicep`).

## Fix

Add the three entries to `DefaultProviders`, matching the existing entry format (name, ID, connection type, connector). Values come straight from each provider's `config.Config`:

| provider | ID | connection type |
|---|---|---|
| bicep | `go.mondoo.com/mql/v13/providers/bicep` | `bicep` |
| helm | `go.mondoo.com/mql/v13/providers/helm` | `helm` |
| kustomize | `go.mondoo.com/mql/v13/providers/kustomize` | `kustomize` |

After this, `EnsureProvider` resolves them and auto-installs the published provider like every other one.

## Notes

- Inserted by hand rather than via `make providers/defaults`: that generator scans only this repo's `./providers`, so a full regen would drop the enterprise-provider entries (from `mql-enterprise-providers`) that are merged into this file. This mirrors how recent providers (e.g. `openai`) were added as single-entry insertions.
- Audited the rest of the map: `bicep`, `helm`, and `kustomize` were the only `providers/` directories missing from it.
- `go build ./providers/` passes; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)