### PR TITLE
✨ azure: typed corsAllowedOrigins on App Service site config

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -4288,6 +4288,8 @@ private azure.subscription.webService.appsiteconfig @defaults("id name") {
   type string
   // Appsite config properties
   properties dict
+  // CORS allowed origins configured for the site (empty when CORS is not configured; "*" allows any origin)
+  corsAllowedOrigins []string
   // Minimum TLS version for the site (1.0, 1.1, 1.2, 1.3)
   minTlsVersion string
   // FTP state for the site (AllAllowed, FtpsOnly, Disabled)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6840,6 +6840,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsiteconfig.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetProperties()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.webService.appsiteconfig.corsAllowedOrigins": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetCorsAllowedOrigins()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.webService.appsiteconfig.minTlsVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetMinTlsVersion()).ToDataRes(types.String)
 	},
@@ -22023,6 +22026,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsiteconfig.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteconfig.corsAllowedOrigins": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).CorsAllowedOrigins, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsiteconfig.minTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50204,6 +50211,7 @@ type mqlAzureSubscriptionWebServiceAppsiteconfig struct {
 	Kind                                plugin.TValue[string]
 	Type                                plugin.TValue[string]
 	Properties                          plugin.TValue[any]
+	CorsAllowedOrigins                  plugin.TValue[[]any]
 	MinTlsVersion                       plugin.TValue[string]
 	FtpsState                           plugin.TValue[string]
 	RemoteDebuggingEnabled              plugin.TValue[bool]
@@ -50275,6 +50283,10 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetType() *plugin.TValue[s
 
 func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetCorsAllowedOrigins() *plugin.TValue[[]any] {
+	return &c.CorsAllowedOrigins
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetMinTlsVersion() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -4578,6 +4578,7 @@ azure.subscription.webService.appsiteauthsettings.unauthenticatedClientAction 13
 azure.subscription.webService.appsiteconfig 9.0.1
 azure.subscription.webService.appsiteconfig.alwaysOn 11.4.28
 azure.subscription.webService.appsiteconfig.autoHealEnabled 13.12.2
+azure.subscription.webService.appsiteconfig.corsAllowedOrigins 13.18.1
 azure.subscription.webService.appsiteconfig.detailedErrorLoggingEnabled 13.12.2
 azure.subscription.webService.appsiteconfig.ftpsState 11.4.28
 azure.subscription.webService.appsiteconfig.http20Enabled 11.4.28

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -690,6 +690,19 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) configuration() (*mqlAzureSubscr
 
 // webAppSiteConfigToMql fetches the site configuration for an App Service site
 // (regular web app or function app) and maps it to an appsiteconfig resource.
+// siteConfigCorsAllowedOrigins returns the CORS allowed origins configured on
+// an App Service site configuration. It is always non-nil so the typed
+// corsAllowedOrigins field is set on every code path that builds an
+// appsiteconfig resource (the value stays an empty list when CORS is not
+// configured).
+func siteConfigCorsAllowedOrigins(props *web.SiteConfig) []any {
+	origins := []any{}
+	if props != nil && props.Cors != nil {
+		origins = convert.SliceStrPtrToInterface(props.Cors.AllowedOrigins)
+	}
+	return origins
+}
+
 func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnection, id string) (*mqlAzureSubscriptionWebServiceAppsiteconfig, error) {
 	ctx := context.Background()
 	token := conn.Token()
@@ -723,11 +736,12 @@ func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnec
 	}
 
 	args := map[string]*llx.RawData{
-		"id":         llx.StringDataPtr(entry.ID),
-		"name":       llx.StringDataPtr(entry.Name),
-		"kind":       llx.StringDataPtr(entry.Kind),
-		"type":       llx.StringDataPtr(entry.Type),
-		"properties": llx.DictData(properties),
+		"id":                 llx.StringDataPtr(entry.ID),
+		"name":               llx.StringDataPtr(entry.Name),
+		"kind":               llx.StringDataPtr(entry.Kind),
+		"type":               llx.StringDataPtr(entry.Type),
+		"properties":         llx.DictData(properties),
+		"corsAllowedOrigins": llx.ArrayData(siteConfigCorsAllowedOrigins(entry.Properties), types.String),
 	}
 
 	if entry.Properties != nil {
@@ -1175,11 +1189,12 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscr
 	}
 
 	args := map[string]*llx.RawData{
-		"id":         llx.StringDataPtr(configuration.ID),
-		"name":       llx.StringDataPtr(configuration.Name),
-		"kind":       llx.StringDataPtr(configuration.Kind),
-		"type":       llx.StringDataPtr(configuration.Type),
-		"properties": llx.DictData(properties),
+		"id":                 llx.StringDataPtr(configuration.ID),
+		"name":               llx.StringDataPtr(configuration.Name),
+		"kind":               llx.StringDataPtr(configuration.Kind),
+		"type":               llx.StringDataPtr(configuration.Type),
+		"properties":         llx.DictData(properties),
+		"corsAllowedOrigins": llx.ArrayData(siteConfigCorsAllowedOrigins(configuration.Properties), types.String),
 	}
 
 	if configuration.Properties != nil {

--- a/providers/azure/resources/web_test.go
+++ b/providers/azure/resources/web_test.go
@@ -6,8 +6,23 @@ package resources
 import (
 	"testing"
 
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSiteConfigCorsAllowedOrigins(t *testing.T) {
+	t.Run("nil props returns empty slice", func(t *testing.T) {
+		assert.Equal(t, []any{}, siteConfigCorsAllowedOrigins(nil))
+	})
+	t.Run("nil cors returns empty slice", func(t *testing.T) {
+		assert.Equal(t, []any{}, siteConfigCorsAllowedOrigins(&web.SiteConfig{}))
+	})
+	t.Run("allowed origins are returned", func(t *testing.T) {
+		a, b := "https://example.com", "*"
+		props := &web.SiteConfig{Cors: &web.CorsSettings{AllowedOrigins: []*string{&a, &b}}}
+		assert.Equal(t, []any{"https://example.com", "*"}, siteConfigCorsAllowedOrigins(props))
+	})
+}
 
 func TestParseVersion(t *testing.T) {
 	assert.False(t, isPlatformEol("python", ""))


### PR DESCRIPTION
## What

Adds a typed `corsAllowedOrigins` field to `azure.subscription.webService.appsiteconfig`, replacing the nested ARM dict access used by App Service / Function App CORS checks:

```mql
# before
appsite.configuration.properties["cors"]["allowedOrigins"].contains("*")
# after
appsite.configuration.corsAllowedOrigins.contains("*")
```

(The sibling check using `authenticationSettings.properties["enabled"]` already has a typed `enabled` field — policy-side cleanup.) `properties` retained for backward compatibility.

## Testing

Extraction factored into the pure helper `siteConfigCorsAllowedOrigins`, shared by both code paths that build an appsiteconfig (the list path and the deployment-slot path) so the field is set consistently. Unit-tested (`TestSiteConfigCorsAllowedOrigins`). `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)