### PR TITLE
✨ okta: typed security notification email flags on organization

### DIFF
--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -89,6 +89,16 @@ okta.organization @defaults("companyName") {
   technicalContact() okta.user
   // Security notification email
   securityNotificationEmails() dict
+  // Whether users can report suspicious activity via email
+  reportSuspiciousActivityEnabled() bool
+  // Whether a notification email is sent when a user signs in from a new device
+  sendEmailForNewDeviceEnabled() bool
+  // Whether a notification email is sent when a user enrolls a new MFA factor
+  sendEmailForFactorEnrollmentEnabled() bool
+  // Whether a notification email is sent when a user resets an MFA factor
+  sendEmailForFactorResetEnabled() bool
+  // Whether a notification email is sent when a user's password is changed
+  sendEmailForPasswordChangedEnabled() bool
   // Okta ThreatInsight settings
   threatInsightSettings() okta.threatsConfiguration
 }

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -327,6 +327,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"okta.organization.securityNotificationEmails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaOrganization).GetSecurityNotificationEmails()).ToDataRes(types.Dict)
 	},
+	"okta.organization.reportSuspiciousActivityEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaOrganization).GetReportSuspiciousActivityEnabled()).ToDataRes(types.Bool)
+	},
+	"okta.organization.sendEmailForNewDeviceEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaOrganization).GetSendEmailForNewDeviceEnabled()).ToDataRes(types.Bool)
+	},
+	"okta.organization.sendEmailForFactorEnrollmentEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaOrganization).GetSendEmailForFactorEnrollmentEnabled()).ToDataRes(types.Bool)
+	},
+	"okta.organization.sendEmailForFactorResetEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaOrganization).GetSendEmailForFactorResetEnabled()).ToDataRes(types.Bool)
+	},
+	"okta.organization.sendEmailForPasswordChangedEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaOrganization).GetSendEmailForPasswordChangedEnabled()).ToDataRes(types.Bool)
+	},
 	"okta.organization.threatInsightSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaOrganization).GetThreatInsightSettings()).ToDataRes(types.Resource("okta.threatsConfiguration"))
 	},
@@ -1263,6 +1278,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"okta.organization.securityNotificationEmails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaOrganization).SecurityNotificationEmails, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"okta.organization.reportSuspiciousActivityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaOrganization).ReportSuspiciousActivityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"okta.organization.sendEmailForNewDeviceEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaOrganization).SendEmailForNewDeviceEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"okta.organization.sendEmailForFactorEnrollmentEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaOrganization).SendEmailForFactorEnrollmentEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"okta.organization.sendEmailForFactorResetEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaOrganization).SendEmailForFactorResetEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"okta.organization.sendEmailForPasswordChangedEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaOrganization).SendEmailForPasswordChangedEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"okta.organization.threatInsightSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2690,28 +2725,33 @@ type mqlOktaOrganization struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOktaOrganizationInternal it will be used here
-	Id                         plugin.TValue[string]
-	CompanyName                plugin.TValue[string]
-	Status                     plugin.TValue[string]
-	Subdomain                  plugin.TValue[string]
-	Address1                   plugin.TValue[string]
-	Address2                   plugin.TValue[string]
-	City                       plugin.TValue[string]
-	State                      plugin.TValue[string]
-	PhoneNumber                plugin.TValue[string]
-	PostalCode                 plugin.TValue[string]
-	Country                    plugin.TValue[string]
-	SupportPhoneNumber         plugin.TValue[string]
-	Website                    plugin.TValue[string]
-	EndUserSupportHelpURL      plugin.TValue[string]
-	Created                    plugin.TValue[*time.Time]
-	LastUpdated                plugin.TValue[*time.Time]
-	ExpiresAt                  plugin.TValue[*time.Time]
-	OptOutCommunicationEmails  plugin.TValue[bool]
-	BillingContact             plugin.TValue[*mqlOktaUser]
-	TechnicalContact           plugin.TValue[*mqlOktaUser]
-	SecurityNotificationEmails plugin.TValue[any]
-	ThreatInsightSettings      plugin.TValue[*mqlOktaThreatsConfiguration]
+	Id                                  plugin.TValue[string]
+	CompanyName                         plugin.TValue[string]
+	Status                              plugin.TValue[string]
+	Subdomain                           plugin.TValue[string]
+	Address1                            plugin.TValue[string]
+	Address2                            plugin.TValue[string]
+	City                                plugin.TValue[string]
+	State                               plugin.TValue[string]
+	PhoneNumber                         plugin.TValue[string]
+	PostalCode                          plugin.TValue[string]
+	Country                             plugin.TValue[string]
+	SupportPhoneNumber                  plugin.TValue[string]
+	Website                             plugin.TValue[string]
+	EndUserSupportHelpURL               plugin.TValue[string]
+	Created                             plugin.TValue[*time.Time]
+	LastUpdated                         plugin.TValue[*time.Time]
+	ExpiresAt                           plugin.TValue[*time.Time]
+	OptOutCommunicationEmails           plugin.TValue[bool]
+	BillingContact                      plugin.TValue[*mqlOktaUser]
+	TechnicalContact                    plugin.TValue[*mqlOktaUser]
+	SecurityNotificationEmails          plugin.TValue[any]
+	ReportSuspiciousActivityEnabled     plugin.TValue[bool]
+	SendEmailForNewDeviceEnabled        plugin.TValue[bool]
+	SendEmailForFactorEnrollmentEnabled plugin.TValue[bool]
+	SendEmailForFactorResetEnabled      plugin.TValue[bool]
+	SendEmailForPasswordChangedEnabled  plugin.TValue[bool]
+	ThreatInsightSettings               plugin.TValue[*mqlOktaThreatsConfiguration]
 }
 
 // createOktaOrganization creates a new instance of this resource
@@ -2860,6 +2900,36 @@ func (c *mqlOktaOrganization) GetTechnicalContact() *plugin.TValue[*mqlOktaUser]
 func (c *mqlOktaOrganization) GetSecurityNotificationEmails() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityNotificationEmails, func() (any, error) {
 		return c.securityNotificationEmails()
+	})
+}
+
+func (c *mqlOktaOrganization) GetReportSuspiciousActivityEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ReportSuspiciousActivityEnabled, func() (bool, error) {
+		return c.reportSuspiciousActivityEnabled()
+	})
+}
+
+func (c *mqlOktaOrganization) GetSendEmailForNewDeviceEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SendEmailForNewDeviceEnabled, func() (bool, error) {
+		return c.sendEmailForNewDeviceEnabled()
+	})
+}
+
+func (c *mqlOktaOrganization) GetSendEmailForFactorEnrollmentEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SendEmailForFactorEnrollmentEnabled, func() (bool, error) {
+		return c.sendEmailForFactorEnrollmentEnabled()
+	})
+}
+
+func (c *mqlOktaOrganization) GetSendEmailForFactorResetEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SendEmailForFactorResetEnabled, func() (bool, error) {
+		return c.sendEmailForFactorResetEnabled()
+	})
+}
+
+func (c *mqlOktaOrganization) GetSendEmailForPasswordChangedEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SendEmailForPasswordChangedEnabled, func() (bool, error) {
+		return c.sendEmailForPasswordChangedEnabled()
 	})
 }
 

--- a/providers/okta/resources/okta.lr.versions
+++ b/providers/okta/resources/okta.lr.versions
@@ -233,7 +233,12 @@ okta.organization.lastUpdated 9.0.0
 okta.organization.optOutCommunicationEmails 9.0.0
 okta.organization.phoneNumber 9.0.0
 okta.organization.postalCode 9.0.0
+okta.organization.reportSuspiciousActivityEnabled 13.2.9
 okta.organization.securityNotificationEmails 9.0.0
+okta.organization.sendEmailForFactorEnrollmentEnabled 13.2.9
+okta.organization.sendEmailForFactorResetEnabled 13.2.9
+okta.organization.sendEmailForNewDeviceEnabled 13.2.9
+okta.organization.sendEmailForPasswordChangedEnabled 13.2.9
 okta.organization.state 9.0.0
 okta.organization.status 9.0.0
 okta.organization.subdomain 9.0.0

--- a/providers/okta/resources/organization.go
+++ b/providers/okta/resources/organization.go
@@ -138,6 +138,52 @@ func (o *mqlOktaOrganization) securityNotificationEmails() (any, error) {
 	return convert.JsonToDict(emails)
 }
 
+// securityNotificationEmailFlag extracts a boolean flag by key from the
+// securityNotificationEmails dict. It returns false when the dict is nil, the
+// key is absent, or the stored value is not a bool.
+func securityNotificationEmailFlag(emails any, key string) bool {
+	m, ok := emails.(map[string]any)
+	if !ok {
+		return false
+	}
+	v, ok := m[key].(bool)
+	if !ok {
+		return false
+	}
+	return v
+}
+
+// securityNotificationFlag reads the memoized securityNotificationEmails dict
+// and extracts the given boolean key, so the typed fields always agree with the
+// dict.
+func (o *mqlOktaOrganization) securityNotificationFlag(key string) (bool, error) {
+	emails := o.GetSecurityNotificationEmails()
+	if emails.Error != nil {
+		return false, emails.Error
+	}
+	return securityNotificationEmailFlag(emails.Data, key), nil
+}
+
+func (o *mqlOktaOrganization) reportSuspiciousActivityEnabled() (bool, error) {
+	return o.securityNotificationFlag("reportSuspiciousActivityEnabled")
+}
+
+func (o *mqlOktaOrganization) sendEmailForNewDeviceEnabled() (bool, error) {
+	return o.securityNotificationFlag("sendEmailForNewDeviceEnabled")
+}
+
+func (o *mqlOktaOrganization) sendEmailForFactorEnrollmentEnabled() (bool, error) {
+	return o.securityNotificationFlag("sendEmailForFactorEnrollmentEnabled")
+}
+
+func (o *mqlOktaOrganization) sendEmailForFactorResetEnabled() (bool, error) {
+	return o.securityNotificationFlag("sendEmailForFactorResetEnabled")
+}
+
+func (o *mqlOktaOrganization) sendEmailForPasswordChangedEnabled() (bool, error) {
+	return o.securityNotificationFlag("sendEmailForPasswordChangedEnabled")
+}
+
 // threatInsightSettings returns the Threat Insight settings for the organization
 func (o *mqlOktaOrganization) threatInsightSettings() (*mqlOktaThreatsConfiguration, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)

--- a/providers/okta/resources/organization_test.go
+++ b/providers/okta/resources/organization_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestSecurityNotificationEmailFlag(t *testing.T) {
+	emails := map[string]any{
+		"reportSuspiciousActivityEnabled":     true,
+		"sendEmailForNewDeviceEnabled":        false,
+		"sendEmailForFactorEnrollmentEnabled": true,
+		"sendEmailForFactorResetEnabled":      false,
+		"sendEmailForPasswordChangedEnabled":  true,
+	}
+
+	tests := []struct {
+		name  string
+		input any
+		key   string
+		want  bool
+	}{
+		{"true value", emails, "reportSuspiciousActivityEnabled", true},
+		{"false value", emails, "sendEmailForNewDeviceEnabled", false},
+		{"another true value", emails, "sendEmailForFactorEnrollmentEnabled", true},
+		{"missing key", emails, "doesNotExist", false},
+		{"nil input", nil, "reportSuspiciousActivityEnabled", false},
+		{"wrong input type", "not a map", "reportSuspiciousActivityEnabled", false},
+		{"non-bool value", map[string]any{"x": "true"}, "x", false},
+		{"empty map", map[string]any{}, "reportSuspiciousActivityEnabled", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := securityNotificationEmailFlag(tt.input, tt.key); got != tt.want {
+				t.Errorf("securityNotificationEmailFlag(%v, %q) = %v, want %v", tt.input, tt.key, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds five typed boolean fields to the `okta.organization` resource, promoting the string-keyed `securityNotificationEmails` dict into first-class typed accessors:

- `reportSuspiciousActivityEnabled`
- `sendEmailForNewDeviceEnabled`
- `sendEmailForFactorEnrollmentEnabled`
- `sendEmailForFactorResetEnabled`
- `sendEmailForPasswordChangedEnabled`

The existing `securityNotificationEmails` dict field is kept for backward compatibility.

## Why

Policies (e.g. `mondoo-okta-security`) currently access these settings via brittle string-key dict lookups like `okta.organization.securityNotificationEmails['reportSuspiciousActivityEnabled'] == true`. Typed bool fields give checks compile-time safety, better autocompletion, and cleaner MQL.

## How

The five resolvers read the same memoized `securityNotificationEmails` dict (sourced from the Okta security-notification-settings API via `convert.JsonToDict`) and extract each key, so the typed fields always agree with the dict. Key extraction is factored into a small pure helper `securityNotificationEmailFlag` that returns `false` for a nil/absent/wrong-typed value, and is unit tested.

## Verification

- `make providers/lr` then `./lr go` + `./lr versions` to regenerate `okta.lr.go` and `okta.lr.versions`
- `SKIP_COMPILE=no make providers/build/okta` — compiles cleanly
- `go vet ./resources/` — clean
- `go test ./resources/` — passes (including new `TestSecurityNotificationEmailFlag`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)