### PR TITLE
🎉 os-13.28.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.27.0",
+	Version: "13.28.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Bumps the **os** provider a minor version: `13.27.0` → `13.28.0`.

### Changes included since os-13.27.0
- ✨ os/pam: add `pam.conf.service` for per-service module queries (#8324)
- 🧹 os/pam: lock `/etc/pam.d` precedence over `/etc/pam.conf` with a test (#8325)

🤖 Generated with [Claude Code](https://claude.com/claude-code)