### PR TITLE
🎉 os-13.23.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.22.1",
+	Version: "13.23.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
## Summary

Release os-13.23.0. Generated by `providers-sdk/v1/util/version`.

### os (13.23.0)
- 🐛 firewalld: trigger command execution before reading stdout (#8245)
- ✨ Add parsed params map to rsyslog.conf resource (#8054) (#8218)
- ✨ Expose PAM module options as parsed key/value pairs (#8055) (#8217)
- ✨ Add success/failure booleans to auditpol.entry (#8056) (#8216)
- ✨ Resolve machine.secureboot on Windows (#8058) (#8215)
- ✨ Add windows.tpm resource (#8057) (#8214)
- ✨ Add windows.eventlog resource for Event Log channel policy (#8059) (#8213)
- ✨ Add windows.rdp (Terminal Services) resource (#8060) (#8212)
- ✨ Add chrony.conf, yum.config, and apt repository resources to the OS provider (#8207)
- ⚡ windows.optionalFeature: look up one feature instead of enumerating all (#8061)

## Test plan
- [ ] Provider builds (`make providers/build/os`)
- [ ] CI release workflow tags + publishes the new provider artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)