### PR TITLE
✨ nutanix: typed usesLdaps on directory service

### DIFF
--- a/providers/nutanix/resources/iam.go
+++ b/providers/nutanix/resources/iam.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 
 	authn "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authn"
 	authz "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authz"
@@ -384,6 +385,20 @@ func (a *mqlNutanix) directoryServices() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+// urlUsesLdaps reports whether the given URL uses the secure LDAPS scheme,
+// matching the "ldaps://" prefix case-insensitively.
+func urlUsesLdaps(url string) bool {
+	return strings.HasPrefix(strings.ToLower(url), "ldaps://")
+}
+
+func (d *mqlNutanixIamDirectoryService) usesLdaps() (bool, error) {
+	url := d.GetUrl()
+	if url.Error != nil {
+		return false, url.Error
+	}
+	return urlUsesLdaps(url.Data), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/nutanix/resources/iam_test.go
+++ b/providers/nutanix/resources/iam_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestUrlUsesLdaps(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "ldaps lowercase", url: "ldaps://dc.example.com:636", want: true},
+		{name: "ldaps uppercase", url: "LDAPS://dc.example.com:636", want: true},
+		{name: "ldaps mixed case", url: "LdApS://dc.example.com:636", want: true},
+		{name: "ldap insecure", url: "ldap://dc.example.com:389", want: false},
+		{name: "empty", url: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := urlUsesLdaps(tt.url); got != tt.want {
+				t.Errorf("urlUsesLdaps(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/nutanix/resources/nutanix.lr
+++ b/providers/nutanix/resources/nutanix.lr
@@ -755,6 +755,8 @@ private nutanix.iam.directoryService @defaults("name directoryType domainName") 
   domainName string
   // Primary server URL
   url string
+  // Whether the primary server URL uses the secure LDAPS scheme
+  usesLdaps() bool
   // Secondary server URLs
   secondaryUrls []string
   // Group search behavior

--- a/providers/nutanix/resources/nutanix.lr.go
+++ b/providers/nutanix/resources/nutanix.lr.go
@@ -990,6 +990,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nutanix.iam.directoryService.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixIamDirectoryService).GetUrl()).ToDataRes(types.String)
 	},
+	"nutanix.iam.directoryService.usesLdaps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNutanixIamDirectoryService).GetUsesLdaps()).ToDataRes(types.Bool)
+	},
 	"nutanix.iam.directoryService.secondaryUrls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixIamDirectoryService).GetSecondaryUrls()).ToDataRes(types.Array(types.String))
 	},
@@ -2369,6 +2372,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nutanix.iam.directoryService.url": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNutanixIamDirectoryService).Url, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"nutanix.iam.directoryService.usesLdaps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNutanixIamDirectoryService).UsesLdaps, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"nutanix.iam.directoryService.secondaryUrls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5215,6 +5222,7 @@ type mqlNutanixIamDirectoryService struct {
 	DirectoryType          plugin.TValue[string]
 	DomainName             plugin.TValue[string]
 	Url                    plugin.TValue[string]
+	UsesLdaps              plugin.TValue[bool]
 	SecondaryUrls          plugin.TValue[[]any]
 	GroupSearchType        plugin.TValue[string]
 	WhiteListedGroups      plugin.TValue[[]any]
@@ -5274,6 +5282,12 @@ func (c *mqlNutanixIamDirectoryService) GetDomainName() *plugin.TValue[string] {
 
 func (c *mqlNutanixIamDirectoryService) GetUrl() *plugin.TValue[string] {
 	return &c.Url
+}
+
+func (c *mqlNutanixIamDirectoryService) GetUsesLdaps() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLdaps, func() (bool, error) {
+		return c.usesLdaps()
+	})
 }
 
 func (c *mqlNutanixIamDirectoryService) GetSecondaryUrls() *plugin.TValue[[]any] {

--- a/providers/nutanix/resources/nutanix.lr.versions
+++ b/providers/nutanix/resources/nutanix.lr.versions
@@ -151,6 +151,7 @@ nutanix.iam.directoryService.name 13.0.0
 nutanix.iam.directoryService.secondaryUrls 13.0.0
 nutanix.iam.directoryService.serviceAccountUsername 13.0.0
 nutanix.iam.directoryService.url 13.0.0
+nutanix.iam.directoryService.usesLdaps 13.0.2
 nutanix.iam.directoryService.whiteListedGroups 13.0.0
 nutanix.iam.group 13.0.0
 nutanix.iam.group.createdBy 13.0.0


### PR DESCRIPTION
## What

Adds a typed `usesLdaps bool` field to the `nutanix.iam.directoryService` resource. It is `true` when the directory service's primary `url` uses the secure `ldaps://` scheme (case-insensitive prefix match).

## Why

The `mondoo-nutanix-security` policy currently asserts the LDAPS scheme with a raw regex:

```
nutanix.directoryServices.all(url == /^ldaps:\/\//i && secondaryUrls.all(_ == /^ldaps:\/\//i))
```

The primary-URL scheme test is a factual property of the resource (a URL scheme check), not a policy opinion, so it's a fair typed promotion. Exposing it as a clean bool lets the policy drop the regex on the primary URL and read `usesLdaps` directly. Only the primary URL is promoted; the secondary-URL AND-logic stays in the policy.

## How

- Schema: added `usesLdaps() bool` (lazy/computed) to the `nutanix.iam.directoryService` block in `nutanix.lr`, regenerated `nutanix.lr.go` and `nutanix.lr.versions`.
- Resolver: `usesLdaps()` reads the memoized `url` getter and delegates to a small pure helper `urlUsesLdaps(string) bool` doing a case-insensitive `ldaps://` prefix check.
- Added a unit test for the helper covering `ldaps://`, `LDAPS://`, mixed case, `ldap://`, and empty input.

## Verification

```
SKIP_COMPILE=no make providers/build/nutanix   # compiles
cd providers/nutanix && go vet ./resources/      # clean
go test ./resources/                             # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)