### PR TITLE
🎉 k8s-13.2.0

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.1.1",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### k8s (13.2.0)
- ✨ k8s: typed container security-context fields (#8278)
- 🧹 Update deps for mql and providers 20260608 (#8244)
- 🧹 Update deps for mql and providers 20260605 (#8196)