### PR TITLE
🧹 os/windows.update: drop unused Description from update history query

### DIFF
--- a/providers/os/resources/windows/update.go
+++ b/providers/os/resources/windows/update.go
@@ -58,7 +58,6 @@ if ($count -gt 0) {
       "Date" = $_.Date
       "Operation" = [int]$_.Operation
       "ResultCode" = [int]$_.ResultCode
-      "Description" = $_.Description
       "SupportUrl" = $_.SupportUrl
       "UpdateID" = $_.UpdateIdentity.UpdateID
       "Categories" = @($_.Categories | ForEach-Object { $_.Name })
@@ -69,14 +68,13 @@ if ($count -gt 0) {
 
 // WindowsUpdateHistoryEntry is a single Windows Update Agent history record.
 type WindowsUpdateHistoryEntry struct {
-	Title       string   `json:"Title"`
-	Date        string   `json:"Date"`
-	Operation   int      `json:"Operation"`
-	ResultCode  int      `json:"ResultCode"`
-	Description string   `json:"Description"`
-	SupportUrl  string   `json:"SupportUrl"`
-	UpdateID    string   `json:"UpdateID"`
-	Categories  []string `json:"Categories"`
+	Title      string   `json:"Title"`
+	Date       string   `json:"Date"`
+	Operation  int      `json:"Operation"`
+	ResultCode int      `json:"ResultCode"`
+	SupportUrl string   `json:"SupportUrl"`
+	UpdateID   string   `json:"UpdateID"`
+	Categories []string `json:"Categories"`
 }
 
 func ParseWindowsUpdateHistory(input io.Reader) ([]WindowsUpdateHistoryEntry, error) {


### PR DESCRIPTION
## What

The Windows Update Agent history query (`WINDOWS_QUERY_UPDATE_HISTORY`) fetched each entry's `Description` into the psobject and unmarshaled it into `WindowsUpdateHistoryEntry` — but nothing ever reads it. `windows.update.entry` has no `description` field, and `newEntry` never maps it.

## Why

Update descriptions are frequently long paragraphs. On hosts with large update histories, every `windows.update.installed` call was marshaling that text in PowerShell, transferring it, and JSON-parsing it in Go, only to discard it. Dropping the property shrinks the per-entry payload for a query like:

```mql
windows.update.installed {
  kbId
}
```

This is the safe, behavior-preserving slice of a broader look at `windows.update` performance — the Go-side filtering/dedup (`FilterInstalledHistory`) is unchanged, and no test or resource field referenced `Description`.

## Test

- `go build ./resources/windows/` — clean
- `go test ./resources/windows/ -run TestParseWindowsUpdateHistory` — pass
