### PR TITLE
✨ gcp/aws/digitalocean: expand GKE node pools, EMR + GenAI fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7429,6 +7429,8 @@ private aws.emr.cluster @defaults("arn") {
   autoScalingRole() aws.iam.role
   // IAM service role assumed by EMR to access AWS resources
   serviceRole() aws.iam.role
+  // Whether Spark Connect sessions are enabled on the cluster
+  sessionEnabled() bool
 }
 
 // Amazon EMR security configuration

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12996,6 +12996,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.emr.cluster.serviceRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetServiceRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
+	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetSessionEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.emr.securityConfiguration.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrSecurityConfiguration).GetName()).ToDataRes(types.String)
 	},
@@ -44425,6 +44428,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.emr.cluster.serviceRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrCluster).ServiceRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).SessionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.emr.securityConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -104821,6 +104828,7 @@ type mqlAwsEmrCluster struct {
 	VisibleToAllUsers          plugin.TValue[bool]
 	AutoScalingRole            plugin.TValue[*mqlAwsIamRole]
 	ServiceRole                plugin.TValue[*mqlAwsIamRole]
+	SessionEnabled             plugin.TValue[bool]
 }
 
 // createAwsEmrCluster creates a new instance of this resource
@@ -105135,6 +105143,12 @@ func (c *mqlAwsEmrCluster) GetServiceRole() *plugin.TValue[*mqlAwsIamRole] {
 		}
 
 		return c.serviceRole()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetSessionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SessionEnabled, func() (bool, error) {
+		return c.sessionEnabled()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4265,6 +4265,7 @@ aws.emr.cluster.scaleDownBehavior 13.21.4
 aws.emr.cluster.securityConfig 13.21.4
 aws.emr.cluster.securityConfiguration 13.3.0
 aws.emr.cluster.serviceRole 13.21.4
+aws.emr.cluster.sessionEnabled 13.32.2
 aws.emr.cluster.status 11.15.2
 aws.emr.cluster.step 13.12.1
 aws.emr.cluster.step.actionOnFailure 13.12.1

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -164,6 +164,7 @@ type mqlAwsEmrClusterInternal struct {
 	cacheVisibleToAllUsers          bool
 	cacheAutoScalingRoleArn         string
 	cacheServiceRoleArn             string
+	cacheSessionEnabled             bool
 	autoTerminationFetched          bool
 	autoTerminationLock             sync.Mutex
 	cacheAutoTerminationIdleTimeout int64
@@ -253,6 +254,9 @@ func (a *mqlAwsEmrCluster) fetchClusterDetails() error {
 	}
 	if resp.Cluster.ServiceRole != nil {
 		a.cacheServiceRoleArn = *resp.Cluster.ServiceRole
+	}
+	if resp.Cluster.SessionEnabled != nil {
+		a.cacheSessionEnabled = *resp.Cluster.SessionEnabled
 	}
 
 	a.clusterDetailsFetched = true
@@ -437,6 +441,13 @@ func (a *mqlAwsEmrCluster) serviceRole() (*mqlAwsIamRole, error) {
 		return nil, err
 	}
 	return mqlRole, nil
+}
+
+func (a *mqlAwsEmrCluster) sessionEnabled() (bool, error) {
+	if err := a.fetchClusterDetails(); err != nil {
+		return false, err
+	}
+	return a.cacheSessionEnabled, nil
 }
 
 // iamRoleByArnOrName resolves an iam.role reference where the input string may

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -1708,6 +1708,15 @@ private digitalocean.gradientai.customModel @defaults("uuid name status") {
   teamId string
   // Region the model is stored in
   storageRegion string
+  // Source location the model was imported from
+  //
+  // Identifies where the model artifacts originate. For a Spaces object
+  // source: `bucket`, `region`, and `prefix`. For a Git/Hugging Face source:
+  // `repoId`, `commitSha`, and `accessType`. The Hugging Face token is
+  // omitted.
+  sourceRef dict
+  // Provider-specific configuration metadata for the model
+  configJson dict
   // Deployments currently serving the model
   activeDeployments []dict
   // Time the model was created

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -2137,6 +2137,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.gradientai.customModel.storageRegion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiCustomModel).GetStorageRegion()).ToDataRes(types.String)
 	},
+	"digitalocean.gradientai.customModel.sourceRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanGradientaiCustomModel).GetSourceRef()).ToDataRes(types.Dict)
+	},
+	"digitalocean.gradientai.customModel.configJson": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanGradientaiCustomModel).GetConfigJson()).ToDataRes(types.Dict)
+	},
 	"digitalocean.gradientai.customModel.activeDeployments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiCustomModel).GetActiveDeployments()).ToDataRes(types.Array(types.Dict))
 	},
@@ -4984,6 +4990,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.gradientai.customModel.storageRegion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanGradientaiCustomModel).StorageRegion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.gradientai.customModel.sourceRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanGradientaiCustomModel).SourceRef, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.gradientai.customModel.configJson": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanGradientaiCustomModel).ConfigJson, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.gradientai.customModel.activeDeployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11579,6 +11593,8 @@ type mqlDigitaloceanGradientaiCustomModel struct {
 	Parameters           plugin.TValue[string]
 	TeamId               plugin.TValue[string]
 	StorageRegion        plugin.TValue[string]
+	SourceRef            plugin.TValue[any]
+	ConfigJson           plugin.TValue[any]
 	ActiveDeployments    plugin.TValue[[]any]
 	CreatedAt            plugin.TValue[*time.Time]
 	UpdatedAt            plugin.TValue[*time.Time]
@@ -11678,6 +11694,14 @@ func (c *mqlDigitaloceanGradientaiCustomModel) GetTeamId() *plugin.TValue[string
 
 func (c *mqlDigitaloceanGradientaiCustomModel) GetStorageRegion() *plugin.TValue[string] {
 	return &c.StorageRegion
+}
+
+func (c *mqlDigitaloceanGradientaiCustomModel) GetSourceRef() *plugin.TValue[any] {
+	return &c.SourceRef
+}
+
+func (c *mqlDigitaloceanGradientaiCustomModel) GetConfigJson() *plugin.TValue[any] {
+	return &c.ConfigJson
 }
 
 func (c *mqlDigitaloceanGradientaiCustomModel) GetActiveDeployments() *plugin.TValue[[]any] {

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -325,6 +325,7 @@ digitalocean.gradientai.batchJobs 13.4.2
 digitalocean.gradientai.customModel 13.4.2
 digitalocean.gradientai.customModel.activeDeployments 13.4.2
 digitalocean.gradientai.customModel.architecture 13.4.2
+digitalocean.gradientai.customModel.configJson 13.5.2
 digitalocean.gradientai.customModel.contextLength 13.4.2
 digitalocean.gradientai.customModel.costEstimatePerMonth 13.4.2
 digitalocean.gradientai.customModel.createdAt 13.4.2
@@ -335,6 +336,7 @@ digitalocean.gradientai.customModel.license 13.4.2
 digitalocean.gradientai.customModel.name 13.4.2
 digitalocean.gradientai.customModel.outputModalities 13.4.2
 digitalocean.gradientai.customModel.parameters 13.4.2
+digitalocean.gradientai.customModel.sourceRef 13.5.2
 digitalocean.gradientai.customModel.sourceType 13.4.2
 digitalocean.gradientai.customModel.status 13.4.2
 digitalocean.gradientai.customModel.storageRegion 13.4.2

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -642,6 +642,19 @@ func (r *mqlDigitaloceanGradientai) customModels() ([]interface{}, error) {
 					}
 					deployments = append(deployments, convert.ToValue(d))
 				}
+				var sourceRef map[string]interface{}
+				if m.SourceRef != nil {
+					// Surface the source location, but omit the Hugging Face
+					// access token.
+					sourceRef = map[string]interface{}{
+						"repoId":     m.SourceRef.RepoId,
+						"commitSha":  m.SourceRef.CommitSha,
+						"accessType": string(m.SourceRef.AccessType),
+						"bucket":     m.SourceRef.Bucket,
+						"region":     m.SourceRef.Region,
+						"prefix":     m.SourceRef.Prefix,
+					}
+				}
 				res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.customModel", map[string]*llx.RawData{
 					"__id":                 llx.StringData(m.Uuid),
 					"uuid":                 llx.StringData(m.Uuid),
@@ -660,6 +673,8 @@ func (r *mqlDigitaloceanGradientai) customModels() ([]interface{}, error) {
 					"parameters":           llx.StringData(m.Parameters),
 					"teamId":               llx.StringData(m.TeamId),
 					"storageRegion":        llx.StringData(m.StorageRegion),
+					"sourceRef":            llx.DictData(sourceRef),
+					"configJson":           llx.DictData(m.ConfigJson),
 					"activeDeployments":    llx.ArrayData(deployments, types.Dict),
 					"createdAt":            llx.TimeDataPtr(gradientaiTime(m.CreatedAt)),
 					"updatedAt":            llx.TimeDataPtr(gradientaiTime(m.UpdatedAt)),

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -4143,6 +4143,15 @@ private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   podIpv4CidrSize int
   // Upgrade settings for the node pool
   upgradeSettings gcp.project.gkeService.cluster.nodepool.upgradeSettings
+  // Node drain behavior applied when nodes are removed
+  //
+  // Controls how nodes are gracefully drained during upgrades, scale-down,
+  // and node pool deletion. Keys: `pdbTimeoutDuration` (how long to wait for
+  // PodDisruptionBudgets to be satisfied before forcing eviction),
+  // `graceTerminationDuration` (the termination grace period granted to pods),
+  // and `respectPdbDuringNodePoolDeletion` (whether PodDisruptionBudgets are
+  // honored when the node pool itself is deleted).
+  nodeDrainConfig dict
   // ETag for optimistic locking
   etag string
 }
@@ -4294,7 +4303,22 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   // Confidential nodes configuration
   confidentialNodes gcp.project.gkeService.cluster.nodepool.config.confidentialNodes
   // GPU Direct configuration
+  //
+  // The `gpuDirectStrategy` key reports the GPU Direct strategy enabled on
+  // the node pool. One of GPU_DIRECT_STRATEGY_UNSPECIFIED or RDMA (GPU Direct
+  // RDMA for high-throughput, low-latency GPU-to-GPU networking).
   gpuDirectConfig dict
+  // containerd runtime configuration
+  //
+  // Surfaces the containerd settings applied to nodes. Keys:
+  // `privateRegistryAccessConfig` (CA-domain configuration for pulling from
+  // private registries, including GCP Secret Manager certificate references),
+  // `writableCgroups`, and `registryHosts` — a list of per-server registry
+  // host configurations (each containerd `hosts.toml`). Every registry host
+  // entry carries a `server`, plus `hosts` with their `capabilities`
+  // (HOST_CAPABILITY_PULL, HOST_CAPABILITY_RESOLVE, HOST_CAPABILITY_PUSH),
+  // headers, CA and client certificates, and dial timeout.
+  containerdConfig dict
 }
 
 // Google Kubernetes Engine (GKE) node pool hardware accelerators configuration
@@ -4362,6 +4386,14 @@ private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults
   id string
   // The Linux kernel parameters to apply to the nodes and all pods running on them
   sysctls map[string]string
+  // Swap memory configuration for the node pool
+  //
+  // Reports how swap is provisioned on nodes. At most one of the profile keys
+  // is set, selecting where swap is backed: `bootDiskProfile` (swap on the
+  // boot disk, sized by `swapSizeGib` or `swapSizePercent`, optionally
+  // encrypted via `encryptionConfig`), `ephemeralLocalSsdProfile`, or
+  // `dedicatedLocalSsdProfile`. When the config is absent, swap is disabled.
+  swapConfig dict
 }
 
 // Google Kubernetes Engine (GKE) node pool parameters that can be configured on Windows nodes

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -6514,6 +6514,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.nodepool.upgradeSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetUpgradeSettings()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.upgradeSettings"))
 	},
+	"gcp.project.gkeService.cluster.nodepool.nodeDrainConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetNodeDrainConfig()).ToDataRes(types.Dict)
+	},
 	"gcp.project.gkeService.cluster.nodepool.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetEtag()).ToDataRes(types.String)
 	},
@@ -6673,6 +6676,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.nodepool.config.gpuDirectConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetGpuDirectConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.gkeService.cluster.nodepool.config.containerdConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetContainerdConfig()).ToDataRes(types.Dict)
+	},
 	"gcp.project.gkeService.cluster.nodepool.config.accelerator.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigAccelerator).GetId()).ToDataRes(types.String)
 	},
@@ -6729,6 +6735,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).GetSysctls()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.swapConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).GetSwapConfig()).ToDataRes(types.Dict)
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).GetOsVersion()).ToDataRes(types.String)
@@ -22359,6 +22368,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceClusterNodepool).UpgradeSettings, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodepoolUpgradeSettings](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.nodepool.nodeDrainConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepool).NodeDrainConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.nodepool.etag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepool).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -22591,6 +22604,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GpuDirectConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.nodepool.config.containerdConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).ContainerdConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.nodepool.config.accelerator.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigAccelerator).__id, ok = v.Value.(string)
 		return
@@ -22689,6 +22706,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).Sysctls, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.swapConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).SwapConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50692,6 +50713,7 @@ type mqlGcpProjectGkeServiceClusterNodepool struct {
 	StatusMessage         plugin.TValue[string]
 	PodIpv4CidrSize       plugin.TValue[int64]
 	UpgradeSettings       plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolUpgradeSettings]
+	NodeDrainConfig       plugin.TValue[any]
 	Etag                  plugin.TValue[string]
 }
 
@@ -50810,6 +50832,10 @@ func (c *mqlGcpProjectGkeServiceClusterNodepool) GetPodIpv4CidrSize() *plugin.TV
 
 func (c *mqlGcpProjectGkeServiceClusterNodepool) GetUpgradeSettings() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolUpgradeSettings] {
 	return &c.UpgradeSettings
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepool) GetNodeDrainConfig() *plugin.TValue[any] {
+	return &c.NodeDrainConfig
 }
 
 func (c *mqlGcpProjectGkeServiceClusterNodepool) GetEtag() *plugin.TValue[string] {
@@ -51112,6 +51138,7 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfig struct {
 	Spot                      plugin.TValue[bool]
 	ConfidentialNodes         plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigConfidentialNodes]
 	GpuDirectConfig           plugin.TValue[any]
+	ContainerdConfig          plugin.TValue[any]
 }
 
 // createGcpProjectGkeServiceClusterNodepoolConfig creates a new instance of this resource
@@ -51305,6 +51332,10 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetConfidentialNodes() *p
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetGpuDirectConfig() *plugin.TValue[any] {
 	return &c.GpuDirectConfig
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetContainerdConfig() *plugin.TValue[any] {
+	return &c.ContainerdConfig
 }
 
 // mqlGcpProjectGkeServiceClusterNodepoolConfigAccelerator for the gcp.project.gkeService.cluster.nodepool.config.accelerator resource
@@ -51617,8 +51648,9 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfigInternal it will be used here
-	Id      plugin.TValue[string]
-	Sysctls plugin.TValue[map[string]any]
+	Id         plugin.TValue[string]
+	Sysctls    plugin.TValue[map[string]any]
+	SwapConfig plugin.TValue[any]
 }
 
 // createGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig creates a new instance of this resource
@@ -51664,6 +51696,10 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) GetId() *p
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) GetSysctls() *plugin.TValue[map[string]any] {
 	return &c.Sysctls
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) GetSwapConfig() *plugin.TValue[any] {
+	return &c.SwapConfig
 }
 
 // mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig for the gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3083,6 +3083,7 @@ gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKey 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes.enabled 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes.id 9.0.0
+gcp.project.gkeService.cluster.nodepool.config.containerdConfig 13.21.2
 gcp.project.gkeService.cluster.nodepool.config.diskSizeGb 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.diskType 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.gcfsConfig 9.0.0
@@ -3105,6 +3106,7 @@ gcp.project.gkeService.cluster.nodepool.config.kubeletConfig.podPidsLimit 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.labels 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.id 9.0.0
+gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.swapConfig 13.21.2
 gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.localSsdCount 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.localSsdEncryptionMode 13.19.2
@@ -3150,6 +3152,7 @@ gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig.id 9.0.0
 gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig.totalEgressBandwidthTier 9.0.0
 gcp.project.gkeService.cluster.nodepool.networkConfig.podIpv4CidrBlock 9.0.0
 gcp.project.gkeService.cluster.nodepool.networkConfig.podRange 9.0.0
+gcp.project.gkeService.cluster.nodepool.nodeDrainConfig 13.21.2
 gcp.project.gkeService.cluster.nodepool.podIpv4CidrSize 11.6.6
 gcp.project.gkeService.cluster.nodepool.status 9.0.0
 gcp.project.gkeService.cluster.nodepool.statusMessage 11.6.6

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -997,6 +997,11 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 		return nil, err
 	}
 
+	var nodeDrainConfig map[string]any
+	if np.NodeDrainConfig != nil {
+		nodeDrainConfig, _ = convert.JsonToDict(np.NodeDrainConfig)
+	}
+
 	res, err := CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool", map[string]*llx.RawData{
 		"id":                llx.StringData(nodePoolId),
 		"name":              llx.StringData(np.Name),
@@ -1014,6 +1019,7 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 		"statusMessage":     llx.StringData(np.StatusMessage),
 		"podIpv4CidrSize":   llx.IntData(int64(np.PodIpv4CidrSize)),
 		"upgradeSettings":   llx.ResourceData(mqlUpgradeSettings, "gcp.project.gkeService.cluster.nodepool.upgradeSettings"),
+		"nodeDrainConfig":   llx.DictData(nodeDrainConfig),
 		"etag":              llx.StringData(np.Etag),
 	})
 	if err != nil {
@@ -1089,9 +1095,14 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 
 	var mqlLinuxNodeCfg plugin.Resource
 	if cfg.LinuxNodeConfig != nil {
+		var swapConfig map[string]any
+		if cfg.LinuxNodeConfig.SwapConfig != nil {
+			swapConfig, _ = convert.JsonToDict(cfg.LinuxNodeConfig.SwapConfig)
+		}
 		mqlLinuxNodeCfg, err = CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig", map[string]*llx.RawData{
-			"id":      llx.StringData(fmt.Sprintf("%s/linuxNodeConfig", nodePoolId)),
-			"sysctls": llx.MapData(convert.MapToInterfaceMap(cfg.LinuxNodeConfig.Sysctls), types.String),
+			"id":         llx.StringData(fmt.Sprintf("%s/linuxNodeConfig", nodePoolId)),
+			"sysctls":    llx.MapData(convert.MapToInterfaceMap(cfg.LinuxNodeConfig.Sysctls), types.String),
+			"swapConfig": llx.DictData(swapConfig),
 		})
 		if err != nil {
 			return nil, err
@@ -1175,6 +1186,11 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 		}
 	}
 
+	var containerdConfig map[string]any
+	if cfg.ContainerdConfig != nil {
+		containerdConfig, _ = convert.JsonToDict(cfg.ContainerdConfig)
+	}
+
 	workloadMetadataMode := ""
 	if cfg.WorkloadMetadataConfig != nil {
 		workloadMetadataMode = cfg.WorkloadMetadataConfig.Mode.String()
@@ -1213,6 +1229,7 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 		"spot":                    llx.BoolData(cfg.Spot),
 		"confidentialNodes":       llx.ResourceData(mqlConfidentialNodes, "gcp.project.gkeService.cluster.nodepool.config.confidentialNodes"),
 		"gpuDirectConfig":         llx.DictData(gpuDirectConfig),
+		"containerdConfig":        llx.DictData(containerdConfig),
 	})
 }
 


### PR DESCRIPTION
Surfaces new resource fields unlocked by SDK bumps that landed in #8196 (GKE container v1.53, EMR v1.61, godo v1.194.1).

## GKE — `cluster.nodepool` (gcp 13.21.2)
- **`nodepool.nodeDrainConfig`** — PDB timeout, grace-termination duration, and respect-PDB-on-deletion behavior applied when nodes are removed during upgrades, scale-down, and node pool deletion.
- **`nodepool.config.containerdConfig`** — containerd runtime settings, including the new per-server **registry host** configs (each a containerd `hosts.toml`): server, host capabilities, headers, CA/client certs, dial timeout, plus private-registry CA-domain config.
- **`nodepool.config.linuxNodeConfig.swapConfig`** — node swap memory profiles (boot-disk / ephemeral-LSSD / dedicated-LSSD).
- **Enum docs:** the `gpuDirectConfig.gpuDirectStrategy` doc now lists the new **`RDMA`** strategy, and `containerdConfig` documents the **`HostCapability`** enum (`PULL`/`RESOLVE`/`PUSH`). The `SHORT_LIVED` upgrade strategy was already listed.

These nested configs have no stable queryable ID and no typed refs to other modeled resources, so per the sub-resource bar they follow the existing dict pattern (`gpuDirectConfig`, `management`) rather than new generated sub-resources.

## AWS EMR — `aws.emr.cluster` (aws 13.32.2)
- **`sessionEnabled`** — whether Spark Connect sessions are enabled on the cluster, resolved through the existing `DescribeCluster` path (no new API call).

## DigitalOcean GenAI — `gradientai.customModel` (digitalocean 13.5.2)
- **`sourceRef`** — the Spaces/Git source location the model was imported from (bucket/region/prefix or repoId/commitSha/accessType). The Hugging Face access token is deliberately omitted.
- **`configJson`** — provider-specific configuration metadata.

## Verification
- `go build ./resources/...` passes for all three providers.
- `.lr.versions` entries at the next patch (gcp 13.21.2, aws 13.32.2, do 13.5.2); no `config.go` version bumps.
- gofmt clean; `.permissions.json` unchanged (no new API calls).