### PR TITLE
✨ health: include host platform in panic reports

### DIFF
--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -6,6 +6,7 @@ package health
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"runtime/debug"
 	"time"
 
@@ -83,9 +84,21 @@ func sendPanic(product, version, build string, r any, stacktrace []byte) {
 	}
 
 	// 2. create local support bundle
-	event := &SendErrorReq{
-		ServiceAccountMrn: opts.ServiceAccountMrn,
-		AgentMrn:          opts.AgentMrn,
+	event := panicEvent(product, version, build, r, stacktrace)
+	event.ServiceAccountMrn = opts.ServiceAccountMrn
+	event.AgentMrn = opts.AgentMrn
+
+	// 3. send error to mondoo platform
+	sendErrorToMondooPlatform(serviceAccount, event)
+
+	log.Info().Msg("reported panic to Mondoo Platform")
+}
+
+// panicEvent builds the error report for a recovered panic, tagged with the
+// platform the binary runs on so reports remain attributable even when no
+// asset context is available (e.g. panics outside a scan).
+func panicEvent(product, version, build string, r any, stacktrace []byte) *SendErrorReq {
+	return &SendErrorReq{
 		Product: &ProductInfo{
 			Name:    product,
 			Version: version,
@@ -95,12 +108,11 @@ func sendPanic(product, version, build string, r any, stacktrace []byte) {
 			Message:    "panic: " + fmt.Sprintf("%v", r),
 			Stacktrace: string(stacktrace),
 		},
+		Tags: map[string]string{
+			"os":   runtime.GOOS,
+			"arch": runtime.GOARCH,
+		},
 	}
-
-	// 3. send error to mondoo platform
-	sendErrorToMondooPlatform(serviceAccount, event)
-
-	log.Info().Msg("reported panic to Mondoo Platform")
 }
 
 func ReportError(product, version, build, err string, opts ...ReportOption) {

--- a/providers-sdk/v1/upstream/health/errors_test.go
+++ b/providers-sdk/v1/upstream/health/errors_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package health
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPanicEventIncludesPlatform(t *testing.T) {
+	event := panicEvent("cnspec", "12.0.0", "abc123", "boom", []byte("stacktrace"))
+
+	require.NotNil(t, event.Product)
+	assert.Equal(t, "cnspec", event.Product.Name)
+	assert.Equal(t, "12.0.0", event.Product.Version)
+	assert.Equal(t, "abc123", event.Product.Build)
+
+	require.NotNil(t, event.Error)
+	assert.Equal(t, "panic: boom", event.Error.Message)
+	assert.Equal(t, "stacktrace", event.Error.Stacktrace)
+
+	assert.Equal(t, runtime.GOOS, event.Tags["os"])
+	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
+}


### PR DESCRIPTION
## What

Tag every panic report sent via `health.ReportPanic` with the host platform (`os`/`arch` from the Go runtime).

## Why

Panic reports carried no platform context unless cnspec's scan pipeline attached asset tags via a custom reporter. Panics outside an asset scan (CLI main, collector, execution manager) arrived with only product name/version/build, making them hard to attribute. The server-side handler already forwards all tags to Sentry and obslog, so no server change is needed.