### PR TITLE
✨ Resolve machine.secureboot on Windows (#8058)

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -305,8 +305,10 @@ machine.cpu @defaults("manufacturer model processorCount coreCount") {
 // Examine whether the system booted in EFI/UEFI mode (`efi`), whether
 // Secure Boot is currently enabled (`enabled`), and whether it is in setup
 // mode (`setupMode`, meaning keys can be modified without authentication).
-// Read from EFI variables on Linux. Used to assert that Secure Boot is
-// enforced and that setup mode is not active.
+// Read from the EFI variables on Linux and from the UEFI firmware on
+// Windows; legacy-BIOS systems resolve to `efi` and `enabled` false rather
+// than erroring. Used to assert that Secure Boot is enforced and that setup
+// mode is not active.
 machine.secureboot @defaults("enabled") {
   // Whether the system is booted in EFI/UEFI mode
   efi() bool

--- a/providers/os/resources/secureboot.go
+++ b/providers/os/resources/secureboot.go
@@ -4,10 +4,14 @@
 package resources
 
 import (
+	"errors"
+	"io"
 	"sync"
 
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/v13/providers/os/resources/windows"
 )
 
 // EFI variable GUID for global Secure Boot variables.
@@ -25,10 +29,18 @@ func (s *mqlMachineSecureboot) id() (string, error) {
 	return "machine.secureboot", nil
 }
 
-// fetchStatus reads the EFI firmware variables once and caches the result.
+// fetchStatus determines the Secure Boot state once and caches the result. On
+// Windows it queries the UEFI firmware via PowerShell; on Linux it reads the
+// EFI firmware variables directly.
 func (s *mqlMachineSecureboot) fetchStatus() error {
 	s.once.Do(func() {
 		conn := s.MqlRuntime.Connection.(shared.Connection)
+
+		if asset := conn.Asset(); asset != nil && asset.Platform != nil && asset.Platform.IsFamily("windows") {
+			s.fetchErr = s.fetchWindowsStatus(conn)
+			return
+		}
+
 		fs := conn.FileSystem()
 
 		// Check if the system is booted in EFI mode by looking for /sys/firmware/efi.
@@ -43,6 +55,30 @@ func (s *mqlMachineSecureboot) fetchStatus() error {
 		s.cacheSetupMode = readEfiVarBool(fs, "SetupMode-"+efiGlobalVariable)
 	})
 	return s.fetchErr
+}
+
+// fetchWindowsStatus queries the UEFI firmware through PowerShell. A non-UEFI
+// (legacy BIOS) host yields efi=false and enabled=false rather than an error,
+// because Confirm-SecureBootUEFI throws on such systems.
+func (s *mqlMachineSecureboot) fetchWindowsStatus(conn shared.Connection) error {
+	executedCmd, err := conn.RunCommand(powershell.Encode(windows.PSConfirmSecureBoot))
+	if err != nil {
+		return err
+	}
+	if executedCmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(executedCmd.Stderr)
+		return errors.New("failed to determine Secure Boot state: " + string(stderr))
+	}
+
+	status, err := windows.ParseSecureBoot(executedCmd.Stdout)
+	if err != nil {
+		return err
+	}
+
+	s.cacheEfi = status.Efi
+	s.cacheEnabled = status.Enabled
+	s.cacheSetupMode = status.SetupMode
+	return nil
 }
 
 // readEfiVarBool reads an EFI variable from /sys/firmware/efi/efivars/ and

--- a/providers/os/resources/windows/secureboot.go
+++ b/providers/os/resources/windows/secureboot.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// PSConfirmSecureBoot reports Secure Boot state. Confirm-SecureBootUEFI throws
+// on non-UEFI (legacy BIOS) systems, so it is wrapped in try/catch: a thrown
+// exception means the host is not UEFI, which yields efi=false and enabled=false
+// instead of an error. SetupMode is read from its UEFI variable when available.
+const PSConfirmSecureBoot = `
+$efi = $false
+$enabled = $false
+$setupMode = $false
+try {
+    $result = Confirm-SecureBootUEFI -ErrorAction Stop
+    $efi = $true
+    $enabled = [bool]$result
+    try {
+        $sm = Get-SecureBootUEFI -Name SetupMode -ErrorAction Stop
+        if ($sm -and $sm.Bytes.Length -ge 1) { $setupMode = ($sm.Bytes[0] -eq 1) }
+    } catch {
+        $setupMode = $false
+    }
+} catch {
+    $efi = $false
+    $enabled = $false
+}
+[PSCustomObject]@{
+  Efi       = $efi
+  Enabled   = $enabled
+  SetupMode = $setupMode
+} | ConvertTo-Json
+`
+
+// SecureBootStatus is the parsed result of PSConfirmSecureBoot.
+type SecureBootStatus struct {
+	Efi       bool `json:"Efi"`
+	Enabled   bool `json:"Enabled"`
+	SetupMode bool `json:"SetupMode"`
+}
+
+// ParseSecureBoot decodes the JSON emitted by PSConfirmSecureBoot. Empty output
+// is treated as a non-UEFI host rather than an error.
+func ParseSecureBoot(r io.Reader) (*SecureBootStatus, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return &SecureBootStatus{}, nil
+	}
+
+	var status SecureBootStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}

--- a/providers/os/resources/windows/secureboot_test.go
+++ b/providers/os/resources/windows/secureboot_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSecureBoot(t *testing.T) {
+	t.Run("UEFI host with Secure Boot enabled", func(t *testing.T) {
+		input := `{ "Efi": true, "Enabled": true, "SetupMode": false }`
+		status, err := ParseSecureBoot(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.True(t, status.Efi)
+		assert.True(t, status.Enabled)
+		assert.False(t, status.SetupMode)
+	})
+
+	t.Run("UEFI host with Secure Boot disabled", func(t *testing.T) {
+		input := `{ "Efi": true, "Enabled": false, "SetupMode": true }`
+		status, err := ParseSecureBoot(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.True(t, status.Efi)
+		assert.False(t, status.Enabled)
+		assert.True(t, status.SetupMode)
+	})
+
+	t.Run("legacy BIOS host", func(t *testing.T) {
+		input := `{ "Efi": false, "Enabled": false, "SetupMode": false }`
+		status, err := ParseSecureBoot(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.False(t, status.Efi)
+		assert.False(t, status.Enabled)
+		assert.False(t, status.SetupMode)
+	})
+
+	t.Run("empty output is treated as a non-UEFI host", func(t *testing.T) {
+		status, err := ParseSecureBoot(strings.NewReader("  \n"))
+		require.NoError(t, err)
+		assert.False(t, status.Efi)
+		assert.False(t, status.Enabled)
+		assert.False(t, status.SetupMode)
+	})
+}


### PR DESCRIPTION
## Summary

Makes Secure Boot state queryable on **Windows** by extending the existing cross-platform `machine.secureboot` resource. Closes #8058.

Today two `mondoo-windows` policies check Secure Boot by parsing PowerShell stdout (`powershell("Confirm-SecureBootUEFI").stdout.trim...`), with inconsistent casing normalization and a `try/catch` wrapper for non-UEFI hosts — error handling that belongs in the provider.

This keeps the same resource shape (`efi`, `enabled`, `setupMode`); no schema/field changes.

## Behavior

`fetchStatus` now branches on the asset platform:

- **Windows** → one PowerShell query (`Confirm-SecureBootUEFI` for efi/enabled, `Get-SecureBootUEFI -Name SetupMode` for setup mode), run once and cached.
- **Linux** → the existing EFI-variable reads under `/sys/firmware/efi`, unchanged.

`Confirm-SecureBootUEFI` throws on non-UEFI (legacy BIOS) systems, so the query wraps it in `try/catch`: a BIOS host resolves to **`efi == false`, `enabled == false`** rather than erroring, satisfying the acceptance criteria.

## Example queries (now identical on Windows and Linux)

```mql
machine.secureboot.enabled
machine.secureboot { efi && enabled && setupMode == false }
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds.
- New unit tests in `windows/secureboot_test.go` cover `ParseSecureBoot` (UEFI enabled/disabled, legacy BIOS, empty output).
- Existing `TestReadEfiVarBool` (Linux path) still passes — that path is untouched.
- Not verified against live infrastructure — no Windows test box available — so the parse/branch logic is covered by unit tests. No new IAM permissions; execution reuses the connection's PowerShell, matching the other `windows.*` resources.