### PR TITLE
⚡ Azure perf: direct-Get inits (Cosmos/Redis) + Defender policy-assignment dedup

### DIFF
--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -58355,7 +58355,7 @@ func (c *mqlAzureSubscriptionMonitorServiceDiagnosticsetting) GetMetrics() *plug
 type mqlAzureSubscriptionCloudDefenderService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceInternal
 	SubscriptionId                  plugin.TValue[string]
 	MonitoringAgentAutoProvision    plugin.TValue[bool]
 	DefenderForServers              plugin.TValue[any]

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.16.1",
-  "generated_at": "2026-06-07T21:00:33-07:00",
+  "generated_at": "2026-06-07T21:40:40-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -747,7 +747,7 @@
     {
       "permission": "Microsoft.DocumentDB/databaseAccounts/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "cosmosdb.go"
     },
     {

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -154,6 +154,29 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azur
 	return CreateResource(a.MqlRuntime, mqlResourceName, args)
 }
 
+type mqlAzureSubscriptionCloudDefenderServiceInternal struct {
+	policyAssignmentsOnce sync.Once
+	policyAssignments     PolicyAssignments
+	policyAssignmentsErr  error
+}
+
+// cachedPolicyAssignments fetches the subscription's policy assignments once and
+// caches the result. Both the forServers and forContainers Defender plans read
+// the same policy-assignments list to derive their enabled/extension state, so
+// without this a scan that touches both plans issues the list call twice.
+func (a *mqlAzureSubscriptionCloudDefenderService) cachedPolicyAssignments(ctx context.Context) (PolicyAssignments, error) {
+	a.policyAssignmentsOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		armConn, err := getArmSecurityConnection(ctx, conn, a.SubscriptionId.Data)
+		if err != nil {
+			a.policyAssignmentsErr = err
+			return
+		}
+		a.policyAssignments, a.policyAssignmentsErr = getPolicyAssignments(ctx, armConn)
+	})
+	return a.policyAssignments, a.policyAssignmentsErr
+}
+
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (any, error) {
 	typed := a.GetForServers()
 	if typed.Error != nil {
@@ -183,7 +206,7 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 	if err != nil {
 		return nil, err
 	}
-	list, err := getPolicyAssignments(ctx, armConn)
+	list, err := a.cachedPolicyAssignments(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +501,7 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSub
 		return nil, err
 	}
 
-	pas, err := getPolicyAssignments(ctx, armConn)
+	pas, err := a.cachedPolicyAssignments(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -55,29 +55,34 @@ func initAzureSubscriptionCosmosDbServiceAccount(runtime *plugin.Runtime, args m
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.cosmosDbService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	cosmosDbSvc := res.(*mqlAzureSubscriptionCosmosDbService)
-	accountList := cosmosDbSvc.GetAccounts()
-	if accountList.Error != nil {
-		return nil, nil, accountList.Error
-	}
 	id, ok := args["id"].Value.(string)
 	if !ok {
 		return nil, nil, errors.New("id must be a non-nil string value")
 	}
-	for _, entry := range accountList.Data {
-		account := entry.(*mqlAzureSubscriptionCosmosDbServiceAccount)
-		if account.Id.Data == id {
-			return args, account, nil
-		}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	accountName, err := resourceID.Component("databaseAccounts")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, errors.New("azure cosmosdb account does not exist")
+	client, err := cosmosdb.NewDatabaseAccountsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, accountName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlAccount, err := cosmosAccountToMql(runtime, &resp.DatabaseAccountGetResults)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlAccount, nil
 }
 
 func (a *mqlAzureSubscriptionCosmosDbService) accounts() ([]any, error) {
@@ -131,124 +136,132 @@ func fetchCosmosDBAccounts(ctx context.Context, runtime *plugin.Runtime, conn *c
 			if account == nil || account.ID == nil {
 				continue
 			}
-			properties, err := convert.JsonToDict(account.Properties)
+			mqlCosmosDbAccount, err := cosmosAccountToMql(runtime, account)
 			if err != nil {
 				return nil, err
-			}
-
-			var publicNetworkAccess *string
-			var disableLocalAuth *bool
-			var isVirtualNetworkFilterEnabled *bool
-			var disableKeyBasedMetadataWriteAccess *bool
-			var enableAutomaticFailover *bool
-			var enableMultipleWriteLocations *bool
-			var minimalTlsVersion *string
-			var defaultIdentity *string
-			if account.Properties != nil {
-				publicNetworkAccess = (*string)(account.Properties.PublicNetworkAccess)
-				disableLocalAuth = account.Properties.DisableLocalAuth
-				isVirtualNetworkFilterEnabled = account.Properties.IsVirtualNetworkFilterEnabled
-				disableKeyBasedMetadataWriteAccess = account.Properties.DisableKeyBasedMetadataWriteAccess
-				enableAutomaticFailover = account.Properties.EnableAutomaticFailover
-				enableMultipleWriteLocations = account.Properties.EnableMultipleWriteLocations
-				minimalTlsVersion = (*string)(account.Properties.MinimalTLSVersion)
-				defaultIdentity = account.Properties.DefaultIdentity
-			}
-
-			ipRangeFilter := []any{}
-			if account.Properties != nil && account.Properties.IPRules != nil {
-				for _, rule := range account.Properties.IPRules {
-					if rule != nil && rule.IPAddressOrRange != nil {
-						ipRangeFilter = append(ipRangeFilter, *rule.IPAddressOrRange)
-					}
-				}
-			}
-
-			var backupType string
-			var backupIntervalMinutes, backupRetentionHours int64
-			var backupRedundancy string
-			if account.Properties != nil && account.Properties.BackupPolicy != nil {
-				bp := account.Properties.BackupPolicy
-				if bp.GetBackupPolicy().Type != nil {
-					backupType = string(*bp.GetBackupPolicy().Type)
-				}
-				if periodic, ok := bp.(*cosmosdb.PeriodicModeBackupPolicy); ok && periodic.PeriodicModeProperties != nil {
-					if periodic.PeriodicModeProperties.BackupIntervalInMinutes != nil {
-						backupIntervalMinutes = int64(*periodic.PeriodicModeProperties.BackupIntervalInMinutes)
-					}
-					if periodic.PeriodicModeProperties.BackupRetentionIntervalInHours != nil {
-						backupRetentionHours = int64(*periodic.PeriodicModeProperties.BackupRetentionIntervalInHours)
-					}
-					if periodic.PeriodicModeProperties.BackupStorageRedundancy != nil {
-						backupRedundancy = string(*periodic.PeriodicModeProperties.BackupStorageRedundancy)
-					}
-				}
-			}
-
-			virtualNetworkRules := []any{}
-			if account.Properties != nil && account.Properties.VirtualNetworkRules != nil {
-				for _, rule := range account.Properties.VirtualNetworkRules {
-					if rule == nil {
-						continue
-					}
-					var subnetId string
-					var ignoreMissing bool
-					if rule.ID != nil {
-						subnetId = *rule.ID
-					}
-					if rule.IgnoreMissingVNetServiceEndpoint != nil {
-						ignoreMissing = *rule.IgnoreMissingVNetServiceEndpoint
-					}
-					ruleId := *account.ID + "/virtualNetworkRules/" + subnetId
-					mqlRule, err := CreateResource(runtime, "azure.subscription.cosmosDbService.account.virtualNetworkRule",
-						map[string]*llx.RawData{
-							"id":                               llx.StringData(ruleId),
-							"subnetId":                         llx.StringData(subnetId),
-							"ignoreMissingVNetServiceEndpoint": llx.BoolData(ignoreMissing),
-						})
-					if err != nil {
-						return nil, err
-					}
-					virtualNetworkRules = append(virtualNetworkRules, mqlRule)
-				}
-			}
-
-			mqlCosmosDbAccount, err := CreateResource(runtime, "azure.subscription.cosmosDbService.account",
-				map[string]*llx.RawData{
-					"__id":                               llx.StringDataPtr(account.ID),
-					"id":                                 llx.StringDataPtr(account.ID),
-					"name":                               llx.StringDataPtr(account.Name),
-					"tags":                               llx.MapData(convert.PtrMapStrToInterface(account.Tags), types.String),
-					"location":                           llx.StringDataPtr(account.Location),
-					"kind":                               llx.StringDataPtr((*string)(account.Kind)),
-					"type":                               llx.StringDataPtr(account.Type),
-					"properties":                         llx.DictData(properties),
-					"publicNetworkAccess":                llx.StringDataPtr(publicNetworkAccess),
-					"disableLocalAuth":                   llx.BoolDataPtr(disableLocalAuth),
-					"isVirtualNetworkFilterEnabled":      llx.BoolDataPtr(isVirtualNetworkFilterEnabled),
-					"disableKeyBasedMetadataWriteAccess": llx.BoolDataPtr(disableKeyBasedMetadataWriteAccess),
-					"enableAutomaticFailover":            llx.BoolDataPtr(enableAutomaticFailover),
-					"enableMultipleWriteLocations":       llx.BoolDataPtr(enableMultipleWriteLocations),
-					"ipRangeFilter":                      llx.ArrayData(ipRangeFilter, types.String),
-					"minimalTlsVersion":                  llx.StringDataPtr(minimalTlsVersion),
-					"defaultIdentity":                    llx.StringDataPtr(defaultIdentity),
-					"backupType":                         llx.StringData(backupType),
-					"backupIntervalInMinutes":            llx.IntData(backupIntervalMinutes),
-					"backupRetentionIntervalInHours":     llx.IntData(backupRetentionHours),
-					"backupStorageRedundancy":            llx.StringData(backupRedundancy),
-					"virtualNetworkRules":                llx.ArrayData(virtualNetworkRules, types.Resource("azure.subscription.cosmosDbService.account.virtualNetworkRule")),
-				})
-			if err != nil {
-				return nil, err
-			}
-			mqlAccount := mqlCosmosDbAccount.(*mqlAzureSubscriptionCosmosDbServiceAccount)
-			if account.Properties != nil && account.Properties.KeyVaultKeyURI != nil {
-				mqlAccount.cacheKeyVaultKeyUri = *account.Properties.KeyVaultKeyURI
 			}
 			res = append(res, mqlCosmosDbAccount)
 		}
 	}
 	return res, nil
+}
+
+func cosmosAccountToMql(runtime *plugin.Runtime, account *cosmosdb.DatabaseAccountGetResults) (plugin.Resource, error) {
+	properties, err := convert.JsonToDict(account.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	var publicNetworkAccess *string
+	var disableLocalAuth *bool
+	var isVirtualNetworkFilterEnabled *bool
+	var disableKeyBasedMetadataWriteAccess *bool
+	var enableAutomaticFailover *bool
+	var enableMultipleWriteLocations *bool
+	var minimalTlsVersion *string
+	var defaultIdentity *string
+	if account.Properties != nil {
+		publicNetworkAccess = (*string)(account.Properties.PublicNetworkAccess)
+		disableLocalAuth = account.Properties.DisableLocalAuth
+		isVirtualNetworkFilterEnabled = account.Properties.IsVirtualNetworkFilterEnabled
+		disableKeyBasedMetadataWriteAccess = account.Properties.DisableKeyBasedMetadataWriteAccess
+		enableAutomaticFailover = account.Properties.EnableAutomaticFailover
+		enableMultipleWriteLocations = account.Properties.EnableMultipleWriteLocations
+		minimalTlsVersion = (*string)(account.Properties.MinimalTLSVersion)
+		defaultIdentity = account.Properties.DefaultIdentity
+	}
+
+	ipRangeFilter := []any{}
+	if account.Properties != nil && account.Properties.IPRules != nil {
+		for _, rule := range account.Properties.IPRules {
+			if rule != nil && rule.IPAddressOrRange != nil {
+				ipRangeFilter = append(ipRangeFilter, *rule.IPAddressOrRange)
+			}
+		}
+	}
+
+	var backupType string
+	var backupIntervalMinutes, backupRetentionHours int64
+	var backupRedundancy string
+	if account.Properties != nil && account.Properties.BackupPolicy != nil {
+		bp := account.Properties.BackupPolicy
+		if bp.GetBackupPolicy().Type != nil {
+			backupType = string(*bp.GetBackupPolicy().Type)
+		}
+		if periodic, ok := bp.(*cosmosdb.PeriodicModeBackupPolicy); ok && periodic.PeriodicModeProperties != nil {
+			if periodic.PeriodicModeProperties.BackupIntervalInMinutes != nil {
+				backupIntervalMinutes = int64(*periodic.PeriodicModeProperties.BackupIntervalInMinutes)
+			}
+			if periodic.PeriodicModeProperties.BackupRetentionIntervalInHours != nil {
+				backupRetentionHours = int64(*periodic.PeriodicModeProperties.BackupRetentionIntervalInHours)
+			}
+			if periodic.PeriodicModeProperties.BackupStorageRedundancy != nil {
+				backupRedundancy = string(*periodic.PeriodicModeProperties.BackupStorageRedundancy)
+			}
+		}
+	}
+
+	virtualNetworkRules := []any{}
+	if account.Properties != nil && account.Properties.VirtualNetworkRules != nil {
+		for _, rule := range account.Properties.VirtualNetworkRules {
+			if rule == nil {
+				continue
+			}
+			var subnetId string
+			var ignoreMissing bool
+			if rule.ID != nil {
+				subnetId = *rule.ID
+			}
+			if rule.IgnoreMissingVNetServiceEndpoint != nil {
+				ignoreMissing = *rule.IgnoreMissingVNetServiceEndpoint
+			}
+			ruleId := *account.ID + "/virtualNetworkRules/" + subnetId
+			mqlRule, err := CreateResource(runtime, "azure.subscription.cosmosDbService.account.virtualNetworkRule",
+				map[string]*llx.RawData{
+					"id":                               llx.StringData(ruleId),
+					"subnetId":                         llx.StringData(subnetId),
+					"ignoreMissingVNetServiceEndpoint": llx.BoolData(ignoreMissing),
+				})
+			if err != nil {
+				return nil, err
+			}
+			virtualNetworkRules = append(virtualNetworkRules, mqlRule)
+		}
+	}
+
+	mqlCosmosDbAccount, err := CreateResource(runtime, "azure.subscription.cosmosDbService.account",
+		map[string]*llx.RawData{
+			"__id":                               llx.StringDataPtr(account.ID),
+			"id":                                 llx.StringDataPtr(account.ID),
+			"name":                               llx.StringDataPtr(account.Name),
+			"tags":                               llx.MapData(convert.PtrMapStrToInterface(account.Tags), types.String),
+			"location":                           llx.StringDataPtr(account.Location),
+			"kind":                               llx.StringDataPtr((*string)(account.Kind)),
+			"type":                               llx.StringDataPtr(account.Type),
+			"properties":                         llx.DictData(properties),
+			"publicNetworkAccess":                llx.StringDataPtr(publicNetworkAccess),
+			"disableLocalAuth":                   llx.BoolDataPtr(disableLocalAuth),
+			"isVirtualNetworkFilterEnabled":      llx.BoolDataPtr(isVirtualNetworkFilterEnabled),
+			"disableKeyBasedMetadataWriteAccess": llx.BoolDataPtr(disableKeyBasedMetadataWriteAccess),
+			"enableAutomaticFailover":            llx.BoolDataPtr(enableAutomaticFailover),
+			"enableMultipleWriteLocations":       llx.BoolDataPtr(enableMultipleWriteLocations),
+			"ipRangeFilter":                      llx.ArrayData(ipRangeFilter, types.String),
+			"minimalTlsVersion":                  llx.StringDataPtr(minimalTlsVersion),
+			"defaultIdentity":                    llx.StringDataPtr(defaultIdentity),
+			"backupType":                         llx.StringData(backupType),
+			"backupIntervalInMinutes":            llx.IntData(backupIntervalMinutes),
+			"backupRetentionIntervalInHours":     llx.IntData(backupRetentionHours),
+			"backupStorageRedundancy":            llx.StringData(backupRedundancy),
+			"virtualNetworkRules":                llx.ArrayData(virtualNetworkRules, types.Resource("azure.subscription.cosmosDbService.account.virtualNetworkRule")),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlAccount := mqlCosmosDbAccount.(*mqlAzureSubscriptionCosmosDbServiceAccount)
+	if account.Properties != nil && account.Properties.KeyVaultKeyURI != nil {
+		mqlAccount.cacheKeyVaultKeyUri = *account.Properties.KeyVaultKeyURI
+	}
+	return mqlCosmosDbAccount, nil
 }
 
 // cosmosEnumStrPtr converts a pointer to a string-based SDK enum into a *string,

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -66,29 +66,43 @@ func initAzureSubscriptionCacheServiceRedisInstance(runtime *plugin.Runtime, arg
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.cacheService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	cacheSvc := res.(*mqlAzureSubscriptionCacheService)
-	redisList := cacheSvc.GetRedis()
-	if redisList.Error != nil {
-		return nil, nil, redisList.Error
-	}
 	id, ok := args["id"].Value.(string)
 	if !ok {
 		return nil, nil, errors.New("id must be a non-nil string value")
 	}
-	for _, entry := range redisList.Data {
-		instance := entry.(*mqlAzureSubscriptionCacheServiceRedisInstance)
-		if instance.Id.Data == id {
-			return args, instance, nil
-		}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	cacheName, err := resourceID.Component("Redis")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, errors.New("azure cache redis instance does not exist")
+	clientFactory, err := armredis.NewClientFactory(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := clientFactory.NewClient().Get(context.Background(), resourceID.ResourceGroup, cacheName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rawData, err := createRedisInstanceRawData(runtime, &resp.ResourceInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := CreateResource(runtime, "azure.subscription.cacheService.redisInstance", rawData)
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlRedis := res.(*mqlAzureSubscriptionCacheServiceRedisInstance)
+	if resp.Properties != nil {
+		mqlRedis.cachePrivateEndpointConnections = resp.Properties.PrivateEndpointConnections
+	}
+	return args, mqlRedis, nil
 }
 
 func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {


### PR DESCRIPTION
## What

Closes the remaining actionable items from the 2026-06-07 Azure performance re-audit. Three changes, all behind-the-scenes (no schema change):

**D2 / D3 — `init` resolves one resource by id without listing the fleet.**
`initAzureSubscriptionCosmosDbServiceAccount` and `initAzureSubscriptionCacheServiceRedisInstance` listed every account / cache in the subscription and looped to find one. `init` runs whenever a single instance is referenced by id (a typed cross-reference, a direct `.account("…")` query, or asset resolution). Both now parse the ARM id and issue a direct `Get(resourceGroup, name)` — the pattern already used by the compute VM/disk and Key Vault inits. Cosmos's per-account conversion is extracted into `cosmosAccountToMql` so the list path and the by-id path share one converter; Redis reuses `createRedisInstanceRawData`.

**D1 — Cloud Defender shares one policy-assignments fetch.**
`forServers` and `forContainers` each independently issued a subscription-wide `Microsoft.Authorization/policyAssignments` list to derive their enabled/extension state. They now share a single `sync.Once`-cached fetch (`cachedPolicyAssignments` on a new service Internal struct).

> The rest of audit item D1 was a **false positive**: the deprecated `defenderForServers`/`defenderForContainers` dict methods already delegate through the cached `GetForServers()`/`GetForContainers()` accessors (the runtime field-cache dedupes them), and `defenderForApis`/`defenderCSPM` are standalone single calls. No duplicate `PricingsClient.Get` exists to remove.

## What this gets you — a mid-sized install (1000 instances, 100 storage accounts, 10 DBs, 30 key vaults)

Honest accounting, per CIS-style scan of that subscription:

| Change | Scope | This install | Saved per scan |
|---|---|---|---|
| **D1** Defender policy-assignments dedup | subscription-level | Defender plans scanned (both `forServers` + `forContainers`) | **1 fewer** subscription-wide policyAssignments list (2 → 1) |
| **D2** Cosmos init direct-Get | per by-id reference | no Cosmos accounts present | 0 (preventative) |
| **D3** Redis init direct-Get | per by-id reference | no Redis caches present | 0 (preventative) |

So for *this exact footprint* the direct win is small and subscription-level: **one redundant Defender policy-assignments list dropped per scan** (that call returns every policy assignment in the subscription, so it's not a trivial payload). D2/D3 are **preventative** — this install has no Cosmos/Redis, and even if the "10 DBs" included Cosmos accounts, a normal `.accounts` list scan doesn't hit `init`; only by-id cross-references do.

The reason there isn't a four-figure call reduction here is that **the fixes that scale with this footprint already shipped** (prior audit work): Key Vault 4×Get→1 (~90 calls saved across 30 vaults), Storage `GetServiceProperties` ×2→×1 (~100 across 100 accounts), SQL `connectionPolicy` per-DB dedup, and compute init direct-Get. This PR is the tail of that effort — it finishes the init-list-everything pattern for the two services that were still missing it, so the moment this install adds Cosmos or Redis and a policy cross-references them, each lookup is **O(1) instead of O(fleet)** (e.g. resolving one Cosmos account by reference goes from listing+converting all of them to a single `Get`).

## Not changed
- No `.lr` / schema change. `azure.lr.go` only gains the embedded Defender Internal struct.
- Same IAM permissions (reads cover both list and get); `permissions.json` only re-annotates the Cosmos/Redis source action (`NewListPager` → `Get`).
- The list paths (`.accounts`, `.redis`) are untouched — full-fleet scans paginate as before.

## Testing
Full provider builds; codegen idempotent; `gofmt` clean. Not yet run against a live subscription.
