### PR TITLE
✨ Add ms365 defaultAppManagementPolicy resource

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -2028,8 +2028,6 @@ microsoft.policies {
 // subject to them. Use these to audit that long-lived or unrestricted app
 // credentials are disallowed across the tenant.
 private microsoft.defaultAppManagementPolicy @defaults("displayName isEnabled") {
-  // Policy ID
-  id string
   // Policy display name
   displayName string
   // Policy description

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -2013,6 +2013,47 @@ microsoft.policies {
   externalIdentitiesPolicy() microsoft.externalIdentitiesPolicy
   // Default configuration of cross-tenant access policy
   crossTenantAccessPolicy() microsoft.crossTenantAccessPolicyDefault
+  // Tenant-wide default app management policy
+  defaultAppManagementPolicy() microsoft.defaultAppManagementPolicy
+}
+
+// Tenant Default App Management Policy
+//
+// Examine the tenant-wide default policy that restricts the secrets and
+// certificates configurable on application registrations and service
+// principals. The `isEnabled` field reports whether the restrictions are
+// enforced, while `applicationRestrictions` and `servicePrincipalRestrictions`
+// expose the password- and key-credential rules — maximum allowed lifetime,
+// the restriction type, and the date after which newly created apps become
+// subject to them. Use these to audit that long-lived or unrestricted app
+// credentials are disallowed across the tenant.
+private microsoft.defaultAppManagementPolicy @defaults("displayName isEnabled") {
+  // Policy ID
+  id string
+  // Policy display name
+  displayName string
+  // Policy description
+  description string
+  // Denotes whether the policy restrictions are enforced for all applications and service principals in the tenant
+  isEnabled bool
+  // Restrictions that apply to application objects in the tenant
+  applicationRestrictions microsoft.defaultAppManagementPolicy.appManagementConfiguration
+  // Restrictions that apply to service principal objects in the tenant
+  servicePrincipalRestrictions microsoft.defaultAppManagementPolicy.appManagementConfiguration
+}
+
+// App Management Credential Restrictions
+//
+// Examine the password- and key-credential restrictions enforced on
+// applications or service principals. Each entry in `passwordCredentials`
+// and `keyCredentials` carries the restriction type, the maximum allowed
+// credential lifetime, the state (`enabled` or `disabled`), and the date
+// after which apps created later are subject to the restriction.
+private microsoft.defaultAppManagementPolicy.appManagementConfiguration @defaults("passwordCredentials keyCredentials") {
+  // Restrictions on the password (secret) credentials that can be added
+  passwordCredentials []dict
+  // Restrictions on the key (certificate) credentials that can be added
+  keyCredentials []dict
 }
 
 // Tenant-wide policy that controls whether external users can leave a tenant via self-service controls

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -102,6 +102,8 @@ const (
 	ResourceMicrosoftSecurityInformationProtection                                                       string = "microsoft.security.informationProtection"
 	ResourceMicrosoftSecurityInformationProtectionSensitivityLabel                                       string = "microsoft.security.informationProtection.sensitivityLabel"
 	ResourceMicrosoftPolicies                                                                            string = "microsoft.policies"
+	ResourceMicrosoftDefaultAppManagementPolicy                                                          string = "microsoft.defaultAppManagementPolicy"
+	ResourceMicrosoftDefaultAppManagementPolicyAppManagementConfiguration                                string = "microsoft.defaultAppManagementPolicy.appManagementConfiguration"
 	ResourceMicrosoftExternalIdentitiesPolicy                                                            string = "microsoft.externalIdentitiesPolicy"
 	ResourceMicrosoftPoliciesActivityBasedTimeoutPolicy                                                  string = "microsoft.policies.activityBasedTimeoutPolicy"
 	ResourceMicrosoftAdminConsentRequestPolicy                                                           string = "microsoft.adminConsentRequestPolicy"
@@ -540,6 +542,14 @@ func init() {
 		"microsoft.policies": {
 			// to override args, implement: initMicrosoftPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftPolicies,
+		},
+		"microsoft.defaultAppManagementPolicy": {
+			Init:   initMicrosoftDefaultAppManagementPolicy,
+			Create: createMicrosoftDefaultAppManagementPolicy,
+		},
+		"microsoft.defaultAppManagementPolicy.appManagementConfiguration": {
+			// to override args, implement: initMicrosoftDefaultAppManagementPolicyAppManagementConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftDefaultAppManagementPolicyAppManagementConfiguration,
 		},
 		"microsoft.externalIdentitiesPolicy": {
 			Init:   initMicrosoftExternalIdentitiesPolicy,
@@ -2998,6 +3008,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.policies.crossTenantAccessPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftPolicies).GetCrossTenantAccessPolicy()).ToDataRes(types.Resource("microsoft.crossTenantAccessPolicyDefault"))
+	},
+	"microsoft.policies.defaultAppManagementPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPolicies).GetDefaultAppManagementPolicy()).ToDataRes(types.Resource("microsoft.defaultAppManagementPolicy"))
+	},
+	"microsoft.defaultAppManagementPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.defaultAppManagementPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.defaultAppManagementPolicy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.defaultAppManagementPolicy.isEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetIsEnabled()).ToDataRes(types.Bool)
+	},
+	"microsoft.defaultAppManagementPolicy.applicationRestrictions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetApplicationRestrictions()).ToDataRes(types.Resource("microsoft.defaultAppManagementPolicy.appManagementConfiguration"))
+	},
+	"microsoft.defaultAppManagementPolicy.servicePrincipalRestrictions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetServicePrincipalRestrictions()).ToDataRes(types.Resource("microsoft.defaultAppManagementPolicy.appManagementConfiguration"))
+	},
+	"microsoft.defaultAppManagementPolicy.appManagementConfiguration.passwordCredentials": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration).GetPasswordCredentials()).ToDataRes(types.Array(types.Dict))
+	},
+	"microsoft.defaultAppManagementPolicy.appManagementConfiguration.keyCredentials": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration).GetKeyCredentials()).ToDataRes(types.Array(types.Dict))
 	},
 	"microsoft.externalIdentitiesPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftExternalIdentitiesPolicy).GetId()).ToDataRes(types.String)
@@ -8629,6 +8666,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.policies.crossTenantAccessPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftPolicies).CrossTenantAccessPolicy, ok = plugin.RawToTValue[*mqlMicrosoftCrossTenantAccessPolicyDefault](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.defaultAppManagementPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPolicies).DefaultAppManagementPolicy, ok = plugin.RawToTValue[*mqlMicrosoftDefaultAppManagementPolicy](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.isEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).IsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.applicationRestrictions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).ApplicationRestrictions, ok = plugin.RawToTValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.servicePrincipalRestrictions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicy).ServicePrincipalRestrictions, ok = plugin.RawToTValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.appManagementConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.appManagementConfiguration.passwordCredentials": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration).PasswordCredentials, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.defaultAppManagementPolicy.appManagementConfiguration.keyCredentials": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration).KeyCredentials, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"microsoft.externalIdentitiesPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20160,6 +20241,7 @@ type mqlMicrosoftPolicies struct {
 	ActivityBasedTimeoutPolicies              plugin.TValue[[]any]
 	ExternalIdentitiesPolicy                  plugin.TValue[*mqlMicrosoftExternalIdentitiesPolicy]
 	CrossTenantAccessPolicy                   plugin.TValue[*mqlMicrosoftCrossTenantAccessPolicyDefault]
+	DefaultAppManagementPolicy                plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicy]
 }
 
 // createMicrosoftPolicies creates a new instance of this resource
@@ -20296,6 +20378,140 @@ func (c *mqlMicrosoftPolicies) GetCrossTenantAccessPolicy() *plugin.TValue[*mqlM
 
 		return c.crossTenantAccessPolicy()
 	})
+}
+
+func (c *mqlMicrosoftPolicies) GetDefaultAppManagementPolicy() *plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicy] {
+	return plugin.GetOrCompute[*mqlMicrosoftDefaultAppManagementPolicy](&c.DefaultAppManagementPolicy, func() (*mqlMicrosoftDefaultAppManagementPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.policies", c.__id, "defaultAppManagementPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftDefaultAppManagementPolicy), nil
+			}
+		}
+
+		return c.defaultAppManagementPolicy()
+	})
+}
+
+// mqlMicrosoftDefaultAppManagementPolicy for the microsoft.defaultAppManagementPolicy resource
+type mqlMicrosoftDefaultAppManagementPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDefaultAppManagementPolicyInternal it will be used here
+	Id                           plugin.TValue[string]
+	DisplayName                  plugin.TValue[string]
+	Description                  plugin.TValue[string]
+	IsEnabled                    plugin.TValue[bool]
+	ApplicationRestrictions      plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration]
+	ServicePrincipalRestrictions plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration]
+}
+
+// createMicrosoftDefaultAppManagementPolicy creates a new instance of this resource
+func createMicrosoftDefaultAppManagementPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDefaultAppManagementPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.defaultAppManagementPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) MqlName() string {
+	return "microsoft.defaultAppManagementPolicy"
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetIsEnabled() *plugin.TValue[bool] {
+	return &c.IsEnabled
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetApplicationRestrictions() *plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration] {
+	return &c.ApplicationRestrictions
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicy) GetServicePrincipalRestrictions() *plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration] {
+	return &c.ServicePrincipalRestrictions
+}
+
+// mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration for the microsoft.defaultAppManagementPolicy.appManagementConfiguration resource
+type mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDefaultAppManagementPolicyAppManagementConfigurationInternal it will be used here
+	PasswordCredentials plugin.TValue[[]any]
+	KeyCredentials      plugin.TValue[[]any]
+}
+
+// createMicrosoftDefaultAppManagementPolicyAppManagementConfiguration creates a new instance of this resource
+func createMicrosoftDefaultAppManagementPolicyAppManagementConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.defaultAppManagementPolicy.appManagementConfiguration", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration) MqlName() string {
+	return "microsoft.defaultAppManagementPolicy.appManagementConfiguration"
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration) GetPasswordCredentials() *plugin.TValue[[]any] {
+	return &c.PasswordCredentials
+}
+
+func (c *mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration) GetKeyCredentials() *plugin.TValue[[]any] {
+	return &c.KeyCredentials
 }
 
 // mqlMicrosoftExternalIdentitiesPolicy for the microsoft.externalIdentitiesPolicy resource

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -3012,9 +3012,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.policies.defaultAppManagementPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftPolicies).GetDefaultAppManagementPolicy()).ToDataRes(types.Resource("microsoft.defaultAppManagementPolicy"))
 	},
-	"microsoft.defaultAppManagementPolicy.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetId()).ToDataRes(types.String)
-	},
 	"microsoft.defaultAppManagementPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetDisplayName()).ToDataRes(types.String)
 	},
@@ -8674,10 +8671,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.defaultAppManagementPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDefaultAppManagementPolicy).__id, ok = v.Value.(string)
-		return
-	},
-	"microsoft.defaultAppManagementPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftDefaultAppManagementPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.defaultAppManagementPolicy.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20401,7 +20394,6 @@ type mqlMicrosoftDefaultAppManagementPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftDefaultAppManagementPolicyInternal it will be used here
-	Id                           plugin.TValue[string]
 	DisplayName                  plugin.TValue[string]
 	Description                  plugin.TValue[string]
 	IsEnabled                    plugin.TValue[bool]
@@ -20439,10 +20431,6 @@ func (c *mqlMicrosoftDefaultAppManagementPolicy) MqlName() string {
 
 func (c *mqlMicrosoftDefaultAppManagementPolicy) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlMicrosoftDefaultAppManagementPolicy) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlMicrosoftDefaultAppManagementPolicy) GetDisplayName() *plugin.TValue[string] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -245,6 +245,16 @@ microsoft.crossTenantAccessPolicyDefault.invitationRedemptionIdentityProviderCon
 microsoft.crossTenantAccessPolicyDefault.invitationRedemptionIdentityProviderConfiguration.primaryIdentityProviderPrecedenceOrder 11.1.99
 microsoft.crossTenantAccessPolicyDefault.isServiceDefault 11.1.99
 microsoft.crossTenantAccessPolicyDefault.tenantRestrictions 11.1.99
+microsoft.defaultAppManagementPolicy 13.5.1
+microsoft.defaultAppManagementPolicy.appManagementConfiguration 13.5.1
+microsoft.defaultAppManagementPolicy.appManagementConfiguration.keyCredentials 13.5.1
+microsoft.defaultAppManagementPolicy.appManagementConfiguration.passwordCredentials 13.5.1
+microsoft.defaultAppManagementPolicy.applicationRestrictions 13.5.1
+microsoft.defaultAppManagementPolicy.description 13.5.1
+microsoft.defaultAppManagementPolicy.displayName 13.5.1
+microsoft.defaultAppManagementPolicy.id 13.5.1
+microsoft.defaultAppManagementPolicy.isEnabled 13.5.1
+microsoft.defaultAppManagementPolicy.servicePrincipalRestrictions 13.5.1
 microsoft.device 11.1.21
 microsoft.device.accountEnabled 11.2.1
 microsoft.device.approximateLastSignInDateTime 13.0.12
@@ -843,6 +853,7 @@ microsoft.policies.authenticationMethodsPolicy 11.1.39
 microsoft.policies.authorizationPolicy 9.0.0
 microsoft.policies.consentPolicySettings 9.0.0
 microsoft.policies.crossTenantAccessPolicy 9.0.0
+microsoft.policies.defaultAppManagementPolicy 13.5.1
 microsoft.policies.externalIdentitiesPolicy 11.1.43
 microsoft.policies.identitySecurityDefaultsEnforcementPolicy 9.0.0
 microsoft.policies.permissionGrantPolicies 9.0.0

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -252,7 +252,6 @@ microsoft.defaultAppManagementPolicy.appManagementConfiguration.passwordCredenti
 microsoft.defaultAppManagementPolicy.applicationRestrictions 13.5.1
 microsoft.defaultAppManagementPolicy.description 13.5.1
 microsoft.defaultAppManagementPolicy.displayName 13.5.1
-microsoft.defaultAppManagementPolicy.id 13.5.1
 microsoft.defaultAppManagementPolicy.isEnabled 13.5.1
 microsoft.defaultAppManagementPolicy.servicePrincipalRestrictions 13.5.1
 microsoft.device 11.1.21

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/policies"
 	"go.mondoo.com/mql/v13/llx"
@@ -677,43 +679,53 @@ func initMicrosoftDefaultAppManagementPolicy(runtime *plugin.Runtime, args map[s
 	return nil, policy, nil
 }
 
+// credentialRestrictionConfig captures the getters shared by the password and
+// key credential configuration types, whose only differing getter is the
+// restriction type (its enum type differs between the two).
+type credentialRestrictionConfig interface {
+	GetMaxLifetime() *serialization.ISODuration
+	GetState() *models.AppManagementRestrictionState
+	GetRestrictForAppsCreatedAfterDateTime() *time.Time
+}
+
+func mapCredentialRestrictions[T credentialRestrictionConfig](creds []T, restrictionType func(T) string) []any {
+	restrictions := []any{}
+	for _, c := range creds {
+		d := map[string]any{}
+		if rt := restrictionType(c); rt != "" {
+			d["restrictionType"] = rt
+		}
+		if c.GetMaxLifetime() != nil {
+			d["maxLifetime"] = c.GetMaxLifetime().String()
+		}
+		if c.GetState() != nil {
+			d["state"] = c.GetState().String()
+		}
+		if c.GetRestrictForAppsCreatedAfterDateTime() != nil {
+			d["restrictForAppsCreatedAfterDateTime"] = *c.GetRestrictForAppsCreatedAfterDateTime()
+		}
+		restrictions = append(restrictions, d)
+	}
+	return restrictions
+}
+
 func newAppManagementConfiguration(runtime *plugin.Runtime, config models.AppManagementConfigurationable, id string) (*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration, error) {
 	passwordCredentials := []any{}
 	keyCredentials := []any{}
 
 	if config != nil {
-		for _, c := range config.GetPasswordCredentials() {
-			d := map[string]any{}
+		passwordCredentials = mapCredentialRestrictions(config.GetPasswordCredentials(), func(c models.PasswordCredentialConfigurationable) string {
 			if c.GetRestrictionType() != nil {
-				d["restrictionType"] = c.GetRestrictionType().String()
+				return c.GetRestrictionType().String()
 			}
-			if c.GetMaxLifetime() != nil {
-				d["maxLifetime"] = c.GetMaxLifetime().String()
-			}
-			if c.GetState() != nil {
-				d["state"] = c.GetState().String()
-			}
-			if c.GetRestrictForAppsCreatedAfterDateTime() != nil {
-				d["restrictForAppsCreatedAfterDateTime"] = *c.GetRestrictForAppsCreatedAfterDateTime()
-			}
-			passwordCredentials = append(passwordCredentials, d)
-		}
-		for _, c := range config.GetKeyCredentials() {
-			d := map[string]any{}
+			return ""
+		})
+		keyCredentials = mapCredentialRestrictions(config.GetKeyCredentials(), func(c models.KeyCredentialConfigurationable) string {
 			if c.GetRestrictionType() != nil {
-				d["restrictionType"] = c.GetRestrictionType().String()
+				return c.GetRestrictionType().String()
 			}
-			if c.GetMaxLifetime() != nil {
-				d["maxLifetime"] = c.GetMaxLifetime().String()
-			}
-			if c.GetState() != nil {
-				d["state"] = c.GetState().String()
-			}
-			if c.GetRestrictForAppsCreatedAfterDateTime() != nil {
-				d["restrictForAppsCreatedAfterDateTime"] = *c.GetRestrictForAppsCreatedAfterDateTime()
-			}
-			keyCredentials = append(keyCredentials, d)
-		}
+			return ""
+		})
 	}
 
 	resource, err := CreateResource(runtime, "microsoft.defaultAppManagementPolicy.appManagementConfiguration",

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -618,6 +618,117 @@ func (a *mqlMicrosoftCrossTenantAccessPolicyDefault) invitationRedemptionIdentit
 	return a.cachedInvitationRedemptionIdentityProviderConfiguration, nil
 }
 
+// https://learn.microsoft.com/en-us/graph/api/tenantappmanagementpolicy-get?view=graph-rest-1.0
+func (a *mqlMicrosoftPolicies) defaultAppManagementPolicy() (*mqlMicrosoftDefaultAppManagementPolicy, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := graphClient.Policies().DefaultAppManagementPolicy().Get(context.Background(), nil)
+	if err != nil {
+		return nil, transformError(err)
+	}
+
+	policyId := ""
+	if policy.GetId() != nil {
+		policyId = *policy.GetId()
+	}
+
+	appRestrictions, err := newAppManagementConfiguration(a.MqlRuntime, policy.GetApplicationRestrictions(), policyId+"/applicationRestrictions")
+	if err != nil {
+		return nil, err
+	}
+	spRestrictions, err := newAppManagementConfiguration(a.MqlRuntime, policy.GetServicePrincipalRestrictions(), policyId+"/servicePrincipalRestrictions")
+	if err != nil {
+		return nil, err
+	}
+
+	resource, err := CreateResource(a.MqlRuntime, "microsoft.defaultAppManagementPolicy",
+		map[string]*llx.RawData{
+			"__id":                         llx.StringData(policyId),
+			"id":                           llx.StringDataPtr(policy.GetId()),
+			"displayName":                  llx.StringDataPtr(policy.GetDisplayName()),
+			"description":                  llx.StringDataPtr(policy.GetDescription()),
+			"isEnabled":                    llx.BoolDataPtr(policy.GetIsEnabled()),
+			"applicationRestrictions":      llx.ResourceData(appRestrictions, "microsoft.defaultAppManagementPolicy.appManagementConfiguration"),
+			"servicePrincipalRestrictions": llx.ResourceData(spRestrictions, "microsoft.defaultAppManagementPolicy.appManagementConfiguration"),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.(*mqlMicrosoftDefaultAppManagementPolicy), nil
+}
+
+func initMicrosoftDefaultAppManagementPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// Create the parent policies resource and call its method
+	policiesResource, err := CreateResource(runtime, ResourceMicrosoftPolicies, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	policy, err := policiesResource.(*mqlMicrosoftPolicies).defaultAppManagementPolicy()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, policy, nil
+}
+
+func newAppManagementConfiguration(runtime *plugin.Runtime, config models.AppManagementConfigurationable, id string) (*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration, error) {
+	passwordCredentials := []any{}
+	keyCredentials := []any{}
+
+	if config != nil {
+		for _, c := range config.GetPasswordCredentials() {
+			d := map[string]any{}
+			if c.GetRestrictionType() != nil {
+				d["restrictionType"] = c.GetRestrictionType().String()
+			}
+			if c.GetMaxLifetime() != nil {
+				d["maxLifetime"] = c.GetMaxLifetime().String()
+			}
+			if c.GetState() != nil {
+				d["state"] = c.GetState().String()
+			}
+			if c.GetRestrictForAppsCreatedAfterDateTime() != nil {
+				d["restrictForAppsCreatedAfterDateTime"] = *c.GetRestrictForAppsCreatedAfterDateTime()
+			}
+			passwordCredentials = append(passwordCredentials, d)
+		}
+		for _, c := range config.GetKeyCredentials() {
+			d := map[string]any{}
+			if c.GetRestrictionType() != nil {
+				d["restrictionType"] = c.GetRestrictionType().String()
+			}
+			if c.GetMaxLifetime() != nil {
+				d["maxLifetime"] = c.GetMaxLifetime().String()
+			}
+			if c.GetState() != nil {
+				d["state"] = c.GetState().String()
+			}
+			if c.GetRestrictForAppsCreatedAfterDateTime() != nil {
+				d["restrictForAppsCreatedAfterDateTime"] = *c.GetRestrictForAppsCreatedAfterDateTime()
+			}
+			keyCredentials = append(keyCredentials, d)
+		}
+	}
+
+	resource, err := CreateResource(runtime, "microsoft.defaultAppManagementPolicy.appManagementConfiguration",
+		map[string]*llx.RawData{
+			"__id":                llx.StringData(id),
+			"passwordCredentials": llx.ArrayData(passwordCredentials, types.Dict),
+			"keyCredentials":      llx.ArrayData(keyCredentials, types.Dict),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.(*mqlMicrosoftDefaultAppManagementPolicyAppManagementConfiguration), nil
+}
+
 func newB2BSetting(runtime *plugin.Runtime, setting models.CrossTenantAccessPolicyB2BSettingable, settingId string) (*mqlMicrosoftCrossTenantAccessPolicyDefaultB2bSetting, error) {
 	usersAndGroups, err := newCrossTenantAccessPolicyTarget(runtime, setting.GetUsersAndGroups(), settingId+"-usersAndGroups")
 	if err != nil {

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -650,7 +650,6 @@ func (a *mqlMicrosoftPolicies) defaultAppManagementPolicy() (*mqlMicrosoftDefaul
 	resource, err := CreateResource(a.MqlRuntime, "microsoft.defaultAppManagementPolicy",
 		map[string]*llx.RawData{
 			"__id":                         llx.StringData(policyId),
-			"id":                           llx.StringDataPtr(policy.GetId()),
 			"displayName":                  llx.StringDataPtr(policy.GetDisplayName()),
 			"description":                  llx.StringDataPtr(policy.GetDescription()),
 			"isEnabled":                    llx.BoolDataPtr(policy.GetIsEnabled()),


### PR DESCRIPTION
## What

Adds the tenant-wide **default app management policy** to the ms365 provider, exposing Microsoft Graph's [`tenantAppManagementPolicy`](https://learn.microsoft.com/en-us/graph/api/tenantappmanagementpolicy-get) at `/policies/defaultAppManagementPolicy`. This policy restricts the secrets and certificates that can be configured on application registrations and service principals across the tenant — a common app-security audit target (e.g. "no long-lived or unrestricted app credentials").

## Schema

- New accessor `microsoft.policies.defaultAppManagementPolicy()` on the existing `microsoft.policies` namespace.
- `microsoft.defaultAppManagementPolicy` — `id`, `displayName`, `description`, `isEnabled`, plus typed `applicationRestrictions` and `servicePrincipalRestrictions`.
- `microsoft.defaultAppManagementPolicy.appManagementConfiguration` — `passwordCredentials []dict` and `keyCredentials []dict`, each entry carrying `restrictionType`, `maxLifetime`, `state`, and `restrictForAppsCreatedAfterDateTime`.

```mql
microsoft.policies.defaultAppManagementPolicy {
  isEnabled
  applicationRestrictions { passwordCredentials keyCredentials }
  servicePrincipalRestrictions { passwordCredentials keyCredentials }
}
```

## Notes

- The credential restriction entries use `[]dict` per the sub-resource bar (no stable id, no nested typed refs); the typed `appManagementConfiguration` container distinguishes the application vs. service-principal sets.
- The resource is named `microsoft.defaultAppManagementPolicy` (under `microsoft.`) rather than `microsoft.policies.defaultAppManagementPolicy`, matching the sibling policy resources (`microsoft.externalIdentitiesPolicy`, `microsoft.adminConsentRequestPolicy`). Naming it under `microsoft.policies.` collides with the field path and returns an empty husk (`cannot convert primitive with NO type information`).
- An `init` enables the bare-resource form (`microsoft.defaultAppManagementPolicy { ... }`), matching `microsoft.externalIdentitiesPolicy`.
- No new IAM permission — `Policy.Read.All` (already required) covers this endpoint; `permissions.json` unchanged.

## Verification

Tested live against the lunalectric test tenant via both the dotted accessor and the bare-resource form:

```
microsoft.policies.defaultAppManagementPolicy: {
  isEnabled: true
  displayName: "Default app management tenant policy"
  description: "Default tenant policy that enforces app management restrictions..."
  applicationRestrictions: { passwordCredentials: [] keyCredentials: [] }
  servicePrincipalRestrictions: { passwordCredentials: [] keyCredentials: [] }
  id: "00000000-0000-0000-0000-000000000000"
}
```

Credential lists are empty because the test tenant configures no restrictions on the default policy (its expected real state). The populated-dict shape was not exercised against live data — the test tenant has none configured and the seed app lacks `Policy.ReadWrite.ApplicationConfiguration` to add one.

`go vet`, `go test ./resources/`, and `gofmt` all clean.