### PR TITLE
🧹 Deprecate duplicate raw ID/ARN fields and add missing subnet references

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1440,7 +1440,11 @@ private aws.efs.mountTarget @defaults("mountTargetId subnetId") {
   // Associated file system ID
   fileSystemId string
   // Subnet ID where mount target resides
-  subnetId string
+  //
+  // Deprecated in favor of `subnet`.
+  subnetId @maturity("deprecated") string
+  // Subnet where the mount target resides
+  subnet() aws.vpc.subnet
   // Availability zone
   availabilityZone string
   // IP address of mount target
@@ -5468,7 +5472,9 @@ private aws.codepipeline.pipeline @defaults("arn name pipelineType region") {
   // Execution mode: QUEUED, SUPERSEDED, or PARALLEL
   executionMode string
   // ARN of the IAM service role CodePipeline uses to execute actions
-  roleArn string
+  //
+  // Deprecated in favor of `role`.
+  roleArn @maturity("deprecated") string
   // IAM service role CodePipeline uses to execute actions
   role() aws.iam.role
   // Single-region artifact store
@@ -8003,7 +8009,9 @@ private aws.eventbridge.endpoint @defaults("arn name state") {
   // with permission to put events on the secondary bus is required.
   replicationConfig dict
   // ARN of the IAM role used to replicate events to the secondary Region
-  roleArn string
+  //
+  // Deprecated in favor of `iamRole`.
+  roleArn @maturity("deprecated") string
   // IAM role used to replicate events to the secondary Region
   iamRole() aws.iam.role
   // Time the endpoint was created
@@ -8540,8 +8548,12 @@ private aws.eventbridge.schedule.flexibleTimeWindow @defaults("mode maximumWindo
 private aws.eventbridge.schedule.target @defaults("targetType arn") {
   // Raw target ARN
   arn string
-  // IAM role assumed when invoking the target (raw ARN; parent schedule also exposes typed iamRole())
-  roleArn string
+  // IAM role assumed when invoking the target
+  //
+  // Deprecated in favor of `iamRole`.
+  roleArn @maturity("deprecated") string
+  // IAM role assumed when invoking the target
+  iamRole() aws.iam.role
   // Target.Input payload sent to the target. WARNING: may contain sensitive data — audit carefully for credentials, tokens, or PII.
   input string
   // Target type discriminator: lambda, sqs, sns, stepFunction, kinesis, firehose, ecs, eventBridge, sagemakerPipeline, codebuild, universal, unknown
@@ -8583,11 +8595,15 @@ private aws.eventbridge.schedule.target.ecsParameters @defaults("launchType task
   // Reference ID for tracking
   referenceId string
   // Subnet IDs the task ENI is placed in
-  subnetIds []string
+  //
+  // Deprecated in favor of `subnets`.
+  subnetIds @maturity("deprecated") []string
   // Subnets the task ENI is placed in
   subnets() []aws.vpc.subnet
   // Security group IDs attached to the task ENI
-  securityGroupIds []string
+  //
+  // Deprecated in favor of `securityGroups`.
+  securityGroupIds @maturity("deprecated") []string
   // Security groups attached to the task ENI
   securityGroups() []aws.ec2.securitygroup
   // Whether the task ENI is assigned a public IP: ENABLED or DISABLED. Audit signal.
@@ -11495,7 +11511,9 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
 // IAM role associated with an RDS DB instance for accessing other AWS services
 private aws.rds.dbinstance.associatedRole @defaults("featureName status") {
   // ARN of the IAM role
-  roleArn string
+  //
+  // Deprecated in favor of `iamRole`.
+  roleArn @maturity("deprecated") string
   // IAM role attached to the DB instance
   iamRole() aws.iam.role
   // Feature the role is associated with (e.g., s3Import, s3Export, Lambda)
@@ -12622,7 +12640,9 @@ private aws.route53.resolver.ruleAssociation @defaults("id name status") {
   // Associated resolver rule
   resolverRule() aws.route53.resolver.rule
   // VPC ID the rule is associated with
-  vpcId string
+  //
+  // Deprecated in favor of `vpc`.
+  vpcId @maturity("deprecated") string
   // Associated VPC
   vpc() aws.vpc
   // Status of the association
@@ -12847,7 +12867,9 @@ private aws.route53.resolver.firewallRuleGroupAssociation @defaults("id name sta
   // Associated rule group
   firewallRuleGroup() aws.route53.resolver.firewallRuleGroup
   // VPC ID the rule group is associated with
-  vpcId string
+  //
+  // Deprecated in favor of `vpc`.
+  vpcId @maturity("deprecated") string
   // Associated VPC
   vpc() aws.vpc
   // Evaluation priority among rule groups bound to the same VPC
@@ -14493,7 +14515,9 @@ private aws.vpc.peeringConnection.peeringVpc {
   // VPC associated with the peering connection (populated if it's in the same account)
   vpc() aws.vpc
   // ID of the VPC associated with the peering connection
-  vpcId string
+  //
+  // Deprecated in favor of `vpc`.
+  vpcId @maturity("deprecated") string
 }
 
 // Amazon EC2 network ACL
@@ -18540,7 +18564,11 @@ private aws.workspaces.directory @defaults("directoryId directoryName state regi
   // IAM role identifier
   iamRoleId string
   // Subnet identifiers
-  subnetIds []string
+  //
+  // Deprecated in favor of `subnets`.
+  subnetIds @maturity("deprecated") []string
+  // Subnets the directory uses
+  subnets() []aws.vpc.subnet
   // Resource tags
   tags() map[string]string
   // AWS region
@@ -18714,7 +18742,11 @@ private aws.workspaces.workspace @defaults("workspaceId userName state region") 
   // Bundle ID used to create the workspace
   bundleId string
   // Subnet ID
-  subnetId string
+  //
+  // Deprecated in favor of `subnet`.
+  subnetId @maturity("deprecated") string
+  // Subnet the WorkSpace resides in
+  subnet() aws.vpc.subnet
   // State: PENDING, AVAILABLE, IMPAIRED, UNHEALTHY, REBOOTING, etc.
   state string
   // Whether the root volume is encrypted
@@ -20577,9 +20609,13 @@ private aws.msk.cluster.serverlessConfig @defaults("iamEnabled networkType") {
 // VPC configuration entry for a serverless MSK cluster
 private aws.msk.cluster.serverlessConfig.vpcConfig @defaults("subnetIds") {
   // Subnet IDs the serverless cluster is attached to
-  subnetIds []string
+  //
+  // Deprecated in favor of `subnets`.
+  subnetIds @maturity("deprecated") []string
   // Security group IDs attached to the serverless cluster
-  securityGroupIds []string
+  //
+  // Deprecated in favor of `securityGroups`.
+  securityGroupIds @maturity("deprecated") []string
   // Subnets the serverless cluster is attached to
   subnets() []aws.vpc.subnet
   // Security groups attached to the serverless cluster
@@ -20651,9 +20687,13 @@ private aws.msk.replicator.kafkaCluster @defaults("kafkaClusterAlias amazonMskCl
   // Alias used to prefix names of replicated topics
   kafkaClusterAlias string
   // Subnet IDs the replicator attaches ENIs to in the client VPC
-  subnetIds []string
+  //
+  // Deprecated in favor of `subnets`.
+  subnetIds @maturity("deprecated") []string
   // Security group IDs attached to the replicator ENIs
-  securityGroupIds []string
+  //
+  // Deprecated in favor of `securityGroups`.
+  securityGroupIds @maturity("deprecated") []string
   // MSK cluster resource (tolerates cross-account ARNs)
   cluster() aws.msk.cluster
   // Subnets the replicator attaches ENIs to
@@ -21716,7 +21756,9 @@ private aws.cloudformation.stack @defaults("name status") {
   // Drift detection status: DRIFTED, IN_SYNC, NOT_CHECKED, UNKNOWN
   driftStatus string
   // ARN of the IAM role used to create or update the stack
-  roleArn string
+  //
+  // Deprecated in favor of `iamRole`.
+  roleArn @maturity("deprecated") string
   // IAM role used to create/update the stack
   iamRole() aws.iam.role
   // Stack parameters
@@ -24330,7 +24372,9 @@ private aws.bedrock.batchInferenceJob @defaults("jobName modelId status") {
   // IAM service role used by the batch inference job
   iamRole() aws.iam.role
   // ARN of the IAM service role used by the batch inference job
-  roleArn string
+  //
+  // Deprecated in favor of `iamRole`.
+  roleArn @maturity("deprecated") string
   // Time the batch inference job was submitted
   submitTime time
   // Time the batch inference job was last modified

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6054,6 +6054,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.mountTarget.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetSubnetId()).ToDataRes(types.String)
 	},
+	"aws.efs.mountTarget.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsMountTarget).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
+	},
 	"aws.efs.mountTarget.availabilityZone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetAvailabilityZone()).ToDataRes(types.String)
 	},
@@ -14168,6 +14171,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eventbridge.schedule.target.roleArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeScheduleTarget).GetRoleArn()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.schedule.target.iamRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeScheduleTarget).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
 	"aws.eventbridge.schedule.target.input": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeScheduleTarget).GetInput()).ToDataRes(types.String)
@@ -25260,6 +25266,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.workspaces.directory.subnetIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesDirectory).GetSubnetIds()).ToDataRes(types.Array(types.String))
 	},
+	"aws.workspaces.directory.subnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesDirectory).GetSubnets()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
+	},
 	"aws.workspaces.directory.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesDirectory).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -25451,6 +25460,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.workspaces.workspace.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetSubnetId()).ToDataRes(types.String)
+	},
+	"aws.workspaces.workspace.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesWorkspace).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
 	},
 	"aws.workspaces.workspace.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetState()).ToDataRes(types.String)
@@ -34411,6 +34423,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.efs.mountTarget.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsMountTarget).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.mountTarget.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsMountTarget).Subnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
 		return
 	},
 	"aws.efs.mountTarget.availabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -46323,6 +46339,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.eventbridge.schedule.target.roleArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEventbridgeScheduleTarget).RoleArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.schedule.target.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeScheduleTarget).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
 		return
 	},
 	"aws.eventbridge.schedule.target.input": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62445,6 +62465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWorkspacesDirectory).SubnetIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.workspaces.directory.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesDirectory).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.workspaces.directory.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesDirectory).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -62723,6 +62747,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.workspaces.workspace.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesWorkspace).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.workspaces.workspace.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesWorkspace).Subnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
 		return
 	},
 	"aws.workspaces.workspace.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -78754,6 +78782,7 @@ type mqlAwsEfsMountTarget struct {
 	MountTargetId      plugin.TValue[string]
 	FileSystemId       plugin.TValue[string]
 	SubnetId           plugin.TValue[string]
+	Subnet             plugin.TValue[*mqlAwsVpcSubnet]
 	AvailabilityZone   plugin.TValue[string]
 	IpAddress          plugin.TValue[string]
 	SecurityGroups     plugin.TValue[[]any]
@@ -78804,6 +78833,22 @@ func (c *mqlAwsEfsMountTarget) GetFileSystemId() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsMountTarget) GetSubnetId() *plugin.TValue[string] {
 	return &c.SubnetId
+}
+
+func (c *mqlAwsEfsMountTarget) GetSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
+	return plugin.GetOrCompute[*mqlAwsVpcSubnet](&c.Subnet, func() (*mqlAwsVpcSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.mountTarget", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
 }
 
 func (c *mqlAwsEfsMountTarget) GetAvailabilityZone() *plugin.TValue[string] {
@@ -110583,6 +110628,7 @@ type mqlAwsEventbridgeScheduleTarget struct {
 	mqlAwsEventbridgeScheduleTargetInternal
 	Arn                   plugin.TValue[string]
 	RoleArn               plugin.TValue[string]
+	IamRole               plugin.TValue[*mqlAwsIamRole]
 	Input                 plugin.TValue[string]
 	TargetType            plugin.TValue[string]
 	EcsParameters         plugin.TValue[*mqlAwsEventbridgeScheduleTargetEcsParameters]
@@ -110631,6 +110677,22 @@ func (c *mqlAwsEventbridgeScheduleTarget) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEventbridgeScheduleTarget) GetRoleArn() *plugin.TValue[string] {
 	return &c.RoleArn
+}
+
+func (c *mqlAwsEventbridgeScheduleTarget) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.IamRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eventbridge.schedule.target", c.__id, "iamRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.iamRole()
+	})
 }
 
 func (c *mqlAwsEventbridgeScheduleTarget) GetInput() *plugin.TValue[string] {
@@ -150806,6 +150868,7 @@ type mqlAwsWorkspacesDirectory struct {
 	SelfservicePermissions         plugin.TValue[any]
 	IamRoleId                      plugin.TValue[string]
 	SubnetIds                      plugin.TValue[[]any]
+	Subnets                        plugin.TValue[[]any]
 	Tags                           plugin.TValue[map[string]any]
 	Region                         plugin.TValue[string]
 }
@@ -150901,6 +150964,22 @@ func (c *mqlAwsWorkspacesDirectory) GetIamRoleId() *plugin.TValue[string] {
 
 func (c *mqlAwsWorkspacesDirectory) GetSubnetIds() *plugin.TValue[[]any] {
 	return &c.SubnetIds
+}
+
+func (c *mqlAwsWorkspacesDirectory) GetSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.workspaces.directory", c.__id, "subnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnets()
+	})
 }
 
 func (c *mqlAwsWorkspacesDirectory) GetTags() *plugin.TValue[map[string]any] {
@@ -151610,6 +151689,7 @@ type mqlAwsWorkspacesWorkspace struct {
 	ComputerName                     plugin.TValue[string]
 	BundleId                         plugin.TValue[string]
 	SubnetId                         plugin.TValue[string]
+	Subnet                           plugin.TValue[*mqlAwsVpcSubnet]
 	State                            plugin.TValue[string]
 	RootVolumeEncryptionEnabled      plugin.TValue[bool]
 	UserVolumeEncryptionEnabled      plugin.TValue[bool]
@@ -151687,6 +151767,22 @@ func (c *mqlAwsWorkspacesWorkspace) GetBundleId() *plugin.TValue[string] {
 
 func (c *mqlAwsWorkspacesWorkspace) GetSubnetId() *plugin.TValue[string] {
 	return &c.SubnetId
+}
+
+func (c *mqlAwsWorkspacesWorkspace) GetSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
+	return plugin.GetOrCompute[*mqlAwsVpcSubnet](&c.Subnet, func() (*mqlAwsVpcSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.workspaces.workspace", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
 }
 
 func (c *mqlAwsWorkspacesWorkspace) GetState() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3787,6 +3787,7 @@ aws.efs.mountTarget.mountTargetId 11.15.2
 aws.efs.mountTarget.networkInterfaceId 11.15.2
 aws.efs.mountTarget.region 11.15.2
 aws.efs.mountTarget.securityGroups 11.15.2
+aws.efs.mountTarget.subnet 13.32.2
 aws.efs.mountTarget.subnetId 11.15.2
 aws.eks 11.15.2
 aws.eks.accessEntry 13.6.3
@@ -4715,6 +4716,7 @@ aws.eventbridge.schedule.target.ecsParameters.taskDefinitionArn 13.19.2
 aws.eventbridge.schedule.target.eventBridgeParameters 13.19.2
 aws.eventbridge.schedule.target.eventBridgeParameters.detailType 13.19.2
 aws.eventbridge.schedule.target.eventBridgeParameters.source 13.19.2
+aws.eventbridge.schedule.target.iamRole 13.32.2
 aws.eventbridge.schedule.target.input 13.19.2
 aws.eventbridge.schedule.target.kinesisParameters 13.19.2
 aws.eventbridge.schedule.target.kinesisParameters.partitionKey 13.19.2
@@ -9866,6 +9868,7 @@ aws.workspaces.directory.region 11.16.1
 aws.workspaces.directory.selfservicePermissions 11.16.1
 aws.workspaces.directory.state 11.16.1
 aws.workspaces.directory.subnetIds 11.16.1
+aws.workspaces.directory.subnets 13.32.2
 aws.workspaces.directory.tags 11.16.1
 aws.workspaces.directory.workspaceAccessProperties 11.16.1
 aws.workspaces.image 11.16.1
@@ -9900,6 +9903,7 @@ aws.workspaces.workspace.region 11.16.1
 aws.workspaces.workspace.rootVolumeEncryptionEnabled 11.16.1
 aws.workspaces.workspace.securityGroups 11.16.1
 aws.workspaces.workspace.state 11.16.1
+aws.workspaces.workspace.subnet 13.32.2
 aws.workspaces.workspace.subnetId 11.16.1
 aws.workspaces.workspace.tags 11.16.1
 aws.workspaces.workspace.userName 11.16.1

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
@@ -552,4 +553,19 @@ func (a *mqlAwsEfsMountTarget) securityGroups() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func (a *mqlAwsEfsMountTarget) subnet() (*mqlAwsVpcSubnet, error) {
+	subnetId := a.SubnetId.Data
+	if subnetId == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	subnetArn := fmt.Sprintf(subnetArnPattern, a.Region.Data, conn.AccountId(), subnetId)
+	res, err := NewResource(a.MqlRuntime, "aws.vpc.subnet", map[string]*llx.RawData{"arn": llx.StringData(subnetArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcSubnet), nil
 }

--- a/providers/aws/resources/aws_eventbridge_scheduler.go
+++ b/providers/aws/resources/aws_eventbridge_scheduler.go
@@ -780,6 +780,20 @@ func (a *mqlAwsEventbridgeSchedule) iamRole() (*mqlAwsIamRole, error) {
 	return res.(*mqlAwsIamRole), nil
 }
 
+func (a *mqlAwsEventbridgeScheduleTarget) iamRole() (*mqlAwsIamRole, error) {
+	roleArn := a.RoleArn.Data
+	if roleArn == "" {
+		a.IamRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringData(roleArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
+}
+
 func (a *mqlAwsEventbridgeSchedule) kmsKey() (*mqlAwsKmsKey, error) {
 	if err := a.fetchDetails(); err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -675,4 +676,42 @@ func newMqlAwsWorkspacesIpGroup(runtime *plugin.Runtime, region string, group wo
 
 func (a *mqlAwsWorkspacesIpGroup) id() (string, error) {
 	return "aws.workspaces.ipGroup/" + a.Region.Data + "/" + a.GroupId.Data, nil
+}
+
+func (a *mqlAwsWorkspacesDirectory) subnets() ([]any, error) {
+	subnetIds := a.SubnetIds.Data
+	if len(subnetIds) == 0 {
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	res := []any{}
+	for _, idAny := range subnetIds {
+		id, ok := idAny.(string)
+		if !ok || id == "" {
+			continue
+		}
+		subnetArn := fmt.Sprintf(subnetArnPattern, region, conn.AccountId(), id)
+		mqlSubnet, err := NewResource(a.MqlRuntime, "aws.vpc.subnet", map[string]*llx.RawData{"arn": llx.StringData(subnetArn)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlSubnet)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsWorkspacesWorkspace) subnet() (*mqlAwsVpcSubnet, error) {
+	subnetId := a.SubnetId.Data
+	if subnetId == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	subnetArn := fmt.Sprintf(subnetArnPattern, a.Region.Data, conn.AccountId(), subnetId)
+	res, err := NewResource(a.MqlRuntime, "aws.vpc.subnet", map[string]*llx.RawData{"arn": llx.StringData(subnetArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcSubnet), nil
 }


### PR DESCRIPTION
## What

A typed-reference sweep across the AWS provider. Two related cleanups, both fully backwards compatible — raw fields keep their type and original `.lr.versions` entry and are marked `@maturity("deprecated")`; nothing is removed.

### 1. Deprecate duplicate raw ID/ARN fields (14)

Audited every raw `vpcId` / `subnetId(s)` / `securityGroupIds` / `roleArn` field and found cases where a typed reference **already existed** in the same resource but the raw duplicate was left undeprecated — the "duplicate ID field" anti-pattern. Deprecated each in favor of the existing ref:

| Raw field | Existing ref | Resources |
|---|---|---|
| `roleArn` | `iamRole` / `role` | codepipeline.pipeline, eventbridge.endpoint, rds.dbinstance.associatedRole, cloudformation.stack, bedrock.batchInferenceJob |
| `vpcId` | `vpc` | route53.resolver.ruleAssociation, route53.resolver.firewallRuleGroupAssociation, vpc.peeringConnection.peeringVpc |
| `subnetIds` / `securityGroupIds` | `subnets` / `securityGroups` | eventbridge.schedule.target.ecsParameters, msk.cluster.serverlessConfig.vpcConfig, msk.replicator.kafkaCluster |

### 2. Add missing typed references (4)

Resources carrying a raw id/ARN with **no** typed ref. Added the accessor and deprecated the raw field:

- `aws.eventbridge.schedule.target.iamRole()`
- `aws.efs.mountTarget.subnet()`
- `aws.workspaces.directory.subnets()`
- `aws.workspaces.workspace.subnet()`

## Backwards compatibility

- No existing field changed type or version. Deprecated fields keep their original `.lr.versions` entries.
- The 4 new accessors are at the next patch version.
- No new IAM permissions — the refs resolve from ids already collected (`NewResource` by ARN).

## Verification

- EFS mount target live: `subnet()` resolves (`subnet.id` / `subnet.arn`) and the deprecated `subnetId` still returns its raw value.
- `gofmt` / `go vet` clean; codegen idempotent; provider builds and installs; `aws.permissions.json` unchanged.

## Context

Follow-on to the AWS security-fields PR (#8234). The earlier scan suggested a large typed-ref backlog, but auditing showed most resources already had typed refs — the real gap was undeprecated raw duplicates (cleaned up here) plus a handful of genuinely missing refs.
