### PR TITLE
✨ Add success/failure booleans to auditpol.entry (#8056)

### DIFF
--- a/providers/os/resources/auditpol.go
+++ b/providers/os/resources/auditpol.go
@@ -56,3 +56,32 @@ func (p *mqlAuditpol) list() ([]any, error) {
 func (p *mqlAuditpolEntry) id() (string, error) {
 	return p.Subcategoryguid.Data, nil
 }
+
+// auditpolInclusionAudits reports whether an auditpol inclusion setting audits
+// the given event kind ("success" or "failure"). The setting is one of
+// "Success", "Failure", "Success and Failure", or "No Auditing".
+func auditpolInclusionAudits(inclusionSetting, kind string) bool {
+	return strings.Contains(strings.ToLower(inclusionSetting), kind)
+}
+
+// success reports whether the inclusion setting audits success events. It is
+// true for "Success" and "Success and Failure", false for "Failure" and
+// "No Auditing".
+func (p *mqlAuditpolEntry) success() (bool, error) {
+	setting := p.GetInclusionsetting()
+	if setting.Error != nil {
+		return false, setting.Error
+	}
+	return auditpolInclusionAudits(setting.Data, "success"), nil
+}
+
+// failure reports whether the inclusion setting audits failure events. It is
+// true for "Failure" and "Success and Failure", false for "Success" and
+// "No Auditing".
+func (p *mqlAuditpolEntry) failure() (bool, error) {
+	setting := p.GetInclusionsetting()
+	if setting.Error != nil {
+		return false, setting.Error
+	}
+	return auditpolInclusionAudits(setting.Data, "failure"), nil
+}

--- a/providers/os/resources/auditpol_internal_test.go
+++ b/providers/os/resources/auditpol_internal_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuditpolInclusionAudits(t *testing.T) {
+	cases := []struct {
+		setting          string
+		success, failure bool
+	}{
+		{"Success", true, false},
+		{"Failure", false, true},
+		{"Success and Failure", true, true},
+		{"No Auditing", false, false},
+		{"", false, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.setting, func(t *testing.T) {
+			assert.Equal(t, c.success, auditpolInclusionAudits(c.setting, "success"))
+			assert.Equal(t, c.failure, auditpolInclusionAudits(c.setting, "failure"))
+		})
+	}
+}

--- a/providers/os/resources/auditpol_test.go
+++ b/providers/os/resources/auditpol_test.go
@@ -44,4 +44,30 @@ func TestResource_Auditpol(t *testing.T) {
 		assert.False(t, r)
 		assert.True(t, found)
 	})
+
+	// success / failure booleans derived from inclusionsetting, exercised
+	// through the resource methods rather than the pure helper.
+	successFailureCases := []struct {
+		subcategory string // its inclusionsetting in the recording
+		success     bool
+		failure     bool
+	}{
+		{"System Integrity", true, true},            // "Success and Failure"
+		{"Security State Change", true, false},      // "Success"
+		{"Security System Extension", false, false}, // "No Auditing"
+	}
+	for _, tc := range successFailureCases {
+		t.Run("success for "+tc.subcategory, func(t *testing.T) {
+			res := testWindowsQuery(t, "auditpol.where(subcategory == '"+tc.subcategory+"')[0].success")
+			assert.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.success, res[0].Data.Value)
+		})
+		t.Run("failure for "+tc.subcategory, func(t *testing.T) {
+			res := testWindowsQuery(t, "auditpol.where(subcategory == '"+tc.subcategory+"')[0].failure")
+			assert.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.failure, res[0].Data.Value)
+		})
+	}
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3551,8 +3551,10 @@ auditpol {
 //
 // Examine a single Windows audit-policy entry: the machine name, policy
 // target, subcategory name and GUID, inclusion setting, and exclusion
-// setting. Iterated from `auditpol` to assert that specific subcategories
-// (e.g., Logon, Account Management) have the expected audit settings.
+// setting, plus the `success` and `failure` booleans derived from the
+// inclusion setting. Iterated from `auditpol` to assert that specific
+// subcategories (e.g., Logon, Account Management) have the expected audit
+// settings.
 auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") {
   // Machine name
   machinename string
@@ -3566,6 +3568,14 @@ auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") {
   inclusionsetting string
   // Exclusive settings
   exclusionsetting string
+  // Whether the inclusion setting audits success events
+  //
+  // True for "Success" and "Success and Failure".
+  success() bool
+  // Whether the inclusion setting audits failure events
+  //
+  // True for "Failure" and "Success and Failure".
+  failure() bool
 }
 
 // Windows local security policy

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -5334,6 +5334,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"auditpol.entry.exclusionsetting": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAuditpolEntry).GetExclusionsetting()).ToDataRes(types.String)
 	},
+	"auditpol.entry.success": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuditpolEntry).GetSuccess()).ToDataRes(types.Bool)
+	},
+	"auditpol.entry.failure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuditpolEntry).GetFailure()).ToDataRes(types.Bool)
+	},
 	"secpol.systemaccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSecpol).GetSystemaccess()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -14453,6 +14459,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"auditpol.entry.exclusionsetting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAuditpolEntry).Exclusionsetting, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"auditpol.entry.success": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuditpolEntry).Success, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"auditpol.entry.failure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuditpolEntry).Failure, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"secpol.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35906,6 +35920,8 @@ type mqlAuditpolEntry struct {
 	Subcategoryguid  plugin.TValue[string]
 	Inclusionsetting plugin.TValue[string]
 	Exclusionsetting plugin.TValue[string]
+	Success          plugin.TValue[bool]
+	Failure          plugin.TValue[bool]
 }
 
 // createAuditpolEntry creates a new instance of this resource
@@ -35967,6 +35983,18 @@ func (c *mqlAuditpolEntry) GetInclusionsetting() *plugin.TValue[string] {
 
 func (c *mqlAuditpolEntry) GetExclusionsetting() *plugin.TValue[string] {
 	return &c.Exclusionsetting
+}
+
+func (c *mqlAuditpolEntry) GetSuccess() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Success, func() (bool, error) {
+		return c.success()
+	})
+}
+
+func (c *mqlAuditpolEntry) GetFailure() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Failure, func() (bool, error) {
+		return c.failure()
+	})
 }
 
 // mqlSecpol for the secpol resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -157,11 +157,13 @@ auditd.rules.syscalls 11.4.21
 auditpol 9.0.1
 auditpol.entry 9.0.1
 auditpol.entry.exclusionsetting 9.0.1
+auditpol.entry.failure 13.22.2
 auditpol.entry.inclusionsetting 9.0.1
 auditpol.entry.machinename 9.0.1
 auditpol.entry.policytarget 9.0.1
 auditpol.entry.subcategory 9.0.1
 auditpol.entry.subcategoryguid 9.0.1
+auditpol.entry.success 13.22.2
 auditpol.list 9.0.1
 augment 13.13.1
 augment.configPath 13.13.1


### PR DESCRIPTION
## Summary

Adds typed `success` / `failure` booleans to `auditpol.entry`, derived from the free-text `inclusionsetting`. Addresses the core of #8056.

`mondoo-windows-security` has ~30 audit-policy checks that string-match `inclusionsetting` against dozens of near-identical `props` (`...AuditpolSuccess19`, `...AuditpolSuccessFailure18`, …) just to spell out the four possible values. These booleans let a check say `auditpol.entry.success` / `.failure` directly.

## Scope

This PR intentionally covers **only the `success`/`failure` booleans**. The issue also proposed a `subcategory(name)` lookup accessor; that is deferred — MQL doesn't support user-supplied arguments on field methods (only `init()` constructors do), so a by-name lookup needs a separate design decision and isn't included here.

## Behavior

`inclusionsetting` is one of `"Success"`, `"Failure"`, `"Success and Failure"`, or `"No Auditing"`:

| inclusionsetting | success | failure |
|---|---|---|
| Success | true | false |
| Failure | false | true |
| Success and Failure | true | true |
| No Auditing | false | false |

## Example queries

```mql
auditpol.where(subcategory == "Logon").all(success && failure)
auditpol.where(subcategory == "Process Creation").all(success)
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (`success`/`failure` registered on `auditpol.entry`).
- Unit test covers the four `inclusionsetting` values (plus empty) for both booleans.
- Existing `auditpol` parser test still passes.
- New `.lr.versions` entries at 13.22.2.