### PR TITLE
🎉 digitalocean-13.6.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.5.1",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### digitalocean (13.6.0)
- ✨ digitalocean: typed firewall ingress/egress rules (#8262)
- 🧹 Update deps for mql and providers 20260608 (#8244)
- ✨ gcp/aws/digitalocean: expand GKE node pools, EMR + GenAI fields (#8198)
- 🧹 Update deps for mql and providers 20260605 (#8196)