### PR TITLE
✨ vsphere: typed ESXi host hardening advanced settings

### DIFF
--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -597,6 +598,105 @@ func (v *mqlVsphereHost) advancedSettings() (map[string]any, error) {
 		return nil, err
 	}
 	return resourceclient.HostOptions(host)
+}
+
+// advancedSettingString looks up a single ESXi advanced (host option) value by
+// key from the memoized advancedSettings map. The map stores every value as its
+// fmt-formatted string, so callers parse from there. A missing key yields an
+// empty string with ok=false, letting numeric resolvers fall back to a zero
+// default rather than erroring on hosts that don't expose the setting.
+func (v *mqlVsphereHost) advancedSettingString(key string) (value string, ok bool, err error) {
+	settings := v.GetAdvancedSettings()
+	if settings.Error != nil {
+		return "", false, settings.Error
+	}
+	raw, found := settings.Data[key]
+	if !found {
+		return "", false, nil
+	}
+	s, _ := raw.(string)
+	return s, true, nil
+}
+
+// advancedSettingInt resolves an integer-valued ESXi advanced setting, returning
+// 0 when the key is absent or empty (the natural default for the lockout/timeout
+// counters these back, where 0 already means "disabled").
+func (v *mqlVsphereHost) advancedSettingInt(key string) (int64, error) {
+	s, ok, err := v.advancedSettingString(key)
+	if err != nil || !ok {
+		return 0, err
+	}
+	return parseHostAdvancedSettingInt(key, s)
+}
+
+// parseHostAdvancedSettingInt converts a stringified ESXi advanced-setting value
+// to an int64. An empty value (an unset option) reads as 0; a non-numeric value
+// is a real error worth surfacing rather than silently zeroing.
+func parseHostAdvancedSettingInt(key, s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("vsphere host advanced setting %q is not an integer %q: %w", key, s, err)
+	}
+	return n, nil
+}
+
+// parseHostBoolSetting interprets ESXi's stringified boolean options. vCenter
+// renders the value as "true"/"false"; some builds surface "1"/"0".
+func parseHostBoolSetting(s string) bool {
+	return s == "true" || s == "1"
+}
+
+func (v *mqlVsphereHost) accountLockFailures() (int64, error) {
+	return v.advancedSettingInt("Security.AccountLockFailures")
+}
+
+func (v *mqlVsphereHost) accountUnlockTime() (int64, error) {
+	return v.advancedSettingInt("Security.AccountUnlockTime")
+}
+
+func (v *mqlVsphereHost) esxiShellInteractiveTimeOut() (int64, error) {
+	return v.advancedSettingInt("UserVars.ESXiShellInteractiveTimeOut")
+}
+
+func (v *mqlVsphereHost) esxiShellTimeOut() (int64, error) {
+	return v.advancedSettingInt("UserVars.ESXiShellTimeOut")
+}
+
+func (v *mqlVsphereHost) dcuiTimeOut() (int64, error) {
+	return v.advancedSettingInt("UserVars.DcuiTimeOut")
+}
+
+func (v *mqlVsphereHost) memShareForceSalting() (int64, error) {
+	return v.advancedSettingInt("Mem.ShareForceSalting")
+}
+
+// mobEnabled reports whether the Managed Object Browser is enabled. ESXi returns
+// the option as a boolean, which advancedSettings stringifies to "true"/"false";
+// older builds may surface "1"/"0", so both spellings are accepted.
+func (v *mqlVsphereHost) mobEnabled() (bool, error) {
+	s, ok, err := v.advancedSettingString("Config.HostAgent.plugins.solo.enableMob")
+	if err != nil || !ok {
+		return false, err
+	}
+	return parseHostBoolSetting(s), nil
+}
+
+func (v *mqlVsphereHost) syslogLogHost() (string, error) {
+	s, _, err := v.advancedSettingString("Syslog.global.logHost")
+	return s, err
+}
+
+func (v *mqlVsphereHost) syslogLogDir() (string, error) {
+	s, _, err := v.advancedSettingString("Syslog.global.logDir")
+	return s, err
+}
+
+func (v *mqlVsphereHost) dvFilterBindIpAddress() (string, error) {
+	s, _, err := v.advancedSettingString("Net.DVFilterBindIpAddress")
+	return s, err
 }
 
 func (v *mqlVsphereHost) services() ([]any, error) {

--- a/providers/vsphere/resources/host_settings_test.go
+++ b/providers/vsphere/resources/host_settings_test.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHostAdvancedSettingInt(t *testing.T) {
+	t.Run("numeric value", func(t *testing.T) {
+		n, err := parseHostAdvancedSettingInt("Security.AccountLockFailures", "5")
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), n)
+	})
+
+	t.Run("empty value reads as zero", func(t *testing.T) {
+		n, err := parseHostAdvancedSettingInt("UserVars.DcuiTimeOut", "")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), n)
+	})
+
+	t.Run("non-numeric value errors", func(t *testing.T) {
+		_, err := parseHostAdvancedSettingInt("Mem.ShareForceSalting", "notanumber")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Mem.ShareForceSalting")
+	})
+}
+
+func TestParseHostBoolSetting(t *testing.T) {
+	assert.True(t, parseHostBoolSetting("true"))
+	assert.True(t, parseHostBoolSetting("1"))
+	assert.False(t, parseHostBoolSetting("false"))
+	assert.False(t, parseHostBoolSetting("0"))
+	assert.False(t, parseHostBoolSetting(""))
+}

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -457,6 +457,26 @@ private vsphere.host @defaults("moid name") {
   firewallOutgoingBlocked bool
   // Whether the host firmware reports UEFI Secure Boot was used during system boot (requires vSphere 8.0.3 or later)
   secureBootEnabled bool
+  // Maximum failed login attempts before an account is locked (Security.AccountLockFailures); 0 disables lockout
+  accountLockFailures() int
+  // Seconds a locked account stays locked before automatic unlock (Security.AccountUnlockTime)
+  accountUnlockTime() int
+  // Idle timeout in seconds for interactive ESXi Shell and SSH sessions (UserVars.ESXiShellInteractiveTimeOut); 0 disables the timeout
+  esxiShellInteractiveTimeOut() int
+  // Availability timeout in seconds for the ESXi Shell and SSH services after they start (UserVars.ESXiShellTimeOut); 0 disables the timeout
+  esxiShellTimeOut() int
+  // Idle timeout in seconds for the Direct Console User Interface (UserVars.DcuiTimeOut); 0 disables the timeout
+  dcuiTimeOut() int
+  // Whether the Managed Object Browser (MOB) is enabled (Config.HostAgent.plugins.solo.enableMob)
+  mobEnabled() bool
+  // Remote syslog host(s) the ESXi host forwards logs to (Syslog.global.logHost); empty when remote logging is not configured
+  syslogLogHost() string
+  // Datastore path where the ESXi host stores persistent logs (Syslog.global.logDir); empty when not configured for persistent logging
+  syslogLogDir() string
+  // Transparent Page Sharing salting mode (Mem.ShareForceSalting); 2 is the secure per-VM default that disables inter-VM page sharing
+  memShareForceSalting() int
+  // IP address the dvFilter network API is bound to (Net.DVFilterBindIpAddress); empty when dvFilter is not configured
+  dvFilterBindIpAddress() string
   // Last time the host booted; zero time if vCenter has never observed a boot
   bootTime time
   // Whether the host is currently in maintenance mode

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -819,6 +819,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.host.secureBootEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetSecureBootEnabled()).ToDataRes(types.Bool)
 	},
+	"vsphere.host.accountLockFailures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetAccountLockFailures()).ToDataRes(types.Int)
+	},
+	"vsphere.host.accountUnlockTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetAccountUnlockTime()).ToDataRes(types.Int)
+	},
+	"vsphere.host.esxiShellInteractiveTimeOut": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetEsxiShellInteractiveTimeOut()).ToDataRes(types.Int)
+	},
+	"vsphere.host.esxiShellTimeOut": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetEsxiShellTimeOut()).ToDataRes(types.Int)
+	},
+	"vsphere.host.dcuiTimeOut": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetDcuiTimeOut()).ToDataRes(types.Int)
+	},
+	"vsphere.host.mobEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetMobEnabled()).ToDataRes(types.Bool)
+	},
+	"vsphere.host.syslogLogHost": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetSyslogLogHost()).ToDataRes(types.String)
+	},
+	"vsphere.host.syslogLogDir": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetSyslogLogDir()).ToDataRes(types.String)
+	},
+	"vsphere.host.memShareForceSalting": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetMemShareForceSalting()).ToDataRes(types.Int)
+	},
+	"vsphere.host.dvFilterBindIpAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetDvFilterBindIpAddress()).ToDataRes(types.String)
+	},
 	"vsphere.host.bootTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetBootTime()).ToDataRes(types.Time)
 	},
@@ -2520,6 +2550,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.secureBootEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).SecureBootEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.accountLockFailures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).AccountLockFailures, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.accountUnlockTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).AccountUnlockTime, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.esxiShellInteractiveTimeOut": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).EsxiShellInteractiveTimeOut, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.esxiShellTimeOut": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).EsxiShellTimeOut, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.dcuiTimeOut": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).DcuiTimeOut, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.mobEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).MobEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.syslogLogHost": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).SyslogLogHost, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.syslogLogDir": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).SyslogLogDir, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.memShareForceSalting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).MemShareForceSalting, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.dvFilterBindIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).DvFilterBindIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"vsphere.host.bootTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5749,44 +5819,54 @@ type mqlVsphereHost struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlVsphereHostInternal
-	Moid                    plugin.TValue[string]
-	Name                    plugin.TValue[string]
-	InventoryPath           plugin.TValue[string]
-	Properties              plugin.TValue[any]
-	StandardSwitch          plugin.TValue[[]any]
-	DistributedSwitch       plugin.TValue[[]any]
-	Adapters                plugin.TValue[[]any]
-	Vmknics                 plugin.TValue[[]any]
-	Packages                plugin.TValue[[]any]
-	AcceptanceLevel         plugin.TValue[string]
-	KernelModules           plugin.TValue[[]any]
-	AdvancedSettings        plugin.TValue[map[string]any]
-	Services                plugin.TValue[[]any]
-	Timezone                plugin.TValue[*mqlVsphereHostTimezone]
-	Ntp                     plugin.TValue[*mqlVsphereHostNtpConfig]
-	Snmp                    plugin.TValue[map[string]any]
-	Tags                    plugin.TValue[[]any]
-	LockdownMode            plugin.TValue[string]
-	FirewallIncomingBlocked plugin.TValue[bool]
-	FirewallOutgoingBlocked plugin.TValue[bool]
-	SecureBootEnabled       plugin.TValue[bool]
-	BootTime                plugin.TValue[*time.Time]
-	InMaintenanceMode       plugin.TValue[bool]
-	RebootRequired          plugin.TValue[bool]
-	Certificate             plugin.TValue[*mqlVsphereHostCertificate]
-	Vendor                  plugin.TValue[string]
-	Model                   plugin.TValue[string]
-	CpuMhz                  plugin.TValue[int64]
-	NumCpuCores             plugin.TValue[int64]
-	FirewallRulesets        plugin.TValue[[]any]
-	IscsiAdapters           plugin.TValue[[]any]
-	Cluster                 plugin.TValue[*mqlVsphereCluster]
-	Datastores              plugin.TValue[[]any]
-	BootInfo                plugin.TValue[*mqlVsphereHostBootInfo]
-	SystemInfo              plugin.TValue[*mqlVsphereHostSystemInfo]
-	DnsConfig               plugin.TValue[*mqlVsphereHostDnsConfig]
-	IpRouteConfig           plugin.TValue[*mqlVsphereHostIpRouteConfig]
-	Vsan                    plugin.TValue[*mqlVsphereHostVsan]
+	Moid                        plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	InventoryPath               plugin.TValue[string]
+	Properties                  plugin.TValue[any]
+	StandardSwitch              plugin.TValue[[]any]
+	DistributedSwitch           plugin.TValue[[]any]
+	Adapters                    plugin.TValue[[]any]
+	Vmknics                     plugin.TValue[[]any]
+	Packages                    plugin.TValue[[]any]
+	AcceptanceLevel             plugin.TValue[string]
+	KernelModules               plugin.TValue[[]any]
+	AdvancedSettings            plugin.TValue[map[string]any]
+	Services                    plugin.TValue[[]any]
+	Timezone                    plugin.TValue[*mqlVsphereHostTimezone]
+	Ntp                         plugin.TValue[*mqlVsphereHostNtpConfig]
+	Snmp                        plugin.TValue[map[string]any]
+	Tags                        plugin.TValue[[]any]
+	LockdownMode                plugin.TValue[string]
+	FirewallIncomingBlocked     plugin.TValue[bool]
+	FirewallOutgoingBlocked     plugin.TValue[bool]
+	SecureBootEnabled           plugin.TValue[bool]
+	AccountLockFailures         plugin.TValue[int64]
+	AccountUnlockTime           plugin.TValue[int64]
+	EsxiShellInteractiveTimeOut plugin.TValue[int64]
+	EsxiShellTimeOut            plugin.TValue[int64]
+	DcuiTimeOut                 plugin.TValue[int64]
+	MobEnabled                  plugin.TValue[bool]
+	SyslogLogHost               plugin.TValue[string]
+	SyslogLogDir                plugin.TValue[string]
+	MemShareForceSalting        plugin.TValue[int64]
+	DvFilterBindIpAddress       plugin.TValue[string]
+	BootTime                    plugin.TValue[*time.Time]
+	InMaintenanceMode           plugin.TValue[bool]
+	RebootRequired              plugin.TValue[bool]
+	Certificate                 plugin.TValue[*mqlVsphereHostCertificate]
+	Vendor                      plugin.TValue[string]
+	Model                       plugin.TValue[string]
+	CpuMhz                      plugin.TValue[int64]
+	NumCpuCores                 plugin.TValue[int64]
+	FirewallRulesets            plugin.TValue[[]any]
+	IscsiAdapters               plugin.TValue[[]any]
+	Cluster                     plugin.TValue[*mqlVsphereCluster]
+	Datastores                  plugin.TValue[[]any]
+	BootInfo                    plugin.TValue[*mqlVsphereHostBootInfo]
+	SystemInfo                  plugin.TValue[*mqlVsphereHostSystemInfo]
+	DnsConfig                   plugin.TValue[*mqlVsphereHostDnsConfig]
+	IpRouteConfig               plugin.TValue[*mqlVsphereHostIpRouteConfig]
+	Vsan                        plugin.TValue[*mqlVsphereHostVsan]
 }
 
 // createVsphereHost creates a new instance of this resource
@@ -6022,6 +6102,66 @@ func (c *mqlVsphereHost) GetFirewallOutgoingBlocked() *plugin.TValue[bool] {
 
 func (c *mqlVsphereHost) GetSecureBootEnabled() *plugin.TValue[bool] {
 	return &c.SecureBootEnabled
+}
+
+func (c *mqlVsphereHost) GetAccountLockFailures() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.AccountLockFailures, func() (int64, error) {
+		return c.accountLockFailures()
+	})
+}
+
+func (c *mqlVsphereHost) GetAccountUnlockTime() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.AccountUnlockTime, func() (int64, error) {
+		return c.accountUnlockTime()
+	})
+}
+
+func (c *mqlVsphereHost) GetEsxiShellInteractiveTimeOut() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.EsxiShellInteractiveTimeOut, func() (int64, error) {
+		return c.esxiShellInteractiveTimeOut()
+	})
+}
+
+func (c *mqlVsphereHost) GetEsxiShellTimeOut() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.EsxiShellTimeOut, func() (int64, error) {
+		return c.esxiShellTimeOut()
+	})
+}
+
+func (c *mqlVsphereHost) GetDcuiTimeOut() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.DcuiTimeOut, func() (int64, error) {
+		return c.dcuiTimeOut()
+	})
+}
+
+func (c *mqlVsphereHost) GetMobEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MobEnabled, func() (bool, error) {
+		return c.mobEnabled()
+	})
+}
+
+func (c *mqlVsphereHost) GetSyslogLogHost() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SyslogLogHost, func() (string, error) {
+		return c.syslogLogHost()
+	})
+}
+
+func (c *mqlVsphereHost) GetSyslogLogDir() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SyslogLogDir, func() (string, error) {
+		return c.syslogLogDir()
+	})
+}
+
+func (c *mqlVsphereHost) GetMemShareForceSalting() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.MemShareForceSalting, func() (int64, error) {
+		return c.memShareForceSalting()
+	})
+}
+
+func (c *mqlVsphereHost) GetDvFilterBindIpAddress() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.DvFilterBindIpAddress, func() (string, error) {
+		return c.dvFilterBindIpAddress()
+	})
 }
 
 func (c *mqlVsphereHost) GetBootTime() *plugin.TValue[*time.Time] {

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -151,6 +151,8 @@ vsphere.folder.name 13.0.12
 vsphere.folders 13.0.12
 vsphere.host 9.0.0
 vsphere.host.acceptanceLevel 9.0.0
+vsphere.host.accountLockFailures 13.4.3
+vsphere.host.accountUnlockTime 13.4.3
 vsphere.host.adapters 9.0.0
 vsphere.host.advancedSettings 9.0.0
 vsphere.host.bootInfo 13.1.1
@@ -177,6 +179,7 @@ vsphere.host.command.inventoryPath 13.1.1
 vsphere.host.command.result 13.1.1
 vsphere.host.cpuMhz 13.0.12
 vsphere.host.datastores 13.0.12
+vsphere.host.dcuiTimeOut 13.4.3
 vsphere.host.distributedSwitch 9.0.0
 vsphere.host.dnsConfig 13.1.1
 vsphere.host.dnsConfig.dhcp 13.1.1
@@ -186,6 +189,9 @@ vsphere.host.dnsConfig.hostName 13.1.1
 vsphere.host.dnsConfig.searchDomains 13.1.1
 vsphere.host.dnsConfig.servers 13.1.1
 vsphere.host.dnsConfig.virtualNicDevice 13.1.1
+vsphere.host.dvFilterBindIpAddress 13.4.3
+vsphere.host.esxiShellInteractiveTimeOut 13.4.3
+vsphere.host.esxiShellTimeOut 13.4.3
 vsphere.host.firewallIncomingBlocked 13.0.11
 vsphere.host.firewallOutgoingBlocked 13.0.11
 vsphere.host.firewallRule 13.1.1
@@ -238,6 +244,8 @@ vsphere.host.kernelModule.version 13.1.1
 vsphere.host.kernelModule.vibAcceptanceLevel 13.1.1
 vsphere.host.kernelModules 9.0.0
 vsphere.host.lockdownMode 13.0.10
+vsphere.host.memShareForceSalting 13.4.3
+vsphere.host.mobEnabled 13.4.3
 vsphere.host.model 13.0.12
 vsphere.host.moid 9.0.0
 vsphere.host.name 9.0.0
@@ -261,6 +269,8 @@ vsphere.host.service.running 13.1.1
 vsphere.host.services 9.0.0
 vsphere.host.snmp 9.0.0
 vsphere.host.standardSwitch 9.0.0
+vsphere.host.syslogLogDir 13.4.3
+vsphere.host.syslogLogHost 13.4.3
 vsphere.host.systemInfo 13.1.1
 vsphere.host.systemInfo.assetTag 13.1.1
 vsphere.host.systemInfo.installDate 13.1.1


### PR DESCRIPTION
## What

Promotes the ESXi host hardening options that `mondoo-vmware-vsphere-esxi-security` audits from string-key `advancedSettings[...]` lookups to typed fields on `vsphere.host`:

| Field | Backing advanced setting |
|-------|--------------------------|
| `accountLockFailures` | `Security.AccountLockFailures` |
| `accountUnlockTime` | `Security.AccountUnlockTime` |
| `esxiShellInteractiveTimeOut` | `UserVars.ESXiShellInteractiveTimeOut` |
| `esxiShellTimeOut` | `UserVars.ESXiShellTimeOut` |
| `dcuiTimeOut` | `UserVars.DcuiTimeOut` |
| `mobEnabled` | `Config.HostAgent.plugins.solo.enableMob` |
| `syslogLogHost` | `Syslog.global.logHost` |
| `syslogLogDir` | `Syslog.global.logDir` |
| `memShareForceSalting` | `Mem.ShareForceSalting` |
| `dvFilterBindIpAddress` | `Net.DVFilterBindIpAddress` |

## Why

These let host hardening checks read `vsphere.host.all(accountLockFailures <= 5)` instead of `vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5` — no string keys, no manual `.downcase`/type juggling. ~10 ESXi baseline checks simplify.

## How

Each resolver reads the already-memoized `advancedSettings` map (which stores every option as its fmt-formatted string), so there are **no additional SOAP calls** and the typed values always agree with the raw map. The `advancedSettings` map is retained for backward compatibility. Parsing is factored into pure, tested helpers `parseHostAdvancedSettingInt` and `parseHostBoolSetting`.

## Verification

- `./lr go` / `./lr versions` regen clean
- `make providers/build/vsphere` compiles
- `go vet ./resources/` clean
- `go test ./resources/` passes (incl. new `host_settings_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)