### PR TITLE
🐛 aws: fix aws.vpc.peeringConnections always returning empty

### DIFF
--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -517,58 +517,70 @@ func (a *mqlAwsVpc) peeringConnections() ([]any, error) {
 	svc := conn.Ec2(a.Region.Data)
 	ctx := context.Background()
 	pcs := []any{}
-	filterKeyVal := "requester-vpc-info.vpc-id"
-	filterKeyVal2 := "accepter-vpc-info.vpc-id"
+	seen := map[string]struct{}{}
 
-	params := &ec2.DescribeVpcPeeringConnectionsInput{Filters: []vpctypes.Filter{{Name: &filterKeyVal, Values: []string{vpc}}, {Name: &filterKeyVal2, Values: []string{vpc}}}}
-	paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(svc, params)
-	for paginator.HasMorePages() {
-		res, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, peerconn := range res.VpcPeeringConnections {
-			status := ""
-			if peerconn.Status != nil {
-				status = *peerconn.Status.Message
-			}
-			// Determine DNS resolution status from peering options
-			dnsResolution := false
-			if peerconn.RequesterVpcInfo != nil && peerconn.RequesterVpcInfo.PeeringOptions != nil &&
-				peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
-				dnsResolution = *peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
-			}
-			if !dnsResolution && peerconn.AccepterVpcInfo != nil && peerconn.AccepterVpcInfo.PeeringOptions != nil &&
-				peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
-				dnsResolution = *peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
-			}
-
-			var requesterAccountId, accepterAccountId string
-			if peerconn.RequesterVpcInfo != nil {
-				requesterAccountId = convert.ToValue(peerconn.RequesterVpcInfo.OwnerId)
-			}
-			if peerconn.AccepterVpcInfo != nil {
-				accepterAccountId = convert.ToValue(peerconn.AccepterVpcInfo.OwnerId)
-			}
-
-			mqlPeerConn, err := CreateResource(a.MqlRuntime, ResourceAwsVpcPeeringConnection,
-				map[string]*llx.RawData{
-					"expirationTime":       llx.TimeDataPtr(peerconn.ExpirationTime),
-					"id":                   llx.StringDataPtr(peerconn.VpcPeeringConnectionId),
-					"status":               llx.StringData(status),
-					"tags":                 llx.MapData(toInterfaceMap(ec2TagsToMap(peerconn.Tags)), types.String),
-					"requesterAccountId":   llx.StringData(requesterAccountId),
-					"accepterAccountId":    llx.StringData(accepterAccountId),
-					"dnsResolutionEnabled": llx.BoolData(dnsResolution),
-				},
-			)
+	// A peering connection records this VPC in exactly one of requester-vpc-info
+	// or accepter-vpc-info, never both. AWS ANDs multiple Filters entries, so a
+	// single request filtering on both keys would require this VPC to be both
+	// ends of the same connection (impossible) and always returns nothing.
+	// Query each side separately and union the results, de-duplicating by id.
+	for _, filterKey := range []string{"requester-vpc-info.vpc-id", "accepter-vpc-info.vpc-id"} {
+		params := &ec2.DescribeVpcPeeringConnectionsInput{Filters: []vpctypes.Filter{{Name: &filterKey, Values: []string{vpc}}}}
+		paginator := ec2.NewDescribeVpcPeeringConnectionsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			res, err := paginator.NextPage(ctx)
 			if err != nil {
 				return nil, err
 			}
-			mqlPeerConn.(*mqlAwsVpcPeeringConnection).peeringConnectionCache = peerconn
-			mqlPeerConn.(*mqlAwsVpcPeeringConnection).region = a.Region.Data
-			pcs = append(pcs, mqlPeerConn)
+
+			for _, peerconn := range res.VpcPeeringConnections {
+				id := convert.ToValue(peerconn.VpcPeeringConnectionId)
+				if _, ok := seen[id]; ok {
+					continue
+				}
+				seen[id] = struct{}{}
+
+				status := ""
+				if peerconn.Status != nil {
+					status = convert.ToValue(peerconn.Status.Message)
+				}
+				// Determine DNS resolution status from peering options
+				dnsResolution := false
+				if peerconn.RequesterVpcInfo != nil && peerconn.RequesterVpcInfo.PeeringOptions != nil &&
+					peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
+					dnsResolution = *peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
+				}
+				if !dnsResolution && peerconn.AccepterVpcInfo != nil && peerconn.AccepterVpcInfo.PeeringOptions != nil &&
+					peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
+					dnsResolution = *peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
+				}
+
+				var requesterAccountId, accepterAccountId string
+				if peerconn.RequesterVpcInfo != nil {
+					requesterAccountId = convert.ToValue(peerconn.RequesterVpcInfo.OwnerId)
+				}
+				if peerconn.AccepterVpcInfo != nil {
+					accepterAccountId = convert.ToValue(peerconn.AccepterVpcInfo.OwnerId)
+				}
+
+				mqlPeerConn, err := CreateResource(a.MqlRuntime, ResourceAwsVpcPeeringConnection,
+					map[string]*llx.RawData{
+						"expirationTime":       llx.TimeDataPtr(peerconn.ExpirationTime),
+						"id":                   llx.StringDataPtr(peerconn.VpcPeeringConnectionId),
+						"status":               llx.StringData(status),
+						"tags":                 llx.MapData(toInterfaceMap(ec2TagsToMap(peerconn.Tags)), types.String),
+						"requesterAccountId":   llx.StringData(requesterAccountId),
+						"accepterAccountId":    llx.StringData(accepterAccountId),
+						"dnsResolutionEnabled": llx.BoolData(dnsResolution),
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				mqlPeerConn.(*mqlAwsVpcPeeringConnection).peeringConnectionCache = peerconn
+				mqlPeerConn.(*mqlAwsVpcPeeringConnection).region = a.Region.Data
+				pcs = append(pcs, mqlPeerConn)
+			}
 		}
 	}
 	return pcs, nil


### PR DESCRIPTION
## Problem

`aws.vpc.peeringConnections` always returned an empty list, even for VPCs with active peering connections. `aws.vpc.peeringConnection.peeringVpc.vpcId` (and the requestor/acceptor VPC accessors) were therefore unreachable.

## Root cause

`DescribeVpcPeeringConnections` was called with **both** the `requester-vpc-info.vpc-id` and `accepter-vpc-info.vpc-id` filters in a single request:

```go
Filters: []vpctypes.Filter{
    {Name: &filterKeyVal,  Values: []string{vpc}}, // requester-vpc-info.vpc-id
    {Name: &filterKeyVal2, Values: []string{vpc}}, // accepter-vpc-info.vpc-id
}
```

AWS combines multiple `Filters` entries with **AND**, so this asks for connections where the same VPC is *both* the requester *and* the accepter — impossible for any real connection — so the result is always empty. Reproduced with the AWS CLI: both filters together → `[]`; each filter alone → the connection.

## Fix

Issue the two filters as **separate** `DescribeVpcPeeringConnections` calls and union the results, de-duplicating by `VpcPeeringConnectionId`. Also harden the status read: `Status.Message` can be nil, so use `convert.ToValue(...)` instead of a raw pointer dereference (previously a latent nil-panic that the always-empty result happened to mask).

## Verification

Built and run against a live AWS account with an active peering connection (`pcx-…`, default VPC as requester):

```
aws.vpcs.where(id == "vpc-6be2c011") {
  peeringConnections { id status requestorVpc { vpcId } acceptorVpc { vpcId } }
}
```
returns:
```
peeringConnections: [{ id: "pcx-0f38c3b4d7c51b023", status: "Active",
  requestorVpc: { vpcId: "vpc-6be2c011" },
  acceptorVpc:  { vpcId: "vpc-0745b78e9d10f57c2" } }]
```
(previously `peeringConnections: []`).

Found during live verification of the last 48h of AWS/Azure/GCP provider changes. No `.lr` schema or `aws.permissions.json` change (same `ec2:DescribeVpcPeeringConnections` permission).