### PR TITLE
🎉 aws-13.34.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.33.1",
+	Version:         "13.34.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.34.0)
- ✨ aws: typed predicates to simplify IAM/S3/EC2/SageMaker security policies (#8265)
- ✨ aws: add aws.kinesis.videoStreams for Kinesis Video Streams (#8263)
- ✨ aws: add batch images() + typed lightsail inbound rules to simplify policy queries (#8261)
- 🧹 aws: bump aws-sdk-go-v2 dependencies (#8259)