### PR TITLE
✨ Add exim MTA configuration resource (#8053)

### DIFF
--- a/providers/os/resources/exim.go
+++ b/providers/os/resources/exim.go
@@ -1,0 +1,254 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+const (
+	// Debian's exim4 split config keeps the dc_* control values, including
+	// dc_local_interfaces, in this file.
+	debianEximConfig = "/etc/exim4/update-exim4.conf.conf"
+	// the monolithic configuration used by RHEL and most source installs
+	monolithicEximConfig = "/etc/exim/exim.conf"
+)
+
+func (e *mqlExim) id() (string, error) {
+	// a constant id keeps creation cheap; configPath() may shell out to
+	// `exim -bP` to locate a non-standard config, which shouldn't run just
+	// to compute the cache key
+	return "exim", nil
+}
+
+func initExim(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok && x != nil {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in exim initialization, it must be a string")
+		}
+		args["configPath"] = llx.StringData(path)
+		delete(args, "path")
+	}
+	return args, nil, nil
+}
+
+func (e *mqlExim) configPath() (string, error) {
+	// only reached when no path was supplied via init
+	conn := e.MqlRuntime.Connection.(shared.Connection)
+	if asset := conn.Asset(); asset != nil && asset.Platform != nil && asset.Platform.IsFamily("debian") {
+		// Debian's exim4-config package keeps dc_local_interfaces in its
+		// split-config control file regardless of where the assembled config
+		// lives, so this is the file to read on Debian-family systems
+		return debianEximConfig, nil
+	}
+
+	// otherwise ask Exim where its configuration lives — this handles BSD
+	// ports/pkgsrc, source installs, and other non-standard prefixes rather
+	// than assuming /etc/exim/exim.conf
+	if path := e.eximConfigureFile(); path != "" {
+		return path, nil
+	}
+	return monolithicEximConfig, nil
+}
+
+// eximConfigureFile returns the configuration file Exim itself reports via
+// `exim -bP configure_file`, or "" when the binary is unavailable.
+func (e *mqlExim) eximConfigureFile() string {
+	o, err := CreateResource(e.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData("exim -bP configure_file"),
+	})
+	if err != nil {
+		return ""
+	}
+	cmd := o.(*mqlCommand)
+
+	exit := cmd.GetExitcode()
+	if exit.Error != nil || exit.Data != 0 {
+		return ""
+	}
+	stdout := cmd.GetStdout()
+	if stdout.Error != nil {
+		return ""
+	}
+
+	// configure_file reports the single config file in use; take the first line
+	path := strings.TrimSpace(stdout.Data)
+	if idx := strings.IndexByte(path, '\n'); idx >= 0 {
+		path = strings.TrimSpace(path[:idx])
+	}
+	// Exim prints just the path here, but normalize defensively in case a build
+	// emits the general `optionname = value` form so the prefix doesn't leak
+	// into the path and break the file read
+	if rest, ok := strings.CutPrefix(path, "configure_file"); ok {
+		if after, ok := strings.CutPrefix(strings.TrimSpace(rest), "="); ok {
+			path = strings.TrimSpace(after)
+		}
+	}
+	return path
+}
+
+func (e *mqlExim) params() (map[string]any, error) {
+	configPath := e.GetConfigPath()
+	if configPath.Error != nil {
+		return nil, configPath.Error
+	}
+	content, err := e.readFile(configPath.Data)
+	if err != nil {
+		return nil, err
+	}
+	return parseEximConfig(content), nil
+}
+
+func (e *mqlExim) localInterfaces() ([]any, error) {
+	params := e.GetParams()
+	if params.Error != nil {
+		return nil, params.Error
+	}
+
+	// Debian split config: dc_local_interfaces is a ' ; '-separated string
+	if v, ok := params.Data["dc_local_interfaces"].(string); ok && v != "" {
+		return splitEximList(v, ";"), nil
+	}
+	// monolithic exim.conf: local_interfaces is an Exim list (default ':'
+	// separator, overridable with a leading '<sep')
+	if v, ok := params.Data["local_interfaces"].(string); ok && v != "" {
+		return parseEximListValue(v), nil
+	}
+	return []any{}, nil
+}
+
+// readFile reads a config file from the target's filesystem. A missing file
+// yields empty content rather than an error, so an MTA that isn't installed
+// resolves cleanly.
+func (e *mqlExim) readFile(path string) (string, error) {
+	conn := e.MqlRuntime.Connection.(shared.Connection)
+	f, err := conn.FileSystem().Open(path)
+	if err != nil {
+		// the connection's virtual filesystem may not return *os.PathError,
+		// so match the wrapped sentinel rather than using os.IsNotExist
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// parseEximConfig parses the macros and main-section options of an Exim config.
+// It handles both the Debian `KEY='value'` form and the monolithic `key = value`
+// form, folds backslash continuations, strips comments, and stops at the first
+// `begin <section>` block (routers, transports, acl, …) so only the main
+// section and macros are returned. Keys that are not simple assignments (named
+// lists like `domainlist x = …`, ACL conditions) are skipped.
+func parseEximConfig(content string) map[string]any {
+	params := map[string]any{}
+	for _, line := range joinEximContinuations(content) {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// the main section ends at the first `begin <section>` directive
+		if trimmed == "begin" || strings.HasPrefix(trimmed, "begin ") {
+			break
+		}
+
+		idx := strings.Index(trimmed, "=")
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(trimmed[:idx])
+		key = strings.TrimSpace(strings.TrimPrefix(key, "hide ")) // `hide key = value`
+		// a simple option or macro has a single-token name; skip named lists
+		// (`domainlist x = …`) and other multi-token left-hand sides
+		if key == "" || strings.ContainsAny(key, " \t") {
+			continue
+		}
+
+		params[key] = unquoteEximValue(strings.TrimSpace(trimmed[idx+1:]))
+	}
+	return params
+}
+
+// joinEximContinuations joins lines ending in a backslash with the following
+// line, matching Exim's line-continuation rule.
+func joinEximContinuations(content string) []string {
+	var logical []string
+	var buf strings.Builder
+	continuing := false
+
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if continuing {
+			buf.WriteString(strings.TrimLeft(line, " \t"))
+		} else {
+			buf.Reset()
+			buf.WriteString(line)
+		}
+
+		if strings.HasSuffix(strings.TrimRight(line, " \t"), "\\") {
+			s := strings.TrimSuffix(strings.TrimRight(buf.String(), " \t"), "\\")
+			buf.Reset()
+			buf.WriteString(s)
+			continuing = true
+			continue
+		}
+
+		logical = append(logical, buf.String())
+		continuing = false
+	}
+	if continuing {
+		logical = append(logical, buf.String())
+	}
+	return logical
+}
+
+// unquoteEximValue strips a matching pair of surrounding single or double
+// quotes (the Debian split config quotes its values).
+func unquoteEximValue(value string) string {
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}
+
+// parseEximListValue parses an Exim list, honoring the optional `<sep` prefix
+// that selects a non-default separator (needed for IPv6 addresses, which
+// otherwise collide with the default ':' separator).
+func parseEximListValue(value string) []any {
+	value = strings.TrimSpace(value)
+	sep := ":"
+	if strings.HasPrefix(value, "<") && len(value) >= 2 {
+		sep = string(value[1])
+		value = strings.TrimSpace(value[2:])
+	}
+	return splitEximList(value, sep)
+}
+
+// splitEximList splits value on sep and trims each token, dropping empties.
+func splitEximList(value, sep string) []any {
+	res := []any{}
+	for _, tok := range strings.Split(value, sep) {
+		if tok = strings.TrimSpace(tok); tok != "" {
+			res = append(res, tok)
+		}
+	}
+	return res
+}

--- a/providers/os/resources/exim_internal_test.go
+++ b/providers/os/resources/exim_internal_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEximConfig(t *testing.T) {
+	t.Run("Debian split-config key='value' form", func(t *testing.T) {
+		content := "# update-exim4.conf.conf\n" +
+			"dc_eximconfig_configtype='internet'\n" +
+			"dc_local_interfaces='127.0.0.1 ; ::1'\n" +
+			"dc_readhost=''\n"
+		got := parseEximConfig(content)
+		assert.Equal(t, "internet", got["dc_eximconfig_configtype"])
+		assert.Equal(t, "127.0.0.1 ; ::1", got["dc_local_interfaces"])
+		assert.Equal(t, "", got["dc_readhost"])
+	})
+
+	t.Run("monolithic key = value form with macros", func(t *testing.T) {
+		content := "# exim.conf\n" +
+			"MACRO = /var/spool/exim\n" +
+			"local_interfaces = <; 127.0.0.1 ; ::1\n" +
+			"primary_hostname = mail.example.com\n"
+		got := parseEximConfig(content)
+		assert.Equal(t, "/var/spool/exim", got["MACRO"])
+		assert.Equal(t, "<; 127.0.0.1 ; ::1", got["local_interfaces"])
+		assert.Equal(t, "mail.example.com", got["primary_hostname"])
+	})
+
+	t.Run("stops at the first begin block", func(t *testing.T) {
+		content := "primary_hostname = mail.example.com\n" +
+			"begin acl\n" +
+			"acl_check_rcpt:\n" +
+			"  accept hosts = +relay = something\n"
+		got := parseEximConfig(content)
+		assert.Equal(t, "mail.example.com", got["primary_hostname"])
+		_, hasAcl := got["acl_check_rcpt:"]
+		assert.False(t, hasAcl)
+		// an option-looking line inside the section must not leak in
+		_, leaked := got["accept hosts"]
+		assert.False(t, leaked)
+	})
+
+	t.Run("hide prefix and named lists", func(t *testing.T) {
+		content := "hide mysql_servers = localhost/db/user/secret\n" +
+			"domainlist local_domains = @\n"
+		got := parseEximConfig(content)
+		assert.Equal(t, "localhost/db/user/secret", got["mysql_servers"])
+		// named-list left-hand side has two tokens; it is not a simple option
+		_, hasNamedList := got["domainlist local_domains"]
+		assert.False(t, hasNamedList)
+	})
+
+	t.Run("backslash continuation", func(t *testing.T) {
+		content := "local_interfaces = <; 127.0.0.1 ; \\\n  ::1\n"
+		got := parseEximConfig(content)
+		assert.Equal(t, "<; 127.0.0.1 ; ::1", got["local_interfaces"])
+	})
+}
+
+func TestUnquoteEximValue(t *testing.T) {
+	assert.Equal(t, "127.0.0.1 ; ::1", unquoteEximValue("'127.0.0.1 ; ::1'"))
+	assert.Equal(t, "internet", unquoteEximValue(`"internet"`))
+	assert.Equal(t, "", unquoteEximValue("''"))
+	assert.Equal(t, "unquoted", unquoteEximValue("unquoted"))
+	assert.Equal(t, "'mismatched", unquoteEximValue("'mismatched"))
+}
+
+func TestParseEximListValue(t *testing.T) {
+	// custom separator via the <sep prefix (needed for IPv6)
+	assert.Equal(t, []any{"127.0.0.1", "::1"}, parseEximListValue("<; 127.0.0.1 ; ::1"))
+	// default ':' separator
+	assert.Equal(t, []any{"127.0.0.1", "192.168.0.1"}, parseEximListValue("127.0.0.1 : 192.168.0.1"))
+	assert.Equal(t, []any{"127.0.0.1"}, parseEximListValue("127.0.0.1"))
+}
+
+func TestSplitEximList(t *testing.T) {
+	assert.Equal(t, []any{"127.0.0.1", "::1"}, splitEximList("127.0.0.1 ; ::1", ";"))
+	assert.Equal(t, []any{}, splitEximList("", ";"))
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3717,6 +3717,27 @@ private postfix.service @defaults("service type command") {
   command string
 }
 
+// Exim mail transfer agent configuration
+//
+// Examine the Exim configuration. `params` holds the macros and main-section
+// options parsed from the active config file — both the Debian
+// `update-exim4.conf.conf` key/value form and the monolithic `exim.conf`
+// main section (options before the first `begin` block). `localInterfaces`
+// normalizes the local interface list, handling the Debian
+// `dc_local_interfaces` `' ; '`-separated form and the Exim `local_interfaces`
+// list, so policies can compare it directly. By default the per-distribution
+// config location is used; select an alternate file with
+// `exim("/path/to/exim.conf")`.
+exim {
+  init(path? string)
+  // Path to the active Exim configuration file
+  configPath() string
+  // Parsed macros and main-section options
+  params() map[string]string
+  // Local interfaces parsed and normalized into a list
+  localInterfaces() []string
+}
+
 // rsyslog daemon configuration
 //
 // Examine effective settings across the main file and included fragments.

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -188,6 +188,7 @@ const (
 	ResourceChronyConf                    string = "chrony.conf"
 	ResourcePostfix                       string = "postfix"
 	ResourcePostfixService                string = "postfix.service"
+	ResourceExim                          string = "exim"
 	ResourceRsyslogConf                   string = "rsyslog.conf"
 	ResourceRsyslogModule                 string = "rsyslog.module"
 	ResourceRsyslogInput                  string = "rsyslog.input"
@@ -1121,6 +1122,10 @@ func init() {
 		"postfix.service": {
 			// to override args, implement: initPostfixService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPostfixService,
+		},
+		"exim": {
+			Init:   initExim,
+			Create: createExim,
 		},
 		"rsyslog.conf": {
 			// to override args, implement: initRsyslogConf(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -5467,6 +5472,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"postfix.service.command": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPostfixService).GetCommand()).ToDataRes(types.String)
+	},
+	"exim.configPath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlExim).GetConfigPath()).ToDataRes(types.String)
+	},
+	"exim.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlExim).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"exim.localInterfaces": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlExim).GetLocalInterfaces()).ToDataRes(types.Array(types.String))
 	},
 	"rsyslog.conf.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRsyslogConf).GetPath()).ToDataRes(types.String)
@@ -14726,6 +14740,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"postfix.service.command": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPostfixService).Command, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"exim.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlExim).__id, ok = v.Value.(string)
+		return
+	},
+	"exim.configPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlExim).ConfigPath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"exim.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlExim).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"exim.localInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlExim).LocalInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"rsyslog.conf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36772,6 +36802,71 @@ func (c *mqlPostfixService) GetMaxProcesses() *plugin.TValue[string] {
 
 func (c *mqlPostfixService) GetCommand() *plugin.TValue[string] {
 	return &c.Command
+}
+
+// mqlExim for the exim resource
+type mqlExim struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlEximInternal it will be used here
+	ConfigPath      plugin.TValue[string]
+	Params          plugin.TValue[map[string]any]
+	LocalInterfaces plugin.TValue[[]any]
+}
+
+// createExim creates a new instance of this resource
+func createExim(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlExim{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("exim", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlExim) MqlName() string {
+	return "exim"
+}
+
+func (c *mqlExim) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlExim) GetConfigPath() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ConfigPath, func() (string, error) {
+		return c.configPath()
+	})
+}
+
+func (c *mqlExim) GetParams() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Params, func() (map[string]any, error) {
+		return c.params()
+	})
+}
+
+func (c *mqlExim) GetLocalInterfaces() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LocalInterfaces, func() ([]any, error) {
+		return c.localInterfaces()
+	})
 }
 
 // mqlRsyslogConf for the rsyslog.conf resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -589,6 +589,10 @@ erlang.packages 13.13.1
 erlang.packages.files 13.13.1
 erlang.packages.list 13.13.1
 erlang.packages.path 13.13.1
+exim 13.23.1
+exim.configPath 13.23.1
+exim.localInterfaces 13.23.1
+exim.params 13.23.1
 file 9.0.0
 file.basename 9.0.0
 file.content 9.0.0


### PR DESCRIPTION
## Summary

Adds an `exim` resource exposing the parsed Exim (Mail Transfer Agent) configuration. Part of #8053 (the `postfix` resource ships as a separate PR, #8220).

Today the `mondoo-linux-security-mail-transfer-agent-is-configured-for-local-only-mode` check matches Exim's config against a hard-coded literal string `"'127.0.0.1 ; ::1'"`, so any whitespace or ordering difference produces a false negative.

## Resource

```
exim {
  init(path? string)         // override the config location
  configPath() string
  params() map[string]string
  localInterfaces() []string
}
```

## Behavior

- **`configPath`** resolves per-distribution: Debian → `/etc/exim4/update-exim4.conf.conf` (the `dc_*` control file the policy reads), otherwise the monolithic `/etc/exim/exim.conf`.
- **`params`** parses macros and main-section options from **both** config forms — the Debian `KEY='value'` form and the monolithic `key = value` form — folding `\` continuations, stripping comments and the `hide` prefix, and **stopping at the first `begin <section>` block** so router/transport/ACL DSL doesn't leak in. Named lists (`domainlist x = …`) and other multi-token left-hand sides are skipped.
- **`localInterfaces`** normalizes the local-interface list: the Debian `dc_local_interfaces` `' ; '`-separated form, and the Exim `local_interfaces` list syntax including the `<sep` separator-override prefix (needed for IPv6, which collides with the default `:` separator).
- **`init(path?)`** overrides the config location; a missing file resolves to empty rather than erroring.

## Example queries

```mql
exim.localInterfaces.containsOnly(["127.0.0.1", "::1"])
```

## Testing

- `go build` / `go vet` clean; `make providers/build/os` succeeds (`exim` registered).
- Unit tests cover `parseEximConfig` (Debian + monolithic forms, macros, `begin`-block stop, `hide` prefix, named-list skip, backslash continuation), `unquoteEximValue`, `parseEximListValue` (default `:` and `<sep` override), and `splitEximList`.
- New `.lr.versions` entries at 13.22.2.