### PR TITLE
🐛 firewalld: trigger command execution before reading stdout

### DIFF
--- a/providers/os/resources/firewalld.go
+++ b/providers/os/resources/firewalld.go
@@ -101,8 +101,9 @@ func (f *mqlFirewalld) fetchStatus() error {
 		return nil
 	}
 	cmd := o.(*mqlCommand)
-	state := strings.TrimSpace(cmd.Stdout.Data)
-	if cmd.GetExitcode().Data != 0 || state != "running" {
+	exitcode := cmd.GetExitcode().Data
+	state := strings.TrimSpace(cmd.GetStdout().Data)
+	if exitcode != 0 || state != "running" {
 		f.cacheStatus = "not running"
 		f.fetched = true
 		return nil


### PR DESCRIPTION
https://github.com/mondoo-community/workspace-verkehrsbuero/issues/75

## Summary
- `firewalld.fetchStatus` read `cmd.Stdout.Data` by direct struct-field access *before* calling any getter on the command resource. Lazy execution is only triggered by `GetStdout()` / `GetExitcode()` (which route through `plugin.GetOrCompute`), so `firewall-cmd --state` never ran for that read and `state` was captured as the zero-value empty string. `state != "running"` was therefore always true, falling through to `cacheStatus = "not running"`.
- Net effect on every host where firewalld is running: `firewalld.status` returns `"not running"`, `firewalld.defaultZone` returns `""`, and `firewalld.zones` returns `[]` (the `cacheStatus != "running"` guard in `zones()` short-circuits to `nil`). Downstream queries like `firewalld.zones.where(interfaces.contains("lo"))` are unreachable.
- Fix: call `GetExitcode()` and `GetStdout()` (in that order) so execution fires and the populated values are read. All other call sites in `firewalld.go` (`defaultZone`, `zones`) already use this ordering — only the `--state` path was inverted.

## Test plan
- [x] `go build ./resources/...` clean
- [x] `go test -run TestParseFirewalld ./resources/` passes
- [ ] Customer-side: `sudo cnspec run -c 'firewalld { status defaultZone }; firewalld.zones { name active interfaces }'` on a host with firewalld running should now report `status: "running"` and a populated zones list, and `firewalld.zones.where(interfaces.contains("lo"))` should resolve the `trusted` zone (reproducer case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)