### PR TITLE
✨ openstack: typed imageSignature on image

### DIFF
--- a/providers/openstack/resources/images.go
+++ b/providers/openstack/resources/images.go
@@ -95,6 +95,30 @@ func (o *mqlOpenstack) images() ([]any, error) {
 	return out, nil
 }
 
+// imageSignatureFromProperties extracts the Glance `img_signature` property
+// value from an image's free-form properties dict. It returns an empty string
+// when the property is absent, null, or not a string (i.e. the image is
+// unsigned).
+func imageSignatureFromProperties(properties any) string {
+	props, ok := properties.(map[string]any)
+	if !ok {
+		return ""
+	}
+	sig, ok := props["img_signature"].(string)
+	if !ok {
+		return ""
+	}
+	return sig
+}
+
+func (r *mqlOpenstackImage) imageSignature() (string, error) {
+	props := r.GetProperties()
+	if props.Error != nil {
+		return "", props.Error
+	}
+	return imageSignatureFromProperties(props.Data), nil
+}
+
 func (r *mqlOpenstackImage) owner() (*mqlOpenstackProject, error) {
 	if r.cacheOwnerID == "" {
 		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/openstack/resources/images_test.go
+++ b/providers/openstack/resources/images_test.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageSignatureFromProperties(t *testing.T) {
+	t.Run("nil properties returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", imageSignatureFromProperties(nil))
+	})
+	t.Run("non-map properties returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", imageSignatureFromProperties("not-a-map"))
+	})
+	t.Run("missing img_signature returns empty string", func(t *testing.T) {
+		props := map[string]any{"os_distro": "ubuntu"}
+		assert.Equal(t, "", imageSignatureFromProperties(props))
+	})
+	t.Run("null img_signature returns empty string", func(t *testing.T) {
+		props := map[string]any{"img_signature": nil}
+		assert.Equal(t, "", imageSignatureFromProperties(props))
+	})
+	t.Run("non-string img_signature returns empty string", func(t *testing.T) {
+		props := map[string]any{"img_signature": 42}
+		assert.Equal(t, "", imageSignatureFromProperties(props))
+	})
+	t.Run("string img_signature is returned", func(t *testing.T) {
+		props := map[string]any{"img_signature": "c2lnbmF0dXJl"}
+		assert.Equal(t, "c2lnbmF0dXJl", imageSignatureFromProperties(props))
+	})
+	t.Run("empty img_signature is returned as empty string", func(t *testing.T) {
+		props := map[string]any{"img_signature": ""}
+		assert.Equal(t, "", imageSignatureFromProperties(props))
+	})
+}

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -736,6 +736,8 @@ private openstack.image @defaults("id name status visibility") {
   //
   // Carries Glance signing fields (`img_signature`, `img_signature_hash_method`, `img_signature_key_type`, `img_signature_certificate_uuid`), kernel/ramdisk references, and OS distro hints.
   properties dict
+  // Glance image signature (`img_signature` property); empty string when the image is unsigned
+  imageSignature() string
   // Creation timestamp
   createdAt time
   // Last update timestamp

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -1341,6 +1341,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.image.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackImage).GetProperties()).ToDataRes(types.Dict)
 	},
+	"openstack.image.imageSignature": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackImage).GetImageSignature()).ToDataRes(types.String)
+	},
 	"openstack.image.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackImage).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -4591,6 +4594,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.image.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackImage).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"openstack.image.imageSignature": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackImage).ImageSignature, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.image.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11073,6 +11080,7 @@ type mqlOpenstackImage struct {
 	Tags             plugin.TValue[[]any]
 	Metadata         plugin.TValue[map[string]any]
 	Properties       plugin.TValue[any]
+	ImageSignature   plugin.TValue[string]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
 	Owner            plugin.TValue[*mqlOpenstackProject]
@@ -11178,6 +11186,12 @@ func (c *mqlOpenstackImage) GetMetadata() *plugin.TValue[map[string]any] {
 
 func (c *mqlOpenstackImage) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlOpenstackImage) GetImageSignature() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ImageSignature, func() (string, error) {
+		return c.imageSignature()
+	})
 }
 
 func (c *mqlOpenstackImage) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -474,6 +474,7 @@ openstack.image.createdAt 13.0.1
 openstack.image.diskFormat 13.0.1
 openstack.image.hidden 13.0.1
 openstack.image.id 13.0.1
+openstack.image.imageSignature 13.3.2
 openstack.image.member 13.0.1
 openstack.image.member.createdAt 13.0.1
 openstack.image.member.image 13.0.1


### PR DESCRIPTION
## What

Adds a typed `imageSignature string` field to the `openstack.image` resource. It promotes the Glance `img_signature` image property out of the untyped `properties` dict, returning an empty string when the image is unsigned. The `properties` dict is retained for backward compatibility.

## Why

Image-signing policies currently have to reach into the free-form dict, e.g. `properties['img_signature'] != null && properties['img_signature'] != ""`. A typed field lets those checks become a clean `imageSignature != ""`, which is clearer and less error-prone.

## How

- Declared `imageSignature() string` (lazy) on `openstack.image` in `openstack.lr`, regenerated `openstack.lr.go` / `openstack.lr.versions`.
- The resolver reads the memoized `properties` dict getter and extracts `img_signature` via a small pure helper, `imageSignatureFromProperties`, which handles nil/non-map/non-string/missing cases by returning `""`. This sources the typed value from the same Glance properties map that backs the dict.
- Added unit tests for the helper.

## Verification

- `SKIP_COMPILE=no make providers/build/openstack` — compiles.
- `go vet ./resources/` — clean.
- `go test ./resources/` — passes (includes new `TestImageSignatureFromProperties`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)