### PR TITLE
✨ network: add dns.dnssec to simplify DNSSEC audits

### DIFF
--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -301,7 +301,7 @@ func (d *mqlDns) dnssec(params any) (*mqlDnsDnssec, error) {
 	algoSet := map[int64]struct{}{}
 
 	if paramsM, ok := params.(map[string]any); ok {
-		if record, ok := paramsM["DNSKEY"].(map[string]any); ok {
+		if record, ok := paramsM["DNSKEY"].(map[string]any); ok && record["rCode"] == dns.RcodeToString[dns.RcodeSuccess] {
 			var name, class string
 			var ttl int64
 			var rdata []any

--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -7,7 +7,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -292,6 +294,85 @@ func (d *mqlDnsDkimRecord) valid() (bool, error) {
 
 	ok, _, _ := d.dkim.Valid()
 	return ok, nil
+}
+
+func (d *mqlDns) dnssec(params any) (*mqlDnsDnssec, error) {
+	keys := []any{}
+	algoSet := map[int64]struct{}{}
+
+	if paramsM, ok := params.(map[string]any); ok {
+		if record, ok := paramsM["DNSKEY"].(map[string]any); ok {
+			var name, class string
+			var ttl int64
+			var rdata []any
+			if record["name"] != nil {
+				name = record["name"].(string)
+			}
+			if record["class"] != nil {
+				class = record["class"].(string)
+			}
+			if record["TTL"] != nil {
+				ttl = record["TTL"].(int64)
+			}
+			if record["rData"] != nil {
+				rdata = record["rData"].([]any)
+			}
+
+			for j := range rdata {
+				entry, ok := rdata[j].(string)
+				if !ok {
+					continue
+				}
+
+				// reuse the dns package to parse the DNSKEY rdata into its fields
+				s := name + "\t" + strconv.FormatInt(ttl, 10) + "\t" + class + "\tDNSKEY\t" + entry
+				rr, err := dns.NewRR(s)
+				if err != nil {
+					return nil, err
+				}
+				key, ok := rr.(*dns.DNSKEY)
+				if !ok {
+					continue
+				}
+
+				// the SEP flag (least-significant bit of the flags field)
+				// marks a key-signing key; flags 257 is a KSK, 256 a ZSK
+				keySigningKey := key.Flags&1 == 1
+				keyResource, err := CreateResource(d.MqlRuntime, "dns.dnssec.key", map[string]*llx.RawData{
+					"__id":          llx.StringData(fmt.Sprintf("dns.dnssec.key/%d/%d/%s", key.Algorithm, key.Flags, key.PublicKey)),
+					"flags":         llx.IntData(int64(key.Flags)),
+					"protocol":      llx.IntData(int64(key.Protocol)),
+					"algorithm":     llx.IntData(int64(key.Algorithm)),
+					"publicKey":     llx.StringData(key.PublicKey),
+					"keySigningKey": llx.BoolData(keySigningKey),
+				})
+				if err != nil {
+					return nil, err
+				}
+				keys = append(keys, keyResource)
+				algoSet[int64(key.Algorithm)] = struct{}{}
+			}
+		}
+	}
+
+	algorithms := make([]any, 0, len(algoSet))
+	for a := range algoSet {
+		algorithms = append(algorithms, a)
+	}
+	slices.SortFunc(algorithms, func(a, b any) int {
+		return int(a.(int64) - b.(int64))
+	})
+
+	res, err := CreateResource(d.MqlRuntime, "dns.dnssec", map[string]*llx.RawData{
+		"__id":       llx.StringData("dns.dnssec/" + d.Fqdn.Data),
+		"enabled":    llx.BoolData(len(keys) > 0),
+		"keys":       llx.ArrayData(keys, types.Resource("dns.dnssec.key")),
+		"algorithms": llx.ArrayData(algorithms, types.Int),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDnsDnssec), nil
 }
 
 // addressesFromParams extracts the resolved IPv4 (A) and IPv6 (AAAA) addresses

--- a/providers/network/resources/dns_test.go
+++ b/providers/network/resources/dns_test.go
@@ -21,6 +21,24 @@ func TestResource_DNS(t *testing.T) {
 	assert.NotEmpty(t, res)
 }
 
+func TestResource_DnsDnssec(t *testing.T) {
+	// cloudflare.com is reliably DNSSEC-signed.
+	res := x.TestQuery(t, `dns("cloudflare.com").dnssec.enabled`)
+	require.NotEmpty(t, res)
+	require.NoError(t, res[0].Data.Error)
+	assert.Equal(t, true, res[0].Data.Value)
+
+	res = x.TestQuery(t, `dns("cloudflare.com").dnssec.keys.all(algorithm > 0 && publicKey != "")`)
+	require.NotEmpty(t, res)
+	require.NoError(t, res[0].Data.Error)
+	assert.Equal(t, true, res[0].Data.Value)
+
+	res = x.TestQuery(t, `dns("cloudflare.com").dnssec.algorithms`)
+	require.NotEmpty(t, res)
+	require.NoError(t, res[0].Data.Error)
+	assert.NotEmpty(t, res[0].Data.Value)
+}
+
 func TestResource_DomainName(t *testing.T) {
 	res := x.TestQuery(t, "domainName")
 	assert.NotEmpty(t, res)

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -454,6 +454,8 @@ dns @defaults("fqdn") {
   mx(params) []dns.mxRecord
   // DKIM TXT records
   dkim(params) []dns.dkimRecord
+  // DNSSEC signing state for the domain
+  dnssec(params) dns.dnssec
   // Reverse DNS (PTR) records for the domain's resolved addresses
   //
   // Resolves the domain's A and AAAA addresses, then looks up the PTR
@@ -493,6 +495,46 @@ dns.mxRecord @defaults("domainName") {
   preference int
   // Domain name
   domainName string
+}
+
+// DNSSEC configuration for a domain
+//
+// Examine whether a domain is signed with DNSSEC and how. Reports whether
+// the domain publishes DNSKEY records, the parsed signing keys, and the
+// distinct algorithm numbers in use, so audits can require DNSSEC and flag
+// weak or deprecated algorithms without parsing raw DNSKEY rdata. `enabled`
+// reflects the presence of published DNSKEY records and does not, on its own,
+// validate the DS chain of trust at the parent zone.
+dns.dnssec @defaults("enabled") {
+  // Whether the domain publishes DNSKEY records
+  enabled bool
+  // Published DNSKEY signing keys
+  keys []dns.dnssec.key
+  // Distinct DNSSEC algorithm numbers across all published keys
+  //
+  // Algorithm numbers as defined in RFC 8624, e.g. 8 (RSASHA256) or
+  // 13 (ECDSAP256SHA256). Use it to flag deprecated algorithms such as
+  // 5/7 (RSASHA1) or 3 (DSA).
+  algorithms []int
+}
+
+// DNSKEY record (RFC 4034)
+//
+// Examine a single published DNSSEC key: its flags, protocol, algorithm
+// number, and base64-encoded public key. `keySigningKey` is true for a
+// key-signing key — the one whose SEP flag is set (flags value 257) — as
+// opposed to a zone-signing key (flags value 256).
+private dns.dnssec.key @defaults("algorithm keySigningKey") {
+  // DNSKEY flags field, e.g. 256 for a zone-signing key or 257 for a key-signing key
+  flags int
+  // Protocol field, always 3 for DNSSEC
+  protocol int
+  // DNSSEC algorithm number (RFC 8624), e.g. 8 (RSASHA256) or 13 (ECDSAP256SHA256)
+  algorithm int
+  // Base64-encoded public key
+  publicKey string
+  // Whether this is a key-signing key (the SEP flag is set)
+  keySigningKey bool
 }
 
 // DKIM public-key DNS record (RFC 6376)

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -40,6 +40,8 @@ const (
 	ResourceDns                     string = "dns"
 	ResourceDnsRecord               string = "dns.record"
 	ResourceDnsMxRecord             string = "dns.mxRecord"
+	ResourceDnsDnssec               string = "dns.dnssec"
+	ResourceDnsDnssecKey            string = "dns.dnssec.key"
 	ResourceDnsDkimRecord           string = "dns.dkimRecord"
 )
 
@@ -142,6 +144,14 @@ func init() {
 		"dns.mxRecord": {
 			// to override args, implement: initDnsMxRecord(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDnsMxRecord,
+		},
+		"dns.dnssec": {
+			// to override args, implement: initDnsDnssec(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDnsDnssec,
+		},
+		"dns.dnssec.key": {
+			// to override args, implement: initDnsDnssecKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDnsDnssecKey,
 		},
 		"dns.dkimRecord": {
 			// to override args, implement: initDnsDkimRecord(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -644,6 +654,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"dns.dkim": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetDkim()).ToDataRes(types.Array(types.Resource("dns.dkimRecord")))
 	},
+	"dns.dnssec": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetDnssec()).ToDataRes(types.Resource("dns.dnssec"))
+	},
 	"dns.reverse": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetReverse()).ToDataRes(types.Array(types.Resource("dns.record")))
 	},
@@ -670,6 +683,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"dns.mxRecord.domainName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDnsMxRecord).GetDomainName()).ToDataRes(types.String)
+	},
+	"dns.dnssec.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssec).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"dns.dnssec.keys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssec).GetKeys()).ToDataRes(types.Array(types.Resource("dns.dnssec.key")))
+	},
+	"dns.dnssec.algorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssec).GetAlgorithms()).ToDataRes(types.Array(types.Int))
+	},
+	"dns.dnssec.key.flags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssecKey).GetFlags()).ToDataRes(types.Int)
+	},
+	"dns.dnssec.key.protocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssecKey).GetProtocol()).ToDataRes(types.Int)
+	},
+	"dns.dnssec.key.algorithm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssecKey).GetAlgorithm()).ToDataRes(types.Int)
+	},
+	"dns.dnssec.key.publicKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssecKey).GetPublicKey()).ToDataRes(types.String)
+	},
+	"dns.dnssec.key.keySigningKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDnsDnssecKey).GetKeySigningKey()).ToDataRes(types.Bool)
 	},
 	"dns.dkimRecord.dnsTxt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDnsDkimRecord).GetDnsTxt()).ToDataRes(types.String)
@@ -1369,6 +1406,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDns).Dkim, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"dns.dnssec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).Dnssec, ok = plugin.RawToTValue[*mqlDnsDnssec](v.Value, v.Error)
+		return
+	},
 	"dns.reverse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDns).Reverse, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1411,6 +1452,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"dns.mxRecord.domainName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDnsMxRecord).DomainName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssec).__id, ok = v.Value.(string)
+		return
+	},
+	"dns.dnssec.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssec).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.keys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssec).Keys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.algorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssec).Algorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.key.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).__id, ok = v.Value.(string)
+		return
+	},
+	"dns.dnssec.key.flags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).Flags, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.key.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).Protocol, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.key.algorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).Algorithm, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.key.publicKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).PublicKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"dns.dnssec.key.keySigningKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDnsDnssecKey).KeySigningKey, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"dns.dkimRecord.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3432,6 +3513,7 @@ type mqlDns struct {
 	Records plugin.TValue[[]any]
 	Mx      plugin.TValue[[]any]
 	Dkim    plugin.TValue[[]any]
+	Dnssec  plugin.TValue[*mqlDnsDnssec]
 	Reverse plugin.TValue[[]any]
 }
 
@@ -3547,6 +3629,27 @@ func (c *mqlDns) GetDkim() *plugin.TValue[[]any] {
 		}
 
 		return c.dkim(vargParams.Data)
+	})
+}
+
+func (c *mqlDns) GetDnssec() *plugin.TValue[*mqlDnsDnssec] {
+	return plugin.GetOrCompute[*mqlDnsDnssec](&c.Dnssec, func() (*mqlDnsDnssec, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("dns", c.__id, "dnssec")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDnsDnssec), nil
+			}
+		}
+
+		vargParams := c.GetParams()
+		if vargParams.Error != nil {
+			return nil, vargParams.Error
+		}
+
+		return c.dnssec(vargParams.Data)
 	})
 }
 
@@ -3697,6 +3800,124 @@ func (c *mqlDnsMxRecord) GetPreference() *plugin.TValue[int64] {
 
 func (c *mqlDnsMxRecord) GetDomainName() *plugin.TValue[string] {
 	return &c.DomainName
+}
+
+// mqlDnsDnssec for the dns.dnssec resource
+type mqlDnsDnssec struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDnsDnssecInternal it will be used here
+	Enabled    plugin.TValue[bool]
+	Keys       plugin.TValue[[]any]
+	Algorithms plugin.TValue[[]any]
+}
+
+// createDnsDnssec creates a new instance of this resource
+func createDnsDnssec(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDnsDnssec{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("dns.dnssec", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDnsDnssec) MqlName() string {
+	return "dns.dnssec"
+}
+
+func (c *mqlDnsDnssec) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDnsDnssec) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlDnsDnssec) GetKeys() *plugin.TValue[[]any] {
+	return &c.Keys
+}
+
+func (c *mqlDnsDnssec) GetAlgorithms() *plugin.TValue[[]any] {
+	return &c.Algorithms
+}
+
+// mqlDnsDnssecKey for the dns.dnssec.key resource
+type mqlDnsDnssecKey struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDnsDnssecKeyInternal it will be used here
+	Flags         plugin.TValue[int64]
+	Protocol      plugin.TValue[int64]
+	Algorithm     plugin.TValue[int64]
+	PublicKey     plugin.TValue[string]
+	KeySigningKey plugin.TValue[bool]
+}
+
+// createDnsDnssecKey creates a new instance of this resource
+func createDnsDnssecKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDnsDnssecKey{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("dns.dnssec.key", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDnsDnssecKey) MqlName() string {
+	return "dns.dnssec.key"
+}
+
+func (c *mqlDnsDnssecKey) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDnsDnssecKey) GetFlags() *plugin.TValue[int64] {
+	return &c.Flags
+}
+
+func (c *mqlDnsDnssecKey) GetProtocol() *plugin.TValue[int64] {
+	return &c.Protocol
+}
+
+func (c *mqlDnsDnssecKey) GetAlgorithm() *plugin.TValue[int64] {
+	return &c.Algorithm
+}
+
+func (c *mqlDnsDnssecKey) GetPublicKey() *plugin.TValue[string] {
+	return &c.PublicKey
+}
+
+func (c *mqlDnsDnssecKey) GetKeySigningKey() *plugin.TValue[bool] {
+	return &c.KeySigningKey
 }
 
 // mqlDnsDkimRecord for the dns.dkimRecord resource

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -48,6 +48,16 @@ dns.dkimRecord.publicKeyData 9.0.1
 dns.dkimRecord.serviceTypes 9.0.1
 dns.dkimRecord.valid 9.0.1
 dns.dkimRecord.version 9.0.1
+dns.dnssec 13.1.1
+dns.dnssec.algorithms 13.1.1
+dns.dnssec.enabled 13.1.1
+dns.dnssec.key 13.1.1
+dns.dnssec.key.algorithm 13.1.1
+dns.dnssec.key.flags 13.1.1
+dns.dnssec.key.keySigningKey 13.1.1
+dns.dnssec.key.protocol 13.1.1
+dns.dnssec.key.publicKey 13.1.1
+dns.dnssec.keys 13.1.1
 dns.fqdn 9.0.1
 dns.mx 9.0.1
 dns.mxRecord 9.0.1


### PR DESCRIPTION
## What

Adds a typed `dns.dnssec` view to the network provider's `dns` resource:

```
dns.dnssec {
  enabled bool            // whether the domain publishes DNSKEY records
  keys []dns.dnssec.key   // parsed DNSKEY signing keys
  algorithms []int        // distinct DNSSEC algorithm numbers in use
}

private dns.dnssec.key {
  flags int               // 256 = ZSK, 257 = KSK
  protocol int            // always 3 for DNSSEC
  algorithm int           // RFC 8624 number, e.g. 13 = ECDSAP256SHA256
  publicKey string        // base64-encoded
  keySigningKey bool      // SEP flag set
}
```

## Why

DNS security policies determine whether a domain is DNSSEC-signed by hand-rolling DNSKEY-record queries:

```mql
# before
dns.records.where(type == "DNSKEY") != empty
dns.records.where(type == "DNSKEY").all(name.contains(domainName.fqdn))

# after
dns.dnssec.enabled
```

The typed `keys`/`algorithms` additionally let audits flag weak/deprecated algorithms (e.g. `5`/`7` RSASHA1) or require a key-signing key without parsing raw DNSKEY rdata.

`enabled` reflects the presence of published DNSKEY records; it does not, on its own, validate the DS chain of trust at the parent zone (documented in the resource).

## Implementation

`dns.dnssec` parses the domain's already-fetched `DNSKEY` records (dnsshake queries all record types) using the `miekg/dns` RR parser — no new network calls. The SEP flag (`flags & 1`) distinguishes KSK from ZSK.

## Tests

- Live unit test against the reliably DNSSEC-signed `cloudflare.com` (enabled, keys have algorithm + public key, algorithms non-empty), mirroring the existing live-DNS test style.
- Verified end-to-end via the CLI: `cloudflare.com` → enabled, 1 KSK, algorithm 13; `neverssl.com` → not enabled.

## Notes

`.lr.versions` entries at `13.1.1`. No new permissions; `network.resources.json` is git-ignored.