### PR TITLE
⭐ health: attach the running query to panic reports

### DIFF
--- a/exec/internal/execution_manager.go
+++ b/exec/internal/execution_manager.go
@@ -100,7 +100,9 @@ func (em *executionManager) Start() {
 				}
 
 				current = item.codeBundle
-				if err := em.executeCodeBundle(item.codeBundle, props, errMsg); err != nil {
+				err := em.executeCodeBundle(item.codeBundle, props, errMsg)
+				current = nil
+				if err != nil {
 					// an error is returned if we cannot execute a query. This happens
 					// if the lumi runtime doesn't report back expected data, there is
 					// a problem with the lumi runtime, or the query is somehow invalid.

--- a/exec/internal/execution_manager.go
+++ b/exec/internal/execution_manager.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/health"
 )
 
 type executionManager struct {
@@ -56,6 +58,18 @@ func (em *executionManager) Start() {
 	em.wg.Add(1)
 	go func() {
 		defer em.wg.Done()
+		// current is the code bundle being executed; the deferred panic
+		// reporter snapshots it at crash time so the report carries WHICH
+		// query was running, not just where the engine died. The recover
+		// stays at the goroutine top — recovering closer to the query and
+		// re-panicking would truncate the stacktrace.
+		var current *llx.CodeBundle
+		defer health.ReportPanicWithTags("mql", mql.Version, mql.Build, func() map[string]string {
+			if current == nil {
+				return nil
+			}
+			return health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
+		})
 		for {
 			// Prioritize stopChan
 			select {
@@ -85,6 +99,7 @@ func (em *executionManager) Start() {
 					props[k] = r.Data
 				}
 
+				current = item.codeBundle
 				if err := em.executeCodeBundle(item.codeBundle, props, errMsg); err != nil {
 					// an error is returned if we cannot execute a query. This happens
 					// if the lumi runtime doesn't report back expected data, there is

--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -54,22 +54,89 @@ func ReportPanic(product, version, build string, reporters ...PanicReportFn) {
 	}
 
 	if r := recover(); r != nil {
-		sendPanic(product, version, build, r, debug.Stack())
-
-		// call additional reporters
-		for _, reporter := range reporters {
-			reporter(product, version, build, r, debug.Stack())
-		}
+		handlePanic(product, version, build, r, nil, reporters)
 
 		// output error to console
 		panic(r)
 	}
 }
 
+// Tag keys for query-context panic tags. The platform's error report
+// handler reads these to surface the crashing query in obslog
+// (mondoo.query.text / mondoo.query.code_id) and Sentry.
+const (
+	TagQueryCodeID = "queryCodeID"
+	TagQuerySource = "querySource"
+)
+
+// querySourceMax bounds the query source attached to a panic report,
+// mirroring the platform's slow-query text bound. Large enough for any
+// real check; bounded so a pathological bundle can't bloat the report.
+const querySourceMax = 2048
+
+// QueryPanicTags builds the crash-time tags identifying the query an
+// executor was running when it panicked. Returns nil when there is no
+// query context so callers can pass the result straight to
+// ReportPanicWithTags.
+func QueryPanicTags(codeID, source string) map[string]string {
+	if codeID == "" && source == "" {
+		return nil
+	}
+	tags := make(map[string]string, 2)
+	if codeID != "" {
+		tags[TagQueryCodeID] = codeID
+	}
+	if source != "" {
+		if r := []rune(source); len(r) > querySourceMax {
+			source = string(r[:querySourceMax])
+		}
+		tags[TagQuerySource] = source
+	}
+	return tags
+}
+
+// PanicTagsFn supplies tags for a panic report. It is invoked only while a
+// panic is being recovered, so implementations can cheaply close over mutable
+// state — e.g. the query an executor is currently running — and snapshot it
+// at crash time.
+type PanicTagsFn func() map[string]string
+
+// ReportPanicWithTags is ReportPanic with crash-time tags attached to the
+// report. Tags are forwarded to the platform (obslog fields and Sentry tags),
+// which is how an executor can record WHICH query was running when the engine
+// panicked — the stacktrace alone only shows where it died.
+//
+// Like ReportPanic, it must be invoked directly via defer.
+func ReportPanicWithTags(product, version, build string, tagsFn PanicTagsFn, reporters ...PanicReportFn) {
+	if build == "" {
+		return // avoid reporting panics from environments that don't set this variable
+	}
+
+	if r := recover(); r != nil {
+		var tags map[string]string
+		if tagsFn != nil {
+			tags = tagsFn()
+		}
+		handlePanic(product, version, build, r, tags, reporters)
+
+		// output error to console
+		panic(r)
+	}
+}
+
+func handlePanic(product, version, build string, r any, tags map[string]string, reporters []PanicReportFn) {
+	sendPanic(product, version, build, r, debug.Stack(), tags)
+
+	// call additional reporters
+	for _, reporter := range reporters {
+		reporter(product, version, build, r, debug.Stack())
+	}
+}
+
 // sendPanic sends a panic to the mondoo platform for further analysis if the
 // service account is configured.
 // This function does not return an error as it is not critical to send the panic to the platform.
-func sendPanic(product, version, build string, r any, stacktrace []byte) {
+func sendPanic(product, version, build string, r any, stacktrace []byte, tags map[string]string) {
 	// 1. read config
 	opts, err := config.Read()
 	if err != nil {
@@ -84,7 +151,7 @@ func sendPanic(product, version, build string, r any, stacktrace []byte) {
 	}
 
 	// 2. create local support bundle
-	event := panicEvent(product, version, build, r, stacktrace)
+	event := panicEvent(product, version, build, r, stacktrace, tags)
 	event.ServiceAccountMrn = opts.ServiceAccountMrn
 	event.AgentMrn = opts.AgentMrn
 
@@ -97,7 +164,14 @@ func sendPanic(product, version, build string, r any, stacktrace []byte) {
 // panicEvent builds the error report for a recovered panic, tagged with the
 // platform the binary runs on so reports remain attributable even when no
 // asset context is available (e.g. panics outside a scan).
-func panicEvent(product, version, build string, r any, stacktrace []byte) *SendErrorReq {
+func panicEvent(product, version, build string, r any, stacktrace []byte, tags map[string]string) *SendErrorReq {
+	allTags := map[string]string{
+		"os":   runtime.GOOS,
+		"arch": runtime.GOARCH,
+	}
+	for k, v := range tags {
+		allTags[k] = v
+	}
 	return &SendErrorReq{
 		Product: &ProductInfo{
 			Name:    product,
@@ -108,10 +182,7 @@ func panicEvent(product, version, build string, r any, stacktrace []byte) *SendE
 			Message:    "panic: " + fmt.Sprintf("%v", r),
 			Stacktrace: string(stacktrace),
 		},
-		Tags: map[string]string{
-			"os":   runtime.GOOS,
-			"arch": runtime.GOARCH,
-		},
+		Tags: allTags,
 	}
 }
 

--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -125,11 +125,12 @@ func ReportPanicWithTags(product, version, build string, tagsFn PanicTagsFn, rep
 }
 
 func handlePanic(product, version, build string, r any, tags map[string]string, reporters []PanicReportFn) {
-	sendPanic(product, version, build, r, debug.Stack(), tags)
+	stack := debug.Stack()
+	sendPanic(product, version, build, r, stack, tags)
 
 	// call additional reporters
 	for _, reporter := range reporters {
-		reporter(product, version, build, r, debug.Stack())
+		reporter(product, version, build, r, stack)
 	}
 }
 
@@ -165,13 +166,14 @@ func sendPanic(product, version, build string, r any, stacktrace []byte, tags ma
 // platform the binary runs on so reports remain attributable even when no
 // asset context is available (e.g. panics outside a scan).
 func panicEvent(product, version, build string, r any, stacktrace []byte, tags map[string]string) *SendErrorReq {
-	allTags := map[string]string{
-		"os":   runtime.GOOS,
-		"arch": runtime.GOARCH,
-	}
+	allTags := make(map[string]string, len(tags)+2)
 	for k, v := range tags {
 		allTags[k] = v
 	}
+	// Platform tags are written last so caller-supplied tags cannot
+	// overwrite them.
+	allTags["os"] = runtime.GOOS
+	allTags["arch"] = runtime.GOARCH
 	return &SendErrorReq{
 		Product: &ProductInfo{
 			Name:    product,

--- a/providers-sdk/v1/upstream/health/errors_test.go
+++ b/providers-sdk/v1/upstream/health/errors_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPanicEventIncludesPlatform(t *testing.T) {
-	event := panicEvent("cnspec", "12.0.0", "abc123", "boom", []byte("stacktrace"))
+	event := panicEvent("cnspec", "12.0.0", "abc123", "boom", []byte("stacktrace"), nil)
 
 	require.NotNil(t, event.Product)
 	assert.Equal(t, "cnspec", event.Product.Name)
@@ -25,4 +25,29 @@ func TestPanicEventIncludesPlatform(t *testing.T) {
 
 	assert.Equal(t, runtime.GOOS, event.Tags["os"])
 	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
+}
+
+func TestPanicEventIncludesQueryTags(t *testing.T) {
+	tags := QueryPanicTags("zLKUfd9hgBY=", "groups.map(name).containsAll(suRestrictedGroups)")
+	event := panicEvent("cnspec", "12.0.0", "abc123", "boom", []byte("stacktrace"), tags)
+
+	assert.Equal(t, "zLKUfd9hgBY=", event.Tags[TagQueryCodeID])
+	assert.Equal(t, "groups.map(name).containsAll(suRestrictedGroups)", event.Tags[TagQuerySource])
+	// baseline platform tags are preserved
+	assert.Equal(t, runtime.GOOS, event.Tags["os"])
+	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
+}
+
+func TestQueryPanicTags(t *testing.T) {
+	assert.Nil(t, QueryPanicTags("", ""))
+
+	tags := QueryPanicTags("abc=", "")
+	assert.Equal(t, map[string]string{TagQueryCodeID: "abc="}, tags)
+
+	long := make([]rune, querySourceMax+100)
+	for i := range long {
+		long[i] = 'x'
+	}
+	tags = QueryPanicTags("", string(long))
+	assert.Len(t, []rune(tags[TagQuerySource]), querySourceMax)
 }

--- a/providers-sdk/v1/upstream/health/errors_test.go
+++ b/providers-sdk/v1/upstream/health/errors_test.go
@@ -38,6 +38,14 @@ func TestPanicEventIncludesQueryTags(t *testing.T) {
 	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
 }
 
+func TestPanicEventPlatformTagsWin(t *testing.T) {
+	event := panicEvent("cnspec", "12.0.0", "abc123", "boom", []byte("st"),
+		map[string]string{"os": "spoofed", "arch": "spoofed"})
+
+	assert.Equal(t, runtime.GOOS, event.Tags["os"])
+	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
+}
+
 func TestQueryPanicTags(t *testing.T) {
 	assert.Nil(t, QueryPanicTags("", ""))
 


### PR DESCRIPTION
## What

- `health.ReportPanicWithTags(product, version, build, tagsFn, reporters...)` — like `ReportPanic`, but attaches tags supplied at crash time. `tagsFn` is only invoked while a panic is being recovered.
- `health.QueryPanicTags(codeID, source)` + exported tag-key constants (`TagQueryCodeID`, `TagQuerySource`) — builds the query-context tags, source bounded to 2048 runes (mirrors the platform's slow-query bound).
- The exec manager's run goroutine now tracks the in-flight `*llx.CodeBundle` and reports it on panic.

## Why

During INC-2026-06-10-client-panic-k8s (#8319), the panic report told us *where* the engine died (`llx.arrayContainsAll`, `builtin_array.go:935`) but not *what it was executing*. Pinning the crash to the su-restriction check took a policy-release diff plus compiled-chunk-ref forensics in the stacktrace; with these tags the report itself would have named the query immediately. Slow-query reports already carry `CodeID` + query text — this brings panic reports to parity.

## Design notes

- The recover stays at the goroutine top: recovering at the query boundary and re-panicking would truncate the stacktrace, which is the part that identifies the engine bug. Instead the goroutine tracks the current bundle and the deferred reporter snapshots it.
- `SendErrorReq.Tags` already exists in the proto and the platform handler already forwards tags to Sentry; a companion server PR maps these two keys to the existing `mondoo.query.text` / `mondoo.query.code_id` obslog fields.
- cnspec's policy executor gets the same wiring in a companion PR (mondoohq/cnspec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
