### PR TITLE
⭐ mqlx: first-class Go API for embedding MQL (ADR 027 + sample implementation)

### DIFF
--- a/docs/adr/027-mqlx-go-embedding-api.md
+++ b/docs/adr/027-mqlx-go-embedding-api.md
@@ -1,0 +1,245 @@
+# ADR 027: mqlx — A First-Class Go API for Embedding MQL
+
+## Status
+
+Proposed
+
+## Context
+
+MQL is a powerful engine, but Go developers who want to embed it face a wall
+of internal machinery. To run a single query and read its results, a consumer
+today must:
+
+1. Wire up a runtime: `providers.Coordinator.NewRuntime()`, detect and start
+   the right provider, and connect to an asset.
+2. Compile: build a `mqlc.CompilerConfig` from the runtime schema and feature
+   flags, call `mqlc.Compile`, and handle a `*llx.CodeBundle`.
+3. Execute: call `exec.ExecuteCode` and receive a checksum-keyed
+   `map[string]*llx.RawResult`.
+4. Consume: walk the raw results, dereference blocks (whose keys are code
+   checksums, not field names), and map every checksum back to a
+   human-readable label through `CodeBundle.Labels` — by hand.
+
+None of these steps is documented as a public workflow; each consumer
+rediscovers it from our own CLI internals and test helpers.
+
+### Evidence: what consumers build today
+
+Prism (our Tetragon-based threat detection engine) is the most demanding MQL
+embedder and shows the real cost. It carries roughly 250 lines of plumbing:
+
+- Manual schema registration, runtime creation, and `ConnectedProvider`
+  wiring for its in-process provider (`detectionengine.go`).
+- Event-to-props conversion through `convert.JsonToDict` and
+  `llx.DictData(...).Result()`.
+- A hand-built 122-line decoder (`mqlcencoding.MQLCDecoder`) that walks
+  resources via `GetData` calls and mapstructure hooks to turn results into
+  typed structs — with open TODOs for unhandled cases.
+- Recompilation of every query for every kernel event, with the TODO
+  "pre-compile all queries passed in by the policy" marking the missing
+  compile-once API.
+
+Every Go service that embeds MQL repeats some subset of this work.
+
+### The missing use case: MQL without infrastructure
+
+Beyond infrastructure queries, there is demand for using MQL as a standalone
+expression engine: evaluating policies and filters over data the caller
+already has (an event, a request, a finding) with no asset, no provider
+install, and no subprocesses. Prism works exactly this way — every query runs
+over an event passed in as a property. The engine supports this today
+(operators, string/array/map/dict functions, and the builtin core resources
+such as `regex` and `time` all run in-process), but there is no API that
+exposes it; consumers must discover the core-provider wiring on their own.
+
+## Desired Outcome
+
+A Go user goes from zero to evaluated, typed query results in a few lines —
+in either of two first-class modes.
+
+**Expression mode** — MQL over your own values, with zero setup:
+
+```go
+env, err := mqlx.NewEnv()
+q, err := env.Compile(`props.name == /admin-.*/ && props.count > 3`,
+    mqlx.WithProps(map[string]any{"name": "", "count": 0}))
+res, err := q.Eval(ctx,
+    mqlx.WithPropValues(map[string]any{"name": "admin-x", "count": 5}))
+res.Value() // true
+```
+
+**Asset mode** — connect once, compile once, evaluate against any number of
+assets, and decode results into native Go structs:
+
+```go
+conn, err := env.ConnectLocal(ctx)
+res, err := conn.Query(ctx, "users { name uid }")
+
+var users []struct {
+    Name string `mql:"name"`
+    UID  int64  `mql:"uid"`
+}
+err = res.Decode(&users)
+```
+
+## Decision
+
+Add a new top-level package `mqlx` (`go.mondoo.com/mql/v13/mqlx`, following
+the `sqlx` naming precedent) as a purely additive facade over the existing
+engine. It introduces four concepts:
+
+| Type | Role | Lifetime / reuse |
+|------|------|------------------|
+| `Env` | feature flags, provider schemas, expression runtime | one per process, concurrent-safe |
+| `Conn` | a connected asset | many queries per Conn, concurrent-safe |
+| `Query` | compiled MQL | immutable; evaluate against any Conn or in expression mode |
+| `Result` | one evaluation's output | `Value()`, `Decode()`, `Err()`, `Raw()` |
+
+### API contract
+
+```go
+// Environment
+func NewEnv(opts ...EnvOption) (*Env, error)
+func WithFeatures(features mql.Features) EnvOption
+func WithProviders(names ...string) EnvOption   // eager schema load
+func WithPrivateProvider(config plugin.Provider, schema resources.ResourcesSchema,
+    plug plugin.ProviderPlugin) EnvOption        // caller-supplied in-process provider
+func (e *Env) Close() error                     // close owned conns + expression runtime
+func (e *Env) Shutdown() error                  // Close + stop the provider coordinator
+
+// Connections (asset mode)
+func (e *Env) Connect(ctx context.Context, asset *inventory.Asset) (*Conn, error)
+func (e *Env) ConnectLocal(ctx context.Context) (*Conn, error)
+func (e *Env) WrapRuntime(rt llx.Runtime) *Conn // escape hatch (tests, custom lifecycles)
+func LocalAsset() *inventory.Asset
+func (c *Conn) Query(ctx context.Context, src string, opts ...CompileOption) (*Result, error)
+func (c *Conn) Close()
+
+// Compilation
+func (e *Env) Compile(src string, opts ...CompileOption) (*Query, error)
+func (e *Env) MustCompile(src string, opts ...CompileOption) *Query
+func WithProps(props map[string]any) CompileOption // typed declarations + defaults
+
+// Evaluation
+func (q *Query) Eval(ctx context.Context, opts ...EvalOption) (*Result, error)   // expression mode
+func (q *Query) EvalOn(ctx context.Context, conn *Conn, opts ...EvalOption) (*Result, error)
+func WithPropValues(props map[string]any) EvalOption // per-eval overrides, type-checked
+
+// Results
+func (r *Result) Value() any              // label-resolved plain Go values
+func (r *Result) Decode(target any) error // struct decoding: mql tag → json tag → field name
+func (r *Result) Err() error              // per-value execution errors, joined
+func (r *Result) FieldErrors() []FieldError
+func (r *Result) Raw() (map[string]*llx.RawResult, *llx.CodeBundle)
+```
+
+### Key design points
+
+**Expression mode is the bare default.** `NewEnv()` with no options is fully
+usable. Internally, the Env lazily builds one runtime backed solely by the
+builtin core provider, which runs in-process — creating it never spawns a
+subprocess and never touches infrastructure. Heterogeneous values passed as
+props (`map[string]any`, `[]any`) convert to MQL dicts, so queries navigate
+them naturally: `props.event.process.binary.contains("/tmp")`.
+
+**The asset binds at evaluation time, not at compile time.** A `Query` is
+asset-independent; `EvalOn` takes the `Conn`. This is what makes
+compile-once/evaluate-many work across fleets and discovered child assets,
+and it matches the engine, where `exec.ExecuteCode` already takes the runtime
+per call.
+
+**Results resolve labels and keep errors.** `Value()` returns blocks as
+`map[string]any` keyed by field labels (duplicate labels are numbered, as in
+the JSON reporter), lists as `[]any`, and scalars as-is. Unlike the existing
+`RawData.Dereference`, per-field execution errors are not dropped: they are
+collected as `FieldError`s with paths (`users[3].name`), surfaced via `Err()`
+and returned by `Decode`, so missing data is never silently zero-valued.
+
+**Decoding preserves fidelity.** `Decode` is a small reflection decoder
+rather than a JSON round-trip, because query values must survive intact:
+int64 beyond 2^53, time values, and IPs all degrade through JSON. Struct
+fields match by `mql` tag, then `json` tag, then field name. Numeric
+conversions are overflow-checked and never silently truncate.
+
+**Typed errors stay accessible.** Compile failures return a `*CompileError`
+wrapping the source and the underlying compiler error, so callers can still
+match typed errors such as `mqlc.ErrIdentifierNotFound` via `errors.As` —
+the existing `exec.Exec` flattens these to strings.
+
+**Schema availability is explicit.** A query compiles only against loaded
+provider schemas. Expression-mode queries always compile; resources of other
+providers require a prior `Connect` or `NewEnv(WithProviders("aws", ...))`.
+
+**Custom resources, not just values.** When data is not a plain value but a
+resource with fields computed lazily in Go — only when an expression reads
+them — `WithPrivateProvider` registers a caller-supplied, in-process provider
+(its `plugin.Provider` config, schema, and `plugin.ProviderPlugin`). "Private"
+distinguishes it from the providers `WithProviders` loads from the shared
+registry: it is a provider only the caller has, an instance handed to the Env
+directly. Its resources compile and evaluate without a subprocess, and field
+resolvers may reference other resources, because the connection is backed by
+the runtime's own callbacks. This is what lets a consumer evaluate MQL against
+a caller-defined resource without implementing `llx.Runtime` by hand. The
+wiring is a thin wrapper over a new supported helper,
+`providers.Runtime.UseInProcessProvider`, which direct `providers` consumers
+can also use.
+
+## Validation
+
+The package ships with a working implementation and a test suite
+(`mqlx/*_test.go`) covering both modes end-to-end: expression evaluation
+against the real in-process core runtime (operators, core resources, props
+with overrides and type checking, concurrent evaluation of one compiled
+query), asset-mode queries against a recorded Linux asset, a caller-supplied
+in-process provider whose resource fields resolve lazily on read (including a
+cross-resource field and error propagation), result normalization (multi-value
+queries, duplicate labels, value errors), and struct decoding (tag fallback
+chain, overflow checks, nested structures, int64 fidelity).
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `mqlx/mqlx.go` | package docs, `Env`, options, expression runtime |
+| `mqlx/conn.go` | `Conn`, `Connect`/`ConnectLocal`/`WrapRuntime` |
+| `mqlx/query.go` | `Query`, `Compile`, `WithProps` |
+| `mqlx/eval.go` | `Eval`/`EvalOn`, property merging and type checks |
+| `mqlx/value.go` | result normalization: labels, paths, field errors |
+| `mqlx/decode.go` | reflection decoder for `Result.Decode` |
+| `providers/runtime.go` | `Runtime.UseInProcessProvider`, the supported connect helper |
+| `exec/exec.go` | execution entrypoint the facade wraps (unchanged) |
+| `mqlc/mqlc.go` | compiler entrypoint the facade wraps (unchanged) |
+
+## Follow-Ups
+
+The facade is designed to absorb these without breaking changes; they are
+intentionally not part of the initial implementation:
+
+1. **Context-aware execution.** `exec` has no `context.Context` today; the
+   graph executor only honors a timeout. Add `exec.ExecuteCodeCtx` and a
+   cancellation case to the executor loop, then thread `ctx` through `Eval`.
+   Until then, `Eval` honors `ctx` between, not during, executions.
+2. **Resource expansion in Decode.** Decoding a bare resource into a struct
+   by fetching its fields through the runtime — replacing prism's
+   `MQLCDecoder`. Until then, queries project fields explicitly
+   (`resource { field1 field2 }`), which is also the cheaper pattern.
+3. **Asset construction sugar and discovery.** `NewAsset(connType, opts...)`
+   helpers, credentials, and an `Env.Discover` API wrapping the discovery
+   engine for fleet-wide compile-once/evaluate-many.
+4. **Consumer migrations.** Move prism and xgrep onto `mqlx` as reference
+   consumers: pre-compiled queries, `WithPrivateProvider` for their custom
+   resources, and `Decode` replace their bespoke `llx.Runtime` and decoder
+   layers.
+
+## Consequences
+
+- Existing APIs (`exec`, `mqlc`, `providers`) are untouched; `mqlx` is purely
+  additive and consumers can adopt it incrementally.
+- A new public surface must be kept stable. The API is intentionally small
+  (four types) and hides engine internals, so the engine keeps freedom to
+  evolve underneath it.
+- Embedding MQL no longer requires knowledge of checksums, labels, code
+  bundles, or provider wiring — which also means fewer consumers depending on
+  those internals directly.
+- The expression-mode runtime keeps one in-process core connection per Env;
+  `Env.Close` releases it.

--- a/mqlx/README.md
+++ b/mqlx/README.md
@@ -1,0 +1,60 @@
+# mqlx
+
+A high-level Go API for embedding MQL — both as a standalone expression engine
+and for querying connected infrastructure.
+
+> [!WARNING]
+> **Experimental.** This package is under active development. Its API may
+> change — or be removed — at any time, without notice and without a
+> deprecation cycle, including in patch releases. Do not depend on it in
+> production until it is marked stable.
+
+## Two modes
+
+**Expression mode** evaluates MQL over values you pass in. It needs no
+providers, no asset, and no subprocesses:
+
+```go
+env, err := mqlx.NewEnv()
+q, err := env.Compile(`props.name == /admin-.*/ && props.count > 3`,
+    mqlx.WithProps(map[string]any{"name": "", "count": 0}))
+res, err := q.Eval(ctx,
+    mqlx.WithPropValues(map[string]any{"name": "admin-x", "count": 5}))
+fmt.Println(res.Value()) // true
+```
+
+**Asset mode** runs queries against connected infrastructure. Connect once,
+compile once, and evaluate against as many assets as needed:
+
+```go
+conn, err := env.ConnectLocal(ctx)
+res, err := conn.Query(ctx, "asset { name platform }")
+
+var info struct {
+    Name     string `mql:"name"`
+    Platform string `mql:"platform"`
+}
+err = res.Decode(&info)
+```
+
+## Custom resources
+
+When your data is not a plain value but a resource with fields computed lazily
+in Go — only when an expression reads them — register a caller-supplied,
+in-process provider with `WithPrivateProvider`. Its resources compile and
+evaluate without a subprocess, and you never implement `llx.Runtime` by hand:
+
+```go
+env, err := mqlx.NewEnv(
+    mqlx.WithPrivateProvider(myprovider.Config, myprovider.Schema(), myprovider.Init()),
+)
+res, err := env.Compile("secret.entropy > 4.0").Eval(ctx)
+```
+
+## Design
+
+See [ADR 027](../docs/adr/027-mqlx-go-embedding-api.md) for the motivation,
+the full API contract, and the roadmap of planned follow-ups.
+
+See [ADR 027](../docs/adr/027-mqlx-go-embedding-api.md) for the motivation,
+the full API contract, and the roadmap of planned follow-ups.

--- a/mqlx/asset_test.go
+++ b/mqlx/asset_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/mqlx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+)
+
+// Asset-mode tests run against a recorded Linux asset; no real connection is
+// made. The runtime is wrapped via WrapRuntime, the escape hatch for callers
+// that manage runtimes themselves.
+var (
+	mockConnOnce sync.Once
+	mockEnv      *mqlx.Env
+	mockConn     *mqlx.Conn
+)
+
+func testConn(t *testing.T) (*mqlx.Env, *mqlx.Conn) {
+	t.Helper()
+	mockConnOnce.Do(func() {
+		var err error
+		mockEnv, err = mqlx.NewEnv(mqlx.WithFeatures(testutils.Features))
+		if err != nil {
+			panic(err.Error())
+		}
+		mockConn = mockEnv.WrapRuntime(testutils.LinuxMock())
+	})
+	return mockEnv, mockConn
+}
+
+func TestAssetValues(t *testing.T) {
+	_, conn := testConn(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		query string
+		want  any
+	}{
+		{"asset.platform", "arch"},
+		{"asset { platform version }", map[string]any{
+			"platform": "arch",
+			"version":  "rolling",
+		}},
+		{"users { name uid }", []any{
+			map[string]any{"name": "root", "uid": int64(0)},
+			map[string]any{"name": "bin", "uid": int64(1)},
+			map[string]any{"name": "chris", "uid": int64(1000)},
+			map[string]any{"name": "christopher", "uid": int64(1001)},
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			res, err := conn.Query(ctx, tc.query)
+			require.NoError(t, err)
+			require.NoError(t, res.Err())
+			assert.Equal(t, tc.want, res.Value())
+		})
+	}
+}
+
+func TestAssetMultiValue(t *testing.T) {
+	_, conn := testConn(t)
+
+	res, err := conn.Query(context.Background(), "asset.platform\nasset.version")
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	m, ok := res.Value().(map[string]any)
+	require.True(t, ok, "expected map, got %T", res.Value())
+	assert.Equal(t, "arch", m["asset.platform"])
+	assert.Equal(t, "rolling", m["asset.version"])
+}
+
+func TestAssetCompileOnceEvalMany(t *testing.T) {
+	env, conn := testConn(t)
+
+	q, err := env.Compile("users.where(uid >= props.min) { name }",
+		mqlx.WithProps(map[string]any{"min": 0}))
+	require.NoError(t, err)
+
+	res, err := q.EvalOn(context.Background(), conn,
+		mqlx.WithPropValues(map[string]any{"min": 1000}))
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	list, ok := res.Value().([]any)
+	require.True(t, ok)
+	assert.Len(t, list, 2)
+}
+
+func TestAssetDecode(t *testing.T) {
+	_, conn := testConn(t)
+
+	res, err := conn.Query(context.Background(), "users { name uid }")
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	type user struct {
+		Name string `mql:"name"`
+		UID  int64  `mql:"uid"`
+	}
+	var users []user
+	require.NoError(t, res.Decode(&users))
+
+	require.Len(t, users, 4)
+	assert.Equal(t, user{Name: "root", UID: 0}, users[0])
+	assert.Equal(t, user{Name: "christopher", UID: 1001}, users[3])
+}
+
+func TestAssetValueError(t *testing.T) {
+	_, conn := testConn(t)
+
+	query := "x = parse.json(content: '{\"arr\": []}').params\nx['arr'][0]"
+	res, err := conn.Query(context.Background(), query)
+	require.NoError(t, err)
+
+	assert.Nil(t, res.Value())
+	require.Error(t, res.Err())
+	assert.Contains(t, res.Err().Error(), "array index out of bound")
+}

--- a/mqlx/conn.go
+++ b/mqlx/conn.go
@@ -1,0 +1,112 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"context"
+	"sync"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"google.golang.org/protobuf/proto"
+)
+
+// Conn is a live connection to a single asset. It is safe for concurrent
+// evaluations. Close releases the underlying provider connection.
+type Conn struct {
+	env     *Env
+	runtime llx.Runtime
+	owned   bool
+	close   sync.Once
+}
+
+// LocalAsset returns an asset describing the local operating system.
+func LocalAsset() *inventory.Asset {
+	return &inventory.Asset{
+		Connections: []*inventory.Config{{Type: "local"}},
+	}
+}
+
+// Connect detects the provider for the given asset, starts it, and connects.
+// The asset is cloned; the caller's copy is not modified.
+func (e *Env) Connect(ctx context.Context, asset *inventory.Asset) (*Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	asset = proto.Clone(asset).(*inventory.Asset)
+
+	rt := providers.Coordinator.NewRuntime()
+	if err := rt.DetectProvider(asset); err != nil {
+		rt.Close()
+		return nil, err
+	}
+	if err := rt.Connect(&plugin.ConnectReq{
+		Features: e.features,
+		Asset:    asset,
+	}); err != nil {
+		rt.Close()
+		return nil, err
+	}
+	if err := e.attachPrivateProviders(rt); err != nil {
+		rt.Close()
+		return nil, err
+	}
+
+	conn := &Conn{env: e, runtime: rt, owned: true}
+	if err := e.trackConn(conn); err != nil {
+		rt.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// ConnectLocal connects to the local operating system.
+func (e *Env) ConnectLocal(ctx context.Context) (*Conn, error) {
+	return e.Connect(ctx, LocalAsset())
+}
+
+// WrapRuntime wraps an existing runtime in a Conn. This is the escape hatch
+// for callers that manage runtime lifecycles themselves (tests, custom
+// discovery loops). The returned Conn does not own the runtime; its Close is
+// a no-op.
+func (e *Env) WrapRuntime(rt llx.Runtime) *Conn {
+	return &Conn{env: e, runtime: rt}
+}
+
+// Close releases the connection. It is a no-op for Conns created via
+// WrapRuntime.
+func (c *Conn) Close() {
+	c.close.Do(func() {
+		if c.owned {
+			c.runtime.Close()
+		}
+	})
+}
+
+// Asset returns the connected asset with the metadata the provider attached
+// during connection, or nil if unavailable.
+func (c *Conn) Asset() *inventory.Asset {
+	rt, ok := c.runtime.(*providers.Runtime)
+	if !ok || rt.Provider == nil || rt.Provider.Connection == nil {
+		return nil
+	}
+	return rt.Provider.Connection.Asset
+}
+
+// Runtime exposes the underlying runtime for advanced use.
+func (c *Conn) Runtime() llx.Runtime {
+	return c.runtime
+}
+
+// Query compiles and evaluates src against this connection in one call. For
+// repeated evaluation, compile once with Env.Compile and use Query.EvalOn.
+func (c *Conn) Query(ctx context.Context, src string, opts ...CompileOption) (*Result, error) {
+	q, err := c.env.Compile(src, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return q.EvalOn(ctx, c)
+}

--- a/mqlx/decode.go
+++ b/mqlx/decode.go
@@ -1,0 +1,339 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"time"
+
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// decode unmarshals a normalized query value into target. It is hand-rolled
+// rather than routed through JSON because query values must keep their
+// fidelity: int64 beyond 2^53, time values, and IPs all lose information in
+// a JSON round-trip.
+func decode(src any, target any) error {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return errors.New("decode target must be a non-nil pointer")
+	}
+	return decodeValue(src, rv.Elem(), "")
+}
+
+func decodeValue(src any, dst reflect.Value, path string) error {
+	if src == nil {
+		return nil
+	}
+
+	// Allocate and follow pointers so that *string, **T etc. work.
+	for dst.Kind() == reflect.Pointer {
+		if dst.IsNil() {
+			dst.Set(reflect.New(dst.Type().Elem()))
+		}
+		dst = dst.Elem()
+	}
+
+	// An empty interface target takes the value as-is.
+	if dst.Kind() == reflect.Interface && dst.NumMethod() == 0 {
+		dst.Set(reflect.ValueOf(src))
+		return nil
+	}
+
+	switch v := src.(type) {
+	case bool:
+		if dst.Kind() == reflect.Bool {
+			dst.SetBool(v)
+			return nil
+		}
+
+	case int64:
+		return decodeInt(v, dst, path)
+
+	case float64:
+		return decodeFloat(v, dst, path)
+
+	case string:
+		if dst.Kind() == reflect.String {
+			dst.SetString(v)
+			return nil
+		}
+
+	case time.Time:
+		return decodeTime(&v, dst, path)
+
+	case *time.Time:
+		return decodeTime(v, dst, path)
+
+	case []byte:
+		if dst.Type() == reflect.TypeFor[[]byte]() {
+			dst.SetBytes(v)
+			return nil
+		}
+		if dst.Kind() == reflect.String {
+			dst.SetString(string(v))
+			return nil
+		}
+
+	case llx.RawIP:
+		if dst.Type() == reflect.TypeFor[llx.RawIP]() {
+			dst.Set(reflect.ValueOf(v))
+			return nil
+		}
+		if dst.Kind() == reflect.String {
+			dst.SetString(v.String())
+			return nil
+		}
+
+	case llx.Range:
+		if dst.Type() == reflect.TypeFor[llx.Range]() {
+			dst.Set(reflect.ValueOf(v))
+			return nil
+		}
+		if dst.Kind() == reflect.String {
+			dst.SetString(v.String())
+			return nil
+		}
+
+	case llx.Resource:
+		return decodeResource(v, dst, path)
+
+	case []any:
+		return decodeSlice(v, dst, path)
+
+	case map[string]any:
+		switch dst.Kind() {
+		case reflect.Struct:
+			return decodeStruct(v, dst, path)
+		case reflect.Map:
+			return decodeMap(v, dst, path)
+		}
+	}
+
+	// Last resort: directly assignable values (e.g. custom leaf types).
+	sv := reflect.ValueOf(src)
+	if sv.Type().AssignableTo(dst.Type()) {
+		dst.Set(sv)
+		return nil
+	}
+
+	return decodeErr(path, src, dst)
+}
+
+func decodeInt(v int64, dst reflect.Value, path string) error {
+	switch dst.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if dst.OverflowInt(v) {
+			return fmt.Errorf("%s: value %d overflows %s", pathLabel(path), v, dst.Type())
+		}
+		dst.SetInt(v)
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v < 0 || dst.OverflowUint(uint64(v)) {
+			return fmt.Errorf("%s: value %d overflows %s", pathLabel(path), v, dst.Type())
+		}
+		dst.SetUint(uint64(v))
+		return nil
+	case reflect.Float32, reflect.Float64:
+		dst.SetFloat(float64(v))
+		return nil
+	}
+	return decodeErr(path, v, dst)
+}
+
+func decodeFloat(v float64, dst reflect.Value, path string) error {
+	switch dst.Kind() {
+	case reflect.Float32, reflect.Float64:
+		dst.SetFloat(v)
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		// Only integral floats convert to ints; never truncate silently. Range
+		// must be checked before int64(v): converting an out-of-range float is
+		// implementation-defined per the Go spec. The || short-circuits so
+		// OverflowInt only runs once int64(v) is well-defined.
+		if v != math.Trunc(v) || v > float64(math.MaxInt64) || v < float64(math.MinInt64) || dst.OverflowInt(int64(v)) {
+			return fmt.Errorf("%s: value %v does not fit %s", pathLabel(path), v, dst.Type())
+		}
+		dst.SetInt(int64(v))
+		return nil
+	}
+	return decodeErr(path, v, dst)
+}
+
+func decodeTime(v *time.Time, dst reflect.Value, path string) error {
+	if v == nil {
+		return nil
+	}
+	if dst.Type() == reflect.TypeFor[time.Time]() {
+		dst.Set(reflect.ValueOf(*v))
+		return nil
+	}
+	return decodeErr(path, v, dst)
+}
+
+func decodeResource(v llx.Resource, dst reflect.Value, path string) error {
+	// A bare resource only carries its identity. To decode its fields,
+	// project them in the query instead: resource { field1 field2 }.
+	if dst.Kind() == reflect.String {
+		dst.SetString(v.MqlID())
+		return nil
+	}
+	if dst.Kind() == reflect.Interface && reflect.TypeOf(v).AssignableTo(dst.Type()) {
+		dst.Set(reflect.ValueOf(v))
+		return nil
+	}
+	return fmt.Errorf("%s: cannot decode resource %s into %s; project its fields in the query instead, e.g. %s { ... }",
+		pathLabel(path), v.MqlName(), dst.Type(), v.MqlName())
+}
+
+func decodeSlice(src []any, dst reflect.Value, path string) error {
+	if dst.Kind() != reflect.Slice {
+		return decodeErr(path, src, dst)
+	}
+	out := reflect.MakeSlice(dst.Type(), len(src), len(src))
+	var errs []error
+	for i := range src {
+		if err := decodeValue(src[i], out.Index(i), fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	dst.Set(out)
+	return errors.Join(errs...)
+}
+
+func decodeMap(src map[string]any, dst reflect.Value, path string) error {
+	if dst.Type().Key().Kind() != reflect.String {
+		return decodeErr(path, src, dst)
+	}
+	out := reflect.MakeMapWithSize(dst.Type(), len(src))
+	elemType := dst.Type().Elem()
+	var errs []error
+	for k, v := range src {
+		elem := reflect.New(elemType).Elem()
+		if err := decodeValue(v, elem, joinPath(path, k)); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		out.SetMapIndex(reflect.ValueOf(k).Convert(dst.Type().Key()), elem)
+	}
+	dst.Set(out)
+	return errors.Join(errs...)
+}
+
+func decodeStruct(src map[string]any, dst reflect.Value, path string) error {
+	exact, fold := structFields(dst.Type())
+	var errs []error
+	for key, val := range src {
+		idx, ok := exact[key]
+		if !ok {
+			idx, ok = fold[strings.ToLower(key)]
+		}
+		if !ok {
+			continue
+		}
+		if err := decodeValue(val, fieldByIndexAlloc(dst, idx), joinPath(path, key)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// structFields indexes the decodable fields of a struct type by their
+// effective name: the `mql` tag if present, else the `json` tag, else the
+// field name. A tag of "-" excludes the field. Fields of anonymous (embedded)
+// structs are promoted, like encoding/json — an embedded field with an
+// explicit tag is treated as a normal named field instead, and a shallower
+// field wins a name collision with a more deeply embedded one.
+func structFields(t reflect.Type) (exact map[string][]int, fold map[string][]int) {
+	exact = map[string][]int{}
+	fold = map[string][]int{}
+	depthOf := map[string]int{}
+
+	var visit func(t reflect.Type, prefix []int, depth int)
+	visit = func(t reflect.Type, prefix []int, depth int) {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			mtag := tagName(f.Tag.Get("mql"))
+			jtag := tagName(f.Tag.Get("json"))
+			hasTag := mtag != "" || jtag != ""
+
+			index := append(append([]int{}, prefix...), i)
+
+			// Promote fields of an untagged embedded struct (or *struct).
+			if f.Anonymous && !hasTag {
+				ft := f.Type
+				if ft.Kind() == reflect.Pointer {
+					ft = ft.Elem()
+				}
+				if ft.Kind() == reflect.Struct {
+					visit(ft, index, depth+1)
+					continue
+				}
+			}
+
+			if !f.IsExported() {
+				continue
+			}
+			name := f.Name
+			if mtag != "" {
+				name = mtag
+			} else if jtag != "" {
+				name = jtag
+			}
+			if name == "-" {
+				continue
+			}
+			if d, seen := depthOf[name]; !seen || depth < d {
+				exact[name] = index
+				depthOf[name] = depth
+			}
+			if _, ok := fold[strings.ToLower(name)]; !ok {
+				fold[strings.ToLower(name)] = index
+			}
+		}
+	}
+	visit(t, nil, 0)
+	return exact, fold
+}
+
+// fieldByIndexAlloc walks an index path (as produced by structFields),
+// dereferencing and allocating nil pointers to embedded structs along the way
+// so the addressed field can be set.
+func fieldByIndexAlloc(v reflect.Value, index []int) reflect.Value {
+	for _, x := range index {
+		for v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v
+}
+
+func tagName(tag string) string {
+	if tag == "" {
+		return ""
+	}
+	if i := strings.Index(tag, ","); i >= 0 {
+		tag = tag[:i]
+	}
+	return tag
+}
+
+func pathLabel(path string) string {
+	if path == "" {
+		return "value"
+	}
+	return path
+}
+
+func decodeErr(path string, src any, dst reflect.Value) error {
+	return fmt.Errorf("%s: cannot decode %T into %s", pathLabel(path), src, dst.Type())
+}

--- a/mqlx/decode_test.go
+++ b/mqlx/decode_test.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeScalars(t *testing.T) {
+	var s string
+	require.NoError(t, decode("hi", &s))
+	assert.Equal(t, "hi", s)
+
+	var b bool
+	require.NoError(t, decode(true, &b))
+	assert.True(t, b)
+
+	var i int
+	require.NoError(t, decode(int64(42), &i))
+	assert.Equal(t, 42, i)
+
+	var u uint16
+	require.NoError(t, decode(int64(65535), &u))
+	assert.Equal(t, uint16(65535), u)
+
+	var f float64
+	require.NoError(t, decode(int64(2), &f))
+	assert.Equal(t, 2.0, f)
+
+	// int64 fidelity: values beyond 2^53 must not lose precision.
+	var big int64
+	require.NoError(t, decode(int64(1<<62+1), &big))
+	assert.Equal(t, int64(1<<62+1), big)
+}
+
+func TestDecodeOverflow(t *testing.T) {
+	var i8 int8
+	require.ErrorContains(t, decode(int64(300), &i8), "overflows")
+
+	var u uint8
+	require.ErrorContains(t, decode(int64(-1), &u), "overflows")
+
+	var i int
+	require.ErrorContains(t, decode(2.5, &i), "does not fit")
+
+	// A float beyond int64's range must error, not produce an
+	// implementation-defined int64(v) conversion.
+	var big int64
+	require.ErrorContains(t, decode(1e19, &big), "does not fit")
+}
+
+func TestDecodeTime(t *testing.T) {
+	now := time.Now()
+
+	var tt time.Time
+	require.NoError(t, decode(&now, &tt))
+	assert.True(t, now.Equal(tt))
+
+	var pt *time.Time
+	require.NoError(t, decode(&now, &pt))
+	require.NotNil(t, pt)
+	assert.True(t, now.Equal(*pt))
+}
+
+func TestDecodeStruct(t *testing.T) {
+	src := map[string]any{
+		"name":       "web-1",
+		"instanceId": "i-123",
+		"running":    true,
+		"cpuCount":   int64(4),
+		"ignored":    "nope",
+	}
+
+	type instance struct {
+		ID       string `mql:"instanceId"`
+		Name     string `json:"name"`
+		Running  bool   // exact field-name match is case-insensitive
+		CPUCount int64  `mql:"cpuCount"`
+		Skipped  string `mql:"-"`
+	}
+
+	var out instance
+	require.NoError(t, decode(src, &out))
+	assert.Equal(t, instance{
+		ID:       "i-123",
+		Name:     "web-1",
+		Running:  true,
+		CPUCount: 4,
+	}, out)
+}
+
+func TestDecodeNested(t *testing.T) {
+	src := []any{
+		map[string]any{
+			"name": "a",
+			"tags": map[string]any{"env": "prod"},
+			"ips":  []any{"10.0.0.1", "10.0.0.2"},
+		},
+		map[string]any{
+			"name": "b",
+			"tags": map[string]any{},
+			"ips":  []any{},
+		},
+	}
+
+	type host struct {
+		Name string            `mql:"name"`
+		Tags map[string]string `mql:"tags"`
+		IPs  []string          `mql:"ips"`
+	}
+
+	var out []host
+	require.NoError(t, decode(src, &out))
+	require.Len(t, out, 2)
+	assert.Equal(t, "prod", out[0].Tags["env"])
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, out[0].IPs)
+}
+
+func TestDecodeEmbedded(t *testing.T) {
+	type Base struct {
+		ID   string `mql:"id"`
+		Name string `mql:"name"`
+	}
+	// value embed, pointer embed, and a field that shadows an embedded one.
+	type Meta struct {
+		Region string `mql:"region"`
+	}
+	type Instance struct {
+		Base
+		*Meta
+		Name string            `mql:"name"` // shadows Base.Name (shallower wins)
+		Tags map[string]string `mql:"tags"`
+	}
+
+	src := map[string]any{
+		"id":     "i-123",
+		"name":   "web-1",
+		"region": "us-east-1",
+		"tags":   map[string]any{"env": "prod"},
+	}
+
+	var out Instance
+	require.NoError(t, decode(src, &out))
+	assert.Equal(t, "i-123", out.ID)         // promoted from Base
+	assert.Equal(t, "web-1", out.Name)       // outer field wins over Base.Name
+	assert.Equal(t, "", out.Base.Name)       // embedded one left untouched
+	require.NotNil(t, out.Meta)              // nil *Meta allocated on demand
+	assert.Equal(t, "us-east-1", out.Region) // promoted from *Meta
+	assert.Equal(t, "prod", out.Tags["env"])
+}
+
+func TestDecodeIntoAny(t *testing.T) {
+	var out any
+	require.NoError(t, decode(map[string]any{"a": int64(1)}, &out))
+	assert.Equal(t, map[string]any{"a": int64(1)}, out)
+}
+
+func TestDecodeNil(t *testing.T) {
+	s := "unchanged"
+	require.NoError(t, decode(nil, &s))
+	assert.Equal(t, "unchanged", s)
+}
+
+func TestDecodeTargetErrors(t *testing.T) {
+	require.ErrorContains(t, decode("x", nil), "non-nil pointer")
+
+	var s string
+	require.ErrorContains(t, decode("x", s), "non-nil pointer")
+
+	var i int
+	require.ErrorContains(t, decode("hello", &i), "cannot decode")
+}

--- a/mqlx/errors.go
+++ b/mqlx/errors.go
@@ -1,0 +1,20 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+// CompileError wraps a compilation failure together with the query source.
+// Unwrap exposes the underlying compiler error, so typed errors such as
+// mqlc.ErrIdentifierNotFound remain accessible via errors.As.
+type CompileError struct {
+	Source string
+	Err    error
+}
+
+func (e *CompileError) Error() string {
+	return "failed to compile MQL: " + e.Err.Error()
+}
+
+func (e *CompileError) Unwrap() error {
+	return e.Err
+}

--- a/mqlx/eval.go
+++ b/mqlx/eval.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"context"
+	"maps"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/v13/exec"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// EvalOption configures a single evaluation.
+type EvalOption func(*evalOptions) error
+
+type evalOptions struct {
+	props map[string]any
+}
+
+// WithPropValues overrides property values declared at compile time with
+// WithProps. Every key must be declared and its value must match the
+// declared type.
+func WithPropValues(props map[string]any) EvalOption {
+	return func(o *evalOptions) error {
+		o.props = props
+		return nil
+	}
+}
+
+// Eval evaluates the query in expression mode: against the environment's
+// internal runtime, which provides MQL's operators and core resources but no
+// infrastructure. Use it to run MQL over values passed in via props. For
+// queries against an asset, use EvalOn.
+func (q *Query) Eval(ctx context.Context, opts ...EvalOption) (*Result, error) {
+	rt, err := q.env.exprRuntime()
+	if err != nil {
+		return nil, err
+	}
+	return q.eval(ctx, rt, opts)
+}
+
+// EvalOn evaluates the query against a connected asset.
+func (q *Query) EvalOn(ctx context.Context, conn *Conn, opts ...EvalOption) (*Result, error) {
+	if conn == nil {
+		return nil, errors.New("cannot evaluate query: no connection provided")
+	}
+	return q.eval(ctx, conn.runtime, opts)
+}
+
+func (q *Query) eval(ctx context.Context, rt llx.Runtime, opts []EvalOption) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var options evalOptions
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	props, err := q.mergeProps(options.props)
+	if err != nil {
+		return nil, err
+	}
+
+	// Queries without entrypoints (e.g. assignments only) produce no values;
+	// the executor cannot run them.
+	if len(q.bundle.CodeV2.Entrypoints()) == 0 {
+		return newResult(q.bundle, nil), nil
+	}
+
+	raw, err := exec.ExecuteCode(rt, q.bundle, props, q.env.features)
+	if err != nil {
+		return nil, err
+	}
+
+	return newResult(q.bundle, raw), nil
+}
+
+// mergeProps combines the compile-time property defaults with per-evaluation
+// overrides, enforcing that overrides are declared and type-correct.
+func (q *Query) mergeProps(overrides map[string]any) (map[string]*llx.Primitive, error) {
+	if len(overrides) == 0 {
+		return q.props, nil
+	}
+
+	props := make(map[string]*llx.Primitive, len(q.props))
+	maps.Copy(props, q.props)
+
+	for k, v := range overrides {
+		declared, ok := props[k]
+		if !ok {
+			return nil, errors.New("property '" + k + "' was not declared at compile time (use WithProps)")
+		}
+		prim, err := ToPrimitive(v)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert property '"+k+"'")
+		}
+		if prim.Type != declared.Type {
+			return nil, errors.New("property '" + k + "' must be of type " +
+				types.Type(declared.Type).Label() + ", got " + types.Type(prim.Type).Label())
+		}
+		props[k] = prim
+	}
+
+	return props, nil
+}

--- a/mqlx/example_test.go
+++ b/mqlx/example_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx_test
+
+import (
+	"context"
+	"fmt"
+
+	"go.mondoo.com/mql/v13/mqlx"
+)
+
+// Evaluate MQL as a pure expression engine: no providers, no asset, no
+// subprocesses. Values are passed in as props and the result comes back as a
+// plain Go value.
+func Example_expressions() {
+	env, err := mqlx.NewEnv()
+	if err != nil {
+		panic(err)
+	}
+	defer env.Close()
+
+	q, err := env.Compile("props.name == /admin-.*/ && props.count > 3",
+		mqlx.WithProps(map[string]any{"name": "", "count": 0}))
+	if err != nil {
+		panic(err)
+	}
+
+	res, err := q.Eval(context.Background(),
+		mqlx.WithPropValues(map[string]any{"name": "admin-x", "count": 5}))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res.Value())
+	// Output: true
+}
+
+// Query the local operating system and decode the result into a struct.
+// This example connects to a real asset, so it is not executed in tests.
+func ExampleEnv_ConnectLocal() {
+	ctx := context.Background()
+
+	env, _ := mqlx.NewEnv()
+	defer func() { _ = env.Shutdown() }()
+
+	conn, err := env.ConnectLocal(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	res, err := conn.Query(ctx, "asset { name platform version }")
+	if err != nil {
+		panic(err)
+	}
+
+	var info struct {
+		Name     string `mql:"name"`
+		Platform string `mql:"platform"`
+		Version  string `mql:"version"`
+	}
+	if err := res.Decode(&info); err != nil {
+		panic(err)
+	}
+	fmt.Println(info.Platform)
+}
+
+// Compile a query once and evaluate it against any number of connections,
+// overriding properties per evaluation.
+func ExampleQuery_EvalOn() {
+	ctx := context.Background()
+
+	env, _ := mqlx.NewEnv(mqlx.WithProviders("aws"))
+	defer func() { _ = env.Shutdown() }()
+
+	conn, err := env.Connect(ctx, mqlx.LocalAsset())
+	if err != nil {
+		panic(err)
+	}
+
+	q, err := env.Compile("users.where(uid >= props.min) { name uid }",
+		mqlx.WithProps(map[string]any{"min": 1000}))
+	if err != nil {
+		panic(err)
+	}
+
+	res, err := q.EvalOn(ctx, conn)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res.Value())
+}

--- a/mqlx/local_test.go
+++ b/mqlx/local_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/mqlx"
+)
+
+// TestConnectLocalE2E connects to the real local OS through installed
+// providers. It is opt-in because it spawns provider subprocesses, which is
+// not suitable for unit-test environments.
+func TestConnectLocalE2E(t *testing.T) {
+	if os.Getenv("MQLX_E2E") == "" {
+		t.Skip("set MQLX_E2E=1 to run the end-to-end local connection test")
+	}
+
+	ctx := context.Background()
+	env, err := mqlx.NewEnv()
+	require.NoError(t, err)
+	defer env.Close()
+
+	conn, err := env.ConnectLocal(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	res, err := conn.Query(ctx, "asset { name platform version }")
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	m, ok := res.Value().(map[string]any)
+	require.True(t, ok, "expected map, got %T", res.Value())
+	assert.NotEmpty(t, m["platform"])
+
+	var info struct {
+		Name     string `mql:"name"`
+		Platform string `mql:"platform"`
+		Version  string `mql:"version"`
+	}
+	require.NoError(t, res.Decode(&info))
+	assert.NotEmpty(t, info.Platform)
+	t.Logf("connected to %s: platform=%s version=%s", info.Name, info.Platform, info.Version)
+}

--- a/mqlx/mqlx.go
+++ b/mqlx/mqlx.go
@@ -1,0 +1,248 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package mqlx provides a high-level API for embedding MQL in Go programs.
+//
+// It covers two modes of use:
+//
+// Expression mode evaluates MQL over values you pass in. It needs no
+// providers, no asset, and no subprocesses — a bare environment is fully
+// usable:
+//
+//	env, err := mqlx.NewEnv()
+//	q, err := env.Compile("props.name == /admin-.*/ && props.count > 3",
+//	    mqlx.WithProps(map[string]any{"name": "", "count": 0}))
+//	res, err := q.Eval(ctx,
+//	    mqlx.WithPropValues(map[string]any{"name": "admin-x", "count": 5}))
+//	fmt.Println(res.Value()) // true
+//
+// Asset mode runs queries against connected infrastructure (a host, a cloud
+// account, a cluster). Connect once, compile once, evaluate against as many
+// assets as needed:
+//
+//	conn, err := env.ConnectLocal(ctx)
+//	res, err := conn.Query(ctx, "asset { name platform }")
+//
+//	var info struct {
+//	    Name     string `mql:"name"`
+//	    Platform string `mql:"platform"`
+//	}
+//	err = res.Decode(&info)
+//
+// Compiled queries (Query) and environments (Env) are safe for concurrent
+// use; compile once and evaluate from many goroutines.
+//
+// Schema availability: a query can only reference resources whose provider
+// schema is loaded. Expression-mode queries (operators, string/array/map
+// methods, and core resources such as regex and time) always compile.
+// Resources of other providers require a prior Connect or
+// NewEnv(WithProviders("aws", ...)).
+package mqlx
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	mql "go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+)
+
+// Env is the environment for compiling and evaluating MQL. It carries the
+// feature set and the provider schemas, and lazily maintains an internal
+// runtime for expression-mode evaluation. Create one Env per process and
+// share it; it is safe for concurrent use.
+type Env struct {
+	features mql.Features
+	private  []privateProvider
+
+	mu     sync.Mutex
+	conns  []*Conn
+	closed bool
+
+	exprOnce sync.Once
+	exprRT   *providers.Runtime
+	exprErr  error
+}
+
+// privateProvider is a caller-supplied, in-process provider registered via
+// WithPrivateProvider.
+type privateProvider struct {
+	config plugin.Provider
+	schema resources.ResourcesSchema
+	plugin plugin.ProviderPlugin
+}
+
+// EnvOption configures an Env during NewEnv.
+type EnvOption func(*Env) error
+
+// WithFeatures sets the MQL feature flags. Default: mql.DefaultFeatures.
+func WithFeatures(features mql.Features) EnvOption {
+	return func(e *Env) error {
+		e.features = features
+		return nil
+	}
+}
+
+// WithProviders eagerly loads the schemas of the named providers (e.g. "aws",
+// "os") so that their resources compile before any connection is made. The
+// providers must be installed; they are not started by this option.
+func WithProviders(names ...string) EnvOption {
+	return func(e *Env) error {
+		for _, name := range names {
+			schema, err := providers.Coordinator.LoadSchema(name)
+			if err != nil {
+				return errors.Wrap(err, "failed to load schema for provider "+name)
+			}
+			if ext, ok := providers.Coordinator.Schema().(providers.ExtensibleSchema); ok {
+				ext.Add(name, schema)
+			}
+		}
+		return nil
+	}
+}
+
+// WithPrivateProvider registers a caller-supplied, in-process provider so its
+// resources can be compiled and evaluated without running a subprocess. Use
+// it when expression mode is not enough because your data is a real resource
+// with fields computed lazily in Go — only when an expression reads them —
+// rather than plain values mapped into props.
+//
+// Unlike the providers loaded by WithProviders, which are discovered from the
+// shared provider registry, a private provider is one only the caller has: an
+// instance you constructed and hand to this Env directly.
+//
+// config identifies the provider (its ID must match the provider ID recorded
+// on the schema's resources), schema is what queries compile against, and
+// plug resolves resources and their fields on demand. Generated providers
+// expose all three as Config, their schema, and Init(). The provider is wired
+// into expression-mode evaluation and into connections opened by this Env.
+func WithPrivateProvider(config plugin.Provider, schema resources.ResourcesSchema, plug plugin.ProviderPlugin) EnvOption {
+	return func(e *Env) error {
+		if schema == nil {
+			return errors.New("cannot register private provider '" + config.Name + "': no schema provided")
+		}
+		if plug == nil {
+			return errors.New("cannot register private provider '" + config.Name + "': no plugin provided")
+		}
+		// Register the schema so queries against the provider's resources
+		// compile.
+		if ext, ok := providers.Coordinator.Schema().(providers.ExtensibleSchema); ok {
+			ext.Add(config.ID, schema)
+		}
+		e.private = append(e.private, privateProvider{config: config, schema: schema, plugin: plug})
+		return nil
+	}
+}
+
+// attachPrivateProviders wires every registered private provider into a
+// runtime so its resources resolve there.
+func (e *Env) attachPrivateProviders(rt *providers.Runtime) error {
+	for _, bp := range e.private {
+		if err := rt.UseInProcessProvider(bp.config, bp.schema, bp.plugin, e.features); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewEnv creates a new environment. With no options it is immediately usable
+// for expression-mode queries.
+//
+// The schema-loading options (WithProviders, WithPrivateProvider) register
+// schemas on the process-global provider coordinator as a side effect.
+// Calling NewEnv with those options concurrently from multiple goroutines is
+// therefore not safe; construct the environment once, before sharing it.
+func NewEnv(opts ...EnvOption) (*Env, error) {
+	e := &Env{
+		features: mql.DefaultFeatures,
+	}
+	for _, opt := range opts {
+		if err := opt(e); err != nil {
+			return nil, err
+		}
+	}
+	return e, nil
+}
+
+// Features returns the feature flags this environment was created with.
+func (e *Env) Features() mql.Features {
+	return e.features
+}
+
+// schema returns the current provider schema. It grows as provider schemas
+// are loaded (via Connect or WithProviders).
+func (e *Env) schema() resources.ResourcesSchema {
+	return providers.Coordinator.Schema()
+}
+
+// exprRuntime returns the internal runtime used for expression-mode
+// evaluation. It is backed solely by the builtin core provider, which runs
+// in-process: creating it never spawns a provider subprocess and never
+// touches any infrastructure.
+func (e *Env) exprRuntime() (*providers.Runtime, error) {
+	e.exprOnce.Do(func() {
+		rt := providers.Coordinator.NewRuntime()
+		rt.AutoUpdate = providers.UpdateProvidersConfig{Enabled: false}
+		// Connect the in-process core provider with the runtime's callbacks, so
+		// resources resolved through it (including any reached from a private
+		// provider) behave like under a normal connection.
+		if err := rt.UseBuiltinProvider(providers.BuiltinCoreID, e.features); err != nil {
+			e.exprErr = err
+			return
+		}
+
+		if err := e.attachPrivateProviders(rt); err != nil {
+			e.exprErr = err
+			return
+		}
+		e.exprRT = rt
+	})
+	return e.exprRT, e.exprErr
+}
+
+func (e *Env) trackConn(c *Conn) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return errors.New("cannot connect: environment is closed")
+	}
+	e.conns = append(e.conns, c)
+	return nil
+}
+
+// Close closes all connections opened through this Env and the internal
+// expression runtime. It does not shut down the provider coordinator; other
+// components in the process may still be using it. Use Shutdown at process
+// exit.
+func (e *Env) Close() error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	conns := e.conns
+	e.conns = nil
+	e.mu.Unlock()
+
+	for _, c := range conns {
+		c.Close()
+	}
+	if e.exprRT != nil {
+		e.exprRT.Close()
+	}
+	return nil
+}
+
+// Shutdown closes the Env and additionally shuts down the provider
+// coordinator, stopping all provider subprocesses. Call it once at process
+// exit; in a process that embeds other MQL consumers, prefer Close.
+func (e *Env) Shutdown() error {
+	if err := e.Close(); err != nil {
+		return err
+	}
+	providers.Coordinator.Shutdown()
+	return nil
+}

--- a/mqlx/mqlx_test.go
+++ b/mqlx/mqlx_test.go
@@ -1,0 +1,191 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/mqlx"
+)
+
+// exprEnv is shared across expression-mode tests: expression mode needs no
+// providers, no asset, and no provider subprocess.
+var (
+	exprEnvOnce sync.Once
+	exprEnv     *mqlx.Env
+)
+
+func testEnv(t *testing.T) *mqlx.Env {
+	t.Helper()
+	exprEnvOnce.Do(func() {
+		var err error
+		exprEnv, err = mqlx.NewEnv()
+		if err != nil {
+			panic(err.Error())
+		}
+	})
+	return exprEnv
+}
+
+func TestExprValues(t *testing.T) {
+	env := testEnv(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		query string
+		want  any
+	}{
+		{"1 + 2", int64(3)},
+		{"'hello world'.contains('world')", true},
+		{"'MQL'.downcase", "mql"},
+		{"semver('1.2.3') < semver('1.10.0')", true},
+		{"[1, 2, 3].where(_ > 1).length", int64(2)},
+		{"{'a': 1, 'b': 2}['b']", int64(2)},
+		{"'joe@example.com' == regex.email", true},
+		{"if (1 > 2) { return 'a' } return 'b'", "b"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			q, err := env.Compile(tc.query)
+			require.NoError(t, err)
+
+			res, err := q.Eval(ctx)
+			require.NoError(t, err)
+			require.NoError(t, res.Err())
+			assert.Equal(t, tc.want, res.Value())
+		})
+	}
+}
+
+func TestExprTime(t *testing.T) {
+	env := testEnv(t)
+
+	res, err := env.MustCompile("time.now").Eval(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	now, ok := res.Value().(*time.Time)
+	require.True(t, ok, "expected *time.Time, got %T", res.Value())
+	assert.WithinDuration(t, time.Now(), *now, time.Minute)
+}
+
+func TestExprProps(t *testing.T) {
+	env := testEnv(t)
+	ctx := context.Background()
+
+	t.Run("defaults and overrides", func(t *testing.T) {
+		q, err := env.Compile("props.a + props.b",
+			mqlx.WithProps(map[string]any{"a": 2, "b": 3}))
+		require.NoError(t, err)
+
+		res, err := q.Eval(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), res.Value())
+
+		res, err = q.Eval(ctx, mqlx.WithPropValues(map[string]any{"a": 40}))
+		require.NoError(t, err)
+		assert.Equal(t, int64(43), res.Value())
+	})
+
+	t.Run("dict props with dot access", func(t *testing.T) {
+		q, err := env.Compile("props.event.process.binary.contains('/tmp')",
+			mqlx.WithProps(map[string]any{"event": map[string]any{}}))
+		require.NoError(t, err)
+
+		event := map[string]any{
+			"process": map[string]any{"binary": "/tmp/evil"},
+		}
+		res, err := q.Eval(ctx, mqlx.WithPropValues(map[string]any{"event": event}))
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		assert.Equal(t, true, res.Value())
+	})
+
+	t.Run("undeclared override", func(t *testing.T) {
+		q, err := env.Compile("props.a", mqlx.WithProps(map[string]any{"a": 1}))
+		require.NoError(t, err)
+
+		_, err = q.Eval(ctx, mqlx.WithPropValues(map[string]any{"b": 2}))
+		require.ErrorContains(t, err, "'b' was not declared")
+	})
+
+	t.Run("type mismatch", func(t *testing.T) {
+		q, err := env.Compile("props.a", mqlx.WithProps(map[string]any{"a": 1}))
+		require.NoError(t, err)
+
+		_, err = q.Eval(ctx, mqlx.WithPropValues(map[string]any{"a": "nope"}))
+		require.ErrorContains(t, err, "must be of type")
+	})
+}
+
+func TestExprMultiValue(t *testing.T) {
+	env := testEnv(t)
+
+	res, err := env.MustCompile("1 + 2\n'a' + 'b'").Eval(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+
+	m, ok := res.Value().(map[string]any)
+	require.True(t, ok, "expected map, got %T", res.Value())
+	require.Len(t, m, 2)
+	// Operator entrypoints label as the operator; identical labels are
+	// disambiguated by numbering.
+	assert.Equal(t, int64(3), m["+"])
+	assert.Equal(t, "ab", m["+ (2)"])
+}
+
+func TestExprAssignmentOnly(t *testing.T) {
+	env := testEnv(t)
+
+	res, err := env.MustCompile("a = 1").Eval(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, res.Value())
+}
+
+func TestCompileError(t *testing.T) {
+	env := testEnv(t)
+
+	_, err := env.Compile("not_a_resource.field")
+	require.Error(t, err)
+
+	var cerr *mqlx.CompileError
+	require.True(t, errors.As(err, &cerr))
+	assert.Equal(t, "not_a_resource.field", cerr.Source)
+}
+
+func TestEvalCancelledContext(t *testing.T) {
+	env := testEnv(t)
+	q := env.MustCompile("1 + 2")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := q.Eval(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryConcurrentEval(t *testing.T) {
+	env := testEnv(t)
+	q, err := env.Compile("props.n * 2", mqlx.WithProps(map[string]any{"n": 0}))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(n int64) {
+			defer wg.Done()
+			res, err := q.Eval(context.Background(),
+				mqlx.WithPropValues(map[string]any{"n": n}))
+			assert.NoError(t, err)
+			assert.Equal(t, n*2, res.Value())
+		}(int64(i))
+	}
+	wg.Wait()
+}

--- a/mqlx/private_test.go
+++ b/mqlx/private_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/mqlx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils/mockprovider"
+)
+
+// privateEnv registers the mockprovider as a caller-supplied private,
+// in-process provider. Its resources (muser, mgroup, ...) have fields that are
+// computed in Go and resolved only when an expression reads them — the case
+// expression mode's eager value-to-dict mapping cannot express.
+func privateEnv(t *testing.T) *mqlx.Env {
+	t.Helper()
+	schema := testutils.MustLoadSchema(testutils.SchemaProvider{Provider: "mockprovider"})
+	env, err := mqlx.NewEnv(
+		mqlx.WithFeatures(testutils.Features),
+		mqlx.WithPrivateProvider(mockprovider.Config, schema, mockprovider.Init()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { env.Close() })
+	return env
+}
+
+func TestPrivateProviderResource(t *testing.T) {
+	env := privateEnv(t)
+	ctx := context.Background()
+
+	t.Run("scalar field", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob").name`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		assert.Equal(t, "bob", res.Value())
+	})
+
+	t.Run("lazily computed resource field", func(t *testing.T) {
+		// muser.group is resolved on read: its Go resolver creates the
+		// mgroup resource only when the expression accesses it.
+		res, err := env.MustCompile(`muser(name: "bob").group.name`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		assert.Equal(t, "group one", res.Value())
+	})
+
+	t.Run("computed dict field", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob").dict["string"]`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		assert.Equal(t, "hello world", res.Value())
+	})
+
+	t.Run("field error surfaces", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob").error`).Eval(ctx)
+		require.NoError(t, err)
+		require.Error(t, res.Err())
+		assert.Contains(t, res.Err().Error(), "error from the mockprovider")
+	})
+
+	t.Run("decode block into struct", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob") { name group { name } }`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+
+		var out struct {
+			Name  string `mql:"name"`
+			Group struct {
+				Name string `mql:"name"`
+			} `mql:"group"`
+		}
+		require.NoError(t, res.Decode(&out))
+		assert.Equal(t, "bob", out.Name)
+		assert.Equal(t, "group one", out.Group.Name)
+	})
+}
+
+func TestPrivateProviderValidation(t *testing.T) {
+	_, err := mqlx.NewEnv(mqlx.WithPrivateProvider(mockprovider.Config, nil, mockprovider.Init()))
+	require.ErrorContains(t, err, "no schema provided")
+
+	schema := testutils.MustLoadSchema(testutils.SchemaProvider{Provider: "mockprovider"})
+	_, err = mqlx.NewEnv(mqlx.WithPrivateProvider(mockprovider.Config, schema, nil))
+	require.ErrorContains(t, err, "no plugin provided")
+}

--- a/mqlx/props.go
+++ b/mqlx/props.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// ToPrimitive converts a Go value into an MQL primitive. Supported types:
+// bool, all int/uint kinds, float32/64, string, time.Time, []any,
+// map[string]any (recursively), and *llx.Primitive (passed through).
+func ToPrimitive(value any) (*llx.Primitive, error) {
+	switch v := value.(type) {
+	case nil:
+		return llx.NilPrimitive, nil
+	case *llx.Primitive:
+		return v, nil
+	case bool:
+		return llx.BoolPrimitive(v), nil
+	case int:
+		return llx.IntPrimitive(int64(v)), nil
+	case int8:
+		return llx.IntPrimitive(int64(v)), nil
+	case int16:
+		return llx.IntPrimitive(int64(v)), nil
+	case int32:
+		return llx.IntPrimitive(int64(v)), nil
+	case int64:
+		return llx.IntPrimitive(v), nil
+	case uint:
+		// uint is 64-bit on most platforms, so it can exceed int64.
+		if uint64(v) > math.MaxInt64 {
+			return nil, errors.New(fmt.Sprintf("uint value %d overflows int64", v))
+		}
+		return llx.IntPrimitive(int64(v)), nil
+	case uint8:
+		return llx.IntPrimitive(int64(v)), nil
+	case uint16:
+		return llx.IntPrimitive(int64(v)), nil
+	case uint32:
+		return llx.IntPrimitive(int64(v)), nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return nil, errors.New(fmt.Sprintf("uint64 value %d overflows int64", v))
+		}
+		return llx.IntPrimitive(int64(v)), nil
+	case float32:
+		return llx.FloatPrimitive(float64(v)), nil
+	case float64:
+		return llx.FloatPrimitive(v), nil
+	case string:
+		return llx.StringPrimitive(v), nil
+	case time.Time:
+		return llx.TimePrimitive(&v), nil
+	case *time.Time:
+		return llx.TimePrimitive(v), nil
+	case []string:
+		return llx.ArrayPrimitiveT(v, llx.StringPrimitive, types.String), nil
+	case []int:
+		return llx.ArrayPrimitiveT(v, func(i int) *llx.Primitive { return llx.IntPrimitive(int64(i)) }, types.Int), nil
+	case []int64:
+		return llx.ArrayPrimitiveT(v, llx.IntPrimitive, types.Int), nil
+	case []float64:
+		return llx.ArrayPrimitiveT(v, llx.FloatPrimitive, types.Float), nil
+	case []bool:
+		return llx.ArrayPrimitiveT(v, llx.BoolPrimitive, types.Bool), nil
+	case map[string]string:
+		return llx.MapPrimitiveT(v, llx.StringPrimitive, types.String), nil
+	case map[string]any, []any:
+		// Heterogeneous, JSON-like data is passed as a dict, so queries can
+		// navigate it with dot access: props.event.process.binary
+		return dictPrimitive(v)
+	default:
+		return nil, errors.New(fmt.Sprintf("unsupported value type %T", value))
+	}
+}
+
+func dictPrimitive(value any) (*llx.Primitive, error) {
+	res := llx.DictData(value).Result()
+	if res.Error != "" {
+		return nil, errors.New("failed to convert value to dict: " + res.Error)
+	}
+	return res.Data, nil
+}
+
+// ToPrimitiveMap converts a map of Go values into MQL primitives via
+// ToPrimitive.
+func ToPrimitiveMap(values map[string]any) (map[string]*llx.Primitive, error) {
+	res := make(map[string]*llx.Primitive, len(values))
+	for k, v := range values {
+		prim, err := ToPrimitive(v)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert value of '"+k+"'")
+		}
+		res[k] = prim
+	}
+	return res, nil
+}

--- a/mqlx/props_test.go
+++ b/mqlx/props_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPrimitiveUintOverflow(t *testing.T) {
+	// uint64 within int64 range converts fine.
+	p, err := ToPrimitive(uint64(42))
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), p.RawData().Value)
+
+	// uint64 above math.MaxInt64 must error rather than silently wrap.
+	_, err = ToPrimitive(uint64(math.MaxInt64) + 1)
+	require.ErrorContains(t, err, "overflows int64")
+
+	// uint (64-bit on most platforms) is guarded the same way.
+	_, err = ToPrimitive(uint(math.MaxUint64))
+	require.ErrorContains(t, err, "overflows int64")
+}

--- a/mqlx/query.go
+++ b/mqlx/query.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/mqlc"
+)
+
+// Query is a compiled MQL query. It is immutable and safe to share across
+// goroutines: compile once, evaluate many times — in expression mode or
+// against any number of connections.
+type Query struct {
+	env    *Env
+	src    string
+	bundle *llx.CodeBundle
+	props  map[string]*llx.Primitive
+}
+
+// CompileOption configures a compilation.
+type CompileOption func(*compileOptions) error
+
+type compileOptions struct {
+	props map[string]any
+}
+
+// WithProps declares the properties a query may reference as props.<name>.
+// The values serve two purposes: they declare each property's type to the
+// compiler, and they act as default values at evaluation time. Override them
+// per evaluation with WithPropValues.
+func WithProps(props map[string]any) CompileOption {
+	return func(o *compileOptions) error {
+		o.props = props
+		return nil
+	}
+}
+
+// Compile compiles an MQL query against the currently loaded provider
+// schemas. The returned Query is reusable and safe for concurrent
+// evaluation.
+func (e *Env) Compile(src string, opts ...CompileOption) (*Query, error) {
+	var options compileOptions
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	props, err := ToPrimitiveMap(options.props)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle, err := mqlc.Compile(src, mqlc.SimpleProps(props), mqlc.NewConfig(e.schema(), e.features))
+	if err != nil {
+		return nil, &CompileError{Source: src, Err: err}
+	}
+
+	return &Query{
+		env:    e,
+		src:    src,
+		bundle: bundle,
+		props:  props,
+	}, nil
+}
+
+// MustCompile is like Compile but panics on error. Use it for query
+// constants whose validity is guaranteed by tests.
+func (e *Env) MustCompile(src string, opts ...CompileOption) *Query {
+	q, err := e.Compile(src, opts...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return q
+}
+
+// Source returns the original MQL source of the query.
+func (q *Query) Source() string {
+	return q.src
+}
+
+// Bundle exposes the compiled code for advanced use (printing, persistence).
+func (q *Query) Bundle() *llx.CodeBundle {
+	return q.bundle
+}

--- a/mqlx/result.go
+++ b/mqlx/result.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"errors"
+	"sync"
+
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// Result holds the output of one query evaluation. Value returns the data as
+// plain Go values, Decode unmarshals it into native structs, and Raw exposes
+// the untouched execution output for advanced use.
+type Result struct {
+	bundle *llx.CodeBundle
+	raw    map[string]*llx.RawResult
+
+	once      sync.Once
+	value     any
+	fieldErrs []FieldError
+}
+
+func newResult(bundle *llx.CodeBundle, raw map[string]*llx.RawResult) *Result {
+	return &Result{bundle: bundle, raw: raw}
+}
+
+func (r *Result) normalize() {
+	r.once.Do(func() {
+		r.value, r.fieldErrs = normalize(r.bundle, r.raw)
+	})
+}
+
+// Value returns the query result as plain Go values: scalars as-is, blocks
+// as map[string]any keyed by field labels, and lists as []any. A query with
+// multiple top-level values returns a map keyed by each value's label.
+// Values that errored during execution are nil; inspect Err or FieldErrors.
+func (r *Result) Value() any {
+	r.normalize()
+	return r.value
+}
+
+// Err reports errors that occurred while producing individual values, joined
+// into one error. It is nil when every value resolved cleanly. Evaluation
+// failures (compile errors, connection loss) are returned by Eval itself,
+// not here.
+func (r *Result) Err() error {
+	r.normalize()
+	if len(r.fieldErrs) == 0 {
+		return nil
+	}
+	errs := make([]error, len(r.fieldErrs))
+	for i := range r.fieldErrs {
+		errs[i] = r.fieldErrs[i]
+	}
+	return errors.Join(errs...)
+}
+
+// FieldErrors lists errors attached to individual values, each with the path
+// of the value inside Value.
+func (r *Result) FieldErrors() []FieldError {
+	r.normalize()
+	return r.fieldErrs
+}
+
+// Decode unmarshals the query result into target, which must be a non-nil
+// pointer to a struct, slice, map, or scalar. Struct fields are matched by
+// the `mql` tag, then the `json` tag, then the field name (exact, then
+// case-insensitive). Fields of anonymous (embedded) structs are promoted, as
+// with encoding/json.
+//
+// If any value carried an execution error, Decode fills target with the data
+// that is available and returns those errors, so missing data is never
+// silently zero-valued.
+func (r *Result) Decode(target any) error {
+	r.normalize()
+	if err := decode(r.value, target); err != nil {
+		return err
+	}
+	return r.Err()
+}
+
+// Raw exposes the untouched execution output: the checksum-keyed results and
+// the compiled code bundle that maps checksums to labels.
+func (r *Result) Raw() (map[string]*llx.RawResult, *llx.CodeBundle) {
+	return r.raw, r.bundle
+}

--- a/mqlx/value.go
+++ b/mqlx/value.go
@@ -1,0 +1,207 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlx
+
+import (
+	"fmt"
+	"sort"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// FieldError is an error attached to an individual value inside a query
+// result, e.g. one unreadable file in a list query. The path locates the
+// value within Result.Value, e.g. "users[3].name"; it is empty when the
+// query's top-level value itself errored.
+type FieldError struct {
+	Path string
+	Err  error
+}
+
+func (e FieldError) Error() string {
+	if e.Path == "" {
+		return e.Err.Error()
+	}
+	return e.Path + ": " + e.Err.Error()
+}
+
+func (e FieldError) Unwrap() error {
+	return e.Err
+}
+
+// normalizer converts raw execution output into plain Go values: blocks
+// become maps keyed by their field labels, arrays become []any, and per-field
+// errors are collected instead of silently dropped.
+type normalizer struct {
+	bundle *llx.CodeBundle
+	errs   []FieldError
+}
+
+func normalize(bundle *llx.CodeBundle, raw map[string]*llx.RawResult) (any, []FieldError) {
+	n := &normalizer{bundle: bundle}
+
+	results := llx.ReturnValuesV2(bundle, func(checksum string) (*llx.RawResult, bool) {
+		res, ok := raw[checksum]
+		return res, ok
+	})
+
+	switch len(results) {
+	case 0:
+		// Queries consisting only of assignments produce no values.
+		return nil, nil
+
+	case 1:
+		res := results[0]
+		if res.Data.Error != nil {
+			n.errs = append(n.errs, FieldError{Path: "", Err: res.Data.Error})
+			return nil, n.errs
+		}
+		return n.value(res.Data, ""), n.errs
+
+	default:
+		// Multiple top-level values (e.g. "asset.name asset.version") are
+		// returned as a map keyed by each value's label, matching how the
+		// CLI reports them.
+		out := make(map[string]any, len(results))
+		seen := make(map[string]int, len(results))
+		for _, res := range results {
+			key := dedupKey(n.label(res.CodeID), seen)
+			if res.Data.Error != nil {
+				n.errs = append(n.errs, FieldError{Path: key, Err: res.Data.Error})
+				out[key] = nil
+				continue
+			}
+			out[key] = n.value(res.Data, key)
+		}
+		return out, n.errs
+	}
+}
+
+func (n *normalizer) value(data *llx.RawData, path string) any {
+	if data == nil || data.Value == nil {
+		return nil
+	}
+
+	switch data.Type.Underlying() {
+	case types.Block:
+		return n.block(data.Value.(map[string]any), path)
+
+	case types.ArrayLike:
+		return n.array(data.Type, data.Value.([]any), path)
+
+	case types.MapLike:
+		if data.Type.Key() == types.String {
+			return n.stringMap(data.Type, data.Value.(map[string]any), path)
+		}
+		return data.Value
+
+	case types.Dict:
+		return n.dict(data.Value, path)
+
+	default:
+		// Scalars and special leaf values (*time.Time, llx.RawIP,
+		// llx.Resource, llx.Range, ...) pass through unchanged.
+		return data.Value
+	}
+}
+
+func (n *normalizer) block(data map[string]any, path string) map[string]any {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		// Blocks carry their binding and bookkeeping under reserved keys.
+		if k == "_" || k == "__t" || k == "__s" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	// Sort for deterministic duplicate-label numbering.
+	sort.Strings(keys)
+
+	res := make(map[string]any, len(keys))
+	seen := make(map[string]int, len(keys))
+	for _, k := range keys {
+		key := dedupKey(n.label(k), seen)
+		childPath := joinPath(path, key)
+
+		child, ok := data[k].(*llx.RawData)
+		if !ok || child == nil {
+			res[key] = nil
+			continue
+		}
+		if child.Error != nil {
+			n.errs = append(n.errs, FieldError{Path: childPath, Err: child.Error})
+			res[key] = nil
+			continue
+		}
+		res[key] = n.value(child, childPath)
+	}
+	return res
+}
+
+func (n *normalizer) array(typ types.Type, data []any, path string) []any {
+	childType := typ.Child()
+	res := make([]any, len(data))
+	for i := range data {
+		res[i] = n.value(&llx.RawData{Type: childType, Value: data[i]}, fmt.Sprintf("%s[%d]", path, i))
+	}
+	return res
+}
+
+func (n *normalizer) stringMap(typ types.Type, data map[string]any, path string) map[string]any {
+	childType := typ.Child()
+	res := make(map[string]any, len(data))
+	for k := range data {
+		res[k] = n.value(&llx.RawData{Type: childType, Value: data[k]}, joinPath(path, k))
+	}
+	return res
+}
+
+func (n *normalizer) dict(data any, path string) any {
+	switch v := data.(type) {
+	case []any:
+		res := make([]any, len(v))
+		for i := range v {
+			res[i] = n.dict(v[i], fmt.Sprintf("%s[%d]", path, i))
+		}
+		return res
+	case map[string]any:
+		res := make(map[string]any, len(v))
+		for k := range v {
+			res[k] = n.dict(v[k], joinPath(path, k))
+		}
+		return res
+	default:
+		return v
+	}
+}
+
+// label resolves a checksum to its human-readable field label.
+func (n *normalizer) label(checksum string) string {
+	if n.bundle != nil && n.bundle.Labels != nil {
+		if l, ok := n.bundle.Labels.Labels[checksum]; ok && l != "" {
+			return l
+		}
+	}
+	return checksum
+}
+
+// dedupKey disambiguates labels that occur more than once in the same scope
+// (e.g. package("a").installed and package("b").installed both label as
+// "package.installed") by numbering repeats: "label", "label (2)", ...
+func dedupKey(base string, seen map[string]int) string {
+	n := seen[base]
+	seen[base]++
+	if n == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s (%d)", base, n+1)
+}
+
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}

--- a/providers-sdk/v1/testutils/mockprovider/mockprovider.go
+++ b/providers-sdk/v1/testutils/mockprovider/mockprovider.go
@@ -71,6 +71,14 @@ func (s *Service) Shutdown(req *plugin.ShutdownReq) (*plugin.ShutdownRes, error)
 	return &plugin.ShutdownRes{}, nil
 }
 
+// Disconnect releases a connection. This provider tracks its own runtimes
+// map, so it overrides the embedded plugin.Service.Disconnect (which operates
+// on a separate, uninitialized map and would otherwise flush a nil memoizer).
+func (s *Service) Disconnect(req *plugin.DisconnectReq) (*plugin.DisconnectRes, error) {
+	delete(s.runtimes, req.Connection)
+	return &plugin.DisconnectRes{}, nil
+}
+
 func (s *Service) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
 	runtime, ok := s.runtimes[req.Connection]
 	if !ok {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -158,10 +158,83 @@ func (r *Runtime) UseProvider(id string) error {
 	return nil
 }
 
+// UseBuiltinProvider sets a builtin (in-process) provider as the runtime's
+// main provider and connects it, so its resources resolve without spawning a
+// subprocess and without any real connection. Unlike a bare UseProvider +
+// plugin.Connect, the connection is backed by the runtime's callbacks, so the
+// provider can create or resolve resources through the runtime — matching how
+// Connect wires every other provider. Used for the core provider when running
+// MQL as a pure expression engine.
+func (r *Runtime) UseBuiltinProvider(id string, features []byte) error {
+	if err := r.UseProvider(id); err != nil {
+		return err
+	}
+	r.features = features
+
+	callbacks := &providerCallbacks{runtime: r}
+	conn, err := r.Provider.Instance.Plugin.Connect(&plugin.ConnectReq{
+		Asset: &inventory.Asset{
+			Connections: []*inventory.Config{{Type: "in-process"}},
+		},
+		Features: features,
+	}, callbacks)
+	if err != nil {
+		return errors.New("failed to connect builtin provider '" + id + "': " + err.Error())
+	}
+
+	r.Provider.Connection = conn
+	r.AddConnectedProvider(r.Provider)
+	return nil
+}
+
 func (r *Runtime) AddConnectedProvider(c *ConnectedProvider) {
 	r.mu.Lock()
 	r.providers[c.Instance.ID] = c
 	r.mu.Unlock()
+}
+
+// UseInProcessProvider registers a caller-supplied, in-process provider plugin
+// with this runtime and connects it, so its resources can be created and their
+// fields resolved on demand without spawning a provider subprocess. The
+// connection is backed by the runtime's callbacks, so a custom resource's
+// field resolvers may reference other resources just like any built-in
+// provider.
+//
+// The provider's schema is what queries compile against; register it with the
+// coordinator (e.g. via the ExtensibleSchema interface) before compiling. The
+// config ID must match the provider ID recorded on that schema's resources.
+func (r *Runtime) UseInProcessProvider(config plugin.Provider, schema resources.ResourcesSchema, plug plugin.ProviderPlugin, features []byte) error {
+	if plug == nil {
+		return errors.New("cannot register in-process provider '" + config.Name + "': no plugin provided")
+	}
+
+	if r.features == nil {
+		r.features = features
+	}
+
+	running := &RunningProvider{
+		Name:    config.Name,
+		ID:      config.ID,
+		Version: config.Version,
+		Plugin:  plug,
+		Schema:  schema,
+	}
+	connected := &ConnectedProvider{Instance: running}
+
+	callbacks := &providerCallbacks{runtime: r}
+	conn, err := plug.Connect(&plugin.ConnectReq{
+		Asset: &inventory.Asset{
+			Connections: []*inventory.Config{{Type: config.Name}},
+		},
+		Features: features,
+	}, callbacks)
+	if err != nil {
+		return errors.New("failed to connect in-process provider '" + config.Name + "': " + err.Error())
+	}
+
+	connected.Connection = conn
+	r.AddConnectedProvider(connected)
+	return nil
 }
 
 // ConnectedProviderIDs returns the IDs of all connected providers


### PR DESCRIPTION
## Summary

Embedding MQL in a Go program today means wiring runtimes and providers by hand, compiling through `mqlc.CompilerConfig`, and walking checksum-keyed `map[string]*llx.RawResult` with manual label resolution. This PR proposes a first-class embedding API and ships a working sample of it:

- **ADR 027** (`docs/adr/027-mqlx-go-embedding-api.md`) — the decision record: motivation (including the ~250 lines of plumbing prism carries today), the full API contract, and the follow-up roadmap (exec context plumbing, custom in-process providers, resource expansion in Decode, discovery, prism migration).
- **`mqlx/`** — a purely additive sample implementation with tests, wrapping the existing `mqlc`/`exec`/`providers` machinery.

## Two first-class modes

**Expression mode** — MQL over your own values; no providers, no asset, no subprocesses:

```go
env, _ := mqlx.NewEnv()
q, _ := env.Compile(`props.name == /admin-.*/ && props.count > 3`,
    mqlx.WithProps(map[string]any{"name": "", "count": 0}))
res, _ := q.Eval(ctx, mqlx.WithPropValues(map[string]any{"name": "admin-x", "count": 5}))
res.Value() // true
```

**Asset mode** — connect once, compile once, evaluate against many assets, decode into structs:

```go
conn, _ := env.ConnectLocal(ctx)
res, _ := conn.Query(ctx, "users { name uid }")

var users []struct {
    Name string `mql:"name"`
    UID  int64  `mql:"uid"`
}
res.Decode(&users)
```

## Design highlights

- `Env` (process) → `Conn` (asset, optional) → `Query` (compiled, immutable, concurrent-safe) → `Result`.
- Expression mode runs on an internal runtime backed by the builtin in-process core provider; `map[string]any` props become dicts, so `props.event.process.binary.contains("/tmp")` works.
- `Result.Value()` returns label-resolved plain Go values; per-field execution errors are collected as path-carrying `FieldError`s instead of being dropped (unlike `RawData.Dereference`).
- `Result.Decode()` is a small reflection decoder (`mql` tag → `json` tag → field name) with overflow checks — no JSON round-trip, preserving int64 >2^53, time, and IP fidelity.
- Compile errors come back as `*CompileError` with `Unwrap()`, keeping typed errors like `mqlc.ErrIdentifierNotFound` reachable via `errors.As`.

## Notes for reviewers

- Found while testing: executing a bundle with zero entrypoints (e.g. `a = 1`) through `exec.ExecuteCode` intermittently panics in `llx._newBlockExecutor` ("no callback points"). The facade guards this the same way `exec.Exec` does; the underlying llx edge may deserve its own fix.
- `parse.*` lives in the os provider, so it is intentionally not part of expression mode (core resources like `regex.*`, `time.*`, and semver are).
- The expression-engine design and prism's needs are validated in the ADR; prism is the intended first migration target.

## Test plan

- `go test ./mqlx/` — expression tests against the real in-process core runtime, asset tests against the recorded Linux mock, decoder units, runnable doc example. Verified with `-count` repetition and `-race`.
- `MQLX_E2E=1 go test ./mqlx/ -run TestConnectLocalE2E` — opt-in end-to-end against the real local OS (passed locally: macOS, decoded into a struct).
- `gofmt`, `golangci-lint run mqlx/...` (0 issues), `go mod tidy` clean; ADR terms added to the spell-check expect list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)