### PR TITLE
✨ azure: typed diskCsiDriverEnabled on AKS cluster

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -139,6 +139,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			diskCsiDriverEnabled := aksDiskCsiDriverEnabled(entry.Properties.StorageProfile)
 			workloadAutoScalerProfile, err := convert.JsonToDict(entry.Properties.WorkloadAutoScalerProfile)
 			if err != nil {
 				return nil, err
@@ -289,6 +290,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 					"podIdentityProfile":                llx.DictData(podIdentityProfile),
 					"securityProfile":                   llx.DictData(securityProfile),
 					"storageProfile":                    llx.DictData(storageProfile),
+					"diskCsiDriverEnabled":              llx.BoolDataPtr(diskCsiDriverEnabled),
 					"workloadAutoScalerProfile":         llx.DictData(workloadAutoScalerProfile),
 					"apiServerAccessProfile":            llx.DictData(apiServerAccessProfile),
 					"enablePrivateCluster":              llx.BoolDataPtr(enablePrivateCluster),
@@ -621,4 +623,14 @@ func (a *mqlAzureSubscriptionAksServiceClusterNodePool) recentlyUsedVersions() (
 		return []any{}, nil
 	}
 	return convert.JsonToDictSlice(profile.Properties.RecentlyUsedVersions)
+}
+
+// aksDiskCsiDriverEnabled reports whether the Azure Disk CSI driver is enabled
+// on an AKS cluster, returning nil (null in MQL) when the storage profile or
+// driver block is absent.
+func aksDiskCsiDriverEnabled(sp *clusters.ManagedClusterStorageProfile) *bool {
+	if sp == nil || sp.DiskCSIDriver == nil {
+		return nil
+	}
+	return sp.DiskCSIDriver.Enabled
 }

--- a/providers/azure/resources/aks_test.go
+++ b/providers/azure/resources/aks_test.go
@@ -1,0 +1,29 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	clusters "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAksDiskCsiDriverEnabled(t *testing.T) {
+	t.Run("nil storage profile returns nil", func(t *testing.T) {
+		assert.Nil(t, aksDiskCsiDriverEnabled(nil))
+	})
+	t.Run("nil disk driver returns nil", func(t *testing.T) {
+		assert.Nil(t, aksDiskCsiDriverEnabled(&clusters.ManagedClusterStorageProfile{}))
+	})
+	t.Run("enabled true", func(t *testing.T) {
+		enabled := true
+		sp := &clusters.ManagedClusterStorageProfile{
+			DiskCSIDriver: &clusters.ManagedClusterStorageProfileDiskCSIDriver{Enabled: &enabled},
+		}
+		got := aksDiskCsiDriverEnabled(sp)
+		assert.NotNil(t, got)
+		assert.True(t, *got)
+	})
+}

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7208,6 +7208,8 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   dnsPrefix string
   // The storage profile of the AKS cluster
   storageProfile dict
+  // Whether the Azure Disk CSI driver is enabled on the cluster
+  diskCsiDriverEnabled bool
   // The workload autoscaler profile of the AKS cluster
   workloadAutoScalerProfile dict
   // The security profile of the AKS cluster

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -10317,6 +10317,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.storageProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetStorageProfile()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.aksService.cluster.diskCsiDriverEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetDiskCsiDriverEnabled()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.aksService.cluster.workloadAutoScalerProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetWorkloadAutoScalerProfile()).ToDataRes(types.Dict)
 	},
@@ -27091,6 +27094,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.storageProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).StorageProfile, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.diskCsiDriverEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).DiskCsiDriverEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.aksService.cluster.workloadAutoScalerProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62336,6 +62343,7 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	Fqdn                              plugin.TValue[string]
 	DnsPrefix                         plugin.TValue[string]
 	StorageProfile                    plugin.TValue[any]
+	DiskCsiDriverEnabled              plugin.TValue[bool]
 	WorkloadAutoScalerProfile         plugin.TValue[any]
 	SecurityProfile                   plugin.TValue[any]
 	PodIdentityProfile                plugin.TValue[any]
@@ -62462,6 +62470,10 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetDnsPrefix() *plugin.TValue[st
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetStorageProfile() *plugin.TValue[any] {
 	return &c.StorageProfile
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetDiskCsiDriverEnabled() *plugin.TValue[bool] {
+	return &c.DiskCsiDriverEnabled
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetWorkloadAutoScalerProfile() *plugin.TValue[any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -69,6 +69,7 @@ azure.subscription.aksService.cluster.createdAt 9.0.1
 azure.subscription.aksService.cluster.defenderEnabled 11.4.28
 azure.subscription.aksService.cluster.disableLocalAccounts 11.4.28
 azure.subscription.aksService.cluster.disableRunCommand 11.4.28
+azure.subscription.aksService.cluster.diskCsiDriverEnabled 13.18.1
 azure.subscription.aksService.cluster.dnsPrefix 9.0.1
 azure.subscription.aksService.cluster.enablePrivateCluster 11.4.28
 azure.subscription.aksService.cluster.enablePrivateClusterPublicFQDN 11.4.28


### PR DESCRIPTION
## What

Adds a typed `diskCsiDriverEnabled` field to `azure.subscription.aksService.cluster`, replacing the nested dict access:

```mql
# before
cluster.storageProfile["diskCSIDriver"]["enabled"]
# after
cluster.diskCsiDriverEnabled
```

(The sibling checks that index `networkProfile["networkPolicy"]`/`["networkPlugin"]` already have typed `networkPolicy`/`networkPlugin` fields — policy-side cleanup.) The `storageProfile` dict is retained for backward compatibility.

## Testing

Extraction factored into the pure helper `aksDiskCsiDriverEnabled` and unit-tested (`TestAksDiskCsiDriverEnabled`, new `aks_test.go`). `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)