### PR TITLE
✨ Expose Graph GUID id on ms365 countryNamedLocation

### DIFF
--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -101,10 +101,6 @@ func (a *mqlMicrosoftConditionalAccessNamedLocations) ipLocations() ([]any, erro
 	return locationDetails, nil
 }
 
-func (m *mqlMicrosoftConditionalAccessCountryNamedLocation) id() (string, error) {
-	return m.Name.Data, nil
-}
-
 func (a *mqlMicrosoftConditionalAccessNamedLocations) countryLocations() ([]any, error) {
 	namedLocations, err := a.loadNamedLocations()
 	if err != nil {
@@ -126,6 +122,8 @@ func (a *mqlMicrosoftConditionalAccessNamedLocations) countryLocations() ([]any,
 			if displayName != nil && lookupMethodStr != nil {
 				locationInfo, err := CreateResource(a.MqlRuntime, "microsoft.conditionalAccess.countryNamedLocation",
 					map[string]*llx.RawData{
+						"__id":         llx.StringDataPtr(countryLocation.GetId()),
+						"id":           llx.StringDataPtr(countryLocation.GetId()),
 						"name":         llx.StringDataPtr(displayName),
 						"lookupMethod": llx.StringDataPtr(lookupMethodStr),
 					})

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -833,9 +833,12 @@ microsoft.conditionalAccess.ipNamedLocation @defaults("id name trusted") {
 // Microsoft Entra Conditional Access Country Named Location
 //
 // Examine a country or region-based named location used in conditional access
-// policy conditions. Exposes the `name` and `lookupMethod` that determines
-// how the country is resolved (by IP address or GPS coordinates).
-microsoft.conditionalAccess.countryNamedLocation @defaults("name lookupMethod") {
+// policy conditions. Exposes the `id` used to reference the location in policy
+// include/exclude location lists, the `name`, and the `lookupMethod` that
+// determines how the country is resolved (by IP address or GPS coordinates).
+microsoft.conditionalAccess.countryNamedLocation @defaults("id name lookupMethod") {
+  // Named location ID
+  id string
   // Named location name
   name string
   // Method to determine the country location

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1706,6 +1706,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.conditionalAccess.ipNamedLocation.modifiedDateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessIpNamedLocation).GetModifiedDateTime()).ToDataRes(types.Time)
 	},
+	"microsoft.conditionalAccess.countryNamedLocation.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessCountryNamedLocation).GetId()).ToDataRes(types.String)
+	},
 	"microsoft.conditionalAccess.countryNamedLocation.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessCountryNamedLocation).GetName()).ToDataRes(types.String)
 	},
@@ -6607,6 +6610,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.conditionalAccess.countryNamedLocation.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftConditionalAccessCountryNamedLocation).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.conditionalAccess.countryNamedLocation.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessCountryNamedLocation).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.conditionalAccess.countryNamedLocation.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15868,6 +15875,7 @@ type mqlMicrosoftConditionalAccessCountryNamedLocation struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftConditionalAccessCountryNamedLocationInternal it will be used here
+	Id           plugin.TValue[string]
 	Name         plugin.TValue[string]
 	LookupMethod plugin.TValue[string]
 }
@@ -15883,12 +15891,7 @@ func createMicrosoftConditionalAccessCountryNamedLocation(runtime *plugin.Runtim
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.conditionalAccess.countryNamedLocation", res.__id)
@@ -15907,6 +15910,10 @@ func (c *mqlMicrosoftConditionalAccessCountryNamedLocation) MqlName() string {
 
 func (c *mqlMicrosoftConditionalAccessCountryNamedLocation) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlMicrosoftConditionalAccessCountryNamedLocation) GetId() *plugin.TValue[string] {
+	return &c.Id
 }
 
 func (c *mqlMicrosoftConditionalAccessCountryNamedLocation) GetName() *plugin.TValue[string] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -130,6 +130,7 @@ microsoft.conditionalAccess.authenticationMethodsPolicy.id 11.1.41
 microsoft.conditionalAccess.authenticationMethodsPolicy.lastModifiedDateTime 11.1.41
 microsoft.conditionalAccess.authenticationMethodsPolicy.policyVersion 11.1.41
 microsoft.conditionalAccess.countryNamedLocation 11.0.46
+microsoft.conditionalAccess.countryNamedLocation.id 13.5.1
 microsoft.conditionalAccess.countryNamedLocation.lookupMethod 11.0.46
 microsoft.conditionalAccess.countryNamedLocation.name 11.0.46
 microsoft.conditionalAccess.ipNamedLocation 11.0.34


### PR DESCRIPTION
## Summary

`microsoft.conditionalAccess.countryNamedLocation` exposed only `name` and `lookupMethod`. The underlying Microsoft Graph object carries a GUID `id` — country named locations derive from the same `namedLocation` base type as IP named locations — but the provider discarded it: `countryLocations()` never called `GetId()`, and the synthetic `id()` returned the display name instead.

Conditional Access policies reference locations by **GUID** in `conditions.locations.includeLocations` / `excludeLocations`. Without the country location's GUID, MQL can't correlate country-based named locations with a policy's location conditions — blocking checks for country-/geography-based CA policies (e.g. CIS Microsoft 365 Foundations Benchmark v7.0.0 control `5.2.2.15`).

This mirrors the IP path, which already maps the GUID to both `__id` and `id`.

## Changes

- Add `id string` to `microsoft.conditionalAccess.countryNamedLocation` in `ms365.lr` (and to `@defaults`).
- In `countryLocations()`, set both `__id` and `id` from `countryLocation.GetId()`; remove the display-name-derived synthetic `id()` method.
- Regenerate `ms365.lr.go` bindings; add the `.lr.versions` entry (`13.5.1`).

This enables MQL such as:

```mql
countryIds = microsoft.conditionalAccess.namedLocations.countryLocations.map(id)
microsoft.conditionalAccess.policies.any(
  state == "enabled" &&
  conditions.locations.includeLocations.any(_.in(countryIds)) &&
  grantControls.builtInControls.contains("block")
)
```

## Verification

- `go build ./...` (ms365 module) passes; `gofmt` clean; `go vet` clean for the changed file (two pre-existing `users.go` warnings are unrelated).
- Generated bindings regenerated and reviewed: new `Id`/`GetId()` on `mqlMicrosoftConditionalAccessCountryNamedLocation`, and `createMicrosoftConditionalAccessCountryNamedLocation` no longer derives `__id` from the name.
- Ran live against a test tenant — the query executes cleanly (the tenant has no named locations configured, so results are empty; no panic from the removed `id()` path). Populating a country named location to confirm the GUID requires `Policy.ReadWrite.ConditionalAccess`, which the available app registration lacks, so live data verification of a non-empty result wasn't possible — but the mapping is identical to the already-shipped IP path.

This is a thin Graph wrapper with no existing conditional-access test harness in the provider (all ms365 tests are pure helper-function unit tests); consistent with the repo's convention that such resources are verified interactively rather than with synthetic Go tests.

Fixes #8072