### PR TITLE
✨ Expose PAM module options as parsed key/value pairs (#8055)

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -983,6 +983,14 @@ private pam.conf.serviceEntry @defaults("service module") {
   module string
   // Configuration options for pam service entry
   options []string
+  // Options parsed into key/value pairs
+  //
+  // `key=value` options become map entries (key lower-cased); bare flags
+  // such as `use_uid` map to an empty string, so `params["use_uid"] != null`
+  // works as an existence check. When the same key appears more than once
+  // the last occurrence wins, matching how PAM evaluates duplicate options.
+  // The raw `options` list is retained unchanged.
+  params(options) map[string]string
 }
 
 // PAM module aggregated view

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2896,6 +2896,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"pam.conf.serviceEntry.options": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConfServiceEntry).GetOptions()).ToDataRes(types.Array(types.String))
 	},
+	"pam.conf.serviceEntry.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConfServiceEntry).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"pam.module.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamModule).GetName()).ToDataRes(types.String)
 	},
@@ -10775,6 +10778,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"pam.conf.serviceEntry.options": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPamConfServiceEntry).Options, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"pam.conf.serviceEntry.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfServiceEntry).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"pam.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25376,6 +25383,7 @@ type mqlPamConfServiceEntry struct {
 	Control    plugin.TValue[string]
 	Module     plugin.TValue[string]
 	Options    plugin.TValue[[]any]
+	Params     plugin.TValue[map[string]any]
 }
 
 // createPamConfServiceEntry creates a new instance of this resource
@@ -25437,6 +25445,17 @@ func (c *mqlPamConfServiceEntry) GetModule() *plugin.TValue[string] {
 
 func (c *mqlPamConfServiceEntry) GetOptions() *plugin.TValue[[]any] {
 	return &c.Options
+}
+
+func (c *mqlPamConfServiceEntry) GetParams() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Params, func() (map[string]any, error) {
+		vargOptions := c.GetOptions()
+		if vargOptions.Error != nil {
+			return nil, vargOptions.Error
+		}
+
+		return c.params(vargOptions.Data)
+	})
 }
 
 // mqlPamModule for the pam.module resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1940,6 +1940,7 @@ pam.conf.serviceEntry.lineNumber 9.0.0
 pam.conf.serviceEntry.module 9.0.0
 pam.conf.serviceEntry.options 9.0.0
 pam.conf.serviceEntry.pamType 9.0.0
+pam.conf.serviceEntry.params 13.22.2
 pam.conf.serviceEntry.service 9.0.0
 pam.conf.services 9.0.0
 pam.module 13.16.10

--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -216,6 +216,12 @@ func aggregatePamParams(optionLists ...[]any) map[string]any {
 	return params
 }
 
+// params parses this entry's raw options into key/value pairs, applying the
+// same rules as the aggregated pam.module.params (see aggregatePamParams).
+func (se *mqlPamConfServiceEntry) params(options []any) (map[string]any, error) {
+	return aggregatePamParams(options), nil
+}
+
 // isPamControlEnabled reports whether a PAM control directive counts as
 // "the module is loaded". Bracketed controls that explicitly route the
 // module to ignore/skip don't count.

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPamConfServiceEntryParams(t *testing.T) {
+	se := &mqlPamConfServiceEntry{}
+
+	t.Run("key=value and bare flags", func(t *testing.T) {
+		got, err := se.params([]any{"use_uid", "group=wheel"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"use_uid": "", "group": "wheel"}, got)
+	})
+
+	t.Run("duplicate keys: last occurrence wins", func(t *testing.T) {
+		got, err := se.params([]any{"group=wheel", "group=admin"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"group": "admin"}, got)
+	})
+
+	t.Run("no options yields an empty map", func(t *testing.T) {
+		got, err := se.params([]any{})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{}, got)
+	})
+}


### PR DESCRIPTION
## Summary

Adds a parsed `params` map to `pam.conf.serviceEntry`, alongside the existing raw `options []string`. Closes #8055.

PAM options are overwhelmingly `key=value` (or bare flags), so policies currently split the strings by hand — e.g. `options.where(_ == /^group=/).map(_.split("group=")[1])`. The `params` map removes that surgery.

## Naming

The issue flagged the field name as open (`optionsMap` / `params` / `settings`). I chose **`params`** to match the existing sibling **`pam.module.params`**, which already exposes the same aggregated `key=value` map — so the per-entry and per-module views use one consistent name and the same parsing rules.

## Behavior

`params` is derived from `options`:

- `key=value` → map entry, key lower-cased (`group=wheel` → `{"group": "wheel"}`)
- bare flag → empty-string value (`use_uid` → `{"use_uid": ""}`), so `params["use_uid"] != null` is an existence check
- **duplicate key: last occurrence wins** (matches how PAM evaluates duplicate flags)
- raw `options []string` retained unchanged

Parsing reuses the same `aggregatePamParams` helper as `pam.module.params`.

## Example queries

```mql
// su restricted to a group, reading the value directly
pam.conf.entries["/etc/pam.d/su"].where(
  pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null
).all(groups.map(name).contains(params["group"]))

// password minimum length
pam.conf.entries["/etc/pam.d/common-password"].any(
  module == "pam_pwquality.so" && params["minlen"].int >= 14
)
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (`params` registered on `pam.conf.serviceEntry`).
- New `TestPamConfServiceEntryParams` covers key=value + bare flags, duplicate-last-wins, and the empty case via the resource method directly.
- The shared parsing is already exhaustively covered by the existing `TestAggregatePamParams`.
- New `.lr.versions` entry at 13.22.2.