### PR TITLE
🎉 openstack-13.3.0

### DIFF
--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.2.1",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### openstack (13.3.0)
- 🛑 typed cross-resource refs for new AI resources (gcp, aws) + finish openstack credential cleanup (#8148)
- ✨ openstack: expose Placement resource providers (GPU/accelerator inventory) (#8134)
- 🛑 openstack: typed cross-resource references; drop redundant raw ID fields (#8126)