### PR TITLE
🎉 network-13.1.0

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.0.7",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	CrossProviderTypes: []string{
 		"go.mondoo.com/mql/providers/os",


### PR DESCRIPTION
Minor version bump for the **network** provider: `13.0.7` → `13.1.0`.

## PRs merged since the last release (network-13.0.7, #7959)

- #8251 — 🌙 Add `dns.reverse` field for reverse DNS (PTR) records
- #8249 — ⭐ Add `tls.certificateMatchesDomain` field