### PR TITLE
🧹 os: handle auid> in auditd syscall auidMin derivation

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -423,8 +423,14 @@ func (s *mqlAuditdRules) parse(content string, errors *multierr.Errors) {
 					}
 				case "auid":
 					switch op {
-					case ">=":
+					case ">=", ">":
+						// auidMin is the effective lower bound, so `auid>999`
+						// (equivalent to `auid>=1000`) and `auid>=1000` both
+						// report 1000.
 						if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+							if op == ">" {
+								n++
+							}
 							auidMin = &n
 						}
 					case "!=":

--- a/providers/os/resources/auditd_internal_test.go
+++ b/providers/os/resources/auditd_internal_test.go
@@ -96,6 +96,23 @@ func TestAuditdSyscallRuleParsing(t *testing.T) {
 	})
 }
 
+func TestAuditdSyscallAuidGreaterThan(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	// `auid>999` is the strict-greater-than spelling of `auid>=1000`; auidMin
+	// reports the effective lower bound of 1000 either way.
+	content := "-a always,exit -F arch=b64 -S execve -F auid>999 -k t\n"
+
+	var errs multierr.Errors
+	rules.parse(content, &errs)
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Syscalls.Data, 1)
+
+	r := rules.Syscalls.Data[0].(*mqlAuditdRuleSyscall)
+	assert.Equal(t, int64(1000), r.AuidMin.Data)
+}
+
 func TestAuditdSyscallRuleRepeatedFlags(t *testing.T) {
 	runtime := newAuditdRulesTestRuntime(t)
 	rules := &mqlAuditdRules{MqlRuntime: runtime}


### PR DESCRIPTION
Follow-up to #8269 addressing a review suggestion that arrived after merge.

`auditd.rule.syscall.auidMin` previously only recognized the `-F auid>=N`
form. auditd also supports the strict `-F auid>N` spelling (e.g. `auid>999`,
which is equivalent to `auid>=1000`). This treats `>` as `auidMin = N + 1`, so
the field reports the effective lower bound regardless of which spelling a rule
uses, and both `auid>999` and `auid>=1000` report `1000`.

Adds a unit test for the `>` form.

No schema change, no new permissions.