### PR TITLE
:star: Add tls.certificateMatchesDomain field

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -181,6 +181,16 @@ tls @defaults("socket domainName") {
   certificates(socket, domainName) []certificate
   // Certificates provided without server name indication (SNI)
   nonSniCertificates(socket, domainName) []certificate
+  // Whether the served leaf certificate covers the connection hostname
+  //
+  // Matches the connection's domain name against the leaf certificate's
+  // Subject Alternative Name DNS entries using RFC 6125 wildcard rules,
+  // so `*.example.com` covers `api.example.com`. Unlike chain
+  // verification, this isolates hostname coverage — it is true when the
+  // certificate vouches for the host you connected to, independent of
+  // chain trust or expiry. Null when the connection has no domain name
+  // to match, such as when connecting directly to an IP address.
+  certificateMatchesDomain() bool
 }
 
 // X.509 certificate bundle

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -368,6 +368,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tls.nonSniCertificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTls).GetNonSniCertificates()).ToDataRes(types.Array(types.Resource("certificate")))
 	},
+	"tls.certificateMatchesDomain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTls).GetCertificateMatchesDomain()).ToDataRes(types.Bool)
+	},
 	"certificates.pem": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCertificates).GetPem()).ToDataRes(types.String)
 	},
@@ -945,6 +948,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"tls.nonSniCertificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTls).NonSniCertificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"tls.certificateMatchesDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTls).CertificateMatchesDomain, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"certificates.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2134,17 +2141,18 @@ type mqlTls struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlTlsInternal
-	Socket             plugin.TValue[*mqlSocket]
-	DomainName         plugin.TValue[string]
-	Params             plugin.TValue[any]
-	Versions           plugin.TValue[[]any]
-	Ciphers            plugin.TValue[[]any]
-	Extensions         plugin.TValue[[]any]
-	NegotiatedGroup    plugin.TValue[string]
-	NegotiatedVersion  plugin.TValue[string]
-	NegotiatedCipher   plugin.TValue[string]
-	Certificates       plugin.TValue[[]any]
-	NonSniCertificates plugin.TValue[[]any]
+	Socket                   plugin.TValue[*mqlSocket]
+	DomainName               plugin.TValue[string]
+	Params                   plugin.TValue[any]
+	Versions                 plugin.TValue[[]any]
+	Ciphers                  plugin.TValue[[]any]
+	Extensions               plugin.TValue[[]any]
+	NegotiatedGroup          plugin.TValue[string]
+	NegotiatedVersion        plugin.TValue[string]
+	NegotiatedCipher         plugin.TValue[string]
+	Certificates             plugin.TValue[[]any]
+	NonSniCertificates       plugin.TValue[[]any]
+	CertificateMatchesDomain plugin.TValue[bool]
 }
 
 // createTls creates a new instance of this resource
@@ -2338,6 +2346,12 @@ func (c *mqlTls) GetNonSniCertificates() *plugin.TValue[[]any] {
 		}
 
 		return c.nonSniCertificates(vargSocket.Data, vargDomainName.Data)
+	})
+}
+
+func (c *mqlTls) GetCertificateMatchesDomain() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CertificateMatchesDomain, func() (bool, error) {
+		return c.certificateMatchesDomain()
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -160,6 +160,7 @@ socket.address 9.0.0
 socket.port 9.0.0
 socket.protocol 9.0.0
 tls 9.0.0
+tls.certificateMatchesDomain 13.0.8
 tls.certificates 9.0.0
 tls.ciphers 9.0.0
 tls.domainName 9.0.0

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -481,6 +481,48 @@ func (s *mqlTls) nonSniCertificates(socket *mqlSocket, domainName string) ([]any
 	return nil, s.populateCertificates(socket, domainName)
 }
 
+// certificateMatchesDomain reports whether the served leaf certificate covers
+// the connection's domain name, applying RFC 6125 SAN matching (including
+// wildcards). It isolates hostname coverage from chain trust and expiry. When
+// there is no domain name to match (e.g. connecting directly to an IP), the
+// field is null.
+func (s *mqlTls) certificateMatchesDomain() (bool, error) {
+	domainName := s.GetDomainName()
+	if domainName.Error != nil {
+		return false, domainName.Error
+	}
+	if domainName.Data == "" {
+		s.CertificateMatchesDomain.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
+	certs := s.GetCertificates()
+	if certs.Error != nil {
+		return false, certs.Error
+	}
+	if len(certs.Data) == 0 {
+		s.CertificateMatchesDomain.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
+	leaf, ok := certs.Data[0].(*mqlCertificate)
+	if !ok || leaf.cert.Data == nil {
+		s.CertificateMatchesDomain.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
+	return certMatchesDomain(leaf.cert.Data, domainName.Data), nil
+}
+
+// certMatchesDomain reports whether the certificate is valid for the given
+// domain name. It applies RFC 6125 matching against the certificate's Subject
+// Alternative Name DNS entries, including wildcards (`*.example.com` covers
+// `api.example.com`). Following modern client behavior, the Subject Common
+// Name is not consulted.
+func certMatchesDomain(cert *x509.Certificate, domainName string) bool {
+	return cert.VerifyHostname(domainName) == nil
+}
+
 // getConnectionState performs a single Go stdlib TLS connection and caches the result.
 // All three negotiated* fields share this connection — only one dial is made.
 func (s *mqlTls) getConnectionState(socket *mqlSocket, domainName string) (*tls.ConnectionState, error) {

--- a/providers/network/resources/tls_match_test.go
+++ b/providers/network/resources/tls_match_test.go
@@ -105,16 +105,16 @@ func TestCertMatchesDomain(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:     "ip SAN match",
-			ips:      []net.IP{net.ParseIP("10.0.0.1")},
-			domain:   "10.0.0.1",
-			want:     true,
+			name:   "ip SAN match",
+			ips:    []net.IP{net.ParseIP("10.0.0.1")},
+			domain: "10.0.0.1",
+			want:   true,
 		},
 		{
-			name:     "ip SAN mismatch",
-			ips:      []net.IP{net.ParseIP("10.0.0.1")},
-			domain:   "10.0.0.2",
-			want:     false,
+			name:   "ip SAN mismatch",
+			ips:    []net.IP{net.ParseIP("10.0.0.1")},
+			domain: "10.0.0.2",
+			want:   false,
 		},
 	}
 

--- a/providers/network/resources/tls_match_test.go
+++ b/providers/network/resources/tls_match_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// makeCert builds a self-signed certificate carrying the given SAN DNS names,
+// SAN IP addresses, and Subject Common Name.
+func makeCert(t *testing.T, commonName string, dnsNames []string, ips []net.IP) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     dnsNames,
+		IPAddresses:  ips,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	return cert
+}
+
+func TestCertMatchesDomain(t *testing.T) {
+	testCases := []struct {
+		name       string
+		commonName string
+		dnsNames   []string
+		ips        []net.IP
+		domain     string
+		want       bool
+	}{
+		{
+			name:     "exact SAN match",
+			dnsNames: []string{"example.com"},
+			domain:   "example.com",
+			want:     true,
+		},
+		{
+			name:     "SAN mismatch",
+			dnsNames: []string{"example.com"},
+			domain:   "other.com",
+			want:     false,
+		},
+		{
+			name:     "wildcard covers subdomain",
+			dnsNames: []string{"*.example.com"},
+			domain:   "api.example.com",
+			want:     true,
+		},
+		{
+			name:     "wildcard does not cover bare apex",
+			dnsNames: []string{"*.example.com"},
+			domain:   "example.com",
+			want:     false,
+		},
+		{
+			name:     "wildcard does not cover nested subdomain",
+			dnsNames: []string{"*.example.com"},
+			domain:   "a.b.example.com",
+			want:     false,
+		},
+		{
+			name:     "case insensitive match",
+			dnsNames: []string{"example.com"},
+			domain:   "EXAMPLE.COM",
+			want:     true,
+		},
+		{
+			name:       "common name is not consulted when SANs present",
+			commonName: "example.com",
+			dnsNames:   []string{"other.com"},
+			domain:     "example.com",
+			want:       false,
+		},
+		{
+			name:       "common name alone never matches",
+			commonName: "example.com",
+			domain:     "example.com",
+			want:       false,
+		},
+		{
+			name:     "ip SAN match",
+			ips:      []net.IP{net.ParseIP("10.0.0.1")},
+			domain:   "10.0.0.1",
+			want:     true,
+		},
+		{
+			name:     "ip SAN mismatch",
+			ips:      []net.IP{net.ParseIP("10.0.0.1")},
+			domain:   "10.0.0.2",
+			want:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := makeCert(t, tc.commonName, tc.dnsNames, tc.ips)
+			if got := certMatchesDomain(cert, tc.domain); got != tc.want {
+				t.Errorf("certMatchesDomain(%q) = %v, want %v", tc.domain, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a `certificateMatchesDomain` boolean to the `tls` resource: whether the served leaf certificate covers the hostname the connection targeted.

## Why

Auditing "is the served cert valid for this host?" currently means hand-rolling RFC 6125 matching in MQL — CN match, exact SAN match, and wildcard SAN match all spelled out by hand:

```
checkA1 = tls.certificates.first.subject.commonName == asset.fqdn
if(tls.certificates.first.subject.commonName.contains(/^\*/)) {
  checkA1 == asset.fqdn.contains(tls.certificates.first.subject.commonName.split("*.")[1])
}
checkA2 = tls.certificates.first.sanExtension.dnsNames.contains(asset.fqdn)
checkA3 = tls.certificates.first.sanExtension.dnsNames.where(_ == /\*/).where(_.split(".")[-2] + "." + _.split(".")[-1]).any(asset.name.contains(_.split("*.")[1]))
checkA1 || checkA2 || checkA3
```

This is verbose, untested, and the wildcard arm is subtly wrong (non-boolean `where` body, matches `asset.name` instead of `asset.fqdn`). The `tls` resource already knows the hostname it connected to (`domainName`) and already runs full chain verification — the matching logic belongs in the provider where it can be tested, not re-derived per query.

The whole block collapses to:

```
tls.certificateMatchesDomain
```

## How

- New computed field `tls.certificateMatchesDomain() bool`.
- Backed by `x509.Certificate.VerifyHostname` against the resource's own `domainName` — SAN DNS names + RFC 6125 wildcards. **No CN fallback**, consistent with the existing chain `Verify` and with modern client/browser behavior (Go dropped CN matching in 1.15). CN-only certs report `false`, which is the correct audit outcome.
- Returns **null** when there's no domain to match (e.g. connecting directly to an IP), so an audit can distinguish "no hostname" from "hostname mismatch".
- Matching extracted into a `certMatchesDomain` helper and covered by a network-free table test (`tls_match_test.go`): exact/mismatch, wildcard covers-subdomain / not-apex / not-nested, case-insensitivity, CN-not-consulted, IP SAN match/mismatch.

## Testing

- `go test ./providers/network/resources/ -run TestCertMatchesDomain` — all 10 cases pass.
- Live: `tls("mondoo.com").certificateMatchesDomain` → `true`.
