### PR TITLE
🎉 os-13.25.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.24.0",
+	Version: "13.25.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.25.0)
- ✨ Add snmpd config resource to simplify SNMP community-string audits (#8256)
- ✨ Add inetd config resource to simplify super-server service audits (#8255)