### PR TITLE
✨ Expose more Azure security state: ADE, App Service Easy Auth, NSG flow logs

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -277,6 +277,14 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   omsInstalled() bool
   // Whether the Dependency Agent extension (used by VM Insights for service-map data) is installed on the VM
   dependencyAgentInstalled() bool
+  // Whether the Azure Disk Encryption (ADE) extension is installed on the VM
+  //
+  // ADE encrypts the OS and data disks from inside the guest using BitLocker
+  // (Windows) or dm-crypt (Linux). A true result indicates the encryption
+  // extension is present; it is distinct from `encryptionAtHost` (platform-side
+  // encryption of the VM host) and from server-side disk encryption set on the
+  // managed disk itself.
+  adeInstalled() bool
   // VM compute disk
   osDisk() azure.subscription.computeService.disk
   // VM compute data disk
@@ -510,6 +518,13 @@ azure.subscription.computeService.disk @defaults("name location properties.osTyp
   diskEncryptionSetId string
   // Disk encryption set used for customer-managed key encryption
   diskEncryptionSet() azure.subscription.computeService.diskEncryptionSet
+  // Whether Azure Disk Encryption (ADE) is enabled on the disk
+  //
+  // True when guest-based encryption settings (BitLocker / dm-crypt, keyed
+  // through Key Vault) are configured on the disk. This is independent of
+  // `encryptionType`, which describes server-side encryption at rest with a
+  // platform or customer-managed key.
+  encryptionSettingsEnabled bool
   // Data access authentication mode (AzureActiveDirectory, None)
   dataAccessAuthMode string
   // Current state of the disk (Unattached, Attached, Reserved, ActiveSAS, ReadyToUpload, ActiveUpload, ActiveSASFrozen)
@@ -2250,6 +2265,13 @@ private azure.subscription.networkService.securityGroup @defaults("id name locat
   securityRules() []azure.subscription.networkService.securityrule
   // Security group default security rules
   defaultSecurityRules() []azure.subscription.networkService.securityrule
+  // Network Watcher flow log that targets this security group
+  //
+  // Resolves the flow log whose target resource is this network security group,
+  // exposing whether flow logging is enabled and its retention policy. Null when
+  // no flow log targets the NSG. Use this to verify NSG flow logs are enabled
+  // with adequate retention without traversing every Network Watcher.
+  flowLog() azure.subscription.networkService.watcher.flowlog
 }
 
 // Azure network security rule
@@ -4124,6 +4146,14 @@ private azure.subscription.webService.appsiteauthsettings @defaults("id name") {
   type string
   // Auth settings properties
   properties dict
+  // Whether App Service Authentication / Authorization (Easy Auth) is enabled
+  enabled bool
+  // Action taken when an unauthenticated client requests the app
+  //
+  // Possible values: AllowAnonymous, RedirectToLoginPage, Show401, Show403.
+  // Anything other than AllowAnonymous means unauthenticated requests are blocked
+  // or redirected to a login provider.
+  unauthenticatedClientAction string
 }
 
 // Azure AppSite config

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -36598,7 +36598,7 @@ func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetManagedServicesKeyVe
 type mqlAzureSubscriptionNetworkService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceInternal
 	SubscriptionId              plugin.TValue[string]
 	Interfaces                  plugin.TValue[[]any]
 	SecurityGroups              plugin.TValue[[]any]

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2298,6 +2298,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.dependencyAgentInstalled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetDependencyAgentInstalled()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.computeService.vm.adeInstalled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetAdeInstalled()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.computeService.vm.osDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetOsDisk()).ToDataRes(types.Resource("azure.subscription.computeService.disk"))
 	},
@@ -2582,6 +2585,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.disk.diskEncryptionSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetDiskEncryptionSet()).ToDataRes(types.Resource("azure.subscription.computeService.diskEncryptionSet"))
+	},
+	"azure.subscription.computeService.disk.encryptionSettingsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetEncryptionSettingsEnabled()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.computeService.disk.dataAccessAuthMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetDataAccessAuthMode()).ToDataRes(types.String)
@@ -4508,6 +4514,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.securityGroup.defaultSecurityRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetDefaultSecurityRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
+	},
+	"azure.subscription.networkService.securityGroup.flowLog": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetFlowLog()).ToDataRes(types.Resource("azure.subscription.networkService.watcher.flowlog"))
 	},
 	"azure.subscription.networkService.securityrule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetId()).ToDataRes(types.String)
@@ -6560,6 +6569,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsiteauthsettings.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).GetProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appsiteauthsettings.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appsiteauthsettings.unauthenticatedClientAction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).GetUnauthenticatedClientAction()).ToDataRes(types.String)
 	},
 	"azure.subscription.webService.appsiteconfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetId()).ToDataRes(types.String)
@@ -14698,6 +14713,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).DependencyAgentInstalled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vm.adeInstalled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).AdeInstalled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vm.osDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).OsDisk, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceDisk](v.Value, v.Error)
 		return
@@ -15092,6 +15111,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.disk.diskEncryptionSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDisk).DiskEncryptionSet, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.disk.encryptionSettingsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceDisk).EncryptionSettingsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.disk.dataAccessAuthMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17880,6 +17903,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.securityGroup.defaultSecurityRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).DefaultSecurityRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityGroup.flowLog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).FlowLog, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceWatcherFlowlog](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.securityrule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20860,6 +20887,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsiteauthsettings.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteauthsettings.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteauthsettings.unauthenticatedClientAction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).UnauthenticatedClientAction, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsiteconfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33455,6 +33490,7 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	AmaInstalled                  plugin.TValue[bool]
 	OmsInstalled                  plugin.TValue[bool]
 	DependencyAgentInstalled      plugin.TValue[bool]
+	AdeInstalled                  plugin.TValue[bool]
 	OsDisk                        plugin.TValue[*mqlAzureSubscriptionComputeServiceDisk]
 	DataDisks                     plugin.TValue[[]any]
 	NetworkInterfaces             plugin.TValue[[]any]
@@ -33605,6 +33641,12 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetOmsInstalled() *plugin.TValue[
 func (c *mqlAzureSubscriptionComputeServiceVm) GetDependencyAgentInstalled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.DependencyAgentInstalled, func() (bool, error) {
 		return c.dependencyAgentInstalled()
+	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetAdeInstalled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AdeInstalled, func() (bool, error) {
+		return c.adeInstalled()
 	})
 }
 
@@ -34184,39 +34226,40 @@ type mqlAzureSubscriptionComputeServiceDisk struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionComputeServiceDiskInternal it will be used here
-	Id                  plugin.TValue[string]
-	Name                plugin.TValue[string]
-	Location            plugin.TValue[string]
-	Tags                plugin.TValue[map[string]any]
-	Type                plugin.TValue[string]
-	ManagedBy           plugin.TValue[string]
-	ManagedByExtended   plugin.TValue[[]any]
-	Zones               plugin.TValue[[]any]
-	Sku                 plugin.TValue[any]
-	Properties          plugin.TValue[any]
-	NetworkAccessPolicy plugin.TValue[string]
-	PublicNetworkAccess plugin.TValue[string]
-	EncryptionType      plugin.TValue[string]
-	DiskEncryptionSetId plugin.TValue[string]
-	DiskEncryptionSet   plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
-	DataAccessAuthMode  plugin.TValue[string]
-	DiskState           plugin.TValue[string]
-	ProvisioningState   plugin.TValue[string]
-	TimeCreated         plugin.TValue[*time.Time]
-	UniqueId            plugin.TValue[string]
-	BurstingEnabled     plugin.TValue[bool]
-	DiskSizeBytes       plugin.TValue[int64]
-	DiskIopsReadWrite   plugin.TValue[int64]
-	DiskMbpsReadWrite   plugin.TValue[int64]
-	DiskIopsReadOnly    plugin.TValue[int64]
-	DiskMbpsReadOnly    plugin.TValue[int64]
-	MaxShares           plugin.TValue[int64]
-	HyperVGeneration    plugin.TValue[string]
-	Tier                plugin.TValue[string]
-	SupportsHibernation plugin.TValue[bool]
-	DiskAccessId        plugin.TValue[string]
-	AvailabilityPolicy  plugin.TValue[any]
-	SystemData          plugin.TValue[any]
+	Id                        plugin.TValue[string]
+	Name                      plugin.TValue[string]
+	Location                  plugin.TValue[string]
+	Tags                      plugin.TValue[map[string]any]
+	Type                      plugin.TValue[string]
+	ManagedBy                 plugin.TValue[string]
+	ManagedByExtended         plugin.TValue[[]any]
+	Zones                     plugin.TValue[[]any]
+	Sku                       plugin.TValue[any]
+	Properties                plugin.TValue[any]
+	NetworkAccessPolicy       plugin.TValue[string]
+	PublicNetworkAccess       plugin.TValue[string]
+	EncryptionType            plugin.TValue[string]
+	DiskEncryptionSetId       plugin.TValue[string]
+	DiskEncryptionSet         plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
+	EncryptionSettingsEnabled plugin.TValue[bool]
+	DataAccessAuthMode        plugin.TValue[string]
+	DiskState                 plugin.TValue[string]
+	ProvisioningState         plugin.TValue[string]
+	TimeCreated               plugin.TValue[*time.Time]
+	UniqueId                  plugin.TValue[string]
+	BurstingEnabled           plugin.TValue[bool]
+	DiskSizeBytes             plugin.TValue[int64]
+	DiskIopsReadWrite         plugin.TValue[int64]
+	DiskMbpsReadWrite         plugin.TValue[int64]
+	DiskIopsReadOnly          plugin.TValue[int64]
+	DiskMbpsReadOnly          plugin.TValue[int64]
+	MaxShares                 plugin.TValue[int64]
+	HyperVGeneration          plugin.TValue[string]
+	Tier                      plugin.TValue[string]
+	SupportsHibernation       plugin.TValue[bool]
+	DiskAccessId              plugin.TValue[string]
+	AvailabilityPolicy        plugin.TValue[any]
+	SystemData                plugin.TValue[any]
 }
 
 // createAzureSubscriptionComputeServiceDisk creates a new instance of this resource
@@ -34326,6 +34369,10 @@ func (c *mqlAzureSubscriptionComputeServiceDisk) GetDiskEncryptionSet() *plugin.
 
 		return c.diskEncryptionSet()
 	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceDisk) GetEncryptionSettingsEnabled() *plugin.TValue[bool] {
+	return &c.EncryptionSettingsEnabled
 }
 
 func (c *mqlAzureSubscriptionComputeServiceDisk) GetDataAccessAuthMode() *plugin.TValue[string] {
@@ -40771,6 +40818,7 @@ type mqlAzureSubscriptionNetworkServiceSecurityGroup struct {
 	Subnets              plugin.TValue[[]any]
 	SecurityRules        plugin.TValue[[]any]
 	DefaultSecurityRules plugin.TValue[[]any]
+	FlowLog              plugin.TValue[*mqlAzureSubscriptionNetworkServiceWatcherFlowlog]
 }
 
 // createAzureSubscriptionNetworkServiceSecurityGroup creates a new instance of this resource
@@ -40899,6 +40947,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetDefaultSecurityRule
 		}
 
 		return c.defaultSecurityRules()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetFlowLog() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceWatcherFlowlog] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceWatcherFlowlog](&c.FlowLog, func() (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.securityGroup", c.__id, "flowLog")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog), nil
+			}
+		}
+
+		return c.flowLog()
 	})
 }
 
@@ -47684,11 +47748,13 @@ type mqlAzureSubscriptionWebServiceAppsiteauthsettings struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionWebServiceAppsiteauthsettingsInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Kind       plugin.TValue[string]
-	Type       plugin.TValue[string]
-	Properties plugin.TValue[any]
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	Kind                        plugin.TValue[string]
+	Type                        plugin.TValue[string]
+	Properties                  plugin.TValue[any]
+	Enabled                     plugin.TValue[bool]
+	UnauthenticatedClientAction plugin.TValue[string]
 }
 
 // createAzureSubscriptionWebServiceAppsiteauthsettings creates a new instance of this resource
@@ -47746,6 +47812,14 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteauthsettings) GetType() *plugin.TV
 
 func (c *mqlAzureSubscriptionWebServiceAppsiteauthsettings) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteauthsettings) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteauthsettings) GetUnauthenticatedClientAction() *plugin.TValue[string] {
+	return &c.UnauthenticatedClientAction
 }
 
 // mqlAzureSubscriptionWebServiceAppsiteconfig for the azure.subscription.webService.appsiteconfig resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -818,6 +818,7 @@ azure.subscription.computeService.disk.diskMbpsReadOnly 11.6.2
 azure.subscription.computeService.disk.diskMbpsReadWrite 11.6.2
 azure.subscription.computeService.disk.diskSizeBytes 11.6.2
 azure.subscription.computeService.disk.diskState 11.6.2
+azure.subscription.computeService.disk.encryptionSettingsEnabled 13.16.2
 azure.subscription.computeService.disk.encryptionType 11.6.1
 azure.subscription.computeService.disk.hyperVGeneration 11.6.2
 azure.subscription.computeService.disk.id 9.0.1
@@ -1020,6 +1021,7 @@ azure.subscription.computeService.snapshot.uniqueId 13.7.1
 azure.subscription.computeService.snapshots 13.7.1
 azure.subscription.computeService.subscriptionId 9.0.1
 azure.subscription.computeService.vm 9.0.1
+azure.subscription.computeService.vm.adeInstalled 13.16.2
 azure.subscription.computeService.vm.adminUsername 11.6.1
 azure.subscription.computeService.vm.amaInstalled 13.12.2
 azure.subscription.computeService.vm.bootDiagnosticsEnabled 13.12.2
@@ -2850,6 +2852,7 @@ azure.subscription.networkService.routeTables 11.4.28
 azure.subscription.networkService.securityGroup 9.0.1
 azure.subscription.networkService.securityGroup.defaultSecurityRules 9.0.1
 azure.subscription.networkService.securityGroup.etag 9.0.1
+azure.subscription.networkService.securityGroup.flowLog 13.16.2
 azure.subscription.networkService.securityGroup.id 9.0.1
 azure.subscription.networkService.securityGroup.interfaces 9.0.1
 azure.subscription.networkService.securityGroup.location 9.0.1
@@ -4275,11 +4278,13 @@ azure.subscription.webService.appsite.virtualNetworkConnections 11.4.32
 azure.subscription.webService.appsite.virtualNetworkSubnet 13.12.2
 azure.subscription.webService.appsite.virtualNetworkSubnetId 13.12.2
 azure.subscription.webService.appsiteauthsettings 9.0.1
+azure.subscription.webService.appsiteauthsettings.enabled 13.16.2
 azure.subscription.webService.appsiteauthsettings.id 9.0.1
 azure.subscription.webService.appsiteauthsettings.kind 9.0.1
 azure.subscription.webService.appsiteauthsettings.name 9.0.1
 azure.subscription.webService.appsiteauthsettings.properties 9.0.1
 azure.subscription.webService.appsiteauthsettings.type 9.0.1
+azure.subscription.webService.appsiteauthsettings.unauthenticatedClientAction 13.16.2
 azure.subscription.webService.appsiteconfig 9.0.1
 azure.subscription.webService.appsiteconfig.alwaysOn 11.4.28
 azure.subscription.webService.appsiteconfig.autoHealEnabled 13.12.2

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -422,6 +422,9 @@ var (
 	dependencyAgentExtensionMatches = map[string][]string{
 		"microsoft.azure.monitoring.dependencyagent": {"DependencyAgentLinux", "DependencyAgentWindows"},
 	}
+	adeExtensionMatches = map[string][]string{
+		"microsoft.azure.security": {"AzureDiskEncryption", "AzureDiskEncryptionForLinux"},
+	}
 )
 
 func (a *mqlAzureSubscriptionComputeServiceVm) mdeInstalled() (bool, error) {
@@ -438,6 +441,10 @@ func (a *mqlAzureSubscriptionComputeServiceVm) omsInstalled() (bool, error) {
 
 func (a *mqlAzureSubscriptionComputeServiceVm) dependencyAgentInstalled() (bool, error) {
 	return a.extensionInstalled(dependencyAgentExtensionMatches)
+}
+
+func (a *mqlAzureSubscriptionComputeServiceVm) adeInstalled() (bool, error) {
+	return a.extensionInstalled(adeExtensionMatches)
 }
 
 func (a *mqlAzureSubscriptionComputeService) disks() ([]any, error) {
@@ -531,6 +538,11 @@ func diskToMql(runtime *plugin.Runtime, disk compute.Disk) (*mqlAzureSubscriptio
 		}
 		args["encryptionType"] = llx.StringDataPtr(stringEnumPtr(encryptionType))
 		args["diskEncryptionSetId"] = llx.StringDataPtr(desID)
+		var encryptionSettingsEnabled *bool
+		if esc := disk.Properties.EncryptionSettingsCollection; esc != nil {
+			encryptionSettingsEnabled = esc.Enabled
+		}
+		args["encryptionSettingsEnabled"] = llx.BoolDataPtr(encryptionSettingsEnabled)
 		args["dataAccessAuthMode"] = llx.StringDataPtr(stringEnumPtr(disk.Properties.DataAccessAuthMode))
 		args["diskState"] = llx.StringDataPtr(stringEnumPtr(disk.Properties.DiskState))
 		args["provisioningState"] = llx.StringDataPtr(disk.Properties.ProvisioningState)

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -411,68 +411,11 @@ func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		type mqlRetentionPolicy struct {
-			Enabled       bool `json:"enabled"`
-			RetentionDays int  `json:"retentionDays"`
-		}
-		type mqlFlowLogAnalytics struct {
-			Enabled             bool   `json:"allowedApplications"`
-			AnalyticsInterval   int    `json:"analyticsInterval"`
-			WorkspaceId         string `json:"workspaceResourceId"`
-			WorkspaceResourceId string `json:"workspaceId"`
-			WorkspaceRegion     string `json:"workspaceRegion"`
-		}
 		for _, flowLog := range page.Value {
-			var retentionPolicy mqlRetentionPolicy
-			if rp := flowLog.Properties.RetentionPolicy; rp != nil {
-				retentionPolicy = mqlRetentionPolicy{
-					Enabled:       convert.ToValue(rp.Enabled),
-					RetentionDays: int(convert.ToValue(rp.Days)),
-				}
+			if flowLog == nil {
+				continue
 			}
-			retentionPolicyDict, err := convert.JsonToDict(retentionPolicy)
-			if err != nil {
-				return nil, err
-			}
-			var flowLogAnalytics mqlFlowLogAnalytics
-			if fac := flowLog.Properties.FlowAnalyticsConfiguration; fac != nil && fac.NetworkWatcherFlowAnalyticsConfiguration != nil {
-				nwfac := fac.NetworkWatcherFlowAnalyticsConfiguration
-				flowLogAnalytics = mqlFlowLogAnalytics{
-					Enabled:             convert.ToValue(nwfac.Enabled),
-					AnalyticsInterval:   int(convert.ToValue(nwfac.TrafficAnalyticsInterval)),
-					WorkspaceRegion:     convert.ToValue(nwfac.WorkspaceRegion),
-					WorkspaceResourceId: convert.ToValue(nwfac.WorkspaceResourceID),
-					WorkspaceId:         convert.ToValue(nwfac.WorkspaceID),
-				}
-			}
-			flowLogAnalyticsDict, err := convert.JsonToDict(flowLogAnalytics)
-			if err != nil {
-				return nil, err
-			}
-			var formatType *string
-			var formatVersion *int32
-			if f := flowLog.Properties.Format; f != nil {
-				formatType = (*string)(f.Type)
-				formatVersion = f.Version
-			}
-			mqlFlowLog, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.watcher.flowlog",
-				map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(flowLog.ID),
-					"name":               llx.StringDataPtr(flowLog.Name),
-					"location":           llx.StringDataPtr(flowLog.Location),
-					"tags":               llx.MapData(convert.PtrMapStrToInterface(flowLog.Tags), types.String),
-					"type":               llx.StringDataPtr(flowLog.Type),
-					"etag":               llx.StringDataPtr(flowLog.Etag),
-					"retentionPolicy":    llx.DictData(retentionPolicyDict),
-					"format":             llx.StringDataPtr(formatType),
-					"version":            llx.IntDataDefault(formatVersion, 0),
-					"enabled":            llx.BoolDataPtr(flowLog.Properties.Enabled),
-					"storageAccountId":   llx.StringDataPtr(flowLog.Properties.StorageID),
-					"targetResourceId":   llx.StringDataPtr(flowLog.Properties.TargetResourceID),
-					"targetResourceGuid": llx.StringDataPtr(flowLog.Properties.TargetResourceGUID),
-					"provisioningState":  llx.StringDataPtr((*string)(flowLog.Properties.ProvisioningState)),
-					"analytics":          llx.DictData(flowLogAnalyticsDict),
-				})
+			mqlFlowLog, err := flowLogToMql(a.MqlRuntime, *flowLog)
 			if err != nil {
 				return nil, err
 			}
@@ -481,6 +424,79 @@ func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
+	type mqlRetentionPolicy struct {
+		Enabled       bool `json:"enabled"`
+		RetentionDays int  `json:"retentionDays"`
+	}
+	type mqlFlowLogAnalytics struct {
+		Enabled             bool   `json:"allowedApplications"`
+		AnalyticsInterval   int    `json:"analyticsInterval"`
+		WorkspaceId         string `json:"workspaceResourceId"`
+		WorkspaceResourceId string `json:"workspaceId"`
+		WorkspaceRegion     string `json:"workspaceRegion"`
+	}
+
+	args := map[string]*llx.RawData{
+		"id":       llx.StringDataPtr(flowLog.ID),
+		"name":     llx.StringDataPtr(flowLog.Name),
+		"location": llx.StringDataPtr(flowLog.Location),
+		"tags":     llx.MapData(convert.PtrMapStrToInterface(flowLog.Tags), types.String),
+		"type":     llx.StringDataPtr(flowLog.Type),
+		"etag":     llx.StringDataPtr(flowLog.Etag),
+	}
+
+	if props := flowLog.Properties; props != nil {
+		var retentionPolicy mqlRetentionPolicy
+		if rp := props.RetentionPolicy; rp != nil {
+			retentionPolicy = mqlRetentionPolicy{
+				Enabled:       convert.ToValue(rp.Enabled),
+				RetentionDays: int(convert.ToValue(rp.Days)),
+			}
+		}
+		retentionPolicyDict, err := convert.JsonToDict(retentionPolicy)
+		if err != nil {
+			return nil, err
+		}
+		var flowLogAnalytics mqlFlowLogAnalytics
+		if fac := props.FlowAnalyticsConfiguration; fac != nil && fac.NetworkWatcherFlowAnalyticsConfiguration != nil {
+			nwfac := fac.NetworkWatcherFlowAnalyticsConfiguration
+			flowLogAnalytics = mqlFlowLogAnalytics{
+				Enabled:             convert.ToValue(nwfac.Enabled),
+				AnalyticsInterval:   int(convert.ToValue(nwfac.TrafficAnalyticsInterval)),
+				WorkspaceRegion:     convert.ToValue(nwfac.WorkspaceRegion),
+				WorkspaceResourceId: convert.ToValue(nwfac.WorkspaceResourceID),
+				WorkspaceId:         convert.ToValue(nwfac.WorkspaceID),
+			}
+		}
+		flowLogAnalyticsDict, err := convert.JsonToDict(flowLogAnalytics)
+		if err != nil {
+			return nil, err
+		}
+		var formatType *string
+		var formatVersion *int32
+		if f := props.Format; f != nil {
+			formatType = (*string)(f.Type)
+			formatVersion = f.Version
+		}
+		args["retentionPolicy"] = llx.DictData(retentionPolicyDict)
+		args["format"] = llx.StringDataPtr(formatType)
+		args["version"] = llx.IntDataDefault(formatVersion, 0)
+		args["enabled"] = llx.BoolDataPtr(props.Enabled)
+		args["storageAccountId"] = llx.StringDataPtr(props.StorageID)
+		args["targetResourceId"] = llx.StringDataPtr(props.TargetResourceID)
+		args["targetResourceGuid"] = llx.StringDataPtr(props.TargetResourceGUID)
+		args["provisioningState"] = llx.StringDataPtr((*string)(props.ProvisioningState))
+		args["analytics"] = llx.DictData(flowLogAnalyticsDict)
+	}
+
+	mqlFlowLog, err := CreateResource(runtime, "azure.subscription.networkService.watcher.flowlog", args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlFlowLog.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkService) loadBalancers() ([]any, error) {
@@ -3778,6 +3794,71 @@ func azureSecGroupToMql(runtime *plugin.Runtime, secGroup network.SecurityGroup)
 	mqlSecGroup := res.(*mqlAzureSubscriptionNetworkServiceSecurityGroup)
 	mqlSecGroup.cacheProperties = secGroup.Properties
 	return mqlSecGroup, nil
+}
+
+// flowLog resolves the Network Watcher flow log whose target resource is this
+// NSG. Flow logs are child resources of Network Watchers, so this enumerates
+// the subscription's watchers and matches each watcher's flow logs against the
+// NSG id. Returns null when no flow log targets the NSG.
+func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) flowLog() (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	nsgID := a.Id.Data
+	resourceID, err := ParseResourceID(nsgID)
+	if err != nil {
+		return nil, err
+	}
+	subId := resourceID.SubscriptionID
+
+	watchersClient, err := network.NewWatchersClient(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	flowLogsClient, err := network.NewFlowLogsClient(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	watcherPager := watchersClient.NewListAllPager(&network.WatchersClientListAllOptions{})
+	for watcherPager.More() {
+		page, err := watcherPager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, watcher := range page.Value {
+			if watcher == nil || watcher.ID == nil || watcher.Name == nil {
+				continue
+			}
+			watcherID, err := ParseResourceID(*watcher.ID)
+			if err != nil {
+				return nil, err
+			}
+			flowLogPager := flowLogsClient.NewListPager(watcherID.ResourceGroup, *watcher.Name, &network.FlowLogsClientListOptions{})
+			for flowLogPager.More() {
+				flowLogPage, err := flowLogPager.NextPage(ctx)
+				if err != nil {
+					return nil, err
+				}
+				for _, flowLog := range flowLogPage.Value {
+					if flowLog == nil || flowLog.Properties == nil || flowLog.Properties.TargetResourceID == nil {
+						continue
+					}
+					if strings.EqualFold(*flowLog.Properties.TargetResourceID, nsgID) {
+						return flowLogToMql(a.MqlRuntime, *flowLog)
+					}
+				}
+			}
+		}
+	}
+
+	// no flow log targets this NSG
+	a.FlowLog.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) interfaces() ([]any, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -3797,68 +3798,113 @@ func azureSecGroupToMql(runtime *plugin.Runtime, secGroup network.SecurityGroup)
 }
 
 // flowLog resolves the Network Watcher flow log whose target resource is this
-// NSG. Flow logs are child resources of Network Watchers, so this enumerates
-// the subscription's watchers and matches each watcher's flow logs against the
-// NSG id. Returns null when no flow log targets the NSG.
+// NSG. Flow logs are child resources of Network Watchers, so rather than
+// enumerating every watcher for each NSG (an N+1 problem when querying
+// `securityGroups { flowLog }`), it resolves the per-subscription
+// networkService singleton and reuses its cached watcher→flow-log index.
+// Returns null when no flow log targets the NSG.
 func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) flowLog() (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	nsgID := a.Id.Data
 	resourceID, err := ParseResourceID(nsgID)
 	if err != nil {
 		return nil, err
 	}
-	subId := resourceID.SubscriptionID
 
-	watchersClient, err := network.NewWatchersClient(subId, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
+	netRes, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService", map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(resourceID.SubscriptionID),
 	})
 	if err != nil {
 		return nil, err
 	}
-	flowLogsClient, err := network.NewFlowLogsClient(subId, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
+	netService := netRes.(*mqlAzureSubscriptionNetworkService)
+
+	index, err := netService.flowLogIndexByTargetResourceId()
 	if err != nil {
 		return nil, err
 	}
-
-	watcherPager := watchersClient.NewListAllPager(&network.WatchersClientListAllOptions{})
-	for watcherPager.More() {
-		page, err := watcherPager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, watcher := range page.Value {
-			if watcher == nil || watcher.ID == nil || watcher.Name == nil {
-				continue
-			}
-			watcherID, err := ParseResourceID(*watcher.ID)
-			if err != nil {
-				return nil, err
-			}
-			flowLogPager := flowLogsClient.NewListPager(watcherID.ResourceGroup, *watcher.Name, &network.FlowLogsClientListOptions{})
-			for flowLogPager.More() {
-				flowLogPage, err := flowLogPager.NextPage(ctx)
-				if err != nil {
-					return nil, err
-				}
-				for _, flowLog := range flowLogPage.Value {
-					if flowLog == nil || flowLog.Properties == nil || flowLog.Properties.TargetResourceID == nil {
-						continue
-					}
-					if strings.EqualFold(*flowLog.Properties.TargetResourceID, nsgID) {
-						return flowLogToMql(a.MqlRuntime, *flowLog)
-					}
-				}
-			}
-		}
+	if flowLog, ok := index[strings.ToLower(nsgID)]; ok {
+		return flowLog, nil
 	}
 
 	// no flow log targets this NSG
 	a.FlowLog.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceInternal struct {
+	flowLogIndexOnce sync.Once
+	flowLogIndex     map[string]*mqlAzureSubscriptionNetworkServiceWatcherFlowlog
+	flowLogIndexErr  error
+}
+
+// flowLogIndexByTargetResourceId lazily builds, once per networkService
+// instance, a map from a (lowercased) target resource id to the Network Watcher
+// flow log that targets it. The subscription's watchers and their flow logs are
+// enumerated a single time so that per-NSG lookups are in-memory.
+func (a *mqlAzureSubscriptionNetworkService) flowLogIndexByTargetResourceId() (map[string]*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
+	a.flowLogIndexOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		ctx := context.Background()
+		token := conn.Token()
+		subId := a.SubscriptionId.Data
+
+		index := map[string]*mqlAzureSubscriptionNetworkServiceWatcherFlowlog{}
+
+		watchersClient, err := network.NewWatchersClient(subId, token, &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.flowLogIndexErr = err
+			return
+		}
+		flowLogsClient, err := network.NewFlowLogsClient(subId, token, &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.flowLogIndexErr = err
+			return
+		}
+
+		watcherPager := watchersClient.NewListAllPager(&network.WatchersClientListAllOptions{})
+		for watcherPager.More() {
+			page, err := watcherPager.NextPage(ctx)
+			if err != nil {
+				a.flowLogIndexErr = err
+				return
+			}
+			for _, watcher := range page.Value {
+				if watcher == nil || watcher.ID == nil || watcher.Name == nil {
+					continue
+				}
+				watcherID, err := ParseResourceID(*watcher.ID)
+				if err != nil {
+					a.flowLogIndexErr = err
+					return
+				}
+				flowLogPager := flowLogsClient.NewListPager(watcherID.ResourceGroup, *watcher.Name, &network.FlowLogsClientListOptions{})
+				for flowLogPager.More() {
+					flowLogPage, err := flowLogPager.NextPage(ctx)
+					if err != nil {
+						a.flowLogIndexErr = err
+						return
+					}
+					for _, flowLog := range flowLogPage.Value {
+						if flowLog == nil || flowLog.Properties == nil || flowLog.Properties.TargetResourceID == nil {
+							continue
+						}
+						mqlFlowLog, err := flowLogToMql(a.MqlRuntime, *flowLog)
+						if err != nil {
+							a.flowLogIndexErr = err
+							return
+						}
+						index[strings.ToLower(*flowLog.Properties.TargetResourceID)] = mqlFlowLog
+					}
+				}
+			}
+		}
+		a.flowLogIndex = index
+	})
+	return a.flowLogIndex, a.flowLogIndexErr
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) interfaces() ([]any, error) {

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -895,13 +895,22 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) authenticationSettings() (*mqlAz
 		return nil, err
 	}
 
+	var enabled *bool
+	var unauthenticatedClientAction *string
+	if configuration.Properties != nil {
+		enabled = configuration.Properties.Enabled
+		unauthenticatedClientAction = (*string)(configuration.Properties.UnauthenticatedClientAction)
+	}
+
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteauthsettings,
 		map[string]*llx.RawData{
-			"id":         llx.StringDataPtr(configuration.ID),
-			"name":       llx.StringDataPtr(configuration.Name),
-			"kind":       llx.StringDataPtr(configuration.Kind),
-			"type":       llx.StringDataPtr(configuration.Type),
-			"properties": llx.DictData(properties),
+			"id":                          llx.StringDataPtr(configuration.ID),
+			"name":                        llx.StringDataPtr(configuration.Name),
+			"kind":                        llx.StringDataPtr(configuration.Kind),
+			"type":                        llx.StringDataPtr(configuration.Type),
+			"properties":                  llx.DictData(properties),
+			"enabled":                     llx.BoolDataPtr(enabled),
+			"unauthenticatedClientAction": llx.StringDataPtr(unauthenticatedClientAction),
 		})
 	if err != nil {
 		return nil, err
@@ -1212,21 +1221,27 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) authenticationSettings() (*mqlAz
 	}
 
 	properties := map[string]any{}
+	var enabled *bool
+	var unauthenticatedClientAction *string
 	if configuration.Properties != nil {
 		props, err := convert.JsonToDict(configuration.Properties)
 		if err != nil {
 			return nil, err
 		}
 		properties = props
+		enabled = configuration.Properties.Enabled
+		unauthenticatedClientAction = (*string)(configuration.Properties.UnauthenticatedClientAction)
 	}
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteauthsettings,
 		map[string]*llx.RawData{
-			"id":         llx.StringDataPtr(configuration.ID),
-			"name":       llx.StringDataPtr(configuration.Name),
-			"kind":       llx.StringDataPtr(configuration.Kind),
-			"type":       llx.StringDataPtr(configuration.Type),
-			"properties": llx.DictData(properties),
+			"id":                          llx.StringDataPtr(configuration.ID),
+			"name":                        llx.StringDataPtr(configuration.Name),
+			"kind":                        llx.StringDataPtr(configuration.Kind),
+			"type":                        llx.StringDataPtr(configuration.Type),
+			"properties":                  llx.DictData(properties),
+			"enabled":                     llx.BoolDataPtr(enabled),
+			"unauthenticatedClientAction": llx.StringDataPtr(unauthenticatedClientAction),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Improves existing **azure** provider resources to better surface security posture, targeting gaps against the CIS Microsoft Azure Foundations Benchmark. No new services — these fill in fields/accessors that audits need on resources we already model.

### Compute — observed disk encryption *state* (CIS §7)
The provider already exposes encryption *configuration* (`encryptionAtHost`, disk `encryptionType`, `diskEncryptionSetId`). These add the missing *state* signals for guest-based Azure Disk Encryption (ADE):

- `azure.subscription.computeService.vm.adeInstalled()` — whether the Azure Disk Encryption extension (BitLocker / dm-crypt) is installed, mirroring the existing `mdeInstalled` / `amaInstalled` extension-detection family.
- `azure.subscription.computeService.disk.encryptionSettingsEnabled` — whether guest-based ADE encryption settings are configured on the disk, independent of `encryptionType` (server-side SSE with a platform or customer-managed key).

### App Service — Easy Auth (CIS §9)
`appsiteauthsettings` previously only exposed a generic `properties` dict. Added typed fields so auth posture is directly assertable:

- `enabled` — whether App Service Authentication / Authorization is on.
- `unauthenticatedClientAction` — what happens to unauthenticated requests (AllowAnonymous / RedirectToLoginPage / Show401 / Show403).

Wired into both the site and deployment-slot auth-settings paths.

### Networking — NSG-to-flow-log link (CIS §6.5)
Network Watcher and flow logs are already modeled, but checking a given NSG's flow-log status meant traversing every watcher. Added:

- `azure.subscription.networkService.securityGroup.flowLog()` — resolves the Network Watcher flow log targeting this NSG (enabled + retention), or null when none. The flow-log mapping is refactored into a shared `flowLogToMql` helper reused by `watcher.flowLogs()`.

To avoid an N+1 (re-enumerating every watcher per NSG), the watcher→flow-log index is built once per subscription and cached on the `networkService` singleton (guarded by `sync.Once`); each NSG resolves that singleton and does an in-memory lookup by target resource id.

## Notes
- New `.lr.versions` entries stamp to `13.16.2` (provider is at `13.16.1`).
- `azure.permissions.json` is unchanged — no new API surface (Watchers/FlowLogs list calls were already used by `watchers()` / `watcher.flowLogs()`).

## Verification
Built, installed, and run live against the **CIS Development** subscription:
- `compute.vms { adeInstalled mdeInstalled }` → `adeInstalled` resolves; `mdeInstalled: true` cross-checks extension detection.
- `compute.disks.first { encryptionType encryptionSettingsEnabled }` → resolves (null for a CMK/SSE disk — correct, no guest ADE).
- `network.securityGroups { flowLog { ... } }` → null on every NSG, confirmed correct (the subscription has zero flow logs configured; positive path reuses the proven `flowLogToMql` helper). Re-verified after the caching change.
- `web.apps { authenticationSettings { enabled unauthenticatedClientAction } }` → `enabled: true` on the test web app.
