### PR TITLE
✨ azure: typed frontendIpConfigs on Application Gateway

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2610,6 +2610,29 @@ azure.subscription.networkService.applicationGateway @defaults("id name location
   listeners []azure.subscription.networkService.applicationGateway.listener
   // SSL certificates uploaded or referenced from Key Vault on the application gateway
   sslCertificates []azure.subscription.networkService.applicationGateway.sslCertificate
+  // Frontend IP configurations on the application gateway (a config with a subnet is internal/private; one with a public IP is internet-facing)
+  frontendIpConfigs []azure.subscription.networkService.applicationGateway.frontendIpConfig
+}
+
+// Azure Application Gateway frontend IP configuration
+//
+// Examine a single frontend IP configuration on an Application Gateway. A
+// configuration bound to a `subnetId` is an internal (private) frontend; one
+// with a `publicIpAddressId` is internet-facing. Use this to audit whether a
+// gateway exposes a public entry point.
+private azure.subscription.networkService.applicationGateway.frontendIpConfig @defaults("name subnetId publicIpAddressId") {
+  // ARM resource ID
+  id string
+  // Frontend IP configuration name
+  name string
+  // ARM resource ID of the bound subnet; non-empty for internal (private) frontends
+  subnetId string
+  // ARM resource ID of the bound public IP address; non-empty for internet-facing frontends
+  publicIpAddressId string
+  // Static private IP address, when allocation is static
+  privateIPAddress string
+  // Private IP allocation method ("Static" or "Dynamic")
+  privateIPAllocationMethod string
 }
 
 // Azure Application Gateway HTTP listener

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2625,13 +2625,17 @@ private azure.subscription.networkService.applicationGateway.frontendIpConfig @d
   id string
   // Frontend IP configuration name
   name string
-  // ARM resource ID of the bound subnet; non-empty for internal (private) frontends
+  // ARM resource ID of the bound subnet; non-empty for internal (private) frontends (cached for the typed `subnet` accessor)
   subnetId string
-  // ARM resource ID of the bound public IP address; non-empty for internet-facing frontends
+  // Bound subnet; null for internet-facing frontends that have no subnet
+  subnet() azure.subscription.networkService.subnet
+  // ARM resource ID of the bound public IP address; non-empty for internet-facing frontends (cached for the typed `publicIpAddress` accessor)
   publicIpAddressId string
+  // Bound public IP address; null for internal frontends that have no public IP
+  publicIpAddress() azure.subscription.networkService.ipAddress
   // Static private IP address, when allocation is static
   privateIPAddress string
-  // Private IP allocation method ("Static" or "Dynamic")
+  // Private IP allocation method (one of Static or Dynamic; current known values from the Azure IPAllocationMethod enum)
   privateIPAllocationMethod string
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5033,8 +5033,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetSubnetId()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPublicIpAddressId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPublicIpAddress()).ToDataRes(types.Resource("azure.subscription.networkService.ipAddress"))
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPrivateIPAddress()).ToDataRes(types.String)
@@ -19415,8 +19421,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).PublicIpAddressId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).PublicIpAddress, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceIpAddress](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44172,7 +44186,9 @@ type mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig struct
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	SubnetId                  plugin.TValue[string]
+	Subnet                    plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	PublicIpAddressId         plugin.TValue[string]
+	PublicIpAddress           plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
 	PrivateIPAddress          plugin.TValue[string]
 	PrivateIPAllocationMethod plugin.TValue[string]
 }
@@ -44226,8 +44242,40 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) G
 	return &c.SubnetId
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway.frontendIpConfig", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPublicIpAddressId() *plugin.TValue[string] {
 	return &c.PublicIpAddressId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPublicIpAddress() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceIpAddress](&c.PublicIpAddress, func() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway.frontendIpConfig", c.__id, "publicIpAddress")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
+			}
+		}
+
+		return c.publicIpAddress()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPrivateIPAddress() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -88,6 +88,7 @@ const (
 	ResourceAzureSubscriptionNetworkServiceWatcherPacketCapture                                  string = "azure.subscription.networkService.watcher.packetCapture"
 	ResourceAzureSubscriptionNetworkServiceWatcherConnectionMonitor                              string = "azure.subscription.networkService.watcher.connectionMonitor"
 	ResourceAzureSubscriptionNetworkServiceApplicationGateway                                    string = "azure.subscription.networkService.applicationGateway"
+	ResourceAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig                    string = "azure.subscription.networkService.applicationGateway.frontendIpConfig"
 	ResourceAzureSubscriptionNetworkServiceApplicationGatewayListener                            string = "azure.subscription.networkService.applicationGateway.listener"
 	ResourceAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate                      string = "azure.subscription.networkService.applicationGateway.sslCertificate"
 	ResourceAzureSubscriptionNetworkServiceWafConfig                                             string = "azure.subscription.networkService.wafConfig"
@@ -708,6 +709,10 @@ func init() {
 		"azure.subscription.networkService.applicationGateway": {
 			Init:   initAzureSubscriptionNetworkServiceApplicationGateway,
 			Create: createAzureSubscriptionNetworkServiceApplicationGateway,
+		},
+		"azure.subscription.networkService.applicationGateway.frontendIpConfig": {
+			// to override args, implement: initAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig,
 		},
 		"azure.subscription.networkService.applicationGateway.listener": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceApplicationGatewayListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -5015,6 +5020,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.applicationGateway.sslCertificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetSslCertificates()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.applicationGateway.sslCertificate")))
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfigs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetFrontendIpConfigs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.applicationGateway.frontendIpConfig")))
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetSubnetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPublicIpAddressId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPrivateIPAddress()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAllocationMethod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetPrivateIPAllocationMethod()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.applicationGateway.listener.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayListener).GetId()).ToDataRes(types.String)
@@ -19367,6 +19393,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.applicationGateway.sslCertificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).SslCertificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).FrontendIpConfigs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).PublicIpAddressId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).PrivateIPAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAllocationMethod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).PrivateIPAllocationMethod, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.applicationGateway.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -43982,6 +44040,7 @@ type mqlAzureSubscriptionNetworkServiceApplicationGateway struct {
 	SslCipherSuites       plugin.TValue[[]any]
 	Listeners             plugin.TValue[[]any]
 	SslCertificates       plugin.TValue[[]any]
+	FrontendIpConfigs     plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceApplicationGateway creates a new instance of this resource
@@ -44099,6 +44158,84 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetListeners() *p
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetSslCertificates() *plugin.TValue[[]any] {
 	return &c.SslCertificates
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetFrontendIpConfigs() *plugin.TValue[[]any] {
+	return &c.FrontendIpConfigs
+}
+
+// mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig for the azure.subscription.networkService.applicationGateway.frontendIpConfig resource
+type mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfigInternal it will be used here
+	Id                        plugin.TValue[string]
+	Name                      plugin.TValue[string]
+	SubnetId                  plugin.TValue[string]
+	PublicIpAddressId         plugin.TValue[string]
+	PrivateIPAddress          plugin.TValue[string]
+	PrivateIPAllocationMethod plugin.TValue[string]
+}
+
+// createAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig creates a new instance of this resource
+func createAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.applicationGateway.frontendIpConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) MqlName() string {
+	return "azure.subscription.networkService.applicationGateway.frontendIpConfig"
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetSubnetId() *plugin.TValue[string] {
+	return &c.SubnetId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPublicIpAddressId() *plugin.TValue[string] {
+	return &c.PublicIpAddressId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPrivateIPAddress() *plugin.TValue[string] {
+	return &c.PrivateIPAddress
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) GetPrivateIPAllocationMethod() *plugin.TValue[string] {
+	return &c.PrivateIPAllocationMethod
 }
 
 // mqlAzureSubscriptionNetworkServiceApplicationGatewayListener for the azure.subscription.networkService.applicationGateway.listener resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2686,7 +2686,9 @@ azure.subscription.networkService.applicationGateway.frontendIpConfig.id 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.name 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAllocationMethod 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddress 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.subnet 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfigs 13.18.1
 azure.subscription.networkService.applicationGateway.id 9.0.13

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2681,6 +2681,14 @@ azure.subscription.networkService.applicationFirewallPolicy.tags 9.0.13
 azure.subscription.networkService.applicationFirewallPolicy.type 9.0.13
 azure.subscription.networkService.applicationGateway 9.0.13
 azure.subscription.networkService.applicationGateway.etag 9.0.13
+azure.subscription.networkService.applicationGateway.frontendIpConfig 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.id 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.name 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAddress 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.privateIPAllocationMethod 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAddressId 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId 13.18.1
+azure.subscription.networkService.applicationGateway.frontendIpConfigs 13.18.1
 azure.subscription.networkService.applicationGateway.id 9.0.13
 azure.subscription.networkService.applicationGateway.listener 13.12.2
 azure.subscription.networkService.applicationGateway.listener.hostName 13.12.2

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -3276,6 +3276,54 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) i
 	return a.Id.Data, nil
 }
 
+// subnet resolves the typed subnet bound to an internal (private) frontend IP
+// configuration from the cached subnetId. Returns null for internet-facing
+// frontends that are not bound to a subnet.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.SubnetId.Data == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.SubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
+// publicIpAddress resolves the typed public IP address bound to an
+// internet-facing frontend IP configuration from the cached publicIpAddressId.
+// Returns null for internal frontends that have no public IP.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) publicIpAddress() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+	if a.PublicIpAddressId.Data == "" {
+		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	azureId, err := ParseResourceID(a.PublicIpAddressId.Data)
+	if err != nil {
+		return nil, err
+	}
+	client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	ipAddressName, err := azureId.Component("publicIPAddresses")
+	if err != nil {
+		return nil, err
+	}
+	ipAddress, err := client.Get(ctx, azureId.ResourceGroup, ipAddressName, &network.PublicIPAddressesClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return azureIpToMql(a.MqlRuntime, ipAddress.PublicIPAddress)
+}
+
 // frontendIpConfigFields extracts the displayable fields from an application
 // gateway frontend IP configuration. subnetId is set for internal (private)
 // frontends; publicIpAddressId is set for internet-facing ones.

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -3132,6 +3132,20 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		}
 	}
 
+	frontendIpConfigs := []any{}
+	if ag.Properties != nil {
+		for _, fc := range ag.Properties.FrontendIPConfigurations {
+			if fc == nil {
+				continue
+			}
+			mqlFc, err := azureAppGatewayFrontendIpConfigToMql(runtime, fc)
+			if err != nil {
+				return nil, err
+			}
+			frontendIpConfigs = append(frontendIpConfigs, mqlFc)
+		}
+	}
+
 	args := map[string]*llx.RawData{
 		"id":                    llx.StringDataPtr(ag.ID),
 		"name":                  llx.StringDataPtr(ag.Name),
@@ -3145,6 +3159,7 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		"sslCipherSuites":       llx.ArrayData(sslCipherSuites, types.String),
 		"listeners":             llx.ArrayData(listeners, types.Resource("azure.subscription.networkService.applicationGateway.listener")),
 		"sslCertificates":       llx.ArrayData(sslCertificates, types.Resource("azure.subscription.networkService.applicationGateway.sslCertificate")),
+		"frontendIpConfigs":     llx.ArrayData(frontendIpConfigs, types.Resource("azure.subscription.networkService.applicationGateway.frontendIpConfig")),
 	}
 
 	mqlAg, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway", args)
@@ -3255,6 +3270,56 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 
 func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayListener) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+// frontendIpConfigFields extracts the displayable fields from an application
+// gateway frontend IP configuration. subnetId is set for internal (private)
+// frontends; publicIpAddressId is set for internet-facing ones.
+func frontendIpConfigFields(fc *network.ApplicationGatewayFrontendIPConfiguration) (id, name, subnetId, publicIpAddressId, privateIPAddress, privateIPAllocationMethod string) {
+	if fc == nil {
+		return
+	}
+	if fc.ID != nil {
+		id = *fc.ID
+	}
+	if fc.Name != nil {
+		name = *fc.Name
+	}
+	if p := fc.Properties; p != nil {
+		if p.Subnet != nil && p.Subnet.ID != nil {
+			subnetId = *p.Subnet.ID
+		}
+		if p.PublicIPAddress != nil && p.PublicIPAddress.ID != nil {
+			publicIpAddressId = *p.PublicIPAddress.ID
+		}
+		if p.PrivateIPAddress != nil {
+			privateIPAddress = *p.PrivateIPAddress
+		}
+		if p.PrivateIPAllocationMethod != nil {
+			privateIPAllocationMethod = string(*p.PrivateIPAllocationMethod)
+		}
+	}
+	return id, name, subnetId, publicIpAddressId, privateIPAddress, privateIPAllocationMethod
+}
+
+func azureAppGatewayFrontendIpConfigToMql(runtime *plugin.Runtime, fc *network.ApplicationGatewayFrontendIPConfiguration) (*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig, error) {
+	id, name, subnetId, publicIpAddressId, privateIPAddress, privateIPAllocationMethod := frontendIpConfigFields(fc)
+	res, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway.frontendIpConfig", map[string]*llx.RawData{
+		"id":                        llx.StringData(id),
+		"name":                      llx.StringData(name),
+		"subnetId":                  llx.StringData(subnetId),
+		"publicIpAddressId":         llx.StringData(publicIpAddressId),
+		"privateIPAddress":          llx.StringData(privateIPAddress),
+		"privateIPAllocationMethod": llx.StringData(privateIPAllocationMethod),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) id() (string, error) {

--- a/providers/azure/resources/network_test.go
+++ b/providers/azure/resources/network_test.go
@@ -6,8 +6,48 @@ package resources
 import (
 	"testing"
 
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFrontendIpConfigFields(t *testing.T) {
+	t.Run("nil config returns empty strings", func(t *testing.T) {
+		id, name, subnetId, publicIpId, privIp, alloc := frontendIpConfigFields(nil)
+		assert.Empty(t, id+name+subnetId+publicIpId+privIp+alloc)
+	})
+	t.Run("internal (private) frontend has subnet, no public IP", func(t *testing.T) {
+		id, name := "/fe/id", "privateFrontend"
+		subnet := "/subnets/internal"
+		priv, alloc := "10.0.0.4", network.IPAllocationMethodStatic
+		fc := &network.ApplicationGatewayFrontendIPConfiguration{
+			ID:   &id,
+			Name: &name,
+			Properties: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+				Subnet:                    &network.SubResource{ID: &subnet},
+				PrivateIPAddress:          &priv,
+				PrivateIPAllocationMethod: &alloc,
+			},
+		}
+		gotId, gotName, gotSubnet, gotPublic, gotPriv, gotAlloc := frontendIpConfigFields(fc)
+		assert.Equal(t, "/fe/id", gotId)
+		assert.Equal(t, "privateFrontend", gotName)
+		assert.Equal(t, "/subnets/internal", gotSubnet)
+		assert.Empty(t, gotPublic)
+		assert.Equal(t, "10.0.0.4", gotPriv)
+		assert.Equal(t, "Static", gotAlloc)
+	})
+	t.Run("internet-facing frontend has public IP, no subnet", func(t *testing.T) {
+		pip := "/publicIPAddresses/pip"
+		fc := &network.ApplicationGatewayFrontendIPConfiguration{
+			Properties: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.SubResource{ID: &pip},
+			},
+		}
+		_, _, gotSubnet, gotPublic, _, _ := frontendIpConfigFields(fc)
+		assert.Empty(t, gotSubnet)
+		assert.Equal(t, "/publicIPAddresses/pip", gotPublic)
+	})
+}
 
 func TestParseAzurePortRange(t *testing.T) {
 	entry := "*,80,1024-65535"


### PR DESCRIPTION
## What

Adds a typed `frontendIpConfigs` sub-resource to `azure.subscription.networkService.applicationGateway`, replacing the raw ARM dict access used to distinguish internal vs internet-facing gateways:

```mql
# before
appGw.properties["frontendIPConfigurations"].any(_["properties"]["subnet"] != empty)
# after
appGw.frontendIpConfigs.any(subnetId != empty)
```

Each `frontendIpConfig` exposes `id`, `name`, `subnetId` (set for internal/private frontends), `publicIpAddressId` (set for internet-facing frontends), `privateIPAddress`, and `privateIPAllocationMethod` — mirroring the existing `listener` and `sslCertificate` sub-resources on the gateway.

(The sibling check that indexes `properties["sslPolicy"]["minProtocolVersion"]` already has a typed `sslMinProtocolVersion` field — policy-side cleanup.) `properties` is retained for backward compatibility.

## Testing

Scalar extraction factored into the pure helper `frontendIpConfigFields` and unit-tested (`TestFrontendIpConfigFields`) covering nil, internal, and internet-facing configs. `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)