### PR TITLE
✨ os: parse Dockerfile RUN/CMD/ENTRYPOINT into typed commands

### DIFF
--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -274,6 +274,10 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 				return nil, err
 			}
 			mountsSecret, mountsSsh := mountTypeFlags(mounts)
+			commands, err := p.runCommandResources(p.locationID(v.Location()), v.CmdLine, !v.PrependShell)
+			if err != nil {
+				return nil, err
+			}
 			runResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
 				"__id":         llx.StringData(p.locationID(v.Location())),
 				"script":       llx.StringData(script),
@@ -284,6 +288,7 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 				"isExecForm":   llx.BoolData(!v.PrependShell),
 				"mountsSecret": llx.BoolData(mountsSecret),
 				"mountsSsh":    llx.BoolData(mountsSsh),
+				"commands":     llx.ArrayData(commands, types.Resource(ResourceDockerFileRunCommand)),
 			})
 			if err != nil {
 				return nil, err
@@ -460,6 +465,10 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 
 	if entrypointRaw != nil {
 		script := strings.Join(entrypointRaw.CmdLine, "\n")
+		commands, err := p.runCommandResources(p.locationID(entrypointRaw.Location()), entrypointRaw.CmdLine, !entrypointRaw.PrependShell)
+		if err != nil {
+			return nil, err
+		}
 		runResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
 			"__id":         llx.StringData(p.locationID(entrypointRaw.Location())),
 			"script":       llx.StringData(script),
@@ -470,6 +479,7 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 			"isExecForm":   llx.BoolData(!entrypointRaw.PrependShell),
 			"mountsSecret": llx.BoolData(false),
 			"mountsSsh":    llx.BoolData(false),
+			"commands":     llx.ArrayData(commands, types.Resource(ResourceDockerFileRunCommand)),
 		})
 		if err != nil {
 			return nil, err
@@ -481,6 +491,10 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 
 	if cmdRaw != nil {
 		script := strings.Join(cmdRaw.CmdLine, "\n")
+		commands, err := p.runCommandResources(p.locationID(cmdRaw.Location()), cmdRaw.CmdLine, !cmdRaw.PrependShell)
+		if err != nil {
+			return nil, err
+		}
 		cmdResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRun, map[string]*llx.RawData{
 			"__id":         llx.StringData(p.locationID(cmdRaw.Location())),
 			"script":       llx.StringData(script),
@@ -491,6 +505,7 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage, isFinal bool) (
 			"isExecForm":   llx.BoolData(!cmdRaw.PrependShell),
 			"mountsSecret": llx.BoolData(false),
 			"mountsSsh":    llx.BoolData(false),
+			"commands":     llx.ArrayData(commands, types.Resource(ResourceDockerFileRunCommand)),
 		})
 		if err != nil {
 			return nil, err
@@ -640,6 +655,53 @@ func runFlagValue(cmd *instructions.RunCommand, name string) string {
 		}
 	}
 	return ""
+}
+
+// runCommandResources builds the parsed docker.file.run.command list for a
+// RUN/CMD/ENTRYPOINT instruction. For exec form the CmdLine is already the argv
+// of a single command; for shell form it is parsed with parseShellCommands.
+func (p *mqlDockerFile) runCommandResources(parentID string, cmdLine []string, execForm bool) ([]any, error) {
+	var argvs [][]string
+	if execForm {
+		if len(cmdLine) > 0 {
+			argvs = [][]string{cmdLine}
+		}
+	} else {
+		argvs = parseShellCommands(strings.Join(cmdLine, " "))
+	}
+
+	out := make([]any, 0, len(argvs))
+	for i, argv := range argvs {
+		if len(argv) == 0 {
+			continue
+		}
+		cmdArgs := argv[1:]
+
+		flags := []any{}
+		subcommand := ""
+		args := make([]any, len(cmdArgs))
+		for j, a := range cmdArgs {
+			args[j] = a
+			if strings.HasPrefix(a, "-") {
+				flags = append(flags, a)
+			} else if subcommand == "" {
+				subcommand = a
+			}
+		}
+
+		resource, err := CreateResource(p.MqlRuntime, ResourceDockerFileRunCommand, map[string]*llx.RawData{
+			"__id":       llx.StringData(parentID + "/command/" + strconv.Itoa(i)),
+			"binary":     llx.StringData(argv[0]),
+			"subcommand": llx.StringData(subcommand),
+			"flags":      llx.ArrayData(flags, types.String),
+			"args":       llx.ArrayData(args, types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, resource)
+	}
+	return out, nil
 }
 
 func (p *mqlDockerFile) mountResources(cmd *instructions.RunCommand) ([]any, error) {

--- a/providers/os/resources/docker_file_shell.go
+++ b/providers/os/resources/docker_file_shell.go
@@ -37,15 +37,15 @@ func lexShell(s string) []shellToken {
 	n := len(runes)
 	for i := 0; i < n; {
 		c := runes[i]
-		switch {
-		case c == ' ' || c == '\t' || c == '\r':
+		switch c {
+		case ' ', '\t', '\r':
 			flush()
 			i++
-		case c == '\n' || c == ';':
+		case '\n', ';':
 			flush()
 			toks = append(toks, shellToken{text: string(c), op: true})
 			i++
-		case c == '&':
+		case '&':
 			flush()
 			if i+1 < n && runes[i+1] == '&' {
 				toks = append(toks, shellToken{text: "&&", op: true})
@@ -54,7 +54,7 @@ func lexShell(s string) []shellToken {
 				toks = append(toks, shellToken{text: "&", op: true})
 				i++
 			}
-		case c == '|':
+		case '|':
 			flush()
 			if i+1 < n && runes[i+1] == '|' {
 				toks = append(toks, shellToken{text: "||", op: true})
@@ -63,7 +63,7 @@ func lexShell(s string) []shellToken {
 				toks = append(toks, shellToken{text: "|", op: true})
 				i++
 			}
-		case c == '\'':
+		case '\'':
 			wordInProgress = true
 			i++
 			for i < n && runes[i] != '\'' {
@@ -73,7 +73,7 @@ func lexShell(s string) []shellToken {
 			if i < n {
 				i++ // closing quote
 			}
-		case c == '"':
+		case '"':
 			wordInProgress = true
 			i++
 			for i < n && runes[i] != '"' {
@@ -91,7 +91,7 @@ func lexShell(s string) []shellToken {
 			if i < n {
 				i++ // closing quote
 			}
-		case c == '\\':
+		case '\\':
 			if i+1 < n {
 				if runes[i+1] == '\n' {
 					i += 2 // line continuation

--- a/providers/os/resources/docker_file_shell.go
+++ b/providers/os/resources/docker_file_shell.go
@@ -1,0 +1,156 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"regexp"
+	"strings"
+)
+
+// shellToken is a single lexed token from a shell script. Operator tokens
+// (&&, ||, ;, |, &, newline) separate commands; everything else is a word.
+type shellToken struct {
+	text string
+	op   bool
+}
+
+// lexShell tokenizes a shell command line into words and operators. It honors
+// single quotes (literal), double quotes (with backslash escapes for " \ $ `),
+// backslash escapes, and line continuations. It is intentionally
+// lightweight: it does not interpret subshells, command substitutions, or
+// redirections, treating their characters as ordinary word content.
+func lexShell(s string) []shellToken {
+	var toks []shellToken
+	var buf strings.Builder
+	wordInProgress := false
+
+	flush := func() {
+		if wordInProgress {
+			toks = append(toks, shellToken{text: buf.String()})
+			buf.Reset()
+			wordInProgress = false
+		}
+	}
+
+	runes := []rune(s)
+	n := len(runes)
+	for i := 0; i < n; {
+		c := runes[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\r':
+			flush()
+			i++
+		case c == '\n' || c == ';':
+			flush()
+			toks = append(toks, shellToken{text: string(c), op: true})
+			i++
+		case c == '&':
+			flush()
+			if i+1 < n && runes[i+1] == '&' {
+				toks = append(toks, shellToken{text: "&&", op: true})
+				i += 2
+			} else {
+				toks = append(toks, shellToken{text: "&", op: true})
+				i++
+			}
+		case c == '|':
+			flush()
+			if i+1 < n && runes[i+1] == '|' {
+				toks = append(toks, shellToken{text: "||", op: true})
+				i += 2
+			} else {
+				toks = append(toks, shellToken{text: "|", op: true})
+				i++
+			}
+		case c == '\'':
+			wordInProgress = true
+			i++
+			for i < n && runes[i] != '\'' {
+				buf.WriteRune(runes[i])
+				i++
+			}
+			if i < n {
+				i++ // closing quote
+			}
+		case c == '"':
+			wordInProgress = true
+			i++
+			for i < n && runes[i] != '"' {
+				if runes[i] == '\\' && i+1 < n {
+					nxt := runes[i+1]
+					if nxt == '"' || nxt == '\\' || nxt == '$' || nxt == '`' {
+						buf.WriteRune(nxt)
+						i += 2
+						continue
+					}
+				}
+				buf.WriteRune(runes[i])
+				i++
+			}
+			if i < n {
+				i++ // closing quote
+			}
+		case c == '\\':
+			if i+1 < n {
+				if runes[i+1] == '\n' {
+					i += 2 // line continuation
+					continue
+				}
+				wordInProgress = true
+				buf.WriteRune(runes[i+1])
+				i += 2
+			} else {
+				i++
+			}
+		default:
+			wordInProgress = true
+			buf.WriteRune(c)
+			i++
+		}
+	}
+	flush()
+	return toks
+}
+
+var shellEnvAssignment = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+// stripEnvAssignments removes leading VAR=value tokens (e.g. the
+// `DEBIAN_FRONTEND=noninteractive` prefix on `apt-get install`) so the first
+// remaining token is the executable. It stops at the first non-assignment.
+func stripEnvAssignments(argv []string) []string {
+	i := 0
+	for i < len(argv) && shellEnvAssignment.MatchString(argv[i]) {
+		i++
+	}
+	return argv[i:]
+}
+
+// parseShellCommands splits a shell script into individual commands on the
+// top-level operators &&, ||, ;, |, & and newlines, then returns the argv of
+// each command with any leading environment assignments removed. Empty
+// commands are dropped.
+func parseShellCommands(script string) [][]string {
+	toks := lexShell(script)
+
+	var cmds [][]string
+	var cur []string
+	push := func() {
+		argv := stripEnvAssignments(cur)
+		if len(argv) > 0 {
+			cmds = append(cmds, argv)
+		}
+		cur = nil
+	}
+
+	for _, t := range toks {
+		if t.op {
+			push()
+			continue
+		}
+		cur = append(cur, t.text)
+	}
+	push()
+
+	return cmds
+}

--- a/providers/os/resources/docker_file_shell_test.go
+++ b/providers/os/resources/docker_file_shell_test.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseShellCommands(t *testing.T) {
+	cases := []struct {
+		name   string
+		script string
+		want   [][]string
+	}{
+		{
+			name:   "single command",
+			script: "apt-get install -y nginx",
+			want:   [][]string{{"apt-get", "install", "-y", "nginx"}},
+		},
+		{
+			name:   "and-chained commands",
+			script: "apt-get update && apt-get install -y nginx",
+			want: [][]string{
+				{"apt-get", "update"},
+				{"apt-get", "install", "-y", "nginx"},
+			},
+		},
+		{
+			name:   "pipe splits commands",
+			script: "curl -fsSL https://example.com | sh",
+			want: [][]string{
+				{"curl", "-fsSL", "https://example.com"},
+				{"sh"},
+			},
+		},
+		{
+			name:   "or and semicolon separators",
+			script: "test -f x || touch x ; echo done",
+			want: [][]string{
+				{"test", "-f", "x"},
+				{"touch", "x"},
+				{"echo", "done"},
+			},
+		},
+		{
+			name:   "leading env assignment is stripped",
+			script: "DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata",
+			want:   [][]string{{"apt-get", "install", "-y", "tzdata"}},
+		},
+		{
+			name:   "multiple env assignments stripped",
+			script: "A=1 B=2 make build",
+			want:   [][]string{{"make", "build"}},
+		},
+		{
+			name:   "operator inside double quotes is not a separator",
+			script: `sh -c "a && b"`,
+			want:   [][]string{{"sh", "-c", "a && b"}},
+		},
+		{
+			name:   "single quotes keep content literal",
+			script: `echo 'hello | world'`,
+			want:   [][]string{{"echo", "hello | world"}},
+		},
+		{
+			name:   "double quoted whitespace stays one token",
+			script: `echo "hello world"`,
+			want:   [][]string{{"echo", "hello world"}},
+		},
+		{
+			name:   "line continuation joins the chain",
+			script: "apt-get update && \\\n    apt-get install -y curl",
+			want: [][]string{
+				{"apt-get", "update"},
+				{"apt-get", "install", "-y", "curl"},
+			},
+		},
+		{
+			name:   "newline separates commands",
+			script: "echo a\necho b",
+			want: [][]string{
+				{"echo", "a"},
+				{"echo", "b"},
+			},
+		},
+		{
+			name:   "backslash escapes a space into the word",
+			script: `echo a\ b`,
+			want:   [][]string{{"echo", "a b"}},
+		},
+		{
+			name:   "empty script yields no commands",
+			script: "   \n  ",
+			want:   nil,
+		},
+		{
+			name:   "concatenated quoted and bare segments form one token",
+			script: `echo foo"bar"baz`,
+			want:   [][]string{{"echo", "foobarbaz"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseShellCommands(tc.script))
+		})
+	}
+}
+
+func TestStripEnvAssignments(t *testing.T) {
+	assert.Equal(t, []string{"make"}, stripEnvAssignments([]string{"A=1", "make"}))
+	assert.Equal(t, []string{"apt-get", "install"}, stripEnvAssignments([]string{"apt-get", "install"}))
+	// A token that merely contains '=' but isn't a leading assignment is kept.
+	assert.Equal(t, []string{"--opt=val"}, stripEnvAssignments([]string{"--opt=val"}))
+	// Stops at the first non-assignment, keeping later '=' tokens.
+	assert.Equal(t, []string{"env", "FOO=bar"}, stripEnvAssignments([]string{"env", "FOO=bar"}))
+}

--- a/providers/os/resources/docker_file_test.go
+++ b/providers/os/resources/docker_file_test.go
@@ -744,3 +744,88 @@ ENTRYPOINT /entry.sh
 	require.True(t, stage.Entrypoint.Data.IsShellForm.Data, `ENTRYPOINT /entry.sh is shell form`)
 	require.False(t, stage.Entrypoint.Data.IsExecForm.Data)
 }
+
+// cmdFields is a test helper that flattens a docker.file.run.command resource
+// into plain Go values for easy assertions.
+func cmdFields(t *testing.T, raw any) (binary, subcommand string, flags, args []string) {
+	t.Helper()
+	c := raw.(*mqlDockerFileRunCommand)
+	binary = c.Binary.Data
+	subcommand = c.Subcommand.Data
+	for _, f := range c.Flags.Data {
+		flags = append(flags, f.(string))
+	}
+	for _, a := range c.Args.Data {
+		args = append(args, a.(string))
+	}
+	return
+}
+
+func TestParseDockerfile_RunCommands(t *testing.T) {
+	src := `
+FROM alpine
+RUN apt-get update && apt-get install -y --no-install-recommends nginx
+RUN ["/bin/sh", "-c", "echo hi"]
+CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+`
+	r := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	file := &mqlFile{
+		Content:    plugin.TValue[string]{Data: src, State: plugin.StateIsSet},
+		Path:       plugin.TValue[string]{Data: "Dockerfile", State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	df := mqlDockerFile{
+		File:       plugin.TValue[*mqlFile]{Data: file, State: plugin.StateIsSet},
+		MqlRuntime: r,
+	}
+	require.NoError(t, df.parse(file))
+
+	stage := df.Stages.Data[0].(*mqlDockerFileStage)
+
+	t.Run("shell-form RUN splits the && chain into two commands", func(t *testing.T) {
+		run := stage.Run.Data[0].(*mqlDockerFileRun)
+		require.Equal(t, 2, len(run.Commands.Data))
+
+		binary, sub, flags, args := cmdFields(t, run.Commands.Data[0])
+		require.Equal(t, "apt-get", binary)
+		require.Equal(t, "update", sub)
+		require.Empty(t, flags)
+		require.Equal(t, []string{"update"}, args)
+
+		binary, sub, flags, args = cmdFields(t, run.Commands.Data[1])
+		require.Equal(t, "apt-get", binary)
+		require.Equal(t, "install", sub)
+		require.Equal(t, []string{"-y", "--no-install-recommends"}, flags)
+		require.Equal(t, []string{"install", "-y", "--no-install-recommends", "nginx"}, args)
+	})
+
+	t.Run("exec-form RUN yields a single command from the argv", func(t *testing.T) {
+		run := stage.Run.Data[1].(*mqlDockerFileRun)
+		require.Equal(t, 1, len(run.Commands.Data))
+		binary, sub, flags, args := cmdFields(t, run.Commands.Data[0])
+		require.Equal(t, "/bin/sh", binary)
+		require.Equal(t, []string{"-c"}, flags)
+		require.Equal(t, "echo hi", sub) // first non-flag arg
+		require.Equal(t, []string{"-c", "echo hi"}, args)
+	})
+
+	t.Run("CMD exposes commands", func(t *testing.T) {
+		require.NotNil(t, stage.Cmd.Data)
+		require.Equal(t, 1, len(stage.Cmd.Data.Commands.Data))
+		binary, _, flags, args := cmdFields(t, stage.Cmd.Data.Commands.Data[0])
+		require.Equal(t, "nginx", binary)
+		require.Equal(t, []string{"-g"}, flags)
+		require.Equal(t, []string{"-g", "daemon off;"}, args)
+	})
+
+	t.Run("ENTRYPOINT exposes commands", func(t *testing.T) {
+		require.NotNil(t, stage.Entrypoint.Data)
+		require.Equal(t, 1, len(stage.Entrypoint.Data.Commands.Data))
+		binary, sub, flags, args := cmdFields(t, stage.Entrypoint.Data.Commands.Data[0])
+		require.Equal(t, "docker-entrypoint.sh", binary)
+		require.Empty(t, flags)
+		require.Empty(t, args)
+		require.Equal(t, "", sub)
+	})
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2931,8 +2931,9 @@ private docker.file.run @defaults("script") {
   // arguments with leading `VAR=value` assignments removed. Exec-form
   // instructions yield a single command from the argv. Use this to audit the
   // program invoked and its options instead of substring-matching the raw
-  // `script`. Parsing is best-effort and does not descend into subshells or
-  // command substitutions.
+  // `script`. Parsing is best-effort: it does not descend into subshells or
+  // command substitutions, and redirections (`>`, `>>`, `<`, `2>&1`) appear as
+  // ordinary tokens in the following command's `args`.
   commands []docker.file.run.command
 }
 
@@ -2952,6 +2953,10 @@ private docker.file.run.command @defaults("binary subcommand") {
   // `install`.
   subcommand string
   // Dash-prefixed options, e.g. ["--no-install-recommends", "-y"]
+  //
+  // A flag that carries an `=`-joined value is kept as one token, so
+  // `--mount=type=bind` matches `flags.contains("--mount=type=bind")` or
+  // `flags.any(_.contains("--mount"))`, not `flags.contains("--mount")`.
   flags []string
   // All arguments after the executable, in the order they appear
   args []string

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2924,6 +2924,37 @@ private docker.file.run @defaults("script") {
   mountsSecret bool
   // Whether the instruction declares a `--mount=type=ssh`
   mountsSsh bool
+  // Individual commands parsed from the instruction
+  //
+  // The script split on the shell operators `&&`, `||`, `;`, and `|` (and
+  // newlines) into separate commands, each tokenized into its executable and
+  // arguments with leading `VAR=value` assignments removed. Exec-form
+  // instructions yield a single command from the argv. Use this to audit the
+  // program invoked and its options instead of substring-matching the raw
+  // `script`. Parsing is best-effort and does not descend into subshells or
+  // command substitutions.
+  commands []docker.file.run.command
+}
+
+// Single command parsed from a Dockerfile RUN, CMD, or ENTRYPOINT
+//
+// One entry per command in the instruction's shell pipeline. Select the
+// program with `binary` and, for tools with subcommands, `subcommand` — for
+// example `binary == "apt-get"` and `subcommand == "install"` — then inspect
+// `flags` for required options such as `--no-install-recommends`.
+private docker.file.run.command @defaults("binary subcommand") {
+  // Executable invoked, e.g. "apt-get", "curl", or "npm"
+  binary string
+  // First non-flag argument, e.g. "install" or "add"
+  //
+  // Empty when the command takes no subcommand. Resolved independently of flag
+  // position, so `apt-get -y install` and `apt-get install -y` both report
+  // `install`.
+  subcommand string
+  // Dash-prefixed options, e.g. ["--no-install-recommends", "-y"]
+  flags []string
+  // All arguments after the executable, in the order they appear
+  args []string
 }
 
 // Dockerfile RUN --mount flag

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -147,6 +147,7 @@ const (
 	ResourceDockerFileExpose              string = "docker.file.expose"
 	ResourceDockerFileFrom                string = "docker.file.from"
 	ResourceDockerFileRun                 string = "docker.file.run"
+	ResourceDockerFileRunCommand          string = "docker.file.run.command"
 	ResourceDockerFileRunMount            string = "docker.file.run.mount"
 	ResourceDockerFileAdd                 string = "docker.file.add"
 	ResourceDockerFileCopy                string = "docker.file.copy"
@@ -968,6 +969,10 @@ func init() {
 		"docker.file.run": {
 			// to override args, implement: initDockerFileRun(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDockerFileRun,
+		},
+		"docker.file.run.command": {
+			// to override args, implement: initDockerFileRunCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDockerFileRunCommand,
 		},
 		"docker.file.run.mount": {
 			// to override args, implement: initDockerFileRunMount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4748,6 +4753,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"docker.file.run.mountsSsh": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileRun).GetMountsSsh()).ToDataRes(types.Bool)
+	},
+	"docker.file.run.commands": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRun).GetCommands()).ToDataRes(types.Array(types.Resource("docker.file.run.command")))
+	},
+	"docker.file.run.command.binary": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRunCommand).GetBinary()).ToDataRes(types.String)
+	},
+	"docker.file.run.command.subcommand": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRunCommand).GetSubcommand()).ToDataRes(types.String)
+	},
+	"docker.file.run.command.flags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRunCommand).GetFlags()).ToDataRes(types.Array(types.String))
+	},
+	"docker.file.run.command.args": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileRunCommand).GetArgs()).ToDataRes(types.Array(types.String))
 	},
 	"docker.file.run.mount.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileRunMount).GetType()).ToDataRes(types.String)
@@ -13855,6 +13875,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.file.run.mountsSsh": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileRun).MountsSsh, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.commands": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRun).Commands, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.command.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRunCommand).__id, ok = v.Value.(string)
+		return
+	},
+	"docker.file.run.command.binary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRunCommand).Binary, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.command.subcommand": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRunCommand).Subcommand, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.command.flags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRunCommand).Flags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"docker.file.run.command.args": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileRunCommand).Args, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"docker.file.run.mount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33947,6 +33991,7 @@ type mqlDockerFileRun struct {
 	IsExecForm   plugin.TValue[bool]
 	MountsSecret plugin.TValue[bool]
 	MountsSsh    plugin.TValue[bool]
+	Commands     plugin.TValue[[]any]
 }
 
 // createDockerFileRun creates a new instance of this resource
@@ -34011,6 +34056,69 @@ func (c *mqlDockerFileRun) GetMountsSecret() *plugin.TValue[bool] {
 
 func (c *mqlDockerFileRun) GetMountsSsh() *plugin.TValue[bool] {
 	return &c.MountsSsh
+}
+
+func (c *mqlDockerFileRun) GetCommands() *plugin.TValue[[]any] {
+	return &c.Commands
+}
+
+// mqlDockerFileRunCommand for the docker.file.run.command resource
+type mqlDockerFileRunCommand struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDockerFileRunCommandInternal it will be used here
+	Binary     plugin.TValue[string]
+	Subcommand plugin.TValue[string]
+	Flags      plugin.TValue[[]any]
+	Args       plugin.TValue[[]any]
+}
+
+// createDockerFileRunCommand creates a new instance of this resource
+func createDockerFileRunCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDockerFileRunCommand{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("docker.file.run.command", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDockerFileRunCommand) MqlName() string {
+	return "docker.file.run.command"
+}
+
+func (c *mqlDockerFileRunCommand) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDockerFileRunCommand) GetBinary() *plugin.TValue[string] {
+	return &c.Binary
+}
+
+func (c *mqlDockerFileRunCommand) GetSubcommand() *plugin.TValue[string] {
+	return &c.Subcommand
+}
+
+func (c *mqlDockerFileRunCommand) GetFlags() *plugin.TValue[[]any] {
+	return &c.Flags
+}
+
+func (c *mqlDockerFileRunCommand) GetArgs() *plugin.TValue[[]any] {
+	return &c.Args
 }
 
 // mqlDockerFileRunMount for the docker.file.run.mount resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -492,6 +492,12 @@ docker.file.multiStage 13.21.1
 docker.file.onbuild 13.16.10
 docker.file.onbuild.expression 13.16.10
 docker.file.run 11.0.2
+docker.file.run.command 13.25.1
+docker.file.run.command.args 13.25.1
+docker.file.run.command.binary 13.25.1
+docker.file.run.command.flags 13.25.1
+docker.file.run.command.subcommand 13.25.1
+docker.file.run.commands 13.25.1
 docker.file.run.isExecForm 13.21.1
 docker.file.run.isShellForm 13.21.1
 docker.file.run.mount 13.16.10


### PR DESCRIPTION
## What

Adds a parsed command view to the `docker.file.run` resource so Dockerfile policies can audit the program invoked and its options instead of substring-matching the raw `script`.

New field on `docker.file.run`:
- `commands []docker.file.run.command`

New private sub-resource `docker.file.run.command`:

| field | meaning |
|---|---|
| `binary` | executable invoked, e.g. `apt-get`, `curl`, `npm` |
| `subcommand` | first non-flag argument (e.g. `install`), resolved independently of flag position |
| `flags` | dash-prefixed options, e.g. `["--no-install-recommends", "-y"]` |
| `args` | all arguments after the executable, in order |

The script is split on the shell operators `&&`, `||`, `;`, `|`, `&` and newlines, and each command is tokenized into argv with leading `VAR=value` assignments removed. Quotes, backslash escapes, and line continuations are honored. Exec-form instructions yield a single command from the argv. Covers RUN, CMD, and ENTRYPOINT. Parsing is best-effort and does not descend into subshells or command substitutions.

## Why

`mondoo-dockerfile-security` and `mondoo-dockerfile-best-practices` check RUN instructions with raw `script.contains("...")` matching — ~31 checks across the two files. That is fragile:

- `script.contains("-y")` matches `-y` anywhere — a path, a filename, `--yes`, a comment.
- `script.contains("apt install")` matches inside `echo`/comments and substring-matches unrelated text.
- Flag-order variations slip through (`apt-get -y install` vs `apt-get install -y`).
- `&&`-chained commands are conflated, so the cleanup in one command can satisfy a check about another.

## Result

```mql
# before (fragile)
run.where(script.contains("apt-get install")).all(script.contains("--no-install-recommends"))

# after (precise)
run.all(commands.where(binary == "apt-get" && subcommand == "install")
                .all(flags.contains("--no-install-recommends")))
```

## Tests

- **Parser unit tests** (`docker_file_shell_test.go`): table-driven coverage of chaining, pipes, `||`/`;`, env-assignment stripping, quoted operators/whitespace, line continuations, escapes, concatenated quoted/bare segments, and empty input; plus `stripEnvAssignments` edge cases.
- **Resource-level tests** (`docker_file_test.go` → `TestParseDockerfile_RunCommands`): verifies `commands` on shell-form RUN (`&&` chain → two commands), exec-form RUN, CMD, and ENTRYPOINT, with binary/subcommand/flags/args assertions.
- **End-to-end**: built+installed the provider and ran the rewritten policy checks against live Dockerfiles — passing checks return `true`, violating Dockerfiles return `false`.

## Notes

No new dependencies (the shell tokenizer is a self-contained helper). No new API calls or permissions; `permissions.json` unaffected. `.lr.versions` entries added at `13.25.1`.