### PR TITLE
✨ terraform: add block.values to flatten nested blocks to plan/state shape

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -455,6 +455,57 @@ func (t *mqlTerraformBlock) arguments() (map[string]any, error) {
 	return hclResolvedAttributesToDict(attributes)
 }
 
+// hclBodyToValuesDict folds an HCL block body into a single dict in the same
+// shape Terraform plan (`change.after`) and state (`values`) expose: scalar
+// arguments become direct values, and each nested block is collected into a
+// list-of-maps keyed by its block type (recursively). This lets one MQL body
+// run against terraform-hcl, terraform-plan, and terraform-state assets
+// instead of three separately-written variants.
+func hclBodyToValuesDict(rawBody hcl.Body) (map[string]any, error) {
+	dict := map[string]any{}
+
+	body, ok := rawBody.(*hclsyntax.Body)
+	if !ok {
+		// .tf.json and other non-native bodies: best effort, attributes only.
+		// Nested-block traversal needs a schema we don't have here.
+		attributes, _ := rawBody.JustAttributes()
+		return hclResolvedAttributesToDict(attributes)
+	}
+
+	attributes := make(map[string]*hcl.Attribute, len(body.Attributes))
+	for name, attr := range body.Attributes {
+		attributes[name] = attr.AsHCLAttribute()
+	}
+	resolved, err := hclResolvedAttributesToDict(attributes)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range resolved {
+		dict[k] = v
+	}
+
+	for _, block := range body.Blocks {
+		child, err := hclBodyToValuesDict(block.Body)
+		if err != nil {
+			return nil, err
+		}
+		existing, _ := dict[block.Type].([]any)
+		dict[block.Type] = append(existing, child)
+	}
+
+	return dict, nil
+}
+
+func (t *mqlTerraformBlock) values() (map[string]any, error) {
+	if t.block.State != plugin.StateIsSet {
+		if t.block.Error != nil {
+			return nil, t.block.Error
+		}
+		return nil, errors.New("cannot get hcl block")
+	}
+	return hclBodyToValuesDict(t.block.Data.Body)
+}
+
 func hclResolvedAttributesToDict(attributes map[string]*hcl.Attribute) (map[string]any, error) {
 	dict := map[string]any{}
 	for k := range attributes {

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -241,3 +241,99 @@ locals {
 	assert.True(t, containsString(amiVal, "var.disaster_recovery_mode"),
 		"ami_id should reference var.disaster_recovery_mode, got: %#v", amiVal)
 }
+
+// resourceBody parses an HCL snippet containing a single resource block and
+// returns that block's body, so tests can exercise nested-block flattening.
+func resourceBody(t *testing.T, src string) *hclsyntax.Body {
+	t.Helper()
+	f, diags := hclsyntax.ParseConfig([]byte(src), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "parse errors: %s", diags.Error())
+	body, ok := f.Body.(*hclsyntax.Body)
+	require.True(t, ok)
+	require.Len(t, body.Blocks, 1, "snippet must contain exactly one top-level block")
+	return body.Blocks[0].Body
+}
+
+// TestHclBodyToValuesDict_FlattensNestedBlocksToPlanStateShape verifies that
+// values() folds child blocks into the arguments dict as lists-of-maps keyed
+// by block type — the same shape Terraform plan (change.after) and state
+// (values) expose — so a single MQL body can run against all three backends.
+func TestHclBodyToValuesDict_FlattensNestedBlocksToPlanStateShape(t *testing.T) {
+	// resource "aws_eks_cluster" "example" { ... }
+	body := resourceBody(t, `
+resource "aws_eks_cluster" "example" {
+  name = "example"
+
+  encryption_config {
+    resources = ["secrets"]
+    provider {
+      key_arn = "arn:aws:kms:us-east-1:111:key/abc"
+    }
+  }
+
+  vpc_config {
+    endpoint_private_access = true
+    endpoint_public_access  = false
+  }
+}
+`)
+
+	values, err := hclBodyToValuesDict(body)
+	require.NoError(t, err)
+
+	// Scalar arguments stay as direct values.
+	assert.Equal(t, "example", values["name"])
+
+	// A nested block becomes a []any of maps keyed by the block type — even
+	// when it appears once — matching the plan/state JSON representation.
+	encList, ok := values["encryption_config"].([]any)
+	require.True(t, ok, "encryption_config should be []any, got %#v", values["encryption_config"])
+	require.Len(t, encList, 1)
+	enc := encList[0].(map[string]any)
+
+	// Nested-within-nested blocks flatten recursively the same way.
+	provList, ok := enc["provider"].([]any)
+	require.True(t, ok, "provider should be []any, got %#v", enc["provider"])
+	require.Len(t, provList, 1)
+	assert.Equal(t, "arn:aws:kms:us-east-1:111:key/abc", provList[0].(map[string]any)["key_arn"])
+
+	// Booleans round-trip as bools so `_['endpoint_public_access'] == false` works.
+	vpcList, ok := values["vpc_config"].([]any)
+	require.True(t, ok, "vpc_config should be []any, got %#v", values["vpc_config"])
+	require.Len(t, vpcList, 1)
+	assert.Equal(t, true, vpcList[0].(map[string]any)["endpoint_private_access"])
+	assert.Equal(t, false, vpcList[0].(map[string]any)["endpoint_public_access"])
+}
+
+// TestHclBodyToValuesDict_RepeatedBlocksBecomeList verifies that repeated
+// nested blocks of the same type (e.g. multiple database_flags) collect into
+// a single list, matching how plan/state represent them.
+func TestHclBodyToValuesDict_RepeatedBlocksBecomeList(t *testing.T) {
+	body := resourceBody(t, `
+resource "google_sql_database_instance" "example" {
+  settings {
+    database_flags {
+      name  = "skip_show_database"
+      value = "on"
+    }
+    database_flags {
+      name  = "local_infile"
+      value = "off"
+    }
+  }
+}
+`)
+
+	values, err := hclBodyToValuesDict(body)
+	require.NoError(t, err)
+
+	settings, ok := values["settings"].([]any)
+	require.True(t, ok)
+	require.Len(t, settings, 1)
+
+	flags, ok := settings[0].(map[string]any)["database_flags"].([]any)
+	require.True(t, ok, "database_flags should be []any, got %#v", settings[0].(map[string]any)["database_flags"])
+	require.Len(t, flags, 2)
+	assert.Equal(t, "skip_show_database", flags[0].(map[string]any)["name"])
+	assert.Equal(t, "local_infile", flags[1].(map[string]any)["name"])
+}

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -84,6 +84,8 @@ private terraform.block @defaults("type labels") {
   end terraform.fileposition
   // Block arguments
   arguments() dict
+  // Arguments with child blocks folded in as lists-of-maps, mirroring the plan (change.after) and state (values) shape
+  values() dict
   // Raw block attributes
   attributes() dict
   // Child blocks

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -246,6 +246,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"terraform.block.arguments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetArguments()).ToDataRes(types.Dict)
 	},
+	"terraform.block.values": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTerraformBlock).GetValues()).ToDataRes(types.Dict)
+	},
 	"terraform.block.attributes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetAttributes()).ToDataRes(types.Dict)
 	},
@@ -566,6 +569,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"terraform.block.arguments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTerraformBlock).Arguments, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"terraform.block.values": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTerraformBlock).Values, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"terraform.block.attributes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1268,6 +1275,7 @@ type mqlTerraformBlock struct {
 	Start        plugin.TValue[*mqlTerraformFileposition]
 	End          plugin.TValue[*mqlTerraformFileposition]
 	Arguments    plugin.TValue[any]
+	Values       plugin.TValue[any]
 	Attributes   plugin.TValue[any]
 	Blocks       plugin.TValue[[]any]
 	Related      plugin.TValue[[]any]
@@ -1348,6 +1356,12 @@ func (c *mqlTerraformBlock) GetEnd() *plugin.TValue[*mqlTerraformFileposition] {
 func (c *mqlTerraformBlock) GetArguments() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Arguments, func() (any, error) {
 		return c.arguments()
+	})
+}
+
+func (c *mqlTerraformBlock) GetValues() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.Values, func() (any, error) {
+		return c.values()
 	})
 }
 

--- a/providers/terraform/resources/terraform.lr.versions
+++ b/providers/terraform/resources/terraform.lr.versions
@@ -15,6 +15,7 @@ terraform.block.resourceType 13.0.15
 terraform.block.snippet 9.0.0
 terraform.block.start 9.0.0
 terraform.block.type 9.0.0
+terraform.block.values 13.1.2
 terraform.blocks 9.0.0
 terraform.datasources 9.0.0
 terraform.file 9.0.0


### PR DESCRIPTION
## What

Adds a `values()` field to the `terraform.block` resource that folds child blocks into the arguments dict as **lists-of-maps keyed by block type** (recursively) — the same shape Terraform plan (`change.after`) and state (`values`) already expose.

```
// terraform.block
values() dict
```

For an HCL `aws_eks_cluster` block, `terraform.resources("aws_eks_cluster")[0].values` now returns:

```json
{
  "name": "example",
  "encryption_config": [
    { "provider": [ { "key_arn": "arn:aws:kms:..." } ], "resources": ["secrets"] }
  ],
  "vpc_config": [
    { "endpoint_private_access": true, "endpoint_public_access": false }
  ]
}
```

— byte-for-byte the plan/state representation.

## Why

A cloud check that runs against Terraform assets is written **three times** today, because the backends expose different shapes:

- **HCL**: nested config blocks are child `terraform.block`s, walked with `blocks.where(type == "x")` and `arguments.foo`.
- **plan**: the same nesting is flattened to lists-of-maps under the attribute key, walked with `change.after.x` and `_['key']`.
- **state**: same flattened shape as plan, rooted at `values.x`.

This forces an HCL-specific traversal dialect that can't be shared with the plan/state bodies. With `values()`, an HCL check body becomes identical to its plan/state siblings except for the selector prefix and root accessor.

### Before / after (EKS CMK check, from `mondoo-aws-security`)

**Before** — HCL variant, its own `blocks.where`/`arguments` dialect:

```coffee
terraform.resources("aws_eks_cluster").all(
  blocks.where( type == "encryption_config" ) != empty &&
  blocks.where( type == "encryption_config" ).all(
    blocks.where( type == "provider" ) != empty &&
    blocks.where( type == "provider" ).all( arguments.key_arn != empty )))
```

**After** — the plan variant's body verbatim, with `change.after` → `values`:

```coffee
terraform.resources("aws_eks_cluster").all(
  values.encryption_config != empty &&
  values.encryption_config.all(
    _['provider'] != empty &&
    _['provider'].all( _['key_arn'] != empty )))
```

This is the prerequisite for collapsing the three per-asset check variants into a single body.

## Testing

- Added `TestHclBodyToValuesDict_FlattensNestedBlocksToPlanStateShape` and `TestHclBodyToValuesDict_RepeatedBlocksBecomeList` (TDD — written failing first).
- `go test ./resources/` passes.
- Verified end-to-end with `mql run terraform . -c '...'` against an EKS HCL fixture: both the `values` dump and a plan-style guarded check body return the expected results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)