### PR TITLE
✨ aws: add batch images() + typed lightsail inbound rules to simplify policy queries

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -21128,6 +21128,16 @@ private aws.batch.jobDefinition @defaults("arn name type status") {
   eks() aws.batch.jobDefinition.eksPodProperties
   // Explicit ECS task properties (populated when running on ECS with explicit shape)
   ecs() dict
+  // Container images referenced by the job definition
+  //
+  // Examine every container image used anywhere in the job definition:
+  // single-node container properties, each multi-node node-range container,
+  // ECS task containers, and EKS pod containers and init containers. Each
+  // entry parses the image reference into `image` (the raw reference),
+  // `registry` (the registry host, with bare names and single-segment
+  // repositories normalized to `docker.io`), `repository`, `tag`, and
+  // `digest`. The `tag` and `digest` are empty when the reference omits them.
+  images() []dict
   // Typed retry strategy
   retry() aws.batch.jobDefinition.retryStrategy
   // Raw retry strategy dict
@@ -21532,14 +21542,48 @@ private aws.lightsail.instance @defaults("name arn state") {
   createdAt time
   // Tags for the instance
   tags map[string]string
-  // Firewall rules (open ports, CIDRs, protocols)
-  firewallRules() []dict
+  // Raw inbound firewall rule dicts
+  //
+  // Deprecated in favor of `inboundRules`, which resolves each rule to a typed
+  // aws.lightsail.instance.inboundRule exposing fromPort, toPort, protocol,
+  // cidrs, ipv6Cidrs, and a publicAccess predicate.
+  firewallRules() @maturity("deprecated") []dict
+  // Inbound firewall rules
+  //
+  // Examine the inbound firewall governing the instance. Each rule exposes the
+  // port range it opens (`fromPort` to `toPort`), the `protocol`, the source
+  // ranges (`cidrs`, `ipv6Cidrs`), and a `publicAccess` predicate that is true
+  // when the rule admits any address (`0.0.0.0/0` or `::/0`) — marking the
+  // port range as reachable from the public internet.
+  inboundRules() []aws.lightsail.instance.inboundRule
   // Open ports on the instance with access policies
   //
   // Each entry has fromPort, toPort, protocol, accessFrom, accessType, commonName, accessDirection, cidrs, ipv6Cidrs, and cidrListAliases.
   ports() []dict
   // Add-ons enabled on the instance (name, status, snapshotTimeOfDay, nextSnapshotTimeOfDay, threshold, duration)
   addOns() []dict
+}
+
+// Inbound firewall rule for a Lightsail instance
+//
+// Examine a single inbound networking rule on the instance — the port range it
+// opens (`fromPort` to `toPort`), the `protocol` (tcp, udp, icmp, icmpv6, or
+// all), and the source ranges (`cidrs`, `ipv6Cidrs`). The `publicAccess`
+// predicate is true when the rule admits any source address (`0.0.0.0/0` or
+// `::/0`), marking the port range as reachable from the public internet.
+private aws.lightsail.instance.inboundRule @defaults("fromPort toPort protocol publicAccess") {
+  // Lowest port in the range the rule opens
+  fromPort int
+  // Highest port in the range the rule opens
+  toPort int
+  // Network protocol the rule applies to: tcp, udp, icmp, icmpv6, or all
+  protocol string
+  // IPv4 source ranges the rule admits, in CIDR notation
+  cidrs []string
+  // IPv6 source ranges the rule admits, in CIDR notation
+  ipv6Cidrs []string
+  // Whether the rule admits any source address (0.0.0.0/0 or ::/0)
+  publicAccess bool
 }
 
 // Amazon Lightsail relational database

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -791,6 +791,7 @@ const (
 	ResourceAwsLightsail                                                        string = "aws.lightsail"
 	ResourceAwsLightsailDistribution                                            string = "aws.lightsail.distribution"
 	ResourceAwsLightsailInstance                                                string = "aws.lightsail.instance"
+	ResourceAwsLightsailInstanceInboundRule                                     string = "aws.lightsail.instance.inboundRule"
 	ResourceAwsLightsailDatabase                                                string = "aws.lightsail.database"
 	ResourceAwsLightsailLoadBalancer                                            string = "aws.lightsail.loadBalancer"
 	ResourceAwsLightsailDisk                                                    string = "aws.lightsail.disk"
@@ -4012,6 +4013,10 @@ func init() {
 		"aws.lightsail.instance": {
 			// to override args, implement: initAwsLightsailInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsLightsailInstance,
+		},
+		"aws.lightsail.instance.inboundRule": {
+			// to override args, implement: initAwsLightsailInstanceInboundRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsLightsailInstanceInboundRule,
 		},
 		"aws.lightsail.database": {
 			// to override args, implement: initAwsLightsailDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -28170,6 +28175,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.batch.jobDefinition.ecs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBatchJobDefinition).GetEcs()).ToDataRes(types.Dict)
 	},
+	"aws.batch.jobDefinition.images": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBatchJobDefinition).GetImages()).ToDataRes(types.Array(types.Dict))
+	},
 	"aws.batch.jobDefinition.retry": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBatchJobDefinition).GetRetry()).ToDataRes(types.Resource("aws.batch.jobDefinition.retryStrategy"))
 	},
@@ -28626,11 +28634,32 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lightsail.instance.firewallRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLightsailInstance).GetFirewallRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.lightsail.instance.inboundRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstance).GetInboundRules()).ToDataRes(types.Array(types.Resource("aws.lightsail.instance.inboundRule")))
+	},
 	"aws.lightsail.instance.ports": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLightsailInstance).GetPorts()).ToDataRes(types.Array(types.Dict))
 	},
 	"aws.lightsail.instance.addOns": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLightsailInstance).GetAddOns()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.lightsail.instance.inboundRule.fromPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetFromPort()).ToDataRes(types.Int)
+	},
+	"aws.lightsail.instance.inboundRule.toPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetToPort()).ToDataRes(types.Int)
+	},
+	"aws.lightsail.instance.inboundRule.protocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetProtocol()).ToDataRes(types.String)
+	},
+	"aws.lightsail.instance.inboundRule.cidrs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetCidrs()).ToDataRes(types.Array(types.String))
+	},
+	"aws.lightsail.instance.inboundRule.ipv6Cidrs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetIpv6Cidrs()).ToDataRes(types.Array(types.String))
+	},
+	"aws.lightsail.instance.inboundRule.publicAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLightsailInstanceInboundRule).GetPublicAccess()).ToDataRes(types.Bool)
 	},
 	"aws.lightsail.database.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLightsailDatabase).GetName()).ToDataRes(types.String)
@@ -66697,6 +66726,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsBatchJobDefinition).Ecs, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.batch.jobDefinition.images": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBatchJobDefinition).Images, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.batch.jobDefinition.retry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBatchJobDefinition).Retry, ok = plugin.RawToTValue[*mqlAwsBatchJobDefinitionRetryStrategy](v.Value, v.Error)
 		return
@@ -67361,12 +67394,44 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLightsailInstance).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.lightsail.instance.inboundRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstance).InboundRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.lightsail.instance.ports": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLightsailInstance).Ports, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.lightsail.instance.addOns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLightsailInstance).AddOns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.fromPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).FromPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.toPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).ToPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.cidrs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).Cidrs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.ipv6Cidrs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).Ipv6Cidrs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.lightsail.instance.inboundRule.publicAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLightsailInstanceInboundRule).PublicAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.lightsail.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -161656,6 +161721,7 @@ type mqlAwsBatchJobDefinition struct {
 	NodeRangeProperties  plugin.TValue[[]any]
 	Eks                  plugin.TValue[*mqlAwsBatchJobDefinitionEksPodProperties]
 	Ecs                  plugin.TValue[any]
+	Images               plugin.TValue[[]any]
 	Retry                plugin.TValue[*mqlAwsBatchJobDefinitionRetryStrategy]
 	RetryStrategy        plugin.TValue[any]
 	JobTimeout           plugin.TValue[*mqlAwsBatchJobDefinitionTimeout]
@@ -161818,6 +161884,12 @@ func (c *mqlAwsBatchJobDefinition) GetEks() *plugin.TValue[*mqlAwsBatchJobDefini
 func (c *mqlAwsBatchJobDefinition) GetEcs() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Ecs, func() (any, error) {
 		return c.ecs()
+	})
+}
+
+func (c *mqlAwsBatchJobDefinition) GetImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Images, func() ([]any, error) {
+		return c.images()
 	})
 }
 
@@ -163346,6 +163418,7 @@ type mqlAwsLightsailInstance struct {
 	CreatedAt                          plugin.TValue[*time.Time]
 	Tags                               plugin.TValue[map[string]any]
 	FirewallRules                      plugin.TValue[[]any]
+	InboundRules                       plugin.TValue[[]any]
 	Ports                              plugin.TValue[[]any]
 	AddOns                             plugin.TValue[[]any]
 }
@@ -163480,6 +163553,22 @@ func (c *mqlAwsLightsailInstance) GetFirewallRules() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsLightsailInstance) GetInboundRules() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InboundRules, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lightsail.instance", c.__id, "inboundRules")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.inboundRules()
+	})
+}
+
 func (c *mqlAwsLightsailInstance) GetPorts() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Ports, func() ([]any, error) {
 		return c.ports()
@@ -163490,6 +163579,75 @@ func (c *mqlAwsLightsailInstance) GetAddOns() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.AddOns, func() ([]any, error) {
 		return c.addOns()
 	})
+}
+
+// mqlAwsLightsailInstanceInboundRule for the aws.lightsail.instance.inboundRule resource
+type mqlAwsLightsailInstanceInboundRule struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsLightsailInstanceInboundRuleInternal it will be used here
+	FromPort     plugin.TValue[int64]
+	ToPort       plugin.TValue[int64]
+	Protocol     plugin.TValue[string]
+	Cidrs        plugin.TValue[[]any]
+	Ipv6Cidrs    plugin.TValue[[]any]
+	PublicAccess plugin.TValue[bool]
+}
+
+// createAwsLightsailInstanceInboundRule creates a new instance of this resource
+func createAwsLightsailInstanceInboundRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsLightsailInstanceInboundRule{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.lightsail.instance.inboundRule", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) MqlName() string {
+	return "aws.lightsail.instance.inboundRule"
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetFromPort() *plugin.TValue[int64] {
+	return &c.FromPort
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetToPort() *plugin.TValue[int64] {
+	return &c.ToPort
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetProtocol() *plugin.TValue[string] {
+	return &c.Protocol
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetCidrs() *plugin.TValue[[]any] {
+	return &c.Cidrs
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetIpv6Cidrs() *plugin.TValue[[]any] {
+	return &c.Ipv6Cidrs
+}
+
+func (c *mqlAwsLightsailInstanceInboundRule) GetPublicAccess() *plugin.TValue[bool] {
+	return &c.PublicAccess
 }
 
 // mqlAwsLightsailDatabase for the aws.lightsail.database resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -964,6 +964,7 @@ aws.batch.jobDefinition.eksPodProperties.metadata 13.14.1
 aws.batch.jobDefinition.eksPodProperties.serviceAccountName 13.14.1
 aws.batch.jobDefinition.eksPodProperties.shareProcessNamespace 13.14.1
 aws.batch.jobDefinition.eksPodProperties.volumes 13.14.1
+aws.batch.jobDefinition.images 13.33.2
 aws.batch.jobDefinition.jobTimeout 13.12.1
 aws.batch.jobDefinition.name 13.1.1
 aws.batch.jobDefinition.nodeMainNode 13.14.1
@@ -5954,6 +5955,14 @@ aws.lightsail.instance.bundleId 13.1.1
 aws.lightsail.instance.cpuCount 13.1.1
 aws.lightsail.instance.createdAt 13.1.1
 aws.lightsail.instance.firewallRules 13.1.1
+aws.lightsail.instance.inboundRule 13.33.2
+aws.lightsail.instance.inboundRule.cidrs 13.33.2
+aws.lightsail.instance.inboundRule.fromPort 13.33.2
+aws.lightsail.instance.inboundRule.ipv6Cidrs 13.33.2
+aws.lightsail.instance.inboundRule.protocol 13.33.2
+aws.lightsail.instance.inboundRule.publicAccess 13.33.2
+aws.lightsail.instance.inboundRule.toPort 13.33.2
+aws.lightsail.instance.inboundRules 13.33.2
 aws.lightsail.instance.ipAddressType 13.21.4
 aws.lightsail.instance.ipv6Addresses 13.1.1
 aws.lightsail.instance.isStaticIp 13.1.1

--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -802,6 +802,119 @@ func (a *mqlAwsBatchJobDefinition) ecs() (any, error) {
 	return convert.JsonToDict(a.cacheEcs)
 }
 
+// images flattens every container image referenced anywhere in the job
+// definition — single-node container properties, multi-node node-range
+// containers, ECS task containers, and EKS pod containers and init containers
+// — and parses each reference into its registry, repository, tag, and digest.
+// Duplicate references are collapsed so the result is the set of distinct
+// images the definition pulls.
+func (a *mqlAwsBatchJobDefinition) images() ([]any, error) {
+	var refs []string
+	refs = appendBatchContainerImage(refs, a.cacheContainerProperties)
+	refs = appendBatchEcsImages(refs, a.cacheEcs)
+	refs = appendBatchEksImages(refs, a.cacheEks)
+	if a.cacheNodeProperties != nil {
+		for i := range a.cacheNodeProperties.NodeRangeProperties {
+			nrp := a.cacheNodeProperties.NodeRangeProperties[i]
+			refs = appendBatchContainerImage(refs, nrp.Container)
+			refs = appendBatchEcsImages(refs, nrp.EcsProperties)
+			refs = appendBatchEksImages(refs, nrp.EksProperties)
+		}
+	}
+
+	res := make([]any, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		registry, repository, tag, digest := parseImageReference(ref)
+		res = append(res, map[string]any{
+			"image":      ref,
+			"registry":   registry,
+			"repository": repository,
+			"tag":        tag,
+			"digest":     digest,
+		})
+	}
+	return res, nil
+}
+
+func appendBatchContainerImage(refs []string, cp *batch_types.ContainerProperties) []string {
+	if cp != nil && cp.Image != nil {
+		refs = append(refs, *cp.Image)
+	}
+	return refs
+}
+
+func appendBatchEcsImages(refs []string, ecs *batch_types.EcsProperties) []string {
+	if ecs == nil {
+		return refs
+	}
+	for _, tp := range ecs.TaskProperties {
+		for _, c := range tp.Containers {
+			if c.Image != nil {
+				refs = append(refs, *c.Image)
+			}
+		}
+	}
+	return refs
+}
+
+func appendBatchEksImages(refs []string, eks *batch_types.EksProperties) []string {
+	if eks == nil || eks.PodProperties == nil {
+		return refs
+	}
+	for _, c := range eks.PodProperties.Containers {
+		if c.Image != nil {
+			refs = append(refs, *c.Image)
+		}
+	}
+	for _, c := range eks.PodProperties.InitContainers {
+		if c.Image != nil {
+			refs = append(refs, *c.Image)
+		}
+	}
+	return refs
+}
+
+// parseImageReference splits a container image reference into its registry
+// host, repository, tag, and digest following Docker reference grammar. A
+// reference with no registry host — a bare name like "nginx" or a
+// single-segment path like "library/nginx" — normalizes to the "docker.io"
+// registry, matching how container runtimes resolve it. The tag and digest are
+// empty when the reference omits them.
+func parseImageReference(ref string) (registry, repository, tag, digest string) {
+	remainder := ref
+	if i := strings.Index(remainder, "@"); i >= 0 {
+		digest = remainder[i+1:]
+		remainder = remainder[:i]
+	}
+
+	name := remainder
+	if i := strings.IndexByte(remainder, '/'); i >= 0 {
+		if first := remainder[:i]; strings.ContainsAny(first, ".:") || first == "localhost" {
+			registry = first
+			name = remainder[i+1:]
+		}
+	}
+	if registry == "" {
+		registry = "docker.io"
+	}
+
+	if i := strings.LastIndexByte(name, ':'); i >= 0 {
+		tag = name[i+1:]
+		repository = name[:i]
+	} else {
+		repository = name
+	}
+	return registry, repository, tag, digest
+}
+
 func (a *mqlAwsBatchJobDefinition) containerProperties() (any, error) {
 	if a.cacheContainerProperties == nil {
 		return nil, nil

--- a/providers/aws/resources/aws_batch_test.go
+++ b/providers/aws/resources/aws_batch_test.go
@@ -184,3 +184,97 @@ func TestBatchChildID(t *testing.T) {
 }
 
 func ptrInt64(v int64) *int64 { return &v }
+
+func TestParseImageReference(t *testing.T) {
+	tests := []struct {
+		ref        string
+		registry   string
+		repository string
+		tag        string
+		digest     string
+	}{
+		// Public AWS ECR.
+		{"public.ecr.aws/foo/bar:1", "public.ecr.aws", "foo/bar", "1", ""},
+		// Explicit Docker Hub hostnames are left as-is.
+		{"docker.io/library/nginx", "docker.io", "library/nginx", "", ""},
+		{"registry.hub.docker.com/library/nginx:1.21", "registry.hub.docker.com", "library/nginx", "1.21", ""},
+		// Bare name and single-segment path normalize to docker.io.
+		{"nginx", "docker.io", "nginx", "", ""},
+		{"nginx:1.21", "docker.io", "nginx", "1.21", ""},
+		{"library/nginx", "docker.io", "library/nginx", "", ""},
+		// Private ECR with a fully-qualified host.
+		{"123456789012.dkr.ecr.us-east-1.amazonaws.com/app:latest", "123456789012.dkr.ecr.us-east-1.amazonaws.com", "app", "latest", ""},
+		// Host with an explicit port.
+		{"myreg:5000/team/app:v2", "myreg:5000", "team/app", "v2", ""},
+		// localhost is treated as a registry host.
+		{"localhost/app", "localhost", "app", "", ""},
+		// Digests, with and without a tag.
+		{"nginx@sha256:abc123", "docker.io", "nginx", "", "sha256:abc123"},
+		{"public.ecr.aws/x/y@sha256:deadbeef", "public.ecr.aws", "x/y", "", "sha256:deadbeef"},
+		{"nginx:1.21@sha256:abc123", "docker.io", "nginx", "1.21", "sha256:abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			registry, repository, tag, digest := parseImageReference(tt.ref)
+			assert.Equal(t, tt.registry, registry, "registry")
+			assert.Equal(t, tt.repository, repository, "repository")
+			assert.Equal(t, tt.tag, tag, "tag")
+			assert.Equal(t, tt.digest, digest, "digest")
+		})
+	}
+}
+
+func TestBatchJobDefinitionImages(t *testing.T) {
+	t.Run("no image sources returns empty", func(t *testing.T) {
+		jd := &mqlAwsBatchJobDefinition{}
+		result, err := jd.images()
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("flattens every location and dedupes", func(t *testing.T) {
+		jd := &mqlAwsBatchJobDefinition{}
+		// Single-node container.
+		jd.cacheContainerProperties = &batch_types.ContainerProperties{
+			Image: aws.String("public.ecr.aws/foo/bar:1"),
+		}
+		// EKS pod containers and init containers.
+		jd.cacheEks = &batch_types.EksProperties{
+			PodProperties: &batch_types.EksPodProperties{
+				Containers:     []batch_types.EksContainer{{Image: aws.String("nginx")}},
+				InitContainers: []batch_types.EksContainer{{Image: aws.String("123456789012.dkr.ecr.us-east-1.amazonaws.com/init:latest")}},
+			},
+		}
+		// ECS task containers.
+		jd.cacheEcs = &batch_types.EcsProperties{
+			TaskProperties: []batch_types.EcsTaskProperties{{
+				Containers: []batch_types.TaskContainerProperties{{Image: aws.String("docker.io/library/redis:7")}},
+			}},
+		}
+		// Multi-node node ranges, including a duplicate of the single-node image.
+		jd.cacheNodeProperties = &batch_types.NodeProperties{
+			NodeRangeProperties: []batch_types.NodeRangeProperty{
+				{Container: &batch_types.ContainerProperties{Image: aws.String("public.ecr.aws/foo/bar:1")}},
+				{Container: &batch_types.ContainerProperties{Image: aws.String("library/busybox")}},
+			},
+		}
+
+		result, err := jd.images()
+		require.NoError(t, err)
+
+		byImage := map[string]map[string]any{}
+		for _, r := range result {
+			entry := r.(map[string]any)
+			byImage[entry["image"].(string)] = entry
+		}
+		// Five distinct images (the duplicate public.ecr.aws ref collapses).
+		require.Len(t, result, 5)
+
+		assert.Equal(t, "public.ecr.aws", byImage["public.ecr.aws/foo/bar:1"]["registry"])
+		assert.Equal(t, "docker.io", byImage["nginx"]["registry"])
+		assert.Equal(t, "docker.io", byImage["library/busybox"]["registry"])
+		assert.Equal(t, "docker.io", byImage["docker.io/library/redis:7"]["registry"])
+		assert.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com", byImage["123456789012.dkr.ecr.us-east-1.amazonaws.com/init:latest"]["registry"])
+		assert.Equal(t, "7", byImage["docker.io/library/redis:7"]["tag"])
+	})
+}

--- a/providers/aws/resources/aws_lightsail.go
+++ b/providers/aws/resources/aws_lightsail.go
@@ -199,11 +199,14 @@ func (a *mqlAwsLightsailInstance) inboundRules() ([]any, error) {
 		return []any{}, nil
 	}
 	res := make([]any, 0, len(a.cacheNetworking.Ports))
-	for i, p := range a.cacheNetworking.Ports {
+	for _, p := range a.cacheNetworking.Ports {
 		publicAccess := slices.Contains(p.Cidrs, "0.0.0.0/0") || slices.Contains(p.Ipv6Cidrs, "::/0")
+		// Lightsail returns one rule per protocol + port range, so that triple is
+		// a stable natural key — preferable to a list index, which would shift the
+		// cached identity if the API ever reorders the rules.
 		rule, err := CreateResource(a.MqlRuntime, "aws.lightsail.instance.inboundRule",
 			map[string]*llx.RawData{
-				"__id":         llx.StringData(fmt.Sprintf("%s/inboundRule/%d", a.Arn.Data, i)),
+				"__id":         llx.StringData(fmt.Sprintf("%s/inboundRule/%s/%d-%d", a.Arn.Data, string(p.Protocol), p.FromPort, p.ToPort)),
 				"fromPort":     llx.IntData(int64(p.FromPort)),
 				"toPort":       llx.IntData(int64(p.ToPort)),
 				"protocol":     llx.StringData(string(p.Protocol)),

--- a/providers/aws/resources/aws_lightsail.go
+++ b/providers/aws/resources/aws_lightsail.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
@@ -186,6 +188,31 @@ func (a *mqlAwsLightsailInstance) firewallRules() ([]any, error) {
 		}
 		if p.CommonName != nil {
 			rule["commonName"] = *p.CommonName
+		}
+		res = append(res, rule)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsLightsailInstance) inboundRules() ([]any, error) {
+	if a.cacheNetworking == nil {
+		return []any{}, nil
+	}
+	res := make([]any, 0, len(a.cacheNetworking.Ports))
+	for i, p := range a.cacheNetworking.Ports {
+		publicAccess := slices.Contains(p.Cidrs, "0.0.0.0/0") || slices.Contains(p.Ipv6Cidrs, "::/0")
+		rule, err := CreateResource(a.MqlRuntime, "aws.lightsail.instance.inboundRule",
+			map[string]*llx.RawData{
+				"__id":         llx.StringData(fmt.Sprintf("%s/inboundRule/%d", a.Arn.Data, i)),
+				"fromPort":     llx.IntData(int64(p.FromPort)),
+				"toPort":       llx.IntData(int64(p.ToPort)),
+				"protocol":     llx.StringData(string(p.Protocol)),
+				"cidrs":        llx.ArrayData(stringsToInterface(p.Cidrs), types.String),
+				"ipv6Cidrs":    llx.ArrayData(stringsToInterface(p.Ipv6Cidrs), types.String),
+				"publicAccess": llx.BoolData(publicAccess),
+			})
+		if err != nil {
+			return nil, err
 		}
 		res = append(res, rule)
 	}


### PR DESCRIPTION
## Why

Several CIS-style cnspec checks carry navigation, null-guarding, and type-coercion that the provider can do once. This pushes that work down into the aws provider so the policy queries collapse to readable one-liners.

## Changes

### `aws.batch.jobDefinition.images()` — new `[]dict`
Flattens every container image referenced anywhere in a job definition — single-node container properties, each multi-node node-range container, ECS task containers, and EKS pod containers and init containers — and parses each reference into `{image, registry, repository, tag, digest}`. Bare names (`nginx`) and single-segment paths (`library/nginx`) normalize to the `docker.io` registry, matching how container runtimes resolve them.

**Before** (10 regexes across two locations, and it missed EKS/ECS entirely):
```
aws.batch.jobDefinitions.where(status == "ACTIVE").none(
  container.image == /^public\.ecr\.aws\// ||
  container.image == /^docker\.io\// ||
  ... 8 more ...
  nodeRangeProperties.any(container.image == /^[^.:\/]+\//)
)
```
**After:**
```
aws.batch.jobDefinitions.where(status == "ACTIVE").none(
  images.any(_['registry'] == "docker.io" ||
             _['registry'] == "registry.hub.docker.com" ||
             _['registry'] == "public.ecr.aws")
)
```

### `aws.lightsail.instance.inboundRule` — new typed sub-resource
Exposed via `inboundRules()` with `fromPort`, `toPort`, `protocol`, `cidrs`, `ipv6Cidrs`, and a derived `publicAccess` bool (true when the rule admits `0.0.0.0/0` or `::/0`). Mirrors the existing `aws.ec2.securitygroup.ippermission` model. The raw `firewallRules() []dict` is **kept and marked `@maturity("deprecated")`** for backwards compatibility.

**Before** (`_['fromPort']` dict access + manual public-cidr filter):
```
aws.lightsail.instances.all(
  firewallRules.where(_['cidrs'].contains("0.0.0.0/0")).none(
    _['fromPort'] <= 22 && _['toPort'] >= 22 || ...
  )
)
```
**After:**
```
aws.lightsail.instances.all(
  inboundRules.where(publicAccess).none(
    fromPort <= 22 && toPort >= 22 || ...
  )
)
```

### SQS / SNS secure-transport — no code change needed
`policyStatements() []aws.iam.policyStatement` already exists on `aws.sqs.queue` and `aws.sns.topic` (same pattern as VPC endpoints, EFS, KMS). The checks simplify against the current schema — the `policy['Statement'] != null` / `Condition != null` guards all disappear:
```
aws.sqs.queue.policyStatements.any(
  effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == "false" ||
  effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == false
)
```
(The `"false"`/`false` pair stays — normalizing the shared `conditions` dict would not be backwards compatible.)

## Altitude

The provider exposes faithful structural data plus well-defined derived predicates (`registry`, `publicAccess`) — not policy judgments. The sensitive-port list and the registry allow/deny list stay in the policy, where the security opinion belongs.

## Compatibility

Purely additive. The only replacement (`firewallRules` → `inboundRules`) keeps the original field, deprecated. No `aws.permissions.json` change — both new fields reuse already-fetched data.

## Tests

- `TestParseImageReference` — table test covering ECR public, Docker Hub aliases, bare/single-segment normalization, private ECR hosts, host:port, `localhost`, and tag+digest combinations.
- `TestBatchJobDefinitionImages` — flattening across all four locations + dedup.

Verified interactively against a live AWS account (queries compile and run; deprecated `firewallRules` still resolves).