### PR TITLE
✨ Add windows.eventlog resource for Event Log channel policy (#8059)

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6289,6 +6289,32 @@ private windows.optionalFeature @defaults("name") {
   state int
 }
 
+// Windows Event Log channel configuration
+//
+// Examine the size and retention policy of a single Windows Event Log
+// channel. The `name` field selects the channel as it appears under the
+// EventLog registry tree — for example `windows.eventlog(name: "Security")`
+// or `windows.eventlog(name: "Application")`. `maxSizeKB` reports the
+// maximum log file size in KB and `retention` decodes how the channel
+// behaves when that size is reached. Each field resolves the Group Policy
+// value first, then the effective channel configuration, and finally the
+// documented Windows default when neither is set.
+windows.eventlog @defaults("name") {
+  init(name string)
+  // Event Log channel name (for example Application, Security, Setup, or System)
+  name string
+  // Maximum log file size in KB (MaxSize)
+  maxSizeKB() int
+  // Retention behavior when the log reaches its maximum size
+  //
+  // One of "overwrite_as_needed" (Retention 0), "overwrite_by_days" (a
+  // positive retention period in seconds), or "never_overwrite" (Retention
+  // 4294967295 or -1).
+  retention() string
+  // Whether the channel overwrites events as needed when full (Retention 0)
+  overwriteAsNeeded() bool
+}
+
 // Windows Remote Desktop / Terminal Services configuration
 //
 // Examine the effective Remote Desktop (Terminal Services) policy posture:

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -317,6 +317,7 @@ const (
 	ResourceWindowsUpdateConfig           string = "windows.update.config"
 	ResourceWindowsServerFeature          string = "windows.serverFeature"
 	ResourceWindowsOptionalFeature        string = "windows.optionalFeature"
+	ResourceWindowsEventlog               string = "windows.eventlog"
 	ResourceWindowsRdp                    string = "windows.rdp"
 	ResourceWindowsFirewall               string = "windows.firewall"
 	ResourceWindowsFirewallProfile        string = "windows.firewall.profile"
@@ -1633,6 +1634,10 @@ func init() {
 		"windows.optionalFeature": {
 			Init:   initWindowsOptionalFeature,
 			Create: createWindowsOptionalFeature,
+		},
+		"windows.eventlog": {
+			Init:   initWindowsEventlog,
+			Create: createWindowsEventlog,
 		},
 		"windows.rdp": {
 			// to override args, implement: initWindowsRdp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -7628,6 +7633,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.optionalFeature.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsOptionalFeature).GetState()).ToDataRes(types.Int)
+	},
+	"windows.eventlog.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsEventlog).GetName()).ToDataRes(types.String)
+	},
+	"windows.eventlog.maxSizeKB": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsEventlog).GetMaxSizeKB()).ToDataRes(types.Int)
+	},
+	"windows.eventlog.retention": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsEventlog).GetRetention()).ToDataRes(types.String)
+	},
+	"windows.eventlog.overwriteAsNeeded": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsEventlog).GetOverwriteAsNeeded()).ToDataRes(types.Bool)
 	},
 	"windows.rdp.networkLevelAuthentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsRdp).GetNetworkLevelAuthentication()).ToDataRes(types.Bool)
@@ -18049,6 +18066,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.optionalFeature.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsOptionalFeature).State, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.eventlog.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsEventlog).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.eventlog.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsEventlog).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.eventlog.maxSizeKB": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsEventlog).MaxSizeKB, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.eventlog.retention": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsEventlog).Retention, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.eventlog.overwriteAsNeeded": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsEventlog).OverwriteAsNeeded, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.rdp.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48097,6 +48134,76 @@ func (c *mqlWindowsOptionalFeature) GetEnabled() *plugin.TValue[bool] {
 
 func (c *mqlWindowsOptionalFeature) GetState() *plugin.TValue[int64] {
 	return &c.State
+}
+
+// mqlWindowsEventlog for the windows.eventlog resource
+type mqlWindowsEventlog struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlWindowsEventlogInternal
+	Name              plugin.TValue[string]
+	MaxSizeKB         plugin.TValue[int64]
+	Retention         plugin.TValue[string]
+	OverwriteAsNeeded plugin.TValue[bool]
+}
+
+// createWindowsEventlog creates a new instance of this resource
+func createWindowsEventlog(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsEventlog{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.eventlog", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsEventlog) MqlName() string {
+	return "windows.eventlog"
+}
+
+func (c *mqlWindowsEventlog) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsEventlog) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlWindowsEventlog) GetMaxSizeKB() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.MaxSizeKB, func() (int64, error) {
+		return c.maxSizeKB()
+	})
+}
+
+func (c *mqlWindowsEventlog) GetRetention() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Retention, func() (string, error) {
+		return c.retention()
+	})
+}
+
+func (c *mqlWindowsEventlog) GetOverwriteAsNeeded() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.OverwriteAsNeeded, func() (bool, error) {
+		return c.overwriteAsNeeded()
+	})
 }
 
 // mqlWindowsRdp for the windows.rdp resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2624,6 +2624,11 @@ windows.bitlocker.volume.protectionStatus 9.0.1
 windows.bitlocker.volume.version 9.0.1
 windows.bitlocker.volumes 9.0.1
 windows.computerInfo 9.0.1
+windows.eventlog 13.22.2
+windows.eventlog.maxSizeKB 13.22.2
+windows.eventlog.name 13.22.2
+windows.eventlog.overwriteAsNeeded 13.22.2
+windows.eventlog.retention 13.22.2
 windows.firewall 9.0.1
 windows.firewall.profile 9.0.1
 windows.firewall.profile.allowInboundRules 9.0.1

--- a/providers/os/resources/windows_eventlog.go
+++ b/providers/os/resources/windows_eventlog.go
@@ -1,0 +1,216 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/registry"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+// Registry locations that back an Event Log channel policy. A value enforced
+// through Group Policy (the policy path) overrides the channel's effective
+// configuration; when neither is set the documented Windows default applies.
+const (
+	eventlogPolicyPathFmt  = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\EventLog\%s`
+	eventlogServicePathFmt = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\EventLog\%s`
+)
+
+// Decoded Retention behaviors.
+const (
+	retentionOverwriteAsNeeded = "overwrite_as_needed"
+	retentionOverwriteByDays   = "overwrite_by_days"
+	retentionNeverOverwrite    = "never_overwrite"
+)
+
+// neverOverwriteRetention is the Retention sentinel (0xFFFFFFFF) that selects
+// "do not overwrite events"; it can also appear as -1 from a signed reading.
+const neverOverwriteRetention int64 = 0xFFFFFFFF
+
+// eventlogDefaultMaxSizeKB is the modern Windows default for the classic
+// channels (20 MB) used when no policy or effective value is configured.
+const eventlogDefaultMaxSizeKB int64 = 20480
+
+type mqlWindowsEventlogInternal struct {
+	lock    sync.Mutex
+	loaded  atomic.Bool
+	loadErr error
+	// each map is value name (lower-cased) -> registry item for one key
+	policy  map[string]registry.RegistryKeyItem
+	service map[string]registry.RegistryKeyItem
+}
+
+func (w *mqlWindowsEventlog) id() (string, error) {
+	return "windows.eventlog/" + w.Name.Data, nil
+}
+
+func initWindowsEventlog(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// the channel is selected purely by name; the field accessors read the
+	// registry lazily, so there is nothing to pre-fetch here
+	return args, nil, nil
+}
+
+// readKey reads a single registry key and returns its values keyed by the
+// lower-cased value name. A missing key yields an empty map rather than an
+// error, so resolution can fall through to the next source or the default.
+func (w *mqlWindowsEventlog) readKey(path string) (map[string]registry.RegistryKeyItem, error) {
+	o, err := CreateResource(w.MqlRuntime, "registrykey", map[string]*llx.RawData{
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := o.(*mqlRegistrykey).getEntries()
+	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			return map[string]registry.RegistryKeyItem{}, nil
+		}
+		return nil, err
+	}
+
+	res := make(map[string]registry.RegistryKeyItem, len(entries))
+	for i := range entries {
+		res[strings.ToLower(entries[i].Key)] = entries[i]
+	}
+	return res, nil
+}
+
+// load reads the policy and effective registry keys exactly once and caches
+// them so every field shares a single set of registry reads.
+func (w *mqlWindowsEventlog) load() error {
+	if w.loaded.Load() {
+		return nil
+	}
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if w.loaded.Load() || w.loadErr != nil {
+		return w.loadErr
+	}
+
+	policy, err := w.readKey(fmt.Sprintf(eventlogPolicyPathFmt, w.Name.Data))
+	if err != nil {
+		w.loadErr = err
+		return err
+	}
+	service, err := w.readKey(fmt.Sprintf(eventlogServicePathFmt, w.Name.Data))
+	if err != nil {
+		w.loadErr = err
+		return err
+	}
+
+	w.policy = policy
+	w.service = service
+	w.loaded.Store(true)
+	return nil
+}
+
+// registryItemInt extracts an int64 from a registry item, accepting both the
+// DWORD form (effective channel config) and the string form ("0", "0xFFFFFFFF")
+// that the Group Policy keys use.
+func registryItemInt(item registry.RegistryKeyItem) (int64, bool) {
+	switch v := item.GetRawValue().(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return 0, false
+		}
+		// base 0 handles 0x-prefixed hex and plain decimal, including -1
+		if n, err := strconv.ParseInt(s, 0, 64); err == nil {
+			return n, true
+		}
+		if n, err := strconv.ParseUint(s, 0, 64); err == nil {
+			return int64(n), true
+		}
+	}
+	return 0, false
+}
+
+func (w *mqlWindowsEventlog) maxSizeKB() (int64, error) {
+	if err := w.load(); err != nil {
+		return 0, err
+	}
+	// the Group Policy MaxSize is already expressed in KB
+	if n, ok := lookupInt(w.policy, "maxsize"); ok {
+		return n, nil
+	}
+	// the effective Services\EventLog MaxSize is in bytes
+	if n, ok := lookupInt(w.service, "maxsize"); ok {
+		return n / 1024, nil
+	}
+	return eventlogDefaultMaxSizeKB, nil
+}
+
+// retentionRaw returns the effective Retention value (policy wins) and whether
+// it was set in either source.
+func (w *mqlWindowsEventlog) retentionRaw() (int64, bool, error) {
+	if err := w.load(); err != nil {
+		return 0, false, err
+	}
+	if n, ok := lookupInt(w.policy, "retention"); ok {
+		return n, true, nil
+	}
+	if n, ok := lookupInt(w.service, "retention"); ok {
+		return n, true, nil
+	}
+	return 0, false, nil
+}
+
+func (w *mqlWindowsEventlog) retention() (string, error) {
+	n, ok, err := w.retentionRaw()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		// Windows overwrites events as needed by default
+		return retentionOverwriteAsNeeded, nil
+	}
+	return decodeRetention(n), nil
+}
+
+// decodeRetention maps a Retention value to a human-readable behavior. The
+// encoding is shared by the modern Group Policy form (0 / 0xFFFFFFFF) and the
+// legacy seconds form (0 = as needed, 0xFFFFFFFF / -1 = never, N = by days).
+func decodeRetention(n int64) string {
+	switch {
+	case n == 0:
+		return retentionOverwriteAsNeeded
+	case n < 0 || n == neverOverwriteRetention:
+		return retentionNeverOverwrite
+	default:
+		return retentionOverwriteByDays
+	}
+}
+
+func (w *mqlWindowsEventlog) overwriteAsNeeded() (bool, error) {
+	n, ok, err := w.retentionRaw()
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return true, nil
+	}
+	return n == 0, nil
+}
+
+// lookupInt returns the int64 value of a registry item from the given key map.
+func lookupInt(items map[string]registry.RegistryKeyItem, name string) (int64, bool) {
+	item, ok := items[name]
+	if !ok {
+		return 0, false
+	}
+	return registryItemInt(item)
+}

--- a/providers/os/resources/windows_eventlog_internal_test.go
+++ b/providers/os/resources/windows_eventlog_internal_test.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers/os/registry"
+)
+
+func dwordItem(key string, n int64) registry.RegistryKeyItem {
+	return registry.RegistryKeyItem{Key: key, Value: registry.RegistryKeyValue{Kind: registry.DWORD, Number: n}}
+}
+
+func szItem(key, s string) registry.RegistryKeyItem {
+	return registry.RegistryKeyItem{Key: key, Value: registry.RegistryKeyValue{Kind: registry.SZ, String: s}}
+}
+
+func TestRegistryItemInt(t *testing.T) {
+	t.Run("DWORD value", func(t *testing.T) {
+		n, ok := registryItemInt(dwordItem("MaxSize", 196608))
+		assert.True(t, ok)
+		assert.Equal(t, int64(196608), n)
+	})
+
+	t.Run("string decimal (Group Policy form)", func(t *testing.T) {
+		n, ok := registryItemInt(szItem("Retention", "0"))
+		assert.True(t, ok)
+		assert.Equal(t, int64(0), n)
+	})
+
+	t.Run("string hex 0xFFFFFFFF", func(t *testing.T) {
+		n, ok := registryItemInt(szItem("Retention", "0xFFFFFFFF"))
+		assert.True(t, ok)
+		assert.Equal(t, int64(0xFFFFFFFF), n)
+	})
+
+	t.Run("string -1", func(t *testing.T) {
+		n, ok := registryItemInt(szItem("Retention", "-1"))
+		assert.True(t, ok)
+		assert.Equal(t, int64(-1), n)
+	})
+
+	t.Run("non-numeric string", func(t *testing.T) {
+		_, ok := registryItemInt(szItem("Retention", "nope"))
+		assert.False(t, ok)
+	})
+}
+
+func TestDecodeRetention(t *testing.T) {
+	assert.Equal(t, retentionOverwriteAsNeeded, decodeRetention(0))
+	assert.Equal(t, retentionNeverOverwrite, decodeRetention(0xFFFFFFFF))
+	assert.Equal(t, retentionNeverOverwrite, decodeRetention(-1))
+	// a positive seconds value (legacy "overwrite by days")
+	assert.Equal(t, retentionOverwriteByDays, decodeRetention(604800))
+}
+
+func TestLookupInt(t *testing.T) {
+	items := map[string]registry.RegistryKeyItem{
+		"maxsize":   dwordItem("MaxSize", 32768),
+		"retention": szItem("Retention", "0"),
+	}
+
+	n, ok := lookupInt(items, "maxsize")
+	assert.True(t, ok)
+	assert.Equal(t, int64(32768), n)
+
+	_, ok = lookupInt(items, "missing")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Adds a `windows.eventlog(name)` resource exposing per-channel Event Log policy settings (max size, retention behavior) as typed fields. Closes #8059.

Today `mondoo-windows-security` has eight checks across four channels (Application, Security, Setup, System) that each read raw registry values under `...\EventLog\<channel>` — the channel name is buried in a long repeated path, and `Retention` is a magic value whose meaning isn't visible in the query. This resource makes those self-documenting.

This follows the same pattern as the `windows.rdp` resource (#8212).

## Behavior

`windows.eventlog(name)` selects a channel and resolves each field in precedence order:

1. **Group Policy** — `HKLM\SOFTWARE\Policies\Microsoft\Windows\EventLog\<name>`
2. **Effective channel config** — `HKLM\SYSTEM\CurrentControlSet\Services\EventLog\<name>`
3. **Documented Windows default**

Reads go through the existing `registrykey` resource (local-native and remote-over-PowerShell), and a missing key falls back gracefully (`codes.NotFound` → empty) instead of erroring.

**Modern + legacy support.** `maxSizeKB` normalizes the policy value (already KB) and the legacy `Services` value (bytes → KB). `retention` / `overwriteAsNeeded` decode the `Retention` value into a human-readable form, accepting both the modern Group Policy string form (`"0"` / `"0xFFFFFFFF"`) and the legacy DWORD seconds form:

| Retention value | Decoded |
|---|---|
| `0` | `overwrite_as_needed` |
| positive (seconds) | `overwrite_by_days` |
| `4294967295` (0xFFFFFFFF) / `-1` | `never_overwrite` |

## Fields

| Field | Type | Source value | Default |
|---|---|---|---|
| `name` | string | (selection key) | — |
| `maxSizeKB` | int | MaxSize | 20480 (20 MB) |
| `retention` | string | Retention (decoded) | `overwrite_as_needed` |
| `overwriteAsNeeded` | bool | Retention == 0 | true |

## Example queries

```mql
windows.eventlog("Security").maxSizeKB >= 196608
windows.eventlog("Security").overwriteAsNeeded        // Retention == 0
windows.eventlog("Application").maxSizeKB >= 32768
windows.eventlog("System").retention == "never_overwrite"
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (resource registered in `os.resources.json`).
- Unit tests cover `registryItemInt` (DWORD, string decimal/hex/`-1`, non-numeric), `decodeRetention` (all three states), and `lookupInt`.
- Not verified against live infrastructure — no Windows test box available — so the parsing/decoding logic is covered by unit tests. No new IAM permissions (reads reuse the existing `registrykey`/`command` resources).