### PR TITLE
✨ github/gitlab: discover CloudFormation, Dockerfile, Bicep, Helm, and Kustomize IaC

### DIFF
--- a/providers/bicep/connection/connection.go
+++ b/providers/bicep/connection/connection.go
@@ -15,7 +15,10 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-var _ plugin.Connection = (*BicepConnection)(nil)
+var (
+	_ plugin.Connection = (*BicepConnection)(nil)
+	_ plugin.Closer     = (*BicepConnection)(nil)
+)
 
 type BicepConnection struct {
 	plugin.Connection
@@ -25,6 +28,7 @@ type BicepConnection struct {
 	bicepFiles      []*BicepFile
 	bicepParamFiles []*BicepParamFile
 	armTemplate     *ARMTemplate
+	closer          func()
 }
 
 // BicepFile holds a Bicep source file path and its raw content.
@@ -60,8 +64,36 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 		asset:      asset,
 	}
 
+	// If a git clone is performed below, clean up the temporary directory on any
+	// error path. Close() is a no-op when nothing was cloned, and the guard is
+	// disarmed once the connection is returned and takes ownership of cleanup.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			conn.Close()
+		}
+	}()
+
 	cc := asset.Connections[0]
 	bicepPath := cc.Options["path"]
+	// When discovered from a git repository (e.g. by the GitHub provider) the
+	// asset carries the repo URL instead of a local path. Clone the repo and
+	// scan the resulting directory for Bicep/ARM files.
+	if bicepPath == "" {
+		if _, ok := cc.Options["http-url"]; ok {
+			clonePath, closer, err := plugin.NewGitClone(asset)
+			if err != nil {
+				return nil, err
+			}
+			conn.closer = closer
+			bicepPath = clonePath
+			// Intentionally do NOT overwrite cc.Options["path"]: the detector
+			// reads it to derive a platform ID, and a non-deterministic temp
+			// clone path would produce a different ID on every scan. The
+			// detector's git-discovered branch (ssh-url) handles naming for
+			// this path.
+		}
+	}
 	conn.path = bicepPath
 
 	fi, err := os.Stat(bicepPath)
@@ -108,7 +140,15 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 		conn.bicepFiles = []*BicepFile{{Path: bicepPath, Content: string(content)}}
 	}
 
+	cleanup = false
 	return conn, nil
+}
+
+// Close cleans up any temporary directory created by a git clone.
+func (c *BicepConnection) Close() {
+	if c.closer != nil {
+		c.closer()
+	}
 }
 
 func (c *BicepConnection) Name() string {

--- a/providers/bicep/provider/provider.go
+++ b/providers/bicep/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/v13/providers/bicep/connection"
 	"go.mondoo.com/mql/v13/providers/bicep/resources"
+	"go.mondoo.com/mql/v13/utils/urlx"
 )
 
 const (
@@ -137,6 +138,21 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.BicepConnectio
 	}
 	PlatformByName("bicep").Apply(asset.Platform)
 
+	// When discovered from a git repository (e.g. by the GitHub provider) prefer
+	// the repo (org/repo) for the name and platform ID. The local path is a
+	// temporary clone directory whose hash would change on every scan.
+	if url, ok := asset.Connections[0].Options["ssh-url"]; ok {
+		domain, org, repo, err := urlx.ParseGitSshUrl(url)
+		if err == nil {
+			platformID := "//platformid.api.mondoo.app/runtime/bicep/domain/" + domain + "/org/" + org + "/repo/" + repo
+			asset.Id = platformID
+			asset.Connections[0].PlatformId = platformID
+			asset.PlatformIds = []string{platformID}
+			asset.Name = "Bicep file " + org + "/" + repo
+			return nil
+		}
+	}
+
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {
 		absPath, _ := filepath.Abs(projectPath)
@@ -146,7 +162,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.BicepConnectio
 		platformID := "//platformid.api.mondoo.app/runtime/bicep/hash/" + hash
 		asset.Connections[0].PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "Bicep Static Analysis " + parseNameFromPath(projectPath)
+		asset.Name = "Bicep file " + parseNameFromPath(projectPath)
 		return nil
 	}
 
@@ -178,7 +194,7 @@ func parseNameFromPath(file string) string {
 
 	// When the user passed a bare "." (current directory) the loop above
 	// hands back "." via path.Base, which makes the asset name read
-	// "Bicep Static Analysis .". Resolve to the absolute path so the
+	// "Bicep file .". Resolve to the absolute path so the
 	// recursion picks up the actual directory basename instead.
 	if name == "." {
 		abspath, err := filepath.Abs(file)

--- a/providers/bicep/provider/provider_test.go
+++ b/providers/bicep/provider/provider_test.go
@@ -14,8 +14,8 @@ import (
 
 // parseNameFromPath used to call filepath.Abs(name) — i.e. on the
 // "." sentinel instead of the original path argument — so the asset
-// name read "Bicep Static Analysis .". The fix passes `file` to Abs
-// so the directory basename is recovered.
+// name read "Bicep file .". The fix passes `file` to Abs so the
+// directory basename is recovered.
 func TestParseNameFromPath_DotResolvesToBasename(t *testing.T) {
 	dir := t.TempDir()
 	cwd, err := os.Getwd()

--- a/providers/cloudformation/connection/connection.go
+++ b/providers/cloudformation/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/aws-cloudformation/rain/cft"
 	"github.com/aws-cloudformation/rain/cft/parse"
@@ -14,7 +15,10 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-var _ plugin.Connection = (*CloudformationConnection)(nil)
+var (
+	_ plugin.Connection = (*CloudformationConnection)(nil)
+	_ plugin.Closer     = (*CloudformationConnection)(nil)
+)
 
 type CloudformationConnection struct {
 	plugin.Connection
@@ -24,6 +28,7 @@ type CloudformationConnection struct {
 	path        string
 	content     string
 	cftTemplate cft.Template
+	closer      func()
 }
 
 func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*CloudformationConnection, error) {
@@ -36,8 +41,33 @@ func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *invent
 	if len(asset.Connections) == 0 {
 		return nil, errors.New("no connection options for asset")
 	}
+
+	// If a git clone is performed below, clean up the temporary directory on any
+	// error path. Close() is a no-op when nothing was cloned, and the guard is
+	// disarmed once the connection is returned and takes ownership of cleanup.
+	cleanupClone := true
+	defer func() {
+		if cleanupClone {
+			conn.Close()
+		}
+	}()
+
 	cc := asset.Connections[0]
 	path := cc.Options["path"]
+	// When discovered from a git repository (e.g. by the GitHub provider) the
+	// asset carries the repo URL plus a repo-relative path to the template.
+	// Clone the repo and resolve the template within the checkout. We keep the
+	// repo-relative path in the options so the detector can build a stable,
+	// human-friendly asset name and platform ID from the repo rather than the
+	// temporary clone directory.
+	if _, ok := cc.Options["http-url"]; ok {
+		clonePath, closer, err := plugin.NewGitClone(asset)
+		if err != nil {
+			return nil, err
+		}
+		conn.closer = closer
+		path = filepath.Join(clonePath, path)
+	}
 	conn.path = path
 
 	// Read the raw bytes up front and parse from them, so we can later extract
@@ -60,7 +90,15 @@ func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *invent
 	}
 	conn.cftTemplate = *cftTemplate
 
+	cleanupClone = false
 	return conn, nil
+}
+
+// Close cleans up any temporary directory created by a git clone.
+func (c *CloudformationConnection) Close() {
+	if c.closer != nil {
+		c.closer()
+	}
 }
 
 func (c *CloudformationConnection) Name() string {

--- a/providers/cloudformation/provider/provider.go
+++ b/providers/cloudformation/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/v13/providers/cloudformation/connection"
 	"go.mondoo.com/mql/v13/providers/cloudformation/resources"
+	"go.mondoo.com/mql/v13/utils/urlx"
 )
 
 const (
@@ -138,6 +139,29 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.Cloudformation
 	}
 	PlatformByName("cloudformation").Apply(asset.Platform)
 
+	// When discovered from a git repository (e.g. by the GitHub provider) prefer
+	// the repo (org/repo) plus the repo-relative template path for the name and
+	// platform ID. The local path is a temporary clone directory whose hash
+	// would change on every scan.
+	if url, ok := asset.Connections[0].Options["ssh-url"]; ok {
+		domain, org, repo, err := urlx.ParseGitSshUrl(url)
+		if err == nil {
+			name := org + "/" + repo
+			platformID := "//platformid.api.mondoo.app/runtime/cloudformation/domain/" + domain + "/org/" + org + "/repo/" + repo
+			// A repository can hold multiple templates; qualify by the
+			// repo-relative path so each one is a distinct asset.
+			if relPath := asset.Connections[0].Options["path"]; relPath != "" {
+				platformID += "/path/" + relPath
+				name += "/" + relPath
+			}
+			asset.Id = platformID
+			asset.Connections[0].PlatformId = platformID
+			asset.PlatformIds = []string{platformID}
+			asset.Name = "CloudFormation template " + name
+			return nil
+		}
+	}
+
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {
 		absPath, _ := filepath.Abs(projectPath)
@@ -147,7 +171,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.Cloudformation
 		platformID := "//platformid.api.mondoo.app/runtime/cloudformation/hash/" + hash
 		asset.Connections[0].PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "CloudFormation Static Analysis " + parseNameFromPath(projectPath)
+		asset.Name = "CloudFormation template " + parseNameFromPath(projectPath)
 		return nil
 	}
 

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -47,6 +47,11 @@ Notes:
 				connection.DiscoveryOrganization,
 				connection.DiscoveryTerraform,
 				connection.DiscoveryK8sManifests,
+				connection.DiscoveryCloudformation,
+				connection.DiscoveryDockerfiles,
+				connection.DiscoveryBicep,
+				connection.DiscoveryHelm,
+				connection.DiscoveryKustomize,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/github/connection/platform.go
+++ b/providers/github/connection/platform.go
@@ -10,13 +10,18 @@ import (
 )
 
 const (
-	DiscoveryAll          = "all"
-	DiscoveryAuto         = "auto"
-	DiscoveryRepos        = "repos"
-	DiscoveryUsers        = "users"
-	DiscoveryOrganization = "organization"
-	DiscoveryTerraform    = "terraform"
-	DiscoveryK8sManifests = "k8s-manifests"
+	DiscoveryAll            = "all"
+	DiscoveryAuto           = "auto"
+	DiscoveryRepos          = "repos"
+	DiscoveryUsers          = "users"
+	DiscoveryOrganization   = "organization"
+	DiscoveryTerraform      = "terraform"
+	DiscoveryK8sManifests   = "k8s-manifests"
+	DiscoveryCloudformation = "cloudformation"
+	DiscoveryDockerfiles    = "dockerfiles"
+	DiscoveryBicep          = "bicep"
+	DiscoveryHelm           = "helm"
+	DiscoveryKustomize      = "kustomize"
 )
 
 // Platforms is the static catalog of platforms the GitHub provider can emit.

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -45,6 +46,11 @@ func handleTargets(targets []string) []string {
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
+			connection.DiscoveryCloudformation,
+			connection.DiscoveryDockerfiles,
+			connection.DiscoveryBicep,
+			connection.DiscoveryHelm,
+			connection.DiscoveryKustomize,
 		}
 	}
 	return targets
@@ -146,20 +152,11 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 				Connections: []*inventory.Config{cfg},
 			})
 
-			if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryTerraform) {
-				terraformAssets, err := discoverTerraform(conn, repo)
-				if err != nil {
-					return nil, err
-				}
-				assetList = append(assetList, terraformAssets...)
+			iacAssets, err := discoverRepoIac(conn, repo, targets)
+			if err != nil {
+				return nil, err
 			}
-			if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryK8sManifests) {
-				k8sAssets, err := discoverK8sManifests(conn, repo)
-				if err != nil {
-					return nil, err
-				}
-				assetList = append(assetList, k8sAssets...)
-			}
+			assetList = append(assetList, iacAssets...)
 		}
 	}
 	if stringx.ContainsAnyOf(targets, connection.DiscoveryUsers) {
@@ -208,20 +205,11 @@ func repo(runtime *plugin.Runtime, repoName string, owner string, conn *connecti
 		Connections: []*inventory.Config{cfg},
 	})
 
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryTerraform) {
-		terraformAssets, err := discoverTerraform(conn, repo)
-		if err != nil {
-			return nil, err
-		}
-		assetList = append(assetList, terraformAssets...)
+	iacAssets, err := discoverRepoIac(conn, repo, targets)
+	if err != nil {
+		return nil, err
 	}
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryK8sManifests) {
-		k8sAssets, err := discoverK8sManifests(conn, repo)
-		if err != nil {
-			return nil, err
-		}
-		assetList = append(assetList, k8sAssets...)
-	}
+	assetList = append(assetList, iacAssets...)
 
 	return assetList, nil
 }
@@ -320,18 +308,216 @@ func (f *ReposFilter) skipRepo(namespace string) bool {
 	return false
 }
 
-func discoverTerraform(conn *connection.GithubConnection, repo *mqlGithubRepository) ([]*inventory.Asset, error) {
-	// For git clone we need to set the user to oauth2 to be usable with the token.
-	conf := conn.Asset().Connections[0]
+// gitCredentials clones the parent GitHub connection credentials for use in a
+// git clone, defaulting the user to "oauth2" so the token works over HTTPS.
+func gitCredentials(conf *inventory.Config) []*vault.Credential {
 	creds := make([]*vault.Credential, len(conf.Credentials))
 	for i := range conf.Credentials {
-		cred := conf.Credentials[i]
-		cc := cred.CloneVT()
+		cc := conf.Credentials[i].CloneVT()
 		if cc.User == "" {
 			cc.User = "oauth2"
 		}
 		creds[i] = cc
 	}
+	return creds
+}
+
+// isHiddenPath reports whether any path segment is hidden (starts with a dot),
+// e.g. files under .github/ or a top-level .drone.yml.
+func isHiddenPath(p string) bool {
+	for _, fragment := range strings.Split(p, "/") {
+		if strings.HasPrefix(fragment, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// searchCode runs a GitHub code search and returns every matching result,
+// following pagination. The code search API returns at most 100 items per page
+// (30 by default), so a repo with many matching files would otherwise be
+// silently truncated to the first page.
+func searchCode(ctx context.Context, client *github.Client, query string) ([]*github.CodeResult, error) {
+	opts := &github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}}
+	var results []*github.CodeResult
+	for {
+		res, resp, err := client.Search.Code(ctx, query, opts)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, res.CodeResults...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return results, nil
+}
+
+// discoverRepoIac runs every IaC discovery target for a single repository.
+//
+// Terraform (a language check) and CloudFormation (a content search for the
+// AWSTemplateFormatVersion marker) each need their own API call. The remaining
+// detectors — k8s manifests, Dockerfiles, Bicep, Helm, and Kustomize — are all
+// filename/extension based, so they share a single recursive git-tree walk
+// rather than spending one GitHub Code Search call per type. The Code Search
+// API is limited to 30 requests/minute, so the previous per-type approach made
+// `--discover all` start throttling at only a handful of repos per org.
+func discoverRepoIac(conn *connection.GithubConnection, repo *mqlGithubRepository, targets []string) ([]*inventory.Asset, error) {
+	var assetList []*inventory.Asset
+
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryTerraform) {
+		terraformAssets, err := discoverTerraform(conn, repo)
+		if err != nil {
+			return nil, err
+		}
+		assetList = append(assetList, terraformAssets...)
+	}
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryCloudformation) {
+		cfAssets, err := discoverCloudformation(conn, repo)
+		if err != nil {
+			return nil, err
+		}
+		assetList = append(assetList, cfAssets...)
+	}
+
+	if !stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryK8sManifests,
+		connection.DiscoveryDockerfiles, connection.DiscoveryBicep, connection.DiscoveryHelm,
+		connection.DiscoveryKustomize) {
+		return assetList, nil
+	}
+
+	iac, err := repoIacFromTree(conn.Context(), conn.Client(), repo)
+	if err != nil {
+		// Tree discovery is best-effort; a missing/empty repo or permission
+		// issue should not fail discovery of the rest of the org.
+		log.Error().Err(err).Str("project", repo.FullName.Data).Msg("failed to walk repository tree for IaC discovery")
+		return assetList, nil
+	}
+
+	creds := gitCredentials(conn.Asset().Connections[0])
+	if iac.hasYaml && stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryK8sManifests) {
+		k8sAsset := gitAsset("k8s", repo, "", creds)
+		k8sAsset.Connections[0].Discover = &inventory.Discovery{Targets: []string{"auto"}}
+		assetList = append(assetList, k8sAsset)
+	}
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryDockerfiles) {
+		for _, path := range iac.dockerfiles {
+			assetList = append(assetList, gitAsset("docker-file", repo, path, creds))
+		}
+	}
+	if iac.hasBicep && stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryBicep) {
+		assetList = append(assetList, gitAsset("bicep", repo, "", creds))
+	}
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryHelm) {
+		for _, dir := range iac.helmChartDirs {
+			assetList = append(assetList, gitAsset("helm", repo, dir, creds))
+		}
+	}
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryKustomize) {
+		for _, dir := range iac.kustomizeDirs {
+			assetList = append(assetList, gitAsset("kustomize", repo, dir, creds))
+		}
+	}
+	return assetList, nil
+}
+
+// repoIac holds the IaC entry points found by a single recursive git-tree walk.
+// CloudFormation is intentionally absent: it requires file-content inspection
+// (the AWSTemplateFormatVersion marker), not a path match.
+type repoIac struct {
+	hasYaml       bool // k8s manifests
+	hasBicep      bool
+	dockerfiles   []string
+	helmChartDirs []string
+	kustomizeDirs []string
+}
+
+// repoIacFromTree fetches the repository's default-branch tree once (recursively)
+// and classifies its files into the IaC entry points each detector needs. The
+// git-tree endpoint is on the generous core rate limit rather than the Code
+// Search limit, so this is one cheap call per repo instead of one Code Search
+// call per IaC type. The switch ordering mirrors the GitLab provider so the two
+// behave identically — notably, Chart.yaml and kustomization.yaml match their
+// own cases and so do not also count as k8s manifests.
+func repoIacFromTree(ctx context.Context, client *github.Client, repo *mqlGithubRepository) (*repoIac, error) {
+	out := &repoIac{}
+
+	ref := repo.DefaultBranchName.Data
+	if ref == "" {
+		// Empty repositories have no default branch and therefore no tree.
+		return out, nil
+	}
+
+	tree, _, err := client.Git.GetTree(ctx, repo.Owner.Data.Login.Data, repo.Name.Data, ref, true)
+	if err != nil {
+		return nil, err
+	}
+	if tree.GetTruncated() {
+		// The recursive tree endpoint truncates rather than paginating, so for
+		// very large repositories some files may be missing from this walk.
+		log.Warn().Str("project", repo.FullName.Data).Msg("github repository tree is truncated; some IaC files may not be discovered")
+	}
+
+	helmSeen := map[string]bool{}
+	kustomizeSeen := map[string]bool{}
+	for _, entry := range tree.Entries {
+		if entry.GetType() != "blob" {
+			continue
+		}
+		path := entry.GetPath()
+		if isHiddenPath(path) {
+			continue
+		}
+
+		base := filepath.Base(path)
+		switch {
+		case strings.HasSuffix(path, ".bicep"):
+			out.hasBicep = true
+		case base == "Chart.yaml":
+			dir := iacDir(path)
+			if !helmSeen[dir] {
+				helmSeen[dir] = true
+				out.helmChartDirs = append(out.helmChartDirs, dir)
+			}
+		case isKustomization(base):
+			dir := iacDir(path)
+			if !kustomizeSeen[dir] {
+				kustomizeSeen[dir] = true
+				out.kustomizeDirs = append(out.kustomizeDirs, dir)
+			}
+		case isDockerfile(base):
+			out.dockerfiles = append(out.dockerfiles, path)
+		case (strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) &&
+			!strings.HasSuffix(path, "mql.yaml") && !strings.HasSuffix(path, "mql.yml"):
+			out.hasYaml = true
+		}
+	}
+	return out, nil
+}
+
+// gitAsset builds a child asset that clones the repository and scans it with the
+// given connection type. path is the repo-relative file or directory to scan,
+// or "" when the connection scans the whole checkout.
+func gitAsset(connType string, repo *mqlGithubRepository, path string, creds []*vault.Credential) *inventory.Asset {
+	opts := map[string]string{
+		"ssh-url":  repo.SshUrl.Data,
+		"http-url": repo.CloneUrl.Data,
+	}
+	if path != "" {
+		opts["path"] = path
+	}
+	return &inventory.Asset{
+		Connections: []*inventory.Config{{
+			Type:        connType,
+			Options:     opts,
+			Credentials: creds,
+		}},
+	}
+}
+
+func discoverTerraform(conn *connection.GithubConnection, repo *mqlGithubRepository) ([]*inventory.Asset, error) {
+	creds := gitCredentials(conn.Asset().Connections[0])
 
 	var res []*inventory.Asset
 	hasTf, err := hasTerraformHcl(conn.Context(), conn.Client(), repo)
@@ -364,70 +550,93 @@ func hasTerraformHcl(ctx context.Context, client *github.Client, repo *mqlGithub
 	return false, nil
 }
 
-func discoverK8sManifests(conn *connection.GithubConnection, repo *mqlGithubRepository) ([]*inventory.Asset, error) {
-	// For git clone we need to set the user to oauth2 to be usable with the token.
-	conf := conn.Asset().Connections[0]
-	creds := make([]*vault.Credential, len(conf.Credentials))
-	for i := range conf.Credentials {
-		cred := conf.Credentials[i]
-		cc := cred.CloneVT()
-		if cc.User == "" {
-			cc.User = "oauth2"
-		}
-		creds[i] = cc
+// discoverCloudformation emits one asset per CloudFormation template found in
+// the repository. The CloudFormation connection scans a single template file
+// (not a directory), so each asset carries its own repo-relative path and
+// performs its own shallow clone of the repo on connect. For a repo with many
+// templates this means several clones of the same repo — an accepted trade-off
+// that keeps the connection's single-template model and avoids a shared clone
+// cache.
+func discoverCloudformation(conn *connection.GithubConnection, repo *mqlGithubRepository) ([]*inventory.Asset, error) {
+	creds := gitCredentials(conn.Asset().Connections[0])
+
+	paths, err := cloudformationTemplatePaths(conn.Context(), conn.Client(), repo)
+	if err != nil {
+		log.Error().Err(err).Str("project", repo.FullName.Data).Msg("failed to discover cloudformation repo")
+		return nil, nil
 	}
 
 	var res []*inventory.Asset
-	hasTf, err := hasYaml(conn.Context(), conn.Client(), repo)
-	if err != nil {
-		log.Error().Err(err).Str("project", repo.FullName.Data).Msg("failed to discover k8s manifests repo")
-	} else if hasTf {
+	for _, path := range paths {
 		res = append(res, &inventory.Asset{
 			Connections: []*inventory.Config{{
-				Type: "k8s",
+				Type: "cloudformation",
 				Options: map[string]string{
 					"ssh-url":  repo.SshUrl.Data,
 					"http-url": repo.CloneUrl.Data,
+					"path":     path,
 				},
 				Credentials: creds,
-				Discover:    &inventory.Discovery{Targets: []string{"auto"}},
 			}},
 		})
 	}
 	return res, nil
 }
 
-// hasYaml will check if the repository contains YAML files
-func hasYaml(ctx context.Context, client *github.Client, repo *mqlGithubRepository) (bool, error) {
-	query := "repo:" + repo.FullName.Data + " extension:yaml OR extension:yml"
-	res, _, err := client.Search.Code(ctx, query, &github.SearchOptions{})
+// cloudformationTemplatePaths searches the repository for CloudFormation/SAM
+// templates. Because CloudFormation templates share the .yaml/.json extensions
+// with many other config files, we match on the template marker
+// `AWSTemplateFormatVersion` rather than the extension alone.
+func cloudformationTemplatePaths(ctx context.Context, client *github.Client, repo *mqlGithubRepository) ([]string, error) {
+	query := "repo:" + repo.FullName.Data + " AWSTemplateFormatVersion"
+	results, err := searchCode(ctx, client, query)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	// Ignore YAML files that are hidden or are in a hidden folder
-	nonHiddenYaml := 0
-	for _, code := range res.CodeResults {
+	var paths []string
+	seen := map[string]bool{}
+	for _, code := range results {
 		path := code.GetPath()
-
-		// Skip MQL files
-		if strings.HasSuffix(path, "mql.yaml") || strings.HasSuffix(path, "mql.yml") {
+		if isHiddenPath(path) || seen[path] {
 			continue
 		}
-
-		fragments := strings.Split(code.GetPath(), "/")
-		// skip hidden files
-		isHidden := false
-		for _, fragment := range fragments {
-			if strings.HasPrefix(fragment, ".") {
-				isHidden = true
-				break
-			}
-		}
-
-		if !isHidden {
-			nonHiddenYaml++
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".yaml", ".yml", ".json", ".template":
+			seen[path] = true
+			paths = append(paths, path)
 		}
 	}
-	return nonHiddenYaml > 0, nil
+	return paths, nil
+}
+
+// isDockerfile reports whether a base file name follows a Dockerfile naming
+// convention: `Dockerfile`, `Dockerfile.<suffix>` (e.g. Dockerfile.prod), or
+// `<prefix>.Dockerfile`/`<prefix>.dockerfile` (e.g. app.Dockerfile). It rejects
+// unrelated names that merely begin with "Dockerfile", like `DockerfileLint.md`.
+func isDockerfile(base string) bool {
+	return base == "Dockerfile" ||
+		strings.HasPrefix(base, "Dockerfile.") ||
+		strings.HasSuffix(base, ".Dockerfile") ||
+		strings.HasSuffix(base, ".dockerfile")
+}
+
+// iacDir returns the repo-relative directory containing the given file, with a
+// top-level file ("." from filepath.Dir) normalized to "" so it joins onto the
+// clone root cleanly.
+func iacDir(path string) string {
+	if dir := filepath.Dir(path); dir != "." {
+		return dir
+	}
+	return ""
+}
+
+// isKustomization reports whether a base file name is one of the recognized
+// Kustomize entry-point file names.
+func isKustomization(base string) bool {
+	switch base {
+	case "kustomization.yaml", "kustomization.yml", "Kustomization":
+		return true
+	}
+	return false
 }

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -41,16 +41,14 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 
 func handleTargets(targets []string) []string {
 	if stringx.Contains(targets, connection.DiscoveryAll) {
+		// CloudFormation, Dockerfile, Bicep, Helm, and Kustomize discovery
+		// each shallow-clone matched repos, so they stay opt-in via an
+		// explicit --discover <type> and are deliberately left out of `all`.
 		return []string{
 			connection.DiscoveryRepos,
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
-			connection.DiscoveryCloudformation,
-			connection.DiscoveryDockerfiles,
-			connection.DiscoveryBicep,
-			connection.DiscoveryHelm,
-			connection.DiscoveryKustomize,
 		}
 	}
 	return targets
@@ -373,7 +371,7 @@ func discoverRepoIac(conn *connection.GithubConnection, repo *mqlGithubRepositor
 		}
 		assetList = append(assetList, terraformAssets...)
 	}
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryCloudformation) {
+	if stringx.Contains(targets, connection.DiscoveryCloudformation) {
 		cfAssets, err := discoverCloudformation(conn, repo)
 		if err != nil {
 			return nil, err
@@ -401,20 +399,20 @@ func discoverRepoIac(conn *connection.GithubConnection, repo *mqlGithubRepositor
 		k8sAsset.Connections[0].Discover = &inventory.Discovery{Targets: []string{"auto"}}
 		assetList = append(assetList, k8sAsset)
 	}
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryDockerfiles) {
+	if stringx.Contains(targets, connection.DiscoveryDockerfiles) {
 		for _, path := range iac.dockerfiles {
 			assetList = append(assetList, gitAsset("docker-file", repo, path, creds))
 		}
 	}
-	if iac.hasBicep && stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryBicep) {
+	if iac.hasBicep && stringx.Contains(targets, connection.DiscoveryBicep) {
 		assetList = append(assetList, gitAsset("bicep", repo, "", creds))
 	}
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryHelm) {
+	if stringx.Contains(targets, connection.DiscoveryHelm) {
 		for _, dir := range iac.helmChartDirs {
 			assetList = append(assetList, gitAsset("helm", repo, dir, creds))
 		}
 	}
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryKustomize) {
+	if stringx.Contains(targets, connection.DiscoveryKustomize) {
 		for _, dir := range iac.kustomizeDirs {
 			assetList = append(assetList, gitAsset("kustomize", repo, dir, creds))
 		}

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -53,6 +53,11 @@ func TestHandleTargets(t *testing.T) {
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
+			connection.DiscoveryCloudformation,
+			connection.DiscoveryDockerfiles,
+			connection.DiscoveryBicep,
+			connection.DiscoveryHelm,
+			connection.DiscoveryKustomize,
 		}, got)
 	})
 
@@ -63,6 +68,11 @@ func TestHandleTargets(t *testing.T) {
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
+			connection.DiscoveryCloudformation,
+			connection.DiscoveryDockerfiles,
+			connection.DiscoveryBicep,
+			connection.DiscoveryHelm,
+			connection.DiscoveryKustomize,
 		}, got)
 	})
 

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -46,18 +46,16 @@ func TestReposFilter_Both(t *testing.T) {
 }
 
 func TestHandleTargets(t *testing.T) {
-	t.Run("all expands to every discovery target", func(t *testing.T) {
+	t.Run("all expands to repos, users, and the cheap per-repo IaC targets", func(t *testing.T) {
+		// The clone-per-match IaC targets (cloudformation, dockerfiles, bicep,
+		// helm, kustomize) are intentionally excluded from `all` and only run
+		// on an explicit --discover <type>.
 		got := handleTargets([]string{connection.DiscoveryAll})
 		assert.Equal(t, []string{
 			connection.DiscoveryRepos,
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
-			connection.DiscoveryCloudformation,
-			connection.DiscoveryDockerfiles,
-			connection.DiscoveryBicep,
-			connection.DiscoveryHelm,
-			connection.DiscoveryKustomize,
 		}, got)
 	})
 
@@ -68,12 +66,18 @@ func TestHandleTargets(t *testing.T) {
 			connection.DiscoveryUsers,
 			connection.DiscoveryTerraform,
 			connection.DiscoveryK8sManifests,
+		}, got)
+	})
+
+	t.Run("opt-in IaC targets pass through unchanged", func(t *testing.T) {
+		in := []string{
 			connection.DiscoveryCloudformation,
 			connection.DiscoveryDockerfiles,
 			connection.DiscoveryBicep,
 			connection.DiscoveryHelm,
 			connection.DiscoveryKustomize,
-		}, got)
+		}
+		assert.Equal(t, in, handleTargets(in))
 	})
 
 	t.Run("explicit targets pass through unchanged", func(t *testing.T) {

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -47,6 +47,11 @@ Notes:
 				provider.DiscoveryProject,
 				provider.DiscoveryTerraform,
 				provider.DiscoveryK8sManifests,
+				provider.DiscoveryCloudformation,
+				provider.DiscoveryDockerfiles,
+				provider.DiscoveryBicep,
+				provider.DiscoveryHelm,
+				provider.DiscoveryKustomize,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/gitlab/provider/discovery.go
+++ b/providers/gitlab/provider/discovery.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,20 @@ import (
 	"go.mondoo.com/mql/v13/providers/gitlab/connection"
 	"golang.org/x/exp/slices"
 )
+
+// iacTargets is the set of chained git-clone discovery targets that scan a
+// repository's contents (Terraform, k8s manifests, CloudFormation, Dockerfiles,
+// Bicep, Helm charts, Kustomize configs). discoverTypes only runs when at least
+// one of these is requested.
+var iacTargets = []string{
+	DiscoveryTerraform,
+	DiscoveryK8sManifests,
+	DiscoveryCloudformation,
+	DiscoveryDockerfiles,
+	DiscoveryBicep,
+	DiscoveryHelm,
+	DiscoveryKustomize,
+}
 
 func (s *Service) discover(root *inventory.Asset, conn *connection.GitLabConnection) (*inventory.Inventory, error) {
 	if conn.Conf.Discover == nil {
@@ -76,7 +91,7 @@ func (s *Service) discover(root *inventory.Asset, conn *connection.GitLabConnect
 		}
 	}
 
-	if slices.Contains(targets, DiscoveryTerraform) || slices.Contains(targets, DiscoveryK8sManifests) {
+	if containsAny(targets, iacTargets) {
 		repos, err := s.discoverTypes(targets, conn, projects)
 		if err != nil {
 			return nil, err
@@ -281,66 +296,145 @@ func listAllGroups(conn *connection.GitLabConnection) ([]*gitlab.Group, error) {
 }
 
 func (s *Service) discoverTypes(targets []string, conn *connection.GitLabConnection, projects []*gitlab.Project) ([]*inventory.Asset, error) {
-	if !slices.Contains(targets, DiscoveryTerraform) && !slices.Contains(targets, DiscoveryK8sManifests) {
+	if !containsAny(targets, iacTargets) {
 		return nil, nil
 	}
 
-	// For git clone we need to set the user to oauth2 to be usable with the token.
-	creds := make([]*vault.Credential, len(conn.Conf.Credentials))
-	for i := range conn.Conf.Credentials {
-		cred := conn.Conf.Credentials[i]
-		cc := cred.CloneVT()
-		if cc.User == "" {
-			cc.User = "oauth2"
-		}
-		creds[i] = cc
-	}
+	creds := gitCredentials(conn.Conf.Credentials)
 
 	var res []*inventory.Asset
 	for i := range projects {
 		project := projects[i]
-		discoveredTypes, err := discoverRepoTypes(conn.Client(), project.ID)
+		types, err := discoverRepoTypes(conn.Client(), project.ID)
 		if err != nil {
-			log.Error().Err(err).Str("project", project.PathWithNamespace).Msg("failed to discover terraform repo in gitlab")
+			log.Error().Err(err).Str("project", project.PathWithNamespace).Msg("failed to discover IaC files in gitlab repo")
 			continue
 		}
 
-		if discoveredTypes.terraform && slices.Contains(targets, DiscoveryTerraform) {
+		repoOpts := func(extra map[string]string) map[string]string {
+			opts := map[string]string{
+				"ssh-url":  project.SSHURLToRepo,
+				"http-url": project.HTTPURLToRepo,
+			}
+			for k, v := range extra {
+				opts[k] = v
+			}
+			return opts
+		}
+
+		if types.terraform && slices.Contains(targets, DiscoveryTerraform) {
 			res = append(res, &inventory.Asset{
 				Connections: []*inventory.Config{{
-					Type: "terraform-hcl-git",
-					Options: map[string]string{
-						"ssh-url":  project.SSHURLToRepo,
-						"http-url": project.HTTPURLToRepo,
-					},
+					Type:        "terraform-hcl-git",
+					Options:     repoOpts(nil),
 					Credentials: creds,
 				}},
 			})
 		}
 
-		if discoveredTypes.k8s && slices.Contains(targets, DiscoveryK8sManifests) {
+		if types.k8s && slices.Contains(targets, DiscoveryK8sManifests) {
 			res = append(res, &inventory.Asset{
 				Connections: []*inventory.Config{{
-					Type: "k8s",
-					Options: map[string]string{
-						"ssh-url":  project.SSHURLToRepo,
-						"http-url": project.HTTPURLToRepo,
-					},
+					Type:        "k8s",
+					Options:     repoOpts(nil),
 					Credentials: creds,
 					Discover:    &inventory.Discovery{Targets: []string{"auto"}},
 				}},
 			})
+		}
+
+		if slices.Contains(targets, DiscoveryCloudformation) {
+			// CloudFormation templates share the .yaml/.yml/.json extensions
+			// with many other configs, so we ask GitLab's blob search for the
+			// `AWSTemplateFormatVersion` marker instead of relying on the
+			// extension alone. The search API requires GitLab's advanced
+			// search backend (Elasticsearch); on instances where it is
+			// unavailable the call returns an error and we just skip
+			// CloudFormation discovery for the project.
+			paths, err := cloudformationTemplatePaths(conn.Client(), project.ID)
+			if err != nil {
+				log.Error().Err(err).Str("project", project.PathWithNamespace).Msg("failed to discover cloudformation templates in gitlab repo")
+			}
+			for _, path := range paths {
+				res = append(res, &inventory.Asset{
+					Connections: []*inventory.Config{{
+						Type:        "cloudformation",
+						Options:     repoOpts(map[string]string{"path": path}),
+						Credentials: creds,
+					}},
+				})
+			}
+		}
+
+		// Each Dockerfile asset clones the repo independently on connect
+		// (the dockerfile connection targets a single file), so a repo with
+		// many Dockerfiles results in several clones — an accepted trade-off
+		// that keeps the connection's single-file model.
+		if slices.Contains(targets, DiscoveryDockerfiles) {
+			for _, path := range types.dockerfiles {
+				res = append(res, &inventory.Asset{
+					Connections: []*inventory.Config{{
+						Type:        "docker-file",
+						Options:     repoOpts(map[string]string{"path": path}),
+						Credentials: creds,
+					}},
+				})
+			}
+		}
+
+		if types.bicep && slices.Contains(targets, DiscoveryBicep) {
+			res = append(res, &inventory.Asset{
+				Connections: []*inventory.Config{{
+					Type:        "bicep",
+					Options:     repoOpts(nil),
+					Credentials: creds,
+				}},
+			})
+		}
+
+		// One asset per chart directory; same clone-per-asset trade-off as
+		// Dockerfiles since the helm connection scans a single chart.
+		if slices.Contains(targets, DiscoveryHelm) {
+			for _, dir := range types.helmChartDirs {
+				res = append(res, &inventory.Asset{
+					Connections: []*inventory.Config{{
+						Type:        "helm",
+						Options:     repoOpts(map[string]string{"path": dir}),
+						Credentials: creds,
+					}},
+				})
+			}
+		}
+
+		// One asset per kustomize directory (base + each overlay).
+		if slices.Contains(targets, DiscoveryKustomize) {
+			for _, dir := range types.kustomizeDirs {
+				res = append(res, &inventory.Asset{
+					Connections: []*inventory.Config{{
+						Type:        "kustomize",
+						Options:     repoOpts(map[string]string{"path": dir}),
+						Credentials: creds,
+					}},
+				})
+			}
 		}
 	}
 	return res, nil
 }
 
 type discoveredTypes struct {
-	terraform bool
-	k8s       bool
+	terraform     bool
+	k8s           bool
+	bicep         bool
+	dockerfiles   []string
+	helmChartDirs []string
+	kustomizeDirs []string
 }
 
-// discoverRepoTypes will check if the repository contains terraform files and yaml files
+// discoverRepoTypes walks the repository tree once and classifies blobs into
+// the IaC categories we recognize. CloudFormation is intentionally absent: it
+// requires content inspection (the `AWSTemplateFormatVersion` marker) and is
+// handled separately via cloudformationTemplatePaths.
 func discoverRepoTypes(client *gitlab.Client, pid any) (*discoveredTypes, error) {
 	opts := &gitlab.ListTreeOptions{
 		ListOptions: gitlab.ListOptions{
@@ -369,35 +463,138 @@ func discoverRepoTypes(client *gitlab.Client, pid any) (*discoveredTypes, error)
 		opts.Page = resp.NextPage
 	}
 
-	terraformFiles := []string{}
-	yamlFiles := []string{}
+	out := &discoveredTypes{}
+	helmSeen := map[string]bool{}
+	kustomizeSeen := map[string]bool{}
 	for i := range nodes {
 		node := nodes[i]
-		fragments := strings.Split(node.Path, "/")
-		isHidden := false
-		for _, f := range fragments {
-			if strings.HasPrefix(f, ".") {
-				isHidden = true
-				break
-			}
-		}
-
-		// Skip hidden and files in hidden folders
-		if isHidden {
+		if node.Type != "blob" || isHiddenPath(node.Path) {
 			continue
 		}
 
-		if node.Type == "blob" && strings.HasSuffix(node.Path, ".tf") {
-			terraformFiles = append(terraformFiles, node.Path)
-		} else if node.Type == "blob" &&
-			!strings.HasSuffix(node.Path, "mql.yaml") && !strings.HasSuffix(node.Path, "mql.yml") &&
-			(strings.HasSuffix(node.Path, ".yaml") || strings.HasSuffix(node.Path, ".yml")) {
-			yamlFiles = append(yamlFiles, node.Path)
+		base := filepath.Base(node.Path)
+		switch {
+		case strings.HasSuffix(node.Path, ".tf"):
+			out.terraform = true
+		case strings.HasSuffix(node.Path, ".bicep"):
+			out.bicep = true
+		case base == "Chart.yaml":
+			dir := iacDir(node.Path)
+			if !helmSeen[dir] {
+				helmSeen[dir] = true
+				out.helmChartDirs = append(out.helmChartDirs, dir)
+			}
+		case isKustomization(base):
+			dir := iacDir(node.Path)
+			if !kustomizeSeen[dir] {
+				kustomizeSeen[dir] = true
+				out.kustomizeDirs = append(out.kustomizeDirs, dir)
+			}
+		case isDockerfile(base):
+			out.dockerfiles = append(out.dockerfiles, node.Path)
+		case (strings.HasSuffix(node.Path, ".yaml") || strings.HasSuffix(node.Path, ".yml")) &&
+			!strings.HasSuffix(node.Path, "mql.yaml") && !strings.HasSuffix(node.Path, "mql.yml"):
+			out.k8s = true
 		}
 	}
+	return out, nil
+}
 
-	return &discoveredTypes{
-		terraform: len(terraformFiles) > 0,
-		k8s:       len(yamlFiles) > 0,
-	}, nil
+// cloudformationTemplatePaths uses GitLab's project-scoped blob search to find
+// files containing the CloudFormation marker `AWSTemplateFormatVersion`, then
+// filters to extensions used by CloudFormation/SAM templates. The search API
+// returns matches in pages of 20 by default; we follow pagination so a project
+// with many templates is not silently truncated.
+func cloudformationTemplatePaths(client *gitlab.Client, pid any) ([]string, error) {
+	opts := &gitlab.SearchOptions{ListOptions: gitlab.ListOptions{PerPage: 100}}
+	var paths []string
+	seen := map[string]bool{}
+	for {
+		blobs, resp, err := client.Search.BlobsByProject(pid, "AWSTemplateFormatVersion", opts)
+		if err != nil {
+			// Discard any partially-collected paths so the caller doesn't
+			// create assets from an incomplete search result.
+			return nil, err
+		}
+		for _, blob := range blobs {
+			if isHiddenPath(blob.Path) || seen[blob.Path] {
+				continue
+			}
+			switch strings.ToLower(filepath.Ext(blob.Path)) {
+			case ".yaml", ".yml", ".json", ".template":
+				seen[blob.Path] = true
+				paths = append(paths, blob.Path)
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return paths, nil
+}
+
+// gitCredentials clones the parent GitLab connection credentials for use in a
+// git clone, defaulting the user to "oauth2" so the token works over HTTPS.
+func gitCredentials(in []*vault.Credential) []*vault.Credential {
+	creds := make([]*vault.Credential, len(in))
+	for i := range in {
+		cc := in[i].CloneVT()
+		if cc.User == "" {
+			cc.User = "oauth2"
+		}
+		creds[i] = cc
+	}
+	return creds
+}
+
+// isHiddenPath reports whether any path segment is hidden (starts with a dot),
+// e.g. files under .gitlab/ or a top-level .gitlab-ci.yml.
+func isHiddenPath(p string) bool {
+	for _, fragment := range strings.Split(p, "/") {
+		if strings.HasPrefix(fragment, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// iacDir returns the repo-relative directory containing the given file, with a
+// top-level file ("." from filepath.Dir) normalized to "" so it joins onto the
+// clone root cleanly.
+func iacDir(path string) string {
+	if dir := filepath.Dir(path); dir != "." {
+		return dir
+	}
+	return ""
+}
+
+// isDockerfile reports whether a base file name follows a Dockerfile naming
+// convention: `Dockerfile`, `Dockerfile.<suffix>` (e.g. Dockerfile.prod), or
+// `<prefix>.Dockerfile`/`<prefix>.dockerfile` (e.g. app.Dockerfile).
+func isDockerfile(base string) bool {
+	return base == "Dockerfile" ||
+		strings.HasPrefix(base, "Dockerfile.") ||
+		strings.HasSuffix(base, ".Dockerfile") ||
+		strings.HasSuffix(base, ".dockerfile")
+}
+
+// isKustomization reports whether a base file name is one of the recognized
+// Kustomize entry-point file names.
+func isKustomization(base string) bool {
+	switch base {
+	case "kustomization.yaml", "kustomization.yml", "Kustomization":
+		return true
+	}
+	return false
+}
+
+// containsAny reports whether any value in needles appears in haystack.
+func containsAny(haystack, needles []string) bool {
+	for _, n := range needles {
+		if slices.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/gitlab/provider/provider.go
+++ b/providers/gitlab/provider/provider.go
@@ -30,8 +30,13 @@ const (
 	DiscoveryGroup   = "groups"
 	DiscoveryProject = "projects"
 	// -- chained git discovery options --
-	DiscoveryTerraform    = "terraform"
-	DiscoveryK8sManifests = "k8s-manifests"
+	DiscoveryTerraform      = "terraform"
+	DiscoveryK8sManifests   = "k8s-manifests"
+	DiscoveryCloudformation = "cloudformation"
+	DiscoveryDockerfiles    = "dockerfiles"
+	DiscoveryBicep          = "bicep"
+	DiscoveryHelm           = "helm"
+	DiscoveryKustomize      = "kustomize"
 )
 
 type Service struct {

--- a/providers/helm/connection/connection.go
+++ b/providers/helm/connection/connection.go
@@ -15,7 +15,10 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
-var _ plugin.Connection = (*HelmConnection)(nil)
+var (
+	_ plugin.Connection = (*HelmConnection)(nil)
+	_ plugin.Closer     = (*HelmConnection)(nil)
+)
 
 // LoadedChart pairs a parsed chart with the filesystem path it was
 // loaded from so the resource layer can distinguish two charts that
@@ -39,6 +42,7 @@ type HelmConnection struct {
 	path       string
 	charts     []LoadedChart
 	renderOpts RenderOptions
+	closer     func()
 }
 
 func NewHelmConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*HelmConnection, error) {
@@ -51,13 +55,39 @@ func NewHelmConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	if len(asset.Connections) == 0 {
 		return nil, errors.New("no connection configuration provided")
 	}
+
+	// If a git clone is performed below, clean up the temporary directory on any
+	// error path. Close() is a no-op when nothing was cloned, and the guard is
+	// disarmed once the connection is returned and takes ownership of cleanup.
+	cleanupClone := true
+	defer func() {
+		if cleanupClone {
+			conn.Close()
+		}
+	}()
+
 	cc := asset.Connections[0]
 	conn.renderOpts = parseRenderOptions(cc.Options)
+
+	// When discovered from a git repository (e.g. by the GitHub provider) the
+	// asset carries the repo URL plus a repo-relative path to the chart
+	// directory. Clone the repo and resolve the chart within the checkout. The
+	// path option is kept relative so the detector can name the asset from the
+	// repo rather than the temporary clone directory.
+	helmPath := cc.Options[OptionPath]
+	if _, ok := cc.Options["http-url"]; ok {
+		clonePath, closer, err := plugin.NewGitClone(asset)
+		if err != nil {
+			return nil, err
+		}
+		conn.closer = closer
+		helmPath = filepath.Join(clonePath, helmPath)
+	}
 
 	// Resolve a possibly-remote chart reference (oci://, http(s) .tgz, or a
 	// chart name with --repo) to a local path. Remote refs download to a
 	// temp dir that's cleaned up once the charts are read into memory.
-	fetched, err := resolveChartRef(cc.Options[OptionPath], cc.Options)
+	fetched, err := resolveChartRef(helmPath, cc.Options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +113,15 @@ func NewHelmConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	}
 	conn.charts = charts
 
+	cleanupClone = false
 	return conn, nil
+}
+
+// Close cleans up any temporary directory created by a git clone.
+func (c *HelmConnection) Close() {
+	if c.closer != nil {
+		c.closer()
+	}
 }
 
 func (c *HelmConnection) Name() string {

--- a/providers/helm/provider/provider.go
+++ b/providers/helm/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/v13/providers/helm/connection"
 	"go.mondoo.com/mql/v13/providers/helm/resources"
+	"go.mondoo.com/mql/v13/utils/urlx"
 )
 
 const (
@@ -180,6 +181,28 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HelmConnection
 	}
 	PlatformByName("helm").Apply(asset.Platform)
 
+	// When discovered from a git repository (e.g. by the GitHub provider) prefer
+	// the repo (org/repo) for the name and platform ID. The local path is a
+	// temporary clone directory whose hash would change on every scan.
+	if url, ok := asset.Connections[0].Options["ssh-url"]; ok {
+		domain, org, repo, err := urlx.ParseGitSshUrl(url)
+		if err == nil {
+			name := org + "/" + repo
+			platformID := "//platformid.api.mondoo.app/runtime/helm/domain/" + domain + "/org/" + org + "/repo/" + repo
+			// A repository can hold multiple charts; qualify by the repo-relative
+			// chart directory so each one is a distinct asset.
+			if relPath := asset.Connections[0].Options["path"]; relPath != "" {
+				platformID += "/path/" + relPath
+				name += "/" + relPath
+			}
+			asset.Id = platformID
+			asset.Connections[0].PlatformId = platformID
+			asset.PlatformIds = []string{platformID}
+			asset.Name = "Helm Chart " + name
+			return nil
+		}
+	}
+
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {
 		absPath, _ := filepath.Abs(projectPath)
@@ -189,7 +212,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HelmConnection
 		platformID := "//platformid.api.mondoo.app/runtime/helm/hash/" + hash
 		asset.Connections[0].PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "Helm Chart Static Analysis " + parseNameFromPath(projectPath)
+		asset.Name = "Helm Chart " + parseNameFromPath(projectPath)
 		return nil
 	}
 

--- a/providers/k8s/connection/manifest/connection.go
+++ b/providers/k8s/connection/manifest/connection.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/shared"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/shared/resources"
+	"go.mondoo.com/mql/v13/utils/urlx"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/version"
@@ -106,9 +107,18 @@ func NewConnection(id uint32, asset *inventory.Asset, opts ...Option) (shared.Co
 		if err != nil {
 			return nil, err
 		}
-		// manifest parent directory name
-		clusterName = shared.ProjectNameFromPath(c.manifestFile)
-		clusterName = "K8s Manifest " + clusterName
+		// Prefer the git repo (org/repo) for a stable, human-friendly name,
+		// matching the Terraform static-analysis naming. The manifest path is a
+		// temporary clone directory (e.g. mql-git-clone3841…) when discovered
+		// from a git repository, so fall back to it only for local manifests.
+		if url := asset.Connections[0].Options["ssh-url"]; url != "" {
+			if _, org, repo, err := urlx.ParseGitSshUrl(url); err == nil {
+				clusterName = "K8s Manifest " + org + "/" + repo
+			}
+		}
+		if clusterName == "" {
+			clusterName = "K8s Manifest " + shared.ProjectNameFromPath(c.manifestFile)
+		}
 	}
 	// discovered assets pass by here
 	// They already have a name, so do not override it here.

--- a/providers/kustomize/connection/connection.go
+++ b/providers/kustomize/connection/connection.go
@@ -22,7 +22,10 @@ import (
 // parse failure on a file that exists.
 var ErrNoKustomization = errors.New("no kustomization file found")
 
-var _ plugin.Connection = (*KustomizeConnection)(nil)
+var (
+	_ plugin.Connection = (*KustomizeConnection)(nil)
+	_ plugin.Closer     = (*KustomizeConnection)(nil)
+)
 
 type KustomizeConnection struct {
 	plugin.Connection
@@ -30,6 +33,7 @@ type KustomizeConnection struct {
 	asset          *inventory.Asset
 	path           string
 	kustomizations []*KustomizationEntry
+	closer         func()
 }
 
 // KustomizationEntry holds a parsed kustomization and its directory path.
@@ -49,9 +53,32 @@ func NewKustomizeConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 		asset:      asset,
 	}
 
+	// If a git clone is performed below, clean up the temporary directory on any
+	// error path. Close() is a no-op when nothing was cloned, and the guard is
+	// disarmed once the connection is returned and takes ownership of cleanup.
+	cleanupClone := true
+	defer func() {
+		if cleanupClone {
+			conn.Close()
+		}
+	}()
+
 	cc := asset.Connections[0]
-	kustomizePath, ok := cc.Options["path"]
-	if !ok || kustomizePath == "" {
+	kustomizePath := cc.Options["path"]
+	// When discovered from a git repository (e.g. by the GitHub provider) the
+	// asset carries the repo URL plus a repo-relative path to the kustomization
+	// directory. Clone the repo and resolve the directory within the checkout.
+	// The path option is kept relative so the detector can name the asset from
+	// the repo rather than the temporary clone directory.
+	if _, ok := cc.Options["http-url"]; ok {
+		clonePath, closer, err := plugin.NewGitClone(asset)
+		if err != nil {
+			return nil, err
+		}
+		conn.closer = closer
+		kustomizePath = filepath.Join(clonePath, kustomizePath)
+	}
+	if kustomizePath == "" {
 		return nil, errors.New("kustomize provider requires a 'path' option")
 	}
 	conn.path = filepath.Clean(kustomizePath)
@@ -68,7 +95,15 @@ func NewKustomizeConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 	}
 	conn.kustomizations = entries
 
+	cleanupClone = false
 	return conn, nil
+}
+
+// Close cleans up any temporary directory created by a git clone.
+func (c *KustomizeConnection) Close() {
+	if c.closer != nil {
+		c.closer()
+	}
 }
 
 func (c *KustomizeConnection) Name() string {

--- a/providers/kustomize/provider/provider.go
+++ b/providers/kustomize/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/v13/providers/kustomize/connection"
 	"go.mondoo.com/mql/v13/providers/kustomize/resources"
+	"go.mondoo.com/mql/v13/utils/urlx"
 )
 
 const (
@@ -132,6 +133,28 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.KustomizeConne
 	}
 	PlatformByName("kustomize").Apply(asset.Platform)
 
+	// When discovered from a git repository (e.g. by the GitHub provider) prefer
+	// the repo (org/repo) for the name and platform ID. The local path is a
+	// temporary clone directory whose hash would change on every scan.
+	if url, ok := asset.Connections[0].Options["ssh-url"]; ok {
+		domain, org, repo, err := urlx.ParseGitSshUrl(url)
+		if err == nil {
+			name := org + "/" + repo
+			platformID := "//platformid.api.mondoo.app/runtime/kustomize/domain/" + domain + "/org/" + org + "/repo/" + repo
+			// A repository can hold multiple kustomizations (e.g. base + overlays);
+			// qualify by the repo-relative directory so each is a distinct asset.
+			if relPath := asset.Connections[0].Options["path"]; relPath != "" {
+				platformID += "/path/" + relPath
+				name += "/" + relPath
+			}
+			asset.Id = platformID
+			asset.Connections[0].PlatformId = platformID
+			asset.PlatformIds = []string{platformID}
+			asset.Name = "Kustomize file " + name
+			return nil
+		}
+	}
+
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {
 		absPath, err := filepath.Abs(projectPath)
@@ -145,7 +168,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.KustomizeConne
 		asset.Id = platformID
 		asset.Connections[0].PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "Kustomize Static Analysis " + parseNameFromPath(projectPath)
+		asset.Name = "Kustomize file " + parseNameFromPath(projectPath)
 		return nil
 	}
 

--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -12,13 +12,17 @@ import (
 	"slices"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/local"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/utils/multierr"
 	"go.mondoo.com/mql/v13/utils/urlx"
 )
 
-var _ shared.Connection = &DockerfileConnection{}
+var (
+	_ shared.Connection = &DockerfileConnection{}
+	_ plugin.Closer     = &DockerfileConnection{}
+)
 
 type DockerfileConnection struct {
 	*local.LocalConnection
@@ -26,6 +30,7 @@ type DockerfileConnection struct {
 	// that we find the file downstream
 	FileAbsSrc string
 	osFamily   shared.OSFamily
+	closer     func()
 }
 
 func NewDockerfileConnection(_ uint32,
@@ -34,6 +39,29 @@ func NewDockerfileConnection(_ uint32,
 ) (*DockerfileConnection, error) {
 	if conf == nil {
 		return nil, errors.New("missing configuration to create dockerfile connection")
+	}
+
+	// When discovered from a git repository (e.g. by the GitHub provider) the
+	// asset carries the repo URL plus a repo-relative path to the Dockerfile.
+	// Clone the repo and resolve the Dockerfile within the checkout. The
+	// deferred cleanup removes the temporary clone directory on any error path;
+	// it is disarmed once ownership of the closer transfers to the connection.
+	var closer func()
+	cleanup := true
+	defer func() {
+		if cleanup && closer != nil {
+			closer()
+		}
+	}()
+	if conf.Path == "" {
+		if _, ok := conf.Options["http-url"]; ok {
+			clonePath, c, err := plugin.NewGitClone(asset)
+			if err != nil {
+				return nil, err
+			}
+			closer = c
+			conf.Path = filepath.Join(clonePath, conf.Options["path"])
+		}
 	}
 
 	src := conf.Path
@@ -72,9 +100,16 @@ func NewDockerfileConnection(_ uint32,
 			return nil, err
 		}
 		platformID := "//platformid.api.mondoo.app/runtime/dockerfile/domain/" + domain + "/org/" + org + "/repo/" + repo
+		name := org + "/" + repo
+		// A repository can contain multiple Dockerfiles; qualify the platform ID
+		// and name with the repo-relative path so each one is a distinct asset.
+		if relPath := conf.Options["path"]; relPath != "" {
+			platformID += "/path/" + relPath
+			name += "/" + relPath
+		}
 		conf.PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "Dockerfile analysis " + org + "/" + repo
+		asset.Name = "Dockerfile " + name
 
 	} else {
 		h := sha256.New()
@@ -84,7 +119,7 @@ func NewDockerfileConnection(_ uint32,
 
 		conf.PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
-		asset.Name = "Dockerfile analysis " + filename
+		asset.Name = "Dockerfile " + filename
 	}
 
 	conn := &DockerfileConnection{
@@ -92,7 +127,10 @@ func NewDockerfileConnection(_ uint32,
 		// here we must use the absolute path of the Dockerfile so
 		// that we find the file downstream
 		FileAbsSrc: absSrc,
+		closer:     closer,
 	}
+	// the connection now owns the clone directory and cleans it up via Close()
+	cleanup = false
 
 	if slices.Contains(localFamily, "darwin") {
 		conn.osFamily = shared.OSFamily_Darwin
@@ -109,4 +147,11 @@ func NewDockerfileConnection(_ uint32,
 
 func (p *DockerfileConnection) OSFamily() shared.OSFamily {
 	return p.osFamily
+}
+
+// Close cleans up any temporary directory created by a git clone.
+func (p *DockerfileConnection) Close() {
+	if p.closer != nil {
+		p.closer()
+	}
 }

--- a/providers/terraform/provider/detector.go
+++ b/providers/terraform/provider/detector.go
@@ -50,7 +50,7 @@ func (s *Service) detect(asset *inventory.Asset, _ *connection.Connection) error
 			asset.PlatformIds = []string{platformID}
 		}
 		asset.Connections[0].PlatformId = asset.PlatformIds[0]
-		asset.Name = "Terraform Static Analysis " + org + "/" + repo
+		asset.Name = "Terraform HCL " + org + "/" + repo
 		return nil
 	}
 
@@ -65,7 +65,7 @@ func (s *Service) detect(asset *inventory.Asset, _ *connection.Connection) error
 			asset.PlatformIds = []string{platformID}
 		}
 		asset.Connections[0].PlatformId = asset.PlatformIds[0]
-		asset.Name = "Terraform Static Analysis " + parseNameFromPath(projectPath)
+		asset.Name = "Terraform HCL " + parseNameFromPath(projectPath)
 		return nil
 	}
 


### PR DESCRIPTION
## What

Extends the **github** provider's infrastructure-as-code discovery beyond Terraform and Kubernetes manifests to also detect **CloudFormation** templates, **Dockerfiles**, **Bicep** files, **Helm** charts, and **Kustomize** configurations in repositories. Each match becomes a child asset that is cloned from git and scanned by the relevant provider.

## Files discovered

Discovery uses the GitHub code-search API (paginated, 100/page) and skips hidden paths (anything with a `.`-prefixed segment, e.g. `.github/`).

| Type | Target flag | Matched files | Asset granularity |
|------|-------------|---------------|-------------------|
| Terraform *(existing)* | `terraform` | repos with the `HCL` language | one per repo |
| Kubernetes manifests *(existing)* | `k8s-manifests` | `*.yaml` / `*.yml` (excl. `*mql.yaml`/`*mql.yml`) | one per repo |
| **CloudFormation** *(new)* | `cloudformation` | `.yaml`/`.yml`/`.json`/`.template` containing the `AWSTemplateFormatVersion` marker (avoids false positives against k8s/other YAML) | one per template |
| **Dockerfile** *(new)* | `dockerfiles` | `Dockerfile`, `Dockerfile.*` (e.g. `Dockerfile.prod`), `*.Dockerfile`, `*.dockerfile` | one per file |
| **Bicep** *(new)* | `bicep` | `*.bicep` | one per repo |
| **Helm** *(new)* | `helm` | `Chart.yaml` | one per chart directory |
| **Kustomize** *(new)* | `kustomize` | `kustomization.yaml` / `kustomization.yml` / `Kustomization` | one per kustomization directory (base + each overlay) |

Like the existing Terraform/k8s detectors, the new ones run only on explicit `--discover all` or `--discover <type>` (not `--discover auto`), so there's no surprise cloning.

## Git-clone support added to downstream providers

None of **bicep**, **cloudformation**, **helm**, **kustomize**, or the **os** dockerfile connection could clone from a git URL before — the dockerfile connection only read `ssh-url` for naming. Each now:
- clones the repo on `http-url` (shallow, via the shared `plugin.NewGitClone`),
- resolves the target within the checkout (CloudFormation/Dockerfile point at a repo-relative file; Helm/Kustomize point at a repo-relative directory; Bicep scans the checkout directory),
- cleans up the temporary clone directory via `Close()`, including on every post-clone error path (deferred cleanup, disarmed once the connection takes ownership).

**Trade-off:** CloudFormation, Dockerfile, Helm, and Kustomize emit one asset per matched file/directory, so a repo with N of them performs N shallow clones. This keeps each connection's existing single-target model and avoids a shared clone cache; documented in the discoverers.

**Note on overlap:** Helm `templates/*.yaml` and `kustomization.yaml` also match the existing k8s `*.yaml` detector, so a chart/kustomize repo can surface under `--discover k8s-manifests` *and* `--discover helm`/`kustomize`. That's intentional — each is a distinct analysis lens — but worth being aware of when running `--discover all`.

## Repo-based naming & stable identity

- **k8s**, **bicep**, **cloudformation**, **helm**, and **kustomize** now name discovered assets from the git repo (`org/repo[/path]`) like Terraform/Dockerfile, instead of the temporary clone directory. Fixes `K8s Manifest directory mql-git-clone3841…` → `K8s Manifest tas50/iac_tests`.
- bicep, cloudformation, helm, and kustomize **platform IDs** are now derived from the repo (and target path) rather than a hash of the temp clone path — which previously changed on every scan, giving a discovered asset a new identity each run.

## Verification

Verified end-to-end against `tas50/iac_tests`. Discovery, naming, and content queries all resolve:

| Asset | Platform | Content checked |
|-------|----------|-----------------|
| `K8s Manifest tas50/iac_tests` | `k8s-manifest` | — (renamed) |
| `CloudFormation template …/cloudformation/s3_bucket.yaml` | `cloudformation` | 2 S3 resources parsed |
| `Dockerfile …/docker/Dockerfile.secure` | `dockerfile` | stages parsed (FROM ubuntu) |
| `Dockerfile …/docker/Dockerfile.insecure` | `dockerfile` | stages parsed |
| `Bicep file tas50/iac_tests` | `bicep` | 2 `.bicep` files, 1 resource each |
| `Helm Chart …/helm/web` | `helm` | chart `web` 0.1.0 parsed |
| `Kustomize file …/kustomize/base` | `kustomize` | 1 resource parsed |
| `Kustomize file …/kustomize/overlays/prod` | `kustomize` | 1 resource parsed |

## Files changed

- `providers/github/{config,connection,resources}` — five discovery targets + detectors + paginated `searchCode` helper + `gitCredentials` dedupe
- `providers/bicep/{provider,connection}`, `providers/cloudformation/{provider,connection}`, `providers/helm/{provider,connection}`, `providers/kustomize/{provider,connection}` — git clone, `Close()`, repo-based name/platform ID
- `providers/os/connection/docker/docker_file_connection.go` — git clone, `Close()`, repo-relative platform ID
- `providers/k8s/connection/manifest/connection.go` — repo-based asset name
