### PR TITLE
✨ os/pam: add pam.conf.service for per-service module queries

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -977,7 +977,10 @@ pam.conf {
 
 // A single entry within a PAM service configuration
 private pam.conf.serviceEntry @defaults("service module") {
-  // Service file that the entry is from
+  // Service the entry belongs to
+  //
+  // The `/etc/pam.d/<service>` file path the line came from, or the service
+  // name in the first column when read from the single-file `/etc/pam.conf`.
   service string
   // Line number in service file (used for ID)
   lineNumber int
@@ -1003,18 +1006,21 @@ private pam.conf.serviceEntry @defaults("service module") {
 //
 // Examine the PAM configuration for a single service selected by name — for
 // example `pam.conf.service(name: "su")` or `pam.conf.service(name: "sshd")`.
-// `entries` are the parsed lines for that service and `modules` aggregates the
-// modules it loads keyed by name, so audits such as
+// The service is resolved from its `/etc/pam.d/<name>` file, or from the lines
+// naming it in the legacy single-file `/etc/pam.conf`. `entries` are the
+// parsed lines for that service and `modules` aggregates the modules it loads
+// keyed by name, so audits such as
 // `pam.conf.service(name: "su").modules["pam_wheel"].params["use_uid"]` work
 // without filtering `pam.conf.entries` by file path.
 private pam.conf.service {
   init(name string)
   // Service name (e.g. `su`, `sshd`, `login`)
   name string
-  // Path of the service configuration file (e.g. `/etc/pam.d/su`)
+  // Path of the configuration file the service is defined in
   //
-  // Empty when the service is defined inside the single-file `/etc/pam.conf`
-  // rather than its own file under `/etc/pam.d`.
+  // `/etc/pam.d/<name>` on systems that use the pam.d directory, or
+  // `/etc/pam.conf` when the service comes from the legacy single file. Empty
+  // when no such service is configured.
   path string
   // Parsed entries for this service, in source order
   entries []pam.conf.serviceEntry

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -999,6 +999,34 @@ private pam.conf.serviceEntry @defaults("service module") {
   params(options) map[string]string
 }
 
+// PAM service configuration
+//
+// Examine the PAM configuration for a single service selected by name — for
+// example `pam.conf.service(name: "su")` or `pam.conf.service(name: "sshd")`.
+// `entries` are the parsed lines for that service and `modules` aggregates the
+// modules it loads keyed by name, so audits such as
+// `pam.conf.service(name: "su").modules["pam_wheel"].params["use_uid"]` work
+// without filtering `pam.conf.entries` by file path.
+private pam.conf.service {
+  init(name string)
+  // Service name (e.g. `su`, `sshd`, `login`)
+  name string
+  // Path of the service configuration file (e.g. `/etc/pam.d/su`)
+  //
+  // Empty when the service is defined inside the single-file `/etc/pam.conf`
+  // rather than its own file under `/etc/pam.d`.
+  path string
+  // Parsed entries for this service, in source order
+  entries []pam.conf.serviceEntry
+  // Modules loaded by this service, keyed by canonical module name
+  //
+  // Each value aggregates every entry in this service that loads the module
+  // (last-write-wins per option), so `modules["pam_wheel"].params["use_uid"]`
+  // and `modules["pam_wheel"].enabled` answer module-level questions without
+  // iterating `entries`.
+  modules() map[string]pam.module
+}
+
 // PAM module aggregated view
 //
 // Examine a single PAM module across every service that loads it. The

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -68,6 +68,7 @@ const (
 	ResourcePackages                      string = "packages"
 	ResourcePamConf                       string = "pam.conf"
 	ResourcePamConfServiceEntry           string = "pam.conf.serviceEntry"
+	ResourcePamConfService                string = "pam.conf.service"
 	ResourcePamModule                     string = "pam.module"
 	ResourceSshd                          string = "sshd"
 	ResourceSshdConfig                    string = "sshd.config"
@@ -654,6 +655,10 @@ func init() {
 		"pam.conf.serviceEntry": {
 			// to override args, implement: initPamConfServiceEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPamConfServiceEntry,
+		},
+		"pam.conf.service": {
+			Init:   initPamConfService,
+			Create: createPamConfService,
 		},
 		"pam.module": {
 			Init:   initPamModule,
@@ -2976,6 +2981,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"pam.conf.serviceEntry.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConfServiceEntry).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"pam.conf.service.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConfService).GetName()).ToDataRes(types.String)
+	},
+	"pam.conf.service.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConfService).GetPath()).ToDataRes(types.String)
+	},
+	"pam.conf.service.entries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConfService).GetEntries()).ToDataRes(types.Array(types.Resource("pam.conf.serviceEntry")))
+	},
+	"pam.conf.service.modules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConfService).GetModules()).ToDataRes(types.Map(types.String, types.Resource("pam.module")))
 	},
 	"pam.module.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamModule).GetName()).ToDataRes(types.String)
@@ -11248,6 +11265,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"pam.conf.serviceEntry.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPamConfServiceEntry).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"pam.conf.service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfService).__id, ok = v.Value.(string)
+		return
+	},
+	"pam.conf.service.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfService).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"pam.conf.service.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfService).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"pam.conf.service.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfService).Entries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"pam.conf.service.modules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConfService).Modules, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"pam.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26500,6 +26537,82 @@ func (c *mqlPamConfServiceEntry) GetParams() *plugin.TValue[map[string]any] {
 		}
 
 		return c.params(vargOptions.Data)
+	})
+}
+
+// mqlPamConfService for the pam.conf.service resource
+type mqlPamConfService struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlPamConfServiceInternal it will be used here
+	Name    plugin.TValue[string]
+	Path    plugin.TValue[string]
+	Entries plugin.TValue[[]any]
+	Modules plugin.TValue[map[string]any]
+}
+
+// createPamConfService creates a new instance of this resource
+func createPamConfService(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlPamConfService{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("pam.conf.service", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlPamConfService) MqlName() string {
+	return "pam.conf.service"
+}
+
+func (c *mqlPamConfService) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlPamConfService) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlPamConfService) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlPamConfService) GetEntries() *plugin.TValue[[]any] {
+	return &c.Entries
+}
+
+func (c *mqlPamConfService) GetModules() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Modules, func() (map[string]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("pam.conf.service", c.__id, "modules")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(map[string]any), nil
+			}
+		}
+
+		return c.modules()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1981,6 +1981,11 @@ pam.conf.entries 9.0.0
 pam.conf.exists 13.26.3
 pam.conf.files 9.0.0
 pam.conf.modules 13.16.10
+pam.conf.service 13.27.1
+pam.conf.service.entries 13.27.1
+pam.conf.service.modules 13.27.1
+pam.conf.service.name 13.27.1
+pam.conf.service.path 13.27.1
 pam.conf.serviceEntry 9.0.0
 pam.conf.serviceEntry.control 9.0.0
 pam.conf.serviceEntry.lineNumber 9.0.0

--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"io"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -324,7 +325,13 @@ func (m *mqlPamModule) id() (string, error) {
 	return "pam.module/" + m.Name.Data, nil
 }
 
-func (s *mqlPamConf) modules(entries map[string]any) ([]any, error) {
+// buildPamModules aggregates the given service entries by canonical module
+// name and returns one pam.module resource per distinct module, in first-seen
+// order. idScope namespaces the cache key: pass "" for the global view across
+// all services, or a service name so a per-service module
+// (e.g. pam.module/su/pam_wheel) does not collide with the global aggregation
+// (pam.module/pam_wheel), which can have different enabled/params values.
+func buildPamModules(runtime *plugin.Runtime, entries map[string]any, idScope string) ([]any, error) {
 	// Collect entries grouped by canonical module name, preserving source
 	// order across files for last-write-wins option aggregation.
 	type moduleAgg struct {
@@ -381,16 +388,108 @@ func (s *mqlPamConf) modules(entries map[string]any) ([]any, error) {
 	for _, name := range order {
 		agg := byName[name]
 		params := aggregatePamParams(agg.optionSets...)
-		res, err := CreateResource(s.MqlRuntime, "pam.module", map[string]*llx.RawData{
+		modArgs := map[string]*llx.RawData{
 			"name":    llx.StringData(agg.name),
 			"params":  llx.MapData(params, types.String),
 			"enabled": llx.BoolData(agg.anyEnabled),
 			"entries": llx.ArrayData(agg.entries, types.Resource("pam.conf.serviceEntry")),
-		})
+		}
+		if idScope != "" {
+			modArgs["__id"] = llx.StringData("pam.module/" + idScope + "/" + agg.name)
+		}
+		res, err := CreateResource(runtime, "pam.module", modArgs)
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
+	}
+	return out, nil
+}
+
+func (s *mqlPamConf) modules(entries map[string]any) ([]any, error) {
+	return buildPamModules(s.MqlRuntime, entries, "")
+}
+
+// initPamConfService selects a single PAM service by name and caches its
+// parsed entries. The service name matches the file basename under
+// /etc/pam.d (e.g. "su" -> /etc/pam.d/su); when no such service is configured
+// the resource is returned with an empty path and no entries rather than an
+// error, so audits can branch on it cleanly.
+func initPamConfService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("pam.conf.service requires a 'name'")
+	}
+	name, ok := nameRaw.Value.(string)
+	if !ok {
+		return nil, nil, errors.New("wrong type for 'name', it must be a string")
+	}
+
+	conf, err := CreateResource(runtime, "pam.conf", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	pamConf := conf.(*mqlPamConf)
+
+	// No PAM configuration on this host: return an empty service rather than
+	// erroring, mirroring pam.conf.exists, so audits don't blow up.
+	exists := pamConf.GetExists()
+	if exists.Error != nil {
+		return nil, nil, exists.Error
+	}
+	if !exists.Data {
+		args["name"] = llx.StringData(name)
+		args["path"] = llx.StringData("")
+		args["entries"] = llx.ArrayData([]any{}, types.Resource("pam.conf.serviceEntry"))
+		return args, nil, nil
+	}
+
+	entries := pamConf.GetEntries()
+	if entries.Error != nil {
+		return nil, nil, entries.Error
+	}
+
+	path := ""
+	serviceEntries := []any{}
+	for filePath, raw := range entries.Data {
+		if filepath.Base(filePath) != name {
+			continue
+		}
+		if list, ok := raw.([]any); ok {
+			serviceEntries = list
+		}
+		path = filePath
+		break
+	}
+
+	args["name"] = llx.StringData(name)
+	args["path"] = llx.StringData(path)
+	args["entries"] = llx.ArrayData(serviceEntries, types.Resource("pam.conf.serviceEntry"))
+	return args, nil, nil
+}
+
+func (s *mqlPamConfService) id() (string, error) {
+	return "pam.conf.service/" + s.Name.Data, nil
+}
+
+func (s *mqlPamConfService) modules() (map[string]any, error) {
+	entries := s.GetEntries()
+	if entries.Error != nil {
+		return nil, entries.Error
+	}
+
+	// Scope the shared aggregator to this single service and key the result
+	// by canonical module name so callers can write modules["pam_wheel"].
+	scoped := map[string]any{s.Name.Data: entries.Data}
+	mods, err := buildPamModules(s.MqlRuntime, scoped, s.Name.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]any, len(mods))
+	for _, m := range mods {
+		mod := m.(*mqlPamModule)
+		out[mod.Name.Data] = mod
 	}
 	return out, nil
 }

--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -411,10 +411,10 @@ func (s *mqlPamConf) modules(entries map[string]any) ([]any, error) {
 }
 
 // initPamConfService selects a single PAM service by name and caches its
-// parsed entries. The service name matches the file basename under
-// /etc/pam.d (e.g. "su" -> /etc/pam.d/su); when no such service is configured
-// the resource is returned with an empty path and no entries rather than an
-// error, so audits can branch on it cleanly.
+// parsed entries. The name matches the file under /etc/pam.d (e.g. "su" ->
+// /etc/pam.d/su) or the service column in the single-file /etc/pam.conf. When
+// no such service is configured the resource is returned with an empty path
+// and no entries rather than an error, so audits can branch on it cleanly.
 func initPamConfService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	nameRaw := args["name"]
 	if nameRaw == nil {
@@ -449,16 +449,22 @@ func initPamConfService(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, entries.Error
 	}
 
+	// entries is keyed by the /etc/pam.d/<name> file path, or by the bare
+	// service name for single-file /etc/pam.conf. filepath.Base matches both.
 	path := ""
 	serviceEntries := []any{}
-	for filePath, raw := range entries.Data {
-		if filepath.Base(filePath) != name {
+	for key, raw := range entries.Data {
+		if filepath.Base(key) != name {
 			continue
 		}
 		if list, ok := raw.([]any); ok {
 			serviceEntries = list
 		}
-		path = filePath
+		if strings.Contains(key, "/") {
+			path = key
+		} else {
+			path = defaultPamConf
+		}
 		break
 	}
 
@@ -522,12 +528,36 @@ func (s *mqlPamConf) entries(files []any) (map[string]any, error) {
 	}
 
 	services := map[string]any{}
-	for basename, content := range contents {
+	for filePath, content := range contents {
+		// Files directly under /etc/pam.d carry one service each (the file
+		// name is the service). The legacy single-file /etc/pam.conf instead
+		// prefixes every line with the service name, so its lines have one
+		// extra leading column. Detect the layout by whether the file lives
+		// in the pam.d directory and group single-file lines by that column.
+		singleFile := filepath.Dir(filePath) != defaultPamDir
+		if !singleFile {
+			// Preserve the empty-service key so e.g.
+			// pam.conf.entries["/etc/pam.d/su"] stays an empty list rather
+			// than null when the file has no parsable entries.
+			if _, ok := services[filePath]; !ok {
+				services[filePath] = []any{}
+			}
+		}
+
 		lines := strings.Split(content, "\n")
-		settings := []any{}
-		var line string
 		for i := range lines {
-			line = lines[i]
+			line := lines[i]
+			service := filePath
+
+			if singleFile {
+				fields := strings.Fields(pam.StripComments(line))
+				if len(fields) < 2 {
+					// Blank/comment line or one with no module reference.
+					continue
+				}
+				service = fields[0]
+				line = strings.Join(fields[1:], " ")
+			}
 
 			entry, err := pam.ParseLine(line)
 			if err != nil {
@@ -540,7 +570,7 @@ func (s *mqlPamConf) entries(files []any) (map[string]any, error) {
 			}
 
 			pamEntry, err := CreateResource(s.MqlRuntime, "pam.conf.serviceEntry", map[string]*llx.RawData{
-				"service":    llx.StringData(basename),
+				"service":    llx.StringData(service),
 				"lineNumber": llx.IntData(int64(i)), // Used for ID
 				"pamType":    llx.StringData(entry.PamType),
 				"control":    llx.StringData(entry.Control),
@@ -550,11 +580,10 @@ func (s *mqlPamConf) entries(files []any) (map[string]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			settings = append(settings, pamEntry.(*mqlPamConfServiceEntry))
 
+			list, _ := services[service].([]any)
+			services[service] = append(list, pamEntry.(*mqlPamConfServiceEntry))
 		}
-
-		services[basename] = settings
 	}
 
 	return services, nil

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -9,12 +9,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
 	"go.mondoo.com/mql/v13/providers/os/resources/filesfind"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
+
+// newPamEntry builds a parsed service-entry resource directly for unit tests.
+func newPamEntry(pamType, control, module string, options []any) *mqlPamConfServiceEntry {
+	set := plugin.StateIsSet
+	return &mqlPamConfServiceEntry{
+		PamType: plugin.TValue[string]{Data: pamType, State: set},
+		Control: plugin.TValue[string]{Data: control, State: set},
+		Module:  plugin.TValue[string]{Data: module, State: set},
+		Options: plugin.TValue[[]any]{Data: options, State: set},
+	}
+}
 
 // newPamRuntime builds a runtime backed by a mock filesystem containing the
 // given files, so pam.conf.exists can be exercised for both the present and
@@ -99,6 +111,45 @@ func TestPamConfPrefersPamDirOverPamConf(t *testing.T) {
 	_, hasPamConfService := entries.Data["login"]
 	assert.False(t, hasPamConfService,
 		"the /etc/pam.conf service must not be parsed while /etc/pam.d exists")
+}
+
+func TestPamConfServiceModules(t *testing.T) {
+	svc := &mqlPamConfService{
+		MqlRuntime: newPamRuntime(t),
+		Name:       plugin.TValue[string]{Data: "su", State: plugin.StateIsSet},
+		Entries: plugin.TValue[[]any]{Data: []any{
+			newPamEntry("auth", "required", "pam_wheel.so", []any{"use_uid", "group=sugroup"}),
+			newPamEntry("auth", "required", "pam_unix.so", []any{}),
+		}, State: plugin.StateIsSet},
+	}
+
+	mods, err := svc.modules()
+	require.NoError(t, err)
+
+	wheel, ok := mods["pam_wheel"].(*mqlPamModule)
+	require.True(t, ok, "pam_wheel keyed by canonical name (no .so)")
+	assert.True(t, wheel.Enabled.Data)
+	assert.Equal(t, "sugroup", wheel.Params.Data["group"])
+	assert.Equal(t, "", wheel.Params.Data["use_uid"], "bare flag present as empty string")
+	// Scoped cache key so a per-service module never collides with the global
+	// pam.module aggregation across all services.
+	assert.Equal(t, "pam.module/su/pam_wheel", wheel.__id)
+
+	_, hasUnix := mods["pam_unix"]
+	assert.True(t, hasUnix)
+}
+
+func TestPamConfServiceMissing(t *testing.T) {
+	// No PAM configuration on the host: the service resolves to an empty husk
+	// rather than erroring, so audits guarded by pam.conf.exists stay clean.
+	args, res, err := initPamConfService(newPamRuntime(t), map[string]*llx.RawData{
+		"name": llx.StringData("su"),
+	})
+	require.NoError(t, err)
+	require.Nil(t, res)
+	assert.Equal(t, "su", args["name"].Value)
+	assert.Equal(t, "", args["path"].Value)
+	assert.Empty(t, args["entries"].Value)
 }
 
 func TestPamConfServiceEntryParams(t *testing.T) {

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,27 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/filesfind"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
+
+// newPamRuntimeWithFiles builds a runtime backed by a mock filesystem whose
+// files have the given contents, so the full files -> entries pipeline runs.
+func newPamRuntimeWithFiles(t *testing.T, files map[string]string) *plugin.Runtime {
+	t.Helper()
+
+	fileData := map[string]*mock.MockFileData{}
+	for path, content := range files {
+		fileData[path] = &mock.MockFileData{Path: path, Content: content}
+	}
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "arch", Family: []string{"arch", "linux"}},
+	}, mock.WithData(&mock.TomlData{Files: fileData}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
 
 // newPamEntry builds a parsed service-entry resource directly for unit tests.
 func newPamEntry(pamType, control, module string, options []any) *mqlPamConfServiceEntry {
@@ -150,6 +172,53 @@ func TestPamConfServiceMissing(t *testing.T) {
 	assert.Equal(t, "su", args["name"].Value)
 	assert.Equal(t, "", args["path"].Value)
 	assert.Empty(t, args["entries"].Value)
+}
+
+func TestPamConfSingleFile(t *testing.T) {
+	// Legacy single-file /etc/pam.conf: every line is prefixed with the
+	// service name. With no /etc/pam.d directory present, files() falls back
+	// to this file and entries() must split off the service column.
+	content := strings.Join([]string{
+		"# legacy single-file pam.conf",
+		"su    auth required pam_wheel.so use_uid group=sugroup",
+		"su    auth required pam_unix.so",
+		"sshd  auth required pam_unix.so",
+		"",
+	}, "\n")
+	rt := newPamRuntimeWithFiles(t, map[string]string{"/etc/pam.conf": content})
+
+	pam := &mqlPamConf{MqlRuntime: rt}
+	entries := pam.GetEntries()
+	require.NoError(t, entries.Error)
+
+	// Keyed by service name (not the file path), one service per first column.
+	suList, ok := entries.Data["su"].([]any)
+	require.True(t, ok, "entries keyed by service name 'su'")
+	assert.Len(t, suList, 2)
+	_, hasSshd := entries.Data["sshd"]
+	assert.True(t, hasSshd)
+	assert.Equal(t, "auth", suList[0].(*mqlPamConfServiceEntry).PamType.Data,
+		"service column stripped, not misparsed as pamType")
+
+	// pam.conf.service resolves the single-file service and reports the
+	// source file as its path. Run the init hook (as the executor does) then
+	// create from the resolved args.
+	args, _, err := initPamConfService(rt, map[string]*llx.RawData{
+		"name": llx.StringData("su"),
+	})
+	require.NoError(t, err)
+	res, err := CreateResource(rt, "pam.conf.service", args)
+	require.NoError(t, err)
+	svc := res.(*mqlPamConfService)
+	assert.Equal(t, "/etc/pam.conf", svc.GetPath().Data)
+
+	mods := svc.GetModules()
+	require.NoError(t, mods.Error)
+	wheel, ok := mods.Data["pam_wheel"].(*mqlPamModule)
+	require.True(t, ok)
+	assert.True(t, wheel.Enabled.Data)
+	assert.Equal(t, "sugroup", wheel.Params.Data["group"])
+	assert.Equal(t, "", wheel.Params.Data["use_uid"])
 }
 
 func TestPamConfServiceEntryParams(t *testing.T) {


### PR DESCRIPTION
## What

Adds `pam.conf.service(name:)` — the PAM configuration for a single service, selected by short service name:

| field | meaning |
|---|---|
| `name` | service name (e.g. `su`, `sshd`) |
| `path` | the file backing it (e.g. `/etc/pam.d/su`); empty if absent |
| `entries` | the parsed lines for that service |
| `modules` | the modules it loads, **keyed by canonical name**, each a `pam.module` aggregating just that service (`enabled` / `params` / `entries`) |

## Why

Auditing a single service previously meant keying `pam.conf.entries` by full file path and hand-filtering by module/pamType/options:

```mql
pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth"
  && module == "pam_wheel.so" && params["use_uid"] != null)
```

With the new resource the same audit reads:

```mql
wheel = pam.conf.service(name: "su").modules["pam_wheel"]
wheel.enabled
wheel.params["use_uid"] != null
```

No `/etc/pam.d/` prefix, no `.so` suffix, no manual `pamType`/`where` — and the per-service `pam.module` answers `enabled`/`params` questions directly. This is the resource-side simplification behind the `mondoo-linux-security` su-restriction check.

## Notes

- **No cache collision:** per-service modules get a service-scoped cache key (`pam.module/<service>/<name>`) so they never alias the global `pam.module` aggregation (which spans all services and can have different `enabled`/`params`). The global `pam.conf.modules` / `pam.module("x")` are unchanged — the aggregation logic was extracted into a shared `buildPamModules` helper.
- **Robust on PAM-less hosts:** like `pam.conf.exists`, a host with no PAM config resolves the service to an empty husk rather than erroring.
- Parses the `/etc/pam.d/<service>` layout (service = file basename), matching the existing parser; the single-file `/etc/pam.conf` service-column format is unparsed as before.

## Testing

- Unit tests: module aggregation + `params`, the service-scoped `__id` (no global collision), and the empty-host path.
- Live (Debian 13): `pam.conf.service("su").modules["pam_wheel"]` → `enabled: true`, `params: {group: "sugroup", use_uid: ""}`; nonexistent service → `0` entries, no error; global `pam.conf.modules` intact.
- `go test ./providers/os/resources/` passes; codegen re-run is deterministic.

New `.lr.versions` entries at `13.26.3` (next patch after the current `13.26.2`).