### PR TITLE
🟢 mqlc: fix pam.conf field-glob test broken by pam.conf.exists

### DIFF
--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1587,29 +1587,33 @@ func TestCompiler_ResourceFieldGlob(t *testing.T) {
 			Type:    string(types.Map(types.String, types.Array(types.Resource("pam.conf.serviceEntry")))),
 			Binding: (2 << 32) | 1,
 		}, res.CodeV2.Blocks[1].Chunks[2])
+		assertFunction(t, "exists", &llx.Function{
+			Type:    string(types.Bool),
+			Binding: (2 << 32) | 1,
+		}, res.CodeV2.Blocks[1].Chunks[3])
 		assertFunction(t, "files", &llx.Function{
 			Type:    string(types.Array(types.Resource("file"))),
 			Binding: (2 << 32) | 1,
-		}, res.CodeV2.Blocks[1].Chunks[3])
+		}, res.CodeV2.Blocks[1].Chunks[4])
 		assertFunction(t, "modules", &llx.Function{
 			Type:    string(types.Array(types.Resource("pam.module"))),
 			Binding: (2 << 32) | 1,
-		}, res.CodeV2.Blocks[1].Chunks[4])
+		}, res.CodeV2.Blocks[1].Chunks[5])
 		assertFunction(t, "services", &llx.Function{
 			Type:    string(types.Map(types.String, types.Array(types.String))),
 			Binding: (2 << 32) | 1,
-		}, res.CodeV2.Blocks[1].Chunks[5])
-		assertFunction(t, "{}", &llx.Function{
-			Type:    string(types.Array(types.Block)),
-			Binding: (2 << 32) | 4,
-			Args:    []*llx.Primitive{llx.FunctionPrimitive(3 << 32)},
 		}, res.CodeV2.Blocks[1].Chunks[6])
 		assertFunction(t, "{}", &llx.Function{
 			Type:    string(types.Array(types.Block)),
 			Binding: (2 << 32) | 5,
-			Args:    []*llx.Primitive{llx.FunctionPrimitive(4 << 32)},
+			Args:    []*llx.Primitive{llx.FunctionPrimitive(3 << 32)},
 		}, res.CodeV2.Blocks[1].Chunks[7])
-		assert.Equal(t, []uint64{(2 << 32) | 2, (2 << 32) | 3, (2 << 32) | 7, (2 << 32) | 8, (2 << 32) | 6},
+		assertFunction(t, "{}", &llx.Function{
+			Type:    string(types.Array(types.Block)),
+			Binding: (2 << 32) | 6,
+			Args:    []*llx.Primitive{llx.FunctionPrimitive(4 << 32)},
+		}, res.CodeV2.Blocks[1].Chunks[8])
+		assert.Equal(t, []uint64{(2 << 32) | 2, (2 << 32) | 3, (2 << 32) | 4, (2 << 32) | 8, (2 << 32) | 9, (2 << 32) | 7},
 			res.CodeV2.Blocks[1].Entrypoints)
 	})
 }


### PR DESCRIPTION
## What

`TestCompiler_ResourceFieldGlob` has been failing on `main`. The `pam.conf.exists` field added in #8322 was never reflected in the test's expected compiler output.

The field glob (`pam.conf { * }`) expands a resource's fields **alphabetically**. `exists` (bool) sorts between `entries` and `files`, so its addition shifted every later chunk ref and the block entrypoint list — but the test still expected the pre-`exists` layout.

## Fix

Update the block-1 assertions to:
- add the `exists` accessor chunk in its alphabetical position,
- renumber the trailing `{}` default-block expansions (now `files` → ref 5, `modules` → ref 6),
- update the entrypoint list to `{2, 3, 4, 8, 9, 7}`.

No production code changes — this is purely the test catching up to the schema.

## Verification

```
go test ./mqlc/   # ok
```

Standalone fix so it can land independently of the pam feature work (#8324).