### PR TITLE
✨ Add typed policy statements and security audit fields across AWS resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -223,6 +223,33 @@ aws.organization @defaults("id masterAccountEmail") {
   delegatedAdministrators() []aws.organization.delegatedAdministrator
   // List of organizational units in the organization
   organizationalUnits() []aws.organization.organizationalUnit
+  // Service control policies defined in the organization, if available to the caller
+  serviceControlPolicies() []aws.organization.serviceControlPolicy
+}
+
+// AWS Organizations service control policy
+//
+// Examine a service control policy (SCP) and the maximum permissions it
+// defines for the accounts, organizational units, and roots it is attached
+// to. The parsed statements expose the allowed or denied actions and the
+// conditions that bound them, so you can audit the organization-wide
+// guardrails that constrain every member account. The policy is selected by
+// its id, for example p-0123456789abcdef.
+private aws.organization.serviceControlPolicy @defaults("name id") {
+  // Unique identifier of the policy
+  id string
+  // ARN of the policy
+  arn string
+  // Friendly name of the policy
+  name string
+  // Description of the policy
+  description string
+  // Whether the policy is managed by AWS rather than the customer
+  awsManaged bool
+  // Raw policy content document (JSON)
+  content() string
+  // Parsed statements from the policy content
+  statements() []aws.iam.policyStatement
 }
 
 // AWS Organization delegated administrator
@@ -267,6 +294,8 @@ private aws.organization.organizationalUnit @defaults("id name path") {
   name string
   // Path in the organization where this OU exists
   path string
+  // Service control policies attached directly to this organizational unit
+  serviceControlPolicies() []aws.organization.serviceControlPolicy
 }
 
 // Amazon Virtual Private Cloud (VPC)
@@ -472,6 +501,8 @@ private aws.vpc.endpoint @defaults("id type region") {
   serviceName string
   // Policy document associated with the endpoint, if applicable
   policyDocument string
+  // Parsed statements from the endpoint policy
+  policyStatements() []aws.iam.policyStatement
   // Subnets for the (interface) endpoint
   subnets []string
   // Whether to associate a private hosted zone with the specified VPC
@@ -1342,6 +1373,8 @@ private aws.efs.filesystem @defaults("name id region") {
   accessPoints() []aws.efs.accessPoint
   // Resource-based policy document (JSON)
   fileSystemPolicy() string
+  // Parsed statements from the file system policy
+  policyStatements() []aws.iam.policyStatement
   // Performance mode: generalPurpose or maxIO
   performanceMode string
   // Throughput mode: bursting, provisioned, or elastic
@@ -1667,6 +1700,8 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   keyManager() string
   // Key policy document in JSON format
   policy() string
+  // Parsed statements from the key policy
+  policyStatements() []aws.iam.policyStatement
   // Describes the type of key material in the key
   //
   // One of: SYMMETRIC_DEFAULT, RSA_2048, RSA_3072, RSA_4096, ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, ECC_SECG_P256K1, HMAC_224, HMAC_256, HMAC_384, HMAC_512, SM2.
@@ -1924,13 +1959,42 @@ private aws.iam.user @defaults("arn name createdAt") {
   // List of group ARNs that the user belongs to
   groups() []string
   // List of access keys metadata associated with the user
-  accessKeys() []dict
+  //
+  // Deprecated in favor of accessKeyDetails, which resolves each key to a
+  // typed aws.iam.user.accessKey exposing status and last-used data.
+  accessKeys() @maturity("deprecated") []dict
+  // Access keys associated with the user, including last-used data
+  accessKeyDetails() []aws.iam.user.accessKey
   // Login profile for the user
   loginProfile() aws.iam.loginProfile
   // Path to the user
   path string
   // List of MFA devices (virtual and hardware) assigned to the user
   mfaDevices() []dict
+}
+
+// IAM user access key
+//
+// Examine an access key belonging to an IAM user, including its activation
+// status and when it was last used. The createdAt and lastUsedDate fields
+// support auditing for unrotated keys (CIS access-key rotation) and unused
+// active keys that should be deactivated. The key is selected by its
+// accessKeyId, for example AKIAIOSFODNN7EXAMPLE.
+private aws.iam.user.accessKey @defaults("accessKeyId status lastUsedDate") {
+  // Access key ID
+  accessKeyId string
+  // Name of the user the access key belongs to
+  username string
+  // Status of the access key: Active or Inactive
+  status string
+  // Time when the access key was created
+  createdAt time
+  // Time when the access key was last used, null if never used
+  lastUsedDate time
+  // Region in which the access key was last used, "N/A" if never used
+  lastUsedRegion string
+  // AWS service most recently accessed with the key, "N/A" if never used
+  lastUsedService string
 }
 
 // AWS IAM instance profile
@@ -1957,6 +2021,36 @@ private aws.iam.loginProfile @defaults("createdAt") {
   passwordResetRequired bool
 }
 
+// Statement from an IAM or resource-based policy
+//
+// Examine a single statement parsed from a policy document. Each statement
+// pairs an effect (Allow or Deny) with the actions, resources, principals,
+// and conditions it covers, so you can audit wildcard actions, anonymous or
+// cross-account principals, and missing condition keys without parsing the
+// raw JSON yourself. The same statement shape is reused across IAM policies,
+// role trust policies, and resource-based policies on KMS keys, S3 buckets,
+// SNS topics, SQS queues, and other services.
+private aws.iam.policyStatement @defaults("effect") {
+  // Statement ID, empty if the statement has none
+  sid string
+  // Effect of the statement: Allow or Deny
+  effect string
+  // Actions the statement applies to
+  actions []string
+  // Actions excluded from the statement (NotAction)
+  notActions []string
+  // Resources the statement applies to
+  resources []string
+  // Resources excluded from the statement (NotResource)
+  notResources []string
+  // Principals the statement applies to, keyed by principal type (AWS, Service, Federated, CanonicalUser)
+  principals map[string][]string
+  // Principals excluded from the statement (NotPrincipal), keyed by principal type
+  notPrincipals map[string][]string
+  // Conditions under which the statement is in effect, keyed by condition operator then condition key
+  conditions dict
+}
+
 // AWS IAM policy
 private aws.iam.policy @defaults("arn name") {
   // ARN of the policy
@@ -1981,6 +2075,8 @@ private aws.iam.policy @defaults("arn name") {
   versions() []aws.iam.policyversion
   // Default version of the policy
   defaultVersion() aws.iam.policyversion
+  // Parsed statements from the policy default version
+  statements() []aws.iam.policyStatement
 
   // List of users attached to the policy
   attachedUsers() []aws.iam.user
@@ -2000,6 +2096,8 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion createdAt") {
   isDefaultVersion bool
   // JSON statements for this policy version
   document() dict
+  // Parsed statements for this policy version
+  statements() []aws.iam.policyStatement
   // Time when this policy version was created
   createdAt time
 }
@@ -2020,6 +2118,8 @@ private aws.iam.role @defaults("arn name") {
   createdAt time
   // Policy document that grants an entity permission to assume the role
   assumeRolePolicyDocument dict
+  // Parsed statements from the role trust policy
+  assumeRolePolicyStatements() []aws.iam.policyStatement
   // Time when the role was last used to make an AWS request
   lastUsedAt time
   // Region in which the role was last used
@@ -4443,6 +4543,8 @@ private aws.sns.topic @defaults("arn") {
   kmsMasterKey() aws.kms.key
   // Access policy for the topic (parsed JSON)
   policy() dict
+  // Parsed statements from the topic access policy
+  policyStatements() []aws.iam.policyStatement
   // Whether the topic is a FIFO topic
   fifoTopic() bool
   // Whether content-based deduplication is enabled (FIFO topics only)
@@ -6590,6 +6692,8 @@ aws.secretsmanager.secret @defaults("arn name") {
   tags map[string]string
   // Resource-based policy attached to the secret (JSON string, empty if none)
   resourcePolicy() string
+  // Parsed statements from the resource-based policy
+  policyStatements() []aws.iam.policyStatement
   // Regions where the secret is replicated
   replicaRegions() []aws.secretsmanager.secret.replicaRegion
   // Secret type: USER (user-created) or MANAGED_EXTERNAL (managed by another service)
@@ -9762,6 +9866,8 @@ private aws.s3.bucket @defaults("name location public") {
   name string
   // Policy associated with the bucket
   policy() aws.s3.bucket.policy
+  // Parsed statements from the bucket policy
+  policyStatements() []aws.iam.policyStatement
   // Tags for the bucket
   tags() map[string]string
   // List of access control grants associated with the bucket
@@ -9796,6 +9902,14 @@ private aws.s3.bucket @defaults("name location public") {
   replicationRules() []aws.s3.bucket.replicationRule
   // Public access block configuration for the bucket
   publicAccessBlock() dict
+  // Whether new public ACLs on the bucket and its objects are blocked
+  blockPublicAcls() bool
+  // Whether new public bucket policies are blocked
+  blockPublicPolicy() bool
+  // Whether existing public ACLs on the bucket and its objects are ignored
+  ignorePublicAcls() bool
+  // Whether cross-account access to the bucket through public policies is restricted
+  restrictPublicBuckets() bool
   // Whether Object Lock is enabled on the bucket (prevents deletion/overwrite for ransomware protection)
   objectLockEnabled() bool
   // Bucket metrics configurations for request metrics
@@ -10002,7 +10116,10 @@ private aws.s3.bucket.policy @defaults("bucketName version") {
   // Version of the policy
   version() string
   // List of statements for the policy
-  statements() []dict
+  //
+  // Deprecated in favor of aws.s3.bucket.policyStatements, which resolves each
+  // statement to a typed aws.iam.policyStatement.
+  statements() @maturity("deprecated") []dict
 }
 
 // Amazon S3 bucket static-website hosting configuration
@@ -10487,6 +10604,10 @@ private aws.backup.vault @defaults("name region") {
   maxRetentionDays int
   // The minimum retention period that the vault retains its recovery points
   minRetentionDays int
+  // Resource-based access policy attached to the vault (JSON string, empty if none)
+  accessPolicy() string
+  // Parsed statements from the vault access policy
+  policyStatements() []aws.iam.policyStatement
 }
 
 // AWS Backup vault recovery point
@@ -10898,6 +11019,8 @@ private aws.sqs.queue {
   fifoThroughputLimit() string
   // Access policy for the queue (parsed JSON)
   policy() dict
+  // Parsed statements from the queue access policy
+  policyStatements() []aws.iam.policyStatement
   // Resource tags for the queue
   tags() map[string]string
   // Whether content-based deduplication is enabled (FIFO queues only)
@@ -12867,6 +12990,8 @@ private aws.ecr.repository @defaults("uri region") {
   scanningFrequency() string
   // Access policy for the repository (parsed JSON; private repositories only)
   policy() dict
+  // Parsed statements from the repository access policy
+  policyStatements() []aws.iam.policyStatement
   // Lifecycle policy for the repository
   lifecyclePolicy() aws.ecr.lifecyclePolicy
   // About text from catalog data (public repositories only)
@@ -13765,6 +13890,8 @@ private aws.lambda.function @defaults("arn") {
   recursiveLoop() string
   // Policy for the function
   policy() dict
+  // Parsed statements from the function resource policy
+  policyStatements() []aws.iam.policyStatement
   // Raw VPC configuration for the Lambda function
   //
   // Deprecated in favor of `vpc()`, `subnets()`, and `securityGroups()`.

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -81407,7 +81407,7 @@ func (c *mqlAwsIamPolicy) GetAttachedGroups() *plugin.TValue[[]any] {
 type mqlAwsIamPolicyversion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsIamPolicyversionInternal it will be used here
+	mqlAwsIamPolicyversionInternal
 	Arn              plugin.TValue[string]
 	VersionId        plugin.TValue[string]
 	IsDefaultVersion plugin.TValue[bool]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22,6 +22,7 @@ const (
 	ResourceAwsBilling                                                          string = "aws.billing"
 	ResourceAwsBillingBudget                                                    string = "aws.billing.budget"
 	ResourceAwsOrganization                                                     string = "aws.organization"
+	ResourceAwsOrganizationServiceControlPolicy                                 string = "aws.organization.serviceControlPolicy"
 	ResourceAwsOrganizationDelegatedAdministrator                               string = "aws.organization.delegatedAdministrator"
 	ResourceAwsOrganizationDelegatedService                                     string = "aws.organization.delegatedService"
 	ResourceAwsOrganizationOrganizationalUnit                                   string = "aws.organization.organizationalUnit"
@@ -94,8 +95,10 @@ const (
 	ResourceAwsIam                                                              string = "aws.iam"
 	ResourceAwsIamUsercredentialreportentry                                     string = "aws.iam.usercredentialreportentry"
 	ResourceAwsIamUser                                                          string = "aws.iam.user"
+	ResourceAwsIamUserAccessKey                                                 string = "aws.iam.user.accessKey"
 	ResourceAwsIamInstanceProfile                                               string = "aws.iam.instanceProfile"
 	ResourceAwsIamLoginProfile                                                  string = "aws.iam.loginProfile"
+	ResourceAwsIamPolicyStatement                                               string = "aws.iam.policyStatement"
 	ResourceAwsIamPolicy                                                        string = "aws.iam.policy"
 	ResourceAwsIamPolicyversion                                                 string = "aws.iam.policyversion"
 	ResourceAwsIamRole                                                          string = "aws.iam.role"
@@ -934,6 +937,10 @@ func init() {
 			// to override args, implement: initAwsOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsOrganization,
 		},
+		"aws.organization.serviceControlPolicy": {
+			// to override args, implement: initAwsOrganizationServiceControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationServiceControlPolicy,
+		},
 		"aws.organization.delegatedAdministrator": {
 			// to override args, implement: initAwsOrganizationDelegatedAdministrator(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsOrganizationDelegatedAdministrator,
@@ -1222,6 +1229,10 @@ func init() {
 			Init:   initAwsIamUser,
 			Create: createAwsIamUser,
 		},
+		"aws.iam.user.accessKey": {
+			// to override args, implement: initAwsIamUserAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamUserAccessKey,
+		},
 		"aws.iam.instanceProfile": {
 			Init:   initAwsIamInstanceProfile,
 			Create: createAwsIamInstanceProfile,
@@ -1229,6 +1240,10 @@ func init() {
 		"aws.iam.loginProfile": {
 			// to override args, implement: initAwsIamLoginProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamLoginProfile,
+		},
+		"aws.iam.policyStatement": {
+			// to override args, implement: initAwsIamPolicyStatement(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamPolicyStatement,
 		},
 		"aws.iam.policy": {
 			// to override args, implement: initAwsIamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4695,6 +4710,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.organization.organizationalUnits": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetOrganizationalUnits()).ToDataRes(types.Array(types.Resource("aws.organization.organizationalUnit")))
 	},
+	"aws.organization.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
+	},
+	"aws.organization.serviceControlPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetId()).ToDataRes(types.String)
+	},
+	"aws.organization.serviceControlPolicy.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetArn()).ToDataRes(types.String)
+	},
+	"aws.organization.serviceControlPolicy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetName()).ToDataRes(types.String)
+	},
+	"aws.organization.serviceControlPolicy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.organization.serviceControlPolicy.awsManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetAwsManaged()).ToDataRes(types.Bool)
+	},
+	"aws.organization.serviceControlPolicy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.organization.delegatedAdministrator.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationDelegatedAdministrator).GetArn()).ToDataRes(types.String)
 	},
@@ -4742,6 +4781,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.organizationalUnit.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetPath()).ToDataRes(types.String)
+	},
+	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
 	},
 	"aws.vpc.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetArn()).ToDataRes(types.String)
@@ -4994,6 +5036,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.endpoint.policyDocument": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetPolicyDocument()).ToDataRes(types.String)
+	},
+	"aws.vpc.endpoint.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcEndpoint).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.vpc.endpoint.subnets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetSubnets()).ToDataRes(types.Array(types.String))
@@ -5937,6 +5982,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.filesystem.fileSystemPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetFileSystemPolicy()).ToDataRes(types.String)
 	},
+	"aws.efs.filesystem.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystem).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.efs.filesystem.performanceMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetPerformanceMode()).ToDataRes(types.String)
 	},
@@ -6306,6 +6354,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetPolicy()).ToDataRes(types.String)
 	},
+	"aws.kms.key.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.kms.key.keySpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetKeySpec()).ToDataRes(types.String)
 	},
@@ -6576,6 +6627,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.user.accessKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetAccessKeys()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.iam.user.accessKeyDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetAccessKeyDetails()).ToDataRes(types.Array(types.Resource("aws.iam.user.accessKey")))
+	},
 	"aws.iam.user.loginProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetLoginProfile()).ToDataRes(types.Resource("aws.iam.loginProfile"))
 	},
@@ -6584,6 +6638,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.user.mfaDevices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetMfaDevices()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.iam.user.accessKey.accessKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetAccessKeyId()).ToDataRes(types.String)
+	},
+	"aws.iam.user.accessKey.username": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetUsername()).ToDataRes(types.String)
+	},
+	"aws.iam.user.accessKey.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.iam.user.accessKey.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.user.accessKey.lastUsedDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetLastUsedDate()).ToDataRes(types.Time)
+	},
+	"aws.iam.user.accessKey.lastUsedRegion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetLastUsedRegion()).ToDataRes(types.String)
+	},
+	"aws.iam.user.accessKey.lastUsedService": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUserAccessKey).GetLastUsedService()).ToDataRes(types.String)
 	},
 	"aws.iam.instanceProfile.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamInstanceProfile).GetArn()).ToDataRes(types.String)
@@ -6608,6 +6683,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.loginProfile.passwordResetRequired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamLoginProfile).GetPasswordResetRequired()).ToDataRes(types.Bool)
+	},
+	"aws.iam.policyStatement.sid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetSid()).ToDataRes(types.String)
+	},
+	"aws.iam.policyStatement.effect": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetEffect()).ToDataRes(types.String)
+	},
+	"aws.iam.policyStatement.actions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetActions()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.policyStatement.notActions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetNotActions()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.policyStatement.resources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetResources()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.policyStatement.notResources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetNotResources()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.policyStatement.principals": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetPrincipals()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
+	"aws.iam.policyStatement.notPrincipals": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetNotPrincipals()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
+	"aws.iam.policyStatement.conditions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyStatement).GetConditions()).ToDataRes(types.Dict)
 	},
 	"aws.iam.policy.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetArn()).ToDataRes(types.String)
@@ -6642,6 +6744,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policy.defaultVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetDefaultVersion()).ToDataRes(types.Resource("aws.iam.policyversion"))
 	},
+	"aws.iam.policy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.iam.policy.attachedUsers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetAttachedUsers()).ToDataRes(types.Array(types.Resource("aws.iam.user")))
 	},
@@ -6662,6 +6767,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.policyversion.document": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetDocument()).ToDataRes(types.Dict)
+	},
+	"aws.iam.policyversion.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyversion).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.iam.policyversion.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetCreatedAt()).ToDataRes(types.Time)
@@ -6686,6 +6794,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.role.assumeRolePolicyDocument": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetAssumeRolePolicyDocument()).ToDataRes(types.Dict)
+	},
+	"aws.iam.role.assumeRolePolicyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetAssumeRolePolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.iam.role.lastUsedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetLastUsedAt()).ToDataRes(types.Time)
@@ -9612,6 +9723,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sns.topic.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetPolicy()).ToDataRes(types.Dict)
 	},
+	"aws.sns.topic.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSnsTopic).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.sns.topic.fifoTopic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetFifoTopic()).ToDataRes(types.Bool)
 	},
@@ -12023,6 +12137,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.secretsmanager.secret.resourcePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetResourcePolicy()).ToDataRes(types.String)
+	},
+	"aws.secretsmanager.secret.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.secretsmanager.secret.replicaRegions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetReplicaRegions()).ToDataRes(types.Array(types.Resource("aws.secretsmanager.secret.replicaRegion")))
@@ -15300,6 +15417,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetPolicy()).ToDataRes(types.Resource("aws.s3.bucket.policy"))
 	},
+	"aws.s3.bucket.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.s3.bucket.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -15347,6 +15467,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.s3.bucket.publicAccessBlock": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetPublicAccessBlock()).ToDataRes(types.Dict)
+	},
+	"aws.s3.bucket.blockPublicAcls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetBlockPublicAcls()).ToDataRes(types.Bool)
+	},
+	"aws.s3.bucket.blockPublicPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetBlockPublicPolicy()).ToDataRes(types.Bool)
+	},
+	"aws.s3.bucket.ignorePublicAcls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetIgnorePublicAcls()).ToDataRes(types.Bool)
+	},
+	"aws.s3.bucket.restrictPublicBuckets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetRestrictPublicBuckets()).ToDataRes(types.Bool)
 	},
 	"aws.s3.bucket.objectLockEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetObjectLockEnabled()).ToDataRes(types.Bool)
@@ -16101,6 +16233,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.backup.vault.minRetentionDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVault).GetMinRetentionDays()).ToDataRes(types.Int)
 	},
+	"aws.backup.vault.accessPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupVault).GetAccessPolicy()).ToDataRes(types.String)
+	},
+	"aws.backup.vault.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupVault).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.backup.vaultRecoveryPoint.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVaultRecoveryPoint).GetArn()).ToDataRes(types.String)
 	},
@@ -16565,6 +16703,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.sqs.queue.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSqsQueue).GetPolicy()).ToDataRes(types.Dict)
+	},
+	"aws.sqs.queue.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSqsQueue).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.sqs.queue.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSqsQueue).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -18738,6 +18879,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecr.repository.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetPolicy()).ToDataRes(types.Dict)
 	},
+	"aws.ecr.repository.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
 	"aws.ecr.repository.lifecyclePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetLifecyclePolicy()).ToDataRes(types.Resource("aws.ecr.lifecyclePolicy"))
 	},
@@ -19709,6 +19853,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.lambda.function.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetPolicy()).ToDataRes(types.Dict)
+	},
+	"aws.lambda.function.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.lambda.function.vpcConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetVpcConfig()).ToDataRes(types.Dict)
@@ -32238,6 +32385,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsOrganization).OrganizationalUnits, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.organization.serviceControlPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.serviceControlPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.awsManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).AwsManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationServiceControlPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.organization.delegatedAdministrator.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationDelegatedAdministrator).__id, ok = v.Value.(string)
 		return
@@ -32312,6 +32495,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.organizationalUnit.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationOrganizationalUnit).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationOrganizationalUnit).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32672,6 +32859,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.endpoint.policyDocument": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcEndpoint).PolicyDocument, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.endpoint.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcEndpoint).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34110,6 +34301,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEfsFilesystem).FileSystemPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.efs.filesystem.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystem).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.efs.filesystem.performanceMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystem).PerformanceMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -34650,6 +34845,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKmsKey).Policy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.kms.key.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.kms.key.keySpec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).KeySpec, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -35034,6 +35233,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamUser).AccessKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.user.accessKeyDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).AccessKeyDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.user.loginProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).LoginProfile, ok = plugin.RawToTValue[*mqlAwsIamLoginProfile](v.Value, v.Error)
 		return
@@ -35044,6 +35247,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.user.mfaDevices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).MfaDevices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.iam.user.accessKey.accessKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).AccessKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.username": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).Username, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.lastUsedDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).LastUsedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.lastUsedRegion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).LastUsedRegion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.accessKey.lastUsedService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUserAccessKey).LastUsedService, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.iam.instanceProfile.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35084,6 +35319,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.loginProfile.passwordResetRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamLoginProfile).PasswordResetRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.iam.policyStatement.sid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Sid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.effect": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Effect, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.actions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Actions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.notActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).NotActions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.resources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.notResources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).NotResources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.principals": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Principals, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.notPrincipals": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).NotPrincipals, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyStatement.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyStatement).Conditions, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35134,6 +35409,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamPolicy).DefaultVersion, ok = plugin.RawToTValue[*mqlAwsIamPolicyversion](v.Value, v.Error)
 		return
 	},
+	"aws.iam.policy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.policy.attachedUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamPolicy).AttachedUsers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -35164,6 +35443,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.policyversion.document": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamPolicyversion).Document, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.policyversion.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyversion).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.policyversion.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35200,6 +35483,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.role.assumeRolePolicyDocument": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).AssumeRolePolicyDocument, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.assumeRolePolicyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).AssumeRolePolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.role.lastUsedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39506,6 +39793,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSnsTopic).Policy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.sns.topic.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSnsTopic).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.sns.topic.fifoTopic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSnsTopic).FifoTopic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -43000,6 +43291,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.secretsmanager.secret.resourcePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecret).ResourcePolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.secretsmanager.secret.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.secretsmanager.secret.replicaRegions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47906,6 +48201,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsS3Bucket).Policy, ok = plugin.RawToTValue[*mqlAwsS3BucketPolicy](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -47968,6 +48267,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.s3.bucket.publicAccessBlock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).PublicAccessBlock, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.blockPublicAcls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).BlockPublicAcls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.blockPublicPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).BlockPublicPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.ignorePublicAcls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).IgnorePublicAcls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.restrictPublicBuckets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).RestrictPublicBuckets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.s3.bucket.objectLockEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49082,6 +49397,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsBackupVault).MinRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"aws.backup.vault.accessPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupVault).AccessPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.backup.vault.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupVault).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.backup.vaultRecoveryPoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupVaultRecoveryPoint).__id, ok = v.Value.(string)
 		return
@@ -49760,6 +50083,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.sqs.queue.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSqsQueue).Policy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.sqs.queue.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSqsQueue).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.sqs.queue.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52862,6 +53189,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcrRepository).Policy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.ecr.repository.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ecr.repository.lifecyclePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrRepository).LifecyclePolicy, ok = plugin.RawToTValue[*mqlAwsEcrLifecyclePolicy](v.Value, v.Error)
 		return
@@ -54280,6 +54611,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).Policy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.lambda.function.vpcConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -72758,6 +73093,7 @@ type mqlAwsOrganization struct {
 	Id                      plugin.TValue[string]
 	DelegatedAdministrators plugin.TValue[[]any]
 	OrganizationalUnits     plugin.TValue[[]any]
+	ServiceControlPolicies  plugin.TValue[[]any]
 }
 
 // createAwsOrganization creates a new instance of this resource
@@ -72857,6 +73193,110 @@ func (c *mqlAwsOrganization) GetOrganizationalUnits() *plugin.TValue[[]any] {
 		}
 
 		return c.organizationalUnits()
+	})
+}
+
+func (c *mqlAwsOrganization) GetServiceControlPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceControlPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization", c.__id, "serviceControlPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceControlPolicies()
+	})
+}
+
+// mqlAwsOrganizationServiceControlPolicy for the aws.organization.serviceControlPolicy resource
+type mqlAwsOrganizationServiceControlPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationServiceControlPolicyInternal it will be used here
+	Id          plugin.TValue[string]
+	Arn         plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Description plugin.TValue[string]
+	AwsManaged  plugin.TValue[bool]
+	Content     plugin.TValue[string]
+	Statements  plugin.TValue[[]any]
+}
+
+// createAwsOrganizationServiceControlPolicy creates a new instance of this resource
+func createAwsOrganizationServiceControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationServiceControlPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.serviceControlPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) MqlName() string {
+	return "aws.organization.serviceControlPolicy"
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetAwsManaged() *plugin.TValue[bool] {
+	return &c.AwsManaged
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		return c.content()
+	})
+}
+
+func (c *mqlAwsOrganizationServiceControlPolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.serviceControlPolicy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
 	})
 }
 
@@ -73037,10 +73477,11 @@ type mqlAwsOrganizationOrganizationalUnit struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsOrganizationOrganizationalUnitInternal it will be used here
-	Arn  plugin.TValue[string]
-	Id   plugin.TValue[string]
-	Name plugin.TValue[string]
-	Path plugin.TValue[string]
+	Arn                    plugin.TValue[string]
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Path                   plugin.TValue[string]
+	ServiceControlPolicies plugin.TValue[[]any]
 }
 
 // createAwsOrganizationOrganizationalUnit creates a new instance of this resource
@@ -73094,6 +73535,22 @@ func (c *mqlAwsOrganizationOrganizationalUnit) GetName() *plugin.TValue[string] 
 
 func (c *mqlAwsOrganizationOrganizationalUnit) GetPath() *plugin.TValue[string] {
 	return &c.Path
+}
+
+func (c *mqlAwsOrganizationOrganizationalUnit) GetServiceControlPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceControlPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.organizationalUnit", c.__id, "serviceControlPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceControlPolicies()
+	})
 }
 
 // mqlAwsVpc for the aws.vpc resource
@@ -73974,6 +74431,7 @@ type mqlAwsVpcEndpoint struct {
 	Region            plugin.TValue[string]
 	ServiceName       plugin.TValue[string]
 	PolicyDocument    plugin.TValue[string]
+	PolicyStatements  plugin.TValue[[]any]
 	Subnets           plugin.TValue[[]any]
 	PrivateDnsEnabled plugin.TValue[bool]
 	State             plugin.TValue[string]
@@ -74047,6 +74505,22 @@ func (c *mqlAwsVpcEndpoint) GetServiceName() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcEndpoint) GetPolicyDocument() *plugin.TValue[string] {
 	return &c.PolicyDocument
+}
+
+func (c *mqlAwsVpcEndpoint) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.endpoint", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
+	})
 }
 
 func (c *mqlAwsVpcEndpoint) GetSubnets() *plugin.TValue[[]any] {
@@ -77866,6 +78340,7 @@ type mqlAwsEfsFilesystem struct {
 	MountTargets             plugin.TValue[[]any]
 	AccessPoints             plugin.TValue[[]any]
 	FileSystemPolicy         plugin.TValue[string]
+	PolicyStatements         plugin.TValue[[]any]
 	PerformanceMode          plugin.TValue[string]
 	ThroughputMode           plugin.TValue[string]
 	SizeInBytes              plugin.TValue[int64]
@@ -78001,6 +78476,22 @@ func (c *mqlAwsEfsFilesystem) GetAccessPoints() *plugin.TValue[[]any] {
 func (c *mqlAwsEfsFilesystem) GetFileSystemPolicy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.FileSystemPolicy, func() (string, error) {
 		return c.fileSystemPolicy()
+	})
+}
+
+func (c *mqlAwsEfsFilesystem) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.filesystem", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -79227,6 +79718,7 @@ type mqlAwsKmsKey struct {
 	Grants                    plugin.TValue[[]any]
 	KeyManager                plugin.TValue[string]
 	Policy                    plugin.TValue[string]
+	PolicyStatements          plugin.TValue[[]any]
 	KeySpec                   plugin.TValue[string]
 	KeyUsage                  plugin.TValue[string]
 	MultiRegion               plugin.TValue[bool]
@@ -79374,6 +79866,22 @@ func (c *mqlAwsKmsKey) GetKeyManager() *plugin.TValue[string] {
 func (c *mqlAwsKmsKey) GetPolicy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Policy, func() (string, error) {
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kms.key", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -80257,6 +80765,7 @@ type mqlAwsIamUser struct {
 	AttachedPolicies plugin.TValue[[]any]
 	Groups           plugin.TValue[[]any]
 	AccessKeys       plugin.TValue[[]any]
+	AccessKeyDetails plugin.TValue[[]any]
 	LoginProfile     plugin.TValue[*mqlAwsIamLoginProfile]
 	Path             plugin.TValue[string]
 	MfaDevices       plugin.TValue[[]any]
@@ -80357,6 +80866,22 @@ func (c *mqlAwsIamUser) GetAccessKeys() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsIamUser) GetAccessKeyDetails() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AccessKeyDetails, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.user", c.__id, "accessKeyDetails")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.accessKeyDetails()
+	})
+}
+
 func (c *mqlAwsIamUser) GetLoginProfile() *plugin.TValue[*mqlAwsIamLoginProfile] {
 	return plugin.GetOrCompute[*mqlAwsIamLoginProfile](&c.LoginProfile, func() (*mqlAwsIamLoginProfile, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80381,6 +80906,80 @@ func (c *mqlAwsIamUser) GetMfaDevices() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.MfaDevices, func() ([]any, error) {
 		return c.mfaDevices()
 	})
+}
+
+// mqlAwsIamUserAccessKey for the aws.iam.user.accessKey resource
+type mqlAwsIamUserAccessKey struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsIamUserAccessKeyInternal it will be used here
+	AccessKeyId     plugin.TValue[string]
+	Username        plugin.TValue[string]
+	Status          plugin.TValue[string]
+	CreatedAt       plugin.TValue[*time.Time]
+	LastUsedDate    plugin.TValue[*time.Time]
+	LastUsedRegion  plugin.TValue[string]
+	LastUsedService plugin.TValue[string]
+}
+
+// createAwsIamUserAccessKey creates a new instance of this resource
+func createAwsIamUserAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamUserAccessKey{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.user.accessKey", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamUserAccessKey) MqlName() string {
+	return "aws.iam.user.accessKey"
+}
+
+func (c *mqlAwsIamUserAccessKey) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamUserAccessKey) GetAccessKeyId() *plugin.TValue[string] {
+	return &c.AccessKeyId
+}
+
+func (c *mqlAwsIamUserAccessKey) GetUsername() *plugin.TValue[string] {
+	return &c.Username
+}
+
+func (c *mqlAwsIamUserAccessKey) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsIamUserAccessKey) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsIamUserAccessKey) GetLastUsedDate() *plugin.TValue[*time.Time] {
+	return &c.LastUsedDate
+}
+
+func (c *mqlAwsIamUserAccessKey) GetLastUsedRegion() *plugin.TValue[string] {
+	return &c.LastUsedRegion
+}
+
+func (c *mqlAwsIamUserAccessKey) GetLastUsedService() *plugin.TValue[string] {
+	return &c.LastUsedService
 }
 
 // mqlAwsIamInstanceProfile for the aws.iam.instanceProfile resource
@@ -80518,6 +81117,90 @@ func (c *mqlAwsIamLoginProfile) GetPasswordResetRequired() *plugin.TValue[bool] 
 	return &c.PasswordResetRequired
 }
 
+// mqlAwsIamPolicyStatement for the aws.iam.policyStatement resource
+type mqlAwsIamPolicyStatement struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsIamPolicyStatementInternal it will be used here
+	Sid           plugin.TValue[string]
+	Effect        plugin.TValue[string]
+	Actions       plugin.TValue[[]any]
+	NotActions    plugin.TValue[[]any]
+	Resources     plugin.TValue[[]any]
+	NotResources  plugin.TValue[[]any]
+	Principals    plugin.TValue[map[string]any]
+	NotPrincipals plugin.TValue[map[string]any]
+	Conditions    plugin.TValue[any]
+}
+
+// createAwsIamPolicyStatement creates a new instance of this resource
+func createAwsIamPolicyStatement(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamPolicyStatement{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.policyStatement", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamPolicyStatement) MqlName() string {
+	return "aws.iam.policyStatement"
+}
+
+func (c *mqlAwsIamPolicyStatement) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamPolicyStatement) GetSid() *plugin.TValue[string] {
+	return &c.Sid
+}
+
+func (c *mqlAwsIamPolicyStatement) GetEffect() *plugin.TValue[string] {
+	return &c.Effect
+}
+
+func (c *mqlAwsIamPolicyStatement) GetActions() *plugin.TValue[[]any] {
+	return &c.Actions
+}
+
+func (c *mqlAwsIamPolicyStatement) GetNotActions() *plugin.TValue[[]any] {
+	return &c.NotActions
+}
+
+func (c *mqlAwsIamPolicyStatement) GetResources() *plugin.TValue[[]any] {
+	return &c.Resources
+}
+
+func (c *mqlAwsIamPolicyStatement) GetNotResources() *plugin.TValue[[]any] {
+	return &c.NotResources
+}
+
+func (c *mqlAwsIamPolicyStatement) GetPrincipals() *plugin.TValue[map[string]any] {
+	return &c.Principals
+}
+
+func (c *mqlAwsIamPolicyStatement) GetNotPrincipals() *plugin.TValue[map[string]any] {
+	return &c.NotPrincipals
+}
+
+func (c *mqlAwsIamPolicyStatement) GetConditions() *plugin.TValue[any] {
+	return &c.Conditions
+}
+
 // mqlAwsIamPolicy for the aws.iam.policy resource
 type mqlAwsIamPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -80534,6 +81217,7 @@ type mqlAwsIamPolicy struct {
 	Scope           plugin.TValue[string]
 	Versions        plugin.TValue[[]any]
 	DefaultVersion  plugin.TValue[*mqlAwsIamPolicyversion]
+	Statements      plugin.TValue[[]any]
 	AttachedUsers   plugin.TValue[[]any]
 	AttachedRoles   plugin.TValue[[]any]
 	AttachedGroups  plugin.TValue[[]any]
@@ -80655,6 +81339,22 @@ func (c *mqlAwsIamPolicy) GetDefaultVersion() *plugin.TValue[*mqlAwsIamPolicyver
 	})
 }
 
+func (c *mqlAwsIamPolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.policy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
+	})
+}
+
 func (c *mqlAwsIamPolicy) GetAttachedUsers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.AttachedUsers, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80712,6 +81412,7 @@ type mqlAwsIamPolicyversion struct {
 	VersionId        plugin.TValue[string]
 	IsDefaultVersion plugin.TValue[bool]
 	Document         plugin.TValue[any]
+	Statements       plugin.TValue[[]any]
 	CreatedAt        plugin.TValue[*time.Time]
 }
 
@@ -80770,6 +81471,22 @@ func (c *mqlAwsIamPolicyversion) GetDocument() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlAwsIamPolicyversion) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.policyversion", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
+	})
+}
+
 func (c *mqlAwsIamPolicyversion) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
@@ -80779,22 +81496,23 @@ type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsIamRoleInternal it will be used here
-	Arn                      plugin.TValue[string]
-	Id                       plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Description              plugin.TValue[string]
-	Tags                     plugin.TValue[map[string]any]
-	CreatedAt                plugin.TValue[*time.Time]
-	AssumeRolePolicyDocument plugin.TValue[any]
-	LastUsedAt               plugin.TValue[*time.Time]
-	LastUsedRegion           plugin.TValue[string]
-	MaxSessionDuration       plugin.TValue[int64]
-	PermissionsBoundaryArn   plugin.TValue[string]
-	PermissionsBoundary      plugin.TValue[*mqlAwsIamPolicy]
-	Path                     plugin.TValue[string]
-	IsServiceLinked          plugin.TValue[bool]
-	AttachedPolicies         plugin.TValue[[]any]
-	InlinePolicies           plugin.TValue[[]any]
+	Arn                        plugin.TValue[string]
+	Id                         plugin.TValue[string]
+	Name                       plugin.TValue[string]
+	Description                plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
+	CreatedAt                  plugin.TValue[*time.Time]
+	AssumeRolePolicyDocument   plugin.TValue[any]
+	AssumeRolePolicyStatements plugin.TValue[[]any]
+	LastUsedAt                 plugin.TValue[*time.Time]
+	LastUsedRegion             plugin.TValue[string]
+	MaxSessionDuration         plugin.TValue[int64]
+	PermissionsBoundaryArn     plugin.TValue[string]
+	PermissionsBoundary        plugin.TValue[*mqlAwsIamPolicy]
+	Path                       plugin.TValue[string]
+	IsServiceLinked            plugin.TValue[bool]
+	AttachedPolicies           plugin.TValue[[]any]
+	InlinePolicies             plugin.TValue[[]any]
 }
 
 // createAwsIamRole creates a new instance of this resource
@@ -80860,6 +81578,22 @@ func (c *mqlAwsIamRole) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsIamRole) GetAssumeRolePolicyDocument() *plugin.TValue[any] {
 	return &c.AssumeRolePolicyDocument
+}
+
+func (c *mqlAwsIamRole) GetAssumeRolePolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AssumeRolePolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.role", c.__id, "assumeRolePolicyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.assumeRolePolicyStatements()
+	})
 }
 
 func (c *mqlAwsIamRole) GetLastUsedAt() *plugin.TValue[*time.Time] {
@@ -92811,6 +93545,7 @@ type mqlAwsSnsTopic struct {
 	SignatureVersion          plugin.TValue[string]
 	KmsMasterKey              plugin.TValue[*mqlAwsKmsKey]
 	Policy                    plugin.TValue[any]
+	PolicyStatements          plugin.TValue[[]any]
 	FifoTopic                 plugin.TValue[bool]
 	ContentBasedDeduplication plugin.TValue[bool]
 	DataProtectionPolicy      plugin.TValue[any]
@@ -92917,6 +93652,22 @@ func (c *mqlAwsSnsTopic) GetKmsMasterKey() *plugin.TValue[*mqlAwsKmsKey] {
 func (c *mqlAwsSnsTopic) GetPolicy() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Policy, func() (any, error) {
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsSnsTopic) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sns.topic", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -101240,6 +101991,7 @@ type mqlAwsSecretsmanagerSecret struct {
 	RotationRules    plugin.TValue[*mqlAwsSecretsmanagerSecretRotationRules]
 	Tags             plugin.TValue[map[string]any]
 	ResourcePolicy   plugin.TValue[string]
+	PolicyStatements plugin.TValue[[]any]
 	ReplicaRegions   plugin.TValue[[]any]
 	Type             plugin.TValue[string]
 	Versions         plugin.TValue[[]any]
@@ -101358,6 +102110,22 @@ func (c *mqlAwsSecretsmanagerSecret) GetTags() *plugin.TValue[map[string]any] {
 func (c *mqlAwsSecretsmanagerSecret) GetResourcePolicy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ResourcePolicy, func() (string, error) {
 		return c.resourcePolicy()
+	})
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.secretsmanager.secret", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -115068,6 +115836,7 @@ type mqlAwsS3Bucket struct {
 	Arn                              plugin.TValue[string]
 	Name                             plugin.TValue[string]
 	Policy                           plugin.TValue[*mqlAwsS3BucketPolicy]
+	PolicyStatements                 plugin.TValue[[]any]
 	Tags                             plugin.TValue[map[string]any]
 	Acl                              plugin.TValue[[]any]
 	Owner                            plugin.TValue[map[string]any]
@@ -115084,6 +115853,10 @@ type mqlAwsS3Bucket struct {
 	EncryptionRules                  plugin.TValue[[]any]
 	ReplicationRules                 plugin.TValue[[]any]
 	PublicAccessBlock                plugin.TValue[any]
+	BlockPublicAcls                  plugin.TValue[bool]
+	BlockPublicPolicy                plugin.TValue[bool]
+	IgnorePublicAcls                 plugin.TValue[bool]
+	RestrictPublicBuckets            plugin.TValue[bool]
 	ObjectLockEnabled                plugin.TValue[bool]
 	MetricsConfigurations            plugin.TValue[[]any]
 	Exists                           plugin.TValue[bool]
@@ -115159,6 +115932,22 @@ func (c *mqlAwsS3Bucket) GetPolicy() *plugin.TValue[*mqlAwsS3BucketPolicy] {
 		}
 
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -115305,6 +116094,30 @@ func (c *mqlAwsS3Bucket) GetReplicationRules() *plugin.TValue[[]any] {
 func (c *mqlAwsS3Bucket) GetPublicAccessBlock() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.PublicAccessBlock, func() (any, error) {
 		return c.publicAccessBlock()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetBlockPublicAcls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.BlockPublicAcls, func() (bool, error) {
+		return c.blockPublicAcls()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetBlockPublicPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.BlockPublicPolicy, func() (bool, error) {
+		return c.blockPublicPolicy()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetIgnorePublicAcls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IgnorePublicAcls, func() (bool, error) {
+		return c.ignorePublicAcls()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetRestrictPublicBuckets() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RestrictPublicBuckets, func() (bool, error) {
+		return c.restrictPublicBuckets()
 	})
 }
 
@@ -118031,6 +118844,8 @@ type mqlAwsBackupVault struct {
 	EncryptionKeyArn plugin.TValue[string]
 	MaxRetentionDays plugin.TValue[int64]
 	MinRetentionDays plugin.TValue[int64]
+	AccessPolicy     plugin.TValue[string]
+	PolicyStatements plugin.TValue[[]any]
 }
 
 // createAwsBackupVault creates a new instance of this resource
@@ -118136,6 +118951,28 @@ func (c *mqlAwsBackupVault) GetMaxRetentionDays() *plugin.TValue[int64] {
 
 func (c *mqlAwsBackupVault) GetMinRetentionDays() *plugin.TValue[int64] {
 	return &c.MinRetentionDays
+}
+
+func (c *mqlAwsBackupVault) GetAccessPolicy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.AccessPolicy, func() (string, error) {
+		return c.accessPolicy()
+	})
+}
+
+func (c *mqlAwsBackupVault) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.backup.vault", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
+	})
 }
 
 // mqlAwsBackupVaultRecoveryPoint for the aws.backup.vaultRecoveryPoint resource
@@ -119766,6 +120603,7 @@ type mqlAwsSqsQueue struct {
 	DeduplicationScope            plugin.TValue[string]
 	FifoThroughputLimit           plugin.TValue[string]
 	Policy                        plugin.TValue[any]
+	PolicyStatements              plugin.TValue[[]any]
 	Tags                          plugin.TValue[map[string]any]
 	ContentBasedDeduplication     plugin.TValue[bool]
 	RedriveAllowPolicy            plugin.TValue[any]
@@ -119929,6 +120767,22 @@ func (c *mqlAwsSqsQueue) GetFifoThroughputLimit() *plugin.TValue[string] {
 func (c *mqlAwsSqsQueue) GetPolicy() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Policy, func() (any, error) {
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsSqsQueue) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sqs.queue", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -127013,6 +127867,7 @@ type mqlAwsEcrRepository struct {
 	CreatedAt          plugin.TValue[*time.Time]
 	ScanningFrequency  plugin.TValue[string]
 	Policy             plugin.TValue[any]
+	PolicyStatements   plugin.TValue[[]any]
 	LifecyclePolicy    plugin.TValue[*mqlAwsEcrLifecyclePolicy]
 	AboutText          plugin.TValue[string]
 	UsageText          plugin.TValue[string]
@@ -127124,6 +127979,22 @@ func (c *mqlAwsEcrRepository) GetScanningFrequency() *plugin.TValue[string] {
 func (c *mqlAwsEcrRepository) GetPolicy() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Policy, func() (any, error) {
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsEcrRepository) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecr.repository", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 
@@ -130566,6 +131437,7 @@ type mqlAwsLambdaFunction struct {
 	DlqTargetArn                  plugin.TValue[string]
 	RecursiveLoop                 plugin.TValue[string]
 	Policy                        plugin.TValue[any]
+	PolicyStatements              plugin.TValue[[]any]
 	VpcConfig                     plugin.TValue[any]
 	Vpc                           plugin.TValue[*mqlAwsVpc]
 	Subnets                       plugin.TValue[[]any]
@@ -130678,6 +131550,22 @@ func (c *mqlAwsLambdaFunction) GetRecursiveLoop() *plugin.TValue[string] {
 func (c *mqlAwsLambdaFunction) GetPolicy() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Policy, func() (any, error) {
 		return c.policy()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -805,6 +805,7 @@ aws.backup.scanJob.statusMessage 13.28.1
 aws.backup.scanJob.vault 13.28.1
 aws.backup.scanJobs 13.28.1
 aws.backup.vault 11.15.2
+aws.backup.vault.accessPolicy 13.32.2
 aws.backup.vault.arn 11.15.2
 aws.backup.vault.createdAt 11.15.2
 aws.backup.vault.encryptionKey 13.12.1
@@ -814,6 +815,7 @@ aws.backup.vault.lockedAt 11.15.2
 aws.backup.vault.maxRetentionDays 11.15.2
 aws.backup.vault.minRetentionDays 11.15.2
 aws.backup.vault.name 11.15.2
+aws.backup.vault.policyStatements 13.32.2
 aws.backup.vault.recoveryPoints 11.15.2
 aws.backup.vault.region 11.15.2
 aws.backup.vaultRecoveryPoint 11.15.2
@@ -3432,6 +3434,7 @@ aws.ecr.repository.lifecyclePolicy 11.15.2
 aws.ecr.repository.name 11.15.2
 aws.ecr.repository.operatingSystems 11.16.1
 aws.ecr.repository.policy 13.5.0
+aws.ecr.repository.policyStatements 13.32.2
 aws.ecr.repository.public 11.15.2
 aws.ecr.repository.region 11.15.2
 aws.ecr.repository.registryId 11.15.2
@@ -3757,6 +3760,7 @@ aws.efs.filesystem.lifecycleState 13.12.1
 aws.efs.filesystem.mountTargets 11.15.2
 aws.efs.filesystem.name 11.15.2
 aws.efs.filesystem.performanceMode 13.12.1
+aws.efs.filesystem.policyStatements 13.32.2
 aws.efs.filesystem.region 11.15.2
 aws.efs.filesystem.replicationConfiguration 13.12.1
 aws.efs.filesystem.replicationConfiguration.creationTime 13.12.1
@@ -5183,17 +5187,30 @@ aws.iam.policy.isAttachable 11.15.2
 aws.iam.policy.name 11.15.2
 aws.iam.policy.policyId 11.15.2
 aws.iam.policy.scope 11.15.2
+aws.iam.policy.statements 13.32.2
 aws.iam.policy.updatedAt 11.15.2
 aws.iam.policy.versions 11.15.2
+aws.iam.policyStatement 13.32.2
+aws.iam.policyStatement.actions 13.32.2
+aws.iam.policyStatement.conditions 13.32.2
+aws.iam.policyStatement.effect 13.32.2
+aws.iam.policyStatement.notActions 13.32.2
+aws.iam.policyStatement.notPrincipals 13.32.2
+aws.iam.policyStatement.notResources 13.32.2
+aws.iam.policyStatement.principals 13.32.2
+aws.iam.policyStatement.resources 13.32.2
+aws.iam.policyStatement.sid 13.32.2
 aws.iam.policyversion 11.15.2
 aws.iam.policyversion.arn 11.15.2
 aws.iam.policyversion.createdAt 11.15.2
 aws.iam.policyversion.document 11.15.2
 aws.iam.policyversion.isDefaultVersion 11.15.2
+aws.iam.policyversion.statements 13.32.2
 aws.iam.policyversion.versionId 11.15.2
 aws.iam.role 11.15.2
 aws.iam.role.arn 11.15.2
 aws.iam.role.assumeRolePolicyDocument 11.15.2
+aws.iam.role.assumeRolePolicyStatements 13.32.2
 aws.iam.role.attachedPolicies 13.6.3
 aws.iam.role.createdAt 11.15.2
 aws.iam.role.description 11.15.2
@@ -5219,6 +5236,15 @@ aws.iam.samlProvider.validUntil 11.15.2
 aws.iam.samlProviders 11.15.2
 aws.iam.serverCertificates 11.15.2
 aws.iam.user 11.15.2
+aws.iam.user.accessKey 13.32.2
+aws.iam.user.accessKey.accessKeyId 13.32.2
+aws.iam.user.accessKey.createdAt 13.32.2
+aws.iam.user.accessKey.lastUsedDate 13.32.2
+aws.iam.user.accessKey.lastUsedRegion 13.32.2
+aws.iam.user.accessKey.lastUsedService 13.32.2
+aws.iam.user.accessKey.status 13.32.2
+aws.iam.user.accessKey.username 13.32.2
+aws.iam.user.accessKeyDetails 13.32.2
 aws.iam.user.accessKeys 11.15.2
 aws.iam.user.arn 11.15.2
 aws.iam.user.attachedPolicies 11.15.2
@@ -5643,6 +5669,7 @@ aws.kms.key.nextRotationAt 13.12.1
 aws.kms.key.onDemandRotationStartedAt 13.12.1
 aws.kms.key.origin 13.6.3
 aws.kms.key.policy 13.2.7
+aws.kms.key.policyStatements 13.32.2
 aws.kms.key.region 11.15.2
 aws.kms.key.rotationPeriodInDays 13.12.1
 aws.kms.key.signingAlgorithms 13.12.1
@@ -5757,6 +5784,7 @@ aws.lambda.function.memorySize 11.15.2
 aws.lambda.function.name 11.15.2
 aws.lambda.function.packageType 11.15.2
 aws.lambda.function.policy 11.15.2
+aws.lambda.function.policyStatements 13.32.2
 aws.lambda.function.provisionedConcurrencyConfig 11.15.2
 aws.lambda.function.provisionedConcurrencyConfig.allocatedConcurrentExecutions 11.15.2
 aws.lambda.function.provisionedConcurrencyConfig.availableConcurrentExecutions 11.15.2
@@ -6762,7 +6790,17 @@ aws.organization.organizationalUnit.arn 13.6.3
 aws.organization.organizationalUnit.id 13.6.3
 aws.organization.organizationalUnit.name 13.6.3
 aws.organization.organizationalUnit.path 13.6.3
+aws.organization.organizationalUnit.serviceControlPolicies 13.32.2
 aws.organization.organizationalUnits 13.6.3
+aws.organization.serviceControlPolicies 13.32.2
+aws.organization.serviceControlPolicy 13.32.2
+aws.organization.serviceControlPolicy.arn 13.32.2
+aws.organization.serviceControlPolicy.awsManaged 13.32.2
+aws.organization.serviceControlPolicy.content 13.32.2
+aws.organization.serviceControlPolicy.description 13.32.2
+aws.organization.serviceControlPolicy.id 13.32.2
+aws.organization.serviceControlPolicy.name 13.32.2
+aws.organization.serviceControlPolicy.statements 13.32.2
 aws.privateca 13.10.0
 aws.privateca.certificateAuthorities 13.10.0
 aws.privateca.certificateAuthority 13.10.0
@@ -7554,6 +7592,8 @@ aws.s3.bucket.accessPoints 13.26.2
 aws.s3.bucket.acl 11.15.2
 aws.s3.bucket.analyticsConfigurations 13.29.1
 aws.s3.bucket.arn 11.15.2
+aws.s3.bucket.blockPublicAcls 13.32.2
+aws.s3.bucket.blockPublicPolicy 13.32.2
 aws.s3.bucket.cors 11.15.2
 aws.s3.bucket.corsrule 11.15.2
 aws.s3.bucket.corsrule.allowedHeaders 11.15.2
@@ -7586,6 +7626,7 @@ aws.s3.bucket.grant.grantee 11.15.2
 aws.s3.bucket.grant.id 11.15.2
 aws.s3.bucket.grant.name 11.15.2
 aws.s3.bucket.grant.permission 11.15.2
+aws.s3.bucket.ignorePublicAcls 13.32.2
 aws.s3.bucket.intelligentTieringConfigurations 13.29.1
 aws.s3.bucket.inventoryConfigurations 13.29.1
 aws.s3.bucket.lifecycleRule 13.6.3
@@ -7618,6 +7659,7 @@ aws.s3.bucket.policy.document 11.15.2
 aws.s3.bucket.policy.name 11.15.2
 aws.s3.bucket.policy.statements 11.15.2
 aws.s3.bucket.policy.version 11.15.2
+aws.s3.bucket.policyStatements 13.32.2
 aws.s3.bucket.public 11.15.2
 aws.s3.bucket.publicAccessBlock 11.15.2
 aws.s3.bucket.replication 11.15.2
@@ -7633,6 +7675,7 @@ aws.s3.bucket.replicationRule.resourceId 11.15.2
 aws.s3.bucket.replicationRule.status 11.15.2
 aws.s3.bucket.replicationRules 11.15.2
 aws.s3.bucket.requestPayment 13.29.1
+aws.s3.bucket.restrictPublicBuckets 13.32.2
 aws.s3.bucket.staticWebsiteHosting 11.15.2
 aws.s3.bucket.tags 11.15.2
 aws.s3.bucket.transferAcceleration 13.29.1
@@ -8636,6 +8679,7 @@ aws.secretsmanager.secret.lastRotatedDate 11.15.2
 aws.secretsmanager.secret.name 11.15.2
 aws.secretsmanager.secret.nextRotationDate 11.15.2
 aws.secretsmanager.secret.owningService 11.15.2
+aws.secretsmanager.secret.policyStatements 13.32.2
 aws.secretsmanager.secret.primaryRegion 11.15.2
 aws.secretsmanager.secret.replicaRegion 13.6.3
 aws.secretsmanager.secret.replicaRegion.id 13.6.3
@@ -8911,6 +8955,7 @@ aws.sns.topic.displayName 13.12.1
 aws.sns.topic.fifoTopic 13.12.1
 aws.sns.topic.kmsMasterKey 11.15.2
 aws.sns.topic.policy 13.6.3
+aws.sns.topic.policyStatements 13.32.2
 aws.sns.topic.region 11.15.2
 aws.sns.topic.signatureVersion 11.15.2
 aws.sns.topic.subscriptions 11.15.2
@@ -8932,6 +8977,7 @@ aws.sqs.queue.maxReceiveCount 11.15.2
 aws.sqs.queue.maximumMessageSize 11.15.2
 aws.sqs.queue.messageRetentionPeriodSeconds 11.15.2
 aws.sqs.queue.policy 13.3.0
+aws.sqs.queue.policyStatements 13.32.2
 aws.sqs.queue.queueType 11.15.2
 aws.sqs.queue.receiveMessageWaitTimeSeconds 11.15.2
 aws.sqs.queue.redriveAllowPolicy 13.12.1
@@ -9374,6 +9420,7 @@ aws.vpc.endpoint.ipAddressType 13.6.3
 aws.vpc.endpoint.networkInterfaces 13.6.3
 aws.vpc.endpoint.ownerId 13.6.3
 aws.vpc.endpoint.policyDocument 11.15.2
+aws.vpc.endpoint.policyStatements 13.32.2
 aws.vpc.endpoint.privateDnsEnabled 11.15.2
 aws.vpc.endpoint.region 11.15.2
 aws.vpc.endpoint.requesterManaged 13.6.3

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.32.1",
-  "generated_at": "2026-06-05T10:50:35-07:00",
+  "generated_at": "2026-06-07T13:33:02-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -60,6 +60,7 @@
     "autoscaling:DescribeAutoScalingGroups",
     "autoscaling:DescribeLaunchConfigurations",
     "backup:GetBackupPlan",
+    "backup:GetBackupVaultAccessPolicy",
     "backup:ListBackupPlans",
     "backup:ListBackupSelections",
     "backup:ListBackupVaults",
@@ -445,6 +446,7 @@
     "guardduty:ListPublishingDestinations",
     "guardduty:ListThreatIntelSets",
     "iam:GenerateCredentialReport",
+    "iam:GetAccessKeyLastUsed",
     "iam:GetAccountPasswordPolicy",
     "iam:GetAccountSummary",
     "iam:GetCredentialReport",
@@ -585,10 +587,13 @@
     "network-firewall:ListTLSInspectionConfigurations",
     "organizations:DescribeAccount",
     "organizations:DescribeOrganization",
+    "organizations:DescribePolicy",
     "organizations:ListAccounts",
     "organizations:ListDelegatedAdministrators",
     "organizations:ListDelegatedServicesForAccount",
     "organizations:ListOrganizationalUnitsForParent",
+    "organizations:ListPolicies",
+    "organizations:ListPoliciesForTarget",
     "organizations:ListRoots",
     "organizations:ListTagsForResource",
     "pipes:DescribePipe",
@@ -1253,6 +1258,12 @@
       "permission": "backup:GetBackupPlan",
       "service": "backup",
       "action": "GetBackupPlan",
+      "source_file": "aws_backups.go"
+    },
+    {
+      "permission": "backup:GetBackupVaultAccessPolicy",
+      "service": "backup",
+      "action": "GetBackupVaultAccessPolicy",
       "source_file": "aws_backups.go"
     },
     {
@@ -3614,6 +3625,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:GetAccessKeyLastUsed",
+      "service": "iam",
+      "action": "GetAccessKeyLastUsed",
+      "source_file": "aws_iam.go"
+    },
+    {
       "permission": "iam:GetAccountPasswordPolicy",
       "service": "iam",
       "action": "GetAccountPasswordPolicy",
@@ -4466,6 +4483,12 @@
       "source_file": "aws_account.go"
     },
     {
+      "permission": "organizations:DescribePolicy",
+      "service": "organizations",
+      "action": "DescribePolicy",
+      "source_file": "aws_account.go"
+    },
+    {
       "permission": "organizations:ListAccounts",
       "service": "organizations",
       "action": "ListAccounts",
@@ -4487,6 +4510,18 @@
       "permission": "organizations:ListOrganizationalUnitsForParent",
       "service": "organizations",
       "action": "ListOrganizationalUnitsForParent",
+      "source_file": "aws_account.go"
+    },
+    {
+      "permission": "organizations:ListPolicies",
+      "service": "organizations",
+      "action": "ListPolicies",
+      "source_file": "aws_account.go"
+    },
+    {
+      "permission": "organizations:ListPoliciesForTarget",
+      "service": "organizations",
+      "action": "ListPoliciesForTarget",
       "source_file": "aws_account.go"
     },
     {

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -532,6 +532,99 @@ func (a *mqlAwsOrganizationOrganizationalUnit) id() (string, error) {
 	return a.Arn.Data, a.Arn.Error
 }
 
+func newServiceControlPolicyResource(runtime *plugin.Runtime, p orgtypes.PolicySummary) (plugin.Resource, error) {
+	return CreateResource(runtime, "aws.organization.serviceControlPolicy",
+		map[string]*llx.RawData{
+			"__id":        llx.StringDataPtr(p.Id),
+			"id":          llx.StringDataPtr(p.Id),
+			"arn":         llx.StringDataPtr(p.Arn),
+			"name":        llx.StringDataPtr(p.Name),
+			"description": llx.StringDataPtr(p.Description),
+			"awsManaged":  llx.BoolData(p.AwsManaged),
+		})
+}
+
+func (a *mqlAwsOrganization) serviceControlPolicies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+
+	res := []any{}
+	paginator := organizations.NewListPoliciesPaginator(client, &organizations.ListPoliciesInput{
+		Filter: orgtypes.PolicyTypeServiceControlPolicy,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for i := range page.Policies {
+			mqlPolicy, err := newServiceControlPolicyResource(a.MqlRuntime, page.Policies[i])
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlPolicy)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAwsOrganizationOrganizationalUnit) serviceControlPolicies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+
+	targetId := a.Id.Data
+	res := []any{}
+	paginator := organizations.NewListPoliciesForTargetPaginator(client, &organizations.ListPoliciesForTargetInput{
+		TargetId: &targetId,
+		Filter:   orgtypes.PolicyTypeServiceControlPolicy,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for i := range page.Policies {
+			mqlPolicy, err := newServiceControlPolicyResource(a.MqlRuntime, page.Policies[i])
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlPolicy)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAwsOrganizationServiceControlPolicy) content() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+
+	id := a.Id.Data
+	resp, err := client.DescribePolicy(ctx, &organizations.DescribePolicyInput{PolicyId: &id})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if resp.Policy == nil || resp.Policy.Content == nil {
+		return "", nil
+	}
+	return *resp.Policy.Content, nil
+}
+
+func (a *mqlAwsOrganizationServiceControlPolicy) statements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetContent())
+}
+
 func (a *mqlAwsOrganizationDelegatedAdministrator) account() (*mqlAwsAccount, error) {
 	mqlAccount, err := NewResource(a.MqlRuntime, "aws.account",
 		map[string]*llx.RawData{

--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -144,6 +145,39 @@ func (a *mqlAwsBackupVault) recoveryPoints() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+func (a *mqlAwsBackupVault) accessPolicy() (string, error) {
+	vArn := a.Arn.Data
+	parsedArn, err := arn.Parse(vArn)
+	if err != nil {
+		return "", err
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Backup(parsedArn.Region)
+	ctx := context.Background()
+
+	name := strings.TrimPrefix(parsedArn.Resource, "backup-vault:")
+	resp, err := svc.GetBackupVaultAccessPolicy(ctx, &backup.GetBackupVaultAccessPolicyInput{
+		BackupVaultName: &name,
+	})
+	if err != nil {
+		// vaults without an access policy return ResourceNotFoundException
+		var rnf *backuptypes.ResourceNotFoundException
+		if errors.As(err, &rnf) {
+			return "", nil
+		}
+		return "", err
+	}
+	if resp.Policy == nil {
+		return "", nil
+	}
+	return *resp.Policy, nil
+}
+
+func (a *mqlAwsBackupVault) policyStatements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetAccessPolicy())
 }
 
 // ========================

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -940,6 +940,8 @@ func (a *mqlAwsIamUser) accessKeyDetails() ([]any, error) {
 		for i := range keysResp.AccessKeyMetadata {
 			key := keysResp.AccessKeyMetadata[i]
 
+			// One GetAccessKeyLastUsed call per key. IAM caps users at 2 access
+			// keys, so this loop makes at most 2 calls and is not an N+1 risk.
 			// AWS returns "N/A" for region and service and a nil date when the
 			// key has never been used.
 			lastUsedRegion := ""
@@ -1387,29 +1389,42 @@ func (a *mqlAwsIamPolicyversion) id() (string, error) {
 	return arn + "/" + versionid, nil
 }
 
+type mqlAwsIamPolicyversionInternal struct {
+	rawDocOnce sync.Once
+	rawDoc     string
+	rawDocErr  error
+}
+
 // rawDocument fetches the policy version document as it is returned by the IAM
-// API: a URL-encoded JSON string. Callers decode and parse it as needed.
+// API: a URL-encoded JSON string. Callers decode and parse it as needed. The
+// result is cached so that document() and statements(), which both rely on it,
+// share a single GetPolicyVersion call.
 func (a *mqlAwsIamPolicyversion) rawDocument() (string, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	a.rawDocOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.Iam("")
-	ctx := context.Background()
+		svc := conn.Iam("")
+		ctx := context.Background()
 
-	arn := a.Arn.Data
-	versionid := a.VersionId.Data
+		arn := a.Arn.Data
+		versionid := a.VersionId.Data
 
-	policyVersion, err := svc.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{
-		PolicyArn: &arn,
-		VersionId: &versionid,
+		policyVersion, err := svc.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{
+			PolicyArn: &arn,
+			VersionId: &versionid,
+		})
+		if err != nil {
+			a.rawDocErr = err
+			return
+		}
+
+		if policyVersion.PolicyVersion.Document == nil {
+			a.rawDocErr = errors.New("could not retrieve the policy document")
+			return
+		}
+		a.rawDoc = *policyVersion.PolicyVersion.Document
 	})
-	if err != nil {
-		return "", err
-	}
-
-	if policyVersion.PolicyVersion.Document == nil {
-		return "", errors.New("could not retrieve the policy document")
-	}
-	return *policyVersion.PolicyVersion.Document, nil
+	return a.rawDoc, a.rawDocErr
 }
 
 func (a *mqlAwsIamPolicyversion) document() (any, error) {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -920,6 +920,65 @@ func (a *mqlAwsIamUser) accessKeys() ([]any, error) {
 	return res, nil
 }
 
+func (a *mqlAwsIamUser) accessKeyDetails() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	username := a.Name.Data
+
+	res := []any{}
+	paginator := iam.NewListAccessKeysPaginator(svc, &iam.ListAccessKeysInput{
+		UserName: &username,
+	})
+	for paginator.HasMorePages() {
+		keysResp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for i := range keysResp.AccessKeyMetadata {
+			key := keysResp.AccessKeyMetadata[i]
+
+			// AWS returns "N/A" for region and service and a nil date when the
+			// key has never been used.
+			lastUsedRegion := ""
+			lastUsedService := ""
+			var lastUsedDate *time.Time
+			if key.AccessKeyId != nil {
+				lastUsed, err := svc.GetAccessKeyLastUsed(ctx, &iam.GetAccessKeyLastUsedInput{
+					AccessKeyId: key.AccessKeyId,
+				})
+				if err != nil {
+					return nil, err
+				}
+				if lastUsed.AccessKeyLastUsed != nil {
+					lastUsedDate = lastUsed.AccessKeyLastUsed.LastUsedDate
+					lastUsedRegion = convert.ToValue(lastUsed.AccessKeyLastUsed.Region)
+					lastUsedService = convert.ToValue(lastUsed.AccessKeyLastUsed.ServiceName)
+				}
+			}
+
+			mqlKey, err := CreateResource(a.MqlRuntime, "aws.iam.user.accessKey",
+				map[string]*llx.RawData{
+					"__id":            llx.StringDataPtr(key.AccessKeyId),
+					"accessKeyId":     llx.StringDataPtr(key.AccessKeyId),
+					"username":        llx.StringDataPtr(key.UserName),
+					"status":          llx.StringData(string(key.Status)),
+					"createdAt":       llx.TimeDataPtr(key.CreateDate),
+					"lastUsedDate":    llx.TimeDataPtr(lastUsedDate),
+					"lastUsedRegion":  llx.StringData(lastUsedRegion),
+					"lastUsedService": llx.StringData(lastUsedService),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlKey)
+		}
+	}
+	return res, nil
+}
+
 func (a *mqlAwsIamUser) policies() ([]any, error) {
 	if a.policiesFetched.Load() {
 		return a.policiesCache, nil
@@ -1328,7 +1387,9 @@ func (a *mqlAwsIamPolicyversion) id() (string, error) {
 	return arn + "/" + versionid, nil
 }
 
-func (a *mqlAwsIamPolicyversion) document() (any, error) {
+// rawDocument fetches the policy version document as it is returned by the IAM
+// API: a URL-encoded JSON string. Callers decode and parse it as needed.
+func (a *mqlAwsIamPolicyversion) rawDocument() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -1348,7 +1409,15 @@ func (a *mqlAwsIamPolicyversion) document() (any, error) {
 	if policyVersion.PolicyVersion.Document == nil {
 		return "", errors.New("could not retrieve the policy document")
 	}
-	decodedValue, err := url.QueryUnescape(*policyVersion.PolicyVersion.Document)
+	return *policyVersion.PolicyVersion.Document, nil
+}
+
+func (a *mqlAwsIamPolicyversion) document() (any, error) {
+	rawDoc, err := a.rawDocument()
+	if err != nil {
+		return "", err
+	}
+	decodedValue, err := url.QueryUnescape(rawDoc)
 	if err != nil {
 		return "", err
 	}

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -1,0 +1,189 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/aws/resources/awspolicy"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// newPolicyStatementResources parses an IAM-grammar policy document (an IAM
+// policy, role trust policy, or any resource-based policy) into a slice of
+// aws.iam.policyStatement resources. The document may be a plain JSON string
+// or, as the IAM API returns policy and trust documents, URL-encoded JSON.
+// parentID is used to build a stable, synthetic __id for each statement.
+func newPolicyStatementResources(runtime *plugin.Runtime, parentID string, policyJSON string) ([]any, error) {
+	if strings.TrimSpace(policyJSON) == "" {
+		return []any{}, nil
+	}
+
+	policy, err := parsePolicyStatements(policyJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]any, 0, len(policy.Statements))
+	for i := range policy.Statements {
+		stmt := policy.Statements[i]
+
+		var conditions any
+		if len(stmt.Condition) > 0 {
+			if err := json.Unmarshal(stmt.Condition, &conditions); err != nil {
+				return nil, err
+			}
+		}
+
+		mqlStatement, err := CreateResource(runtime, ResourceAwsIamPolicyStatement,
+			map[string]*llx.RawData{
+				"__id":          llx.StringData(fmt.Sprintf("%s/statement/%d", parentID, i)),
+				"sid":           llx.StringData(stmt.Sid),
+				"effect":        llx.StringData(stmt.Effect),
+				"actions":       llx.ArrayData(convert.SliceAnyToInterface(stmt.Action.Value()), types.String),
+				"notActions":    llx.ArrayData(convert.SliceAnyToInterface(stmt.NotAction.Value()), types.String),
+				"resources":     llx.ArrayData(convert.SliceAnyToInterface(stmt.Resource.Value()), types.String),
+				"notResources":  llx.ArrayData(convert.SliceAnyToInterface(stmt.NotResource.Value()), types.String),
+				"principals":    llx.MapData(stringSliceMapToAny(stmt.Principal.Data()), types.Array(types.String)),
+				"notPrincipals": llx.MapData(stringSliceMapToAny(stmt.NotPrincipal.Data()), types.Array(types.String)),
+				"conditions":    llx.DictData(conditions),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlStatement)
+	}
+	return res, nil
+}
+
+// parsePolicyStatements unmarshals a policy document into the shared
+// S3BucketPolicy shape, which preserves the full principal map and the Not*
+// elements across every AWS policy grammar. It first tries the raw bytes and
+// falls back to URL-decoding, since IAM policy and role trust documents are
+// returned URL-encoded while resource-based policies are not.
+func parsePolicyStatements(policyJSON string) (*awspolicy.S3BucketPolicy, error) {
+	var policy awspolicy.S3BucketPolicy
+	if err := json.Unmarshal([]byte(policyJSON), &policy); err != nil {
+		decoded, decodeErr := url.QueryUnescape(policyJSON)
+		if decodeErr != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(decoded), &policy); err != nil {
+			return nil, err
+		}
+	}
+	return &policy, nil
+}
+
+// policyStatementsFromString parses a resource policy held as a raw JSON
+// string field (e.g. an EFS file system policy or VPC endpoint policy).
+func policyStatementsFromString(runtime *plugin.Runtime, parentID string, doc *plugin.TValue[string]) ([]any, error) {
+	if doc.Error != nil {
+		return nil, doc.Error
+	}
+	return newPolicyStatementResources(runtime, parentID, doc.Data)
+}
+
+// policyStatementsFromDict parses a resource policy held as a parsed dict
+// field (e.g. an SNS topic or SQS queue policy). The dict is round-tripped
+// back to JSON, which is loss-free because these policies are stored as the
+// faithful raw document rather than a reduced shape.
+func policyStatementsFromDict(runtime *plugin.Runtime, parentID string, doc *plugin.TValue[any]) ([]any, error) {
+	if doc.Error != nil {
+		return nil, doc.Error
+	}
+	if doc.Data == nil {
+		return []any{}, nil
+	}
+	raw, err := json.Marshal(doc.Data)
+	if err != nil {
+		return nil, err
+	}
+	return newPolicyStatementResources(runtime, parentID, string(raw))
+}
+
+func (a *mqlAwsIamPolicy) statements() ([]any, error) {
+	defaultVersion, err := a.defaultVersion()
+	if err != nil {
+		return nil, err
+	}
+	return defaultVersion.statements()
+}
+
+func (a *mqlAwsIamPolicyversion) statements() ([]any, error) {
+	rawDoc, err := a.rawDocument()
+	if err != nil {
+		return nil, err
+	}
+	parentID := a.Arn.Data + "/" + a.VersionId.Data
+	return newPolicyStatementResources(a.MqlRuntime, parentID, rawDoc)
+}
+
+func (a *mqlAwsIamRole) assumeRolePolicyStatements() ([]any, error) {
+	doc := a.GetAssumeRolePolicyDocument()
+	if doc.Error != nil {
+		return nil, doc.Error
+	}
+	if doc.Data == nil {
+		return []any{}, nil
+	}
+	raw, err := json.Marshal(doc.Data)
+	if err != nil {
+		return nil, err
+	}
+	return newPolicyStatementResources(a.MqlRuntime, a.Arn.Data+"/trust", string(raw))
+}
+
+func (a *mqlAwsKmsKey) policyStatements() ([]any, error) {
+	policy := a.GetPolicy()
+	if policy.Error != nil {
+		return nil, policy.Error
+	}
+	return newPolicyStatementResources(a.MqlRuntime, a.Arn.Data, policy.Data)
+}
+
+func (a *mqlAwsVpcEndpoint) policyStatements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Id.Data, a.GetPolicyDocument())
+}
+
+func (a *mqlAwsEfsFilesystem) policyStatements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetFileSystemPolicy())
+}
+
+func (a *mqlAwsSnsTopic) policyStatements() ([]any, error) {
+	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+}
+
+func (a *mqlAwsSqsQueue) policyStatements() ([]any, error) {
+	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+}
+
+func (a *mqlAwsEcrRepository) policyStatements() ([]any, error) {
+	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+}
+
+func (a *mqlAwsLambdaFunction) policyStatements() ([]any, error) {
+	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+}
+
+func (a *mqlAwsSecretsmanagerSecret) policyStatements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetResourcePolicy())
+}
+
+func (a *mqlAwsS3Bucket) policyStatements() ([]any, error) {
+	policy := a.GetPolicy()
+	if policy.Error != nil {
+		return nil, policy.Error
+	}
+	if policy.Data == nil {
+		return []any{}, nil
+	}
+	return policyStatementsFromString(a.MqlRuntime, a.Name.Data, policy.Data.GetDocument())
+}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -581,6 +581,36 @@ func (a *mqlAwsS3Bucket) fetchPublicAccessBlock() (*s3types.PublicAccessBlockCon
 	return a.publicAccessConfig, a.publicAccessErr
 }
 
+// s3PublicAccessBlockFlag resolves one block-public-access setting. When no
+// public access block configuration exists on the bucket, the protection is
+// not in effect, so each flag reports false.
+func (a *mqlAwsS3Bucket) s3PublicAccessBlockFlag(get func(*s3types.PublicAccessBlockConfiguration) *bool) (bool, error) {
+	config, err := a.fetchPublicAccessBlock()
+	if err != nil {
+		return false, err
+	}
+	if config == nil {
+		return false, nil
+	}
+	return convert.ToValue(get(config)), nil
+}
+
+func (a *mqlAwsS3Bucket) blockPublicAcls() (bool, error) {
+	return a.s3PublicAccessBlockFlag(func(c *s3types.PublicAccessBlockConfiguration) *bool { return c.BlockPublicAcls })
+}
+
+func (a *mqlAwsS3Bucket) blockPublicPolicy() (bool, error) {
+	return a.s3PublicAccessBlockFlag(func(c *s3types.PublicAccessBlockConfiguration) *bool { return c.BlockPublicPolicy })
+}
+
+func (a *mqlAwsS3Bucket) ignorePublicAcls() (bool, error) {
+	return a.s3PublicAccessBlockFlag(func(c *s3types.PublicAccessBlockConfiguration) *bool { return c.IgnorePublicAcls })
+}
+
+func (a *mqlAwsS3Bucket) restrictPublicBuckets() (bool, error) {
+	return a.s3PublicAccessBlockFlag(func(c *s3types.PublicAccessBlockConfiguration) *bool { return c.RestrictPublicBuckets })
+}
+
 func (a *mqlAwsS3Bucket) publicAccessBlock() (any, error) {
 	config, err := a.fetchPublicAccessBlock()
 	if err != nil {

--- a/providers/aws/resources/awspolicy/s3bucketpolicy.go
+++ b/providers/aws/resources/awspolicy/s3bucketpolicy.go
@@ -99,7 +99,7 @@ func (v *Principal) UnmarshalJSON(b []byte) error {
 				p[key] = []string{fmt.Sprintf("%v", subv)}
 			case []any:
 				var items []string
-				for _, item := range v {
+				for _, item := range subv {
 					items = append(items, fmt.Sprintf("%v", item))
 				}
 				p[key] = items

--- a/providers/aws/resources/awspolicy/s3bucketpolicy_test.go
+++ b/providers/aws/resources/awspolicy/s3bucketpolicy_test.go
@@ -51,3 +51,25 @@ func TestPolicyPrincipal(t *testing.T) {
 		"AWS": {"*"},
 	}, policy.Statements[0].Principal.Data())
 }
+
+// TestPolicyPrincipalArray guards against a regression where an array-valued
+// principal (e.g. {"Service": ["a", "b"]}) was rendered as a single bracketed
+// string instead of a slice of the individual values.
+func TestPolicyPrincipalArray(t *testing.T) {
+	doc := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": {"Service": ["lambda.amazonaws.com", "logs.amazonaws.com"]},
+			"Action": "sts:AssumeRole"
+		}]
+	}`
+
+	var policy S3BucketPolicy
+	err := json.Unmarshal([]byte(doc), &policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]string{
+		"Service": {"lambda.amazonaws.com", "logs.amazonaws.com"},
+	}, policy.Statements[0].Principal.Data())
+}


### PR DESCRIPTION
## What

Surfaces security-relevant data across the AWS provider that previously required hand-parsing raw JSON in MQL, or wasn't modeled at all. The centerpiece is a single reusable parsed policy-statement type that ~12 resources now share.

**All changes are additive and backwards compatible** — no existing field changed type or version. Two fields that the new typed accessors supersede are deprecated (`@maturity("deprecated")`), not removed, and keep their original `.lr.versions` entries.

## Highlights

### Shared `aws.iam.policyStatement`
One typed statement — `effect`, `actions`/`notActions`, `resources`/`notResources`, `principals`/`notPrincipals` (typed `map[string][]string`, so `principals["AWS"]` is queryable), and `conditions`. Parsed with the existing shared `awspolicy` grammar. Wired to:

- IAM policies & policy versions (`statements()`), role trust policies (`assumeRolePolicyStatements`)
- KMS keys, S3 buckets, SNS topics, SQS queues, ECR repos, EFS file systems, VPC endpoints, Lambda functions, Secrets Manager secrets, Backup vaults (`policyStatements()`)

This makes audits like wildcard actions (`s3:*`), anonymous principals (`Principal: "*"`), and cross-account trust uniform across services.

### IAM credential depth
`aws.iam.user.accessKeyDetails()` → typed `aws.iam.user.accessKey` with `status`, `createdAt`, and last-used `date`/`region`/`service` — the data behind CIS access-key rotation and unused-key audits.

### Organizations service control policies
New `aws.organization.serviceControlPolicy` (reuses `policyStatement`) via `serviceControlPolicies()` on the organization and each OU. SCPs were not modeled at all before.

### S3 public access block
`blockPublicAcls`, `blockPublicPolicy`, `ignorePublicAcls`, `restrictPublicBuckets` typed booleans alongside the existing opaque dict.

### New `aws.backup.vault.accessPolicy()`
The vault resource-based policy was unmodeled; now fetched (with graceful handling of vaults that have no policy) and exposed as both raw JSON and parsed statements.

## Deprecations (per reviewer convention)

| Deprecated | Replacement |
|---|---|
| `aws.s3.bucket.policy.statements() []dict` | `aws.s3.bucket.policyStatements` |
| `aws.iam.user.accessKeys() []dict` | `aws.iam.user.accessKeyDetails` |

## Bug fix

The shared `awspolicy` principal parser rendered array-valued principals (`{"Service": ["a","b"]}`) as a single bracketed string. Fixed, with a regression test.

## Permissions

Auto-extracted into `aws.permissions.json`: `iam:GetAccessKeyLastUsed`, `backup:GetBackupVaultAccessPolicy`, `organizations:ListPolicies`, `organizations:ListPoliciesForTarget`, `organizations:DescribePolicy`.

## Verification

Tested live against a real AWS account:

- KMS key policy → `principals.AWS = ["*"]` correctly surfaced
- IAM role trust → `Service: ["ec2.amazonaws.com"]`; IAM policy/version statements
- IAM access keys → real `lastUsedService`/`lastUsedDate`/`status`
- S3 bucket policy (Deny `*`) and Lambda resource policy via both string and dict paths
- Backup vault → parsed Deny-all access policy
- S3 PAB flags resolve correctly
- SCPs return gracefully empty from a member account (full content verification needs the management account)
- `awspolicy` unit tests pass; `gofmt`/`go vet` clean; codegen idempotent

## Not included

The remaining opaque-dict breakouts I'd scoped but deferred (same additive pattern, follow-on PR): EKS `logging()` log-type booleans, Athena result-encryption + `kmsKey()`, Glue securityConfiguration `kmsKey()` refs, ElastiCache `transitEncryptionMode`, and the raw-`kmsKeyId` → typed-`kmsKey()` audit.
