### PR TITLE
🐛 llx: stop array contains/difference builtins panicking on a null argument

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -815,6 +815,14 @@ func arrayDifferenceV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64
 		return nil, rref, err
 	}
 
+	// A null argument (e.g. a missing map key resolving to a typed null
+	// array) propagates as null, mirroring the receiver-nil guard above.
+	// Without this the `arg.Value.([]any)` assertion below panics, which
+	// crashes the whole scan rather than failing the single check.
+	if arg.Value == nil {
+		return &RawData{Type: bind.Type, Error: arg.Error}, 0, nil
+	}
+
 	t := types.Type(arg.Type)
 	if t != bind.Type {
 		return nil, 0, errors.New("called `difference` with wrong type (got: " + t.Label() + ", expected:" + bind.Type.Label() + ")")
@@ -920,6 +928,14 @@ func arrayContainsAll(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 		return nil, rref, err
 	}
 
+	// A null argument (e.g. a missing map key resolving to a typed null
+	// array) propagates as null, mirroring the receiver-nil guard above.
+	// Without this the `arg.Value.([]any)` assertion below panics, which
+	// crashes the whole scan rather than failing the single check.
+	if arg.Value == nil {
+		return &RawData{Type: bind.Type, Error: arg.Error}, 0, nil
+	}
+
 	t := types.Type(arg.Type)
 	if t != bind.Type {
 		return nil, 0, errors.New("called `arrayNone` with wrong type (got: " + t.Label() + ", expected:" + bind.Type.Label() + ")")
@@ -971,6 +987,14 @@ func arrayContainsNone(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64
 	arg, rref, err := e.resolveValue(argRef, ref)
 	if err != nil || rref > 0 {
 		return nil, rref, err
+	}
+
+	// A null argument (e.g. a missing map key resolving to a typed null
+	// array) propagates as null, mirroring the receiver-nil guard above.
+	// Without this the `arg.Value.([]any)` assertion below panics, which
+	// crashes the whole scan rather than failing the single check.
+	if arg.Value == nil {
+		return &RawData{Type: bind.Type, Error: arg.Error}, 0, nil
 	}
 
 	t := types.Type(arg.Type)

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -741,6 +741,22 @@ func TestArray(t *testing.T) {
 			Code:        "['x'].containsAll([asset.labels['nope']])",
 			Expectation: []any{nil},
 		},
+		// Regression: a null argument (e.g. a missing map key resolving to a
+		// typed null array, as happens on hosts with no /etc/pam.d) must
+		// propagate as null instead of panicking the whole scan with
+		// "interface conversion: interface {} is nil, not []interface {}".
+		{
+			Code:        "a = {a: [1,2]}; [1,2,3].containsAll(a['b'])",
+			Expectation: nil,
+		},
+		{
+			Code:        "a = {a: [1,2]}; [1,2,3].containsNone(a['b'])",
+			Expectation: nil,
+		},
+		{
+			Code:        "a = {a: [1,2]}; [1,2,3] - a['b']",
+			Expectation: nil,
+		},
 		{
 			Code:        "['a','b'] != /c/",
 			ResultIndex: 0, Expectation: true,

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -757,6 +757,15 @@ func TestArray(t *testing.T) {
 			Code:        "a = {a: [1,2]}; [1,2,3] - a['b']",
 			Expectation: nil,
 		},
+		// Regression: containsAll of an empty (typed, non-null) list is
+		// vacuously satisfied, so the compiled `== []` check is true. The
+		// mondoo-linux-security su-restriction check relies on this for
+		// `groups.containsAll(suRestrictedGroups)` when no group is configured
+		// and suRestrictedGroups is an empty []string.
+		{
+			Code:        `a = ["x", "y"]; ["wheel", "sudo"].containsAll(a.where(false))`,
+			ResultIndex: 1, Expectation: true,
+		},
 		{
 			Code:        "['a','b'] != /c/",
 			ResultIndex: 0, Expectation: true,


### PR DESCRIPTION
Fixes #8319

## Problem

A surge of client scan panics (`panic: interface conversion: interface {} is nil, not []interface {}`) traced to the array `contains*`/`difference` builtins.

`arrayContainsAll`, `arrayContainsNone`, and `arrayDifferenceV2` guard the **receiver** array against null but then perform an unchecked `arg.Value.([]any)` on the **argument**. When the argument resolves to a *typed null array* — e.g. a `map[string][]T` key miss like `pam.conf.services["su"]` on hosts with no `/etc/pam.d` (container-optimized k8s node OSes: COS, Flatcar, Bottlerocket) — that type assertion panics.

Because the MQL executor runs blocks in goroutines, the panic is unrecoverable by the caller and **crashes the entire scan** rather than failing the single check. The `dict` variants (`dictContainsAll`/`dictContainsNone`) already use the safe comma-ok form, so only the array variants were affected.

## Fix

Guard the argument the same way the receiver is already guarded: a null argument propagates as null (placed before the type check so an untyped null short-circuits cleanly too). The compiled `… == []` wrapper then resolves the check to a clean pass/fail.

After the fix, `realArray.containsAll(nullArg)` returns null → the check resolves to `false` (fails cleanly) instead of crashing. Whether a pam-absent host should pass or fail the check remains a policy decision; the engine's responsibility here is simply to not panic.

## Testing

- Reproduced the exact panic with `a = {a: [1,2]}; [1,2,3].containsAll(a['b'])` (typed-null arg via map key miss); confirmed crash pre-fix, clean result post-fix.
- Added regression cases for `containsAll` / `containsNone` / `difference` to `TestArray`.
- `go test ./llx/` and the full `./providers/core/resources/` suite pass.