### PR TITLE
✨ gcp: typed retentionPeriod and softDeleteRetentionDuration on bucket

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2399,6 +2399,8 @@ private gcp.project.storageService.bucket @defaults("id") {
   retentionPolicy dict
   // Whether the bucket's retention policy is locked (retentionPolicy.isLocked == true)
   retentionPolicyLocked bool
+  // Retention period in seconds enforced by the retention policy (0 when no policy is set)
+  retentionPeriod int
   // Whether bucket access logs are configured (logging.logBucket is set)
   loggingEnabled bool
   // Encryption configuration
@@ -2437,6 +2439,8 @@ private gcp.project.storageService.bucket @defaults("id") {
   uniformBucketLevelAccessEnabled() bool
   // Soft delete policy (retentionDurationSeconds, effectiveTime)
   softDeletePolicy dict
+  // Soft-delete retention duration in seconds (0 when no soft-delete policy is set)
+  softDeleteRetentionDuration int
   // Whether soft-delete is enabled — true when softDeletePolicy.retentionDurationSeconds > 0
   softDeletePolicyEnabled() bool
   // Object retention mode (Enabled or empty)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4847,6 +4847,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.storageService.bucket.retentionPolicyLocked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetRetentionPolicyLocked()).ToDataRes(types.Bool)
 	},
+	"gcp.project.storageService.bucket.retentionPeriod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetRetentionPeriod()).ToDataRes(types.Int)
+	},
 	"gcp.project.storageService.bucket.loggingEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetLoggingEnabled()).ToDataRes(types.Bool)
 	},
@@ -4891,6 +4894,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.storageService.bucket.softDeletePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeletePolicy()).ToDataRes(types.Dict)
+	},
+	"gcp.project.storageService.bucket.softDeleteRetentionDuration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeleteRetentionDuration()).ToDataRes(types.Int)
 	},
 	"gcp.project.storageService.bucket.softDeletePolicyEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeletePolicyEnabled()).ToDataRes(types.Bool)
@@ -20219,6 +20225,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectStorageServiceBucket).RetentionPolicyLocked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.storageService.bucket.retentionPeriod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).RetentionPeriod, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
 	"gcp.project.storageService.bucket.loggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).LoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -20277,6 +20287,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.storageService.bucket.softDeletePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).SoftDeletePolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.softDeleteRetentionDuration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).SoftDeleteRetentionDuration, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"gcp.project.storageService.bucket.softDeletePolicyEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -46257,6 +46271,7 @@ type mqlGcpProjectStorageServiceBucket struct {
 	IamConfiguration                plugin.TValue[any]
 	RetentionPolicy                 plugin.TValue[any]
 	RetentionPolicyLocked           plugin.TValue[bool]
+	RetentionPeriod                 plugin.TValue[int64]
 	LoggingEnabled                  plugin.TValue[bool]
 	Encryption                      plugin.TValue[any]
 	DefaultKmsKey                   plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
@@ -46272,6 +46287,7 @@ type mqlGcpProjectStorageServiceBucket struct {
 	UniformBucketLevelAccess        plugin.TValue[any]
 	UniformBucketLevelAccessEnabled plugin.TValue[bool]
 	SoftDeletePolicy                plugin.TValue[any]
+	SoftDeleteRetentionDuration     plugin.TValue[int64]
 	SoftDeletePolicyEnabled         plugin.TValue[bool]
 	ObjectRetentionMode             plugin.TValue[string]
 	Autoclass                       plugin.TValue[any]
@@ -46395,6 +46411,10 @@ func (c *mqlGcpProjectStorageServiceBucket) GetRetentionPolicyLocked() *plugin.T
 	return &c.RetentionPolicyLocked
 }
 
+func (c *mqlGcpProjectStorageServiceBucket) GetRetentionPeriod() *plugin.TValue[int64] {
+	return &c.RetentionPeriod
+}
+
 func (c *mqlGcpProjectStorageServiceBucket) GetLoggingEnabled() *plugin.TValue[bool] {
 	return &c.LoggingEnabled
 }
@@ -46469,6 +46489,10 @@ func (c *mqlGcpProjectStorageServiceBucket) GetUniformBucketLevelAccessEnabled()
 
 func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeletePolicy() *plugin.TValue[any] {
 	return &c.SoftDeletePolicy
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeleteRetentionDuration() *plugin.TValue[int64] {
+	return &c.SoftDeleteRetentionDuration
 }
 
 func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeletePolicyEnabled() *plugin.TValue[bool] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4557,6 +4557,7 @@ gcp.project.storageService.bucket.projectId 9.0.0
 gcp.project.storageService.bucket.projectNumber 9.0.0
 gcp.project.storageService.bucket.public 13.12.2
 gcp.project.storageService.bucket.publicAccessPrevention 13.1.2
+gcp.project.storageService.bucket.retentionPeriod 13.22.2
 gcp.project.storageService.bucket.retentionPolicy 9.0.0
 gcp.project.storageService.bucket.retentionPolicyLocked 13.12.2
 gcp.project.storageService.bucket.rpo 11.6.6
@@ -4564,6 +4565,7 @@ gcp.project.storageService.bucket.satisfiesPZI 13.16.3
 gcp.project.storageService.bucket.satisfiesPZS 11.6.6
 gcp.project.storageService.bucket.softDeletePolicy 13.7.2
 gcp.project.storageService.bucket.softDeletePolicyEnabled 13.12.2
+gcp.project.storageService.bucket.softDeleteRetentionDuration 13.22.2
 gcp.project.storageService.bucket.softDeleteTime 13.16.3
 gcp.project.storageService.bucket.storageClass 9.0.0
 gcp.project.storageService.bucket.uniformBucketLevelAccess 13.7.2

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -122,6 +122,24 @@ func (g *mqlGcpProjectStorageService) buckets() ([]any, error) {
 	return res, nil
 }
 
+// bucketRetentionPeriodSeconds returns the retention period (in seconds)
+// enforced by a bucket's retention policy, or 0 when no policy is set.
+func bucketRetentionPeriodSeconds(rp *storage.BucketRetentionPolicy) int64 {
+	if rp == nil {
+		return 0
+	}
+	return rp.RetentionPeriod
+}
+
+// bucketSoftDeleteRetentionSeconds returns the soft-delete retention duration
+// (in seconds), or 0 when no soft-delete policy is set.
+func bucketSoftDeleteRetentionSeconds(sdp *storage.BucketSoftDeletePolicy) int64 {
+	if sdp == nil {
+		return 0
+	}
+	return sdp.RetentionDurationSeconds
+}
+
 // mqlBucketFromAPI converts a *storage.Bucket into a fully-populated mql
 // resource. Used by buckets() during a list and by init when resolving a
 // single bucket by name.
@@ -223,32 +241,34 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 		"iamConfiguration":      llx.DictData(iamConfigurationDict),
 		"retentionPolicy":       llx.DictData(retentionPolicy),
 		"retentionPolicyLocked": llx.BoolData(bucket.RetentionPolicy != nil && bucket.RetentionPolicy.IsLocked),
+		"retentionPeriod":       llx.IntData(bucketRetentionPeriodSeconds(bucket.RetentionPolicy)),
 		"loggingEnabled":        llx.BoolData(bucket.Logging != nil && bucket.Logging.LogBucket != ""),
 		"encryption":            llx.DictData(enc),
 		"lifecycle": llx.ArrayData(
 			storageLifecycleRulesToArrayInterface(runtime, bucket.Id, bucket.Lifecycle),
 			types.Resource("gcp.project.storageService.bucket.lifecycleRule"),
 		),
-		"defaultEventBasedHold":    llx.BoolData(bucket.DefaultEventBasedHold),
-		"rpo":                      llx.StringData(bucket.Rpo),
-		"satisfiesPZS":             llx.BoolData(bucket.SatisfiesPZS),
-		"satisfiesPZI":             llx.BoolData(bucket.SatisfiesPZI),
-		"versioningEnabled":        llx.BoolData(bucket.Versioning != nil && bucket.Versioning.Enabled),
-		"publicAccessPrevention":   llx.StringData(publicAccessPrevention),
-		"metageneration":           llx.IntData(bucket.Metageneration),
-		"uniformBucketLevelAccess": llx.DictData(uniformBucketLevelAccess),
-		"softDeletePolicy":         llx.DictData(softDeletePolicy),
-		"softDeleteTime":           llx.TimeDataPtr(softDeleteTime),
-		"objectRetentionMode":      llx.StringData(objectRetentionMode),
-		"autoclass":                llx.DictData(autoclass),
-		"ipFilter":                 llx.DictData(ipFilter),
-		"hierarchicalNamespace":    llx.DictData(hierarchicalNamespace),
-		"customPlacementConfig":    llx.DictData(customPlacementConfig),
-		"logging":                  llx.DictData(logging),
-		"cors":                     llx.ArrayData(cors, types.Dict),
-		"website":                  llx.DictData(website),
-		"billing":                  llx.DictData(billing),
-		"owner":                    llx.DictData(owner),
+		"defaultEventBasedHold":       llx.BoolData(bucket.DefaultEventBasedHold),
+		"rpo":                         llx.StringData(bucket.Rpo),
+		"satisfiesPZS":                llx.BoolData(bucket.SatisfiesPZS),
+		"satisfiesPZI":                llx.BoolData(bucket.SatisfiesPZI),
+		"versioningEnabled":           llx.BoolData(bucket.Versioning != nil && bucket.Versioning.Enabled),
+		"publicAccessPrevention":      llx.StringData(publicAccessPrevention),
+		"metageneration":              llx.IntData(bucket.Metageneration),
+		"uniformBucketLevelAccess":    llx.DictData(uniformBucketLevelAccess),
+		"softDeletePolicy":            llx.DictData(softDeletePolicy),
+		"softDeleteRetentionDuration": llx.IntData(bucketSoftDeleteRetentionSeconds(bucket.SoftDeletePolicy)),
+		"softDeleteTime":              llx.TimeDataPtr(softDeleteTime),
+		"objectRetentionMode":         llx.StringData(objectRetentionMode),
+		"autoclass":                   llx.DictData(autoclass),
+		"ipFilter":                    llx.DictData(ipFilter),
+		"hierarchicalNamespace":       llx.DictData(hierarchicalNamespace),
+		"customPlacementConfig":       llx.DictData(customPlacementConfig),
+		"logging":                     llx.DictData(logging),
+		"cors":                        llx.ArrayData(cors, types.Dict),
+		"website":                     llx.DictData(website),
+		"billing":                     llx.DictData(billing),
+		"owner":                       llx.DictData(owner),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/storage_test.go
+++ b/providers/gcp/resources/storage_test.go
@@ -110,3 +110,14 @@ func TestEvaluateBucketPublic(t *testing.T) {
 		})
 	}
 }
+
+func TestBucketRetentionHelpers(t *testing.T) {
+	t.Run("nil policies return 0", func(t *testing.T) {
+		assert.Equal(t, int64(0), bucketRetentionPeriodSeconds(nil))
+		assert.Equal(t, int64(0), bucketSoftDeleteRetentionSeconds(nil))
+	})
+	t.Run("values are returned", func(t *testing.T) {
+		assert.Equal(t, int64(86400), bucketRetentionPeriodSeconds(&storage.BucketRetentionPolicy{RetentionPeriod: 86400}))
+		assert.Equal(t, int64(604800), bucketSoftDeleteRetentionSeconds(&storage.BucketSoftDeletePolicy{RetentionDurationSeconds: 604800}))
+	})
+}


### PR DESCRIPTION
## What

Adds two typed int fields to `gcp.project.storageService.bucket`, replacing raw dict indexing:

```mql
# before
bucket.retentionPolicy['retentionPeriod']
bucket.softDeletePolicy['retentionDurationSeconds']
# after
bucket.retentionPeriod
bucket.softDeleteRetentionDuration
```

(The neighboring `retentionPolicy['isLocked']` and `iamConfiguration['publicAccessPrevention']` checks already have typed `retentionPolicyLocked` / `publicAccessPrevention` fields — policy-side cleanup.) The dicts are retained for backward compatibility.

## Testing

Extraction factored into the pure helpers `bucketRetentionPeriodSeconds` and `bucketSoftDeleteRetentionSeconds` and unit-tested. `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)