### PR TITLE
✨ Add IoT Hub diagnostic settings and Front Door WAF security policies to the Azure provider

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1741,6 +1741,7 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.Cdn/aFDEndpoints/read":     "Microsoft.Cdn/profiles/afdendpoints/read",
 	"Microsoft.Cdn/aFDOriginGroups/read":  "Microsoft.Cdn/profiles/origingroups/read",
 	"Microsoft.Cdn/aFDOrigins/read":       "Microsoft.Cdn/profiles/origingroups/origins/read",
+	"Microsoft.Cdn/securityPolicies/read": "Microsoft.Cdn/profiles/securitypolicies/read",
 
 	// ContainerRegistry: sub-resources need registries/ parent path
 	"Microsoft.ContainerRegistry/cacheRules/read":          "Microsoft.ContainerRegistry/registries/cacheRules/read",

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7504,6 +7504,8 @@ private azure.subscription.iotService.iotHub @defaults("id name location") {
   enableDataResidency bool
   // Network rule set: defaultAction, applyToBuiltInEventHubEndpoint, ipRules
   networkRuleSet dict
+  // Diagnostic settings configured on the IoT hub (forwarding logs and metrics to Log Analytics, storage, or Event Hub)
+  diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
 }
 
 // Azure Cache for Redis
@@ -9274,6 +9276,24 @@ azure.subscription.frontDoorService.profile @defaults("id name location") {
   customDomains() []azure.subscription.frontDoorService.profile.customDomain
   // Origin groups in this profile
   originGroups() []azure.subscription.frontDoorService.profile.originGroup
+  // Security policies (Web Application Firewall associations) attached to this profile
+  securityPolicies() []azure.subscription.frontDoorService.profile.securityPolicy
+}
+
+// Azure Front Door security policy associating a WAF policy with domains
+private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id name policyType wafPolicyId") {
+  // Security policy resource ID
+  id string
+  // Security policy name
+  name string
+  // Security policy type (e.g. "WebApplicationFirewall")
+  policyType string
+  // ARM resource ID of the associated WAF policy (empty if none is associated)
+  wafPolicyId string
+  // Domains and path patterns the WAF policy is associated with
+  associations []dict
+  // Provisioning state
+  provisioningState string
 }
 
 // Azure Front Door / CDN endpoint

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -344,6 +344,7 @@ const (
 	ResourceAzureSubscriptionDnsServicePrivateZoneVirtualNetworkLink                             string = "azure.subscription.dnsService.privateZone.virtualNetworkLink"
 	ResourceAzureSubscriptionFrontDoorService                                                    string = "azure.subscription.frontDoorService"
 	ResourceAzureSubscriptionFrontDoorServiceProfile                                             string = "azure.subscription.frontDoorService.profile"
+	ResourceAzureSubscriptionFrontDoorServiceProfileSecurityPolicy                               string = "azure.subscription.frontDoorService.profile.securityPolicy"
 	ResourceAzureSubscriptionFrontDoorServiceProfileEndpoint                                     string = "azure.subscription.frontDoorService.profile.endpoint"
 	ResourceAzureSubscriptionFrontDoorServiceProfileEndpointRoute                                string = "azure.subscription.frontDoorService.profile.endpoint.route"
 	ResourceAzureSubscriptionFrontDoorServiceProfileCustomDomain                                 string = "azure.subscription.frontDoorService.profile.customDomain"
@@ -1711,6 +1712,10 @@ func init() {
 		"azure.subscription.frontDoorService.profile": {
 			// to override args, implement: initAzureSubscriptionFrontDoorServiceProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionFrontDoorServiceProfile,
+		},
+		"azure.subscription.frontDoorService.profile.securityPolicy": {
+			// to override args, implement: initAzureSubscriptionFrontDoorServiceProfileSecurityPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionFrontDoorServiceProfileSecurityPolicy,
 		},
 		"azure.subscription.frontDoorService.profile.endpoint": {
 			// to override args, implement: initAzureSubscriptionFrontDoorServiceProfileEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -10617,6 +10622,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.iotService.iotHub.networkRuleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetNetworkRuleSet()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
+	},
 	"azure.subscription.cacheService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -12479,6 +12487,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.originGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfile).GetOriginGroups()).ToDataRes(types.Array(types.Resource("azure.subscription.frontDoorService.profile.originGroup")))
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfile).GetSecurityPolicies()).ToDataRes(types.Array(types.Resource("azure.subscription.frontDoorService.profile.securityPolicy")))
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.policyType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetPolicyType()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetWafPolicyId()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.associations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetAssociations()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.provisioningState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetProvisioningState()).ToDataRes(types.String)
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetId()).ToDataRes(types.String)
@@ -26778,6 +26807,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionIotServiceIotHub).NetworkRuleSet, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cacheService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheService).__id, ok = v.Value.(string)
 		return
@@ -29556,6 +29589,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.originGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfile).OriginGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfile).SecurityPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.policyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).PolicyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).WafPolicyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.associations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).Associations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -61766,6 +61831,7 @@ type mqlAzureSubscriptionIotServiceIotHub struct {
 	AllowedFqdnList               plugin.TValue[[]any]
 	EnableDataResidency           plugin.TValue[bool]
 	NetworkRuleSet                plugin.TValue[any]
+	DiagnosticSettings            plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionIotServiceIotHub creates a new instance of this resource
@@ -61875,6 +61941,22 @@ func (c *mqlAzureSubscriptionIotServiceIotHub) GetEnableDataResidency() *plugin.
 
 func (c *mqlAzureSubscriptionIotServiceIotHub) GetNetworkRuleSet() *plugin.TValue[any] {
 	return &c.NetworkRuleSet
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetDiagnosticSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DiagnosticSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.iotService.iotHub", c.__id, "diagnosticSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.diagnosticSettings()
+	})
 }
 
 // mqlAzureSubscriptionCacheService for the azure.subscription.cacheService resource
@@ -68979,6 +69061,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfile struct {
 	Endpoints         plugin.TValue[[]any]
 	CustomDomains     plugin.TValue[[]any]
 	OriginGroups      plugin.TValue[[]any]
+	SecurityPolicies  plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfile creates a new instance of this resource
@@ -69100,6 +69183,96 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfile) GetOriginGroups() *plugin.
 
 		return c.originGroups()
 	})
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfile) GetSecurityPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile", c.__id, "securityPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityPolicies()
+	})
+}
+
+// mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy for the azure.subscription.frontDoorService.profile.securityPolicy resource
+type mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicyInternal it will be used here
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	PolicyType        plugin.TValue[string]
+	WafPolicyId       plugin.TValue[string]
+	Associations      plugin.TValue[[]any]
+	ProvisioningState plugin.TValue[string]
+}
+
+// createAzureSubscriptionFrontDoorServiceProfileSecurityPolicy creates a new instance of this resource
+func createAzureSubscriptionFrontDoorServiceProfileSecurityPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.frontDoorService.profile.securityPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) MqlName() string {
+	return "azure.subscription.frontDoorService.profile.securityPolicy"
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetPolicyType() *plugin.TValue[string] {
+	return &c.PolicyType
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetWafPolicyId() *plugin.TValue[string] {
+	return &c.WafPolicyId
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetAssociations() *plugin.TValue[[]any] {
+	return &c.Associations
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetProvisioningState() *plugin.TValue[string] {
+	return &c.ProvisioningState
 }
 
 // mqlAzureSubscriptionFrontDoorServiceProfileEndpoint for the azure.subscription.frontDoorService.profile.endpoint resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1877,6 +1877,14 @@ azure.subscription.frontDoorService.profile.originGroup.provisioningState 13.3.3
 azure.subscription.frontDoorService.profile.originGroups 13.3.3
 azure.subscription.frontDoorService.profile.provisioningState 13.3.3
 azure.subscription.frontDoorService.profile.resourceState 13.3.3
+azure.subscription.frontDoorService.profile.securityPolicies 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.associations 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.id 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.name 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.policyType 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.provisioningState 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId 13.16.2
 azure.subscription.frontDoorService.profile.sku 13.3.3
 azure.subscription.frontDoorService.profile.tags 13.3.3
 azure.subscription.frontDoorService.profiles 13.3.3
@@ -1923,6 +1931,7 @@ azure.subscription.iotService 11.3.0
 azure.subscription.iotService.hubs 11.3.0
 azure.subscription.iotService.iotHub 13.5.1
 azure.subscription.iotService.iotHub.allowedFqdnList 13.5.1
+azure.subscription.iotService.iotHub.diagnosticSettings 13.16.2
 azure.subscription.iotService.iotHub.disableDeviceSAS 13.5.1
 azure.subscription.iotService.iotHub.disableLocalAuth 13.5.1
 azure.subscription.iotService.iotHub.disableModuleSAS 13.5.1

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.16.1",
-  "generated_at": "2026-06-07T08:40:15-07:00",
+  "generated_at": "2026-06-07T09:09:05-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -30,7 +30,7 @@
     "Microsoft.Cdn/profiles/origingroups/origins/read",
     "Microsoft.Cdn/profiles/origingroups/read",
     "Microsoft.Cdn/profiles/read",
-    "Microsoft.Cdn/securityPolicies/read",
+    "Microsoft.Cdn/profiles/securitypolicies/read",
     "Microsoft.CognitiveServices/accounts/connections/read",
     "Microsoft.CognitiveServices/accounts/defenderForAISettings/read",
     "Microsoft.CognitiveServices/accounts/deployments/read",
@@ -388,7 +388,7 @@
       "source_file": "frontdoor.go"
     },
     {
-      "permission": "Microsoft.Cdn/securityPolicies/read",
+      "permission": "Microsoft.Cdn/profiles/securitypolicies/read",
       "service": "Microsoft.Cdn",
       "action": "NewListByProfilePager",
       "source_file": "frontdoor.go"

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.16.1",
-  "generated_at": "2026-06-05T10:50:35-07:00",
+  "generated_at": "2026-06-07T08:40:15-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -30,6 +30,7 @@
     "Microsoft.Cdn/profiles/origingroups/origins/read",
     "Microsoft.Cdn/profiles/origingroups/read",
     "Microsoft.Cdn/profiles/read",
+    "Microsoft.Cdn/securityPolicies/read",
     "Microsoft.CognitiveServices/accounts/connections/read",
     "Microsoft.CognitiveServices/accounts/defenderForAISettings/read",
     "Microsoft.CognitiveServices/accounts/deployments/read",
@@ -384,6 +385,12 @@
       "permission": "Microsoft.Cdn/profiles/read",
       "service": "Microsoft.Cdn",
       "action": "NewListPager",
+      "source_file": "frontdoor.go"
+    },
+    {
+      "permission": "Microsoft.Cdn/securityPolicies/read",
+      "service": "Microsoft.Cdn",
+      "action": "NewListByProfilePager",
       "source_file": "frontdoor.go"
     },
     {

--- a/providers/azure/resources/frontdoor.go
+++ b/providers/azure/resources/frontdoor.go
@@ -53,6 +53,87 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin) id() (str
 	return a.Id.Data, nil
 }
 
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfile) securityPolicies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	profileName := a.Name.Data
+
+	client, err := armcdn.NewSecurityPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pager := client.NewListByProfilePager(resourceID.ResourceGroup, profileName, nil)
+	var res []any
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, sp := range page.Value {
+			if sp == nil {
+				continue
+			}
+
+			var policyType, wafPolicyId, provisioningState string
+			associations := []any{}
+			if props := sp.Properties; props != nil {
+				if props.ProvisioningState != nil {
+					provisioningState = string(*props.ProvisioningState)
+				}
+				if params := props.Parameters; params != nil {
+					if base := params.GetSecurityPolicyPropertiesParameters(); base != nil && base.Type != nil {
+						policyType = string(*base.Type)
+					}
+					if waf, ok := params.(*armcdn.SecurityPolicyWebApplicationFirewallParameters); ok && waf != nil {
+						if waf.WafPolicy != nil && waf.WafPolicy.ID != nil {
+							wafPolicyId = *waf.WafPolicy.ID
+						}
+						for _, assoc := range waf.Associations {
+							if assoc == nil {
+								continue
+							}
+							d, err := convert.JsonToDict(assoc)
+							if err != nil {
+								return nil, err
+							}
+							associations = append(associations, d)
+						}
+					}
+				}
+			}
+
+			mqlSp, err := CreateResource(a.MqlRuntime, "azure.subscription.frontDoorService.profile.securityPolicy", map[string]*llx.RawData{
+				"id":                llx.StringDataPtr(sp.ID),
+				"name":              llx.StringDataPtr(sp.Name),
+				"policyType":        llx.StringData(policyType),
+				"wafPolicyId":       llx.StringData(wafPolicyId),
+				"associations":      llx.ArrayData(associations, types.Dict),
+				"provisioningState": llx.StringData(provisioningState),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlSp)
+		}
+	}
+
+	return res, nil
+}
+
 func (a *mqlAzureSubscriptionFrontDoorService) profiles() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()

--- a/providers/azure/resources/frontdoor.go
+++ b/providers/azure/resources/frontdoor.go
@@ -99,6 +99,8 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) securityPolicies() ([]any,
 						policyType = string(*base.Type)
 					}
 					if waf, ok := params.(*armcdn.SecurityPolicyWebApplicationFirewallParameters); ok && waf != nil {
+						// TODO: expose wafPolicyId as a typed reference (e.g. a frontDoorWebApplicationFirewallPolicy
+						// resource) once a Front Door WAF policy resource is modeled in this provider; ARM ID for now.
 						if waf.WafPolicy != nil && waf.WafPolicy.ID != nil {
 							wafPolicyId = *waf.WafPolicy.ID
 						}

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -19,6 +19,11 @@ func (a *mqlAzureSubscriptionIotServiceIotHub) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+func (a *mqlAzureSubscriptionIotServiceIotHub) diagnosticSettings() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
+}
+
 func initAzureSubscriptionIotService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil


### PR DESCRIPTION
## What

Adds two security-relevant fields to the Azure provider so policy authors can write checks against them:

### `azure.subscription.iotService.iotHub.diagnosticSettings()`
Lists the diagnostic settings configured on an IoT hub. Implemented by reusing the shared `getDiagnosticSettings(id, runtime, conn)` helper already used by the batch, web, key vault, and cosmosdb resources — a three-line method, no new fetch logic.

### `azure.subscription.frontDoorService.profile.securityPolicies()`
Lists the Front Door security policies on a profile via the CDN `SecurityPoliciesClient.NewListByProfilePager`. Each policy is surfaced through a new `azure.subscription.frontDoorService.profile.securityPolicy` resource exposing:

- `id`, `name`, `policyType`
- `wafPolicyId` — ARM ID of the associated Web Application Firewall policy (empty if none)
- `associations` — domains and path patterns the WAF policy is bound to
- `provisioningState`

## Why

These fields back two new checks in the `mondoo-azure-security` policy (cnspec): "diagnostic settings enabled for IoT Hub" and "WAF policy attached to Front Door profiles". Neither was expressible before because the runtime resources exposed no corresponding field.

## Changes

- `providers/azure/resources/azure.lr` — schema for the two fields + the new `securityPolicy` resource
- `providers/azure/resources/iot.go` — `diagnosticSettings()` method
- `providers/azure/resources/frontdoor.go` — `securityPolicies()` method + `securityPolicy` id
- Regenerated `azure.lr.go`, `azure.lr.versions`, `azure.permissions.json` (adds `Microsoft.Cdn/securityPolicies/read`)

## Testing

- `make providers/build/azure` succeeds (codegen + compile clean)
- Installed locally; the two new fields resolve and the dependent cnspec policy checks compile against the rebuilt schema via `cnspec policy lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)