### PR TITLE
✨ os/pam: add pam.conf.exists to check whether PAM config is present

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -954,6 +954,12 @@ packages {
 // Examine /etc/pam.d service entries with their type, control, and module
 pam.conf {
   init(path string)
+  // Whether PAM configuration is present on the system
+  //
+  // True when either the `/etc/pam.d` directory or the `/etc/pam.conf` file
+  // exists. Use it to guard PAM audits on hosts that ship no PAM
+  // configuration, such as container-optimized OS images.
+  exists() bool
   // List of files that make up the PAM configuration
   files() []file
   // The raw PAM configuration (across all files)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2938,6 +2938,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"packages.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackages).GetList()).ToDataRes(types.Array(types.Resource("package")))
 	},
+	"pam.conf.exists": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConf).GetExists()).ToDataRes(types.Bool)
+	},
 	"pam.conf.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConf).GetFiles()).ToDataRes(types.Array(types.Resource("file")))
 	},
@@ -11189,6 +11192,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"pam.conf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPamConf).__id, ok = v.Value.(string)
+		return
+	},
+	"pam.conf.exists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConf).Exists, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"pam.conf.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26279,6 +26286,7 @@ type mqlPamConf struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlPamConfInternal it will be used here
+	Exists   plugin.TValue[bool]
 	Files    plugin.TValue[[]any]
 	Content  plugin.TValue[string]
 	Services plugin.TValue[map[string]any]
@@ -26321,6 +26329,12 @@ func (c *mqlPamConf) MqlName() string {
 
 func (c *mqlPamConf) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlPamConf) GetExists() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Exists, func() (bool, error) {
+		return c.exists()
+	})
 }
 
 func (c *mqlPamConf) GetFiles() *plugin.TValue[[]any] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1978,6 +1978,7 @@ packages.list 9.0.0
 pam.conf 9.0.0
 pam.conf.content 9.0.0
 pam.conf.entries 9.0.0
+pam.conf.exists 13.26.3
 pam.conf.files 9.0.0
 pam.conf.modules 13.16.10
 pam.conf.serviceEntry 9.0.0

--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -70,6 +70,29 @@ func (se *mqlPamConfServiceEntry) id() (string, error) {
 	return id, nil
 }
 
+// exists reports whether any PAM configuration is present, checking the
+// pam.d directory and the single-file pam.conf the same way files() selects
+// between them. Unlike files() it never errors when nothing is found, so
+// audits can guard PAM checks on hosts that ship no PAM configuration.
+func (s *mqlPamConf) exists() (bool, error) {
+	for _, path := range []string{defaultPamDir, defaultPamConf} {
+		raw, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return false, err
+		}
+		exist := raw.(*mqlFile).GetExists()
+		if exist.Error != nil {
+			return false, exist.Error
+		}
+		if exist.Data {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GetFiles is called when the user has not provided a custom path. Otherwise files are set in the init
 // method and this function is never called then since the data is already cached.
 func (s *mqlPamConf) files() ([]any, error) {

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -8,7 +8,56 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
 )
+
+// newPamRuntime builds a runtime backed by a mock filesystem containing the
+// given files, so pam.conf.exists can be exercised for both the present and
+// absent cases without disturbing the shared LinuxMock recording.
+func newPamRuntime(t *testing.T, files ...string) *plugin.Runtime {
+	t.Helper()
+
+	fileData := map[string]*mock.MockFileData{}
+	for _, f := range files {
+		fileData[f] = &mock.MockFileData{Path: f}
+	}
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "arch", Family: []string{"arch", "linux"}},
+	}, mock.WithData(&mock.TomlData{Files: fileData}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+func TestPamConfExists(t *testing.T) {
+	t.Run("true when /etc/pam.conf is present", func(t *testing.T) {
+		pam := &mqlPamConf{MqlRuntime: newPamRuntime(t, "/etc/pam.conf")}
+		got, err := pam.exists()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("true when the /etc/pam.d directory is present", func(t *testing.T) {
+		pam := &mqlPamConf{MqlRuntime: newPamRuntime(t, "/etc/pam.d")}
+		got, err := pam.exists()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("false without erroring when no PAM config is present", func(t *testing.T) {
+		pam := &mqlPamConf{MqlRuntime: newPamRuntime(t)}
+		got, err := pam.exists()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
 
 func TestPamConfServiceEntryParams(t *testing.T) {
 	se := &mqlPamConfServiceEntry{}

--- a/providers/os/resources/pam_test.go
+++ b/providers/os/resources/pam_test.go
@@ -15,4 +15,11 @@ func TestResource_Pam(t *testing.T) {
 		assert.NotEmpty(t, res)
 		assert.Error(t, res[0].Data.Error, "returned an error")
 	})
+
+	t.Run("exists is false without erroring when files are missing", func(t *testing.T) {
+		res := x.TestQuery(t, "pam.conf.exists")
+		assert.NotEmpty(t, res)
+		assert.NoError(t, res[0].Data.Error)
+		assert.Equal(t, false, res[0].Data.Value)
+	})
 }


### PR DESCRIPTION
## What

Adds a `pam.conf.exists` bool field: **true** when either the `/etc/pam.d` directory or the `/etc/pam.conf` file is present, **false** otherwise. Unlike `pam.conf.files` (and the fields derived from it), it never errors when no PAM configuration is found.

## Why

Audits that query the `pam` resource (`services`, `modules`, `entries`, …) hit an error or a typed-null on hosts that ship **no** PAM configuration — container-optimized k8s node images such as COS, Flatcar, and Bottlerocket have no `/etc/pam.d`. There was previously no clean way to guard such a check, so policies either errored or fed a null into downstream builtins.

Policies can now guard cleanly:

```mql
pam.conf.exists
# or
if (pam.conf.exists) {
  # ...PAM-based checks (su restriction, faillock, pwquality, ...)...
}
```

This is the resource-level complement to the engine hardening in #8320 / #8321 (which stop the null from crashing scans in the first place): those make the engine robust; this gives content authors an explicit signal to branch on.

## Testing

- Unit test: `pam.conf.exists` returns `false` with no error on a file-less mock.
- Live: returns `true` on a Debian 13 host (30 `/etc/pam.d` files).
- `go test ./providers/os/resources/` passes; codegen re-run is deterministic.