### PR TITLE
✨ GCP typed cross-references: network & service-account traversal

### DIFF
--- a/providers/gcp/resources/apigateway.go
+++ b/providers/gcp/resources/apigateway.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -207,6 +208,20 @@ func (g *mqlGcpProjectApiGatewayServiceApi) configs() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func (g *mqlGcpProjectApiGatewayServiceApiConfig) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.GatewayServiceAccount.Error != nil {
+		return nil, g.GatewayServiceAccount.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.GatewayServiceAccount.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
 }
 
 func (g *mqlGcpProjectApiGatewayServiceApiConfig) id() (string, error) {

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -318,6 +318,20 @@ func (g *mqlGcpProjectCloudFunction) serviceAccount() (*mqlGcpProjectIamServiceS
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
+func (g *mqlGcpProjectCloudFunction) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.Network.Error != nil {
+		return nil, g.Network.Error
+	}
+	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func (g *mqlGcpProjectCloudFunction) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -235,6 +235,22 @@ func fnV2BuildConfig(runtime *plugin.Runtime, parentName string, cfg *functionsp
 	return res.(*mqlGcpProjectCloudFunctionV2BuildConfig), nil
 }
 
+func (g *mqlGcpProjectCloudFunctionV2BuildConfig) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccount.Error != nil {
+		return nil, g.ServiceAccount.Error
+	}
+	// buildConfig.serviceAccount is a full "projects/{p}/serviceAccounts/{email}"
+	// path, so resolveServiceAccountRef derives the project — no fallback needed.
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccount.Data, "")
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
 func (g *mqlGcpProjectCloudFunctionV2BuildConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -525,6 +525,20 @@ func buildWorkerPoolNetworkConfig(runtime *plugin.Runtime, parentName string, cf
 	return res.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig), nil
 }
 
+func (g *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) peeredNetworkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.PeeredNetwork.Error != nil {
+		return nil, g.PeeredNetwork.Error
+	}
+	n, err := getNetworkByUrl(g.PeeredNetwork.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.PeeredNetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func (g *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -131,6 +131,34 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 	return res, nil
 }
 
+func (g *mqlGcpProjectCloudSchedulerServiceJob) oidcServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.OidcServiceAccountEmail.Error != nil {
+		return nil, g.OidcServiceAccountEmail.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.OidcServiceAccountEmail.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.OidcServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
+func (g *mqlGcpProjectCloudSchedulerServiceJob) oauthServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.OauthServiceAccountEmail.Error != nil {
+		return nil, g.OauthServiceAccountEmail.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.OauthServiceAccountEmail.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.OauthServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
 func (g *mqlGcpProjectCloudSchedulerServiceJob) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -72,6 +72,35 @@ func projectFromResourceName(name string) string {
 	return ""
 }
 
+// resolveServiceAccountRef resolves a service account reference to the typed
+// gcp.project.iamService.serviceAccount resource. The raw value may be a bare
+// email or a full "projects/{project}/serviceAccounts/{email}" path; for a bare
+// email the fallbackProjectId is used. Returns nil when the reference is empty
+// or cannot be resolved to a project + email.
+func resolveServiceAccountRef(runtime *plugin.Runtime, raw, fallbackProjectId string) (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	projectId, email := fallbackProjectId, raw
+	if idx := strings.Index(raw, "/serviceAccounts/"); idx != -1 {
+		email = raw[idx+len("/serviceAccounts/"):]
+		if p := projectFromResourceName(raw); p != "" {
+			projectId = p
+		}
+	}
+	if projectId == "" || email == "" {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"email":     llx.StringData(email),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
+}
+
 // protoToDict converts a protobuf message to a map[string]any suitable for use as a dict field.
 // Returns nil for nil input, including typed nil interface values.
 func protoToDict(msg proto.Message) (map[string]any, error) {

--- a/providers/gcp/resources/dataplex.go
+++ b/providers/gcp/resources/dataplex.go
@@ -156,6 +156,20 @@ func dataplexLocation(name string) string {
 	return ""
 }
 
+func (g *mqlGcpProjectDataplexServiceLake) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccount.Error != nil {
+		return nil, g.ServiceAccount.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccount.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
 func (g *mqlGcpProjectDataplexServiceLake) zones() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -664,6 +664,34 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 	return mqlClusters, nil
 }
 
+func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) network() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.NetworkUri.Error != nil {
+		return nil, g.NetworkUri.Error
+	}
+	n, err := getNetworkByUrl(g.NetworkUri.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
+func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
+	if g.SubnetworkUri.Error != nil {
+		return nil, g.SubnetworkUri.Error
+	}
+	s, err := getSubnetworkByUrl(g.SubnetworkUri.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil {
+		g.Subnetwork.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return s, nil
+}
+
 func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -123,6 +123,20 @@ func initGcpProjectDnsService(runtime *plugin.Runtime, args map[string]*llx.RawD
 	return args, nil, nil
 }
 
+func (g *mqlGcpProjectDnsServiceManagedzone) peeringNetworkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.PeeringNetwork.Error != nil {
+		return nil, g.PeeringNetwork.Error
+	}
+	n, err := getNetworkByUrl(g.PeeringNetwork.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.PeeringNetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func (g *mqlGcpProjectDnsServiceManagedzone) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -325,6 +325,8 @@ private gcp.project.redisService.instance @defaults("name") {
   // the instance is connected. If left unspecified, the `default`
   // network will be used.
   AuthorizedNetwork string
+  // VPC network the instance is attached to (resolved from AuthorizedNetwork)
+  network() gcp.project.computeService.network
   // Cloud IAM identity used by import / export operations to transfer data to/from Cloud Storage
   persistenceIamIdentity string
   // The network connect mode of the Redis instance
@@ -2674,6 +2676,8 @@ private gcp.project.sqlService.instance @defaults("name") {
   localRootEnabled() bool
   // Service account email address
   serviceAccountEmailAddress string
+  // Service account identity the instance uses (resolved from serviceAccountEmailAddress)
+  serviceAccount() gcp.project.iamService.serviceAccount
   // Instance state
   state string
   // List of the databases in the current SQL instance
@@ -3027,6 +3031,8 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   ipv4Enabled bool
   // Resource link for the VPC network from which the private IPs can access the Cloud SQL instance
   privateNetwork string
+  // VPC network from which private IPs can reach the instance (resolved from privateNetwork)
+  network() gcp.project.computeService.network
   // Whether SSL connections over IP are enforced
   requireSsl bool
   // Specifies how SSL/TLS is enforced in database connections.
@@ -3561,6 +3567,8 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   forwardingTargets []string
   // Fully qualified URL of the VPC network this private zone peers with for DNS resolution (empty when peering is not configured)
   peeringNetwork string
+  // VPC network this private zone peers with for DNS resolution (resolved from peeringNetwork)
+  peeringNetworkRef() gcp.project.computeService.network
   // Cloud DNS record set in the zone
   recordSets() []gcp.project.dnsService.recordset
   // IAM policy bindings for this managed zone
@@ -5585,6 +5593,8 @@ private gcp.project.cloudFunction @defaults("name") {
   buildEnvVars map[string]string
   // VPC network that this cloud function can connect to
   network string
+  // VPC network this function can connect to (resolved from network)
+  networkRef() gcp.project.computeService.network
   // Maximum number of function instances that may coexist at a given time
   maxInstances int
   // Lower bound for the number of function instances that may coexist at a given time
@@ -5680,6 +5690,8 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   dockerRepository string
   // Service account to use for the build
   serviceAccount string
+  // Service account identity used for the build (resolved from serviceAccount)
+  serviceAccountRef() gcp.project.iamService.serviceAccount
 }
 
 // Google Cloud (GCP) Cloud Function v2 service (Cloud Run) configuration
@@ -5798,6 +5810,8 @@ private gcp.project.dataplexService.lake @defaults("name state location") {
   labels map[string]string
   // Service account associated with the lake, used to access managed resources
   serviceAccount string
+  // Service account identity associated with the lake (resolved from serviceAccount)
+  serviceAccountRef() gcp.project.iamService.serviceAccount
   // Resource name of the attached Dataproc Metastore service, if any
   metastoreService string
   // Number of active assets in the lake
@@ -6115,6 +6129,8 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   metadata map[string]string
   // Compute Engine network to be used for machine communications
   networkUri string
+  // Compute Engine network used for machine communications (resolved from networkUri)
+  network() gcp.project.computeService.network
   // Node group affinity for sole-tenant clusters
   nodeGroupAffinity dict
   // Type of IPv6 access for the cluster
@@ -6131,6 +6147,8 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   shieldedInstanceConfig gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig
   // Compute Engine subnetwork to use for machine communications
   subnetworkUri string
+  // Compute Engine subnetwork used for machine communications (resolved from subnetworkUri)
+  subnetwork() gcp.project.computeService.subnetwork
   // Compute Engine tags
   tags []string
   // Zone where the Compute Engine cluster is located
@@ -9112,8 +9130,12 @@ private gcp.project.cloudSchedulerService.job @defaults("name state schedule") {
   targetType string
   // Service account email used to mint the OIDC token for HTTP target authentication (empty if not configured)
   oidcServiceAccountEmail string
+  // Service account identity used to mint the OIDC token (resolved from oidcServiceAccountEmail)
+  oidcServiceAccount() gcp.project.iamService.serviceAccount
   // Service account email used to mint the OAuth token for HTTP target authentication (empty if not configured)
   oauthServiceAccountEmail string
+  // Service account identity used to mint the OAuth token (resolved from oauthServiceAccountEmail)
+  oauthServiceAccount() gcp.project.iamService.serviceAccount
 }
 
 // Google Cloud (GCP) App Engine
@@ -9304,6 +9326,8 @@ private gcp.project.apiGatewayService.apiConfig @defaults("name state") {
   serviceConfigId string
   // IAM service account that gateways serving this config use to authenticate to other services
   gatewayServiceAccount string
+  // Service account identity gateways serving this config authenticate as (resolved from gatewayServiceAccount)
+  serviceAccount() gcp.project.iamService.serviceAccount
   // The time the API config was created
   createTime time
   // The time the API config was last updated
@@ -11056,6 +11080,8 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Network for private endpoints
   network string
+  // VPC network used for private endpoints (resolved from network)
+  networkRef() gcp.project.computeService.network
   // Whether private service connect is enabled
   enablePrivateServiceConnect bool
   // Traffic split (model ID to traffic percentage)
@@ -11130,6 +11156,8 @@ private gcp.project.vertexaiService.pipelineJob @defaults("name displayName stat
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // VPC network the resource is attached to
   network string
+  // VPC network the resource is attached to (resolved from network)
+  networkRef() gcp.project.computeService.network
   // Encryption spec
   encryptionSpec dict
   // Customer-managed Cloud KMS key used to encrypt this resource at rest
@@ -11334,6 +11362,8 @@ private gcp.project.vertexaiService.indexEndpoint @defaults("displayName") {
   deployedIndexes []dict
   // Network for private endpoints
   network string
+  // VPC network used for private endpoints (resolved from network)
+  networkRef() gcp.project.computeService.network
   // Whether public endpoint is enabled
   publicEndpointEnabled bool
   // Public endpoint domain name
@@ -13486,7 +13516,10 @@ private gcp.project.cloudBuildService.trigger @defaults("name description disabl
   // Variable substitutions (key-value pairs)
   substitutions map[string]string
   // Service account resource name used for builds from this trigger
-  serviceAccount string
+  //
+  // Deprecated in favor of `iamServiceAccount`, which resolves the identity to
+  // the service account resource (the resource name is its `name`).
+  serviceAccount @maturity("deprecated") string
   // IAM service account used for builds from this trigger
   iamServiceAccount() gcp.project.iamService.serviceAccount
   // GitHub event configuration
@@ -13639,6 +13672,8 @@ private gcp.project.cloudBuildService.workerPool.networkConfig @defaults("egress
   id string
   // Peered VPC network name
   peeredNetwork string
+  // Peered VPC network the worker pool connects through (resolved from peeredNetwork)
+  peeredNetworkRef() gcp.project.computeService.network
   // Peered network IP range
   peeredNetworkIpRange string
   // Egress option (NO_PUBLIC_EGRESS, PUBLIC_EGRESS)

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -321,10 +321,11 @@ private gcp.project.redisService.instance @defaults("name") {
   memorySizeGb int
   // The full name of the Google Compute Engine network
   //
-  // The [VPC network](https://cloud.google.com/vpc/docs/vpc) to which
-  // the instance is connected. If left unspecified, the `default`
-  // network will be used.
-  AuthorizedNetwork string
+  // Deprecated in favor of `network`, which resolves the VPC network
+  // resource. The [VPC network](https://cloud.google.com/vpc/docs/vpc) to
+  // which the instance is connected; if left unspecified, the `default`
+  // network is used.
+  AuthorizedNetwork @maturity("deprecated") string
   // VPC network the instance is attached to (resolved from AuthorizedNetwork)
   network() gcp.project.computeService.network
   // Cloud IAM identity used by import / export operations to transfer data to/from Cloud Storage
@@ -2675,7 +2676,9 @@ private gcp.project.sqlService.instance @defaults("name") {
   // Whether a built-in 'root' user exists (the most common SQL hardening finding)
   localRootEnabled() bool
   // Service account email address
-  serviceAccountEmailAddress string
+  //
+  // Deprecated in favor of `serviceAccount`, which resolves the service account resource (the email is its `email`).
+  serviceAccountEmailAddress @maturity("deprecated") string
   // Service account identity the instance uses (resolved from serviceAccountEmailAddress)
   serviceAccount() gcp.project.iamService.serviceAccount
   // Instance state
@@ -3030,7 +3033,9 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   // Whether the instance is assigned a public IP address
   ipv4Enabled bool
   // Resource link for the VPC network from which the private IPs can access the Cloud SQL instance
-  privateNetwork string
+  //
+  // Deprecated in favor of `network`, which resolves the VPC network resource.
+  privateNetwork @maturity("deprecated") string
   // VPC network from which private IPs can reach the instance (resolved from privateNetwork)
   network() gcp.project.computeService.network
   // Whether SSL connections over IP are enforced
@@ -3566,7 +3571,9 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   // IPv4 addresses of the name servers this private zone forwards outbound queries to (empty when forwarding is not configured)
   forwardingTargets []string
   // Fully qualified URL of the VPC network this private zone peers with for DNS resolution (empty when peering is not configured)
-  peeringNetwork string
+  //
+  // Deprecated in favor of `peeringNetworkRef`, which resolves the VPC network resource.
+  peeringNetwork @maturity("deprecated") string
   // VPC network this private zone peers with for DNS resolution (resolved from peeringNetwork)
   peeringNetworkRef() gcp.project.computeService.network
   // Cloud DNS record set in the zone
@@ -5592,7 +5599,9 @@ private gcp.project.cloudFunction @defaults("name") {
   // Build environment variables that are available during build time
   buildEnvVars map[string]string
   // VPC network that this cloud function can connect to
-  network string
+  //
+  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
+  network @maturity("deprecated") string
   // VPC network this function can connect to (resolved from network)
   networkRef() gcp.project.computeService.network
   // Maximum number of function instances that may coexist at a given time
@@ -5689,7 +5698,9 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   // User-managed repository in Artifact Registry for storing built images
   dockerRepository string
   // Service account to use for the build
-  serviceAccount string
+  //
+  // Deprecated in favor of `serviceAccountRef`, which resolves the service account resource.
+  serviceAccount @maturity("deprecated") string
   // Service account identity used for the build (resolved from serviceAccount)
   serviceAccountRef() gcp.project.iamService.serviceAccount
 }
@@ -5809,7 +5820,9 @@ private gcp.project.dataplexService.lake @defaults("name state location") {
   // User-provided labels
   labels map[string]string
   // Service account associated with the lake, used to access managed resources
-  serviceAccount string
+  //
+  // Deprecated in favor of `serviceAccountRef`, which resolves the service account resource.
+  serviceAccount @maturity("deprecated") string
   // Service account identity associated with the lake (resolved from serviceAccount)
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Resource name of the attached Dataproc Metastore service, if any
@@ -6128,7 +6141,9 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   // Compute Engine metadata entries
   metadata map[string]string
   // Compute Engine network to be used for machine communications
-  networkUri string
+  //
+  // Deprecated in favor of `network`, which resolves the VPC network resource.
+  networkUri @maturity("deprecated") string
   // Compute Engine network used for machine communications (resolved from networkUri)
   network() gcp.project.computeService.network
   // Node group affinity for sole-tenant clusters
@@ -6146,7 +6161,9 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   // Shielded instance config for clusters using Compute Engine Shielded VMs
   shieldedInstanceConfig gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig
   // Compute Engine subnetwork to use for machine communications
-  subnetworkUri string
+  //
+  // Deprecated in favor of `subnetwork`, which resolves the subnetwork resource.
+  subnetworkUri @maturity("deprecated") string
   // Compute Engine subnetwork used for machine communications (resolved from subnetworkUri)
   subnetwork() gcp.project.computeService.subnetwork
   // Compute Engine tags
@@ -9129,11 +9146,15 @@ private gcp.project.cloudSchedulerService.job @defaults("name state schedule") {
   // Target type: "httpTarget", "pubsubTarget", or "appEngineHttpTarget"
   targetType string
   // Service account email used to mint the OIDC token for HTTP target authentication (empty if not configured)
-  oidcServiceAccountEmail string
+  //
+  // Deprecated in favor of `oidcServiceAccount`, which resolves the service account resource.
+  oidcServiceAccountEmail @maturity("deprecated") string
   // Service account identity used to mint the OIDC token (resolved from oidcServiceAccountEmail)
   oidcServiceAccount() gcp.project.iamService.serviceAccount
   // Service account email used to mint the OAuth token for HTTP target authentication (empty if not configured)
-  oauthServiceAccountEmail string
+  //
+  // Deprecated in favor of `oauthServiceAccount`, which resolves the service account resource.
+  oauthServiceAccountEmail @maturity("deprecated") string
   // Service account identity used to mint the OAuth token (resolved from oauthServiceAccountEmail)
   oauthServiceAccount() gcp.project.iamService.serviceAccount
 }
@@ -9325,7 +9346,9 @@ private gcp.project.apiGatewayService.apiConfig @defaults("name state") {
   // ID of the associated service config
   serviceConfigId string
   // IAM service account that gateways serving this config use to authenticate to other services
-  gatewayServiceAccount string
+  //
+  // Deprecated in favor of `serviceAccount`, which resolves the service account resource.
+  gatewayServiceAccount @maturity("deprecated") string
   // Service account identity gateways serving this config authenticate as (resolved from gatewayServiceAccount)
   serviceAccount() gcp.project.iamService.serviceAccount
   // The time the API config was created
@@ -11079,7 +11102,9 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   // Customer-managed Cloud KMS key used to encrypt this resource at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Network for private endpoints
-  network string
+  //
+  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
+  network @maturity("deprecated") string
   // VPC network used for private endpoints (resolved from network)
   networkRef() gcp.project.computeService.network
   // Whether private service connect is enabled
@@ -11155,7 +11180,9 @@ private gcp.project.vertexaiService.pipelineJob @defaults("name displayName stat
   // Service account identity the pipeline job runs as
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // VPC network the resource is attached to
-  network string
+  //
+  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
+  network @maturity("deprecated") string
   // VPC network the resource is attached to (resolved from network)
   networkRef() gcp.project.computeService.network
   // Encryption spec
@@ -11361,7 +11388,9 @@ private gcp.project.vertexaiService.indexEndpoint @defaults("displayName") {
   // Deployed indexes
   deployedIndexes []dict
   // Network for private endpoints
-  network string
+  //
+  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
+  network @maturity("deprecated") string
   // VPC network used for private endpoints (resolved from network)
   networkRef() gcp.project.computeService.network
   // Whether public endpoint is enabled
@@ -13671,7 +13700,9 @@ private gcp.project.cloudBuildService.workerPool.networkConfig @defaults("egress
   // Internal ID
   id string
   // Peered VPC network name
-  peeredNetwork string
+  //
+  // Deprecated in favor of `peeredNetworkRef`, which resolves the VPC network resource.
+  peeredNetwork @maturity("deprecated") string
   // Peered VPC network the worker pool connects through (resolved from peeredNetwork)
   peeredNetworkRef() gcp.project.computeService.network
   // Peered network IP range

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2582,6 +2582,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.redisService.instance.AuthorizedNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetAuthorizedNetwork()).ToDataRes(types.String)
 	},
+	"gcp.project.redisService.instance.network": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceInstance).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.redisService.instance.persistenceIamIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetPersistenceIamIdentity()).ToDataRes(types.String)
 	},
@@ -5078,6 +5081,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.serviceAccountEmailAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetServiceAccountEmailAddress()).ToDataRes(types.String)
 	},
+	"gcp.project.sqlService.instance.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.sqlService.instance.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetState()).ToDataRes(types.String)
 	},
@@ -5464,6 +5470,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetPrivateNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.network": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetRequireSsl()).ToDataRes(types.Bool)
@@ -5992,6 +6001,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dnsService.managedzone.peeringNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPeeringNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.dnsService.managedzone.peeringNetworkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPeeringNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.dnsService.managedzone.recordSets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetRecordSets()).ToDataRes(types.Array(types.Resource("gcp.project.dnsService.recordset")))
@@ -7829,6 +7841,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetNetwork()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudFunction.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.cloudFunction.maxInstances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetMaxInstances()).ToDataRes(types.Int)
 	},
@@ -7948,6 +7963,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccount()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).GetId()).ToDataRes(types.String)
@@ -8074,6 +8092,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dataplexService.lake.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataplexServiceLake).GetServiceAccount()).ToDataRes(types.String)
+	},
+	"gcp.project.dataplexService.lake.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDataplexServiceLake).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.dataplexService.lake.metastoreService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataplexServiceLake).GetMetastoreService()).ToDataRes(types.String)
@@ -8390,6 +8411,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dataprocService.cluster.config.gceCluster.networkUri": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetNetworkUri()).ToDataRes(types.String)
 	},
+	"gcp.project.dataprocService.cluster.config.gceCluster.network": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.nodeGroupAffinity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetNodeGroupAffinity()).ToDataRes(types.Dict)
 	},
@@ -8413,6 +8437,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetSubnetworkUri()).ToDataRes(types.String)
+	},
+	"gcp.project.dataprocService.cluster.config.gceCluster.subnetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetSubnetwork()).ToDataRes(types.Resource("gcp.project.computeService.subnetwork"))
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetTags()).ToDataRes(types.Array(types.String))
@@ -11435,8 +11462,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOidcServiceAccountEmail()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudSchedulerService.job.oidcServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOidcServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOauthServiceAccountEmail()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudSchedulerService.job.oauthServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOauthServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.appEngineService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAppEngineService).GetProjectId()).ToDataRes(types.String)
@@ -11611,6 +11644,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.apiGatewayService.apiConfig.gatewayServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetGatewayServiceAccount()).ToDataRes(types.String)
+	},
+	"gcp.project.apiGatewayService.apiConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.apiGatewayService.apiConfig.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetCreateTime()).ToDataRes(types.Time)
@@ -13421,6 +13457,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.endpoint.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetNetwork()).ToDataRes(types.String)
 	},
+	"gcp.project.vertexaiService.endpoint.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.vertexaiService.endpoint.enablePrivateServiceConnect": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetEnablePrivateServiceConnect()).ToDataRes(types.Bool)
 	},
@@ -13489,6 +13528,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.pipelineJob.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.pipelineJob.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.vertexaiService.pipelineJob.encryptionSpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetEncryptionSpec()).ToDataRes(types.Dict)
@@ -13705,6 +13747,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.indexEndpoint.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.indexEndpoint.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.vertexaiService.indexEndpoint.publicEndpointEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetPublicEndpointEnabled()).ToDataRes(types.Bool)
@@ -15857,6 +15902,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetPeeredNetwork()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetPeeredNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkIpRange": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetPeeredNetworkIpRange()).ToDataRes(types.String)
 	},
@@ -16965,6 +17013,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.instance.AuthorizedNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceInstance).AuthorizedNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.redisService.instance.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceInstance).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.instance.persistenceIamIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20499,6 +20551,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).ServiceAccountEmailAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -21053,6 +21109,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).PrivateNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21817,6 +21877,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dnsService.managedzone.peeringNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).PeeringNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dnsService.managedzone.peeringNetworkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).PeeringNetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dnsService.managedzone.recordSets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24539,6 +24603,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunction.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunction.maxInstances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).MaxInstances, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -24705,6 +24773,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24889,6 +24961,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dataplexService.lake.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataplexServiceLake).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dataplexService.lake.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDataplexServiceLake).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dataplexService.lake.metastoreService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25343,6 +25419,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).NetworkUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.dataprocService.cluster.config.gceCluster.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.nodeGroupAffinity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).NodeGroupAffinity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -25373,6 +25453,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).SubnetworkUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dataprocService.cluster.config.gceCluster.subnetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).Subnetwork, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSubnetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29795,8 +29879,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudSchedulerServiceJob).OidcServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudSchedulerService.job.oidcServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudSchedulerServiceJob).OidcServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudSchedulerServiceJob).OauthServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudSchedulerService.job.oauthServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudSchedulerServiceJob).OauthServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.appEngineService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30061,6 +30153,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.apiGatewayService.apiConfig.gatewayServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectApiGatewayServiceApiConfig).GatewayServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.apiGatewayService.apiConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiGatewayServiceApiConfig).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.apiGatewayService.apiConfig.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32699,6 +32795,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.vertexaiService.endpoint.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceEndpoint).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
 	"gcp.project.vertexaiService.endpoint.enablePrivateServiceConnect": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).EnablePrivateServiceConnect, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -32797,6 +32897,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.pipelineJob.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServicePipelineJob).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.pipelineJob.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServicePipelineJob).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.pipelineJob.encryptionSpec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33109,6 +33213,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.indexEndpoint.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.indexEndpoint.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.indexEndpoint.publicEndpointEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36287,6 +36395,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).PeeredNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).PeeredNetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkIpRange": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).PeeredNetworkIpRange, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -38405,6 +38517,7 @@ type mqlGcpProjectRedisServiceInstance struct {
 	RedisConfigs                 plugin.TValue[map[string]any]
 	MemorySizeGb                 plugin.TValue[int64]
 	AuthorizedNetwork            plugin.TValue[string]
+	Network                      plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PersistenceIamIdentity       plugin.TValue[string]
 	ConnectMode                  plugin.TValue[string]
 	AuthEnabled                  plugin.TValue[bool]
@@ -38530,6 +38643,22 @@ func (c *mqlGcpProjectRedisServiceInstance) GetMemorySizeGb() *plugin.TValue[int
 
 func (c *mqlGcpProjectRedisServiceInstance) GetAuthorizedNetwork() *plugin.TValue[string] {
 	return &c.AuthorizedNetwork
+}
+
+func (c *mqlGcpProjectRedisServiceInstance) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.redisService.instance", c.__id, "network")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.network()
+	})
 }
 
 func (c *mqlGcpProjectRedisServiceInstance) GetPersistenceIamIdentity() *plugin.TValue[string] {
@@ -46723,6 +46852,7 @@ type mqlGcpProjectSqlServiceInstance struct {
 	HasBuiltInUsers                            plugin.TValue[bool]
 	LocalRootEnabled                           plugin.TValue[bool]
 	ServiceAccountEmailAddress                 plugin.TValue[string]
+	ServiceAccount                             plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	State                                      plugin.TValue[string]
 	Databases                                  plugin.TValue[[]any]
 	Users                                      plugin.TValue[[]any]
@@ -46935,6 +47065,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetLocalRootEnabled() *plugin.TValue[b
 
 func (c *mqlGcpProjectSqlServiceInstance) GetServiceAccountEmailAddress() *plugin.TValue[string] {
 	return &c.ServiceAccountEmailAddress
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstance) GetState() *plugin.TValue[string] {
@@ -47991,6 +48137,7 @@ type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	HasOpenAuthorizedNetworks               plugin.TValue[bool]
 	Ipv4Enabled                             plugin.TValue[bool]
 	PrivateNetwork                          plugin.TValue[string]
+	Network                                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	RequireSsl                              plugin.TValue[bool]
 	SslMode                                 plugin.TValue[string]
 	EnablePrivatePathForGoogleCloudServices plugin.TValue[bool]
@@ -48062,6 +48209,22 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetIpv4Enabled(
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetPrivateNetwork() *plugin.TValue[string] {
 	return &c.PrivateNetwork
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance.settings.ipConfiguration", c.__id, "network")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.network()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetRequireSsl() *plugin.TValue[bool] {
@@ -49664,6 +49827,7 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	PrivateVisibilityConfig    plugin.TValue[any]
 	ForwardingTargets          plugin.TValue[[]any]
 	PeeringNetwork             plugin.TValue[string]
+	PeeringNetworkRef          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	RecordSets                 plugin.TValue[[]any]
 	IamPolicy                  plugin.TValue[[]any]
 }
@@ -49777,6 +49941,22 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetForwardingTargets() *plugin.TVal
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetPeeringNetwork() *plugin.TValue[string] {
 	return &c.PeeringNetwork
+}
+
+func (c *mqlGcpProjectDnsServiceManagedzone) GetPeeringNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.PeeringNetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dnsService.managedzone", c.__id, "peeringNetworkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.peeringNetworkRef()
+	})
 }
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetRecordSets() *plugin.TValue[[]any] {
@@ -56305,6 +56485,7 @@ type mqlGcpProjectCloudFunction struct {
 	EnvVars               plugin.TValue[map[string]any]
 	BuildEnvVars          plugin.TValue[map[string]any]
 	Network               plugin.TValue[string]
+	NetworkRef            plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	MaxInstances          plugin.TValue[int64]
 	MinInstances          plugin.TValue[int64]
 	VpcConnector          plugin.TValue[string]
@@ -56458,6 +56639,22 @@ func (c *mqlGcpProjectCloudFunction) GetBuildEnvVars() *plugin.TValue[map[string
 
 func (c *mqlGcpProjectCloudFunction) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectCloudFunction) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectCloudFunction) GetMaxInstances() *plugin.TValue[int64] {
@@ -56713,6 +56910,7 @@ type mqlGcpProjectCloudFunctionV2BuildConfig struct {
 	EnvironmentVariables plugin.TValue[map[string]any]
 	DockerRepository     plugin.TValue[string]
 	ServiceAccount       plugin.TValue[string]
+	ServiceAccountRef    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 }
 
 // createGcpProjectCloudFunctionV2BuildConfig creates a new instance of this resource
@@ -56782,6 +56980,22 @@ func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepository() *plugin.
 
 func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccount() *plugin.TValue[string] {
 	return &c.ServiceAccount
+}
+
+func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunctionV2.buildConfig", c.__id, "serviceAccountRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccountRef()
+	})
 }
 
 // mqlGcpProjectCloudFunctionV2ServiceConfig for the gcp.project.cloudFunctionV2.serviceConfig resource
@@ -57131,6 +57345,7 @@ type mqlGcpProjectDataplexServiceLake struct {
 	Updated                      plugin.TValue[*time.Time]
 	Labels                       plugin.TValue[map[string]any]
 	ServiceAccount               plugin.TValue[string]
+	ServiceAccountRef            plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	MetastoreService             plugin.TValue[string]
 	ActiveAssets                 plugin.TValue[int64]
 	SecurityPolicyApplyingAssets plugin.TValue[int64]
@@ -57215,6 +57430,22 @@ func (c *mqlGcpProjectDataplexServiceLake) GetLabels() *plugin.TValue[map[string
 
 func (c *mqlGcpProjectDataplexServiceLake) GetServiceAccount() *plugin.TValue[string] {
 	return &c.ServiceAccount
+}
+
+func (c *mqlGcpProjectDataplexServiceLake) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dataplexService.lake", c.__id, "serviceAccountRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccountRef()
+	})
 }
 
 func (c *mqlGcpProjectDataplexServiceLake) GetMetastoreService() *plugin.TValue[string] {
@@ -58122,6 +58353,7 @@ type mqlGcpProjectDataprocServiceClusterConfigGceCluster struct {
 	InternalIpOnly          plugin.TValue[bool]
 	Metadata                plugin.TValue[map[string]any]
 	NetworkUri              plugin.TValue[string]
+	Network                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	NodeGroupAffinity       plugin.TValue[any]
 	PrivateIpv6GoogleAccess plugin.TValue[string]
 	ReservationAffinity     plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceClusterReservationAffinity]
@@ -58130,6 +58362,7 @@ type mqlGcpProjectDataprocServiceClusterConfigGceCluster struct {
 	ServiceAccountScopes    plugin.TValue[[]any]
 	ShieldedInstanceConfig  plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceClusterShieldedInstanceConfig]
 	SubnetworkUri           plugin.TValue[string]
+	Subnetwork              plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	Tags                    plugin.TValue[[]any]
 	ZoneUri                 plugin.TValue[string]
 }
@@ -58195,6 +58428,22 @@ func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetNetworkUri() *p
 	return &c.NetworkUri
 }
 
+func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dataprocService.cluster.config.gceCluster", c.__id, "network")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.network()
+	})
+}
+
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetNodeGroupAffinity() *plugin.TValue[any] {
 	return &c.NodeGroupAffinity
 }
@@ -58237,6 +58486,22 @@ func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetShieldedInstanc
 
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetSubnetworkUri() *plugin.TValue[string] {
 	return &c.SubnetworkUri
+}
+
+func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetSubnetwork() *plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSubnetwork](&c.Subnetwork, func() (*mqlGcpProjectComputeServiceSubnetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dataprocService.cluster.config.gceCluster", c.__id, "subnetwork")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceSubnetwork), nil
+			}
+		}
+
+		return c.subnetwork()
+	})
 }
 
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetTags() *plugin.TValue[[]any] {
@@ -68482,7 +68747,9 @@ type mqlGcpProjectCloudSchedulerServiceJob struct {
 	RetryConfig              plugin.TValue[*mqlGcpRetryConfig]
 	TargetType               plugin.TValue[string]
 	OidcServiceAccountEmail  plugin.TValue[string]
+	OidcServiceAccount       plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	OauthServiceAccountEmail plugin.TValue[string]
+	OauthServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 }
 
 // createGcpProjectCloudSchedulerServiceJob creates a new instance of this resource
@@ -68570,8 +68837,40 @@ func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOidcServiceAccountEmail() *pl
 	return &c.OidcServiceAccountEmail
 }
 
+func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOidcServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.OidcServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudSchedulerService.job", c.__id, "oidcServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.oidcServiceAccount()
+	})
+}
+
 func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOauthServiceAccountEmail() *plugin.TValue[string] {
 	return &c.OauthServiceAccountEmail
+}
+
+func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOauthServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.OauthServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudSchedulerService.job", c.__id, "oauthServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.oauthServiceAccount()
+	})
 }
 
 // mqlGcpProjectAppEngineService for the gcp.project.appEngineService resource
@@ -69232,6 +69531,7 @@ type mqlGcpProjectApiGatewayServiceApiConfig struct {
 	State                 plugin.TValue[string]
 	ServiceConfigId       plugin.TValue[string]
 	GatewayServiceAccount plugin.TValue[string]
+	ServiceAccount        plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	CreateTime            plugin.TValue[*time.Time]
 	UpdateTime            plugin.TValue[*time.Time]
 	Labels                plugin.TValue[map[string]any]
@@ -69297,6 +69597,22 @@ func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetServiceConfigId() *plugin.T
 
 func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetGatewayServiceAccount() *plugin.TValue[string] {
 	return &c.GatewayServiceAccount
+}
+
+func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.apiGatewayService.apiConfig", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -75581,6 +75897,7 @@ type mqlGcpProjectVertexaiServiceEndpoint struct {
 	EncryptionSpec              plugin.TValue[any]
 	KmsKey                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	Network                     plugin.TValue[string]
+	NetworkRef                  plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EnablePrivateServiceConnect plugin.TValue[bool]
 	TrafficSplit                plugin.TValue[map[string]any]
 	Labels                      plugin.TValue[map[string]any]
@@ -75668,6 +75985,22 @@ func (c *mqlGcpProjectVertexaiServiceEndpoint) GetKmsKey() *plugin.TValue[*mqlGc
 
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectVertexaiServiceEndpoint) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.endpoint", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetEnablePrivateServiceConnect() *plugin.TValue[bool] {
@@ -75815,6 +76148,7 @@ type mqlGcpProjectVertexaiServicePipelineJob struct {
 	ServiceAccount    plugin.TValue[string]
 	ServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Network           plugin.TValue[string]
+	NetworkRef        plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EncryptionSpec    plugin.TValue[any]
 	KmsKey            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	TemplateUri       plugin.TValue[string]
@@ -75905,6 +76239,22 @@ func (c *mqlGcpProjectVertexaiServicePipelineJob) GetServiceAccountRef() *plugin
 
 func (c *mqlGcpProjectVertexaiServicePipelineJob) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectVertexaiServicePipelineJob) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.pipelineJob", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectVertexaiServicePipelineJob) GetEncryptionSpec() *plugin.TValue[any] {
@@ -76535,6 +76885,7 @@ type mqlGcpProjectVertexaiServiceIndexEndpoint struct {
 	Description              plugin.TValue[string]
 	DeployedIndexes          plugin.TValue[[]any]
 	Network                  plugin.TValue[string]
+	NetworkRef               plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PublicEndpointEnabled    plugin.TValue[bool]
 	PublicEndpointDomainName plugin.TValue[string]
 	Labels                   plugin.TValue[map[string]any]
@@ -76599,6 +76950,22 @@ func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetDeployedIndexes() *plugin
 
 func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.indexEndpoint", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetPublicEndpointEnabled() *plugin.TValue[bool] {
@@ -84384,6 +84751,7 @@ type mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig struct {
 	// optional: if you define mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfigInternal it will be used here
 	Id                   plugin.TValue[string]
 	PeeredNetwork        plugin.TValue[string]
+	PeeredNetworkRef     plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PeeredNetworkIpRange plugin.TValue[string]
 	EgressOption         plugin.TValue[string]
 }
@@ -84431,6 +84799,22 @@ func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetId() *plugin.
 
 func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetPeeredNetwork() *plugin.TValue[string] {
 	return &c.PeeredNetwork
+}
+
+func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetPeeredNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.PeeredNetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudBuildService.workerPool.networkConfig", c.__id, "peeredNetworkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.peeredNetworkRef()
+	})
 }
 
 func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetPeeredNetworkIpRange() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -318,6 +318,7 @@ gcp.project.apiGatewayService.apiConfig.labels 13.15.1
 gcp.project.apiGatewayService.apiConfig.name 13.15.1
 gcp.project.apiGatewayService.apiConfig.openapiDocuments 13.15.1
 gcp.project.apiGatewayService.apiConfig.projectId 13.15.1
+gcp.project.apiGatewayService.apiConfig.serviceAccount 13.21.2
 gcp.project.apiGatewayService.apiConfig.serviceConfigId 13.15.1
 gcp.project.apiGatewayService.apiConfig.state 13.15.1
 gcp.project.apiGatewayService.apiConfig.updateTime 13.15.1
@@ -955,6 +956,7 @@ gcp.project.cloudBuildService.workerPool.networkConfig.egressOption 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.id 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetwork 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkIpRange 13.7.2
+gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef 13.21.2
 gcp.project.cloudBuildService.workerPool.projectId 13.7.2
 gcp.project.cloudBuildService.workerPool.state 13.7.2
 gcp.project.cloudBuildService.workerPool.updateTime 13.7.2
@@ -1060,6 +1062,7 @@ gcp.project.cloudFunction.maxInstances 9.0.0
 gcp.project.cloudFunction.minInstances 9.0.0
 gcp.project.cloudFunction.name 9.0.0
 gcp.project.cloudFunction.network 9.0.0
+gcp.project.cloudFunction.networkRef 13.21.2
 gcp.project.cloudFunction.projectId 9.0.0
 gcp.project.cloudFunction.runtime 9.0.0
 gcp.project.cloudFunction.secretEnvVars 9.0.0
@@ -1084,6 +1087,7 @@ gcp.project.cloudFunctionV2.buildConfig.environmentVariables 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.id 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.runtime 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.serviceAccount 13.7.2
+gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef 13.21.2
 gcp.project.cloudFunctionV2.buildConfig.source 13.7.2
 gcp.project.cloudFunctionV2.createTime 13.7.2
 gcp.project.cloudFunctionV2.description 13.7.2
@@ -1278,7 +1282,9 @@ gcp.project.cloudSchedulerService.job 11.6.6
 gcp.project.cloudSchedulerService.job.description 11.6.6
 gcp.project.cloudSchedulerService.job.lastAttemptTime 11.6.6
 gcp.project.cloudSchedulerService.job.name 11.6.6
+gcp.project.cloudSchedulerService.job.oauthServiceAccount 13.21.2
 gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail 13.18.1
+gcp.project.cloudSchedulerService.job.oidcServiceAccount 13.21.2
 gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail 13.18.1
 gcp.project.cloudSchedulerService.job.projectId 11.6.6
 gcp.project.cloudSchedulerService.job.retryConfig 11.6.6
@@ -2390,6 +2396,7 @@ gcp.project.dataplexService.lake.name 13.18.1
 gcp.project.dataplexService.lake.projectId 13.18.1
 gcp.project.dataplexService.lake.securityPolicyApplyingAssets 13.18.1
 gcp.project.dataplexService.lake.serviceAccount 13.18.1
+gcp.project.dataplexService.lake.serviceAccountRef 13.21.2
 gcp.project.dataplexService.lake.state 13.18.1
 gcp.project.dataplexService.lake.uid 13.18.1
 gcp.project.dataplexService.lake.updated 13.18.1
@@ -2454,6 +2461,7 @@ gcp.project.dataprocService.cluster.config.gceCluster.confidentialInstance 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.id 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.internalIpOnly 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.metadata 9.0.0
+gcp.project.dataprocService.cluster.config.gceCluster.network 13.21.2
 gcp.project.dataprocService.cluster.config.gceCluster.networkUri 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.nodeGroupAffinity 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.privateIpv6GoogleAccess 9.0.0
@@ -2471,6 +2479,7 @@ gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.ena
 gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.enableSecureBoot 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.enableVtpm 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.id 9.0.0
+gcp.project.dataprocService.cluster.config.gceCluster.subnetwork 13.21.2
 gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.tags 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.zoneUri 9.0.0
@@ -2806,6 +2815,7 @@ gcp.project.dnsService.managedzone.name 9.0.0
 gcp.project.dnsService.managedzone.nameServerSet 9.0.0
 gcp.project.dnsService.managedzone.nameServers 9.0.0
 gcp.project.dnsService.managedzone.peeringNetwork 13.18.1
+gcp.project.dnsService.managedzone.peeringNetworkRef 13.21.2
 gcp.project.dnsService.managedzone.privateVisibilityConfig 13.9.1
 gcp.project.dnsService.managedzone.projectId 9.0.0
 gcp.project.dnsService.managedzone.recordSets 9.0.0
@@ -4097,6 +4107,7 @@ gcp.project.redisService.instance.maintenanceSchedule 11.0.79
 gcp.project.redisService.instance.maintenanceVersion 11.0.79
 gcp.project.redisService.instance.memorySizeGb 11.0.79
 gcp.project.redisService.instance.name 11.0.79
+gcp.project.redisService.instance.network 13.21.2
 gcp.project.redisService.instance.nodeInfo 11.0.79
 gcp.project.redisService.instance.nodeInfo.id 11.0.79
 gcp.project.redisService.instance.nodeInfo.projectId 11.0.79
@@ -4373,6 +4384,7 @@ gcp.project.sqlService.instance.satisfiesPzs 11.6.6
 gcp.project.sqlService.instance.scheduledMaintenance 13.16.3
 gcp.project.sqlService.instance.secondaryZone 11.6.6
 gcp.project.sqlService.instance.serverCaCertExpiration 13.18.1
+gcp.project.sqlService.instance.serviceAccount 13.21.2
 gcp.project.sqlService.instance.serviceAccountEmailAddress 9.0.0
 gcp.project.sqlService.instance.settings 9.0.0
 gcp.project.sqlService.instance.settings.activationPolicy 9.0.0
@@ -4425,6 +4437,7 @@ gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoo
 gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetworks 13.12.2
 gcp.project.sqlService.instance.settings.ipConfiguration.id 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled 9.0.0
+gcp.project.sqlService.instance.settings.ipConfiguration.network 13.21.2
 gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig 13.10.1
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.allowedConsumerProjects 13.10.1
@@ -4657,6 +4670,7 @@ gcp.project.vertexaiService.endpoint.kmsKey 13.19.2
 gcp.project.vertexaiService.endpoint.labels 13.1.2
 gcp.project.vertexaiService.endpoint.name 13.1.2
 gcp.project.vertexaiService.endpoint.network 13.1.2
+gcp.project.vertexaiService.endpoint.networkRef 13.21.2
 gcp.project.vertexaiService.endpoint.trafficSplit 13.1.2
 gcp.project.vertexaiService.endpoint.updatedAt 13.1.2
 gcp.project.vertexaiService.endpoints 13.1.2
@@ -4725,6 +4739,7 @@ gcp.project.vertexaiService.indexEndpoint.kmsKey 13.19.2
 gcp.project.vertexaiService.indexEndpoint.labels 13.6.1
 gcp.project.vertexaiService.indexEndpoint.name 13.6.1
 gcp.project.vertexaiService.indexEndpoint.network 13.6.1
+gcp.project.vertexaiService.indexEndpoint.networkRef 13.21.2
 gcp.project.vertexaiService.indexEndpoint.publicEndpointDomainName 13.6.1
 gcp.project.vertexaiService.indexEndpoint.publicEndpointEnabled 13.6.1
 gcp.project.vertexaiService.indexEndpoint.updated 13.6.1
@@ -4858,6 +4873,7 @@ gcp.project.vertexaiService.pipelineJob.kmsKey 13.19.2
 gcp.project.vertexaiService.pipelineJob.labels 13.1.2
 gcp.project.vertexaiService.pipelineJob.name 13.1.2
 gcp.project.vertexaiService.pipelineJob.network 13.1.2
+gcp.project.vertexaiService.pipelineJob.networkRef 13.21.2
 gcp.project.vertexaiService.pipelineJob.pipelineSpec 13.1.2
 gcp.project.vertexaiService.pipelineJob.runtimeConfig 13.1.2
 gcp.project.vertexaiService.pipelineJob.serviceAccount 13.1.2

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -138,6 +138,20 @@ func (g *mqlGcpProjectRedisService) id() (string, error) {
 	return fmt.Sprintf("gcp.project/%s/redisService", g.ProjectId.Data), nil
 }
 
+func (g *mqlGcpProjectRedisServiceInstance) network() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.AuthorizedNetwork.Error != nil {
+		return nil, g.AuthorizedNetwork.Error
+	}
+	n, err := getNetworkByUrl(g.AuthorizedNetwork.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func (g *mqlGcpProjectRedisServiceInstance) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -757,6 +757,34 @@ func (g *mqlGcpProjectSqlServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyr
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
+func (g *mqlGcpProjectSqlServiceInstance) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccountEmailAddress.Error != nil {
+		return nil, g.ServiceAccountEmailAddress.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccountEmailAddress.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) network() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.PrivateNetwork.Error != nil {
+		return nil, g.PrivateNetwork.Error
+	}
+	n, err := getNetworkByUrl(g.PrivateNetwork.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func (g *mqlGcpProjectSqlServiceInstance) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -461,6 +461,20 @@ func (g *mqlGcpProjectVertexaiServiceEndpoint) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }
 
+func (g *mqlGcpProjectVertexaiServiceEndpoint) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.Network.Error != nil {
+		return nil, g.Network.Error
+	}
+	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 type mqlGcpProjectVertexaiServiceEndpointDeploymentInternal struct {
 	cacheModelName string
 	cacheProjectId string
@@ -664,6 +678,34 @@ func (g *mqlGcpProjectVertexaiServicePipelineJob) serviceAccountRef() (*mqlGcpPr
 		return nil, err
 	}
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
+}
+
+func (g *mqlGcpProjectVertexaiServicePipelineJob) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.Network.Error != nil {
+		return nil, g.Network.Error
+	}
+	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
+func (g *mqlGcpProjectVertexaiServiceIndexEndpoint) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.Network.Error != nil {
+		return nil, g.Network.Error
+	}
+	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
 }
 
 func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {


### PR DESCRIPTION
## What

Adds typed accessors so a query can traverse from a resource directly to the **network** or **service account** it references, instead of string-matching raw URLs/emails. This is the typed-reference gate applied across the data, serverless, AI, and networking services.

Example:
```
gcp.project.sqlService.instances.where( settings.ipConfiguration.network.autoCreateSubnetworks )
gcp.project.cloudSchedulerService.jobs.first.oidcServiceAccount.keys
```

| Theme | Resource | Accessor (resolved from) |
|---|---|---|
| Network | `sqlService.instance.settings.ipConfiguration` | `network()` (privateNetwork) |
| | `redisService.instance` | `network()` (AuthorizedNetwork) |
| | `dataprocService.cluster.config.gceCluster` | `network()` / `subnetwork()` |
| | `vertexaiService.endpoint` / `indexEndpoint` / `pipelineJob` | `networkRef()` |
| | `cloudFunction` | `networkRef()` |
| | `dnsService.managedzone` | `peeringNetworkRef()` |
| | `cloudBuildService.workerPool.networkConfig` | `peeredNetworkRef()` |
| Service account | `sqlService.instance` | `serviceAccount()` (serviceAccountEmailAddress) |
| | `dataplexService.lake` | `serviceAccountRef()` |
| | `cloudFunctionV2.buildConfig` | `serviceAccountRef()` |
| | `cloudSchedulerService.job` | `oidcServiceAccount()` / `oauthServiceAccount()` |
| | `apiGatewayService.apiConfig` | `serviceAccount()` (gatewayServiceAccount) |

## Implementation notes

- Network refs reuse the existing `getNetworkByUrl` / `getSubnetworkByUrl` helpers, which already handle both full self-link URLs and bare `projects/{p}/global/networks/{n}` resource paths (and Vertex's project-number paths).
- New `resolveServiceAccountRef` helper handles both a bare email (+ the resource's `projectId`) and a full `projects/{p}/serviceAccounts/{email}` path (used by `cloudFunctionV2.buildConfig`, which has no `projectId` of its own).
- **Naming/deprecation:** descriptively-named raw fields (`privateNetwork`, `networkUri`, `serviceAccountEmailAddress`, …) are kept with a clean accessor, matching the existing `dataproc.gceCluster` pattern (`serviceAccountEmail` + `serviceAccount()`). Where the raw field already occupies the clean name (`network`, `serviceAccount`), the accessor uses the `*Ref` suffix and the raw field is kept as the canonical reference value. The one deprecation is `cloudBuildService.trigger.serviceAccount`, since the typed `iamServiceAccount()` already covers it.

## Scope

This is Themes 1+2 (network + service-account) of the broader typed-reference audit. Compute load-balancer traversal (needs new `get*ByUrl` resolvers) and intra-service refs (need new `init`s on some targets) are deferred to follow-ups.

## Testing

- `make providers/build/gcp`, `go build ./...`, `go vet ./resources/`, `gofmt -l` — clean
- `go test ./resources/` (full package incl. permissions) — pass
- 16 new `.lr.versions` entries at `13.21.2`; `gcp.permissions.json` unchanged (resolution reuses existing network/SA list permissions)
- Live verification against a real GCP project still pending