### PR TITLE
✨ aws: predicates to simplify CloudTrail monitoring, security-group and Lambda policies

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -8983,6 +8983,22 @@ private aws.cloudwatch.loggroup.metricsfilter @defaults("filterName") {
   applyOnTransformedLogs bool
   // Creation time of the metric filter
   createdAt time
+  // Event names the filter pattern selects on
+  //
+  // The values extracted from `$.eventName = "…"` terms in the filter pattern.
+  // Empty when the pattern does not constrain the event name.
+  monitoredEventNames() []string
+  // Event sources the filter pattern selects on
+  //
+  // The values extracted from `$.eventSource = "…"` terms in the filter
+  // pattern. Empty when the pattern does not constrain the event source.
+  monitoredEventSources() []string
+  // Whether a triggered alarm notifies an active subscriber
+  //
+  // True when one of the filter's metrics has an alarm whose actions include an
+  // SNS topic with at least one confirmed (non-pending, non-deleted)
+  // subscription.
+  hasActiveAlarm() bool
 }
 
 // Amazon CloudWatch log group subscription filter
@@ -14012,6 +14028,12 @@ private aws.lambda.function @defaults("arn") {
   policy() dict
   // Parsed statements from the function resource policy
   policyStatements() []aws.iam.policyStatement
+  // Whether the resource policy grants access to any principal
+  //
+  // True when an Allow statement grants a wildcard principal (`*`) without a
+  // scoping condition on `aws:SourceArn`, `aws:SourceAccount`, or
+  // `aws:PrincipalOrgID`. False when the function has no resource policy.
+  allowsPublicAccess() bool
   // Raw VPC configuration for the Lambda function
   //
   // Deprecated in favor of `vpc()`, `subnets()`, and `securityGroups()`.
@@ -15911,6 +15933,11 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
   prefixLists() []aws.ec2.managedPrefixList
   // List of user ID group pairs
   userIdGroupPairs []dict
+  // Whether the rule allows traffic from the entire internet
+  //
+  // True when the IPv4 ranges include `0.0.0.0/0` or the IPv6 ranges include
+  // `::/0`.
+  includesPublicSource() bool
 }
 
 // AWS Config

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -14588,6 +14588,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudwatch.loggroup.metricsfilter.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroupMetricsfilter).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"aws.cloudwatch.loggroup.metricsfilter.monitoredEventNames": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupMetricsfilter).GetMonitoredEventNames()).ToDataRes(types.Array(types.String))
+	},
+	"aws.cloudwatch.loggroup.metricsfilter.monitoredEventSources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupMetricsfilter).GetMonitoredEventSources()).ToDataRes(types.Array(types.String))
+	},
+	"aws.cloudwatch.loggroup.metricsfilter.hasActiveAlarm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupMetricsfilter).GetHasActiveAlarm()).ToDataRes(types.Bool)
+	},
 	"aws.cloudwatch.loggroup.subscriptionfilter.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetId()).ToDataRes(types.String)
 	},
@@ -19964,6 +19973,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.policyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
+	"aws.lambda.function.allowsPublicAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetAllowsPublicAccess()).ToDataRes(types.Bool)
+	},
 	"aws.lambda.function.vpcConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetVpcConfig()).ToDataRes(types.Dict)
 	},
@@ -22270,6 +22282,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.ippermission.userIdGroupPairs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetUserIdGroupPairs()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.ec2.securitygroup.ippermission.includesPublicSource": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIncludesPublicSource()).ToDataRes(types.Bool)
 	},
 	"aws.config.recorders": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfig).GetRecorders()).ToDataRes(types.Array(types.Resource("aws.config.recorder")))
@@ -47101,6 +47116,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudwatchLoggroupMetricsfilter).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.cloudwatch.loggroup.metricsfilter.monitoredEventNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupMetricsfilter).MonitoredEventNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.metricsfilter.monitoredEventSources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupMetricsfilter).MonitoredEventSources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.metricsfilter.hasActiveAlarm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupMetricsfilter).HasActiveAlarm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.cloudwatch.loggroup.subscriptionfilter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).__id, ok = v.Value.(string)
 		return
@@ -54917,6 +54944,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaFunction).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.function.allowsPublicAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).AllowsPublicAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.function.vpcConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).VpcConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -58271,6 +58302,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.ippermission.userIdGroupPairs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2SecuritygroupIppermission).UserIdGroupPairs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.includesPublicSource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermission).IncludesPublicSource, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -112721,6 +112756,9 @@ type mqlAwsCloudwatchLoggroupMetricsfilter struct {
 	MetricTransformations  plugin.TValue[[]any]
 	ApplyOnTransformedLogs plugin.TValue[bool]
 	CreatedAt              plugin.TValue[*time.Time]
+	MonitoredEventNames    plugin.TValue[[]any]
+	MonitoredEventSources  plugin.TValue[[]any]
+	HasActiveAlarm         plugin.TValue[bool]
 }
 
 // createAwsCloudwatchLoggroupMetricsfilter creates a new instance of this resource
@@ -112790,6 +112828,24 @@ func (c *mqlAwsCloudwatchLoggroupMetricsfilter) GetApplyOnTransformedLogs() *plu
 
 func (c *mqlAwsCloudwatchLoggroupMetricsfilter) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+func (c *mqlAwsCloudwatchLoggroupMetricsfilter) GetMonitoredEventNames() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.MonitoredEventNames, func() ([]any, error) {
+		return c.monitoredEventNames()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroupMetricsfilter) GetMonitoredEventSources() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.MonitoredEventSources, func() ([]any, error) {
+		return c.monitoredEventSources()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroupMetricsfilter) GetHasActiveAlarm() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasActiveAlarm, func() (bool, error) {
+		return c.hasActiveAlarm()
+	})
 }
 
 // mqlAwsCloudwatchLoggroupSubscriptionfilter for the aws.cloudwatch.loggroup.subscriptionfilter resource
@@ -132142,6 +132198,7 @@ type mqlAwsLambdaFunction struct {
 	RecursiveLoop                 plugin.TValue[string]
 	Policy                        plugin.TValue[any]
 	PolicyStatements              plugin.TValue[[]any]
+	AllowsPublicAccess            plugin.TValue[bool]
 	VpcConfig                     plugin.TValue[any]
 	Vpc                           plugin.TValue[*mqlAwsVpc]
 	Subnets                       plugin.TValue[[]any]
@@ -132270,6 +132327,12 @@ func (c *mqlAwsLambdaFunction) GetPolicyStatements() *plugin.TValue[[]any] {
 		}
 
 		return c.policyStatements()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetAllowsPublicAccess() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsPublicAccess, func() (bool, error) {
+		return c.allowsPublicAccess()
 	})
 }
 
@@ -140300,17 +140363,18 @@ type mqlAwsEc2SecuritygroupIppermission struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEc2SecuritygroupIppermissionInternal
-	Id               plugin.TValue[string]
-	FromPort         plugin.TValue[int64]
-	ToPort           plugin.TValue[int64]
-	IpProtocol       plugin.TValue[string]
-	IpRanges         plugin.TValue[[]any]
-	IpRangeDetails   plugin.TValue[[]any]
-	Ipv6Ranges       plugin.TValue[[]any]
-	Ipv6RangeDetails plugin.TValue[[]any]
-	PrefixListIds    plugin.TValue[[]any]
-	PrefixLists      plugin.TValue[[]any]
-	UserIdGroupPairs plugin.TValue[[]any]
+	Id                   plugin.TValue[string]
+	FromPort             plugin.TValue[int64]
+	ToPort               plugin.TValue[int64]
+	IpProtocol           plugin.TValue[string]
+	IpRanges             plugin.TValue[[]any]
+	IpRangeDetails       plugin.TValue[[]any]
+	Ipv6Ranges           plugin.TValue[[]any]
+	Ipv6RangeDetails     plugin.TValue[[]any]
+	PrefixListIds        plugin.TValue[[]any]
+	PrefixLists          plugin.TValue[[]any]
+	UserIdGroupPairs     plugin.TValue[[]any]
+	IncludesPublicSource plugin.TValue[bool]
 }
 
 // createAwsEc2SecuritygroupIppermission creates a new instance of this resource
@@ -140404,6 +140468,12 @@ func (c *mqlAwsEc2SecuritygroupIppermission) GetPrefixLists() *plugin.TValue[[]a
 
 func (c *mqlAwsEc2SecuritygroupIppermission) GetUserIdGroupPairs() *plugin.TValue[[]any] {
 	return &c.UserIdGroupPairs
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermission) GetIncludesPublicSource() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IncludesPublicSource, func() (bool, error) {
+		return c.includesPublicSource()
+	})
 }
 
 // mqlAwsConfig for the aws.config resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1753,10 +1753,13 @@ aws.cloudwatch.loggroup.metricsfilter.applyOnTransformedLogs 13.26.3
 aws.cloudwatch.loggroup.metricsfilter.createdAt 13.26.3
 aws.cloudwatch.loggroup.metricsfilter.filterName 11.15.2
 aws.cloudwatch.loggroup.metricsfilter.filterPattern 11.15.2
+aws.cloudwatch.loggroup.metricsfilter.hasActiveAlarm 13.33.2
 aws.cloudwatch.loggroup.metricsfilter.id 11.15.2
 aws.cloudwatch.loggroup.metricsfilter.logGroupName 13.26.3
 aws.cloudwatch.loggroup.metricsfilter.metricTransformations 13.26.3
 aws.cloudwatch.loggroup.metricsfilter.metrics 11.15.2
+aws.cloudwatch.loggroup.metricsfilter.monitoredEventNames 13.33.2
+aws.cloudwatch.loggroup.metricsfilter.monitoredEventSources 13.33.2
 aws.cloudwatch.loggroup.name 11.15.2
 aws.cloudwatch.loggroup.region 11.15.2
 aws.cloudwatch.loggroup.resourcePolicy 13.26.3
@@ -3224,6 +3227,7 @@ aws.ec2.securitygroup.ipPermissionsEgress 11.15.2
 aws.ec2.securitygroup.ippermission 11.15.2
 aws.ec2.securitygroup.ippermission.fromPort 11.15.2
 aws.ec2.securitygroup.ippermission.id 11.15.2
+aws.ec2.securitygroup.ippermission.includesPublicSource 13.33.2
 aws.ec2.securitygroup.ippermission.ipProtocol 11.15.2
 aws.ec2.securitygroup.ippermission.ipRangeDetails 13.23.2
 aws.ec2.securitygroup.ippermission.ipRanges 11.15.2
@@ -5785,6 +5789,7 @@ aws.lambda.function.alias.name 11.15.2
 aws.lambda.function.alias.revisionId 11.15.2
 aws.lambda.function.alias.routingConfigWeights 11.15.2
 aws.lambda.function.aliases 11.15.2
+aws.lambda.function.allowsPublicAccess 13.33.2
 aws.lambda.function.architectures 11.15.2
 aws.lambda.function.arn 11.15.2
 aws.lambda.function.codeSha256 11.15.2

--- a/providers/aws/resources/aws_cloudwatch_metricsfilter.go
+++ b/providers/aws/resources/aws_cloudwatch_metricsfilter.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"regexp"
+	"strings"
+)
+
+// filterPatternValueRe matches an equality selector in a CloudWatch Logs metric
+// filter pattern — `$.<field> = <value>` — capturing the value whether it is
+// quoted or bare. The `=` is not preceded by `!`, so `!=` selectors are
+// excluded. Built per field by extractFilterPatternValues.
+func filterPatternValueRe(field string) *regexp.Regexp {
+	return regexp.MustCompile(`\$\.` + regexp.QuoteMeta(field) + `\s*=\s*(?:"([^"]*)"|([^\s)|&"]+))`)
+}
+
+// extractFilterPatternValues returns the distinct values a metric filter pattern
+// selects for a given JSON field via `$.<field> = <value>` terms, preserving
+// the order they appear. Inequality (`!=`) terms are ignored.
+func extractFilterPatternValues(pattern, field string) []string {
+	matches := filterPatternValueRe(field).FindAllStringSubmatch(pattern, -1)
+	res := []string{}
+	seen := map[string]struct{}{}
+	for _, m := range matches {
+		v := m[1]
+		if v == "" {
+			v = m[2]
+		}
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		res = append(res, v)
+	}
+	return res
+}
+
+func (a *mqlAwsCloudwatchLoggroupMetricsfilter) monitoredEventNames() ([]any, error) {
+	pattern := a.GetFilterPattern()
+	if pattern.Error != nil {
+		return nil, pattern.Error
+	}
+	return toAnySlice(extractFilterPatternValues(pattern.Data, "eventName")), nil
+}
+
+func (a *mqlAwsCloudwatchLoggroupMetricsfilter) monitoredEventSources() ([]any, error) {
+	pattern := a.GetFilterPattern()
+	if pattern.Error != nil {
+		return nil, pattern.Error
+	}
+	return toAnySlice(extractFilterPatternValues(pattern.Data, "eventSource")), nil
+}
+
+// isActiveSubscriptionArn reports whether an SNS subscription ARN belongs to a
+// confirmed subscriber. SNS reports "PendingConfirmation" or "Deleted" in place
+// of a real ARN for subscriptions that cannot receive notifications.
+func isActiveSubscriptionArn(arn string) bool {
+	return arn != "" && arn != "PendingConfirmation" && arn != "Deleted"
+}
+
+// hasActiveAlarm reports whether any of the filter's metrics has an alarm that
+// notifies a confirmed SNS subscriber. It walks metrics -> alarms -> SNS topic
+// actions -> subscriptions, the same chain CIS monitoring controls assert.
+func (a *mqlAwsCloudwatchLoggroupMetricsfilter) hasActiveAlarm() (bool, error) {
+	metrics := a.GetMetrics()
+	if metrics.Error != nil {
+		return false, metrics.Error
+	}
+	for _, m := range metrics.Data {
+		metric := m.(*mqlAwsCloudwatchMetric)
+		alarms := metric.GetAlarms()
+		if alarms.Error != nil {
+			return false, alarms.Error
+		}
+		for _, al := range alarms.Data {
+			alarm := al.(*mqlAwsCloudwatchMetricsalarm)
+			actions := alarm.GetActions()
+			if actions.Error != nil {
+				return false, actions.Error
+			}
+			for _, ac := range actions.Data {
+				topic := ac.(*mqlAwsSnsTopic)
+				arn := topic.GetArn()
+				if arn.Error != nil {
+					return false, arn.Error
+				}
+				if !strings.HasPrefix(arn.Data, "arn:aws:sns:") {
+					continue
+				}
+				subs := topic.GetSubscriptions()
+				if subs.Error != nil {
+					return false, subs.Error
+				}
+				for _, s := range subs.Data {
+					sub := s.(*mqlAwsSnsSubscription)
+					subArn := sub.GetArn()
+					if subArn.Error != nil {
+						return false, subArn.Error
+					}
+					if isActiveSubscriptionArn(subArn.Data) {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+	return false, nil
+}

--- a/providers/aws/resources/aws_cloudwatch_metricsfilter.go
+++ b/providers/aws/resources/aws_cloudwatch_metricsfilter.go
@@ -8,19 +8,26 @@ import (
 	"strings"
 )
 
+// Compiled once for the two fields the metric-filter accessors select on,
+// rather than recompiling on every call.
+var (
+	monitoredEventNameRe   = filterPatternValueRe("eventName")
+	monitoredEventSourceRe = filterPatternValueRe("eventSource")
+)
+
 // filterPatternValueRe matches an equality selector in a CloudWatch Logs metric
 // filter pattern — `$.<field> = <value>` — capturing the value whether it is
 // quoted or bare. The `=` is not preceded by `!`, so `!=` selectors are
-// excluded. Built per field by extractFilterPatternValues.
+// excluded.
 func filterPatternValueRe(field string) *regexp.Regexp {
 	return regexp.MustCompile(`\$\.` + regexp.QuoteMeta(field) + `\s*=\s*(?:"([^"]*)"|([^\s)|&"]+))`)
 }
 
 // extractFilterPatternValues returns the distinct values a metric filter pattern
-// selects for a given JSON field via `$.<field> = <value>` terms, preserving
-// the order they appear. Inequality (`!=`) terms are ignored.
-func extractFilterPatternValues(pattern, field string) []string {
-	matches := filterPatternValueRe(field).FindAllStringSubmatch(pattern, -1)
+// selects via the `$.<field> = <value>` terms matched by re, preserving the
+// order they appear. Inequality (`!=`) terms are ignored.
+func extractFilterPatternValues(re *regexp.Regexp, pattern string) []string {
+	matches := re.FindAllStringSubmatch(pattern, -1)
 	res := []string{}
 	seen := map[string]struct{}{}
 	for _, m := range matches {
@@ -45,7 +52,7 @@ func (a *mqlAwsCloudwatchLoggroupMetricsfilter) monitoredEventNames() ([]any, er
 	if pattern.Error != nil {
 		return nil, pattern.Error
 	}
-	return toAnySlice(extractFilterPatternValues(pattern.Data, "eventName")), nil
+	return toAnySlice(extractFilterPatternValues(monitoredEventNameRe, pattern.Data)), nil
 }
 
 func (a *mqlAwsCloudwatchLoggroupMetricsfilter) monitoredEventSources() ([]any, error) {
@@ -53,7 +60,7 @@ func (a *mqlAwsCloudwatchLoggroupMetricsfilter) monitoredEventSources() ([]any, 
 	if pattern.Error != nil {
 		return nil, pattern.Error
 	}
-	return toAnySlice(extractFilterPatternValues(pattern.Data, "eventSource")), nil
+	return toAnySlice(extractFilterPatternValues(monitoredEventSourceRe, pattern.Data)), nil
 }
 
 // isActiveSubscriptionArn reports whether an SNS subscription ARN belongs to a

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2048,6 +2048,33 @@ func (a *mqlAwsEc2SecuritygroupIppermission) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+// includesPublicSource reports whether the rule allows traffic from the entire
+// internet — an IPv4 range of 0.0.0.0/0 or an IPv6 range of ::/0.
+func (a *mqlAwsEc2SecuritygroupIppermission) includesPublicSource() (bool, error) {
+	ipv4 := a.GetIpRanges()
+	if ipv4.Error != nil {
+		return false, ipv4.Error
+	}
+	if anyStringEquals(ipv4.Data, "0.0.0.0/0") {
+		return true, nil
+	}
+	ipv6 := a.GetIpv6Ranges()
+	if ipv6.Error != nil {
+		return false, ipv6.Error
+	}
+	return anyStringEquals(ipv6.Data, "::/0"), nil
+}
+
+// anyStringEquals reports whether any element of the slice equals target.
+func anyStringEquals(list []any, target string) bool {
+	for _, item := range list {
+		if s, ok := item.(string); ok && s == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *mqlAwsEc2InstanceDevice) id() (string, error) {
 	return a.VolumeId.Data, nil
 }

--- a/providers/aws/resources/aws_foundation_helpers_test.go
+++ b/providers/aws/resources/aws_foundation_helpers_test.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestExtractFilterPatternValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		field   string
+		want    []string
+	}{
+		{
+			name:    "quoted event source",
+			pattern: `{ ($.eventSource = "organizations.amazonaws.com") }`,
+			field:   "eventSource",
+			want:    []string{"organizations.amazonaws.com"},
+		},
+		{
+			name:    "unquoted no spaces",
+			pattern: `($.eventName=DeleteGroupPolicy)||($.eventName=PutGroupPolicy)`,
+			field:   "eventName",
+			want:    []string{"DeleteGroupPolicy", "PutGroupPolicy"},
+		},
+		{
+			name:    "unquoted with spaces",
+			pattern: `($.eventName = CreateVpc) || ($.eventName = DeleteVpc)`,
+			field:   "eventName",
+			want:    []string{"CreateVpc", "DeleteVpc"},
+		},
+		{
+			name:    "inequality is excluded",
+			pattern: `($.errorCode = "AccessDenied*") && ($.eventName != "HeadBucket")`,
+			field:   "eventName",
+			want:    []string{},
+		},
+		{
+			name:    "errorCode with wildcard value",
+			pattern: `($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*")`,
+			field:   "errorCode",
+			want:    []string{"*UnauthorizedOperation", "AccessDenied*"},
+		},
+		{
+			name:    "dotted field name",
+			pattern: `$.userIdentity.type = "Root" && $.eventType != "AwsServiceEvent"`,
+			field:   "userIdentity.type",
+			want:    []string{"Root"},
+		},
+		{
+			name:    "deduplicates repeats",
+			pattern: `($.eventName = StopLogging) || ($.eventName = StopLogging)`,
+			field:   "eventName",
+			want:    []string{"StopLogging"},
+		},
+		{
+			name:    "no match",
+			pattern: `($.eventName = ConsoleLogin)`,
+			field:   "eventSource",
+			want:    []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, extractFilterPatternValues(tc.pattern, tc.field))
+		})
+	}
+}
+
+func TestIsActiveSubscriptionArn(t *testing.T) {
+	assert.True(t, isActiveSubscriptionArn("arn:aws:sns:us-east-1:123456789012:topic:uuid"))
+	assert.False(t, isActiveSubscriptionArn(""))
+	assert.False(t, isActiveSubscriptionArn("PendingConfirmation"))
+	assert.False(t, isActiveSubscriptionArn("Deleted"))
+}
+
+func TestAnyStringEquals(t *testing.T) {
+	assert.True(t, anyStringEquals([]any{"10.0.0.0/8", "0.0.0.0/0"}, "0.0.0.0/0"))
+	assert.False(t, anyStringEquals([]any{"10.0.0.0/8"}, "0.0.0.0/0"))
+	assert.False(t, anyStringEquals([]any{}, "0.0.0.0/0"))
+}
+
+func TestIpPermissionIncludesPublicSource(t *testing.T) {
+	mk := func(ipv4, ipv6 []any) *mqlAwsEc2SecuritygroupIppermission {
+		p := &mqlAwsEc2SecuritygroupIppermission{}
+		p.IpRanges = plugin.TValue[[]any]{Data: ipv4, State: plugin.StateIsSet}
+		p.Ipv6Ranges = plugin.TValue[[]any]{Data: ipv6, State: plugin.StateIsSet}
+		return p
+	}
+
+	t.Run("public ipv4", func(t *testing.T) {
+		got, err := mk([]any{"0.0.0.0/0"}, nil).includesPublicSource()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+	t.Run("public ipv6", func(t *testing.T) {
+		got, err := mk([]any{"10.0.0.0/8"}, []any{"::/0"}).includesPublicSource()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+	t.Run("private only", func(t *testing.T) {
+		got, err := mk([]any{"10.0.0.0/8", "192.168.0.0/16"}, []any{"2001:db8::/32"}).includesPublicSource()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
+func TestHasWildcardPrincipal(t *testing.T) {
+	assert.True(t, hasWildcardPrincipal(map[string]any{"AWS": []any{"*"}}))
+	assert.True(t, hasWildcardPrincipal(map[string]any{"Service": []any{"s3.amazonaws.com", "*"}}))
+	assert.False(t, hasWildcardPrincipal(map[string]any{"AWS": []any{"arn:aws:iam::123456789012:root"}}))
+	assert.False(t, hasWildcardPrincipal(nil))
+}
+
+func TestHasSourceScopingCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions any
+		want       bool
+	}{
+		{
+			name:       "scoped by source account",
+			conditions: map[string]any{"StringEquals": map[string]any{"aws:SourceAccount": "123456789012"}},
+			want:       true,
+		},
+		{
+			name:       "scoped by source arn (case-insensitive key)",
+			conditions: map[string]any{"ArnLike": map[string]any{"AWS:SourceArn": "arn:aws:s3:::bucket"}},
+			want:       true,
+		},
+		{
+			name:       "wildcard scoping value does not count",
+			conditions: map[string]any{"StringEquals": map[string]any{"aws:SourceArn": "*"}},
+			want:       false,
+		},
+		{
+			name:       "wildcard in list value does not count",
+			conditions: map[string]any{"StringEquals": map[string]any{"aws:PrincipalOrgID": []any{"*"}}},
+			want:       false,
+		},
+		{
+			name:       "unrelated condition key",
+			conditions: map[string]any{"StringEquals": map[string]any{"aws:Region": "us-east-1"}},
+			want:       false,
+		},
+		{
+			name:       "nil",
+			conditions: nil,
+			want:       false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasSourceScopingCondition(tc.conditions))
+		})
+	}
+}

--- a/providers/aws/resources/aws_foundation_helpers_test.go
+++ b/providers/aws/resources/aws_foundation_helpers_test.go
@@ -69,7 +69,7 @@ func TestExtractFilterPatternValues(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, extractFilterPatternValues(tc.pattern, tc.field))
+			assert.Equal(t, tc.want, extractFilterPatternValues(filterPatternValueRe(tc.field), tc.pattern))
 		})
 	}
 }

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -562,6 +563,107 @@ func (a *mqlAwsLambdaFunction) policy() (any, error) {
 	}
 
 	return nil, nil
+}
+
+// allowsPublicAccess reports whether the function's resource policy grants a
+// wildcard principal access through an Allow statement that lacks a scoping
+// condition on aws:SourceArn, aws:SourceAccount, or aws:PrincipalOrgID. It is
+// false when the function has no resource policy.
+func (a *mqlAwsLambdaFunction) allowsPublicAccess() (bool, error) {
+	stmts, err := a.policyStatements()
+	if err != nil {
+		return false, err
+	}
+	for _, raw := range stmts {
+		stmt := raw.(*mqlAwsIamPolicyStatement)
+		effect := stmt.GetEffect()
+		if effect.Error != nil {
+			return false, effect.Error
+		}
+		if !strings.EqualFold(effect.Data, "Allow") {
+			continue
+		}
+		principals := stmt.GetPrincipals()
+		if principals.Error != nil {
+			return false, principals.Error
+		}
+		if !hasWildcardPrincipal(principals.Data) {
+			continue
+		}
+		conditions := stmt.GetConditions()
+		if conditions.Error != nil {
+			return false, conditions.Error
+		}
+		if !hasSourceScopingCondition(conditions.Data) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// hasWildcardPrincipal reports whether a parsed policy-statement principal map
+// grants access to the `*` wildcard under any principal type.
+func hasWildcardPrincipal(principals any) bool {
+	m, ok := principals.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, v := range m {
+		list, ok := v.([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range list {
+			if s, ok := item.(string); ok && s == "*" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasSourceScopingCondition reports whether a statement condition map scopes
+// access with a non-wildcard aws:SourceArn, aws:SourceAccount, or
+// aws:PrincipalOrgID value.
+func hasSourceScopingCondition(conditions any) bool {
+	m, ok := conditions.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, opVal := range m {
+		keys, ok := opVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		for key, val := range keys {
+			if isSourceScopingKey(key) && !conditionValueIsWildcard(val) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isSourceScopingKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "aws:sourcearn", "aws:sourceaccount", "aws:principalorgid":
+		return true
+	}
+	return false
+}
+
+func conditionValueIsWildcard(val any) bool {
+	switch v := val.(type) {
+	case string:
+		return v == "*"
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == "*" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (a *mqlAwsLambdaFunction) urlConfig() (*mqlAwsLambdaFunctionUrlConfig, error) {


### PR DESCRIPTION
## Why

The AWS foundations / CIS policy set is dominated by ~30 near-identical CloudTrail "metric filter + alarm" checks. Each one hand-parses the CloudWatch Logs filter pattern (long `||`-chains of regexes, or one giant `.contains('…DSL string…')`) and then repeats the same `metrics → alarms → SNS action → active-subscription` walk inline. This adds typed resource-side helpers so those checks become short and correct. Additive only.

## What changed

| Resource | Added |
|---|---|
| `aws.cloudwatch.loggroup.metricsfilter` | `hasActiveAlarm()` — metric → alarm → SNS topic action → confirmed (non-`PendingConfirmation`/`Deleted`) subscription |
| `aws.cloudwatch.loggroup.metricsfilter` | `monitoredEventNames []string`, `monitoredEventSources []string` — values from `$.eventName = …` / `$.eventSource = …` selectors (inequality terms ignored) |
| `aws.ec2.securitygroup.ippermission` | `includesPublicSource()` — `0.0.0.0/0` or `::/0` |
| `aws.lambda.function` | `allowsPublicAccess()` — Allow statement with a wildcard principal lacking an `aws:SourceArn`/`SourceAccount`/`PrincipalOrgID` scoping condition |

## Simplifications enabled

A typical CloudTrail monitoring check goes from ~25 lines to:
```
aws.cloudtrail.trail.eventSelectorEntries.any(includeManagementEvents && readWriteType == 'All')
aws.cloudtrail.trail.logGroup.metricsFilters.where(
  monitoredEventNames.containsAll(props.orgEventNames)
).all(hasActiveAlarm)
```
The ~8 selector-specific controls (root usage, console-MFA, unauthorized API, auth failures — which key on `userIdentity.type`, `errorCode`, etc.) keep a small `.contains(...)` for their unusual selector but still collapse the whole alarm tail to `.all(hasActiveAlarm)`.

`aws-ec2-restricted-common-ports` (24 repeated lines) → `.none(includesPublicSource && toPort == …)`.
`aws-lambda-function-public-access-prohibited` (~20 lines walking Statement/Principal/Condition) → `!allowsPublicAccess`.

## Notes

- The regex-disjunction filter family has a latent operator-precedence bug (`contains(A) && contains(B) || contains(C) || …` parses as `(A && B) || C || …`); `monitoredEventNames` sidesteps it by giving policies a real list to test with `containsAll`/`containsAny`.
- Policy rewrites (and that precedence fix) live in cnspec, not this repo.

## Testing

- Connection-free unit tests for all pure logic: filter-pattern value extraction (quoted/unquoted/dotted fields, `!=` excluded, dedup), active-subscription check, public-source check, wildcard-principal and source-scoping-condition logic — all green.
- `includesPublicSource` and `allowsPublicAccess` verified live against a real AWS account.
- `hasActiveAlarm`/`monitoredEvent*` are unit-tested for logic; the test account has no metric filters to exercise them live (the field accessors build/install cleanly and follow the same pattern as the verified resources).
- `aws.permissions.json` unchanged (all fields reuse existing API calls).
