### PR TITLE
🎉 aws-13.35.0, azure-13.18.0, os-13.26.0, network-13.2.0, ms365-13.6.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.34.0",
+	Version:         "13.35.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.17.0",
+	Version: "13.18.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.5.0",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	CrossProviderTypes: []string{
 		"go.mondoo.com/mql/providers/os",

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.25.0",
+	Version: "13.26.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Minor version bump for the **aws**, **azure**, **os**, **network**, and **ms365** providers.

| Provider | Old | New |
|---|---|---|
| aws | 13.34.0 | 13.35.0 |
| azure | 13.17.0 | 13.18.0 |
| os | 13.25.0 | 13.26.0 |
| network | 13.1.0 | 13.2.0 |
| ms365 | 13.5.0 | 13.6.0 |

## Changes since last release

### aws (since #8266)
- ✨ add cloudtrail.trail.capturesAllManagementEvents predicate (#8268)
- ✨ predicates to simplify CloudTrail monitoring, security-group and Lambda policies (#8267)

### azure (since #8247)
- ✨ bump kusto SDK to v2 and add Data Explorer database/RBAC/network resources (#8260)
- 🧹 Update deps for mql and providers 20260608 (#8244)

### os (since #8257)
- ✨ parse Dockerfile RUN/CMD/ENTRYPOINT into typed commands (#8270)
- 🐳 add docker.file.stage.oci for quick OpenContainer label access (#8271)
- 🧹 handle auid> in auditd syscall auidMin derivation (#8272)
- ✨ typed auditd syscall-rule accessors to simplify audit policies (#8269)
- ✨ Add windows.scheduledTask resource for Task Scheduler audits (#8258)

### network (since #8253)
- 🟢 make live DNS tests resilient to restricted CI networks (#8280)
- ✨ add tls.cipher / tls.cipherSuites typed cipher suites (#8277)
- ✨ add dns.spfRecord and dns.dmarcRecord typed parsers (#8276)
- ✨ add dns.dnssec to simplify DNSSEC audits (#8274)
- ✨ add http.header.server accessor (#8275)

### ms365 (since #8185)
- ✨ Add copilot and enforcementPlanes fields to dlpCompliancePolicy (#8225)
- ✨ Add defaultAppManagementPolicy resource (#8227)
- 🧹 Update deps for mql and providers 20260608 (#8244)
- ✨ Add exchangeonline *Entry fields for deprecated-field migration (#8222, #8223)
- 🐛 rename `length` field to `count` on list-wrapper resources (#8219)
- ✨ Expose Graph GUID id on countryNamedLocation (#8211)
- 🧹 Update deps for mql and providers 20260605 (#8196)