### PR TITLE
✨ os: typed auditd syscall-rule accessors to simplify audit policies

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -338,7 +339,14 @@ func (s *mqlAuditdRules) parse(content string, errors *multierr.Errors) {
 				args["permissions"] = llx.StringData(v)
 
 			case "-S":
-				syscalls = append(syscalls, v)
+				// -S accepts a comma-separated list of syscalls (and may be
+				// repeated); store each syscall individually so policies can
+				// match them as a flat list.
+				for _, sc := range strings.Split(v, ",") {
+					if sc != "" {
+						syscalls = append(syscalls, sc)
+					}
+				}
 
 			default:
 				other = append(other, [2]string{k, v})
@@ -393,6 +401,44 @@ func (s *mqlAuditdRules) parse(content string, errors *multierr.Errors) {
 				}
 			}
 			args["comparisons"] = llx.ArrayData(comparisons, types.Dict)
+
+			// Derive convenience accessors from the parsed -F fields so policies
+			// can match the common arch/auid filters directly instead of
+			// re-implementing the key/op/value lookups in MQL.
+			var arch string
+			var auidMin *int64
+			excludesUnsetAuid := false
+			for _, raw := range fields {
+				f, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				key, _ := f["key"].(string)
+				op, _ := f["op"].(string)
+				val, _ := f["value"].(string)
+				switch key {
+				case "arch":
+					if op == "=" {
+						arch = val
+					}
+				case "auid":
+					switch op {
+					case ">=":
+						if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+							auidMin = &n
+						}
+					case "!=":
+						// auid is unset for processes without a login UID;
+						// the kernel reports it as the raw sentinels below.
+						if val == "unset" || val == "4294967295" || val == "-1" {
+							excludesUnsetAuid = true
+						}
+					}
+				}
+			}
+			args["arch"] = llx.StringData(arch)
+			args["auidMin"] = llx.IntDataPtr(auidMin)
+			args["excludesUnsetAuid"] = llx.BoolData(excludesUnsetAuid)
 
 			if _, ok := args["keyname"]; !ok {
 				args["keyname"] = llx.StringData("")

--- a/providers/os/resources/auditd_internal_test.go
+++ b/providers/os/resources/auditd_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/multierr"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
 
@@ -50,4 +51,156 @@ func TestAuditdRulesMissingPathReturnsEmptyLists(t *testing.T) {
 	require.NoError(t, syscalls.Error)
 	assert.Empty(t, syscalls.Data)
 	assert.Equal(t, plugin.StateIsSet, syscalls.State)
+}
+
+func TestAuditdSyscallRuleParsing(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	content := `
+# 64-bit DAC permission modification rule
+-a always,exit -F arch=b64 -S chmod,fchmod,chown -F auid>=1000 -F auid!=unset -k perm_mod
+# 32-bit variant using the raw unset sentinel
+-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+# rule without any arch or auid filters
+-a always,exit -S execve -k exec
+`
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Syscalls.Data, 3)
+
+	t.Run("b64 rule derives arch, auidMin and excludesUnsetAuid", func(t *testing.T) {
+		r := rules.Syscalls.Data[0].(*mqlAuditdRuleSyscall)
+		assert.Equal(t, "b64", r.Arch.Data)
+		assert.Equal(t, []any{"chmod", "fchmod", "chown"}, r.Syscalls.Data)
+		assert.Equal(t, int64(1000), r.AuidMin.Data)
+		assert.Equal(t, plugin.StateIsSet, r.AuidMin.State)
+		assert.True(t, r.ExcludesUnsetAuid.Data)
+		assert.Equal(t, "perm_mod", r.Keyname.Data)
+	})
+
+	t.Run("b32 rule treats the 4294967295 sentinel as unset", func(t *testing.T) {
+		r := rules.Syscalls.Data[1].(*mqlAuditdRuleSyscall)
+		assert.Equal(t, "b32", r.Arch.Data)
+		assert.Equal(t, int64(1000), r.AuidMin.Data)
+		assert.True(t, r.ExcludesUnsetAuid.Data)
+	})
+
+	t.Run("rule without arch/auid filters leaves fields empty and auidMin null", func(t *testing.T) {
+		r := rules.Syscalls.Data[2].(*mqlAuditdRuleSyscall)
+		assert.Equal(t, "", r.Arch.Data)
+		assert.False(t, r.ExcludesUnsetAuid.Data)
+		assert.NotEqual(t, 0, r.AuidMin.State&plugin.StateIsNull)
+	})
+}
+
+func TestAuditdSyscallRuleRepeatedFlags(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	// Syscalls may be supplied via repeated -S flags as well as comma lists;
+	// both forms must accumulate into a single flat syscalls list.
+	content := "-a always,exit -F arch=b64 -S open -S openat,creat -k access\n"
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Syscalls.Data, 1)
+
+	r := rules.Syscalls.Data[0].(*mqlAuditdRuleSyscall)
+	assert.Equal(t, []any{"open", "openat", "creat"}, r.Syscalls.Data)
+}
+
+func TestAuditdControlRuleParsing(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	content := `
+# comment line, must be skipped
+
+-D
+-b 8192
+-f 1
+--backlog_wait_time 60000
+`
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Controls.Data, 4)
+	assert.Empty(t, rules.Syscalls.Data)
+	assert.Empty(t, rules.Files.Data)
+
+	got := map[string]string{}
+	for _, raw := range rules.Controls.Data {
+		c := raw.(*mqlAuditdRuleControl)
+		got[c.Flag.Data] = c.Value.Data
+	}
+	assert.Equal(t, map[string]string{
+		"-D":                  "",
+		"-b":                  "8192",
+		"-f":                  "1",
+		"--backlog_wait_time": "60000",
+	}, got)
+}
+
+func TestAuditdFileRuleParsing(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	content := `
+-w /etc/shadow -p wa -k identity
+-w /etc/passwd
+`
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Files.Data, 2)
+
+	shadow := rules.Files.Data[0].(*mqlAuditdRuleFile)
+	assert.Equal(t, "/etc/shadow", shadow.Path.Data)
+	assert.Equal(t, "wa", shadow.Permissions.Data)
+	assert.Equal(t, "identity", shadow.Keyname.Data)
+
+	// A watch with no -p/-k still parses, with empty permissions and keyname.
+	passwd := rules.Files.Data[1].(*mqlAuditdRuleFile)
+	assert.Equal(t, "/etc/passwd", passwd.Path.Data)
+	assert.Equal(t, "", passwd.Permissions.Data)
+	assert.Equal(t, "", passwd.Keyname.Data)
+}
+
+func TestAuditdSyscallFieldOperatorParsing(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	// Exercises the reOperator ordering (>= must win over =/>) and a key-only
+	// field with no operator.
+	content := "-a always,exit -F arch=b64 -F auid>=1000 -F success!=0 -F exit -S execve -k t\n"
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Syscalls.Data, 1)
+
+	got := map[string][2]string{} // key -> {op, value}
+	keyOnly := []string{}
+	for _, raw := range rules.Syscalls.Data[0].(*mqlAuditdRuleSyscall).Fields.Data {
+		f := raw.(map[string]any)
+		key, _ := f["key"].(string)
+		op, hasOp := f["op"].(string)
+		if !hasOp {
+			keyOnly = append(keyOnly, key)
+			continue
+		}
+		val, _ := f["value"].(string)
+		got[key] = [2]string{op, val}
+	}
+
+	assert.Equal(t, [2]string{"=", "b64"}, got["arch"])
+	assert.Equal(t, [2]string{">=", "1000"}, got["auid"])
+	assert.Equal(t, [2]string{"!=", "0"}, got["success"])
+	assert.Contains(t, keyOnly, "exit")
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1262,6 +1262,24 @@ private auditd.rule.syscall @defaults("action list") {
   comparisons []dict
   // The key name for related rules as specified by -k
   keyname string
+  // CPU architecture this rule is restricted to
+  //
+  // The value of the `-F arch=` filter, normally `b64` or `b32`. Empty when
+  // the rule has no architecture filter and therefore applies to all
+  // architectures.
+  arch string
+  // Minimum audit UID this rule is restricted to
+  //
+  // The threshold N from a `-F auid>=N` filter, commonly `1000` to target
+  // interactive users above the system UID range. Null when the rule has no
+  // `auid>=` filter.
+  auidMin int
+  // Whether the rule excludes events with an unset audit UID
+  //
+  // True when the rule carries a `-F auid!=unset` filter (also matching the
+  // raw sentinels `4294967295` and `-1`), which drops events from daemons
+  // and other processes that never had a login UID assigned.
+  excludesUnsetAuid bool
 }
 
 // Apache2 HTTP Server

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3156,6 +3156,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"auditd.rule.syscall.keyname": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAuditdRuleSyscall).GetKeyname()).ToDataRes(types.String)
 	},
+	"auditd.rule.syscall.arch": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuditdRuleSyscall).GetArch()).ToDataRes(types.String)
+	},
+	"auditd.rule.syscall.auidMin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuditdRuleSyscall).GetAuidMin()).ToDataRes(types.Int)
+	},
+	"auditd.rule.syscall.excludesUnsetAuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuditdRuleSyscall).GetExcludesUnsetAuid()).ToDataRes(types.Bool)
+	},
 	"apache2.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlApache2).GetVersion()).ToDataRes(types.String)
 	},
@@ -11475,6 +11484,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"auditd.rule.syscall.keyname": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAuditdRuleSyscall).Keyname, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"auditd.rule.syscall.arch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuditdRuleSyscall).Arch, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"auditd.rule.syscall.auidMin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuditdRuleSyscall).AuidMin, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"auditd.rule.syscall.excludesUnsetAuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuditdRuleSyscall).ExcludesUnsetAuid, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"apache2.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27554,12 +27575,15 @@ type mqlAuditdRuleSyscall struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAuditdRuleSyscallInternal it will be used here
-	Action      plugin.TValue[string]
-	List        plugin.TValue[string]
-	Syscalls    plugin.TValue[[]any]
-	Fields      plugin.TValue[[]any]
-	Comparisons plugin.TValue[[]any]
-	Keyname     plugin.TValue[string]
+	Action            plugin.TValue[string]
+	List              plugin.TValue[string]
+	Syscalls          plugin.TValue[[]any]
+	Fields            plugin.TValue[[]any]
+	Comparisons       plugin.TValue[[]any]
+	Keyname           plugin.TValue[string]
+	Arch              plugin.TValue[string]
+	AuidMin           plugin.TValue[int64]
+	ExcludesUnsetAuid plugin.TValue[bool]
 }
 
 // createAuditdRuleSyscall creates a new instance of this resource
@@ -27621,6 +27645,18 @@ func (c *mqlAuditdRuleSyscall) GetComparisons() *plugin.TValue[[]any] {
 
 func (c *mqlAuditdRuleSyscall) GetKeyname() *plugin.TValue[string] {
 	return &c.Keyname
+}
+
+func (c *mqlAuditdRuleSyscall) GetArch() *plugin.TValue[string] {
+	return &c.Arch
+}
+
+func (c *mqlAuditdRuleSyscall) GetAuidMin() *plugin.TValue[int64] {
+	return &c.AuidMin
+}
+
+func (c *mqlAuditdRuleSyscall) GetExcludesUnsetAuid() *plugin.TValue[bool] {
+	return &c.ExcludesUnsetAuid
 }
 
 // mqlApache2 for the apache2 resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -144,7 +144,10 @@ auditd.rule.file.path 11.4.21
 auditd.rule.file.permissions 11.4.21
 auditd.rule.syscall 11.4.21
 auditd.rule.syscall.action 11.4.21
+auditd.rule.syscall.arch 13.25.1
+auditd.rule.syscall.auidMin 13.25.1
 auditd.rule.syscall.comparisons 11.4.21
+auditd.rule.syscall.excludesUnsetAuid 13.25.1
 auditd.rule.syscall.fields 11.4.21
 auditd.rule.syscall.keyname 11.4.21
 auditd.rule.syscall.list 11.4.21


### PR DESCRIPTION
## What

Adds three derived accessors to the `auditd.rule.syscall` resource and fixes `-S` syscall-list parsing, so Linux audit policies can express "ensure events of type X are collected" checks without hand-parsing the raw `fields []dict`.

New fields on `auditd.rule.syscall`:

| field | meaning |
|---|---|
| `arch` | value of the `-F arch=` filter (`b64`/`b32`), empty when the rule has no arch filter |
| `auidMin` | threshold *N* from `-F auid>=N`; null when absent |
| `excludesUnsetAuid` | true when `-F auid!=unset` is present (also matching the raw sentinels `4294967295` / `-1`) |

Also: **comma-separated `-S` lists are now split** into individual syscalls (`-S chmod,fchmod,chown` → three entries). `auditctl` accepts comma lists, and without splitting the `.map(syscalls).flat.containsAll([...])` pattern these policies rely on cannot match.

## Why

Today every audit-collection check in `mondoo-linux-security` repeats a ~20-line block that re-implements the same `arch` / `auid>=1000` / `auid!=unset` / `keyname` matching against the untyped field list, duplicated once for `b32` and once for `b64`. The triplet `fields.contains(key == "auid" && op == ">=" && value == "1000")` and the `["unset","4294967295","-1"]` enumeration are fragile and copy-pasted across ~17 checks.

## Result

The repeated DAC-permission check collapses from ~20 lines to:

```mql
["b32","b64"].all(a:
  auditd.rules.syscalls.where(
    arch == a && auidMin == 1000 && excludesUnsetAuid && keyname == "perm_mod"
  ).map(syscalls).flat.containsAll(scs))
```

## Tests

`auditd_internal_test.go` adds coverage for:
- the derived `arch` / `auidMin` / `excludesUnsetAuid` fields, the `4294967295` sentinel, and null `auidMin`
- comma-separated and repeated `-S` accumulation
- previously-untested control-rule (`-D`/`-b`/`-f`/`--backlog_wait_time`), file-watch, and `-F` operator-precedence parsing branches

All existing auditd tests still pass.

## Notes

No new API calls or permissions; `permissions.json` is unaffected. `.lr.versions` entries added at `13.25.1`.