### PR TITLE
✨ terraform: add resourceType and resourceName to terraform.block

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -341,6 +341,30 @@ func (t *mqlTerraformBlock) nameLabel() (string, error) {
 	return labels[0].(string), nil
 }
 
+// resourceType returns the Terraform resource type (the first label, e.g.
+// "aws_instance"). It mirrors terraform.state.resource.type and
+// terraform.plan.resourceChange.type so HCL policies can use the same field
+// name as plan/state policies instead of nameLabel.
+func (t *mqlTerraformBlock) resourceType() (string, error) {
+	labels := t.Labels.Data
+	if len(labels) == 0 {
+		return "", nil
+	}
+	return labels[0].(string), nil
+}
+
+// resourceName returns the Terraform resource name (the second label, e.g.
+// "web" in `resource "aws_instance" "web"`). It mirrors
+// terraform.state.resource.name and terraform.plan.resourceChange.name,
+// replacing the cryptic labels[1] index access in policies.
+func (t *mqlTerraformBlock) resourceName() (string, error) {
+	labels := t.Labels.Data
+	if len(labels) < 2 {
+		return "", nil
+	}
+	return labels[1].(string), nil
+}
+
 func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	tfraw, err := CreateResource(runtime, "terraform", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -10,7 +10,52 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+func blockWithLabels(labels ...string) *mqlTerraformBlock {
+	data := make([]any, len(labels))
+	for i, l := range labels {
+		data[i] = l
+	}
+	b := &mqlTerraformBlock{}
+	b.Labels = plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet}
+	return b
+}
+
+func TestBlockResourceTypeAndName(t *testing.T) {
+	// resource "aws_instance" "web" { ... }
+	b := blockWithLabels("aws_instance", "web")
+	rt, err := b.resourceType()
+	require.NoError(t, err)
+	assert.Equal(t, "aws_instance", rt)
+	rn, err := b.resourceName()
+	require.NoError(t, err)
+	assert.Equal(t, "web", rn)
+
+	// resourceType mirrors nameLabel (first label)
+	nl, err := b.nameLabel()
+	require.NoError(t, err)
+	assert.Equal(t, nl, rt)
+
+	// Blocks without a second label (e.g. provider blocks) yield an empty name.
+	single := blockWithLabels("aws")
+	rn, err = single.resourceName()
+	require.NoError(t, err)
+	assert.Equal(t, "", rn)
+	rt, err = single.resourceType()
+	require.NoError(t, err)
+	assert.Equal(t, "aws", rt)
+
+	// Blocks with no labels yield empty strings rather than panicking.
+	none := blockWithLabels()
+	rt, err = none.resourceType()
+	require.NoError(t, err)
+	assert.Equal(t, "", rt)
+	rn, err = none.resourceName()
+	require.NoError(t, err)
+	assert.Equal(t, "", rn)
+}
 
 // parseAttrs parses an HCL snippet and returns the top-level attributes.
 // The snippet must contain attribute definitions only (no blocks).

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -74,6 +74,10 @@ private terraform.block @defaults("type labels") {
   labels []string
   // Block name label
   nameLabel() string
+  // Terraform resource type, e.g. "aws_instance" (mirrors terraform.state.resource.type and terraform.plan.resourceChange.type)
+  resourceType() string
+  // Terraform resource name, e.g. "web" in `resource "aws_instance" "web"` (mirrors terraform.state.resource.name and terraform.plan.resourceChange.name)
+  resourceName() string
   // Block start position
   start terraform.fileposition
   // Block end position

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -231,6 +231,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"terraform.block.nameLabel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetNameLabel()).ToDataRes(types.String)
 	},
+	"terraform.block.resourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTerraformBlock).GetResourceType()).ToDataRes(types.String)
+	},
+	"terraform.block.resourceName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTerraformBlock).GetResourceName()).ToDataRes(types.String)
+	},
 	"terraform.block.start": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetStart()).ToDataRes(types.Resource("terraform.fileposition"))
 	},
@@ -540,6 +546,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"terraform.block.nameLabel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTerraformBlock).NameLabel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"terraform.block.resourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTerraformBlock).ResourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"terraform.block.resourceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTerraformBlock).ResourceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"terraform.block.start": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1246,16 +1260,18 @@ type mqlTerraformBlock struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlTerraformBlockInternal
-	Type       plugin.TValue[string]
-	Labels     plugin.TValue[[]any]
-	NameLabel  plugin.TValue[string]
-	Start      plugin.TValue[*mqlTerraformFileposition]
-	End        plugin.TValue[*mqlTerraformFileposition]
-	Arguments  plugin.TValue[any]
-	Attributes plugin.TValue[any]
-	Blocks     plugin.TValue[[]any]
-	Related    plugin.TValue[[]any]
-	Snippet    plugin.TValue[string]
+	Type         plugin.TValue[string]
+	Labels       plugin.TValue[[]any]
+	NameLabel    plugin.TValue[string]
+	ResourceType plugin.TValue[string]
+	ResourceName plugin.TValue[string]
+	Start        plugin.TValue[*mqlTerraformFileposition]
+	End          plugin.TValue[*mqlTerraformFileposition]
+	Arguments    plugin.TValue[any]
+	Attributes   plugin.TValue[any]
+	Blocks       plugin.TValue[[]any]
+	Related      plugin.TValue[[]any]
+	Snippet      plugin.TValue[string]
 }
 
 // createTerraformBlock creates a new instance of this resource
@@ -1306,6 +1322,18 @@ func (c *mqlTerraformBlock) GetLabels() *plugin.TValue[[]any] {
 func (c *mqlTerraformBlock) GetNameLabel() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.NameLabel, func() (string, error) {
 		return c.nameLabel()
+	})
+}
+
+func (c *mqlTerraformBlock) GetResourceType() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ResourceType, func() (string, error) {
+		return c.resourceType()
+	})
+}
+
+func (c *mqlTerraformBlock) GetResourceName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ResourceName, func() (string, error) {
+		return c.resourceName()
 	})
 }
 

--- a/providers/terraform/resources/terraform.lr.versions
+++ b/providers/terraform/resources/terraform.lr.versions
@@ -10,6 +10,8 @@ terraform.block.end 9.0.0
 terraform.block.labels 9.0.0
 terraform.block.nameLabel 9.0.0
 terraform.block.related 9.0.12
+terraform.block.resourceName 13.0.15
+terraform.block.resourceType 13.0.15
 terraform.block.snippet 9.0.0
 terraform.block.start 9.0.0
 terraform.block.type 9.0.0


### PR DESCRIPTION
## What

Adds two computed fields to `terraform.block`:

| field | returns | example |
|-------|---------|---------|
| `resourceType` | first label | `"aws_instance"` |
| `resourceName` | second label | `"web"` |

```coffee
terraform.resources("aws_vpc").all(resourceName != "")   // was: labels[1] != ""
```

## Why

This is the first **"Tier 1"** slice of an effort to make Terraform policy queries simpler and more uniform across the `terraform-hcl` / `terraform-plan` / `terraform-state` platforms.

Today the three platforms expose the same concepts under different names:

- **HCL** (`terraform.block`): type via `nameLabel`, name only via the cryptic positional `labels[1]`.
- **Plan** (`terraform.plan.resourceChange`) and **State** (`terraform.state.resource`): readable `type` and `name` fields.

So an author writing the HCL variant of a check has to remember a different idiom than the plan/state variants. These two fields close that gap on the HCL side — `resourceType`/`resourceName` mirror the `type`/`name` already present on plan/state resources, and `resourceName` retires the `labels[1]` index access that shows up throughout the content policies.

(Same spirit as the recent *"bicep: simpler query ergonomics"* provider changes.)

## Scope / safety

- **Pure additions** — no existing field changes. `resourceType` returns the same value as `nameLabel`; `nameLabel` is retained.
- Both fields return `""` (not a panic) when the label is absent, e.g. `provider` blocks that have no second label.
- Generated `terraform.lr.go` and `terraform.lr.versions` regenerated with `lr go` / `lr versions`; new fields stamped at the next patch (`13.0.15`). `config/config.go` left for release tooling, matching recent feature PRs.

## Tests

- New `TestBlockResourceTypeAndName` covers the two-label, single-label, and no-label cases.
- `go test ./...` passes for the terraform provider.
- Verified end-to-end: built the provider, installed it locally, and confirmed `terraform.resources("aws_instance").all(resourceType == "aws_instance")` and `terraform.resources("aws_vpc").all(resourceName != "")` compile via `cnspec policy lint`.

## Follow-ups (not in this PR)

The remaining Tier 1 ideas need MQL language support or carry heuristic risk, so they are deferred:
- A parameterized child-block accessor (`block.block("security_rule")`) to replace `blocks.where(type == "...")` — `.lr` fields can't take user-supplied values and maps can't hold resources, so this needs language-level support.
- Auto-parsing JSON-string attributes (e.g. IAM `policy`) so plan/state stop falling back to substring `.contains()` matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)