### PR TITLE
✨ Add copilot and enforcementPlanes fields to ms365 dlpCompliancePolicy

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -3616,6 +3616,18 @@ private ms365.exchangeonline.dlpCompliancePolicy @defaults("name mode enabled wo
   whenCreated time
   // Date and time the policy was last changed
   whenChanged time
+  // Enforcement planes
+  //
+  // Layers where the policy's actions run. Values include Browser (unmanaged
+  // cloud apps in Microsoft Edge for Business), CopilotExperiences (Microsoft
+  // 365 Copilot interactions), Application (Entra-registered enterprise
+  // applications), and Network.
+  enforcementPlanes []string
+  // Microsoft 365 Copilot location scope
+  //
+  // Inclusion and exclusion scoping for the Microsoft 365 Copilot location the
+  // policy covers, or null when the policy doesn't apply to Copilot.
+  copilot dict
 }
 
 // Teams Protection Policy configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -4541,6 +4541,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.exchangeonline.dlpCompliancePolicy.whenChanged": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetWhenChanged()).ToDataRes(types.Time)
 	},
+	"ms365.exchangeonline.dlpCompliancePolicy.enforcementPlanes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetEnforcementPlanes()).ToDataRes(types.Array(types.String))
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.copilot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).GetCopilot()).ToDataRes(types.Dict)
+	},
 	"ms365.exchangeonline.teamsProtectionPolicy.zapEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineTeamsProtectionPolicy).GetZapEnabled()).ToDataRes(types.Bool)
 	},
@@ -10909,6 +10915,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.exchangeonline.dlpCompliancePolicy.whenChanged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).WhenChanged, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.enforcementPlanes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).EnforcementPlanes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.dlpCompliancePolicy.copilot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineDlpCompliancePolicy).Copilot, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"ms365.exchangeonline.teamsProtectionPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26056,6 +26070,8 @@ type mqlMs365ExchangeonlineDlpCompliancePolicy struct {
 	DistributionStatus plugin.TValue[string]
 	WhenCreated        plugin.TValue[*time.Time]
 	WhenChanged        plugin.TValue[*time.Time]
+	EnforcementPlanes  plugin.TValue[[]any]
+	Copilot            plugin.TValue[any]
 }
 
 // createMs365ExchangeonlineDlpCompliancePolicy creates a new instance of this resource
@@ -26136,6 +26152,14 @@ func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetWhenCreated() *plugin.TVa
 
 func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetWhenChanged() *plugin.TValue[*time.Time] {
 	return &c.WhenChanged
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetEnforcementPlanes() *plugin.TValue[[]any] {
+	return &c.EnforcementPlanes
+}
+
+func (c *mqlMs365ExchangeonlineDlpCompliancePolicy) GetCopilot() *plugin.TValue[any] {
+	return &c.Copilot
 }
 
 // mqlMs365ExchangeonlineTeamsProtectionPolicy for the ms365.exchangeonline.teamsProtectionPolicy resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1272,9 +1272,11 @@ ms365.exchangeonline.dkimSigningConfigEntry.status 13.3.1
 ms365.exchangeonline.dkimSigningConfigs 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy.comment 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.copilot 13.5.1
 ms365.exchangeonline.dlpCompliancePolicy.createdBy 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy.distributionStatus 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy.enabled 13.3.1
+ms365.exchangeonline.dlpCompliancePolicy.enforcementPlanes 13.5.1
 ms365.exchangeonline.dlpCompliancePolicy.guid 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy.isValid 13.3.1
 ms365.exchangeonline.dlpCompliancePolicy.mode 13.3.1

--- a/providers/ms365/resources/ms365_securitycompliance_dlp.go
+++ b/providers/ms365/resources/ms365_securitycompliance_dlp.go
@@ -10,6 +10,8 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // dlpPolicies returns the Data Loss Prevention compliance policies as typed
@@ -38,6 +40,11 @@ func convertDlpCompliancePolicies(runtime *plugin.Runtime, raw []any) ([]any, er
 			id = dlpString(m, "Name")
 		}
 
+		copilot, err := convert.JsonToDict(m["Copilot"])
+		if err != nil {
+			return nil, err
+		}
+
 		mql, err := CreateResource(runtime, "ms365.exchangeonline.dlpCompliancePolicy",
 			map[string]*llx.RawData{
 				"__id":               llx.StringData("dlpCompliancePolicy-" + id),
@@ -53,6 +60,8 @@ func convertDlpCompliancePolicies(runtime *plugin.Runtime, raw []any) ([]any, er
 				"distributionStatus": llx.StringData(dlpString(m, "DistributionStatus")),
 				"whenCreated":        llx.TimeDataPtr(dlpTime(m, "WhenCreated")),
 				"whenChanged":        llx.TimeDataPtr(dlpTime(m, "WhenChanged")),
+				"enforcementPlanes":  llx.ArrayData(dlpStringSlice(m, "EnforcementPlanes"), types.String),
+				"copilot":            llx.DictData(copilot),
 			})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

Adds two Microsoft Purview DLP policy properties to `ms365.exchangeonline.dlpCompliancePolicy`:

- **`enforcementPlanes []string`** — the layers where the policy's actions run. Per the `Get-DlpCompliancePolicy` schema this is a `MultiValuedProperty` with values `Browser`, `CopilotExperiences`, `Application`, and `Network`.
- **`copilot dict`** — the Microsoft 365 Copilot location scope. There's no scalar `-Copilot` parameter; it's a location collection (set via `-Locations`) that serializes as null/array-of-objects and varies by module version, so it's modeled as a `dict` rather than guessing a typed shape. This matches the resource's existing defensive extraction (the underlying data comes from the Security & Compliance PowerShell report).

`enforcementPlanes` reuses the existing `dlpStringSlice` helper; `copilot` is extracted via `convert.JsonToDict`. Neither value identifies a modeled resource, so no typed accessors are warranted.

## Verification

Built and installed the provider, then queried the live test tenant:

\`\`\`
ms365.exchangeonline.securityAndCompliance.dlpPolicies { name enforcementPlanes copilot }
→ enforcementPlanes: []   copilot: {}   (both default policies)
\`\`\`

Both fields resolve without error. The tenant's two legacy default policies have neither configured, so populated shapes weren't observable live — the field types are grounded in the `Get-DlpCompliancePolicy` cmdlet reference.

## Notes

- New `.lr.versions` entries land at `13.5.1` (next patch after the provider's current `13.5.0`).
- No `.permissions.json` change — this is PowerShell-backed, not a new IAM/SDK call.