### PR TITLE
⚡ Cache GCP HTTP clients/credentials per scope set; fix enabled-services race

### DIFF
--- a/providers/gcp/connection/clients.go
+++ b/providers/gcp/connection/clients.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/pkg/errors"
@@ -18,7 +20,34 @@ import (
 	"google.golang.org/api/transport"
 )
 
+// scopeCacheKey builds an order-independent cache key from a scope set so that
+// Client/Credentials calls with the same scopes (in any order) share a cached
+// result.
+func scopeCacheKey(scopes []string) string {
+	sorted := make([]string, len(scopes))
+	copy(sorted, scopes)
+	sort.Strings(sorted)
+	return strings.Join(sorted, " ")
+}
+
+// Credentials returns OAuth credentials for the given scopes, building them
+// once per scope set and caching the result on the connection. The credentials
+// carry a token source that refreshes internally, so reuse is both correct and
+// avoids re-parsing the service account / re-reading ADC on every call.
 func (c *GcpConnection) Credentials(scopes ...string) (*googleoauth.Credentials, error) {
+	key := scopeCacheKey(scopes)
+	if v, ok := c.credsCache.Load(key); ok {
+		return v.(*googleoauth.Credentials), nil
+	}
+	creds, err := c.buildCredentials(scopes...)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := c.credsCache.LoadOrStore(key, creds)
+	return actual.(*googleoauth.Credentials), nil
+}
+
+func (c *GcpConnection) buildCredentials(scopes ...string) (*googleoauth.Credentials, error) {
 	ctx := context.Background()
 	credParams := googleoauth.CredentialsParams{
 		Scopes:  scopes,
@@ -38,7 +67,23 @@ func (c *GcpConnection) Credentials(scopes ...string) (*googleoauth.Credentials,
 	return googleoauth.FindDefaultCredentials(ctx, scopes...)
 }
 
+// Client returns an HTTP client authorized for the given scopes, building it
+// once per scope set and caching it on the connection. http.Client is safe for
+// concurrent use, so the cached instance is shared across all callers.
 func (c *GcpConnection) Client(scope ...string) (*http.Client, error) {
+	key := scopeCacheKey(scope)
+	if v, ok := c.clientCache.Load(key); ok {
+		return v.(*http.Client), nil
+	}
+	client, err := c.buildClient(scope...)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := c.clientCache.LoadOrStore(key, client)
+	return actual.(*http.Client), nil
+}
+
+func (c *GcpConnection) buildClient(scope ...string) (*http.Client, error) {
 	ctx := context.Background()
 
 	// use service account from secret if one is provided

--- a/providers/gcp/connection/connection.go
+++ b/providers/gcp/connection/connection.go
@@ -5,6 +5,7 @@ package connection
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog/log"
@@ -36,6 +37,13 @@ type GcpConnection struct {
 	asset *inventory.Asset
 
 	opts gcpConnectionOptions
+
+	// clientCache and credsCache memoize the HTTP client / credentials per
+	// sorted scope set so that the per-asset auth stack (credential parse,
+	// token source, HTTP transport) is built once rather than on every API
+	// call. Keyed by scopeCacheKey.
+	clientCache sync.Map
+	credsCache  sync.Map
 }
 
 type gcpConnectionOptions struct {

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -34,10 +34,12 @@ func (g *mqlGcpProjects) id() (string, error) {
 
 type mqlGcpProjectInternal struct {
 	// serviceEnabled services
-	enabledServices map[string]struct{}
-	iamPolicyOnce   sync.Once
-	iamPolicyCache  *cloudresourcemanager.Policy
-	iamPolicyErr    error
+	enabledServices     map[string]struct{}
+	enabledServicesOnce sync.Once
+	enabledServicesErr  error
+	iamPolicyOnce       sync.Once
+	iamPolicyCache      *cloudresourcemanager.Policy
+	iamPolicyErr        error
 }
 
 func initGcpProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -533,23 +535,24 @@ func projectToMql(runtime *plugin.Runtime, p *cloudresourcemanager.Project) (*mq
 }
 
 func (g *mqlGcpProject) getEnabledServices() (map[string]struct{}, error) {
-	if g.enabledServices != nil {
-		return g.enabledServices, nil
-	}
+	g.enabledServicesOnce.Do(func() {
+		services := make(map[string]struct{})
+		enabledServices, err := g.fetchServices("state:ENABLED")
+		if err != nil {
+			g.enabledServicesErr = err
+			return
+		}
 
-	g.enabledServices = make(map[string]struct{})
-	enabledServices, err := g.fetchServices("state:ENABLED")
-	if err != nil {
-		return nil, err
-	}
+		for i := range enabledServices {
+			srv := enabledServices[i].(*mqlGcpService)
+			services[srv.Name.Data] = struct{}{}
+		}
+		// publish the fully-built map only after population so concurrent
+		// readers never observe a partially-filled map
+		g.enabledServices = services
+	})
 
-	for i := range enabledServices {
-		entry := enabledServices[i]
-		srv := entry.(*mqlGcpService)
-		g.enabledServices[srv.Name.Data] = struct{}{}
-	}
-
-	return g.enabledServices, nil
+	return g.enabledServices, g.enabledServicesErr
 }
 
 // isServiceEnabled is an internal helper function to check if a service is serviceEnabled


### PR DESCRIPTION
## What

Performance Tier 1 from the provider-wide API-call audit: the connection's `Client()` and `Credentials()` cached **nothing**, rebuilding the full auth stack on every call.

### The problem
`connection/clients.go` `Client()` / `Credentials()` re-ran the entire auth dance per invocation — re-parsing the service-account JSON (or re-reading ADC via `FindDefaultCredentials`), minting a fresh token source, and constructing a new `http.Client` + transport. With **~130 `Client()` call sites** across 35 files — many inside *per-item* field accessors (e.g. `machineType()` builds one per instance) — this overhead multiplied across the whole provider on top of the actual API round-trips.

### The fix
`Client()` and `Credentials()` now memoize on the `GcpConnection`, keyed by the **sorted scope set** (`sync.Map` + `scopeCacheKey`). The original bodies are preserved as `buildClient`/`buildCredentials`.
- `http.Client` is safe for concurrent use, so the cached instance is shared across all callers.
- The credentials' OAuth token source refreshes internally, so reuse is correct **and** stops re-minting tokens per call.
- Zero behavior change — same auth paths (service-account secret vs ADC), same quota-project plumbing.

### Bonus (Tier 4 — concurrency correctness)
`gcp.project.getEnabledServices()` did an unguarded check-then-set: it published a freshly-`make`d **empty** map (`g.enabledServices = make(...)`) *before* populating it, so a concurrent `isServiceEnabled()` from parallel service accessors could read a partial/empty map and mis-report a service as disabled. Now wrapped in `sync.Once`, building the map locally and publishing only when fully populated.

## What this buys (impact)

**Important framing:** this does **not** change the count of GCP *resource* API calls (List/Get on VMs, networks, LBs, DBs) — those are unchanged. It removes the **per-call auth overhead** that rode on top of every one of them. (Cutting the resource-call count itself is Tier 2 — see follow-up.)

**Mechanism:** before this PR, every `conn.Client(scope)` built a new token source that minted a fresh bearer token on first use — a round-trip to Google's token endpoint (or the metadata server). After it, that happens once per distinct scope set (~5–10 of them across the provider) and refreshes ~hourly.

**For a mid-sized project** (~hundreds of each: VMs, networks, load balancers, DBs, plus tables/keys/secrets/topics) a comprehensive cnspec scan hits many per-item accessors that each built their own client:

| | Before | After |
|---|---|---|
| `conn.Client()` / `Credentials()` builds | ~1,000–5,000 | ~5–10 (one per scope set) |
| OAuth token-endpoint round-trips | ~hundreds–thousands | ~one per scope set per hour |
| Service-account-JSON parses / TLS-transport allocations | ~1,000–5,000 | ~5–10 |

So the auth/token traffic drops by ~2–3 orders of magnitude, and the per-call CPU + allocation churn is essentially eliminated.

**Practical effect:**
- **Latency**: each eliminated token mint was a ~50–150 ms round-trip; removing hundreds–thousands of them shaves meaningful seconds off scan wall-clock and removes a token-endpoint rate-limit/quota risk that bites hardest exactly when scanning many assets concurrently.
- **CPU/memory**: thousands of credential parses and `http.Client`/TLS-transport allocations per scan → gone; lower GC churn and steady-state memory.
- **Correctness (race fix)**: under parallel accessors, the old `getEnabledServices` could mis-read a service as *disabled* and silently skip its resources from results — an intermittent wrong answer, now deterministic.

## Testing

- `go build ./...`, `go vet ./connection/ ./resources/` — clean (the pre-existing `gcloud_config.go:30` unreachable-code note is untouched)
- `gofmt -l` — clean
- `go test -race ./connection/` and `go test ./resources/` — pass
- No `.lr`/schema changes; no codegen, no permission changes

## Follow-up

This is Tier 1 (+ the trivial Tier 4 race) of the audit. **Tier 2** — the actual resource-call reduction — is the next PR: direct-`Get`-first in the resolve-by-name `init`s (compute instance / service account / network / subnetwork) and the `region()`/`zone()`/`machineType()` N+1s. Example on 300 VMs: `instances { machineType }` today makes ~300 `MachineTypes.Get` + ~300 zone `Get` calls; Tier 2 collapses each to a single cached `AggregatedList`. Tier 3 is per-item SDK-client reuse (Pub/Sub, BigQuery table IAM, Bigtable, Dataproc).