### PR TITLE
:star: Add dns.reverse field for reverse DNS (PTR) records

### DIFF
--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -293,3 +293,83 @@ func (d *mqlDnsDkimRecord) valid() (bool, error) {
 	ok, _, _ := d.dkim.Valid()
 	return ok, nil
 }
+
+// addressesFromParams extracts the resolved IPv4 (A) and IPv6 (AAAA) addresses
+// from a dns params dict.
+func addressesFromParams(params any) ([]string, error) {
+	paramsM, ok := params.(map[string]any)
+	if !ok {
+		return nil, errors.New("incorrect structure of params received")
+	}
+
+	addrs := []string{}
+	for _, key := range []string{"A", "AAAA"} {
+		entry, ok := paramsM[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		rdata, ok := entry["rData"].([]any)
+		if !ok {
+			continue
+		}
+		for _, v := range rdata {
+			if s, ok := v.(string); ok && s != "" {
+				addrs = append(addrs, s)
+			}
+		}
+	}
+	return addrs, nil
+}
+
+func (d *mqlDns) reverse(params any) ([]any, error) {
+	addrs, err := addressesFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resultMap := make(map[string]*mqlDnsRecord)
+	for _, addr := range addrs {
+		// dns.ReverseAddr builds the in-addr.arpa (IPv4) or ip6.arpa (IPv6)
+		// name; it returns an error for malformed addresses, which we skip.
+		arpa, err := dns.ReverseAddr(addr)
+		if err != nil {
+			continue
+		}
+
+		shaker, err := dnsshake.New(arpa)
+		if err != nil {
+			return nil, err
+		}
+
+		records, err := shaker.Query("PTR")
+		if err != nil {
+			return nil, err
+		}
+
+		ptr, ok := records["PTR"]
+		if !ok || ptr.RCode != dns.RcodeToString[dns.RcodeSuccess] {
+			continue
+		}
+
+		o, err := CreateResource(d.MqlRuntime, "dns.record", map[string]*llx.RawData{
+			"name":  llx.StringData(ptr.Name),
+			"ttl":   llx.IntData(ptr.TTL),
+			"class": llx.StringData(ptr.Class),
+			"type":  llx.StringData(ptr.Type),
+			"rdata": llx.ArrayData(llx.TArr2Raw(ptr.RData), types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		record := o.(*mqlDnsRecord)
+		resultMap[record.__id] = record
+	}
+
+	keys := sortx.Keys(resultMap)
+	res := []any{}
+	for i := range keys {
+		res = append(res, resultMap[keys[i]])
+	}
+	return res, nil
+}

--- a/providers/network/resources/dns_reverse_test.go
+++ b/providers/network/resources/dns_reverse_test.go
@@ -1,0 +1,99 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestAddressesFromParams(t *testing.T) {
+	testCases := []struct {
+		name    string
+		params  any
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "single A record",
+			params: map[string]any{
+				"A": map[string]any{"rData": []any{"1.2.3.4"}},
+			},
+			want: []string{"1.2.3.4"},
+		},
+		{
+			name: "multiple A records and AAAA",
+			params: map[string]any{
+				"A":    map[string]any{"rData": []any{"1.2.3.4", "5.6.7.8"}},
+				"AAAA": map[string]any{"rData": []any{"2001:db8::1"}},
+			},
+			want: []string{"1.2.3.4", "5.6.7.8", "2001:db8::1"},
+		},
+		{
+			name: "no address records",
+			params: map[string]any{
+				"MX": map[string]any{"rData": []any{"mail.example.com"}},
+			},
+			want: []string{},
+		},
+		{
+			name: "empty and non-string rdata skipped",
+			params: map[string]any{
+				"A": map[string]any{"rData": []any{"1.2.3.4", "", 42}},
+			},
+			want: []string{"1.2.3.4"},
+		},
+		{
+			name:    "wrong params type",
+			params:  "not a map",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := addressesFromParams(tc.params)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("addressesFromParams() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("addressesFromParams() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReverseAddrName documents the in-addr.arpa / ip6.arpa names the reverse
+// field relies on — the transform that previously had to be hand-rolled in MQL.
+func TestReverseAddrName(t *testing.T) {
+	testCases := []struct {
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{addr: "1.2.3.4", want: "4.3.2.1.in-addr.arpa."},
+		{addr: "2001:db8::1", want: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."},
+		{addr: "not-an-ip", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.addr, func(t *testing.T) {
+			got, err := dns.ReverseAddr(tc.addr)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("dns.ReverseAddr(%q) error = %v, wantErr %v", tc.addr, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got != tc.want {
+				t.Errorf("dns.ReverseAddr(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -444,6 +444,13 @@ dns @defaults("fqdn") {
   mx(params) []dns.mxRecord
   // DKIM TXT records
   dkim(params) []dns.dkimRecord
+  // Reverse DNS (PTR) records for the domain's resolved addresses
+  //
+  // Resolves the domain's A and AAAA addresses, then looks up the PTR
+  // record for each — the forward-confirmed reverse DNS round trip. Use
+  // it to confirm an address resolves back to the expected hostname
+  // without hand-building `in-addr.arpa` names.
+  reverse(params) []dns.record
 }
 
 // DNS record

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -641,6 +641,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"dns.dkim": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetDkim()).ToDataRes(types.Array(types.Resource("dns.dkimRecord")))
 	},
+	"dns.reverse": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetReverse()).ToDataRes(types.Array(types.Resource("dns.record")))
+	},
 	"dns.record.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDnsRecord).GetName()).ToDataRes(types.String)
 	},
@@ -1357,6 +1360,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"dns.dkim": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDns).Dkim, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"dns.reverse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).Reverse, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"dns.record.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3411,6 +3418,7 @@ type mqlDns struct {
 	Records plugin.TValue[[]any]
 	Mx      plugin.TValue[[]any]
 	Dkim    plugin.TValue[[]any]
+	Reverse plugin.TValue[[]any]
 }
 
 // createDns creates a new instance of this resource
@@ -3525,6 +3533,27 @@ func (c *mqlDns) GetDkim() *plugin.TValue[[]any] {
 		}
 
 		return c.dkim(vargParams.Data)
+	})
+}
+
+func (c *mqlDns) GetReverse() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Reverse, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("dns", c.__id, "reverse")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargParams := c.GetParams()
+		if vargParams.Error != nil {
+			return nil, vargParams.Error
+		}
+
+		return c.reverse(vargParams.Data)
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -62,6 +62,7 @@ dns.record.rdata 9.0.1
 dns.record.ttl 9.0.1
 dns.record.type 9.0.1
 dns.records 9.0.1
+dns.reverse 13.0.8
 domainName 9.0.1
 domainName.effectiveTLDPlusOne 9.0.1
 domainName.fqdn 9.0.1


### PR DESCRIPTION
## What

Adds a `reverse` field to the `dns` resource: the reverse DNS (PTR) records for the domain's resolved addresses.

## Why

Verifying that a domain's address resolves back to its hostname (forward-confirmed reverse DNS) currently means reversing the IPv4 octets and building the `in-addr.arpa` name by hand in MQL, then doing a second nested `dns()` lookup:

```
reverseDNSDomain =
  dns.params.A.rData.first.split(".")[3] + "."
    + dns.params.A.rData.first.split(".")[2] + "."
    + dns.params.A.rData.first.split(".")[1] + "."
    + dns.params.A.rData.first.split(".")[0]
    + ".in-addr.arpa"
dns(reverseDNSDomain).params.PTR.rData.any(_.contains(domainName.fqdn))
```

This is verbose, **IPv4-only** (hardcoded to four octets), only checks the *first* A record, and the transform can't be tested.

## How

The new `reverse` field resolves the domain's A and AAAA addresses, builds the reverse-lookup name for each with `dns.ReverseAddr` (covering both `in-addr.arpa` and `ip6.arpa`), runs the PTR lookup, and returns the results as `[]dns.record` — so `.rdata`, `.name`, `.ttl` all work as they do for forward records.

- Covers **all** A and AAAA addresses, not just the first.
- IPv6 works for free.
- The address-extraction and arpa-transform logic lives in Go and is unit-tested.

The whole block collapses to:

```
dns("example.com").reverse.any(rdata.any(_.contains(domainName.fqdn)))
```

## Testing

- `go test ./providers/network/resources/ -run 'TestAddressesFromParams|TestReverseAddrName'` — passes (address extraction across A/AAAA/empty/malformed shapes; IPv4 + IPv6 arpa names).
- `golangci-lint run ./resources/...` — 0 issues.
- Live, against a domain with PTR records for both IPv4 and IPv6:

```
dns("one.one.one.one").reverse { name rdata }
# => 1.1.1.1.in-addr.arpa. -> one.one.one.one.
#    1.0.0.1.in-addr.arpa. -> one.one.one.one.
#    ...2.6.0.6.4.7.0.0...ip6.arpa. -> one.one.one.one.

dns("one.one.one.one").reverse.any(rdata.any(_.contains("one.one.one.one")))
# => true
```
