### PR TITLE
✨ azure: typed publicNetworkAccess on Function App

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -8859,6 +8859,8 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   managedServiceIdentityId string
   // Identity used to resolve Key Vault references in app settings and connection strings (resource ID of a user-assigned identity, or "SystemAssigned")
   keyVaultReferenceIdentity string
+  // Whether public network access is enabled ("Enabled" or "Disabled")
+  publicNetworkAccess string
   // Function App properties
   properties dict
   // Site configuration: minimum TLS version, FTPS state, HTTP/2, always-on, remote debugging, and IP restrictions

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -12201,6 +12201,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetKeyVaultReferenceIdentity()).ToDataRes(types.String)
 	},
+	"azure.subscription.functionsService.functionApp.publicNetworkAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetPublicNetworkAccess()).ToDataRes(types.String)
+	},
 	"azure.subscription.functionsService.functionApp.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetProperties()).ToDataRes(types.Dict)
 	},
@@ -29867,6 +29870,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).KeyVaultReferenceIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.publicNetworkAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).PublicNetworkAccess, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.functionsService.functionApp.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -69140,6 +69147,7 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	ClientCertMode            plugin.TValue[string]
 	ManagedServiceIdentityId  plugin.TValue[string]
 	KeyVaultReferenceIdentity plugin.TValue[string]
+	PublicNetworkAccess       plugin.TValue[string]
 	Properties                plugin.TValue[any]
 	Configuration             plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
 	Functions                 plugin.TValue[[]any]
@@ -69230,6 +69238,10 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetManagedServiceIdent
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetKeyVaultReferenceIdentity() *plugin.TValue[string] {
 	return &c.KeyVaultReferenceIdentity
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetPublicNetworkAccess() *plugin.TValue[string] {
+	return &c.PublicNetworkAccess
 }
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetProperties() *plugin.TValue[any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2012,6 +2012,7 @@ azure.subscription.functionsService.functionApp.location 13.3.3
 azure.subscription.functionsService.functionApp.managedServiceIdentityId 13.3.3
 azure.subscription.functionsService.functionApp.name 13.3.3
 azure.subscription.functionsService.functionApp.properties 13.3.3
+azure.subscription.functionsService.functionApp.publicNetworkAccess 13.18.1
 azure.subscription.functionsService.functionApp.state 13.3.3
 azure.subscription.functionsService.functionApp.tags 13.3.3
 azure.subscription.functionsService.functionApps 13.3.3

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -152,7 +152,7 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 	}
 
 	var state, defaultHostName, clientCertMode, managedServiceIdentityId string
-	var keyVaultReferenceIdentity string
+	var keyVaultReferenceIdentity, publicNetworkAccess string
 	var httpsOnly, clientCertEnabled bool
 	if site.Properties != nil {
 		if site.Properties.State != nil {
@@ -173,6 +173,9 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		if site.Properties.KeyVaultReferenceIdentity != nil {
 			keyVaultReferenceIdentity = *site.Properties.KeyVaultReferenceIdentity
 		}
+		if site.Properties.PublicNetworkAccess != nil {
+			publicNetworkAccess = *site.Properties.PublicNetworkAccess
+		}
 	}
 	if site.Identity != nil && site.Identity.PrincipalID != nil {
 		managedServiceIdentityId = *site.Identity.PrincipalID
@@ -191,6 +194,7 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		"clientCertMode":            llx.StringData(clientCertMode),
 		"managedServiceIdentityId":  llx.StringData(managedServiceIdentityId),
 		"keyVaultReferenceIdentity": llx.StringData(keyVaultReferenceIdentity),
+		"publicNetworkAccess":       llx.StringData(publicNetworkAccess),
 		"properties":                llx.DictData(properties),
 	})
 }

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -23,6 +23,16 @@ func (a *mqlAzureSubscriptionFunctionsService) id() (string, error) {
 	return "azure.subscription.functions/" + a.SubscriptionId.Data, nil
 }
 
+// functionAppPublicNetworkAccess returns the site's public network access
+// setting ("Enabled" or "Disabled"), or "" when the properties or field are
+// absent.
+func functionAppPublicNetworkAccess(props *web.SiteProperties) string {
+	if props == nil || props.PublicNetworkAccess == nil {
+		return ""
+	}
+	return *props.PublicNetworkAccess
+}
+
 func initAzureSubscriptionFunctionsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil
@@ -152,8 +162,9 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 	}
 
 	var state, defaultHostName, clientCertMode, managedServiceIdentityId string
-	var keyVaultReferenceIdentity, publicNetworkAccess string
+	var keyVaultReferenceIdentity string
 	var httpsOnly, clientCertEnabled bool
+	publicNetworkAccess := functionAppPublicNetworkAccess(site.Properties)
 	if site.Properties != nil {
 		if site.Properties.State != nil {
 			state = *site.Properties.State
@@ -172,9 +183,6 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		}
 		if site.Properties.KeyVaultReferenceIdentity != nil {
 			keyVaultReferenceIdentity = *site.Properties.KeyVaultReferenceIdentity
-		}
-		if site.Properties.PublicNetworkAccess != nil {
-			publicNetworkAccess = *site.Properties.PublicNetworkAccess
 		}
 	}
 	if site.Identity != nil && site.Identity.PrincipalID != nil {

--- a/providers/azure/resources/functions_publicnetwork_test.go
+++ b/providers/azure/resources/functions_publicnetwork_test.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFunctionAppPublicNetworkAccess(t *testing.T) {
+	t.Run("nil properties returns empty", func(t *testing.T) {
+		assert.Equal(t, "", functionAppPublicNetworkAccess(nil))
+	})
+	t.Run("nil field returns empty", func(t *testing.T) {
+		assert.Equal(t, "", functionAppPublicNetworkAccess(&web.SiteProperties{}))
+	})
+	t.Run("disabled value is returned", func(t *testing.T) {
+		v := "Disabled"
+		assert.Equal(t, "Disabled", functionAppPublicNetworkAccess(&web.SiteProperties{PublicNetworkAccess: &v}))
+	})
+}


### PR DESCRIPTION
## What

PR in the series replacing raw ARM `properties[...]` indexing in `mondoo-azure-security`. Adds a typed `publicNetworkAccess` field to `azure.subscription.functionsService.functionApp`:

```mql
# before
functionApp.properties["publicNetworkAccess"]
# after
functionApp.publicNetworkAccess
```

(The other field that check indexed, `keyVaultReferenceIdentity`, was already typed — that part is a policy-side cleanup.) `properties` is retained for backward compatibility.

## Testing

Trivial `*string` passthrough from `SiteProperties.PublicNetworkAccess`; verified by `go build ./...`, lr regen, and the existing `go test ./resources/...` suite. No pure helper to unit-test (the populator needs a runtime), and the provider has no recorded ARM fixtures for function apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)