### PR TITLE
✨ Add snmpd config resource to simplify SNMP community-string audits

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1148,6 +1148,39 @@ private inetd.config.entry @defaults("name protocol server") @context("file.cont
   arguments string
 }
 
+// Net-SNMP daemon (snmpd) namespace
+//
+// Use snmpd.config to examine the effective SNMP daemon configuration.
+snmpd {}
+
+// Net-SNMP daemon (snmpd) configuration
+//
+// Examine the snmpd.conf settings that govern SNMP access — community
+// strings, VACM users, and listen addresses. The configuration is assembled
+// from the main snmpd.conf together with any drop-in files under
+// snmpd.conf.d and files pulled in by includeFile and includeDir directives.
+// A missing configuration yields empty accessors, so audits such as
+// rwCommunities == [] hold trivially on hosts that don't run snmpd.
+snmpd.config {
+  init(path? string)
+  // Primary snmpd configuration file
+  file() file
+  // All files making up the SNMP daemon configuration (main file, drop-ins, and includes)
+  files(file) []file
+  // Merged contents of all configuration files
+  content(files) string
+  // Read-only community strings, from rocommunity and rocommunity6 directives
+  roCommunities(content) []string
+  // Read-write community strings, from rwcommunity and rwcommunity6 directives
+  rwCommunities(content) []string
+  // Read-only VACM users, from rouser directives
+  roUsers(content) []string
+  // Read-write VACM users, from rwuser directives
+  rwUsers(content) []string
+  // Addresses snmpd listens on, from agentAddress directives
+  agentAddresses(content) []string
+}
+
 // auditd (Linux Audit Daemon) global configuration
 //
 // Examine /etc/audit/auditd.conf parameters

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -75,6 +75,8 @@ const (
 	ResourceInetd                         string = "inetd"
 	ResourceInetdConfig                   string = "inetd.config"
 	ResourceInetdConfigEntry              string = "inetd.config.entry"
+	ResourceSnmpd                         string = "snmpd"
+	ResourceSnmpdConfig                   string = "snmpd.config"
 	ResourceAuditdConfig                  string = "auditd.config"
 	ResourceAuditdRules                   string = "auditd.rules"
 	ResourceAuditdRule                    string = "auditd.rule"
@@ -673,6 +675,14 @@ func init() {
 		"inetd.config.entry": {
 			// to override args, implement: initInetdConfigEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createInetdConfigEntry,
+		},
+		"snmpd": {
+			// to override args, implement: initSnmpd(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createSnmpd,
+		},
+		"snmpd.config": {
+			Init:   initSnmpdConfig,
+			Create: createSnmpdConfig,
 		},
 		"auditd.config": {
 			Init:   initAuditdConfig,
@@ -3045,6 +3055,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"inetd.config.entry.context": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlInetdConfigEntry).GetContext()).ToDataRes(types.Resource("file.context"))
+	},
+	"snmpd.config.file": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"snmpd.config.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetFiles()).ToDataRes(types.Array(types.Resource("file")))
+	},
+	"snmpd.config.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetContent()).ToDataRes(types.String)
+	},
+	"snmpd.config.roCommunities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetRoCommunities()).ToDataRes(types.Array(types.String))
+	},
+	"snmpd.config.rwCommunities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetRwCommunities()).ToDataRes(types.Array(types.String))
+	},
+	"snmpd.config.roUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetRoUsers()).ToDataRes(types.Array(types.String))
+	},
+	"snmpd.config.rwUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetRwUsers()).ToDataRes(types.Array(types.String))
+	},
+	"snmpd.config.agentAddresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnmpdConfig).GetAgentAddresses()).ToDataRes(types.Array(types.String))
 	},
 	"auditd.config.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAuditdConfig).GetFile()).ToDataRes(types.Resource("file"))
@@ -11086,6 +11120,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"inetd.config.entry.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlInetdConfigEntry).Context, ok = plugin.RawToTValue[*mqlFileContext](v.Value, v.Error)
+		return
+	},
+	"snmpd.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpd).__id, ok = v.Value.(string)
+		return
+	},
+	"snmpd.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"snmpd.config.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.roCommunities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).RoCommunities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.rwCommunities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).RwCommunities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.roUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).RoUsers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.rwUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).RwUsers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"snmpd.config.agentAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnmpdConfig).AgentAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"auditd.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26429,6 +26503,200 @@ func (c *mqlInetdConfigEntry) GetContext() *plugin.TValue[*mqlFileContext] {
 		}
 
 		return c.context()
+	})
+}
+
+// mqlSnmpd for the snmpd resource
+type mqlSnmpd struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlSnmpdInternal it will be used here
+}
+
+// createSnmpd creates a new instance of this resource
+func createSnmpd(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlSnmpd{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("snmpd", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlSnmpd) MqlName() string {
+	return "snmpd"
+}
+
+func (c *mqlSnmpd) MqlID() string {
+	return c.__id
+}
+
+// mqlSnmpdConfig for the snmpd.config resource
+type mqlSnmpdConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlSnmpdConfigInternal it will be used here
+	File           plugin.TValue[*mqlFile]
+	Files          plugin.TValue[[]any]
+	Content        plugin.TValue[string]
+	RoCommunities  plugin.TValue[[]any]
+	RwCommunities  plugin.TValue[[]any]
+	RoUsers        plugin.TValue[[]any]
+	RwUsers        plugin.TValue[[]any]
+	AgentAddresses plugin.TValue[[]any]
+}
+
+// createSnmpdConfig creates a new instance of this resource
+func createSnmpdConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlSnmpdConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("snmpd.config", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlSnmpdConfig) MqlName() string {
+	return "snmpd.config"
+}
+
+func (c *mqlSnmpdConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlSnmpdConfig) GetFile() *plugin.TValue[*mqlFile] {
+	return plugin.GetOrCompute[*mqlFile](&c.File, func() (*mqlFile, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("snmpd.config", c.__id, "file")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlFile), nil
+			}
+		}
+
+		return c.file()
+	})
+}
+
+func (c *mqlSnmpdConfig) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("snmpd.config", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.files(vargFile.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		vargFiles := c.GetFiles()
+		if vargFiles.Error != nil {
+			return "", vargFiles.Error
+		}
+
+		return c.content(vargFiles.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetRoCommunities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoCommunities, func() ([]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.roCommunities(vargContent.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetRwCommunities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RwCommunities, func() ([]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.rwCommunities(vargContent.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetRoUsers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoUsers, func() ([]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.roUsers(vargContent.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetRwUsers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RwUsers, func() ([]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.rwUsers(vargContent.Data)
+	})
+}
+
+func (c *mqlSnmpdConfig) GetAgentAddresses() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AgentAddresses, func() ([]any, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.agentAddresses(vargContent.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2276,6 +2276,16 @@ shadow.entry.reserved 9.0.1
 shadow.entry.user 9.0.1
 shadow.entry.warndays 9.0.1
 shadow.list 9.0.1
+snmpd 13.24.1
+snmpd.config 13.24.1
+snmpd.config.agentAddresses 13.24.1
+snmpd.config.content 13.24.1
+snmpd.config.file 13.24.1
+snmpd.config.files 13.24.1
+snmpd.config.roCommunities 13.24.1
+snmpd.config.roUsers 13.24.1
+snmpd.config.rwCommunities 13.24.1
+snmpd.config.rwUsers 13.24.1
 snowflake.cortex 13.13.1
 snowflake.cortex.configPath 13.13.1
 snowflake.cortex.skill 13.13.1

--- a/providers/os/resources/snmpd.go
+++ b/providers/os/resources/snmpd.go
@@ -1,0 +1,263 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/resources/snmpd"
+)
+
+const (
+	defaultSnmpdConfig = "/etc/snmp/snmpd.conf"
+	snmpdDropInDirName = "snmpd.conf.d"
+)
+
+func initSnmpdConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in snmpd.config initialization, it must be a string")
+		}
+
+		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		args["file"] = llx.ResourceData(f, "file")
+
+		delete(args, "path")
+	}
+
+	return args, nil, nil
+}
+
+func (s *mqlSnmpdConfig) id() (string, error) {
+	file := s.GetFile()
+	if file.Error != nil {
+		return "", file.Error
+	}
+	return "snmpd.config/" + file.Data.Path.Data, nil
+}
+
+func (s *mqlSnmpdConfig) file() (*mqlFile, error) {
+	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(defaultSnmpdConfig),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return f.(*mqlFile), nil
+}
+
+// fileResource resolves a path into the corresponding file resource.
+func (s *mqlSnmpdConfig) fileResource(path string) (*mqlFile, error) {
+	raw, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw.(*mqlFile), nil
+}
+
+func (s *mqlSnmpdConfig) files(file *mqlFile) ([]any, error) {
+	if file == nil {
+		return nil, errors.New("no base snmpd config file to read")
+	}
+
+	visited := map[string]bool{}
+	res := []any{}
+
+	if err := s.collectFile(file, visited, &res); err != nil {
+		return nil, err
+	}
+
+	// snmpd reads a snmpd.conf.d drop-in directory alongside the main config.
+	// We include it implicitly so audits don't have to know the on-disk layout.
+	dropInDir := filepath.Join(filepath.Dir(file.Path.Data), snmpdDropInDirName)
+	if err := s.collectDir(dropInDir, false, visited, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// collectFile appends a file and recursively resolves its includeFile and
+// includeDir directives. The visited set guards against include cycles.
+func (s *mqlSnmpdConfig) collectFile(file *mqlFile, visited map[string]bool, res *[]any) error {
+	path := file.Path.Data
+	if visited[path] {
+		return nil
+	}
+	visited[path] = true
+
+	content, err := snmpdFileContent(file)
+	if err != nil {
+		return err
+	}
+
+	*res = append(*res, file)
+	if content == "" {
+		return nil
+	}
+
+	base := filepath.Dir(path)
+	for _, d := range snmpd.Parse(content) {
+		if len(d.Args) == 0 {
+			continue
+		}
+		switch strings.ToLower(d.Keyword) {
+		case "includefile":
+			f, err := s.fileResource(resolveSnmpdPath(d.Args[0], base))
+			if err != nil {
+				return err
+			}
+			if err := s.collectFile(f, visited, res); err != nil {
+				return err
+			}
+		case "includedir":
+			// includeDir only reads files ending in .conf.
+			if err := s.collectDir(resolveSnmpdPath(d.Args[0], base), true, visited, res); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// collectDir appends the files in dir (sorted) and resolves their includes.
+// When onlyConf is set, only files ending in .conf are read, matching snmpd's
+// includeDir behavior. A missing directory is not an error.
+func (s *mqlSnmpdConfig) collectDir(dir string, onlyConf bool, visited map[string]bool, res *[]any) error {
+	d, err := s.fileResource(dir)
+	if err != nil {
+		return err
+	}
+	exists := d.GetExists()
+	if exists.Error != nil {
+		return exists.Error
+	}
+	if !exists.Data {
+		return nil
+	}
+
+	files, err := getSortedPathFiles(s.MqlRuntime, dir)
+	if err != nil {
+		return err
+	}
+
+	for i := range files {
+		f := files[i].(*mqlFile)
+		if onlyConf && !strings.HasSuffix(f.Path.Data, ".conf") {
+			continue
+		}
+		if err := s.collectFile(f, visited, res); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resolveSnmpdPath resolves an include path relative to the including file's
+// directory, leaving absolute paths untouched.
+func resolveSnmpdPath(path, base string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(base, path)
+}
+
+// snmpdFileContent returns the file's content, or an empty string when the
+// file is absent. A missing snmpd.conf is a normal state (the host simply
+// doesn't run snmpd), so it yields no directives rather than an error.
+func snmpdFileContent(file *mqlFile) (string, error) {
+	exists := file.GetExists()
+	if exists.Error != nil {
+		return "", exists.Error
+	}
+	if !exists.Data {
+		return "", nil
+	}
+
+	content := file.GetContent()
+	if content.Error != nil {
+		return "", content.Error
+	}
+	if content.IsNull() {
+		return "", nil
+	}
+	return content.Data, nil
+}
+
+func (s *mqlSnmpdConfig) content(files []any) (string, error) {
+	parts := make([]string, 0, len(files))
+	for i := range files {
+		c, err := snmpdFileContent(files[i].(*mqlFile))
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, c)
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// firstArgsByKeyword collects the first argument of every directive whose
+// keyword matches one of the given keywords (compared case-insensitively).
+// This is the community string for ro/rwcommunity and the user name for
+// ro/rwuser, dropping any trailing source or OID-restriction arguments.
+func firstArgsByKeyword(content string, keywords ...string) []any {
+	set := make(map[string]struct{}, len(keywords))
+	for _, k := range keywords {
+		set[k] = struct{}{}
+	}
+
+	res := []any{}
+	for _, d := range snmpd.Parse(content) {
+		if _, ok := set[strings.ToLower(d.Keyword)]; ok && len(d.Args) > 0 {
+			res = append(res, d.Args[0])
+		}
+	}
+	return res
+}
+
+func (s *mqlSnmpdConfig) roCommunities(content string) ([]any, error) {
+	return firstArgsByKeyword(content, "rocommunity", "rocommunity6"), nil
+}
+
+func (s *mqlSnmpdConfig) rwCommunities(content string) ([]any, error) {
+	return firstArgsByKeyword(content, "rwcommunity", "rwcommunity6"), nil
+}
+
+func (s *mqlSnmpdConfig) roUsers(content string) ([]any, error) {
+	return firstArgsByKeyword(content, "rouser"), nil
+}
+
+func (s *mqlSnmpdConfig) rwUsers(content string) ([]any, error) {
+	return firstArgsByKeyword(content, "rwuser"), nil
+}
+
+func (s *mqlSnmpdConfig) agentAddresses(content string) ([]any, error) {
+	res := []any{}
+	for _, d := range snmpd.Parse(content) {
+		if strings.ToLower(d.Keyword) != "agentaddress" {
+			continue
+		}
+		// agentAddress takes a comma-separated list of transport specifiers.
+		for _, part := range strings.Split(strings.Join(d.Args, " "), ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				res = append(res, p)
+			}
+		}
+	}
+	return res, nil
+}

--- a/providers/os/resources/snmpd/parser.go
+++ b/providers/os/resources/snmpd/parser.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package snmpd parses Net-SNMP daemon (snmpd.conf) configuration files.
+package snmpd
+
+import "strings"
+
+// Directive is a single configuration directive: a keyword followed by its
+// whitespace-separated arguments.
+type Directive struct {
+	// Keyword is the directive name as written (case preserved). Callers that
+	// match on it should fold case, since snmpd keywords are case-insensitive.
+	Keyword string
+	// Args holds the tokenized arguments after the keyword.
+	Args []string
+	// Line is the 1-based line number of this directive within its file.
+	Line int
+}
+
+// Parse reads snmpd.conf content and returns its directives in order. Comment
+// lines and blank lines produce no directive. A `#` outside of quotes begins a
+// comment that runs to the end of the line. Double- and single-quoted tokens
+// keep their interior whitespace and are returned without the quotes.
+func Parse(content string) []Directive {
+	res := []Directive{}
+	for i, raw := range strings.Split(content, "\n") {
+		tokens := tokenize(raw)
+		if len(tokens) == 0 {
+			continue
+		}
+		res = append(res, Directive{
+			Keyword: tokens[0],
+			Args:    tokens[1:],
+			Line:    i + 1,
+		})
+	}
+	return res
+}
+
+// tokenize splits a single line into whitespace-separated tokens, honoring
+// quoting and stopping at an unquoted comment.
+func tokenize(line string) []string {
+	var tokens []string
+	runes := []rune(line)
+	n := len(runes)
+	i := 0
+
+	for i < n {
+		// skip leading whitespace
+		for i < n && isSpace(runes[i]) {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		// a `#` at a token boundary starts a comment
+		if runes[i] == '#' {
+			break
+		}
+
+		var sb strings.Builder
+		if runes[i] == '"' || runes[i] == '\'' {
+			quote := runes[i]
+			i++
+			for i < n && runes[i] != quote {
+				if runes[i] == '\\' && i+1 < n {
+					i++
+				}
+				sb.WriteRune(runes[i])
+				i++
+			}
+			if i < n {
+				i++ // consume the closing quote
+			}
+		} else {
+			for i < n && !isSpace(runes[i]) {
+				sb.WriteRune(runes[i])
+				i++
+			}
+		}
+		tokens = append(tokens, sb.String())
+	}
+
+	return tokens
+}
+
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\r'
+}

--- a/providers/os/resources/snmpd/parser_test.go
+++ b/providers/os/resources/snmpd/parser_test.go
@@ -1,0 +1,75 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package snmpd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	content := `# /etc/snmp/snmpd.conf
+   # indented comment
+agentAddress  udp:161,udp6:[::1]:161
+
+rocommunity  public  10.0.0.0/24 -V systemonly
+rocommunity6 public6
+rwcommunity  private             # inline comment after the directive
+rouser   authOnlyUser
+rwuser   adminUser priv
+
+includeDir /etc/snmp/snmpd.conf.d
+`
+
+	directives := Parse(content)
+
+	t.Run("comments and blank lines are skipped", func(t *testing.T) {
+		for _, d := range directives {
+			assert.NotEqual(t, "#", d.Keyword)
+		}
+		require.Len(t, directives, 7)
+	})
+
+	t.Run("keyword and args are tokenized", func(t *testing.T) {
+		assert.Equal(t, "agentAddress", directives[0].Keyword)
+		assert.Equal(t, []string{"udp:161,udp6:[::1]:161"}, directives[0].Args)
+		assert.Equal(t, 3, directives[0].Line)
+	})
+
+	t.Run("trailing arguments are preserved", func(t *testing.T) {
+		assert.Equal(t, "rocommunity", directives[1].Keyword)
+		assert.Equal(t, []string{"public", "10.0.0.0/24", "-V", "systemonly"}, directives[1].Args)
+	})
+
+	t.Run("inline comment is stripped", func(t *testing.T) {
+		assert.Equal(t, "rwcommunity", directives[3].Keyword)
+		assert.Equal(t, []string{"private"}, directives[3].Args)
+	})
+
+	t.Run("includeDir is a normal directive", func(t *testing.T) {
+		last := directives[len(directives)-1]
+		assert.Equal(t, "includeDir", last.Keyword)
+		assert.Equal(t, []string{"/etc/snmp/snmpd.conf.d"}, last.Args)
+	})
+}
+
+func TestParseQuoted(t *testing.T) {
+	directives := Parse(`rocommunity "my secret community" 127.0.0.1`)
+	require.Len(t, directives, 1)
+	assert.Equal(t, "rocommunity", directives[0].Keyword)
+	assert.Equal(t, []string{"my secret community", "127.0.0.1"}, directives[0].Args)
+}
+
+func TestParseHashInQuotesIsNotComment(t *testing.T) {
+	directives := Parse(`rocommunity "pa#ss"`)
+	require.Len(t, directives, 1)
+	assert.Equal(t, []string{"pa#ss"}, directives[0].Args)
+}
+
+func TestParseEmpty(t *testing.T) {
+	assert.Empty(t, Parse(""))
+	assert.Empty(t, Parse("# only comments\n\n   \n"))
+}


### PR DESCRIPTION
Resolves #8248.

## Summary

Adds a native `snmpd.config` resource to the **os** provider so auditing SNMP daemon settings becomes a one-liner instead of the multi-file `files.find` / `content.lines` regex construction.

The impact-100 check **"Ensure SNMP config does not contain read-write community strings"** collapses from a hand-stitched scan of `/etc/snmp/snmpd.conf` plus the `snmpd.conf.d` drop-in directory to:

```mql
snmpd.config.rwCommunities == []
```

The "file doesn't exist" case is handled for free — a missing `snmpd.conf` yields empty accessors, so the check holds trivially on hosts that don't run snmpd.

## What's added

- **`snmpd`** namespace + **`snmpd.config`** resource: `file`, `files`, `content`, and typed accessors `roCommunities`, `rwCommunities`, `roUsers`, `rwUsers`, `agentAddresses`.
- The config is assembled from the main `snmpd.conf` together with drop-in files under `snmpd.conf.d` and files pulled in by `includeFile` / `includeDir` directives (cycle-guarded; `includeDir` reads only `.conf` files, matching Net-SNMP). Policy authors no longer need to know the on-disk layout.
- Parser package `providers/os/resources/snmpd/` with unit tests: tokenizes directives, honors `#` comments and quoted tokens (a `#` inside quotes is not a comment), and preserves repeated keys (multiple `rocommunity` lines) which a flat `map` would lose.
- Typed accessors return just the community/user/address token, dropping trailing source and OID-restriction args (`rocommunity public 10.0.0.0/24 -V systemonly` → `public`) for clean equality checks, per the issue's recommendation. `agentAddresses` splits the comma-separated transport list.

## Verification

Tested against a live Debian 13 host:

- **Absent file** (host's real state): all accessors → `[]`; `rwCommunities == []` → `true` with no `exists` guard.
- **Synthetic config** with a `snmpd.conf.d` drop-in and an `includeFile`:
  - `files` → main `snmpd.conf` + `extra.conf` (from `includeFile`) + `snmpd.conf.d/local.conf` (drop-in), confirming both include resolution and implicit drop-in discovery.
  - `roCommunities` → `["public", "publicv6"]` (rocommunity from main + rocommunity6 from drop-in, OID-restriction stripped); `rwCommunities` → `["fromInclude"]`; `roUsers`/`rwUsers` token-only; `agentAddresses` → `["udp:161", "udp6:[::1]:161"]`.
  - The exact one-liner `snmpd.config.rwCommunities == []` flags the rw community when present and returns `true` once the rw entries are removed.
- Parser unit tests pass; `go build ./...` and the os resources suite are green; gofmt clean; codegen idempotent.

New `.lr.versions` entries are at `13.24.1` (next os-provider patch).

## Deferred (per the issue's open questions)

- No generic lossy `params map[string]string` — typed accessors + `content` cover the known audits without inviting lossy queries on repeated keys.

Sibling to #8250 (inetd), which follows the same shape.