### PR TITLE
✨ network: add http.header.server accessor

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -332,6 +332,11 @@ func (x *mqlHttpHeader) referrerPolicy() (string, error) {
 	return parseSingleHeaderValue(params, ok, &x.ReferrerPolicy)
 }
 
+func (x *mqlHttpHeader) server() (string, error) {
+	params, ok := x.Params.Data["Server"]
+	return parseSingleHeaderValue(params, ok, &x.Server)
+}
+
 func (x *mqlHttpHeader) contentType() (*mqlHttpHeaderContentType, error) {
 	raw, ok := x.Params.Data["Content-Type"]
 	if !ok {

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestHttpHeaderServer(t *testing.T) {
+	t.Run("returns the Server header value", func(t *testing.T) {
+		h := &mqlHttpHeader{
+			Params: plugin.TValue[map[string]any]{
+				Data:  map[string]any{"Server": []any{"nginx"}},
+				State: plugin.StateIsSet,
+			},
+		}
+		v, err := h.server()
+		require.NoError(t, err)
+		assert.Equal(t, "nginx", v)
+	})
+
+	t.Run("is null when the Server header is absent", func(t *testing.T) {
+		h := &mqlHttpHeader{
+			Params: plugin.TValue[map[string]any]{
+				Data:  map[string]any{},
+				State: plugin.StateIsSet,
+			},
+		}
+		v, err := h.server()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.NotEqual(t, 0, h.Server.State&plugin.StateIsNull)
+	})
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -70,6 +70,12 @@ private http.header @defaults("length=params.length") {
   setCookie() http.header.setCookie
   // Content-Security-Policy header
   csp() map[string]string
+  // Server header value, e.g. "nginx" or "Apache/2.4.62"
+  //
+  // The product token(s) the server discloses about itself. Empty when no
+  // Server header is sent. Frequently flagged by hardening policies because it
+  // leaks the server software and sometimes its version.
+  server() string
 }
 
 // HTTP header Strict-Transport-Security

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -272,6 +272,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"http.header.csp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeader).GetCsp()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"http.header.server": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHttpHeader).GetServer()).ToDataRes(types.String)
+	},
 	"http.header.sts.maxAge": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeaderSts).GetMaxAge()).ToDataRes(types.Time)
 	},
@@ -799,6 +802,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"http.header.csp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHttpHeader).Csp, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"http.header.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHttpHeader).Server, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"http.header.sts.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1685,6 +1692,7 @@ type mqlHttpHeader struct {
 	ContentType         plugin.TValue[*mqlHttpHeaderContentType]
 	SetCookie           plugin.TValue[*mqlHttpHeaderSetCookie]
 	Csp                 plugin.TValue[map[string]any]
+	Server              plugin.TValue[string]
 }
 
 // createHttpHeader creates a new instance of this resource
@@ -1813,6 +1821,12 @@ func (c *mqlHttpHeader) GetSetCookie() *plugin.TValue[*mqlHttpHeaderSetCookie] {
 func (c *mqlHttpHeader) GetCsp() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Csp, func() (map[string]any, error) {
 		return c.csp()
+	})
+}
+
+func (c *mqlHttpHeader) GetServer() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Server, func() (string, error) {
+		return c.server()
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -84,6 +84,7 @@ http.header.contentType.type 9.0.5
 http.header.csp 9.0.5
 http.header.params 9.0.5
 http.header.referrerPolicy 9.0.5
+http.header.server 13.1.1
 http.header.setCookie 9.0.5
 http.header.setCookie.name 9.0.5
 http.header.setCookie.params 9.0.5


### PR DESCRIPTION
## What

Adds a typed `server() string` accessor to `http.header`, returning the `Server` response header value (joined product tokens), null when the header is absent. Mirrors the existing single-value accessors (`referrerPolicy`, `xContentTypeOptions`, `xFrameOptions`).

## Why

HTTP security policies test the `Server` header with an awkward two-part construction that mixes a presence check with a raw `params` map lookup and an array `map(downcase)`:

```mql
# before
http.get.header.params.keys.none("Server")
  || http.get.header.params["Server"].map(downcase).none(_ == /nginx|microsoft|apache|lsws|openresty/)

# after
http.get.header.server.downcase.find(/nginx|microsoft|apache|lsws|openresty/) == empty
```

## Tests

Internal test covering the present and absent (null) cases. (`Server` is already canonical-cased by `textproto.CanonicalMIMEHeaderKey`, so no casing pitfalls.)

## Notes

`.lr.versions` entry at `13.1.1`. No new permissions; `network.resources.json` is git-ignored.