### PR TITLE
🐛 aws: drop deprecated kinesisStreamArn from userAccessLoggingSetting defaults

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.33.0",
+	Version:         "13.33.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -18838,7 +18838,7 @@ private aws.workspaces.ipGroup @defaults("groupId groupName region") {
 }
 
 // Amazon WorkSpaces Web user access logging setting
-private aws.workspacesweb.userAccessLoggingSetting @defaults("userAccessLoggingSettingsArn kinesisStreamArn region") {
+private aws.workspacesweb.userAccessLoggingSetting @defaults("userAccessLoggingSettingsArn region") {
   // Settings ARN
   userAccessLoggingSettingsArn string
   // Kinesis data stream for logging

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.32.1",
-  "generated_at": "2026-06-07T13:33:02-07:00",
+  "version": "13.33.1",
+  "generated_at": "2026-06-08T11:10:44-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",


### PR DESCRIPTION
## Summary

`aws.workspacesweb.userAccessLoggingSetting` listed the deprecated `kinesisStreamArn` field in its `@defaults(...)`. Default fields are auto-expanded into the compiled query so the resource can be rendered, so merely *referencing* the resource pulled in `kinesisStreamArn` and tripped `query-deprecated-symbol` — even when the query never touches that field:

```mql
aws.workspacesweb.portals.all(userAccessLoggingSetting != null)
```
→ warned: `uses deprecated field 'aws.workspacesweb.userAccessLoggingSetting.kinesisStreamArn'`

This blocked migrating the deprecated `portal.userAccessLoggingSettingsArn` string to the typed `portal.userAccessLoggingSetting` resource — switching just traded one deprecation warning for another, so the warning could not be cleared in cnspec-enterprise-policies.

## Fix

Remove `kinesisStreamArn` from `@defaults` so referencing the resource no longer forces its initialization. The field stays available and still `@maturity("deprecated")`, so callers who *explicitly* select it still get the deprecation warning — which is the intended behavior.

## Changes

- `providers/aws/resources/aws.lr` — drop `kinesisStreamArn` from the resource's `@defaults(...)`
- `providers/aws/config/config.go` — bump aws provider to `13.33.1`
- `providers/aws/resources/aws.permissions.json` — regenerated (version header only; no permission changes)

Fixes #8224