### PR TITLE
🐛 types: stop equality comparators panicking on a null array element

### DIFF
--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -732,6 +732,15 @@ func TestArray(t *testing.T) {
 			Code:        "a = [1]; [2,1,2,1].containsNone(a)",
 			Expectation: []any{int64(1), int64(1)},
 		},
+		// Regression: a null array element (here a missing map key) surfaces as
+		// a nil interface. The element comparators must handle it instead of
+		// panicking with "interface conversion: interface {} is nil, not
+		// string", which would crash the whole scan. The nil filter never
+		// matches "x", so it remains in the leftover.
+		{
+			Code:        "['x'].containsAll([asset.labels['nope']])",
+			Expectation: []any{nil},
+		},
 		{
 			Code:        "['a','b'] != /c/",
 			ResultIndex: 0, Expectation: true,

--- a/types/types.go
+++ b/types/types.go
@@ -338,24 +338,47 @@ func (typ Type) Label() string {
 }
 
 // Equal provides a set of function for a range of types to test if 2 values
-// of that type are equal
+// of that type are equal.
+//
+// A null array element surfaces here as a nil interface, so every comparator
+// guards against it: two nils are equal, a nil and a value are not. Without
+// this the type assertions below panic (e.g. `interface {} is nil, not
+// string`), which crashes the entire scan instead of failing one comparison.
 var Equal = map[Type]func(any, any) bool{
 	Bool: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(bool) == right.(bool)
 	},
 	Int: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(int64) == right.(int64)
 	},
 	Float: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(float64) == right.(float64)
 	},
 	String: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(string) == right.(string)
 	},
 	Regex: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(string) == right.(string)
 	},
 	Time: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		l := left.(*time.Time)
 		r := right.(*time.Time)
 		if l == nil || r == nil {
@@ -365,6 +388,9 @@ var Equal = map[Type]func(any, any) bool{
 	},
 	// types.Dict: func(left, right any) bool {},
 	Score: func(left, right any) bool {
+		if left == nil || right == nil {
+			return left == nil && right == nil
+		}
 		return left.(int32) == right.(int32)
 	},
 }

--- a/types/types.go
+++ b/types/types.go
@@ -381,6 +381,9 @@ var Equal = map[Type]func(any, any) bool{
 		}
 		l := left.(*time.Time)
 		r := right.(*time.Time)
+		// The guard above only catches an untyped nil interface; a typed
+		// (*time.Time)(nil) element still reaches here, so keep checking the
+		// pointer before dereferencing it.
 		if l == nil || r == nil {
 			return false
 		}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -41,5 +42,30 @@ func TestTypes(t *testing.T) {
 
 		// test for human friendly name
 		assert.Equal(t, test.ExpectedLabel, test.T.Label())
+	}
+}
+
+func TestEqual_NilOperands(t *testing.T) {
+	// A null array element surfaces as a nil interface value. The Equal
+	// comparators must treat nil safely (nil == nil, nil \!= value) instead
+	// of panicking on the type assertion, which would crash the whole scan.
+	cases := []struct {
+		typ   Type
+		value any
+	}{
+		{Bool, true},
+		{Int, int64(1)},
+		{Float, 1.5},
+		{String, "x"},
+		{Regex, "x"},
+		{Score, int32(1)},
+		{Time, &time.Time{}},
+	}
+	for _, c := range cases {
+		eq, ok := Equal[c.typ]
+		assert.True(t, ok, c.typ.Label())
+		assert.False(t, eq(c.value, nil), "%s: value == nil", c.typ.Label())
+		assert.False(t, eq(nil, c.value), "%s: nil == value", c.typ.Label())
+		assert.True(t, eq(nil, nil), "%s: nil == nil", c.typ.Label())
 	}
 }


### PR DESCRIPTION
## Problem

A second latent panic in the same family as #8320: `panic: interface conversion: interface {} is nil, not string`.

The `types.Equal` comparators (`Bool`, `Int`, `Float`, `String`, `Regex`, `Score`, `Time`) perform unguarded type assertions like `left.(string)`. A **null array element** surfaces as a nil interface — e.g. `["x"].containsAll([asset.labels["nope"]])`, where the map miss yields a null string wrapped in an array — so the assertion panics.

These comparators back **every** array element-comparison builtin (`containsAll`, `containsNone`, `containsOnly`, `difference`). Because the MQL executor runs blocks in goroutines, the panic is unrecoverable and **crashes the whole scan** rather than failing the single comparison.

(`Time` already nil-checked its dereferenced pointer, but still asserted `left.(*time.Time)` on a nil *interface* first, so it was vulnerable to the same crash.)

## Fix

Guard each comparator against nil operands: two nils are equal, a nil and a value are not. This is the natural equality semantics and protects all callers at the root.

## Relationship to #8320

Independent and complementary. #8320 handles the *whole argument array* being null; this handles a null *element inside* an otherwise-present array. Both were uncovered while reproducing the `pam`-absent k8s scan crashes; either can crash a scan on its own. No overlapping lines — they can merge in any order.

## Testing

- Added `TestEqual_NilOperands` unit test in `types/` exercising every comparator with `(value, nil)`, `(nil, value)`, `(nil, nil)`; confirmed it panics pre-fix, passes post-fix.
- Added an e2e regression in `TestArray` (`['x'].containsAll([asset.labels['nope']])`) that drives the full executor path.
- `go test ./types/ ./llx/ ./providers/core/resources/` all pass.