### PR TITLE
Switch the edge to the arc runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -75,7 +75,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,4 +87,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -60,6 +60,15 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.protoc-version }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Inspect builder
+        run: docker buildx inspect --bootstrap
+
       - name: Log in to the Container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -31,7 +31,7 @@ jobs:
       id-token: "write"
 
     runs-on:
-      group: Default
+      group: arc-runners
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -61,10 +61,10 @@ jobs:
           version: ${{ env.protoc-version }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Inspect builder
         run: docker buildx inspect --bootstrap

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: false
         type: boolean
+      dry-run:
+        description: "Skip publishing to registry (build only)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: goreleaser-edge
@@ -73,7 +78,7 @@ jobs:
           distribution: goreleaser
           # auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor
           version: v2.16.0
-          args: release -f .github/.goreleaser-edge.yml --clean --timeout 120m
+          args: release -f .github/.goreleaser-edge.yml --clean --timeout 120m ${{ inputs.dry-run == true && '--skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: markdown-link-check
         uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -27,7 +27,7 @@ jobs:
       all: ${{ steps.changed.outputs.all }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
       - name: Install Go

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -25,7 +25,7 @@ jobs:
       group: Default
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -27,7 +27,7 @@ jobs:
       all: ${{ steps.changed.outputs.all }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -102,7 +102,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -202,7 +202,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # figure out the PR for this commit
       - uses: cloudposse-github-actions/get-pr@ba7d9e7db690abb3c5b84f4337cd51e75f7cfb71 # v2.0.0
         id: pr

--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Import environment variables from file
         shell: bash

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -39,7 +39,7 @@ jobs:
       build_list: ${{ steps.providers.outputs.build_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
         provider: ${{ fromJSON(needs.scoping.outputs.build_list) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -113,7 +113,7 @@ jobs:
     if: ${{ needs.scoping.outputs.build_list != '[]' }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         provider: ${{ fromJSON(needs.scoping.outputs.build_list) }}
     steps:

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         default: false
         type: boolean
+      max_parallel:
+        description: "Max parallel arch builds per provider (leave empty to auto-detect from physical cores)"
+        type: number
+        required: false
 
 permissions:
   contents: read
@@ -185,6 +189,7 @@ jobs:
           TSIGN_ACCOUNT_NAME: ${{ vars.TSIGN_ACCOUNT_NAME }}
           TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
           TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.TSIGN_ACCESS_TOKEN }}
+          MAX_PARALLEL: ${{ inputs.max_parallel }}
 
       - name: "Publish Provider"
         if: ${{ ! inputs.skip_publish }}

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   scoping:
     name: "Scoping"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     outputs:
       providers: ${{ steps.providers.outputs.providers }}
@@ -102,7 +102,7 @@ jobs:
   provider-build:
     name: "${{ matrix.provider }}"
     runs-on:
-      group: Default
+      group: arc-runners
     environment: prod
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -30,7 +30,7 @@ jobs:
       # The GITHUB_TOKEN is limited when creating PRs from a workflow
       # because of that we use a ssh key for which the limitations do not apply
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ssh-key: ${{ secrets.CNQUERY_DEPLOY_KEY_PRIV }}
           fetch-depth: 0

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -21,7 +21,7 @@ jobs:
       # The GITHUB_TOKEN is limited when creating PRs from a workflow
       # because of that we use a ssh key for which the limitations do not apply
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ssh-key: ${{ secrets.CNQUERY_DEPLOY_KEY_PRIV }}
 

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -30,7 +30,8 @@ get_physical_cores() {
       ;;
   esac
 }
-MAX_PARALLEL=${MAX_PARALLEL:-$(get_physical_cores)}
+_cores=$(get_physical_cores)
+MAX_PARALLEL=${MAX_PARALLEL:-$(( _cores > 1 ? _cores - 1 : 1 ))}
 
 cd $REPOROOT
 

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -12,8 +12,25 @@ PROVIDER_PATH=$REPOROOT/providers/$PROVIDER_NAME
 PROVIDER_DIST=$PROVIDER_PATH/dist
 BUNDLE_DIST=$REPOROOT/dist
 
-# Maximum number of parallel arch builds (default: all 11 at once)
-MAX_PARALLEL=${MAX_PARALLEL:-11}
+# Maximum number of parallel arch builds (default: physical core count)
+get_physical_cores() {
+  case "$(uname -s)" in
+    Darwin)
+      sysctl -n hw.physicalcpu 2>/dev/null || echo 4
+      ;;
+    Linux)
+      # Count unique (physical_id, core_id) pairs; fall back to nproc/2 on VMs
+      local count
+      count=$(grep -E "^(physical id|core id)" /proc/cpuinfo 2>/dev/null \
+              | paste - - | sort -u | wc -l)
+      [ "${count:-0}" -gt 0 ] && echo "$count" || echo $(( $(nproc --all 2>/dev/null || echo 8) / 2 ))
+      ;;
+    *)
+      echo 4
+      ;;
+  esac
+}
+MAX_PARALLEL=${MAX_PARALLEL:-$(get_physical_cores)}
 
 cd $REPOROOT
 

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -12,26 +12,8 @@ PROVIDER_PATH=$REPOROOT/providers/$PROVIDER_NAME
 PROVIDER_DIST=$PROVIDER_PATH/dist
 BUNDLE_DIST=$REPOROOT/dist
 
-# Maximum number of parallel arch builds (default: physical core count)
-get_physical_cores() {
-  case "$(uname -s)" in
-    Darwin)
-      sysctl -n hw.physicalcpu 2>/dev/null || echo 4
-      ;;
-    Linux)
-      # Count unique (physical_id, core_id) pairs; fall back to nproc/2 on VMs
-      local count
-      count=$(grep -E "^(physical id|core id)" /proc/cpuinfo 2>/dev/null \
-              | paste - - | sort -u | wc -l)
-      [ "${count:-0}" -gt 0 ] && echo "$count" || echo $(( $(nproc --all 2>/dev/null || echo 8) / 2 ))
-      ;;
-    *)
-      echo 4
-      ;;
-  esac
-}
-_cores=$(get_physical_cores)
-MAX_PARALLEL=${MAX_PARALLEL:-$(( _cores > 1 ? _cores - 1 : 1 ))}
+# Maximum number of parallel arch builds (default: 1 — serial builds are faster due to reduced CPU/IO contention)
+MAX_PARALLEL=${MAX_PARALLEL:-1}
 
 cd $REPOROOT
 


### PR DESCRIPTION
This PR will switch the workflows to the new ARC runners.

In testing this workflow I found that there was significant improvement if we don't try and build the provider archs in parallel, so I've set it to 1 arch at a time.  I have bumped the provider parallel builds from 2 > 4 due to increased runner pool.

 1 x Provider Builds > 1x Arch Build (e.g. amd64) > Spawns a go process x cpu core.  Multiple arch flood the system.
 
 After we bed these runners in we can try to increase the number and do some benchmarks.

I've added the ability to the control this setting with an workflow input.

I've also patched the github action versions.