### PR TITLE
🐛 os: resolve auditpol success/failure across OS display languages

### DIFF
--- a/providers/os/resources/auditpol.go
+++ b/providers/os/resources/auditpol.go
@@ -57,31 +57,71 @@ func (p *mqlAuditpolEntry) id() (string, error) {
 	return p.Subcategoryguid.Data, nil
 }
 
-// auditpolInclusionAudits reports whether an auditpol inclusion setting audits
-// the given event kind ("success" or "failure"). The setting is one of
-// "Success", "Failure", "Success and Failure", or "No Auditing".
-func auditpolInclusionAudits(inclusionSetting, kind string) bool {
-	return strings.Contains(strings.ToLower(inclusionSetting), kind)
+// auditpolAuditFlags records whether an inclusion setting audits success and/or
+// failure events.
+type auditpolAuditFlags struct {
+	success bool
+	failure bool
+}
+
+// auditpolInclusionSettings maps every "Inclusion Setting" value auditpol /r can
+// emit to whether it audits success and/or failure events. auditpol localizes
+// this column to the OS display language, so the same setting appears under
+// several spellings; keys are lowercased. Settings that audit neither event
+// (e.g. "No Auditing" and its localized forms) are intentionally absent and
+// resolve to the zero value via the map lookup. Supported languages: English,
+// German, Dutch, Italian.
+var auditpolInclusionSettings = map[string]auditpolAuditFlags{
+	// English
+	"success":             {success: true},
+	"failure":             {failure: true},
+	"success and failure": {success: true, failure: true},
+	// German
+	"erfolg":            {success: true},
+	"fehler":            {failure: true},
+	"erfolg und fehler": {success: true, failure: true},
+	// Dutch
+	"geslaagd":            {success: true},
+	"mislukt":             {failure: true},
+	"geslaagd en mislukt": {success: true, failure: true},
+	// Italian
+	"operazione riuscita":       {success: true},
+	"errore":                    {failure: true},
+	"esito positivo e negativo": {success: true, failure: true},
+	// French. auditpol may render the capital "É" with or without its accent,
+	// so accept both spellings of the failure forms.
+	"succès":          {success: true},
+	"échec":           {failure: true},
+	"echec":           {failure: true},
+	"succès et échec": {success: true, failure: true},
+	"succès et echec": {success: true, failure: true},
+}
+
+// auditpolInclusionAudits reports whether the given (possibly localized)
+// inclusion setting audits success and failure events. Unrecognized settings
+// audit neither.
+func auditpolInclusionAudits(inclusionSetting string) auditpolAuditFlags {
+	return auditpolInclusionSettings[strings.ToLower(strings.TrimSpace(inclusionSetting))]
 }
 
 // success reports whether the inclusion setting audits success events. It is
-// true for "Success" and "Success and Failure", false for "Failure" and
-// "No Auditing".
+// true for "Success" and "Success and Failure" (and their localized forms),
+// false for "Failure" and "No Auditing".
 func (p *mqlAuditpolEntry) success() (bool, error) {
 	setting := p.GetInclusionsetting()
 	if setting.Error != nil {
 		return false, setting.Error
 	}
-	return auditpolInclusionAudits(setting.Data, "success"), nil
+	return auditpolInclusionAudits(setting.Data).success, nil
 }
 
 // failure reports whether the inclusion setting audits failure events. It is
-// true for "Failure" and "Success and Failure", false for "Success" and
-// "No Auditing".
+// true for "Failure" and "Success and Failure" (and their localized forms),
+// false for "Success" and "No Auditing".
 func (p *mqlAuditpolEntry) failure() (bool, error) {
 	setting := p.GetInclusionsetting()
 	if setting.Error != nil {
 		return false, setting.Error
 	}
-	return auditpolInclusionAudits(setting.Data, "failure"), nil
+	return auditpolInclusionAudits(setting.Data).failure, nil
 }

--- a/providers/os/resources/auditpol_internal_test.go
+++ b/providers/os/resources/auditpol_internal_test.go
@@ -14,17 +14,41 @@ func TestAuditpolInclusionAudits(t *testing.T) {
 		setting          string
 		success, failure bool
 	}{
+		// English
 		{"Success", true, false},
 		{"Failure", false, true},
 		{"Success and Failure", true, true},
 		{"No Auditing", false, false},
+		// German
+		{"Erfolg", true, false},
+		{"Fehler", false, true},
+		{"Erfolg und Fehler", true, true},
+		// Dutch
+		{"Geslaagd", true, false},
+		{"Mislukt", false, true},
+		{"Geslaagd en mislukt", true, true},
+		// Italian
+		{"Operazione riuscita", true, false},
+		{"Errore", false, true},
+		{"Esito positivo e negativo", true, true},
+		// French (with and without the accent on the capital É)
+		{"Succès", true, false},
+		{"Échec", false, true},
+		{"Echec", false, true},
+		{"Succès et échec", true, true},
+		{"Succès et echec", true, true},
+		// case-insensitive and whitespace-tolerant
+		{"  success and failure  ", true, true},
+		// unrecognized settings audit neither
+		{"unbekannt", false, false},
 		{"", false, false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.setting, func(t *testing.T) {
-			assert.Equal(t, c.success, auditpolInclusionAudits(c.setting, "success"))
-			assert.Equal(t, c.failure, auditpolInclusionAudits(c.setting, "failure"))
+			flags := auditpolInclusionAudits(c.setting)
+			assert.Equal(t, c.success, flags.success, "success")
+			assert.Equal(t, c.failure, flags.failure, "failure")
 		})
 	}
 }

--- a/providers/os/resources/auditpol_test.go
+++ b/providers/os/resources/auditpol_test.go
@@ -4,9 +4,12 @@
 package resources_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
 )
 
 func TestResource_Auditpol(t *testing.T) {
@@ -68,6 +71,63 @@ func TestResource_Auditpol(t *testing.T) {
 			assert.NotEmpty(t, res)
 			assert.Empty(t, res[0].Result().Error)
 			assert.Equal(t, tc.failure, res[0].Data.Value)
+		})
+	}
+}
+
+// TestResource_AuditpolGerman exercises success/failure end-to-end against a
+// recording of a German-localized `auditpol /r`, where both the subcategory
+// names and the inclusion settings are localized ("Erfolg und Fehler" etc.).
+// It proves the parse -> resource -> locale-table chain on non-English output
+// and that the cnspec audit-policy queries — which select by locale-independent
+// GUID and assert on the success/failure booleans — hold on a German system.
+func TestResource_AuditpolGerman(t *testing.T) {
+	abs, err := filepath.Abs("testdata/auditpol_windows_de.json")
+	require.NoError(t, err)
+	de := testutils.InitTester(testutils.RecordingMock(abs))
+
+	// subcategoryguid -> expected booleans for its German inclusion setting.
+	cases := []struct {
+		guid             string
+		setting          string
+		success, failure bool
+	}{
+		{"0CCE9239-69AE-11D9-BED3-505054503030", "Erfolg und Fehler", true, true},
+		{"0CCE922F-69AE-11D9-BED3-505054503030", "Erfolg", true, false},
+		{"0CCE9234-69AE-11D9-BED3-505054503030", "Fehler", false, true},
+		{"0CCE9211-69AE-11D9-BED3-505054503030", "Keine Überwachung", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.setting, func(t *testing.T) {
+			res := de.TestQuery(t, "auditpol.where(subcategoryguid == '"+tc.guid+"')[0].success")
+			require.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.success, res[0].Data.Value, "success")
+
+			res = de.TestQuery(t, "auditpol.where(subcategoryguid == '"+tc.guid+"')[0].failure")
+			require.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.failure, res[0].Data.Value, "failure")
+		})
+	}
+
+	// The exact assertion patterns the cnspec mondoo-windows-security queries
+	// use, verified against the German recording (props removed in cnspec#2744).
+	patternCases := []struct {
+		query string
+		want  bool
+	}{
+		{"auditpol.where(subcategoryguid == '0CCE9217-69AE-11D9-BED3-505054503030').all(failure)", true},
+		{"auditpol.where(subcategoryguid == '0CCE922F-69AE-11D9-BED3-505054503030').all(success)", true},
+		{"auditpol.where(subcategoryguid == '0CCE9239-69AE-11D9-BED3-505054503030').all(success && failure)", true},
+		{"auditpol.where(subcategoryguid == '0CCE9234-69AE-11D9-BED3-505054503030').all(failure && success == false)", true},
+	}
+	for _, tc := range patternCases {
+		t.Run(tc.query, func(t *testing.T) {
+			res := de.TestQuery(t, tc.query)
+			require.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.want, res[0].Data.Value)
 		})
 	}
 }

--- a/providers/os/resources/testdata/auditpol_windows_de.json
+++ b/providers/os/resources/testdata/auditpol_windows_de.json
@@ -1,0 +1,48 @@
+{
+  "assets": [
+    {
+      "asset": {
+        "id": "windows-server-de",
+        "platform_ids": [
+          "windows"
+        ],
+        "name": "windows-de",
+        "platform": {
+          "name": "windows",
+          "arch": "x86_64",
+          "title": "Windows Server",
+          "family": [
+            "windows",
+            "os"
+          ],
+          "build": "rolling",
+          "version": "2022"
+        }
+      },
+      "connections": [
+        {
+          "url": "local://",
+          "provider": "os",
+          "connector": "local",
+          "version": ""
+        }
+      ],
+      "resources": [
+        {
+          "Resource": "powershell",
+          "ID": "[Console]::OutputEncoding = [Text.Encoding]::UTF8;auditpol /get /category:* /r",
+          "Fields": {
+            "exitcode": {
+              "type": "\u0005",
+              "value": 0
+            },
+            "stdout": {
+              "type": "\u0007",
+              "value": "Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting\r\r\nWIN-DE-TEST,System,Sicherheitssystemerweiterung,{0CCE9211-69AE-11D9-BED3-505054503030},Keine Überwachung,\r\r\nWIN-DE-TEST,System,Kontosperrung,{0CCE9217-69AE-11D9-BED3-505054503030},Erfolg und Fehler,\r\r\nWIN-DE-TEST,System,Richtlinienänderungen überwachen,{0CCE922F-69AE-11D9-BED3-505054503030},Erfolg,\r\r\nWIN-DE-TEST,System,Spezielle Anmeldung,{0CCE9234-69AE-11D9-BED3-505054503030},Fehler,\r\r\nWIN-DE-TEST,System,Sicherheitsgruppenverwaltung,{0CCE9239-69AE-11D9-BED3-505054503030},Erfolg und Fehler,\r\r\n"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

`auditpol /r` localizes the **Inclusion Setting** column to the OS display language, but `auditpol.entry.success` / `auditpol.entry.failure` matched only the English words `"success"` / `"failure"` as substrings. On localized Windows the column reads e.g. `Erfolg und Fehler` (de) or `Esito positivo e negativo` (it), so both booleans wrongly returned `false`.

To work around this, cnspec policies have been carrying per-locale string props keyed on `windows.computerInfo['OsLocale']`:

```yaml
switch(windows.computerInfo['OsLocale']) {
  case _ == "de-DE": "Erfolg und Fehler";
  case _ == "it-IT": "Esito positivo e negativo";
  default: "Success and Failure";
}
```

## Change

Replace the substring match with a lookup table of the localized inclusion-setting strings (lowercased, whitespace-trimmed). Unrecognized settings — including localized "No Auditing" — audit neither, the safe default.

| | Success | Failure | Success and Failure |
|---|---|---|---|
| English | `Success` | `Failure` | `Success and Failure` |
| German | `Erfolg` | `Fehler` | `Erfolg und Fehler` |
| Dutch | `Geslaagd` | `Mislukt` | `Geslaagd en mislukt` |
| Italian | `Operazione riuscita` | `Errore` | `Esito positivo e negativo` |
| French | `Succès` | `Échec` (also `Echec`) | `Succès et échec` |

French is included with and without the accent on the capital `É`, which Windows renders inconsistently.

## Impact — replaces the cnspec props removed in mondoohq/cnspec#2744

That PR removes 27 sets of `OsLocale`-switch props and replaces each with a boolean assertion. The four patterns it uses all map exactly to this change:

| Replacement | Old prop logic | True when inclusion setting is… |
|---|---|---|
| `.all(success)` | `== Success \|\| == "Success and Failure"` | Success, Success and Failure |
| `.all(failure)` | `== Failure \|\| == "Success and Failure"` | Failure, Success and Failure |
| `.all(success && failure)` | `== "Success and Failure"` | Success and Failure only |
| `.all(failure && success == false)` | *(failure-only)* | Failure only |

Note the removed props only had `de-DE` + `it-IT` cases plus an English default, so they were already broken on Dutch/French systems (fell through to English and mismatched). This change reaches full parity for en/de/it and additionally fixes nl/fr.

## Tests

- `TestAuditpolInclusionAudits` — unit-tests the locale table for all five languages × three states, plus accent/case/whitespace/unrecognized edges.
- `TestResource_AuditpolGerman` — end-to-end test against a recording of a German-localized `auditpol /r` (localized subcategory names *and* inclusion settings, UTF-8 umlauts). Drives `success`/`failure` through the real resource methods and verifies the four cnspec#2744 assertion patterns hold on a German system, selecting by locale-independent `subcategoryguid`.

## Note on source data

German, Italian, and English strings come from real localized systems (the existing cnspec props). Dutch and French strings were sourced from Microsoft Learn (nl-nl / fr-fr) docs; the standalone-vs-combined French forms and the `É` accent rendering are the only spots with residual uncertainty. A quick `auditpol /get /category:* /r` on a real Dutch or French box would confirm the exact column spelling — if any differ, it's a one-line map edit (and the test recording is trivially extended to that locale).