### PR TITLE
✨ azure: typed osType on virtual machines

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -345,6 +345,8 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   sshPublicKeys []dict
   // Whether password authentication is disabled for SSH on the Linux VM
   disablePasswordAuthentication bool
+  // Operating system type of the OS disk ("Linux" or "Windows")
+  osType string
   // Whether the VM agent is provisioned (Linux/Windows)
   provisionVMAgent bool
   // Whether automatic OS upgrades by the platform are enabled (WindowsConfiguration.EnableAutomaticUpdates)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2493,6 +2493,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.disablePasswordAuthentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetDisablePasswordAuthentication()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.computeService.vm.osType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetOsType()).ToDataRes(types.String)
+	},
 	"azure.subscription.computeService.vm.provisionVMAgent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetProvisionVMAgent()).ToDataRes(types.Bool)
 	},
@@ -15743,6 +15746,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.vm.disablePasswordAuthentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).DisablePasswordAuthentication, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.osType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).OsType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.vm.provisionVMAgent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35672,6 +35679,7 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	TimeCreated                   plugin.TValue[*time.Time]
 	SshPublicKeys                 plugin.TValue[[]any]
 	DisablePasswordAuthentication plugin.TValue[bool]
+	OsType                        plugin.TValue[string]
 	ProvisionVMAgent              plugin.TValue[bool]
 	EnableAutomaticUpdates        plugin.TValue[bool]
 	PatchMode                     plugin.TValue[string]
@@ -35949,6 +35957,10 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetSshPublicKeys() *plugin.TValue
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetDisablePasswordAuthentication() *plugin.TValue[bool] {
 	return &c.DisablePasswordAuthentication
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetOsType() *plugin.TValue[string] {
+	return &c.OsType
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetProvisionVMAgent() *plugin.TValue[bool] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1100,6 +1100,7 @@ azure.subscription.computeService.vm.name 9.0.1
 azure.subscription.computeService.vm.networkInterfaces 13.7.1
 azure.subscription.computeService.vm.omsInstalled 13.12.2
 azure.subscription.computeService.vm.osDisk 9.0.1
+azure.subscription.computeService.vm.osType 13.18.1
 azure.subscription.computeService.vm.patchMode 13.5.1
 azure.subscription.computeService.vm.properties 9.0.1
 azure.subscription.computeService.vm.provisionVMAgent 13.5.1

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -42,6 +42,17 @@ func (a *mqlAzureSubscriptionComputeService) id() (string, error) {
 	return "azure.subscription.compute/" + a.SubscriptionId.Data, nil
 }
 
+// vmOsType returns the OS type of a virtual machine's OS disk ("Linux" or
+// "Windows"), or nil when the properties, storage profile, or OS disk are
+// absent — guarding the three-level nil chain so a partially-populated VM
+// doesn't panic.
+func vmOsType(props *compute.VirtualMachineProperties) *string {
+	if props == nil || props.StorageProfile == nil || props.StorageProfile.OSDisk == nil {
+		return nil
+	}
+	return stringEnumPtr(props.StorageProfile.OSDisk.OSType)
+}
+
 func getState(vm compute.VirtualMachineInstanceView) string {
 	if vm.Statuses == nil {
 		return "unknown"
@@ -205,11 +216,8 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 
 	var bootDiagnosticsEnabled bool
 	var bootDiagnosticsStorageUri, userData string
-	var osType *string
+	osType := vmOsType(vm.Properties)
 	if vm.Properties != nil {
-		if sp := vm.Properties.StorageProfile; sp != nil && sp.OSDisk != nil {
-			osType = stringEnumPtr(sp.OSDisk.OSType)
-		}
 		if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
 			if dp.BootDiagnostics.Enabled != nil {
 				bootDiagnosticsEnabled = *dp.BootDiagnostics.Enabled

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -205,7 +205,11 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 
 	var bootDiagnosticsEnabled bool
 	var bootDiagnosticsStorageUri, userData string
+	var osType *string
 	if vm.Properties != nil {
+		if sp := vm.Properties.StorageProfile; sp != nil && sp.OSDisk != nil {
+			osType = stringEnumPtr(sp.OSDisk.OSType)
+		}
 		if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
 			if dp.BootDiagnostics.Enabled != nil {
 				bootDiagnosticsEnabled = *dp.BootDiagnostics.Enabled
@@ -260,6 +264,7 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 			"timeCreated":                   llx.TimeDataPtr(timeCreated),
 			"sshPublicKeys":                 llx.ArrayData(sshPublicKeys, types.Dict),
 			"disablePasswordAuthentication": llx.BoolDataPtr(disablePasswordAuth),
+			"osType":                        llx.StringDataPtr(osType),
 			"provisionVMAgent":              llx.BoolDataPtr(provisionVMAgent),
 			"enableAutomaticUpdates":        llx.BoolDataPtr(enableAutomaticUpdates),
 			"patchMode":                     llx.StringData(patchMode),

--- a/providers/azure/resources/compute_extras_test.go
+++ b/providers/azure/resources/compute_extras_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVmOsType(t *testing.T) {
+	t.Run("nil properties returns nil", func(t *testing.T) {
+		assert.Nil(t, vmOsType(nil))
+	})
+	t.Run("nil storage profile returns nil", func(t *testing.T) {
+		assert.Nil(t, vmOsType(&compute.VirtualMachineProperties{}))
+	})
+	t.Run("nil os disk returns nil", func(t *testing.T) {
+		props := &compute.VirtualMachineProperties{StorageProfile: &compute.StorageProfile{}}
+		assert.Nil(t, vmOsType(props))
+	})
+	t.Run("linux os type", func(t *testing.T) {
+		linux := compute.OperatingSystemTypesLinux
+		props := &compute.VirtualMachineProperties{
+			StorageProfile: &compute.StorageProfile{
+				OSDisk: &compute.OSDisk{OSType: &linux},
+			},
+		}
+		got := vmOsType(props)
+		assert.NotNil(t, got)
+		assert.Equal(t, "Linux", *got)
+	})
+}


### PR DESCRIPTION
## What

Adds a typed `osType` field to `azure.subscription.computeService.vm`, replacing the nested ARM dict access:

```mql
# before
vm.properties['storageProfile']['osDisk']['osType']
# after
vm.osType
```

(The sibling check that uses `osProfile.linuxConfiguration.disablePasswordAuthentication` already has a typed `disablePasswordAuthentication` field — that's a policy-side cleanup.) `properties` is retained for backward compatibility.

## Testing

Trivial enum passthrough from `StorageProfile.OSDisk.OSType`; verified by `go build ./...`, lr regen, and `go test ./resources/...`. The provider has no recorded ARM fixtures for VMs and the populator needs a runtime, so there's no pure helper to unit-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)