### PR TITLE
✨ GCP security long-tail: SCC finding context, GKE posture, org/folder contacts, predicates

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3148,7 +3148,7 @@ func (g *mqlGcpProjectComputeServiceSslCertificate) expired() (bool, error) {
 	}
 	t, err := time.Parse(time.RFC3339, g.ExpireTime.Data)
 	if err != nil {
-		return false, nil
+		return false, fmt.Errorf("parsing ssl certificate expireTime %q: %w", g.ExpireTime.Data, err)
 	}
 	return t.Before(time.Now()), nil
 }

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2820,6 +2820,17 @@ func (g *mqlGcpProjectComputeServiceForwardingRule) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProjectComputeServiceForwardingRule) isExternal() (bool, error) {
+	if g.LoadBalancingScheme.Error != nil {
+		return false, g.LoadBalancingScheme.Error
+	}
+	switch g.LoadBalancingScheme.Data {
+	case "EXTERNAL", "EXTERNAL_MANAGED":
+		return true, nil
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProjectComputeServiceForwardingRule) network() (*mqlGcpProjectComputeServiceNetwork, error) {
 	if g.NetworkUrl.Error != nil {
 		return nil, g.NetworkUrl.Error
@@ -3126,6 +3137,20 @@ func (g *mqlGcpProjectComputeService) sslPolicies() ([]any, error) {
 
 func (g *mqlGcpProjectComputeServiceSslCertificate) id() (string, error) {
 	return g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectComputeServiceSslCertificate) expired() (bool, error) {
+	if g.ExpireTime.Error != nil {
+		return false, g.ExpireTime.Error
+	}
+	if g.ExpireTime.Data == "" {
+		return false, nil
+	}
+	t, err := time.Parse(time.RFC3339, g.ExpireTime.Data)
+	if err != nil {
+		return false, nil
+	}
+	return t.Before(time.Now()), nil
 }
 
 func (g *mqlGcpProjectComputeService) sslCertificates() ([]any, error) {
@@ -3632,6 +3657,15 @@ func (g *mqlGcpProjectComputeServiceInstance) blockProjectSshKeysEnabled() (bool
 	return metadataBoolFlag(md.Data, "block-project-ssh-keys"), nil
 }
 
+func (g *mqlGcpProjectComputeServiceInstance) hasInstanceSshKeys() (bool, error) {
+	md := g.GetMetadata()
+	if md.Error != nil {
+		return false, md.Error
+	}
+	s, _ := md.Data["ssh-keys"].(string)
+	return s != "", nil
+}
+
 func (g *mqlGcpProjectComputeServiceInstance) osLoginEnabled() (bool, error) {
 	md := g.GetMetadata()
 	if md.Error != nil {
@@ -3858,5 +3892,17 @@ func (g *mqlGcpProjectComputeServiceBackendService) iapEnabled() (bool, error) {
 		return false, nil
 	}
 	enabled, _ := iapMap["enabled"].(bool)
+	return enabled, nil
+}
+
+func (g *mqlGcpProjectComputeServiceBackendService) loggingEnabled() (bool, error) {
+	if g.LogConfig.Error != nil {
+		return false, g.LogConfig.Error
+	}
+	logMap, ok := g.LogConfig.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	enabled, _ := logMap["enable"].(bool)
 	return enabled, nil
 }

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -5,8 +5,10 @@ package resources
 
 import (
 	"context"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -14,6 +16,54 @@ import (
 	"google.golang.org/api/essentialcontacts/v1"
 	"google.golang.org/api/option"
 )
+
+// essentialContactsForParent lists Essential Contacts for a resource parent of
+// the form "projects/{id}", "folders/{id}", or "organizations/{id}" and builds
+// the corresponding gcp.essentialContact resources.
+func essentialContactsForParent(runtime *plugin.Runtime, conn *connection.GcpConnection, parent string) ([]any, error) {
+	client, err := conn.Client(essentialcontacts.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	contactSvc, err := essentialcontacts.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+
+	var mqlContacts []any
+	process := func(page *essentialcontacts.GoogleCloudEssentialcontactsV1ListContactsResponse) error {
+		for _, c := range page.Contacts {
+			mqlC, err := CreateResource(runtime, "gcp.essentialContact", map[string]*llx.RawData{
+				"resourcePath":           llx.StringData(c.Name),
+				"email":                  llx.StringData(c.Email),
+				"languageTag":            llx.StringData(c.LanguageTag),
+				"notificationCategories": llx.ArrayData(convert.SliceAnyToInterface(c.NotificationCategorySubscriptions), types.String),
+				"validated":              llx.TimeDataPtr(parseTime(c.ValidateTime)),
+				"validationState":        llx.StringData(c.ValidationState),
+			})
+			if err != nil {
+				return err
+			}
+			mqlContacts = append(mqlContacts, mqlC)
+		}
+		return nil
+	}
+
+	switch {
+	case strings.HasPrefix(parent, "organizations/"):
+		err = contactSvc.Organizations.Contacts.List(parent).Pages(ctx, process)
+	case strings.HasPrefix(parent, "folders/"):
+		err = contactSvc.Folders.Contacts.List(parent).Pages(ctx, process)
+	default:
+		err = contactSvc.Projects.Contacts.List(parent).Pages(ctx, process)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return mqlContacts, nil
+}
 
 func (g *mqlGcpProject) essentialContacts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
@@ -31,39 +81,24 @@ func (g *mqlGcpProject) essentialContacts() ([]any, error) {
 		return nil, nil
 	}
 
-	client, err := conn.Client(essentialcontacts.CloudPlatformScope)
-	if err != nil {
-		return nil, err
-	}
+	return essentialContactsForParent(g.MqlRuntime, conn, "projects/"+projectId)
+}
 
-	ctx := context.Background()
-
-	contactSvc, err := essentialcontacts.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
+func (g *mqlGcpOrganization) essentialContacts() ([]any, error) {
+	if g.Id.Error != nil {
+		return nil, g.Id.Error
 	}
+	// Id is already in "organizations/{id}" form (see initGcpOrganization).
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	return essentialContactsForParent(g.MqlRuntime, conn, g.Id.Data)
+}
 
-	var mqlContacts []any
-	if err := contactSvc.Projects.Contacts.List("projects/"+projectId).Pages(ctx, func(page *essentialcontacts.GoogleCloudEssentialcontactsV1ListContactsResponse) error {
-		for _, c := range page.Contacts {
-			mqlC, err := CreateResource(g.MqlRuntime, "gcp.essentialContact", map[string]*llx.RawData{
-				"resourcePath":           llx.StringData(c.Name),
-				"email":                  llx.StringData(c.Email),
-				"languageTag":            llx.StringData(c.LanguageTag),
-				"notificationCategories": llx.ArrayData(convert.SliceAnyToInterface(c.NotificationCategorySubscriptions), types.String),
-				"validated":              llx.TimeDataPtr(parseTime(c.ValidateTime)),
-				"validationState":        llx.StringData(c.ValidationState),
-			})
-			if err != nil {
-				return err
-			}
-			mqlContacts = append(mqlContacts, mqlC)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
+func (g *mqlGcpFolder) essentialContacts() ([]any, error) {
+	if g.Id.Error != nil {
+		return nil, g.Id.Error
 	}
-	return mqlContacts, nil
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	return essentialContactsForParent(g.MqlRuntime, conn, "folders/"+g.Id.Data)
 }
 
 func (g *mqlGcpEssentialContact) id() (string, error) {

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -88,17 +88,24 @@ func (g *mqlGcpOrganization) essentialContacts() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
 	}
-	// Id is already in "organizations/{id}" form (see initGcpOrganization).
+	// Id is normally "organizations/{id}" (set from org.Name); guard against a
+	// bare id so the parent path is never double-prefixed.
+	parent := g.Id.Data
+	if !strings.HasPrefix(parent, "organizations/") {
+		parent = "organizations/" + parent
+	}
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-	return essentialContactsForParent(g.MqlRuntime, conn, g.Id.Data)
+	return essentialContactsForParent(g.MqlRuntime, conn, parent)
 }
 
 func (g *mqlGcpFolder) essentialContacts() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
 	}
+	// Folder Id is "folders/{id}" when discovered via listing but bare "{id}"
+	// when resolved directly; folderResourceName normalizes both.
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-	return essentialContactsForParent(g.MqlRuntime, conn, "folders/"+g.Id.Data)
+	return essentialContactsForParent(g.MqlRuntime, conn, folderResourceName(g.Id.Data))
 }
 
 func (g *mqlGcpEssentialContact) id() (string, error) {

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -99,6 +99,8 @@ gcp.organization @defaults("name") {
   customRoles() []gcp.organization.role
   // Cloud Logging configuration scoped to the organization
   logging() gcp.organization.loggingService
+  // Essential Contacts configured at the organization level for security, technical, and other notification categories
+  essentialContacts() []gcp.essentialContact
 }
 
 // Google Cloud (GCP) IAM custom role defined at the organization level
@@ -653,6 +655,8 @@ private gcp.folder @defaults("name") {
   auditConfig() []gcp.resourcemanager.auditConfig
   // Cloud Logging configuration scoped to the folder
   logging() gcp.folder.loggingService
+  // Essential Contacts configured at the folder level for security, technical, and other notification categories
+  essentialContacts() []gcp.essentialContact
 }
 
 // Google Cloud (GCP) projects
@@ -1183,6 +1187,8 @@ private gcp.project.computeService.forwardingRule {
   labels map[string]string
   // Forwarding rule type
   loadBalancingScheme string
+  // Whether the forwarding rule is internet-facing (loadBalancingScheme is EXTERNAL or EXTERNAL_MANAGED)
+  isExternal() bool
   // Opaque filter criteria used by the load balancer to restrict routing configuration to a limited set of xDS-compliant clients
   metadataFilters []dict
   // Forwarding rule name
@@ -1380,6 +1386,8 @@ gcp.project.computeService.instance @defaults("name id") {
   blockProjectSshKeysEnabled() bool
   // Whether OS Login is enabled on this instance — checks instance metadata 'enable-oslogin', then falls back to project commonInstanceMetadata when unset
   osLoginEnabled() bool
+  // Whether instance-level SSH keys are set in metadata ('ssh-keys'), which grant access outside OS Login / IAM and are unmanaged
+  hasInstanceSshKeys() bool
   // Whether instance metadata 'serial-port-enable' is set to true (interactive serial console)
   serialPortEnabled() bool
   // Private IPv6 google access type for the VM
@@ -2249,6 +2257,8 @@ private gcp.project.computeService.backendService @defaults("name") {
   cloudArmorEnabled() bool
   // Whether Identity-Aware Proxy is enabled for the backend service (iap.enabled is true)
   iapEnabled() bool
+  // Whether load-balancer request logging is enabled for the backend service (logConfig.enable is true)
+  loggingEnabled() bool
   // Client TLS policy and subject alternative names for the backend service
   securitySettings dict
   // URL of the networksecurity ClientTlsPolicy that describes how clients authenticate with the backends
@@ -3693,6 +3703,12 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   autopilotEnabled bool
   // Whether Autopilot workloads may request the NET_ADMIN capability, relaxing the default privileged-container guardrail
   autopilotWorkloadPolicyAllowNetAdmin bool
+  // Whether Vertical Pod Autoscaling is enabled for the cluster
+  verticalPodAutoscalingEnabled bool
+  // Whether intra-node visibility is enabled, making pod-to-pod traffic on the same node visible to VPC networking (and its flow logs)
+  intraNodeVisibilityEnabled bool
+  // Default maximum number of pods that can run on a node, bounding per-node blast radius and IP consumption (0 when unset)
+  defaultMaxPodsPerNode int
   // Resource usage export configuration
   //
   // Holds `enableNetworkEgressMetering`, `enableResourceConsumptionMetering`,
@@ -5497,6 +5513,11 @@ private gcp.project.iamService.workloadIdentityPool.provider @defaults("displayN
   attributeMapping map[string]string
   // CEL expression evaluated against the external token. When empty, every external token that satisfies the mapping is accepted.
   attributeCondition string
+  // Whether an attribute condition is set on the provider
+  //
+  // When false, every external token that satisfies the mapping is accepted —
+  // the classic over-broad workload-identity-federation misconfiguration.
+  hasAttributeCondition() bool
   // Discriminator for which credential family this provider trusts: `aws`, `oidc`, `saml`, or `x509`.
   providerType string
   // For AWS providers: the AWS account ID whose IAM roles/users may federate
@@ -6720,6 +6741,8 @@ private gcp.project.monitoringService.alertPolicy {
   validity dict
   // Notification channel URLs to which notifications should be sent when incidents are opened or closed
   notificationChannelUrls []string
+  // Notification channels to which notifications are sent when incidents open or close
+  notificationChannels() []gcp.project.monitoringService.notificationChannel
   // Creation timestamp
   created time
   // Email address of the user who created the alert policy
@@ -8004,6 +8027,8 @@ private gcp.project.computeService.sslCertificate @defaults("name type") {
   selfLink string
   // Expiration time
   expireTime string
+  // Whether the certificate has already expired
+  expired() bool
   // Creation timestamp
   createdAt time
 }
@@ -11974,6 +11999,17 @@ private gcp.scc.finding @defaults("name category severity") {
   compliances []dict
   // Vulnerability details, including the CVE and its CVSS scores, when the finding describes a known vulnerability
   vulnerability dict
+  // Access details for the finding
+  //
+  // The principal, caller IP, user agent, and method that performed the
+  // action that triggered the finding — the "who" behind a threat finding.
+  access dict
+  // Network connections associated with the finding (source/destination IP and port, protocol) — the command-and-control or data-movement tuples
+  connections []dict
+  // Kubernetes details for the finding (affected pods, namespaces, roles, and bindings) when the finding concerns a GKE workload
+  kubernetes dict
+  // IAM bindings associated with the finding — the role and members granted (the ADD/REMOVE action) that triggered or relates to the finding
+  iamBindings []dict
   // Finding class (THREAT, VULNERABILITY, MISCONFIGURATION, etc.)
   findingClass string
   // State (ACTIVE, INACTIVE)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2381,6 +2381,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.organization.logging": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpOrganization).GetLogging()).ToDataRes(types.Resource("gcp.organization.loggingService"))
 	},
+	"gcp.organization.essentialContacts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpOrganization).GetEssentialContacts()).ToDataRes(types.Array(types.Resource("gcp.essentialContact")))
+	},
 	"gcp.organization.role.organizationId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpOrganizationRole).GetOrganizationId()).ToDataRes(types.String)
 	},
@@ -2962,6 +2965,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.folder.logging": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpFolder).GetLogging()).ToDataRes(types.Resource("gcp.folder.loggingService"))
+	},
+	"gcp.folder.essentialContacts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpFolder).GetEssentialContacts()).ToDataRes(types.Array(types.Resource("gcp.essentialContact")))
 	},
 	"gcp.projects.parentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjects).GetParentId()).ToDataRes(types.String)
@@ -3560,6 +3566,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.forwardingRule.loadBalancingScheme": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetLoadBalancingScheme()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.forwardingRule.isExternal": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetIsExternal()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.forwardingRule.metadataFilters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetMetadataFilters()).ToDataRes(types.Array(types.Dict))
 	},
@@ -3778,6 +3787,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.osLoginEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetOsLoginEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.hasInstanceSshKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasInstanceSshKeys()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.instance.serialPortEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetSerialPortEnabled()).ToDataRes(types.Bool)
@@ -4672,6 +4684,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.backendService.iapEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetIapEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.backendService.loggingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceBackendService).GetLoggingEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.backendService.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecuritySettings()).ToDataRes(types.Dict)
@@ -6103,6 +6118,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.autopilotWorkloadPolicyAllowNetAdmin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetAutopilotWorkloadPolicyAllowNetAdmin()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.verticalPodAutoscalingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetVerticalPodAutoscalingEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.intraNodeVisibilityEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetIntraNodeVisibilityEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.defaultMaxPodsPerNode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetDefaultMaxPodsPerNode()).ToDataRes(types.Int)
 	},
 	"gcp.project.gkeService.cluster.resourceUsageExportConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetResourceUsageExportConfig()).ToDataRes(types.Dict)
@@ -7718,6 +7742,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.iamService.workloadIdentityPool.provider.attributeCondition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).GetAttributeCondition()).ToDataRes(types.String)
 	},
+	"gcp.project.iamService.workloadIdentityPool.provider.hasAttributeCondition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).GetHasAttributeCondition()).ToDataRes(types.Bool)
+	},
 	"gcp.project.iamService.workloadIdentityPool.provider.providerType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).GetProviderType()).ToDataRes(types.String)
 	},
@@ -9032,6 +9059,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.monitoringService.alertPolicy.notificationChannelUrls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceAlertPolicy).GetNotificationChannelUrls()).ToDataRes(types.Array(types.String))
 	},
+	"gcp.project.monitoringService.alertPolicy.notificationChannels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectMonitoringServiceAlertPolicy).GetNotificationChannels()).ToDataRes(types.Array(types.Resource("gcp.project.monitoringService.notificationChannel")))
+	},
 	"gcp.project.monitoringService.alertPolicy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceAlertPolicy).GetCreated()).ToDataRes(types.Time)
 	},
@@ -10330,6 +10360,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.sslCertificate.expireTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetExpireTime()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.sslCertificate.expired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetExpired()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.sslCertificate.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetCreatedAt()).ToDataRes(types.Time)
@@ -14351,6 +14384,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.scc.finding.vulnerability": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpSccFinding).GetVulnerability()).ToDataRes(types.Dict)
 	},
+	"gcp.scc.finding.access": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpSccFinding).GetAccess()).ToDataRes(types.Dict)
+	},
+	"gcp.scc.finding.connections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpSccFinding).GetConnections()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.scc.finding.kubernetes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpSccFinding).GetKubernetes()).ToDataRes(types.Dict)
+	},
+	"gcp.scc.finding.iamBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpSccFinding).GetIamBindings()).ToDataRes(types.Array(types.Dict))
+	},
 	"gcp.scc.finding.findingClass": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpSccFinding).GetFindingClass()).ToDataRes(types.String)
 	},
@@ -16622,6 +16667,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpOrganization).Logging, ok = plugin.RawToTValue[*mqlGcpOrganizationLoggingService](v.Value, v.Error)
 		return
 	},
+	"gcp.organization.essentialContacts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpOrganization).EssentialContacts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.organization.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpOrganizationRole).__id, ok = v.Value.(string)
 		return
@@ -17474,6 +17523,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpFolder).Logging, ok = plugin.RawToTValue[*mqlGcpFolderLoggingService](v.Value, v.Error)
 		return
 	},
+	"gcp.folder.essentialContacts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpFolder).EssentialContacts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.projects.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjects).__id, ok = v.Value.(string)
 		return
@@ -18310,6 +18363,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceForwardingRule).LoadBalancingScheme, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.forwardingRule.isExternal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceForwardingRule).IsExternal, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.forwardingRule.metadataFilters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).MetadataFilters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -18616,6 +18673,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.osLoginEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).OsLoginEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.hasInstanceSshKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).HasInstanceSshKeys, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.serialPortEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19876,6 +19937,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.backendService.iapEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).IapEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.backendService.loggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceBackendService).LoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.backendService.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21940,6 +22005,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.autopilotWorkloadPolicyAllowNetAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).AutopilotWorkloadPolicyAllowNetAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.verticalPodAutoscalingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).VerticalPodAutoscalingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.intraNodeVisibilityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).IntraNodeVisibilityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.defaultMaxPodsPerNode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).DefaultMaxPodsPerNode, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.resourceUsageExportConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24342,6 +24419,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).AttributeCondition, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.iamService.workloadIdentityPool.provider.hasAttributeCondition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).HasAttributeCondition, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.iamService.workloadIdentityPool.provider.providerType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceWorkloadIdentityPoolProvider).ProviderType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -26250,6 +26331,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectMonitoringServiceAlertPolicy).NotificationChannelUrls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.monitoringService.alertPolicy.notificationChannels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectMonitoringServiceAlertPolicy).NotificationChannels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.monitoringService.alertPolicy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectMonitoringServiceAlertPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -28144,6 +28229,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.sslCertificate.expireTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslCertificate).ExpireTime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.sslCertificate.expired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSslCertificate).Expired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.sslCertificate.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33998,6 +34087,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpSccFinding).Vulnerability, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.scc.finding.access": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpSccFinding).Access, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.scc.finding.connections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpSccFinding).Connections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.scc.finding.kubernetes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpSccFinding).Kubernetes, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.scc.finding.iamBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpSccFinding).IamBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.scc.finding.findingClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpSccFinding).FindingClass, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -37269,6 +37374,7 @@ type mqlGcpOrganization struct {
 	NetworkSecurityProfileGroups plugin.TValue[[]any]
 	CustomRoles                  plugin.TValue[[]any]
 	Logging                      plugin.TValue[*mqlGcpOrganizationLoggingService]
+	EssentialContacts            plugin.TValue[[]any]
 }
 
 // createGcpOrganization creates a new instance of this resource
@@ -37641,6 +37747,22 @@ func (c *mqlGcpOrganization) GetLogging() *plugin.TValue[*mqlGcpOrganizationLogg
 		}
 
 		return c.logging()
+	})
+}
+
+func (c *mqlGcpOrganization) GetEssentialContacts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EssentialContacts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.organization", c.__id, "essentialContacts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.essentialContacts()
 	})
 }
 
@@ -39446,19 +39568,20 @@ type mqlGcpFolder struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpFolderInternal
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Created     plugin.TValue[*time.Time]
-	Updated     plugin.TValue[*time.Time]
-	ParentId    plugin.TValue[string]
-	State       plugin.TValue[string]
-	DeleteTime  plugin.TValue[*time.Time]
-	Folders     plugin.TValue[*mqlGcpFolders]
-	Projects    plugin.TValue[*mqlGcpProjects]
-	OrgPolicies plugin.TValue[[]any]
-	IamPolicy   plugin.TValue[[]any]
-	AuditConfig plugin.TValue[[]any]
-	Logging     plugin.TValue[*mqlGcpFolderLoggingService]
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	Created           plugin.TValue[*time.Time]
+	Updated           plugin.TValue[*time.Time]
+	ParentId          plugin.TValue[string]
+	State             plugin.TValue[string]
+	DeleteTime        plugin.TValue[*time.Time]
+	Folders           plugin.TValue[*mqlGcpFolders]
+	Projects          plugin.TValue[*mqlGcpProjects]
+	OrgPolicies       plugin.TValue[[]any]
+	IamPolicy         plugin.TValue[[]any]
+	AuditConfig       plugin.TValue[[]any]
+	Logging           plugin.TValue[*mqlGcpFolderLoggingService]
+	EssentialContacts plugin.TValue[[]any]
 }
 
 // createGcpFolder creates a new instance of this resource
@@ -39619,6 +39742,22 @@ func (c *mqlGcpFolder) GetLogging() *plugin.TValue[*mqlGcpFolderLoggingService] 
 		}
 
 		return c.logging()
+	})
+}
+
+func (c *mqlGcpFolder) GetEssentialContacts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EssentialContacts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.folder", c.__id, "essentialContacts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.essentialContacts()
 	})
 }
 
@@ -42400,6 +42539,7 @@ type mqlGcpProjectComputeServiceForwardingRule struct {
 	IsMirroringCollector          plugin.TValue[bool]
 	Labels                        plugin.TValue[map[string]any]
 	LoadBalancingScheme           plugin.TValue[string]
+	IsExternal                    plugin.TValue[bool]
 	MetadataFilters               plugin.TValue[[]any]
 	Name                          plugin.TValue[string]
 	NetworkUrl                    plugin.TValue[string]
@@ -42506,6 +42646,12 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetLabels() *plugin.TValue[m
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetLoadBalancingScheme() *plugin.TValue[string] {
 	return &c.LoadBalancingScheme
+}
+
+func (c *mqlGcpProjectComputeServiceForwardingRule) GetIsExternal() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsExternal, func() (bool, error) {
+		return c.isExternal()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetMetadataFilters() *plugin.TValue[[]any] {
@@ -42913,6 +43059,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	HasFullCloudPlatformScope       plugin.TValue[bool]
 	BlockProjectSshKeysEnabled      plugin.TValue[bool]
 	OsLoginEnabled                  plugin.TValue[bool]
+	HasInstanceSshKeys              plugin.TValue[bool]
 	SerialPortEnabled               plugin.TValue[bool]
 	PrivateIpv6GoogleAccess         plugin.TValue[string]
 	ReservationAffinity             plugin.TValue[any]
@@ -43100,6 +43247,12 @@ func (c *mqlGcpProjectComputeServiceInstance) GetBlockProjectSshKeysEnabled() *p
 func (c *mqlGcpProjectComputeServiceInstance) GetOsLoginEnabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.OsLoginEnabled, func() (bool, error) {
 		return c.osLoginEnabled()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetHasInstanceSshKeys() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasInstanceSshKeys, func() (bool, error) {
+		return c.hasInstanceSshKeys()
 	})
 }
 
@@ -45400,6 +45553,7 @@ type mqlGcpProjectComputeServiceBackendService struct {
 	SecurityPolicy                  plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
 	CloudArmorEnabled               plugin.TValue[bool]
 	IapEnabled                      plugin.TValue[bool]
+	LoggingEnabled                  plugin.TValue[bool]
 	SecuritySettings                plugin.TValue[any]
 	SecuritySettingsClientTlsPolicy plugin.TValue[string]
 	SecuritySettingsSubjectAltNames plugin.TValue[[]any]
@@ -45622,6 +45776,12 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetCloudArmorEnabled() *plug
 func (c *mqlGcpProjectComputeServiceBackendService) GetIapEnabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IapEnabled, func() (bool, error) {
 		return c.iapEnabled()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceBackendService) GetLoggingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LoggingEnabled, func() (bool, error) {
+		return c.loggingEnabled()
 	})
 }
 
@@ -50004,6 +50164,9 @@ type mqlGcpProjectGkeServiceCluster struct {
 	EnableKubernetesAlpha                plugin.TValue[bool]
 	AutopilotEnabled                     plugin.TValue[bool]
 	AutopilotWorkloadPolicyAllowNetAdmin plugin.TValue[bool]
+	VerticalPodAutoscalingEnabled        plugin.TValue[bool]
+	IntraNodeVisibilityEnabled           plugin.TValue[bool]
+	DefaultMaxPodsPerNode                plugin.TValue[int64]
 	ResourceUsageExportConfig            plugin.TValue[any]
 	Location                             plugin.TValue[string]
 	Endpoint                             plugin.TValue[string]
@@ -50178,6 +50341,18 @@ func (c *mqlGcpProjectGkeServiceCluster) GetAutopilotEnabled() *plugin.TValue[bo
 
 func (c *mqlGcpProjectGkeServiceCluster) GetAutopilotWorkloadPolicyAllowNetAdmin() *plugin.TValue[bool] {
 	return &c.AutopilotWorkloadPolicyAllowNetAdmin
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetVerticalPodAutoscalingEnabled() *plugin.TValue[bool] {
+	return &c.VerticalPodAutoscalingEnabled
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetIntraNodeVisibilityEnabled() *plugin.TValue[bool] {
+	return &c.IntraNodeVisibilityEnabled
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetDefaultMaxPodsPerNode() *plugin.TValue[int64] {
+	return &c.DefaultMaxPodsPerNode
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetResourceUsageExportConfig() *plugin.TValue[any] {
@@ -55972,23 +56147,24 @@ type mqlGcpProjectIamServiceWorkloadIdentityPoolProvider struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectIamServiceWorkloadIdentityPoolProviderInternal it will be used here
-	ProjectId            plugin.TValue[string]
-	Name                 plugin.TValue[string]
-	ProviderId           plugin.TValue[string]
-	PoolId               plugin.TValue[string]
-	DisplayName          plugin.TValue[string]
-	Description          plugin.TValue[string]
-	State                plugin.TValue[string]
-	Disabled             plugin.TValue[bool]
-	ExpireTime           plugin.TValue[*time.Time]
-	AttributeMapping     plugin.TValue[map[string]any]
-	AttributeCondition   plugin.TValue[string]
-	ProviderType         plugin.TValue[string]
-	AwsAccountId         plugin.TValue[string]
-	OidcIssuerUri        plugin.TValue[string]
-	OidcAllowedAudiences plugin.TValue[[]any]
-	SamlIdpMetadataXml   plugin.TValue[string]
-	X509TrustAnchorCount plugin.TValue[int64]
+	ProjectId             plugin.TValue[string]
+	Name                  plugin.TValue[string]
+	ProviderId            plugin.TValue[string]
+	PoolId                plugin.TValue[string]
+	DisplayName           plugin.TValue[string]
+	Description           plugin.TValue[string]
+	State                 plugin.TValue[string]
+	Disabled              plugin.TValue[bool]
+	ExpireTime            plugin.TValue[*time.Time]
+	AttributeMapping      plugin.TValue[map[string]any]
+	AttributeCondition    plugin.TValue[string]
+	HasAttributeCondition plugin.TValue[bool]
+	ProviderType          plugin.TValue[string]
+	AwsAccountId          plugin.TValue[string]
+	OidcIssuerUri         plugin.TValue[string]
+	OidcAllowedAudiences  plugin.TValue[[]any]
+	SamlIdpMetadataXml    plugin.TValue[string]
+	X509TrustAnchorCount  plugin.TValue[int64]
 }
 
 // createGcpProjectIamServiceWorkloadIdentityPoolProvider creates a new instance of this resource
@@ -56070,6 +56246,12 @@ func (c *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) GetAttributeMappin
 
 func (c *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) GetAttributeCondition() *plugin.TValue[string] {
 	return &c.AttributeCondition
+}
+
+func (c *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) GetHasAttributeCondition() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasAttributeCondition, func() (bool, error) {
+		return c.hasAttributeCondition()
+	})
 }
 
 func (c *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) GetProviderType() *plugin.TValue[string] {
@@ -60262,6 +60444,7 @@ type mqlGcpProjectMonitoringServiceAlertPolicy struct {
 	Enabled                 plugin.TValue[bool]
 	Validity                plugin.TValue[any]
 	NotificationChannelUrls plugin.TValue[[]any]
+	NotificationChannels    plugin.TValue[[]any]
 	Created                 plugin.TValue[*time.Time]
 	CreatedBy               plugin.TValue[string]
 	Updated                 plugin.TValue[*time.Time]
@@ -60344,6 +60527,22 @@ func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetValidity() *plugin.TValue
 
 func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetNotificationChannelUrls() *plugin.TValue[[]any] {
 	return &c.NotificationChannelUrls
+}
+
+func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetNotificationChannels() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.NotificationChannels, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.monitoringService.alertPolicy", c.__id, "notificationChannels")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.notificationChannels()
+	})
 }
 
 func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetCreated() *plugin.TValue[*time.Time] {
@@ -64637,6 +64836,7 @@ type mqlGcpProjectComputeServiceSslCertificate struct {
 	Region                  plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                plugin.TValue[string]
 	ExpireTime              plugin.TValue[string]
+	Expired                 plugin.TValue[bool]
 	CreatedAt               plugin.TValue[*time.Time]
 }
 
@@ -64731,6 +64931,12 @@ func (c *mqlGcpProjectComputeServiceSslCertificate) GetSelfLink() *plugin.TValue
 
 func (c *mqlGcpProjectComputeServiceSslCertificate) GetExpireTime() *plugin.TValue[string] {
 	return &c.ExpireTime
+}
+
+func (c *mqlGcpProjectComputeServiceSslCertificate) GetExpired() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Expired, func() (bool, error) {
+		return c.expired()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceSslCertificate) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -78503,6 +78709,10 @@ type mqlGcpSccFinding struct {
 	MuteUpdateTime   plugin.TValue[*time.Time]
 	Compliances      plugin.TValue[[]any]
 	Vulnerability    plugin.TValue[any]
+	Access           plugin.TValue[any]
+	Connections      plugin.TValue[[]any]
+	Kubernetes       plugin.TValue[any]
+	IamBindings      plugin.TValue[[]any]
 	FindingClass     plugin.TValue[string]
 	State            plugin.TValue[string]
 	ResourceName     plugin.TValue[string]
@@ -78602,6 +78812,22 @@ func (c *mqlGcpSccFinding) GetCompliances() *plugin.TValue[[]any] {
 
 func (c *mqlGcpSccFinding) GetVulnerability() *plugin.TValue[any] {
 	return &c.Vulnerability
+}
+
+func (c *mqlGcpSccFinding) GetAccess() *plugin.TValue[any] {
+	return &c.Access
+}
+
+func (c *mqlGcpSccFinding) GetConnections() *plugin.TValue[[]any] {
+	return &c.Connections
+}
+
+func (c *mqlGcpSccFinding) GetKubernetes() *plugin.TValue[any] {
+	return &c.Kubernetes
+}
+
+func (c *mqlGcpSccFinding) GetIamBindings() *plugin.TValue[[]any] {
+	return &c.IamBindings
 }
 
 func (c *mqlGcpSccFinding) GetFindingClass() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -71,6 +71,7 @@ gcp.folder 9.0.0
 gcp.folder.auditConfig 13.16.3
 gcp.folder.created 9.0.0
 gcp.folder.deleteTime 11.6.6
+gcp.folder.essentialContacts 13.21.2
 gcp.folder.folders 9.0.0
 gcp.folder.iamPolicy 13.16.3
 gcp.folder.id 9.0.0
@@ -140,6 +141,7 @@ gcp.organization.customConstraints 13.15.1
 gcp.organization.customRoles 13.16.3
 gcp.organization.customerId 13.15.1
 gcp.organization.deleteTime 11.6.6
+gcp.organization.essentialContacts 13.21.2
 gcp.organization.folders 9.0.0
 gcp.organization.iamPolicy 9.0.0
 gcp.organization.id 9.0.0
@@ -1426,6 +1428,7 @@ gcp.project.computeService.backendService.loadBalancingScheme 9.0.0
 gcp.project.computeService.backendService.localityLbPolicies 9.0.0
 gcp.project.computeService.backendService.localityLbPolicy 9.0.0
 gcp.project.computeService.backendService.logConfig 9.0.0
+gcp.project.computeService.backendService.loggingEnabled 13.21.2
 gcp.project.computeService.backendService.maxStreamDuration 9.0.0
 gcp.project.computeService.backendService.name 9.0.0
 gcp.project.computeService.backendService.network 13.6.1
@@ -1566,6 +1569,7 @@ gcp.project.computeService.forwardingRule.ipAddress 9.0.0
 gcp.project.computeService.forwardingRule.ipCollection 13.1.2
 gcp.project.computeService.forwardingRule.ipProtocol 9.0.0
 gcp.project.computeService.forwardingRule.ipVersion 9.0.0
+gcp.project.computeService.forwardingRule.isExternal 13.21.2
 gcp.project.computeService.forwardingRule.isMirroringCollector 9.0.0
 gcp.project.computeService.forwardingRule.labels 9.0.0
 gcp.project.computeService.forwardingRule.loadBalancingScheme 9.0.0
@@ -1657,6 +1661,7 @@ gcp.project.computeService.instance.enableVtpm 9.0.0
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
 gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2
+gcp.project.computeService.instance.hasInstanceSshKeys 13.21.2
 gcp.project.computeService.instance.hasPublicIp 13.12.2
 gcp.project.computeService.instance.hostname 9.0.0
 gcp.project.computeService.instance.id 9.0.0
@@ -2099,6 +2104,7 @@ gcp.project.computeService.sslCertificate 11.5.1
 gcp.project.computeService.sslCertificate.createdAt 11.5.1
 gcp.project.computeService.sslCertificate.description 11.5.1
 gcp.project.computeService.sslCertificate.expireTime 11.5.1
+gcp.project.computeService.sslCertificate.expired 13.21.2
 gcp.project.computeService.sslCertificate.id 11.5.1
 gcp.project.computeService.sslCertificate.managed 11.5.1
 gcp.project.computeService.sslCertificate.managedStatus 13.18.1
@@ -3009,6 +3015,7 @@ gcp.project.gkeService.cluster.currentNodeCount 11.6.6
 gcp.project.gkeService.cluster.databaseEncryption 9.0.0
 gcp.project.gkeService.cluster.databaseEncryptionKey 13.2.3
 gcp.project.gkeService.cluster.databaseEncryptionState 13.2.3
+gcp.project.gkeService.cluster.defaultMaxPodsPerNode 13.21.2
 gcp.project.gkeService.cluster.description 9.0.0
 gcp.project.gkeService.cluster.enableKubernetesAlpha 9.0.0
 gcp.project.gkeService.cluster.enableTpu 11.6.6
@@ -3021,6 +3028,7 @@ gcp.project.gkeService.cluster.id 9.0.0
 gcp.project.gkeService.cluster.identityServiceConfig 9.0.0
 gcp.project.gkeService.cluster.initialClusterVersion 9.0.0
 gcp.project.gkeService.cluster.initialNodeCount 13.1.2
+gcp.project.gkeService.cluster.intraNodeVisibilityEnabled 13.21.2
 gcp.project.gkeService.cluster.ipAllocationPolicy 9.0.0
 gcp.project.gkeService.cluster.ipAllocationPolicy.clusterIpv4CidrBlock 9.0.0
 gcp.project.gkeService.cluster.ipAllocationPolicy.clusterSecondaryRangeName 9.0.0
@@ -3223,6 +3231,7 @@ gcp.project.gkeService.cluster.status 9.0.0
 gcp.project.gkeService.cluster.subnetwork 9.0.0
 gcp.project.gkeService.cluster.tpuIpv4CidrBlock 13.1.2
 gcp.project.gkeService.cluster.userManagedKeysConfig 13.16.3
+gcp.project.gkeService.cluster.verticalPodAutoscalingEnabled 13.21.2
 gcp.project.gkeService.cluster.workloadIdentityConfig 9.0.0
 gcp.project.gkeService.cluster.workloadIdentityEnabled 13.12.2
 gcp.project.gkeService.clusters 9.0.0
@@ -3331,6 +3340,7 @@ gcp.project.iamService.workloadIdentityPool.provider.description 13.13.4
 gcp.project.iamService.workloadIdentityPool.provider.disabled 13.13.4
 gcp.project.iamService.workloadIdentityPool.provider.displayName 13.13.4
 gcp.project.iamService.workloadIdentityPool.provider.expireTime 13.13.4
+gcp.project.iamService.workloadIdentityPool.provider.hasAttributeCondition 13.21.2
 gcp.project.iamService.workloadIdentityPool.provider.name 13.13.4
 gcp.project.iamService.workloadIdentityPool.provider.oidcAllowedAudiences 13.13.4
 gcp.project.iamService.workloadIdentityPool.provider.oidcIssuerUri 13.13.4
@@ -3712,6 +3722,7 @@ gcp.project.monitoringService.alertPolicy.enabled 9.0.0
 gcp.project.monitoringService.alertPolicy.labels 9.0.0
 gcp.project.monitoringService.alertPolicy.name 9.0.0
 gcp.project.monitoringService.alertPolicy.notificationChannelUrls 9.0.0
+gcp.project.monitoringService.alertPolicy.notificationChannels 13.21.2
 gcp.project.monitoringService.alertPolicy.projectId 9.0.0
 gcp.project.monitoringService.alertPolicy.updated 9.0.0
 gcp.project.monitoringService.alertPolicy.updatedBy 9.0.0
@@ -5060,14 +5071,18 @@ gcp.scc.bigQueryExport.mostRecentEditor 13.3.4
 gcp.scc.bigQueryExport.name 13.3.4
 gcp.scc.bigQueryExport.updateTime 13.3.4
 gcp.scc.finding 13.3.4
+gcp.scc.finding.access 13.21.2
 gcp.scc.finding.category 13.3.4
 gcp.scc.finding.chokepoint 13.3.5
 gcp.scc.finding.compliances 13.21.2
+gcp.scc.finding.connections 13.21.2
 gcp.scc.finding.createTime 13.3.4
 gcp.scc.finding.eventTime 13.3.4
 gcp.scc.finding.externalExposure 13.3.5
 gcp.scc.finding.externalUri 13.3.4
 gcp.scc.finding.findingClass 13.3.4
+gcp.scc.finding.iamBindings 13.21.2
+gcp.scc.finding.kubernetes 13.21.2
 gcp.scc.finding.mute 13.3.4
 gcp.scc.finding.muteInitiator 13.21.2
 gcp.scc.finding.muteUpdateTime 13.21.2

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -344,6 +344,10 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			}
 		}
 
+		verticalPodAutoscalingEnabled := c.GetVerticalPodAutoscaling().GetEnabled()
+		intraNodeVisibilityEnabled := c.GetNetworkConfig().GetEnableIntraNodeVisibility()
+		defaultMaxPodsPerNode := c.GetDefaultMaxPodsConstraint().GetMaxPodsPerNode()
+
 		var addonsConfig plugin.Resource
 		if c.AddonsConfig != nil {
 			var httpLoadBalancing map[string]any
@@ -848,6 +852,9 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"autopilotEnabled":                     llx.BoolData(autopilotEnabled),
 			"autopilotWorkloadPolicyAllowNetAdmin": llx.BoolData(autopilotAllowNetAdmin),
 			"resourceUsageExportConfig":            llx.DictData(resourceUsageExportConfig),
+			"verticalPodAutoscalingEnabled":        llx.BoolData(verticalPodAutoscalingEnabled),
+			"intraNodeVisibilityEnabled":           llx.BoolData(intraNodeVisibilityEnabled),
+			"defaultMaxPodsPerNode":                llx.IntData(defaultMaxPodsPerNode),
 			"location":                             llx.StringData(c.Location),
 			"endpoint":                             llx.StringData(c.Endpoint),
 			"initialClusterVersion":                llx.StringData(c.InitialClusterVersion),

--- a/providers/gcp/resources/iam_workload_identity.go
+++ b/providers/gcp/resources/iam_workload_identity.go
@@ -176,6 +176,13 @@ func (g *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) id() (string, erro
 	return g.Name.Data, g.Name.Error
 }
 
+func (g *mqlGcpProjectIamServiceWorkloadIdentityPoolProvider) hasAttributeCondition() (bool, error) {
+	if g.AttributeCondition.Error != nil {
+		return false, g.AttributeCondition.Error
+	}
+	return g.AttributeCondition.Data != "", nil
+}
+
 // flattenWifProviderConfig extracts the credential-family discriminator and
 // the per-family fields from a WorkloadIdentityPoolProvider. Exactly one of
 // Aws, Oidc, Saml, or X509 should be set; the rest return zero values. For

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -92,6 +92,47 @@ func (g *mqlGcpProjectMonitoringServiceAlertPolicy) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }
 
+// notificationChannels resolves the alert policy's channel resource names to
+// the typed notification channels listed by the parent monitoring service.
+func (g *mqlGcpProjectMonitoringServiceAlertPolicy) notificationChannels() ([]any, error) {
+	if g.NotificationChannelUrls.Error != nil {
+		return nil, g.NotificationChannelUrls.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	if len(g.NotificationChannelUrls.Data) == 0 {
+		return []any{}, nil
+	}
+
+	res, err := CreateResource(g.MqlRuntime, "gcp.project.monitoringService", map[string]*llx.RawData{
+		"projectId": llx.StringData(g.ProjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	channels := res.(*mqlGcpProjectMonitoringService).GetNotificationChannels()
+	if channels.Error != nil {
+		return nil, channels.Error
+	}
+
+	byName := make(map[string]*mqlGcpProjectMonitoringServiceNotificationChannel, len(channels.Data))
+	for _, c := range channels.Data {
+		ch := c.(*mqlGcpProjectMonitoringServiceNotificationChannel)
+		byName[ch.Name.Data] = ch
+	}
+
+	out := make([]any, 0, len(g.NotificationChannelUrls.Data))
+	for _, u := range g.NotificationChannelUrls.Data {
+		if name, ok := u.(string); ok {
+			if ch, found := byName[name]; found {
+				out = append(out, ch)
+			}
+		}
+	}
+	return out, nil
+}
+
 func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error

--- a/providers/gcp/resources/securitycenter.go
+++ b/providers/gcp/resources/securitycenter.go
@@ -139,6 +139,34 @@ func listSCCFindings(runtime *plugin.Runtime, conn *connection.GcpConnection, pa
 			return nil, err
 		}
 
+		access, err := protoToDict(f.GetAccess())
+		if err != nil {
+			return nil, err
+		}
+
+		kubernetes, err := protoToDict(f.GetKubernetes())
+		if err != nil {
+			return nil, err
+		}
+
+		connections := make([]any, 0, len(f.GetConnections()))
+		for _, c := range f.GetConnections() {
+			d, err := protoToDict(c)
+			if err != nil {
+				return nil, err
+			}
+			connections = append(connections, d)
+		}
+
+		iamBindings := make([]any, 0, len(f.GetIamBindings()))
+		for _, b := range f.GetIamBindings() {
+			d, err := protoToDict(b)
+			if err != nil {
+				return nil, err
+			}
+			iamBindings = append(iamBindings, d)
+		}
+
 		mqlFinding, err := CreateResource(runtime, "gcp.scc.finding", map[string]*llx.RawData{
 			"name":             llx.StringData(f.Name),
 			"parent":           llx.StringData(f.Parent),
@@ -154,6 +182,10 @@ func listSCCFindings(runtime *plugin.Runtime, conn *connection.GcpConnection, pa
 			"muteUpdateTime":   llx.TimeDataPtr(timestampAsTimePtr(f.GetMuteUpdateTime())),
 			"compliances":      llx.ArrayData(compliances, types.Dict),
 			"vulnerability":    llx.DictData(vulnerability),
+			"access":           llx.DictData(access),
+			"connections":      llx.ArrayData(connections, types.Dict),
+			"kubernetes":       llx.DictData(kubernetes),
+			"iamBindings":      llx.ArrayData(iamBindings, types.Dict),
 			"findingClass":     llx.StringData(f.FindingClass.String()),
 			"state":            llx.StringData(f.State.String()),
 			"resourceName":     llx.StringData(f.ResourceName),


### PR DESCRIPTION
## What

Additive enrichment of already-modeled GCP resources — the remaining field-level security gaps after the prior two PRs (#8231, #8233). All backwards-compatible; nothing replaced, so no deprecations.

| Theme | Resource | Added |
|---|---|---|
| Threat-finding context | `scc.finding` | `access`, `connections`, `kubernetes`, `iamBindings` |
| GKE posture | `gkeService.cluster` | `verticalPodAutoscalingEnabled`, `intraNodeVisibilityEnabled`, `defaultMaxPodsPerNode` |
| Org/folder parity | `organization`, `folder` | `essentialContacts()` (project already had it) |
| Alert routing | `monitoringService.alertPolicy` | typed `notificationChannels()` (raw `notificationChannelUrls` kept) |
| Predicates | `computeService.backendService` | `loggingEnabled()` |
| | `computeService.forwardingRule` | `isExternal()` |
| | `iamService.workloadIdentityPool.provider` | `hasAttributeCondition()` |
| | `computeService.instance` | `hasInstanceSshKeys()` |
| | `computeService.sslCertificate` | `expired()` |

The SCC dicts turn a finding from "category + severity" into something you can pivot on — the caller principal/IP (`access`), C2 network tuples (`connections`), affected pods/RBAC (`kubernetes`), and the IAM grant that triggered it (`iamBindings`).

## Dropped after verification

- **`organization.role.grantsImpersonation`** — the org role already exposes `grantsServiceAccountImpersonation()` (the audit confused it with the binding-level `grantsImpersonation()`); no parity gap.
- **`scc.notificationConfig.serviceAccountRef`** — the notificationConfig is org-scoped with a service-agent SA and no project context, so a typed project-SA ref can't resolve correctly (same reasoning as the AlloyDB drop earlier).

## Testing

- `make providers/build/gcp`, `go build ./...`, `go vet ./resources/`, `gofmt -l` — clean
- `go test ./resources/` (full package incl. permissions) — pass
- New `.lr.versions` entries all at `13.21.2`; `gcp.permissions.json` unchanged (no new API calls — org/folder contacts reuse `essentialcontacts.contacts.list`, alert channels reuse the existing list call)
- Live verification against a real GCP project still pending (no creds in the authoring session)