### PR TITLE
✨ azure: typed Cosmos DB account network/consistency/CORS/location fields

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -5614,6 +5614,14 @@ azure.subscription.cosmosDbService.account @defaults("name kind location") {
   backupRetentionIntervalInHours int
   // Backup storage redundancy (for Periodic backup policy: "Geo", "Local", "Zone")
   backupStorageRedundancy string
+  // Default consistency level ("Eventual", "Session", "BoundedStaleness", "Strong", "ConsistentPrefix")
+  defaultConsistencyLevel string
+  // Network ACL bypass setting ("None" or "AzureServices")
+  networkAclBypass string
+  // Allowed origins from the account's CORS policies (empty when CORS is not configured)
+  corsAllowedOrigins []string
+  // Names of the regions the account is deployed to (more than one indicates multi-region)
+  locations []string
   // Virtual network rules for the Cosmos DB account
   virtualNetworkRules []azure.subscription.cosmosDbService.account.virtualNetworkRule
   // Private endpoint connections for the Cosmos DB account

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -8460,6 +8460,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cosmosDbService.account.backupStorageRedundancy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetBackupStorageRedundancy()).ToDataRes(types.String)
 	},
+	"azure.subscription.cosmosDbService.account.defaultConsistencyLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetDefaultConsistencyLevel()).ToDataRes(types.String)
+	},
+	"azure.subscription.cosmosDbService.account.networkAclBypass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetNetworkAclBypass()).ToDataRes(types.String)
+	},
+	"azure.subscription.cosmosDbService.account.corsAllowedOrigins": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetCorsAllowedOrigins()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.cosmosDbService.account.locations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetLocations()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.cosmosDbService.account.virtualNetworkRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccount).GetVirtualNetworkRules()).ToDataRes(types.Array(types.Resource("azure.subscription.cosmosDbService.account.virtualNetworkRule")))
 	},
@@ -24367,6 +24379,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cosmosDbService.account.backupStorageRedundancy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCosmosDbServiceAccount).BackupStorageRedundancy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cosmosDbService.account.defaultConsistencyLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServiceAccount).DefaultConsistencyLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cosmosDbService.account.networkAclBypass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServiceAccount).NetworkAclBypass, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cosmosDbService.account.corsAllowedOrigins": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServiceAccount).CorsAllowedOrigins, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cosmosDbService.account.locations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServiceAccount).Locations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cosmosDbService.account.virtualNetworkRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55711,6 +55739,10 @@ type mqlAzureSubscriptionCosmosDbServiceAccount struct {
 	BackupIntervalInMinutes            plugin.TValue[int64]
 	BackupRetentionIntervalInHours     plugin.TValue[int64]
 	BackupStorageRedundancy            plugin.TValue[string]
+	DefaultConsistencyLevel            plugin.TValue[string]
+	NetworkAclBypass                   plugin.TValue[string]
+	CorsAllowedOrigins                 plugin.TValue[[]any]
+	Locations                          plugin.TValue[[]any]
 	VirtualNetworkRules                plugin.TValue[[]any]
 	PrivateEndpointConnections         plugin.TValue[[]any]
 	SqlRoleDefinitions                 plugin.TValue[[]any]
@@ -55845,6 +55877,22 @@ func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetBackupRetentionIntervalI
 
 func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetBackupStorageRedundancy() *plugin.TValue[string] {
 	return &c.BackupStorageRedundancy
+}
+
+func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetDefaultConsistencyLevel() *plugin.TValue[string] {
+	return &c.DefaultConsistencyLevel
+}
+
+func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetNetworkAclBypass() *plugin.TValue[string] {
+	return &c.NetworkAclBypass
+}
+
+func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetCorsAllowedOrigins() *plugin.TValue[[]any] {
+	return &c.CorsAllowedOrigins
+}
+
+func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetLocations() *plugin.TValue[[]any] {
+	return &c.Locations
 }
 
 func (c *mqlAzureSubscriptionCosmosDbServiceAccount) GetVirtualNetworkRules() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1535,6 +1535,8 @@ azure.subscription.cosmosDbService.account.backupIntervalInMinutes 13.1.8
 azure.subscription.cosmosDbService.account.backupRetentionIntervalInHours 13.1.8
 azure.subscription.cosmosDbService.account.backupStorageRedundancy 13.1.8
 azure.subscription.cosmosDbService.account.backupType 13.1.8
+azure.subscription.cosmosDbService.account.corsAllowedOrigins 13.18.1
+azure.subscription.cosmosDbService.account.defaultConsistencyLevel 13.18.1
 azure.subscription.cosmosDbService.account.defaultIdentity 13.1.8
 azure.subscription.cosmosDbService.account.diagnosticSettings 13.8.2
 azure.subscription.cosmosDbService.account.disableKeyBasedMetadataWriteAccess 11.4.28
@@ -1547,8 +1549,10 @@ azure.subscription.cosmosDbService.account.ipRangeFilter 11.4.28
 azure.subscription.cosmosDbService.account.isVirtualNetworkFilterEnabled 11.4.28
 azure.subscription.cosmosDbService.account.kind 9.0.1
 azure.subscription.cosmosDbService.account.location 9.0.1
+azure.subscription.cosmosDbService.account.locations 13.18.1
 azure.subscription.cosmosDbService.account.minimalTlsVersion 11.4.28
 azure.subscription.cosmosDbService.account.name 9.0.1
+azure.subscription.cosmosDbService.account.networkAclBypass 13.18.1
 azure.subscription.cosmosDbService.account.privateEndpointConnections 13.8.2
 azure.subscription.cosmosDbService.account.properties 9.0.1
 azure.subscription.cosmosDbService.account.publicNetworkAccess 11.4.28

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -201,6 +201,8 @@ func cosmosAccountToMql(runtime *plugin.Runtime, account *cosmosdb.DatabaseAccou
 		}
 	}
 
+	defaultConsistencyLevel, networkAclBypass, corsAllowedOrigins, locations := cosmosNetworkConsistency(account.Properties)
+
 	virtualNetworkRules := []any{}
 	if account.Properties != nil && account.Properties.VirtualNetworkRules != nil {
 		for _, rule := range account.Properties.VirtualNetworkRules {
@@ -252,6 +254,10 @@ func cosmosAccountToMql(runtime *plugin.Runtime, account *cosmosdb.DatabaseAccou
 			"backupIntervalInMinutes":            llx.IntData(backupIntervalMinutes),
 			"backupRetentionIntervalInHours":     llx.IntData(backupRetentionHours),
 			"backupStorageRedundancy":            llx.StringData(backupRedundancy),
+			"defaultConsistencyLevel":            llx.StringDataPtr(defaultConsistencyLevel),
+			"networkAclBypass":                   llx.StringDataPtr(networkAclBypass),
+			"corsAllowedOrigins":                 llx.ArrayData(corsAllowedOrigins, types.String),
+			"locations":                          llx.ArrayData(locations, types.String),
 			"virtualNetworkRules":                llx.ArrayData(virtualNetworkRules, types.Resource("azure.subscription.cosmosDbService.account.virtualNetworkRule")),
 		})
 	if err != nil {
@@ -272,6 +278,34 @@ func cosmosEnumStrPtr[T ~string](v *T) *string {
 	}
 	s := string(*v)
 	return &s
+}
+
+// cosmosNetworkConsistency extracts the default consistency level, network ACL
+// bypass setting, CORS allowed origins, and deployed region names from a Cosmos
+// DB account's properties. Consistency level and ACL bypass stay nil (null in
+// MQL) when absent; the slices are always non-nil so callers can assert on
+// length without a null guard.
+func cosmosNetworkConsistency(props *cosmosdb.DatabaseAccountGetProperties) (defaultConsistencyLevel, networkAclBypass *string, corsAllowedOrigins, locations []any) {
+	corsAllowedOrigins = []any{}
+	locations = []any{}
+	if props == nil {
+		return nil, nil, corsAllowedOrigins, locations
+	}
+	if props.ConsistencyPolicy != nil {
+		defaultConsistencyLevel = cosmosEnumStrPtr(props.ConsistencyPolicy.DefaultConsistencyLevel)
+	}
+	networkAclBypass = cosmosEnumStrPtr(props.NetworkACLBypass)
+	for _, cors := range props.Cors {
+		if cors != nil && cors.AllowedOrigins != nil {
+			corsAllowedOrigins = append(corsAllowedOrigins, *cors.AllowedOrigins)
+		}
+	}
+	for _, loc := range props.Locations {
+		if loc != nil && loc.LocationName != nil {
+			locations = append(locations, *loc.LocationName)
+		}
+	}
+	return defaultConsistencyLevel, networkAclBypass, corsAllowedOrigins, locations
 }
 
 // fetchMongoClusters lists the Cosmos DB for MongoDB (vCore) clusters

--- a/providers/azure/resources/cosmosdb_extras_test.go
+++ b/providers/azure/resources/cosmosdb_extras_test.go
@@ -188,6 +188,47 @@ func TestIsCosmosServerlessThroughputError(t *testing.T) {
 	})
 }
 
+func TestCosmosNetworkConsistency(t *testing.T) {
+	t.Run("nil props returns nils and empty slices", func(t *testing.T) {
+		dcl, bypass, cors, locs := cosmosNetworkConsistency(nil)
+		assert.Nil(t, dcl)
+		assert.Nil(t, bypass)
+		assert.Equal(t, []any{}, cors)
+		assert.Equal(t, []any{}, locs)
+	})
+
+	t.Run("populated props map to typed values", func(t *testing.T) {
+		strong := cosmos.DefaultConsistencyLevelStrong
+		bypassNone := cosmos.NetworkACLBypassNone
+		origin1, origin2 := "https://example.com", "*"
+		east, west := "East US", "West US"
+		props := &cosmos.DatabaseAccountGetProperties{
+			ConsistencyPolicy: &cosmos.ConsistencyPolicy{DefaultConsistencyLevel: &strong},
+			NetworkACLBypass:  &bypassNone,
+			Cors: []*cosmos.CorsPolicy{
+				{AllowedOrigins: &origin1},
+				{AllowedOrigins: &origin2},
+				{AllowedOrigins: nil},
+			},
+			Locations: []*cosmos.Location{
+				{LocationName: &east},
+				{LocationName: &west},
+				nil,
+			},
+		}
+		dcl, bypass, cors, locs := cosmosNetworkConsistency(props)
+		assert.Equal(t, "Strong", *dcl)
+		assert.Equal(t, "None", *bypass)
+		assert.Equal(t, []any{"https://example.com", "*"}, cors)
+		assert.Equal(t, []any{"East US", "West US"}, locs)
+	})
+
+	t.Run("nil consistency policy leaves level nil", func(t *testing.T) {
+		dcl, _, _, _ := cosmosNetworkConsistency(&cosmos.DatabaseAccountGetProperties{})
+		assert.Nil(t, dcl)
+	})
+}
+
 func TestIsCosmosForbiddenError(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {
 		assert.False(t, isCosmosForbiddenError(nil))


### PR DESCRIPTION
## What

PR 1 of a series adding typed fields to Azure resources so `mondoo-azure-security` checks can stop indexing the raw ARM `properties` dict.

`azure.subscription.cosmosDbService.account` already types most settings (publicNetworkAccess, backupType, privateEndpointConnections, keyVaultKeyUri…), but four checks still reach into `properties[...]`. This promotes those:

| New typed field | Replaces |
|---|---|
| `defaultConsistencyLevel` | `properties["consistencyPolicy"]["defaultConsistencyLevel"]` |
| `networkAclBypass` | `properties["networkAclBypass"]` |
| `corsAllowedOrigins` | `properties["cors"][*]["allowedOrigins"]` |
| `locations` | `properties["locations"]` (region names; `.length > 1` ⇒ multi-region) |

```mql
# before
account.properties["consistencyPolicy"]["defaultConsistencyLevel"].in(["Strong","BoundedStaleness"])
account.properties["cors"] == null || account.properties["cors"].none(_["allowedOrigins"] == "*")
# after
account.defaultConsistencyLevel.in(["Strong","BoundedStaleness"])
account.corsAllowedOrigins.none(_ == "*")
```

The raw `properties` dict is retained for backward compatibility — purely additive.

## Testing

- Extraction factored into the pure helper `cosmosNetworkConsistency` and unit-tested (`TestCosmosNetworkConsistency`), matching the existing `cosmosdb_extras_test.go` style (hand-built SDK structs; the provider has no recorded ARM fixtures here).
- `go build ./...` and `go test ./resources/...` pass; lr regenerated.

A follow-up cnspec PR will migrate the policy queries once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)