### PR TITLE
🧹 providers: test that every local provider is registered in defaults.go

### DIFF
--- a/providers/defaults_test.go
+++ b/providers/defaults_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDefaultProvidersIncludesAllLocalProviders guards against the recurring
+// mistake of adding a provider to ./providers without regenerating
+// defaults.go (see PR #8187, which had to retroactively register bicep, helm,
+// and kustomize). Every provider directory in this repository must have a
+// matching entry in DefaultProviders. Extra entries (external providers that
+// don't live in this repo) are fine — we only require the local ones to be
+// present.
+//
+// Fix a failure by running: make providers/defaults
+func TestDefaultProvidersIncludesAllLocalProviders(t *testing.T) {
+	// The test runs with the package directory as its working directory, so
+	// ./ is the providers/ directory that holds every provider subdirectory.
+	entries, err := os.ReadDir(".")
+	assert.NoError(t, err)
+
+	foundProvider := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+
+		// A provider directory is identified by its config/config.go. This
+		// skips non-provider directories (e.g. test fixtures) without needing
+		// a hardcoded allowlist.
+		if _, err := os.Stat(filepath.Join(name, "config", "config.go")); err != nil {
+			continue
+		}
+		foundProvider = true
+
+		assert.Containsf(t, DefaultProviders, name,
+			"provider %q is missing from DefaultProviders; run `make providers/defaults` to regenerate providers/defaults.go", name)
+	}
+
+	// Sanity check: make sure the directory scan actually discovered
+	// providers, so a future refactor that breaks the scan doesn't silently
+	// turn this into a no-op test.
+	assert.True(t, foundProvider, "no provider directories were discovered; the directory scan is likely broken")
+}


### PR DESCRIPTION
## What

Adds `TestDefaultProvidersIncludesAllLocalProviders` to the `providers` package: it scans the `providers/` directory for every provider (identified by `config/config.go`) and asserts each one has an entry in the `DefaultProviders` map in `providers/defaults.go`.

## Why

`providers/defaults.go` is auto-generated by `make providers/defaults`, but it's committed to the repo — so it's easy to add a new provider directory and forget to regenerate it. That's exactly what happened before #8187, which had to retroactively register `bicep`, `helm`, and `kustomize`. This test is the missing tripwire that catches the omission in CI instead of after release.

## Behavior

- Discovers providers by directory scan (no hardcoded allowlist), so new providers are covered automatically.
- Extra entries for **external** providers that don't live in this repo (e.g. `ai`, `bigip`, `junos`, `fortios`, `panos`) are allowed — the test only requires that every *local* provider is present.
- A sanity assertion ensures the scan actually found providers, so a refactor can't silently turn it into a no-op.
- On failure the message points at the fix: `run \`make providers/defaults\``.

## Verification

- Passes against the current tree.
- Confirmed it fails with a clear message when a local provider is removed from the map (temporarily deleted the `bicep` entry to prove it isn't a no-op), then passes once restored.
- `gofmt`-clean; `defaults.go` is unmodified.