### PR TITLE
✨ Add windows.tpm resource (#8057)

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6333,6 +6333,29 @@ windows.rdp {
   maxDisconnectionTimeMs() int
 }
 
+// Windows Trusted Platform Module (TPM)
+//
+// Examine the Trusted Platform Module state: whether a TPM is present,
+// ready for use, enabled, and activated, along with its major specification
+// version and manufacturer version string. Presence and a 2.0 specification
+// version are prerequisites for Windows 11 readiness and several BitLocker
+// and device-health controls. On a system without a TPM the fields resolve
+// cleanly — present is false — rather than erroring.
+windows.tpm {
+  // Whether a TPM is present on the system
+  present() bool
+  // Whether the TPM is ready for use
+  ready() bool
+  // Whether the TPM is enabled
+  enabled() bool
+  // Whether the TPM is activated
+  activated() bool
+  // Major TPM specification version, for example "2.0"
+  specVersion() string
+  // TPM manufacturer version string
+  manufacturerVersion() string
+}
+
 // Windows Firewall (Advanced Security)
 //
 // Examine global settings, per-profile defaults, and individual firewall rules

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -318,6 +318,7 @@ const (
 	ResourceWindowsServerFeature          string = "windows.serverFeature"
 	ResourceWindowsOptionalFeature        string = "windows.optionalFeature"
 	ResourceWindowsRdp                    string = "windows.rdp"
+	ResourceWindowsTpm                    string = "windows.tpm"
 	ResourceWindowsFirewall               string = "windows.firewall"
 	ResourceWindowsFirewallProfile        string = "windows.firewall.profile"
 	ResourceWindowsFirewallRule           string = "windows.firewall.rule"
@@ -1637,6 +1638,10 @@ func init() {
 		"windows.rdp": {
 			// to override args, implement: initWindowsRdp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsRdp,
+		},
+		"windows.tpm": {
+			// to override args, implement: initWindowsTpm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsTpm,
 		},
 		"windows.firewall": {
 			// to override args, implement: initWindowsFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -7667,6 +7672,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.rdp.maxDisconnectionTimeMs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsRdp).GetMaxDisconnectionTimeMs()).ToDataRes(types.Int)
+	},
+	"windows.tpm.present": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetPresent()).ToDataRes(types.Bool)
+	},
+	"windows.tpm.ready": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetReady()).ToDataRes(types.Bool)
+	},
+	"windows.tpm.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"windows.tpm.activated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetActivated()).ToDataRes(types.Bool)
+	},
+	"windows.tpm.specVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetSpecVersion()).ToDataRes(types.String)
+	},
+	"windows.tpm.manufacturerVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsTpm).GetManufacturerVersion()).ToDataRes(types.String)
 	},
 	"windows.firewall.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsFirewall).GetSettings()).ToDataRes(types.Dict)
@@ -18105,6 +18128,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.rdp.maxDisconnectionTimeMs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsRdp).MaxDisconnectionTimeMs, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.tpm.present": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).Present, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.ready": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).Ready, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.activated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).Activated, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.specVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).SpecVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.tpm.manufacturerVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsTpm).ManufacturerVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48231,6 +48282,92 @@ func (c *mqlWindowsRdp) GetMaxIdleTimeMs() *plugin.TValue[int64] {
 func (c *mqlWindowsRdp) GetMaxDisconnectionTimeMs() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.MaxDisconnectionTimeMs, func() (int64, error) {
 		return c.maxDisconnectionTimeMs()
+	})
+}
+
+// mqlWindowsTpm for the windows.tpm resource
+type mqlWindowsTpm struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlWindowsTpmInternal
+	Present             plugin.TValue[bool]
+	Ready               plugin.TValue[bool]
+	Enabled             plugin.TValue[bool]
+	Activated           plugin.TValue[bool]
+	SpecVersion         plugin.TValue[string]
+	ManufacturerVersion plugin.TValue[string]
+}
+
+// createWindowsTpm creates a new instance of this resource
+func createWindowsTpm(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsTpm{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.tpm", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsTpm) MqlName() string {
+	return "windows.tpm"
+}
+
+func (c *mqlWindowsTpm) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsTpm) GetPresent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Present, func() (bool, error) {
+		return c.present()
+	})
+}
+
+func (c *mqlWindowsTpm) GetReady() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Ready, func() (bool, error) {
+		return c.ready()
+	})
+}
+
+func (c *mqlWindowsTpm) GetEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Enabled, func() (bool, error) {
+		return c.enabled()
+	})
+}
+
+func (c *mqlWindowsTpm) GetActivated() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Activated, func() (bool, error) {
+		return c.activated()
+	})
+}
+
+func (c *mqlWindowsTpm) GetSpecVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SpecVersion, func() (string, error) {
+		return c.specVersion()
+	})
+}
+
+func (c *mqlWindowsTpm) GetManufacturerVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManufacturerVersion, func() (string, error) {
+		return c.manufacturerVersion()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2718,6 +2718,13 @@ windows.serverFeature.installed 11.2.6
 windows.serverFeature.name 11.2.6
 windows.serverFeature.path 11.2.6
 windows.serverFeatures 11.2.6
+windows.tpm 13.22.2
+windows.tpm.activated 13.22.2
+windows.tpm.enabled 13.22.2
+windows.tpm.manufacturerVersion 13.22.2
+windows.tpm.present 13.22.2
+windows.tpm.ready 13.22.2
+windows.tpm.specVersion 13.22.2
 windows.update 13.20.1
 windows.update.available 13.20.1
 windows.update.config 13.20.1

--- a/providers/os/resources/windows/tpm.go
+++ b/providers/os/resources/windows/tpm.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// PSGetTpm collects Trusted Platform Module state. Get-Tpm provides the
+// presence/readiness flags and the manufacturer version, while the Win32_Tpm
+// WMI class provides the specification version. Errors are suppressed so a
+// machine without a TPM yields present=false rather than failing.
+const PSGetTpm = `
+$ErrorActionPreference = 'SilentlyContinue'
+$tpm = Get-Tpm
+$spec = (Get-CimInstance -Namespace 'root\cimv2\Security\MicrosoftTpm' -ClassName Win32_Tpm).SpecVersion
+[PSCustomObject]@{
+  TpmPresent          = [bool]$tpm.TpmPresent
+  TpmReady            = [bool]$tpm.TpmReady
+  TpmEnabled          = [bool]$tpm.TpmEnabled
+  TpmActivated        = [bool]$tpm.TpmActivated
+  ManufacturerVersion = [string]$tpm.ManufacturerVersion
+  SpecVersion         = [string]$spec
+} | ConvertTo-Json
+`
+
+// TpmInfo is the parsed result of PSGetTpm.
+type TpmInfo struct {
+	TpmPresent          bool   `json:"TpmPresent"`
+	TpmReady            bool   `json:"TpmReady"`
+	TpmEnabled          bool   `json:"TpmEnabled"`
+	TpmActivated        bool   `json:"TpmActivated"`
+	ManufacturerVersion string `json:"ManufacturerVersion"`
+	// SpecVersion is the raw Win32_Tpm value, e.g. "2.0, 0, 1.59".
+	SpecVersion string `json:"SpecVersion"`
+}
+
+// MajorSpecVersion returns just the major specification version (e.g. "2.0")
+// from the raw, comma-separated Win32_Tpm SpecVersion value.
+func (t *TpmInfo) MajorSpecVersion() string {
+	major, _, _ := strings.Cut(t.SpecVersion, ",")
+	return strings.TrimSpace(major)
+}
+
+// ParseTpm decodes the JSON emitted by PSGetTpm. Empty output (no object
+// produced) is treated as an absent TPM rather than an error.
+func ParseTpm(r io.Reader) (*TpmInfo, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return &TpmInfo{}, nil
+	}
+
+	var info TpmInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/providers/os/resources/windows/tpm_test.go
+++ b/providers/os/resources/windows/tpm_test.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTpm(t *testing.T) {
+	t.Run("a present TPM 2.0", func(t *testing.T) {
+		input := `{
+  "TpmPresent": true,
+  "TpmReady": true,
+  "TpmEnabled": true,
+  "TpmActivated": true,
+  "ManufacturerVersion": "7.2.3.1",
+  "SpecVersion": "2.0, 0, 1.59"
+}`
+		info, err := ParseTpm(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.True(t, info.TpmPresent)
+		assert.True(t, info.TpmReady)
+		assert.True(t, info.TpmEnabled)
+		assert.True(t, info.TpmActivated)
+		assert.Equal(t, "7.2.3.1", info.ManufacturerVersion)
+		assert.Equal(t, "2.0", info.MajorSpecVersion())
+	})
+
+	t.Run("no TPM present", func(t *testing.T) {
+		input := `{
+  "TpmPresent": false,
+  "TpmReady": false,
+  "TpmEnabled": false,
+  "TpmActivated": false,
+  "ManufacturerVersion": "",
+  "SpecVersion": ""
+}`
+		info, err := ParseTpm(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.False(t, info.TpmPresent)
+		assert.Equal(t, "", info.MajorSpecVersion())
+	})
+
+	t.Run("empty output is treated as an absent TPM", func(t *testing.T) {
+		info, err := ParseTpm(strings.NewReader("   \n"))
+		require.NoError(t, err)
+		assert.False(t, info.TpmPresent)
+		assert.Equal(t, "", info.MajorSpecVersion())
+	})
+}
+
+func TestMajorSpecVersion(t *testing.T) {
+	assert.Equal(t, "2.0", (&TpmInfo{SpecVersion: "2.0, 0, 1.59"}).MajorSpecVersion())
+	assert.Equal(t, "1.2", (&TpmInfo{SpecVersion: "1.2"}).MajorSpecVersion())
+	assert.Equal(t, "", (&TpmInfo{SpecVersion: ""}).MajorSpecVersion())
+}

--- a/providers/os/resources/windows_tpm.go
+++ b/providers/os/resources/windows_tpm.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/v13/providers/os/resources/windows"
+)
+
+type mqlWindowsTpmInternal struct {
+	lock    sync.Mutex
+	loaded  atomic.Bool
+	loadErr error
+	info    *windows.TpmInfo
+}
+
+func (w *mqlWindowsTpm) id() (string, error) {
+	return "windows.tpm", nil
+}
+
+// load runs the TPM query exactly once and caches the result so every field
+// shares a single PowerShell invocation.
+func (w *mqlWindowsTpm) load() (*windows.TpmInfo, error) {
+	if w.loaded.Load() {
+		return w.info, nil
+	}
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if w.loaded.Load() || w.loadErr != nil {
+		return w.info, w.loadErr
+	}
+
+	conn := w.MqlRuntime.Connection.(shared.Connection)
+	executedCmd, err := conn.RunCommand(powershell.Encode(windows.PSGetTpm))
+	if err != nil {
+		w.loadErr = err
+		return nil, err
+	}
+	if executedCmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(executedCmd.Stderr)
+		w.loadErr = errors.New("failed to retrieve TPM information: " + string(stderr))
+		return nil, w.loadErr
+	}
+
+	info, err := windows.ParseTpm(executedCmd.Stdout)
+	if err != nil {
+		w.loadErr = err
+		return nil, err
+	}
+
+	w.info = info
+	w.loaded.Store(true)
+	return info, nil
+}
+
+func (w *mqlWindowsTpm) present() (bool, error) {
+	info, err := w.load()
+	if err != nil {
+		return false, err
+	}
+	return info.TpmPresent, nil
+}
+
+func (w *mqlWindowsTpm) ready() (bool, error) {
+	info, err := w.load()
+	if err != nil {
+		return false, err
+	}
+	return info.TpmReady, nil
+}
+
+func (w *mqlWindowsTpm) enabled() (bool, error) {
+	info, err := w.load()
+	if err != nil {
+		return false, err
+	}
+	return info.TpmEnabled, nil
+}
+
+func (w *mqlWindowsTpm) activated() (bool, error) {
+	info, err := w.load()
+	if err != nil {
+		return false, err
+	}
+	return info.TpmActivated, nil
+}
+
+func (w *mqlWindowsTpm) specVersion() (string, error) {
+	info, err := w.load()
+	if err != nil {
+		return "", err
+	}
+	return info.MajorSpecVersion(), nil
+}
+
+func (w *mqlWindowsTpm) manufacturerVersion() (string, error) {
+	info, err := w.load()
+	if err != nil {
+		return "", err
+	}
+	return info.ManufacturerVersion, nil
+}


### PR DESCRIPTION
## Summary

Adds a `windows.tpm` resource exposing Trusted Platform Module state (presence, readiness, enabled/activated status, spec version) as typed fields. Closes #8057.

Today `mondoo-windows-11-compatibility-tpm-present` and related checks bypass the resource layer — two `powershell(...)` invocations with `.stdout.trim` comparisons, and a fragile `Win32_Tpm.SpecVersion` parse (`"2.0, 0, 1.59"` split inside the PowerShell string). TPM 2.0 presence is also a prerequisite for several BitLocker / device-health controls, so a first-class resource has broad reuse.

This follows the same pattern as the `windows.rdp` (#8212) and `windows.eventlog` (#8213) resources.

## Behavior

A single PowerShell query combining `Get-Tpm` (presence/readiness flags, manufacturer version) and `Win32_Tpm` (spec version) is run **once** and cached across all fields. `specVersion` returns just the major version (`"2.0"`), parsed in the provider. Errors are suppressed in the query so a machine **without a TPM resolves cleanly to `present == false`** rather than erroring.

## Fields

| Field | Type | Source |
|---|---|---|
| `present` | bool | `Get-Tpm` TpmPresent |
| `ready` | bool | `Get-Tpm` TpmReady |
| `enabled` | bool | `Get-Tpm` TpmEnabled |
| `activated` | bool | `Get-Tpm` TpmActivated |
| `specVersion` | string | `Win32_Tpm` SpecVersion, major version only |
| `manufacturerVersion` | string | `Get-Tpm` ManufacturerVersion |

## Example queries

```mql
// Windows 11 readiness
windows.tpm.present && windows.tpm.specVersion == "2.0"

// stronger posture check
windows.tpm { present && ready && enabled }
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (resource registered in `os.resources.json`).
- Unit tests in `windows/tpm_test.go` cover `ParseTpm` (present TPM 2.0, no-TPM, empty output) and `MajorSpecVersion` parsing.
- Not verified against live infrastructure — no Windows test box available — so the parse/decode logic is covered by unit tests. No new IAM permissions; execution reuses the connection's PowerShell, matching the other `windows.*` resources.