### PR TITLE
✨ Add parsed params map to rsyslog.conf resource (#8054)

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3674,6 +3674,14 @@ rsyslog.conf {
   content(files) string
   // List of settings for this rsyslog service
   settings(content) []string
+  // Legacy `$Directive value` settings parsed into key/value pairs
+  //
+  // The leading `$` is stripped from each key and the value is trimmed of
+  // surrounding whitespace, so `params["FileCreateMode"] == "0640"` works
+  // regardless of the spacing used in the file. When the same directive
+  // appears more than once the last occurrence wins. The raw `settings`
+  // list is retained unchanged.
+  params(content) map[string]string
   // Loaded modules (modern module() and legacy $ModLoad)
   modules(files) []rsyslog.module
   // Configured inputs (modern input() and legacy $Input* directives)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -5428,6 +5428,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"rsyslog.conf.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRsyslogConf).GetSettings()).ToDataRes(types.Array(types.String))
 	},
+	"rsyslog.conf.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRsyslogConf).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"rsyslog.conf.modules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRsyslogConf).GetModules()).ToDataRes(types.Array(types.Resource("rsyslog.module")))
 	},
@@ -14627,6 +14630,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"rsyslog.conf.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlRsyslogConf).Settings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"rsyslog.conf.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRsyslogConf).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"rsyslog.conf.modules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36475,6 +36482,7 @@ type mqlRsyslogConf struct {
 	Files    plugin.TValue[[]any]
 	Content  plugin.TValue[string]
 	Settings plugin.TValue[[]any]
+	Params   plugin.TValue[map[string]any]
 	Modules  plugin.TValue[[]any]
 	Inputs   plugin.TValue[[]any]
 	Actions  plugin.TValue[[]any]
@@ -36564,6 +36572,17 @@ func (c *mqlRsyslogConf) GetSettings() *plugin.TValue[[]any] {
 		}
 
 		return c.settings(vargContent.Data)
+	})
+}
+
+func (c *mqlRsyslogConf) GetParams() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Params, func() (map[string]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.params(vargContent.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2133,6 +2133,7 @@ rsyslog.conf.content 9.0.1
 rsyslog.conf.files 9.0.1
 rsyslog.conf.inputs 13.16.10
 rsyslog.conf.modules 13.16.10
+rsyslog.conf.params 13.22.2
 rsyslog.conf.path 9.0.1
 rsyslog.conf.rules 13.16.10
 rsyslog.conf.settings 9.0.1

--- a/providers/os/resources/rsyslog.go
+++ b/providers/os/resources/rsyslog.go
@@ -412,6 +412,32 @@ func (s *mqlRsyslogConf) settings(content string) ([]any, error) {
 	return settings, nil
 }
 
+// params parses the legacy `$Directive value` settings across all included
+// config fragments into key/value pairs. The leading `$` is stripped from each
+// key and the value is trimmed of surrounding whitespace; when the same
+// directive appears more than once the last occurrence wins.
+func (s *mqlRsyslogConf) params(content string) (map[string]any, error) {
+	params := map[string]any{}
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.Trim(stripRsyslogComment(raw), " \t\r")
+		if !strings.HasPrefix(line, "$") {
+			continue
+		}
+
+		directive := line[1:]
+		idx := strings.IndexAny(directive, " \t")
+		if idx < 0 {
+			// a bare `$Directive` with no value — skip rather than record an
+			// empty value, since legacy directives always carry a value
+			continue
+		}
+
+		key := directive[:idx]
+		params[key] = strings.TrimSpace(directive[idx:])
+	}
+	return params, nil
+}
+
 // parsedEntries walks every fragment in `files` and returns the unified
 // list of typed entries from all of them. The result is memoized on the
 // Internal struct so the four typed accessors share one parse pass per

--- a/providers/os/resources/rsyslog_internal_test.go
+++ b/providers/os/resources/rsyslog_internal_test.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,31 @@ func TestStripRsyslogComment(t *testing.T) {
 			assert.Equal(t, tt.want, stripRsyslogComment(tt.in))
 		})
 	}
+}
+
+func TestRsyslogConfParams(t *testing.T) {
+	s := &mqlRsyslogConf{}
+
+	content := strings.Join([]string{
+		"# rsyslog configuration",
+		"$FileCreateMode 0640",
+		"$FileOwner   syslog",  // extra spacing is trimmed
+		"$DirCreateMode\t0755", // tab separator
+		"$FileGroup adm # inline comment is stripped",
+		"module(load=\"imuxsock\")", // modern syntax is ignored
+		"*.info /var/log/messages",  // selector lines are ignored
+		"$FileCreateMode 0600",      // duplicate: last occurrence wins
+		"$ActionResumeRetryCount",   // bare directive with no value is skipped
+	}, "\n")
+
+	got, err := s.params(content)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"FileCreateMode": "0600",
+		"FileOwner":      "syslog",
+		"DirCreateMode":  "0755",
+		"FileGroup":      "adm",
+	}, got)
 }
 
 func TestParseRsyslogIncludes(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a parsed key/value `params` map to `rsyslog.conf`, derived from the legacy `$Directive value` settings. Closes #8054.

Today `rsyslog.conf.settings` is only a `[]string` of raw lines, forcing policies into literal substring matching like `rsyslog.conf.settings.contains("$FileCreateMode 0640")` — which breaks on extra whitespace, a stricter value (`0600`), or quoting. `params` lets a policy ask "what is the effective FileCreateMode?".

This follows the same pattern as the PAM `params` change (#8217).

## Behavior

`params` parses the legacy `$Name value` directive form across all included config fragments:

- leading `$` stripped from the key (`$FileCreateMode 0640` → `{"FileCreateMode": "0640"}`)
- value trimmed of surrounding whitespace (internal whitespace preserved)
- whitespace separator may be spaces or a tab
- inline `#` comments stripped (reusing `stripRsyslogComment`, quote-aware)
- duplicate directive: **last occurrence wins**
- non-`$` lines (modern `module(...)`/`action(...)`, selector rules) are ignored
- raw `settings []string` retained unchanged

## Example queries

```mql
// default file permissions, whitespace-independent
rsyslog.conf.params["FileCreateMode"] == "0640"
rsyslog.conf.params["FileCreateMode"] != null
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (`params` registered on `rsyslog.conf`).
- New `TestRsyslogConfParams` covers `$`-stripping, extra-space + tab separators, inline-comment stripping, duplicate-last-wins, ignored modern/selector lines, and a bare valueless directive.
- New `.lr.versions` entry at 13.22.2.

## Note

This parses the **legacy `$Directive`** form, as the issue specifies. The modern `global(...)`/`action(...)` module syntax is already surfaced structurally via the existing `modules()`/`inputs()`/`actions()`/`rules()` accessors; folding those into `params` would be a separate change.