### PR TITLE
🎉 snowflake-13.3.0, okta-13.3.0, nutanix-13.1.0, openstack-13.4.0, tailscale-13.3.0, vsphere-13.5.0

### DIFF
--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.0.1",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "13.2.8",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.3.1",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.2.9",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.2.3",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.4.2",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Minor version bump for six providers to release the typed-field additions merged since the last release ([#8284](https://github.com/mondoohq/mql/pull/8284)).

### snowflake (13.2.9 → 13.3.0)
- ✨ snowflake: typed networkPolicy on account (#8311)

### okta (13.2.8 → 13.3.0)
- ✨ okta: typed security notification email flags on organization (#8308)

### nutanix (13.0.1 → 13.1.0)
- ✨ nutanix: typed usesLdaps on directory service (#8310)

### openstack (13.3.1 → 13.4.0)
- ✨ openstack: typed imageSignature on image (#8309)

### tailscale (13.2.3 → 13.3.0)
- ✨ tailscale: typed hasExpiration and isRevoked on authKey (#8307)

### vsphere (13.4.2 → 13.5.0)
- ✨ vsphere: typed ESXi host hardening advanced settings (#8306)

🤖 Generated with [Claude Code](https://claude.com/claude-code)