### PR TITLE
🧹 os/pam: lock /etc/pam.d precedence over /etc/pam.conf with a test

### DIFF
--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -96,8 +96,10 @@ func (s *mqlPamConf) exists() (bool, error) {
 // GetFiles is called when the user has not provided a custom path. Otherwise files are set in the init
 // method and this function is never called then since the data is already cached.
 func (s *mqlPamConf) files() ([]any, error) {
-	// check if the pam.d directory exists and is a directory
-	// according to the pam spec, pam prefers the directory if it  exists over the single file config
+	// Linux-PAM uses the /etc/pam.d directory when it exists and ignores the
+	// legacy single-file /etc/pam.conf entirely; only when /etc/pam.d is absent
+	// does it fall back to /etc/pam.conf. We parse the same source PAM itself
+	// uses so audits reflect the effective configuration rather than dead files.
 	// see http://www.linux-pam.org/Linux-PAM-html/sag-configuration.html
 	raw, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
 		"path": llx.StringData(defaultPamDir),

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/resources/filesfind"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
 
@@ -57,6 +59,46 @@ func TestPamConfExists(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, got)
 	})
+}
+
+func TestPamConfPrefersPamDirOverPamConf(t *testing.T) {
+	// When /etc/pam.d exists, Linux-PAM ignores /etc/pam.conf entirely. Our
+	// parsing must do the same: only the pam.d files are read, and a service
+	// defined only in /etc/pam.conf must not appear.
+	findCmd := filesfind.BuildFilesFindCmd(defaultPamDir, false, "file", "", 0, "", nil)
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "arch", Family: []string{"arch", "linux", "unix"}},
+	}, mock.WithData(&mock.TomlData{
+		Files: map[string]*mock.MockFileData{
+			defaultPamDir:         {Path: defaultPamDir, StatData: mock.FileInfo{Mode: os.ModeDir | 0o755}},
+			defaultPamDir + "/su": {Path: defaultPamDir + "/su", Content: "auth required pam_wheel.so use_uid\n"},
+			defaultPamConf:        {Path: defaultPamConf, Content: "login auth required pam_unix.so\n"},
+		},
+		Commands: map[string]*mock.Command{
+			findCmd: {Stdout: defaultPamDir + "/su\n"},
+		},
+	}))
+	require.NoError(t, err)
+	rt := &plugin.Runtime{Connection: conn, Resources: &syncx.Map[plugin.Resource]{}}
+
+	pam := &mqlPamConf{MqlRuntime: rt}
+
+	files := pam.GetFiles()
+	require.NoError(t, files.Error)
+	paths := make([]string, 0, len(files.Data))
+	for _, f := range files.Data {
+		paths = append(paths, f.(*mqlFile).Path.Data)
+	}
+	assert.Equal(t, []string{defaultPamDir + "/su"}, paths,
+		"only /etc/pam.d files are read; /etc/pam.conf is ignored")
+
+	entries := pam.GetEntries()
+	require.NoError(t, entries.Error)
+	_, hasPamDirService := entries.Data[defaultPamDir+"/su"]
+	assert.True(t, hasPamDirService, "the pam.d service is parsed")
+	_, hasPamConfService := entries.Data["login"]
+	assert.False(t, hasPamConfService,
+		"the /etc/pam.conf service must not be parsed while /etc/pam.d exists")
 }
 
 func TestPamConfServiceEntryParams(t *testing.T) {


### PR DESCRIPTION
## What

Locks in (with a test) the rule that **`/etc/pam.d` takes precedence over `/etc/pam.conf`**, matching Linux-PAM.

Linux-PAM uses the `/etc/pam.d` directory when it exists and **ignores** the legacy single-file `/etc/pam.conf` entirely; it only falls back to `/etc/pam.conf` when `/etc/pam.d` is absent. `pam.conf.files` already behaves this way (either/or), but the behavior had no test guarding it.

## Changes

- **Test** `TestPamConfPrefersPamDirOverPamConf`: with both `/etc/pam.d` (containing an `su` service file) **and** `/etc/pam.conf` present, asserts `files()` reads **only** the `/etc/pam.d` files and the service defined solely in `/etc/pam.conf` (`login`) is **not** parsed.
- **Comment**: `files()` now states the precedence explicitly (we parse the same source PAM itself uses, so audits reflect the effective config rather than dead files).

No behavior change — this codifies and documents existing, correct behavior.

## Testing

- `go test ./providers/os/resources/` passes (the new test + full suite).
- Verified live on Debian 13, which ships **both** files: `pam.conf.files` lists 30 `/etc/pam.d/*` files and **zero** `/etc/pam.conf` — confirming the legacy file is ignored when `/etc/pam.d` exists.

Independent of #8324 — this only concerns the existing `files()` precedence.