### PR TITLE
🎉 azure-13.19.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.18.0",
+	Version: "13.19.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.19.0)
- ✨ azure: typed publicNetworkAccess on Function App (#8294)
- ✨ azure: typed osType on virtual machines (#8295)
- ✨ azure: typed corsAllowedOrigins on App Service site configuration (#8296)
- ✨ azure: typed diskCsiDriverEnabled on AKS cluster (#8297)
- ✨ azure: typed frontendIpConfigs on Application Gateway (#8298)
- ✨ azure: typed Cosmos DB account network/consistency/CORS/location fields (#8293)