### PR TITLE
✨ ms365: typed Secure Score controls and unified audit log accessor

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1682,8 +1682,15 @@ private microsoft.security.securityscore @defaults("id azureTenantId") {
   averageComparativeScores []dict
   // Secure Score tenant ID
   azureTenantId string
-  // Secure Score control scores
-  controlScores []dict
+  // Secure Score control scores as raw dictionaries
+  //
+  // Deprecated in favor of `controls`.
+  controlScores @maturity("deprecated") []dict
+  // Per-control score breakdown for the Secure Score
+  //
+  // Each entry exposes the control's `controlName`, `controlCategory`,
+  // `description`, and tenant-achieved `score`.
+  controls []microsoft.security.securityscore.controlScore
   // Secure Score creation time
   createdDateTime time
   // Secure Score current score
@@ -1696,6 +1703,27 @@ private microsoft.security.securityscore @defaults("id azureTenantId") {
   maxScore float
   // Secure Score vendor information
   vendorInformation dict
+}
+
+// Microsoft Secure Score control score
+//
+// A single security control's contribution to the tenant Secure Score. Exposes
+// the `controlName`, the `controlCategory` (Identity, Data, Device, Apps,
+// Infrastructure), the human-readable `description`, and the tenant-achieved
+// `score` for the control.
+private microsoft.security.securityscore.controlScore @defaults("controlName score") {
+  // Control score ID (parent score ID and control name)
+  id string
+  // Control action category (Identity, Data, Device, Apps, Infrastructure)
+  controlCategory string
+  // Control unique name
+  controlName string
+  // Description of the control
+  description string
+  // Tenant-achieved score for the control
+  //
+  // Varies day to day depending on tenant operations on the control.
+  score float
 }
 
 // Microsoft Entra ID Risky User
@@ -3491,6 +3519,11 @@ ms365.exchangeonline {
   owaMailboxPolicies() []ms365.exchangeonline.owaMailboxPolicyEntry
   // Admin audit log configuration
   adminAuditLogConfig() dict
+  // Whether unified audit log ingestion is enabled for the organization
+  //
+  // When true, admin and user activity is recorded to the unified audit log and
+  // available for search in the Microsoft Purview compliance portal.
+  unifiedAuditLogIngestionEnabled() bool
   // List of phishing filter policies
   phishFilterPolicy() []dict
   // Quarantine policies as raw dictionaries

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1712,8 +1712,6 @@ private microsoft.security.securityscore @defaults("id azureTenantId") {
 // Infrastructure), the human-readable `description`, and the tenant-achieved
 // `score` for the control.
 private microsoft.security.securityscore.controlScore @defaults("controlName score") {
-  // Control score ID (parent score ID and control name)
-  id string
   // Control action category (Identity, Data, Device, Apps, Infrastructure)
   controlCategory string
   // Control unique name

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -92,6 +92,7 @@ const (
 	ResourceMicrosoftOauth2PermissionGrant                                                               string = "microsoft.oauth2PermissionGrant"
 	ResourceMicrosoftSecurity                                                                            string = "microsoft.security"
 	ResourceMicrosoftSecuritySecurityscore                                                               string = "microsoft.security.securityscore"
+	ResourceMicrosoftSecuritySecurityscoreControlScore                                                   string = "microsoft.security.securityscore.controlScore"
 	ResourceMicrosoftSecurityRiskyUser                                                                   string = "microsoft.security.riskyUser"
 	ResourceMicrosoftSecurityRiskDetection                                                               string = "microsoft.security.riskDetection"
 	ResourceMicrosoftSecurityAlert                                                                       string = "microsoft.security.alert"
@@ -502,6 +503,10 @@ func init() {
 		"microsoft.security.securityscore": {
 			// to override args, implement: initMicrosoftSecuritySecurityscore(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftSecuritySecurityscore,
+		},
+		"microsoft.security.securityscore.controlScore": {
+			// to override args, implement: initMicrosoftSecuritySecurityscoreControlScore(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftSecuritySecurityscoreControlScore,
 		},
 		"microsoft.security.riskyUser": {
 			// to override args, implement: initMicrosoftSecurityRiskyUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2682,6 +2687,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.security.securityscore.controlScores": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecuritySecurityscore).GetControlScores()).ToDataRes(types.Array(types.Dict))
 	},
+	"microsoft.security.securityscore.controls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscore).GetControls()).ToDataRes(types.Array(types.Resource("microsoft.security.securityscore.controlScore")))
+	},
 	"microsoft.security.securityscore.createdDateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecuritySecurityscore).GetCreatedDateTime()).ToDataRes(types.Time)
 	},
@@ -2699,6 +2707,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.security.securityscore.vendorInformation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecuritySecurityscore).GetVendorInformation()).ToDataRes(types.Dict)
+	},
+	"microsoft.security.securityscore.controlScore.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.security.securityscore.controlScore.controlCategory": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetControlCategory()).ToDataRes(types.String)
+	},
+	"microsoft.security.securityscore.controlScore.controlName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetControlName()).ToDataRes(types.String)
+	},
+	"microsoft.security.securityscore.controlScore.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.security.securityscore.controlScore.score": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetScore()).ToDataRes(types.Float)
 	},
 	"microsoft.security.riskyUser.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecurityRiskyUser).GetId()).ToDataRes(types.String)
@@ -4412,6 +4435,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ms365.exchangeonline.adminAuditLogConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365Exchangeonline).GetAdminAuditLogConfig()).ToDataRes(types.Dict)
+	},
+	"ms365.exchangeonline.unifiedAuditLogIngestionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365Exchangeonline).GetUnifiedAuditLogIngestionEnabled()).ToDataRes(types.Bool)
 	},
 	"ms365.exchangeonline.phishFilterPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365Exchangeonline).GetPhishFilterPolicy()).ToDataRes(types.Array(types.Dict))
@@ -8195,6 +8221,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftSecuritySecurityscore).ControlScores, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"microsoft.security.securityscore.controls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscore).Controls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"microsoft.security.securityscore.createdDateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftSecuritySecurityscore).CreatedDateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -8217,6 +8247,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.security.securityscore.vendorInformation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftSecuritySecurityscore).VendorInformation, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.controlCategory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).ControlCategory, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.controlName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).ControlName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.security.securityscore.controlScore.score": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).Score, ok = plugin.RawToTValue[float64](v.Value, v.Error)
 		return
 	},
 	"microsoft.security.riskyUser.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10757,6 +10811,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.exchangeonline.adminAuditLogConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365Exchangeonline).AdminAuditLogConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"ms365.exchangeonline.unifiedAuditLogIngestionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365Exchangeonline).UnifiedAuditLogIngestionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"ms365.exchangeonline.phishFilterPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19235,6 +19293,7 @@ type mqlMicrosoftSecuritySecurityscore struct {
 	AverageComparativeScores plugin.TValue[[]any]
 	AzureTenantId            plugin.TValue[string]
 	ControlScores            plugin.TValue[[]any]
+	Controls                 plugin.TValue[[]any]
 	CreatedDateTime          plugin.TValue[*time.Time]
 	CurrentScore             plugin.TValue[float64]
 	EnabledServices          plugin.TValue[[]any]
@@ -19300,6 +19359,10 @@ func (c *mqlMicrosoftSecuritySecurityscore) GetControlScores() *plugin.TValue[[]
 	return &c.ControlScores
 }
 
+func (c *mqlMicrosoftSecuritySecurityscore) GetControls() *plugin.TValue[[]any] {
+	return &c.Controls
+}
+
 func (c *mqlMicrosoftSecuritySecurityscore) GetCreatedDateTime() *plugin.TValue[*time.Time] {
 	return &c.CreatedDateTime
 }
@@ -19322,6 +19385,75 @@ func (c *mqlMicrosoftSecuritySecurityscore) GetMaxScore() *plugin.TValue[float64
 
 func (c *mqlMicrosoftSecuritySecurityscore) GetVendorInformation() *plugin.TValue[any] {
 	return &c.VendorInformation
+}
+
+// mqlMicrosoftSecuritySecurityscoreControlScore for the microsoft.security.securityscore.controlScore resource
+type mqlMicrosoftSecuritySecurityscoreControlScore struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftSecuritySecurityscoreControlScoreInternal it will be used here
+	Id              plugin.TValue[string]
+	ControlCategory plugin.TValue[string]
+	ControlName     plugin.TValue[string]
+	Description     plugin.TValue[string]
+	Score           plugin.TValue[float64]
+}
+
+// createMicrosoftSecuritySecurityscoreControlScore creates a new instance of this resource
+func createMicrosoftSecuritySecurityscoreControlScore(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftSecuritySecurityscoreControlScore{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.security.securityscore.controlScore", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) MqlName() string {
+	return "microsoft.security.securityscore.controlScore"
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetControlCategory() *plugin.TValue[string] {
+	return &c.ControlCategory
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetControlName() *plugin.TValue[string] {
+	return &c.ControlName
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetScore() *plugin.TValue[float64] {
+	return &c.Score
 }
 
 // mqlMicrosoftSecurityRiskyUser for the microsoft.security.riskyUser resource
@@ -25422,6 +25554,7 @@ type mqlMs365Exchangeonline struct {
 	OwaMailboxPolicy                 plugin.TValue[[]any]
 	OwaMailboxPolicies               plugin.TValue[[]any]
 	AdminAuditLogConfig              plugin.TValue[any]
+	UnifiedAuditLogIngestionEnabled  plugin.TValue[bool]
 	PhishFilterPolicy                plugin.TValue[[]any]
 	QuarantinePolicy                 plugin.TValue[[]any]
 	QuarantinePolicies               plugin.TValue[[]any]
@@ -25728,6 +25861,12 @@ func (c *mqlMs365Exchangeonline) GetOwaMailboxPolicies() *plugin.TValue[[]any] {
 func (c *mqlMs365Exchangeonline) GetAdminAuditLogConfig() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.AdminAuditLogConfig, func() (any, error) {
 		return c.adminAuditLogConfig()
+	})
+}
+
+func (c *mqlMs365Exchangeonline) GetUnifiedAuditLogIngestionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UnifiedAuditLogIngestionEnabled, func() (bool, error) {
+		return c.unifiedAuditLogIngestionEnabled()
 	})
 }
 

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -2708,9 +2708,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.security.securityscore.vendorInformation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecuritySecurityscore).GetVendorInformation()).ToDataRes(types.Dict)
 	},
-	"microsoft.security.securityscore.controlScore.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetId()).ToDataRes(types.String)
-	},
 	"microsoft.security.securityscore.controlScore.controlCategory": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecuritySecurityscoreControlScore).GetControlCategory()).ToDataRes(types.String)
 	},
@@ -8251,10 +8248,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.security.securityscore.controlScore.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).__id, ok = v.Value.(string)
-		return
-	},
-	"microsoft.security.securityscore.controlScore.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftSecuritySecurityscoreControlScore).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.security.securityscore.controlScore.controlCategory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19392,7 +19385,6 @@ type mqlMicrosoftSecuritySecurityscoreControlScore struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMicrosoftSecuritySecurityscoreControlScoreInternal it will be used here
-	Id              plugin.TValue[string]
 	ControlCategory plugin.TValue[string]
 	ControlName     plugin.TValue[string]
 	Description     plugin.TValue[string]
@@ -19410,12 +19402,7 @@ func createMicrosoftSecuritySecurityscoreControlScore(runtime *plugin.Runtime, a
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.security.securityscore.controlScore", res.__id)
@@ -19434,10 +19421,6 @@ func (c *mqlMicrosoftSecuritySecurityscoreControlScore) MqlName() string {
 
 func (c *mqlMicrosoftSecuritySecurityscoreControlScore) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlMicrosoftSecuritySecurityscoreControlScore) GetControlCategory() *plugin.TValue[string] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -990,7 +990,14 @@ microsoft.security.securityscore 9.0.0
 microsoft.security.securityscore.activeUserCount 9.0.0
 microsoft.security.securityscore.averageComparativeScores 9.0.0
 microsoft.security.securityscore.azureTenantId 9.0.0
+microsoft.security.securityscore.controlScore 13.6.1
+microsoft.security.securityscore.controlScore.controlCategory 13.6.1
+microsoft.security.securityscore.controlScore.controlName 13.6.1
+microsoft.security.securityscore.controlScore.description 13.6.1
+microsoft.security.securityscore.controlScore.id 13.6.1
+microsoft.security.securityscore.controlScore.score 13.6.1
 microsoft.security.securityscore.controlScores 9.0.0
+microsoft.security.securityscore.controls 13.6.1
 microsoft.security.securityscore.createdDateTime 9.0.0
 microsoft.security.securityscore.currentScore 9.0.0
 microsoft.security.securityscore.enabledServices 9.0.0
@@ -1542,6 +1549,7 @@ ms365.exchangeonline.transportRuleEntry.routeMessageOutboundRequireTls 13.3.1
 ms365.exchangeonline.transportRuleEntry.senderDomainIs 13.5.1
 ms365.exchangeonline.transportRuleEntry.state 13.3.1
 ms365.exchangeonline.transportRules 13.3.1
+ms365.exchangeonline.unifiedAuditLogIngestionEnabled 13.6.1
 ms365.exchangeonlineMailboxAuditBypassAssociation 11.1.43
 ms365.exchangeonlineMailboxAuditBypassAssociation.auditBypassEnabled 11.1.43
 ms365.exchangeonlineMailboxAuditBypassAssociation.name 11.1.43

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -994,7 +994,6 @@ microsoft.security.securityscore.controlScore 13.6.1
 microsoft.security.securityscore.controlScore.controlCategory 13.6.1
 microsoft.security.securityscore.controlScore.controlName 13.6.1
 microsoft.security.securityscore.controlScore.description 13.6.1
-microsoft.security.securityscore.controlScore.id 13.6.1
 microsoft.security.securityscore.controlScore.score 13.6.1
 microsoft.security.securityscore.controlScores 9.0.0
 microsoft.security.securityscore.controls 13.6.1

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -520,6 +520,7 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 	adminAuditLogConfig, adminAuditLogConfigErr := convert.JsonToDict(report.AdminAuditLogConfig)
 	r.AdminAuditLogConfig = plugin.TValue[any]{Data: adminAuditLogConfig, State: plugin.StateIsSet, Error: adminAuditLogConfigErr}
+	r.UnifiedAuditLogIngestionEnabled = plugin.TValue[bool]{Data: dictBoolValue(adminAuditLogConfig, "unifiedAuditLogIngestionEnabled"), State: plugin.StateIsSet, Error: adminAuditLogConfigErr}
 
 	phishFilterPolicy, phishFilterPolicyErr := convert.JsonToDictSlice(report.PhishFilterPolicy)
 	r.PhishFilterPolicy = plugin.TValue[[]any]{Data: phishFilterPolicy, State: plugin.StateIsSet, Error: phishFilterPolicyErr}
@@ -770,6 +771,26 @@ func (r *mqlMs365Exchangeonline) owaMailboxPolicy() ([]any, error) {
 
 func (r *mqlMs365Exchangeonline) adminAuditLogConfig() (any, error) {
 	return nil, r.getExchangeReport()
+}
+
+func (r *mqlMs365Exchangeonline) unifiedAuditLogIngestionEnabled() (bool, error) {
+	return false, r.getExchangeReport()
+}
+
+// dictBoolValue does a case-insensitive lookup of key in a JsonToDict result
+// and returns its bool value, or false when the key is absent or not a bool.
+func dictBoolValue(d any, key string) bool {
+	m, ok := d.(map[string]any)
+	if !ok {
+		return false
+	}
+	for k, v := range m {
+		if strings.EqualFold(k, key) {
+			b, _ := v.(bool)
+			return b
+		}
+	}
+	return false
 }
 
 func (r *mqlMs365Exchangeonline) phishFilterPolicy() ([]any, error) {

--- a/providers/ms365/resources/security_securescores.go
+++ b/providers/ms365/resources/security_securescores.go
@@ -20,6 +20,10 @@ func (m *mqlMicrosoftSecuritySecurityscore) id() (string, error) {
 	return m.Id.Data, nil
 }
 
+func (m *mqlMicrosoftSecuritySecurityscoreControlScore) id() (string, error) {
+	return m.Id.Data, nil
+}
+
 func newMqlMicrosoftSecureScore(runtime *plugin.Runtime, score models.SecureScoreable) (*mqlMicrosoftSecuritySecurityscore, error) {
 	if score == nil {
 		return nil, nil
@@ -34,14 +38,33 @@ func newMqlMicrosoftSecureScore(runtime *plugin.Runtime, score models.SecureScor
 		averageComparativeScores = append(averageComparativeScores, entry)
 	}
 
+	// controlScores is the deprecated raw-dict form; controls is the typed form.
 	controlScores := []any{}
+	controls := []any{}
 	graphControlScores := score.GetControlScores()
 	for j := range graphControlScores {
-		entry, err := convert.JsonToDict(newControlScore(graphControlScores[j]))
+		cs := newControlScore(graphControlScores[j])
+		if cs == nil {
+			continue
+		}
+		entry, err := convert.JsonToDict(cs)
 		if err != nil {
 			return nil, err
 		}
 		controlScores = append(controlScores, entry)
+
+		csResource, err := CreateResource(runtime, "microsoft.security.securityscore.controlScore",
+			map[string]*llx.RawData{
+				"id":              llx.StringData(convert.ToValue(score.GetId()) + "/" + convert.ToValue(cs.ControlName)),
+				"controlCategory": llx.StringDataPtr(cs.ControlCategory),
+				"controlName":     llx.StringDataPtr(cs.ControlName),
+				"description":     llx.StringDataPtr(cs.Description),
+				"score":           llx.FloatData(convert.ToValue(cs.Score)),
+			})
+		if err != nil {
+			return nil, err
+		}
+		controls = append(controls, csResource)
 	}
 
 	vendorInformation, err := convert.JsonToDict(newSecurityVendorInformation(score.GetVendorInformation()))
@@ -60,6 +83,7 @@ func newMqlMicrosoftSecureScore(runtime *plugin.Runtime, score models.SecureScor
 			"averageComparativeScores": llx.ArrayData(averageComparativeScores, types.Any),
 			"azureTenantId":            llx.StringDataPtr(score.GetAzureTenantId()),
 			"controlScores":            llx.ArrayData(controlScores, types.Any),
+			"controls":                 llx.ArrayData(controls, types.Resource("microsoft.security.securityscore.controlScore")),
 			"createdDateTime":          llx.TimeDataPtr(score.GetCreatedDateTime()),
 			"currentScore":             llx.FloatData(convert.ToValue(score.GetCurrentScore())),
 			"enabledServices":          llx.ArrayData(enabledServices, types.String),

--- a/providers/ms365/resources/security_securescores.go
+++ b/providers/ms365/resources/security_securescores.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/security"
@@ -17,10 +18,6 @@ import (
 )
 
 func (m *mqlMicrosoftSecuritySecurityscore) id() (string, error) {
-	return m.Id.Data, nil
-}
-
-func (m *mqlMicrosoftSecuritySecurityscoreControlScore) id() (string, error) {
 	return m.Id.Data, nil
 }
 
@@ -53,9 +50,17 @@ func newMqlMicrosoftSecureScore(runtime *plugin.Runtime, score models.SecureScor
 		}
 		controlScores = append(controlScores, entry)
 
+		// __id must be unique per control within a score. controlName is the
+		// natural key; fall back to the loop index when it is empty so unnamed
+		// controls don't collide in the resource cache.
+		controlName := convert.ToValue(cs.ControlName)
+		controlID := convert.ToValue(score.GetId()) + "/" + controlName
+		if controlName == "" {
+			controlID = convert.ToValue(score.GetId()) + "/#" + strconv.Itoa(j)
+		}
 		csResource, err := CreateResource(runtime, "microsoft.security.securityscore.controlScore",
 			map[string]*llx.RawData{
-				"id":              llx.StringData(convert.ToValue(score.GetId()) + "/" + convert.ToValue(cs.ControlName)),
+				"__id":            llx.StringData(controlID),
 				"controlCategory": llx.StringDataPtr(cs.ControlCategory),
 				"controlName":     llx.StringDataPtr(cs.ControlName),
 				"description":     llx.StringDataPtr(cs.Description),


### PR DESCRIPTION
## What

Two `mondoo-m365-security` checks reach into raw `dict` fields because the typed accessor doesn't exist yet. This adds the typed fields while keeping the dicts for backward compatibility — purely additive, no breaking type changes.

### `microsoft.security.securityscore` — new `controls`

The Secure Score control breakdown was only available as `controlScores []dict`, so five checks did:

```mql
microsoft.security.latestSecureScores.controlScores.where(controlName == 'AdminMFAV2').all(_['score'] == 10)
```

This adds a typed `controls []microsoft.security.securityscore.controlScore` (`controlCategory`, `controlName`, `description`, `score`) — the `ControlScore` struct already existed in Go and was being `JsonToDict`-ed. Checks become:

```mql
microsoft.security.latestSecureScores.controls.where(controlName == 'AdminMFAV2').all(score == 10)
```

The existing `controlScores` field is **marked `@maturity("deprecated")` and still populated** (rather than retyped) so nothing breaks.

### `ms365.exchangeonline` — new `unifiedAuditLogIngestionEnabled`

One check did dict indexing:

```mql
ms365.exchangeonline.adminAuditLogConfig['unifiedAuditLogIngestionEnabled'] == true
```

This adds a typed `unifiedAuditLogIngestionEnabled` bool:

```mql
ms365.exchangeonline.unifiedAuditLogIngestionEnabled == true
```

The accessor does a **case-insensitive** lookup over the admin-audit-log config — `Get-AdminAuditLogConfig` emits the property as `UnifiedAuditLogIngestionEnabled` (PascalCase), while the old check indexed lowercase, so the typed accessor is robust to the casing either way.

## Scope notes

I deliberately did **not** touch two things the broader analysis surfaced:
- `microsoft.devicemanagement.deviceConfigurations.settings` is a documented union-dict by design (per-platform `@odata.type` keys); dot-access is the intended interface.
- `microsoft.domain.serviceConfigurationRecords` is already typed; only the DMARC checks reach into the core `dns()` resource, which is out of scope here.

## Testing

- `go build ./...`, `go vet ./resources/`, `go test ./resources/...` all pass
- Generated files regenerated via `./lr go` + `./lr versions` + `gen/main.go`

A follow-up `cnspec` PR will migrate the six policy queries to the new fields once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)