### PR TITLE
🐛 ms365: rename `length` field to `count` on list-wrapper resources

### DIFF
--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -65,7 +65,7 @@ func (a *mqlMicrosoftApplications) list() ([]any, error) {
 	return res, nil
 }
 
-func (a *mqlMicrosoftApplications) length() (int64, error) {
+func (a *mqlMicrosoftApplications) count() (int64, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()
 	if err != nil {
@@ -74,16 +74,16 @@ func (a *mqlMicrosoftApplications) length() (int64, error) {
 
 	opts := &applications.CountRequestBuilderGetRequestConfiguration{Headers: abstractions.NewRequestHeaders()}
 	opts.Headers.Add("ConsistencyLevel", "eventual")
-	length, err := graphClient.Applications().Count().Get(context.Background(), opts)
+	count, err := graphClient.Applications().Count().Get(context.Background(), opts)
 	if err != nil {
 		return 0, err
 	}
-	if length == nil {
+	if count == nil {
 		// This should never happen, but we better check
 		return 0, errors.New("unable to count applications, counter parameter API returned nil")
 	}
 
-	return int64(*length), nil
+	return int64(*count), nil
 }
 
 // newMqlMicrosoftApplication creates a new mqlMicrosoftApplication resource

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -330,7 +330,7 @@ func (a *mqlMicrosoftGroupOwner) servicePrincipal() (*mqlMicrosoftServiceprincip
 	return spResource.(*mqlMicrosoftServiceprincipal), nil
 }
 
-func (a *mqlMicrosoftGroups) length() (int64, error) {
+func (a *mqlMicrosoftGroups) count() (int64, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()
 	if err != nil {
@@ -339,14 +339,14 @@ func (a *mqlMicrosoftGroups) length() (int64, error) {
 
 	opts := &groups.CountRequestBuilderGetRequestConfiguration{Headers: abstractions.NewRequestHeaders()}
 	opts.Headers.Add("ConsistencyLevel", "eventual")
-	length, err := graphClient.Groups().Count().Get(context.Background(), opts)
+	count, err := graphClient.Groups().Count().Get(context.Background(), opts)
 	if err != nil {
 		return 0, err
 	}
-	if length == nil {
+	if count == nil {
 		// This should never happen, but we better check
 		return 0, errors.New("unable to count groups, counter parameter API returned nil")
 	}
 
-	return int64(*length), nil
+	return int64(*count), nil
 }

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -120,11 +120,11 @@ private microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleS
 // Iterate over all Microsoft Entra ID (formerly Azure AD) groups in the tenant.
 // Each entry is a `microsoft.group` exposing `displayName`, `securityEnabled`,
 // `mailEnabled`, `groupTypes`, membership rules, expiration settings, and
-// on-premises sync status. Use `length` to count the total number of groups.
+// on-premises sync status. Use `count` to get the total number of groups.
 microsoft.groups {
   []microsoft.group
   // Total number of Microsoft groups
-  length() int
+  count() int
 }
 
 // Microsoft 365 Group Setting
@@ -159,12 +159,12 @@ microsoft.settingValue  @defaults("name value") {
 // Iterate over all application registrations in the tenant. Each entry is a
 // `microsoft.application` exposing identity details (`id`, `appId`, `name`),
 // credential health (`hasExpiredCredentials`, `secrets`, `certificates`),
-// sign-in audience, and linked service principal. Use `length` to count
+// sign-in audience, and linked service principal. Use `count` to get
 // the total number of registered applications.
 microsoft.applications {
   []microsoft.application
   // Total number of application registrations
-  length() int
+  count() int
 }
 
 // Microsoft Entra Tenant

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1076,8 +1076,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings.recurrence": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings).GetRecurrence()).ToDataRes(types.Dict)
 	},
-	"microsoft.groups.length": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftGroups).GetLength()).ToDataRes(types.Int)
+	"microsoft.groups.count": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftGroups).GetCount()).ToDataRes(types.Int)
 	},
 	"microsoft.groups.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftGroups).GetList()).ToDataRes(types.Array(types.Resource("microsoft.group")))
@@ -1097,8 +1097,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.settingValue.value": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSettingValue).GetValue()).ToDataRes(types.String)
 	},
-	"microsoft.applications.length": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftApplications).GetLength()).ToDataRes(types.Int)
+	"microsoft.applications.count": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplications).GetCount()).ToDataRes(types.Int)
 	},
 	"microsoft.applications.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplications).GetList()).ToDataRes(types.Array(types.Resource("microsoft.application")))
@@ -5588,8 +5588,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftGroups).__id, ok = v.Value.(string)
 		return
 	},
-	"microsoft.groups.length": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftGroups).Length, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+	"microsoft.groups.count": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftGroups).Count, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"microsoft.groups.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5628,8 +5628,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftApplications).__id, ok = v.Value.(string)
 		return
 	},
-	"microsoft.applications.length": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftApplications).Length, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+	"microsoft.applications.count": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplications).Count, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"microsoft.applications.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12616,8 +12616,8 @@ type mqlMicrosoftGroups struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftGroupsInternal it will be used here
-	Length plugin.TValue[int64]
-	List   plugin.TValue[[]any]
+	Count plugin.TValue[int64]
+	List  plugin.TValue[[]any]
 }
 
 // createMicrosoftGroups creates a new instance of this resource
@@ -12652,9 +12652,9 @@ func (c *mqlMicrosoftGroups) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlMicrosoftGroups) GetLength() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.Length, func() (int64, error) {
-		return c.length()
+func (c *mqlMicrosoftGroups) GetCount() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.Count, func() (int64, error) {
+		return c.count()
 	})
 }
 
@@ -12782,8 +12782,8 @@ type mqlMicrosoftApplications struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftApplicationsInternal it will be used here
-	Length plugin.TValue[int64]
-	List   plugin.TValue[[]any]
+	Count plugin.TValue[int64]
+	List  plugin.TValue[[]any]
 }
 
 // createMicrosoftApplications creates a new instance of this resource
@@ -12818,9 +12818,9 @@ func (c *mqlMicrosoftApplications) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlMicrosoftApplications) GetLength() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.Length, func() (int64, error) {
-		return c.length()
+func (c *mqlMicrosoftApplications) GetCount() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.Count, func() (int64, error) {
+		return c.count()
 	})
 }
 

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -64,7 +64,7 @@ microsoft.application.tags 9.0.0
 microsoft.application.tokenEncryptionKeyId 9.0.0
 microsoft.application.web 9.0.0
 microsoft.applications 11.1.19
-microsoft.applications.length 11.1.19
+microsoft.applications.count 13.5.1
 microsoft.applications.list 11.1.19
 microsoft.authenticationMethodConfiguration 11.1.99
 microsoft.authenticationMethodConfiguration.excludeTargets 11.1.99
@@ -711,7 +711,7 @@ microsoft.groupLifecyclePolicy.id 11.1.42
 microsoft.groupLifecyclePolicy.managedGroupTypes 11.1.42
 microsoft.groupSettings 9.0.0
 microsoft.groups 11.1.19
-microsoft.groups.length 11.1.19
+microsoft.groups.count 13.5.1
 microsoft.groups.list 11.1.19
 microsoft.identityAndAccess 11.1.40
 microsoft.identityAndAccess.accessReviewDefinition 11.1.46


### PR DESCRIPTION
## Summary

Fixes #7714.

The list-wrapper resources `microsoft.applications` and `microsoft.groups` declared a field named **`length`**, which collides with the builtin MQL `length` operator. The compiler resolved `length` as the operator rather than the field, so the field was effectively unqueryable.

This renames the field to **`count`** on both resources — matching the convention used across every other provider (aws/azure/gcp/digitalocean/cloudflare/slack all expose a `count` field for this purpose). The field still resolves the total via the efficient Microsoft Graph `Count()` endpoint (no full pagination), and is now reachable as `microsoft.applications.count` / `microsoft.groups.count` without colliding with the builtin.

`microsoft.users` was already unaffected (it never declared a `length` field).

## Breaking change (no functional loss)

This is technically a breaking field rename (`length` → `count`), and that is intentional and safe: the `length` field is **already broken today** — it collides with the builtin operator and cannot be queried at all. Nothing can depend on a field that never resolved, so there is no loss of functionality and no consumer that the rename could break. The rename simply makes the previously-unreachable count reachable under a usable name.

## Changes

- `ms365.lr`: `length() int` → `count() int` on `microsoft.applications` and `microsoft.groups` (+ doc-comment wording)
- `applications.go` / `groups.go`: rename the `length()` method to `count()`
- Regenerated `ms365.lr.go`, `ms365.resources.json`; `.lr.versions` entries updated to `13.5.1`

## Verification

Built and installed the local provider, ran against the live lunalectricsandbox tenant:

```
microsoft.applications.count => 7   (matches microsoft.applications.list.length)
microsoft.groups.count       => 4   (matches microsoft.groups.list.length)
```

The count comes from the Graph `Count()` API and matches the actual list length in both cases.

## Note on the block form

`microsoft.applications { count }` (the block syntax in the original repro) still does not resolve `count` — that's expected: a `{ }` block on a list-wrapper iterates over the *element* type (`microsoft.application`), which has no `count` field. The wrapper-level total is accessed via dotted notation: `microsoft.applications.count`. The original `{ length }` failure was the builtin-collision symptom; with the rename, the field has a usable, unambiguous name.