### PR TITLE
🎉 gcp-13.23.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.22.1",
+	Version: "13.23.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.23.0)
- ✨ gcp: typed serviceAccount/network/enableWebAccess on Vertex AI custom job (#8302)
- ✨ gcp: typed dnssecNonExistence on DNS managed zone (#8303)
- ✨ gcp: typed insecure RBAC binding flags on GKE cluster (#8299)
- ✨ gcp: typed retentionPeriod and softDeleteRetentionDuration on bucket (#8301)