### PR TITLE
✨ tailscale: typed hasExpiration and isRevoked on authKey

### DIFF
--- a/providers/tailscale/resources/keys.go
+++ b/providers/tailscale/resources/keys.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"time"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -16,6 +17,31 @@ import (
 
 func (r *mqlTailscaleAuthKey) id() (string, error) {
 	return "tailscale/authKey/" + r.Id.Data, nil
+}
+
+// timeIsSet reports whether a Tailscale timestamp represents a real value.
+// Tailscale encodes "unset" timestamps as the zero time (Unix epoch 0 /
+// 0001-01-01), which the resource carries as a nil or zero-valued *time.Time.
+func timeIsSet(t *time.Time) bool {
+	return t != nil && !t.IsZero()
+}
+
+// hasExpiration reports whether the key has an expiration set. A key with no
+// expiration carries the zero time in `expires`.
+func (r *mqlTailscaleAuthKey) hasExpiration() (bool, error) {
+	if r.Expires.Error != nil {
+		return false, r.Expires.Error
+	}
+	return timeIsSet(r.Expires.Data), nil
+}
+
+// isRevoked reports whether the key has been revoked. A key that has not been
+// revoked carries the zero time in `revoked`.
+func (r *mqlTailscaleAuthKey) isRevoked() (bool, error) {
+	if r.Revoked.Error != nil {
+		return false, r.Revoked.Error
+	}
+	return timeIsSet(r.Revoked.Data), nil
 }
 
 func initTailscaleAuthKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/tailscale/resources/keys_test.go
+++ b/providers/tailscale/resources/keys_test.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeIsSet(t *testing.T) {
+	set := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	zero := time.Time{}
+	epoch := time.Unix(0, 0)
+
+	tests := []struct {
+		name string
+		in   *time.Time
+		want bool
+	}{
+		{name: "nil pointer", in: nil, want: false},
+		{name: "zero time (0001-01-01)", in: &zero, want: false},
+		{name: "real timestamp", in: &set, want: true},
+		// Tailscale's "unset" is the Go zero time; a genuine Unix epoch 0 is
+		// non-zero in Go terms and is treated as set.
+		{name: "unix epoch 0", in: &epoch, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := timeIsSet(tc.in); got != tc.want {
+				t.Fatalf("timeIsSet(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/tailscale/resources/tailscale.lr
+++ b/providers/tailscale/resources/tailscale.lr
@@ -225,8 +225,12 @@ private tailscale.authKey @defaults("id description expires revoked") {
   created time
   // Time the key expires; the zero value means the key never expires
   expires time
+  // Whether the key has an expiration set (false means the key never expires)
+  hasExpiration() bool
   // Time the key was revoked; the zero value means the key has not been revoked
   revoked time
+  // Whether the key has been revoked
+  isRevoked() bool
   // Whether the key has been marked invalid (revoked or its tailnet was deleted)
   invalid bool
   // Whether the key can be used to authenticate more than one device

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -341,8 +341,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.authKey.expires": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetExpires()).ToDataRes(types.Time)
 	},
+	"tailscale.authKey.hasExpiration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAuthKey).GetHasExpiration()).ToDataRes(types.Bool)
+	},
 	"tailscale.authKey.revoked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetRevoked()).ToDataRes(types.Time)
+	},
+	"tailscale.authKey.isRevoked": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAuthKey).GetIsRevoked()).ToDataRes(types.Bool)
 	},
 	"tailscale.authKey.invalid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetInvalid()).ToDataRes(types.Bool)
@@ -729,8 +735,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTailscaleAuthKey).Expires, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"tailscale.authKey.hasExpiration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAuthKey).HasExpiration, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"tailscale.authKey.revoked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAuthKey).Revoked, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"tailscale.authKey.isRevoked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAuthKey).IsRevoked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"tailscale.authKey.invalid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1467,7 +1481,9 @@ type mqlTailscaleAuthKey struct {
 	UserId        plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	Expires       plugin.TValue[*time.Time]
+	HasExpiration plugin.TValue[bool]
 	Revoked       plugin.TValue[*time.Time]
+	IsRevoked     plugin.TValue[bool]
 	Invalid       plugin.TValue[bool]
 	Reusable      plugin.TValue[bool]
 	Ephemeral     plugin.TValue[bool]
@@ -1532,8 +1548,20 @@ func (c *mqlTailscaleAuthKey) GetExpires() *plugin.TValue[*time.Time] {
 	return &c.Expires
 }
 
+func (c *mqlTailscaleAuthKey) GetHasExpiration() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasExpiration, func() (bool, error) {
+		return c.hasExpiration()
+	})
+}
+
 func (c *mqlTailscaleAuthKey) GetRevoked() *plugin.TValue[*time.Time] {
 	return &c.Revoked
+}
+
+func (c *mqlTailscaleAuthKey) GetIsRevoked() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsRevoked, func() (bool, error) {
+		return c.isRevoked()
+	})
 }
 
 func (c *mqlTailscaleAuthKey) GetInvalid() *plugin.TValue[bool] {

--- a/providers/tailscale/resources/tailscale.lr.versions
+++ b/providers/tailscale/resources/tailscale.lr.versions
@@ -25,8 +25,10 @@ tailscale.authKey.created 13.1.8
 tailscale.authKey.description 13.1.8
 tailscale.authKey.ephemeral 13.1.8
 tailscale.authKey.expires 13.1.8
+tailscale.authKey.hasExpiration 13.2.4
 tailscale.authKey.id 13.1.8
 tailscale.authKey.invalid 13.1.8
+tailscale.authKey.isRevoked 13.2.4
 tailscale.authKey.preauthorized 13.1.8
 tailscale.authKey.reusable 13.1.8
 tailscale.authKey.revoked 13.1.8


### PR DESCRIPTION
## What

Adds two computed boolean fields to the `tailscale.authKey` resource:

- `hasExpiration bool` — true when the key has an expiration set.
- `isRevoked bool` — true when the key has been revoked.

## Why

The `mondoo-tailscale-security` policy currently expresses "key is not revoked and has an expiration" with a zero-time workaround:

```
tailscale.authKeys.where(invalid == false && revoked.unix == 0).all(expires.unix > 0)
```

This leans on the implementation detail that Tailscale encodes unset timestamps as the zero time (Unix epoch 0 / `0001-01-01`). Surfacing typed booleans lets policies read the intent directly (`hasExpiration`, `isRevoked`) instead of reasoning about `.unix == 0` / `.unix > 0`.

## How

- Declared `hasExpiration()` and `isRevoked()` as lazy resolver fields in `tailscale.lr` and regenerated `tailscale.lr.go` / `tailscale.lr.versions`.
- Implemented both resolvers in `keys.go`, computed from the existing `expires` / `revoked` fields (backed by the SDK's `time.Time` values) via a small pure `timeIsSet` helper that treats nil or zero time as "unset".
- Unit-tested `timeIsSet` (nil, Go zero time, real timestamp, Unix epoch 0).

## Verification

- `./lr go` + `./lr versions` regen clean.
- `SKIP_COMPILE=no make providers/build/tailscale` compiles.
- `go vet ./resources/` passes.
- `go test ./resources/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)