### PR TITLE
✨ cos: emit pkg:cos PURLs for COS packages

### DIFF
--- a/providers/os/resources/packages/cos_packages.go
+++ b/providers/os/resources/packages/cos_packages.go
@@ -76,8 +76,7 @@ func ParseCosPackages(pf *inventory.Platform, input io.Reader) ([]Package, error
 	}
 
 	pkgs := make([]Package, len(cPkgs.InstalledPackages))
-	for i := range cPkgs.InstalledPackages {
-		src := cPkgs.InstalledPackages[i]
+	for i, src := range cPkgs.InstalledPackages {
 		// older /etc/cos-package-info.json entries only populate `version`
 		// with the COS image version; newer ones add `ebuild_version`. Prefer
 		// the ebuild version when present and fall back so we still emit a

--- a/providers/os/resources/packages/cos_packages.go
+++ b/providers/os/resources/packages/cos_packages.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/purl"
 )
 
 const (
@@ -28,7 +30,8 @@ type cosPackage struct {
 }
 
 type CosPkgManager struct {
-	conn shared.Connection
+	conn     shared.Connection
+	platform *inventory.Platform
 }
 
 func (cpm *CosPkgManager) Name() string {
@@ -48,14 +51,14 @@ func (cpm *CosPkgManager) List() ([]Package, error) {
 	}
 	defer fr.Close()
 
-	return ParseCosPackages(fr)
+	return ParseCosPackages(cpm.platform, fr)
 }
 
 func (cpm *CosPkgManager) Available() (map[string]PackageUpdate, error) {
 	return nil, errors.New("cannot determine available packages for cos")
 }
 
-func ParseCosPackages(input io.Reader) ([]Package, error) {
+func ParseCosPackages(pf *inventory.Platform, input io.Reader) ([]Package, error) {
 	data, err := io.ReadAll(input)
 	if err != nil {
 		return nil, err
@@ -74,12 +77,40 @@ func ParseCosPackages(input io.Reader) ([]Package, error) {
 
 	pkgs := make([]Package, len(cPkgs.InstalledPackages))
 	for i := range cPkgs.InstalledPackages {
-		pkgs[i].Name = cPkgs.InstalledPackages[i].Name
-		pkgs[i].Version = cPkgs.InstalledPackages[i].EbuildVersion
+		src := cPkgs.InstalledPackages[i]
+		// older /etc/cos-package-info.json entries only populate `version`
+		// with the COS image version; newer ones add `ebuild_version`. Prefer
+		// the ebuild version when present and fall back so we still emit a
+		// usable PURL.
+		version := src.EbuildVersion
+		if version == "" {
+			version = src.Version
+		}
+		pkgs[i].Name = src.Name
+		pkgs[i].Version = version
 		pkgs[i].Format = CosPkgFormat
+		pkgs[i].PUrl = newCosPurl(pf, src.Name, version, src.Version)
 	}
 
 	return pkgs, nil
+}
+
+// newCosPurl builds a PURL for a COS package. Shape follows osv-scalibr and
+// the open purl-spec PR #270: `pkg:cos/<name>@<version>?distro=cos-<id>`. We
+// deviate from scalibr by using the ebuild version (the actual upstream
+// package version, useful for CVE matching) instead of the COS image version;
+// the image version is preserved as a `build` qualifier so it isn't lost.
+func newCosPurl(pf *inventory.Platform, name, ebuildVersion, imageVersion string) string {
+	qualifiers := map[string]string{}
+	if imageVersion != "" && imageVersion != ebuildVersion {
+		qualifiers[purl.QualifierBuild] = imageVersion
+	}
+	return purl.NewPackageURL(pf, purl.TypeCos, name, ebuildVersion,
+		// pkg:cos has no namespace (matches osv-scalibr); override the
+		// platform-derived default that NewPackageURL would otherwise set.
+		purl.WithNamespace(""),
+		purl.WithQualifiers(qualifiers),
+	).String()
 }
 
 func (cpm *CosPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {

--- a/providers/os/resources/packages/cos_packages_test.go
+++ b/providers/os/resources/packages/cos_packages_test.go
@@ -9,21 +9,67 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
 func TestParseCosPackages(t *testing.T) {
 	f, err := os.Open("testdata/cos-package-info.json")
 	require.NoError(t, err)
+	defer f.Close()
 
-	m, err := ParseCosPackages(f)
-	assert.Nil(t, err)
-	assert.Equal(t, 3, len(m), "detected the right amount of packages")
-
-	p := Package{
-		Name:    "zlib",
-		Version: "1.2.11-r4",
-		Arch:    "",
-		Format:  "cos",
+	pf := &inventory.Platform{
+		Name:    "cos",
+		Version: "97",
+		Arch:    "x86_64",
+		Labels:  map[string]string{"distro-id": "cos"},
 	}
-	assert.Contains(t, m, p)
+
+	m, err := ParseCosPackages(pf, f)
+	require.NoError(t, err)
+	require.Len(t, m, 4)
+
+	byName := map[string]Package{}
+	for _, p := range m {
+		byName[p.Name] = p
+	}
+
+	zlib := byName["zlib"]
+	assert.Equal(t, "zlib", zlib.Name)
+	assert.Equal(t, "1.2.11-r4", zlib.Version)
+	assert.Equal(t, "cos", zlib.Format)
+	// `pkg:cos` shape from osv-scalibr / purl-spec PR #270, with the ebuild
+	// version in the @version slot and the COS image version preserved as
+	// the build qualifier.
+	assert.Contains(t, zlib.PUrl, "pkg:cos/zlib@1.2.11-r4")
+	assert.Contains(t, zlib.PUrl, "build=16919.103.16")
+	assert.Contains(t, zlib.PUrl, "distro=cos-97")
+	assert.NotContains(t, zlib.PUrl, "namespace")
+	assert.NotContains(t, zlib.PUrl, "pkg:cos/sys-libs/") // no namespace
+
+	// Falls back to `version` when `ebuild_version` is missing; in that case
+	// we skip the build qualifier (it would equal the version).
+	ca := byName["ca-certificates"]
+	assert.Equal(t, "20230311.3.96.1", ca.Version)
+	assert.Contains(t, ca.PUrl, "pkg:cos/ca-certificates@20230311.3.96.1")
+	assert.NotContains(t, ca.PUrl, "build=")
+}
+
+func TestParseCosPackages_NoPlatform(t *testing.T) {
+	f, err := os.Open("testdata/cos-package-info.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	m, err := ParseCosPackages(nil, f)
+	require.NoError(t, err)
+	require.Len(t, m, 4)
+
+	byName := map[string]Package{}
+	for _, p := range m {
+		byName[p.Name] = p
+	}
+
+	// Without a platform we still emit a structurally-valid PURL — just no
+	// distro qualifier and no arch.
+	assert.Contains(t, byName["zlib"].PUrl, "pkg:cos/zlib@1.2.11-r4")
+	assert.Contains(t, byName["zlib"].PUrl, "build=16919.103.16")
 }

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -142,7 +142,7 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	case asset.Platform.Name == "solaris":
 		pms = append(pms, &SolarisPkgManager{conn: conn})
 	case asset.Platform.Name == "cos":
-		pms = append(pms, &CosPkgManager{conn: conn})
+		pms = append(pms, &CosPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.Name == "freebsd" || asset.Platform.Name == "dragonflybsd": // both use pkg cli
 		pms = append(pms, &FreeBSDPkgManager{conn: conn})
 	case asset.Platform.Name == "netbsd":

--- a/providers/os/resources/packages/testdata/cos-package-info.json
+++ b/providers/os/resources/packages/testdata/cos-package-info.json
@@ -17,6 +17,11 @@
       "name": "baselayout",
       "version": "16919.103.16",
       "ebuild_version": "2.2-r1"
+    },
+    {
+      "category": "app-misc",
+      "name": "ca-certificates",
+      "version": "20230311.3.96.1"
     }
   ]
 }

--- a/providers/os/resources/purl/platform_purl.go
+++ b/providers/os/resources/purl/platform_purl.go
@@ -33,7 +33,7 @@ func NewPlatformPurl(platform *inventory.Platform) (string, error) {
 	qualifiers[QualifierDistro] = strings.Join(distroQualifiers, "-")
 
 	if platform.Build != "" {
-		qualifiers["build"] = platform.Build
+		qualifiers[QualifierBuild] = platform.Build
 	}
 
 	// e.g. used on suse linux

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -16,6 +16,7 @@ const (
 	QualifierArch   = "arch"
 	QualifierDistro = "distro"
 	QualifierEpoch  = "epoch"
+	QualifierBuild  = "build"
 )
 
 // PackageURL is a helper struct that renters a package url based of an inventory

--- a/providers/os/resources/purl/purl_types.go
+++ b/providers/os/resources/purl/purl_types.go
@@ -21,6 +21,10 @@ var (
 	Type_X_Platform Type = "platform"
 	// TypeSnap is a pkg:snap purl.
 	TypeSnap Type = "snap"
+	// TypeCos is a pkg:cos purl for Google Container-Optimized OS packages.
+	// Tracks the shape proposed in package-url/purl-spec#270 and emitted by
+	// osv-scalibr; not (yet) in the formal purl-spec registry.
+	TypeCos Type = "cos"
 	// Types we use coming from:
 	// https://github.com/package-url/packageurl-go/blob/master/packageurl.go#L54
 	TypeGeneric = Type(packageurl.TypeGeneric)
@@ -43,6 +47,7 @@ var (
 		TypeEbuild:      {},
 		TypeNix:         {},
 		TypeRPM:         {},
+		TypeCos:         {},
 	}
 )
 


### PR DESCRIPTION
## Summary

- COS packages previously had no PURL — `/etc/cos-package-info.json` was parsed but `Package.PUrl` was never set, so downstream SBOM tooling synthesized a `pkg:generic/cos/...` fallback and logged warnings about packages with empty PURLs.
- Now `cos_packages.go` emits `pkg:cos/<name>@<ebuild_version>?build=<BUILD_ID>&distro=cos-<VERSION_ID>`. Shape follows [osv-scalibr](https://github.com/google/osv-scalibr/blob/main/extractor/filesystem/os/cos/cos.go) and the open [purl-spec PR #270](https://github.com/package-url/purl-spec/pull/270) — the only tools in the ecosystem that handle COS today.
- We deviate from scalibr in one place: the `@version` slot holds the **ebuild version** (the actual upstream package version, useful for CVE matching), not the COS image version. The image `BUILD_ID` is preserved as the `build` qualifier so it isn't lost.
- Older `cos-package-info.json` entries that only populate `version` (no `ebuild_version`) fall back to the COS image version and skip the redundant `build` qualifier so we don't emit `build=X&@X` duplication.

### Example output

For a typical COS 97 node (`BUILD_ID=16919.103.16`):

```
pkg:cos/zlib@1.2.11-r4?build=16919.103.16&distro=cos-97
pkg:cos/baselayout@2.2-r1?build=16919.103.16&distro=cos-97
pkg:cos/ca-certificates@20230311.3.96.1?distro=cos-97   # fallback path
```

### Files touched

- `providers/os/resources/purl/purl_types.go` — new `TypeCos` registered in `KnownTypes`.
- `providers/os/resources/purl/purl.go` — new `QualifierBuild = "build"` constant.
- `providers/os/resources/purl/platform_purl.go` — adopts the constant.
- `providers/os/resources/packages/cos_packages.go` — `CosPkgManager` now carries `*inventory.Platform`; `newCosPurl` emits the new shape.
- `providers/os/resources/packages/packages.go` — threads `asset.Platform` when constructing `CosPkgManager`.
- `providers/os/resources/packages/testdata/cos-package-info.json` — added a `ca-certificates` entry without `ebuild_version` to lock in the fallback path.

## Test plan

- [x] `go test ./providers/os/resources/packages/ -run TestParseCosPackages` — passes (covers PURL shape, build qualifier, ebuild-version fallback, no-platform path).
- [x] `go test ./providers/os/resources/purl/...` — existing purl suite still passes.
- [x] `go vet ./providers/os/resources/packages/... ./providers/os/resources/purl/...` — clean.
- [x] End-to-end smoke against a mock COS root: `mql run filesystem /tmp/cos-mock-root -c 'packages.list { name version purl }'` correctly detects `platform=cos build=16919.103.16` and emits the new PURLs for all four test packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)