### PR TITLE
✨ aws: add cloudtrail.trail.capturesAllManagementEvents predicate

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9795,6 +9795,11 @@ private aws.cloudtrail.trail @defaults("name region") {
   eventSelectors() @maturity("deprecated") []dict
   // Typed event selector configuration for the trail
   eventSelectorEntries() []aws.cloudtrail.trail.eventSelector
+  // Whether the trail logs all management events
+  //
+  // True when an event selector includes management events and applies to both
+  // read and write events (`readWriteType` of `All`).
+  capturesAllManagementEvents() bool
   // Advanced event selectors configured for the trail
   advancedEventSelectors() []aws.cloudtrail.trail.advancedEventSelector
   // Region in which the trail was created (home region)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -15332,6 +15332,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudtrail.trail.eventSelectorEntries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetEventSelectorEntries()).ToDataRes(types.Array(types.Resource("aws.cloudtrail.trail.eventSelector")))
 	},
+	"aws.cloudtrail.trail.capturesAllManagementEvents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetCapturesAllManagementEvents()).ToDataRes(types.Bool)
+	},
 	"aws.cloudtrail.trail.advancedEventSelectors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetAdvancedEventSelectors()).ToDataRes(types.Array(types.Resource("aws.cloudtrail.trail.advancedEventSelector")))
 	},
@@ -48218,6 +48221,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudtrail.trail.eventSelectorEntries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudtrailTrail).EventSelectorEntries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.capturesAllManagementEvents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).CapturesAllManagementEvents, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.cloudtrail.trail.advancedEventSelectors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -115553,6 +115560,7 @@ type mqlAwsCloudtrailTrail struct {
 	CloudWatchLogsLogGroupArn            plugin.TValue[string]
 	EventSelectors                       plugin.TValue[[]any]
 	EventSelectorEntries                 plugin.TValue[[]any]
+	CapturesAllManagementEvents          plugin.TValue[bool]
 	AdvancedEventSelectors               plugin.TValue[[]any]
 	Region                               plugin.TValue[string]
 	HasInsightSelectors                  plugin.TValue[bool]
@@ -115754,6 +115762,12 @@ func (c *mqlAwsCloudtrailTrail) GetEventSelectorEntries() *plugin.TValue[[]any] 
 		}
 
 		return c.eventSelectorEntries()
+	})
+}
+
+func (c *mqlAwsCloudtrailTrail) GetCapturesAllManagementEvents() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CapturesAllManagementEvents, func() (bool, error) {
+		return c.capturesAllManagementEvents()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1639,6 +1639,7 @@ aws.cloudtrail.trail.advancedEventSelector.fieldSelectors 13.12.1
 aws.cloudtrail.trail.advancedEventSelector.name 13.12.1
 aws.cloudtrail.trail.advancedEventSelectors 13.12.1
 aws.cloudtrail.trail.arn 11.15.2
+aws.cloudtrail.trail.capturesAllManagementEvents 13.34.1
 aws.cloudtrail.trail.cloudWatchLogsLogGroupArn 11.15.2
 aws.cloudtrail.trail.cloudWatchLogsRole 13.12.1
 aws.cloudtrail.trail.cloudWatchLogsRoleArn 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.33.1",
-  "generated_at": "2026-06-08T14:47:26-07:00",
+  "version": "13.34.0",
+  "generated_at": "2026-06-08T18:27:34-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -390,6 +390,30 @@ func (a *mqlAwsCloudtrailTrail) getEventSelectorsData() (*cloudtrail.GetEventSel
 	return resp, nil
 }
 
+// capturesAllManagementEvents reports whether any event selector logs
+// management events for both read and write events (readWriteType "All").
+func (a *mqlAwsCloudtrailTrail) capturesAllManagementEvents() (bool, error) {
+	entries := a.GetEventSelectorEntries()
+	if entries.Error != nil {
+		return false, entries.Error
+	}
+	for _, e := range entries.Data {
+		sel := e.(*mqlAwsCloudtrailTrailEventSelector)
+		mgmt := sel.GetIncludeManagementEvents()
+		if mgmt.Error != nil {
+			return false, mgmt.Error
+		}
+		rw := sel.GetReadWriteType()
+		if rw.Error != nil {
+			return false, rw.Error
+		}
+		if mgmt.Data && rw.Data == "All" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (a *mqlAwsCloudtrailTrail) eventSelectorEntries() ([]any, error) {
 	resp, err := a.getEventSelectorsData()
 	if err != nil {

--- a/providers/aws/resources/aws_cloudtrail_trail_test.go
+++ b/providers/aws/resources/aws_cloudtrail_trail_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestCapturesAllManagementEvents(t *testing.T) {
+	selector := func(mgmt bool, readWriteType string) *mqlAwsCloudtrailTrailEventSelector {
+		sel := &mqlAwsCloudtrailTrailEventSelector{}
+		sel.IncludeManagementEvents = plugin.TValue[bool]{Data: mgmt, State: plugin.StateIsSet}
+		sel.ReadWriteType = plugin.TValue[string]{Data: readWriteType, State: plugin.StateIsSet}
+		return sel
+	}
+	trail := func(sels ...*mqlAwsCloudtrailTrailEventSelector) *mqlAwsCloudtrailTrail {
+		entries := make([]any, len(sels))
+		for i, s := range sels {
+			entries[i] = s
+		}
+		tr := &mqlAwsCloudtrailTrail{}
+		tr.EventSelectorEntries = plugin.TValue[[]any]{Data: entries, State: plugin.StateIsSet}
+		return tr
+	}
+
+	tests := []struct {
+		name string
+		sels []*mqlAwsCloudtrailTrailEventSelector
+		want bool
+	}{
+		{"management + All", []*mqlAwsCloudtrailTrailEventSelector{selector(true, "All")}, true},
+		{"management but write only", []*mqlAwsCloudtrailTrailEventSelector{selector(true, "WriteOnly")}, false},
+		{"All but no management", []*mqlAwsCloudtrailTrailEventSelector{selector(false, "All")}, false},
+		{"matches among several", []*mqlAwsCloudtrailTrailEventSelector{selector(false, "ReadOnly"), selector(true, "All")}, true},
+		{"no selectors", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := trail(tc.sels...).capturesAllManagementEvents()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Why

Every CIS CloudTrail monitoring check (~30 of them) repeats this line verbatim:
```
aws.cloudtrail.trail.eventSelectorEntries.any(includeManagementEvents == true && readWriteType == 'All')
```
This adds a predicate so it collapses to `aws.cloudtrail.trail.capturesAllManagementEvents`. Combined with the previously merged `hasActiveAlarm` and `monitoredEventNames`/`monitoredEventSources` (#8267), a full monitoring check now reads:
```
aws.cloudtrail.trail.capturesAllManagementEvents
aws.cloudtrail.trail.logGroup.metricsFilters.where(monitoredEventNames.containsAll(props.x)).all(hasActiveAlarm)
```

## What changed

- `aws.cloudtrail.trail.capturesAllManagementEvents() bool` — true when an event selector includes management events with `readWriteType` of `All`.

## Notes

- Faithful to the existing checks: it inspects the **basic** event selectors (`eventSelectorEntries`) only — same scope the policies already asserted. (Trails configured purely via *advanced* event selectors return `false`, exactly as the original `eventSelectorEntries.any(...)` did.)
- `aws.permissions.json` diff is only the version/timestamp syncing to the released `13.34.0`; the permission list is unchanged.

## Testing

- Connection-free unit test covering management/`readWriteType` combinations (management+All, write-only, no-management, match-among-several, empty) — green.
- Smoke-tested live against a real account; resolves correctly (returns `false` for a trail that uses advanced selectors with an empty basic `eventSelectorEntries`, matching original semantics).
