### PR TITLE
🐛 llx: guard bytes2time against short buffers

### DIFF
--- a/llx/byte_conversions.go
+++ b/llx/byte_conversions.go
@@ -48,7 +48,13 @@ func bytes2float(b []byte) float64 {
 }
 
 func bytes2time(b []byte) time.Time {
+	// A valid encoding is 12 bytes: 8 for seconds, 4 for nanoseconds.
+	// Fall back to the zero time on a short buffer instead of slicing
+	// out of range, matching ptime2raw's handling of an empty value.
+	if len(b) < 12 {
+		return time.Unix(0, 0)
+	}
 	secs := int64(binary.LittleEndian.Uint64(b[0:8]))
-	nanos := int64(binary.LittleEndian.Uint32(b[8:]))
+	nanos := int64(binary.LittleEndian.Uint32(b[8:12]))
 	return time.Unix(secs, nanos)
 }

--- a/llx/byte_conversions_test.go
+++ b/llx/byte_conversions_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytes2time(t *testing.T) {
+	t.Run("round-trips a value encoded by TimePrimitive", func(t *testing.T) {
+		want := time.Unix(1717689600, 123)
+		got := bytes2time(TimePrimitive(&want).Value)
+		assert.Equal(t, want.UnixNano(), got.UnixNano())
+	})
+
+	t.Run("falls back to zero time on a short buffer", func(t *testing.T) {
+		// A valid encoding is 12 bytes; shorter buffers must not panic on the
+		// b[0:8]/b[8:12] slices but fall back to the zero time.
+		for n := range 12 {
+			require.NotPanics(t, func() {
+				assert.Equal(t, time.Unix(0, 0), bytes2time(make([]byte, n)), "length %d", n)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## What

`bytes2time` sliced `b[0:8]` and `b[8:]` without checking the buffer length. A `Primitive` of type `time` whose `Value` is non-empty but shorter than the 12-byte encoding (8 bytes of seconds + 4 bytes of nanoseconds) therefore triggered a slice-out-of-range panic during conversion.

`ptime2raw` already special-cases an empty `Value` (returning the epoch) but does not cover a short-but-non-empty one, so the panic was reachable for any partially-formed time value.

## Change

- `bytes2time` now falls back to the zero time on a buffer shorter than 12 bytes instead of slicing out of range, matching `ptime2raw`'s handling of an empty value. The full-length path also reads `b[8:12]` explicitly to make the 12-byte contract obvious.
- Adds `byte_conversions_test.go` covering a `TimePrimitive` round-trip and every short length (0–11 bytes).

## Test

```
go test ./llx/ -run TestBytes2time -v
```

Both subtests pass.

## Note

`bytes2int` in the same file has the same shape (it panics rather than returning an error on a malformed varint). I left it out to keep this change focused; happy to follow up on it separately.