### PR TITLE
✨ gcp: typed serviceAccount/network/enableWebAccess on Vertex AI custom job

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -11317,6 +11317,16 @@ private gcp.project.vertexaiService.customJob @defaults("displayName state") {
   state string
   // Job spec (worker pool specs, scheduling, etc.)
   jobSpec dict
+  // Email of the service account the job runs as (jobSpec.serviceAccount); empty when the default is used
+  serviceAccount string
+  // The job's run-as service account, resolved to the typed resource
+  serviceAccountRef() gcp.project.iamService.serviceAccount
+  // Resource name of the VPC network the job peers with (jobSpec.network); empty when none
+  network string
+  // The job's peering VPC network, resolved to the typed resource
+  networkRef() gcp.project.computeService.network
+  // Whether interactive web-access portals are enabled for the job (jobSpec.enableWebAccessPortals)
+  enableWebAccess bool
   // User-defined key/value labels for organizing the resource
   labels map[string]string
   // Encryption spec

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -11318,14 +11318,18 @@ private gcp.project.vertexaiService.customJob @defaults("displayName state") {
   // Job spec (worker pool specs, scheduling, etc.)
   jobSpec dict
   // Email of the service account the job runs as (jobSpec.serviceAccount); empty when the default is used
-  serviceAccount string
+  //
+  // Deprecated in favor of `serviceAccountRef`.
+  serviceAccount @maturity("deprecated") string
   // The job's run-as service account, resolved to the typed resource
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Resource name of the VPC network the job peers with (jobSpec.network); empty when none
-  network string
+  //
+  // Deprecated in favor of `networkRef`.
+  network @maturity("deprecated") string
   // The job's peering VPC network, resolved to the typed resource
   networkRef() gcp.project.computeService.network
-  // Whether interactive web-access portals are enabled for the job (jobSpec.enableWebAccessPortals)
+  // Whether interactive web access is enabled for the job (jobSpec.enableWebAccess)
   enableWebAccess bool
   // User-defined key/value labels for organizing the resource
   labels map[string]string

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -13670,6 +13670,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.customJob.jobSpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetJobSpec()).ToDataRes(types.Dict)
 	},
+	"gcp.project.vertexaiService.customJob.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetServiceAccount()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.customJob.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.vertexaiService.customJob.network": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.vertexaiService.customJob.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
+	"gcp.project.vertexaiService.customJob.enableWebAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetEnableWebAccess()).ToDataRes(types.Bool)
+	},
 	"gcp.project.vertexaiService.customJob.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -33101,6 +33116,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.customJob.jobSpec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceCustomJob).JobSpec, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.customJob.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceCustomJob).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.customJob.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceCustomJob).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.customJob.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceCustomJob).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.customJob.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceCustomJob).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
+	"gcp.project.vertexaiService.customJob.enableWebAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectVertexaiServiceCustomJob).EnableWebAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.customJob.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -76643,18 +76678,23 @@ type mqlGcpProjectVertexaiServiceCustomJob struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectVertexaiServiceCustomJobInternal
-	Name           plugin.TValue[string]
-	DisplayName    plugin.TValue[string]
-	State          plugin.TValue[string]
-	JobSpec        plugin.TValue[any]
-	Labels         plugin.TValue[map[string]any]
-	EncryptionSpec plugin.TValue[any]
-	KmsKey         plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	Error          plugin.TValue[any]
-	Created        plugin.TValue[*time.Time]
-	Updated        plugin.TValue[*time.Time]
-	StartTime      plugin.TValue[*time.Time]
-	EndTime        plugin.TValue[*time.Time]
+	Name              plugin.TValue[string]
+	DisplayName       plugin.TValue[string]
+	State             plugin.TValue[string]
+	JobSpec           plugin.TValue[any]
+	ServiceAccount    plugin.TValue[string]
+	ServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Network           plugin.TValue[string]
+	NetworkRef        plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	EnableWebAccess   plugin.TValue[bool]
+	Labels            plugin.TValue[map[string]any]
+	EncryptionSpec    plugin.TValue[any]
+	KmsKey            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	Error             plugin.TValue[any]
+	Created           plugin.TValue[*time.Time]
+	Updated           plugin.TValue[*time.Time]
+	StartTime         plugin.TValue[*time.Time]
+	EndTime           plugin.TValue[*time.Time]
 }
 
 // createGcpProjectVertexaiServiceCustomJob creates a new instance of this resource
@@ -76708,6 +76748,50 @@ func (c *mqlGcpProjectVertexaiServiceCustomJob) GetState() *plugin.TValue[string
 
 func (c *mqlGcpProjectVertexaiServiceCustomJob) GetJobSpec() *plugin.TValue[any] {
 	return &c.JobSpec
+}
+
+func (c *mqlGcpProjectVertexaiServiceCustomJob) GetServiceAccount() *plugin.TValue[string] {
+	return &c.ServiceAccount
+}
+
+func (c *mqlGcpProjectVertexaiServiceCustomJob) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.customJob", c.__id, "serviceAccountRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccountRef()
+	})
+}
+
+func (c *mqlGcpProjectVertexaiServiceCustomJob) GetNetwork() *plugin.TValue[string] {
+	return &c.Network
+}
+
+func (c *mqlGcpProjectVertexaiServiceCustomJob) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.vertexaiService.customJob", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
+}
+
+func (c *mqlGcpProjectVertexaiServiceCustomJob) GetEnableWebAccess() *plugin.TValue[bool] {
+	return &c.EnableWebAccess
 }
 
 func (c *mqlGcpProjectVertexaiServiceCustomJob) GetLabels() *plugin.TValue[map[string]any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4614,6 +4614,7 @@ gcp.project.vertexaiService.cachedContents 13.20.2
 gcp.project.vertexaiService.customJob 13.6.1
 gcp.project.vertexaiService.customJob.created 13.6.1
 gcp.project.vertexaiService.customJob.displayName 13.6.1
+gcp.project.vertexaiService.customJob.enableWebAccess 13.22.2
 gcp.project.vertexaiService.customJob.encryptionSpec 13.6.1
 gcp.project.vertexaiService.customJob.endTime 13.6.1
 gcp.project.vertexaiService.customJob.error 13.6.1
@@ -4621,6 +4622,10 @@ gcp.project.vertexaiService.customJob.jobSpec 13.6.1
 gcp.project.vertexaiService.customJob.kmsKey 13.19.2
 gcp.project.vertexaiService.customJob.labels 13.6.1
 gcp.project.vertexaiService.customJob.name 13.6.1
+gcp.project.vertexaiService.customJob.network 13.22.2
+gcp.project.vertexaiService.customJob.networkRef 13.22.2
+gcp.project.vertexaiService.customJob.serviceAccount 13.22.2
+gcp.project.vertexaiService.customJob.serviceAccountRef 13.22.2
 gcp.project.vertexaiService.customJob.startTime 13.6.1
 gcp.project.vertexaiService.customJob.state 13.6.1
 gcp.project.vertexaiService.customJob.updated 13.6.1

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -948,6 +948,47 @@ func (g *mqlGcpProjectVertexaiServiceCustomJob) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }
 
+func (g *mqlGcpProjectVertexaiServiceCustomJob) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccount.Error != nil {
+		return nil, g.ServiceAccount.Error
+	}
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	email := g.ServiceAccount.Data
+	projectId := projectFromResourceName(g.Name.Data)
+	if email == "" || projectId == "" {
+		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"email":     llx.StringData(email),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
+}
+
+func (g *mqlGcpProjectVertexaiServiceCustomJob) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.Network.Error != nil {
+		return nil, g.Network.Error
+	}
+	if g.Network.Data == "" {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
 func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -1018,11 +1059,20 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 	return args, res, nil
 }
 
+// customJobSpecFields extracts the security-relevant scalar fields from a
+// Vertex AI custom-job spec — the run-as service account, the peering network,
+// and whether interactive web-access portals are enabled. The protobuf getters
+// are nil-safe, so an absent spec yields zero values.
+func customJobSpecFields(spec *aiplatformpb.CustomJobSpec) (serviceAccount, network string, enableWebAccess bool) {
+	return spec.GetServiceAccount(), spec.GetNetwork(), spec.GetEnableWebAccess()
+}
+
 func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.CustomJob) (*mqlGcpProjectVertexaiServiceCustomJob, error) {
 	jobSpec, err := protoToDict(job.JobSpec)
 	if err != nil {
 		return nil, err
 	}
+	serviceAccount, network, enableWebAccess := customJobSpecFields(job.GetJobSpec())
 	encryptionSpec, err := protoToDict(job.EncryptionSpec)
 	if err != nil {
 		return nil, err
@@ -1033,17 +1083,20 @@ func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.Cu
 	}
 
 	res, err := CreateResource(runtime, "gcp.project.vertexaiService.customJob", map[string]*llx.RawData{
-		"name":           llx.StringData(job.Name),
-		"displayName":    llx.StringData(job.DisplayName),
-		"state":          llx.StringData(job.State.String()),
-		"jobSpec":        llx.DictData(jobSpec),
-		"labels":         llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
-		"encryptionSpec": llx.DictData(encryptionSpec),
-		"error":          llx.DictData(errorDict),
-		"created":        llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
-		"updated":        llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
-		"startTime":      llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
-		"endTime":        llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
+		"name":            llx.StringData(job.Name),
+		"displayName":     llx.StringData(job.DisplayName),
+		"state":           llx.StringData(job.State.String()),
+		"jobSpec":         llx.DictData(jobSpec),
+		"serviceAccount":  llx.StringData(serviceAccount),
+		"network":         llx.StringData(network),
+		"enableWebAccess": llx.BoolData(enableWebAccess),
+		"labels":          llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
+		"encryptionSpec":  llx.DictData(encryptionSpec),
+		"error":           llx.DictData(errorDict),
+		"created":         llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
+		"updated":         llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
+		"startTime":       llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
+		"endTime":         llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/vertexai_extras_test.go
+++ b/providers/gcp/resources/vertexai_extras_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomJobSpecFields(t *testing.T) {
+	t.Run("nil spec yields zero values", func(t *testing.T) {
+		sa, net, web := customJobSpecFields(nil)
+		assert.Equal(t, "", sa)
+		assert.Equal(t, "", net)
+		assert.False(t, web)
+	})
+	t.Run("fields are surfaced", func(t *testing.T) {
+		spec := &aiplatformpb.CustomJobSpec{
+			ServiceAccount:  "sa@project.iam.gserviceaccount.com",
+			Network:         "projects/123/global/networks/default",
+			EnableWebAccess: true,
+		}
+		sa, net, web := customJobSpecFields(spec)
+		assert.Equal(t, "sa@project.iam.gserviceaccount.com", sa)
+		assert.Equal(t, "projects/123/global/networks/default", net)
+		assert.True(t, web)
+	})
+}


### PR DESCRIPTION
## What

Adds typed fields to `gcp.project.vertexaiService.customJob`, replacing raw `jobSpec` dict indexing:

```mql
# before
job.jobSpec['serviceAccount']
job.jobSpec['network']
job.jobSpec['enableWebAccessPortals']
# after
job.serviceAccount        # + job.serviceAccountRef for the typed resource
job.network               # + job.networkRef for the typed resource
job.enableWebAccess
```

Because `serviceAccount` and `network` reference modeled resources, I added `serviceAccountRef()` / `networkRef()` typed accessors alongside the raw strings — mirroring the existing `pipelineJob.serviceAccountRef()` and `endpoint.networkRef()` — to satisfy the typed-reference convention up front. `jobSpec` dict retained for backward compatibility.

## Testing

Scalar extraction factored into the pure helper `customJobSpecFields` (nil-safe via protobuf getters) and unit-tested. `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)