### PR TITLE
✨ gcp: typed dnssecNonExistence on DNS managed zone

### DIFF
--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -74,6 +74,15 @@ type mqlGcpProjectDnsServiceInternal struct {
 	serviceChecked bool
 }
 
+// managedZoneDnssecNonExistence returns the DNSSEC proof-of-nonexistence mode
+// ("nsec" or "nsec3") for a managed zone, or "" when DNSSEC is not configured.
+func managedZoneDnssecNonExistence(cfg *dns.ManagedZoneDnsSecConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.NonExistence
+}
+
 func (g *mqlGcpProjectDnsService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -184,6 +193,7 @@ func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
 			var mqlDnssecCfg map[string]any
 			dnssecAlgorithms := []any{}
 			dnssecAlgorithmSet := map[string]struct{}{}
+			dnssecNonExistence := managedZoneDnssecNonExistence(managedZone.DnssecConfig)
 			if managedZone.DnssecConfig != nil {
 				keySpecs := make([]any, 0, len(managedZone.DnssecConfig.DefaultKeySpecs))
 				for _, keySpec := range managedZone.DnssecConfig.DefaultKeySpecs {
@@ -253,6 +263,7 @@ func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
 				"labels":                     llx.MapData(convert.MapToInterfaceMap(managedZone.Labels), types.String),
 				"cloudLoggingEnabled":        llx.BoolData(managedZone.CloudLoggingConfig != nil && managedZone.CloudLoggingConfig.EnableLogging),
 				"dnssecEnabled":              llx.BoolData(managedZone.DnssecConfig != nil && managedZone.DnssecConfig.State == "on"),
+				"dnssecNonExistence":         llx.StringData(dnssecNonExistence),
 				"dnssecDefaultKeyAlgorithms": llx.ArrayData(dnssecAlgorithms, types.String),
 				"privateVisibilityConfig":    llx.DictData(mqlPrivateVisibilityCfg),
 				"forwardingTargets":          llx.ArrayData(forwardingTargets, types.String),

--- a/providers/gcp/resources/dns_test.go
+++ b/providers/gcp/resources/dns_test.go
@@ -1,0 +1,20 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/dns/v1"
+)
+
+func TestManagedZoneDnssecNonExistence(t *testing.T) {
+	t.Run("nil config returns empty", func(t *testing.T) {
+		assert.Equal(t, "", managedZoneDnssecNonExistence(nil))
+	})
+	t.Run("value is returned", func(t *testing.T) {
+		assert.Equal(t, "nsec3", managedZoneDnssecNonExistence(&dns.ManagedZoneDnsSecConfig{NonExistence: "nsec3"}))
+	})
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -3562,6 +3562,8 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   cloudLoggingEnabled bool
   // Whether DNSSEC is enabled
   dnssecEnabled bool
+  // DNSSEC proof-of-nonexistence mode ("nsec" or "nsec3"); empty when DNSSEC is not configured
+  dnssecNonExistence string
   // Whether DNSSEC is enabled but uses a weak signing algorithm (RSASHA1 / RSASHA1-NSEC3-SHA1)
   dnsSecAlgorithmWeak() bool
   // DNSSEC signing algorithms of the zone's default key specs (e.g. rsasha256, ecdsap256sha256, rsasha1)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5987,6 +5987,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dnsService.managedzone.dnssecEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetDnssecEnabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.dnsService.managedzone.dnssecNonExistence": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetDnssecNonExistence()).ToDataRes(types.String)
+	},
 	"gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetDnsSecAlgorithmWeak()).ToDataRes(types.Bool)
 	},
@@ -21857,6 +21860,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dnsService.managedzone.dnssecEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).DnssecEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dnsService.managedzone.dnssecNonExistence": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).DnssecNonExistence, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49822,6 +49829,7 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	Labels                     plugin.TValue[map[string]any]
 	CloudLoggingEnabled        plugin.TValue[bool]
 	DnssecEnabled              plugin.TValue[bool]
+	DnssecNonExistence         plugin.TValue[string]
 	DnsSecAlgorithmWeak        plugin.TValue[bool]
 	DnssecDefaultKeyAlgorithms plugin.TValue[[]any]
 	PrivateVisibilityConfig    plugin.TValue[any]
@@ -49919,6 +49927,10 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetCloudLoggingEnabled() *plugin.TV
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetDnssecEnabled() *plugin.TValue[bool] {
 	return &c.DnssecEnabled
+}
+
+func (c *mqlGcpProjectDnsServiceManagedzone) GetDnssecNonExistence() *plugin.TValue[string] {
+	return &c.DnssecNonExistence
 }
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetDnsSecAlgorithmWeak() *plugin.TValue[bool] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -2807,6 +2807,7 @@ gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak 13.12.2
 gcp.project.dnsService.managedzone.dnssecConfig 9.0.0
 gcp.project.dnsService.managedzone.dnssecDefaultKeyAlgorithms 13.18.1
 gcp.project.dnsService.managedzone.dnssecEnabled 13.1.2
+gcp.project.dnsService.managedzone.dnssecNonExistence 13.22.2
 gcp.project.dnsService.managedzone.forwardingTargets 13.18.1
 gcp.project.dnsService.managedzone.iamPolicy 13.9.1
 gcp.project.dnsService.managedzone.id 9.0.0


### PR DESCRIPTION
## What

Adds a typed `dnssecNonExistence` field to `gcp.project.dnsService.managedzone`, replacing raw dict indexing:

```mql
# before
zone.dnssecConfig['nonExistence']
# after
zone.dnssecNonExistence
```

(The neighboring `dnssecConfig['state']` checks already have the typed `dnssecEnabled` field — policy-side cleanup.) The `dnssecConfig` dict is retained for backward compatibility.

## Testing

Extraction factored into the pure helper `managedZoneDnssecNonExistence` and unit-tested. `go build ./...`, lr regen, and `go test ./resources/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)