### PR TITLE
⚡ os/windows.update: pre-filter update history to succeeded installs in PowerShell

### DIFF
--- a/providers/os/resources/windows/update.go
+++ b/providers/os/resources/windows/update.go
@@ -42,9 +42,14 @@ func ParseKBID(s string) string {
 }
 
 // WINDOWS_QUERY_UPDATE_HISTORY enumerates the Windows Update Agent install
-// history via the COM API. Results include uninstalled and failed entries;
-// callers filter on Operation == Installation and ResultCode == Succeeded.
-// Dates serialize as PowerShell "/Date(ms)/" strings.
+// history via the COM API, pre-filtering in PowerShell to succeeded
+// installations (Operation == Installation, ResultCode == Succeeded) so that
+// only those entries are turned into objects and serialized — uninstalls,
+// failures, and aborted/in-progress entries are dropped before the expensive
+// per-entry work. Go's FilterInstalledHistory re-applies the same predicate
+// (and de-duplicates by KB), so the two must stay in sync; see
+// TestUpdateHistoryQueryFilterMatchesGo. Dates serialize as PowerShell
+// "/Date(ms)/" strings.
 var WINDOWS_QUERY_UPDATE_HISTORY = `
 $ProgressPreference='SilentlyContinue';
 $session = New-Object -ComObject Microsoft.Update.Session
@@ -52,7 +57,9 @@ $searcher = $session.CreateUpdateSearcher()
 $count = $searcher.GetTotalHistoryCount()
 $history = @()
 if ($count -gt 0) {
-  $history = $searcher.QueryHistory(0, $count) | ForEach-Object {
+  $history = $searcher.QueryHistory(0, $count) |
+    Where-Object { $_.Operation -eq 1 -and $_.ResultCode -eq 2 } |
+    ForEach-Object {
     New-Object psobject -Property @{
       "Title" = $_.Title
       "Date" = $_.Date

--- a/providers/os/resources/windows/update_test.go
+++ b/providers/os/resources/windows/update_test.go
@@ -4,6 +4,7 @@
 package windows
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestUpdateHistoryQueryFilterMatchesGo guards that the PowerShell-side
+// Where-Object pre-filter uses the same Operation/ResultCode codes that the
+// Go-side FilterInstalledHistory enforces. If the constants change, the
+// embedded query must change with them or installed updates would silently
+// disappear.
+func TestUpdateHistoryQueryFilterMatchesGo(t *testing.T) {
+	want := fmt.Sprintf("$_.Operation -eq %d -and $_.ResultCode -eq %d",
+		UpdateOperationInstallation, UpdateResultSucceeded)
+	assert.Contains(t, WINDOWS_QUERY_UPDATE_HISTORY, want,
+		"PowerShell pre-filter must match the Go install/succeeded predicate")
+}
 
 func TestParseWindowsUpdateHistory(t *testing.T) {
 	r, err := os.Open("./testdata/update_history.json")


### PR DESCRIPTION
## What

`windows.update.installed` runs `WINDOWS_QUERY_UPDATE_HISTORY`. Today it calls `QueryHistory(0, $count)` and, for **every** entry in the history — uninstalls, failed installs, aborted/in-progress entries included — builds a `psobject` (with a per-entry `Categories` COM walk) and a JSON record. Go's `FilterInstalledHistory` then throws away everything that isn't a succeeded installation.

This PR moves that predicate into the PowerShell pipeline:

```powershell
$searcher.QueryHistory(0, $count) |
  Where-Object { $_.Operation -eq 1 -and $_.ResultCode -eq 2 } |
  ForEach-Object { New-Object psobject -Property @{ ... } }
```

so the expensive per-entry work — `New-Object psobject`, the `Categories` COM iteration, JSON serialization, and stdout transfer — only happens for the entries we actually keep. The Go-side filter stays as a redundant safety net and still de-duplicates by KB. A new test (`TestUpdateHistoryQueryFilterMatchesGo`) keeps the PowerShell codes (`1`/`2`) in sync with the `UpdateOperationInstallation` / `UpdateResultSucceeded` constants.

**Behavior is unchanged** — same result set, just computed in the right place.

## What this saves (and what it doesn't)

The filter removes **uninstalls and non-succeeded (failed/aborted/in-progress) entries** before any per-entry cost is paid. It does **not** remove duplicate *succeeded* installs that share a KB — notably the daily Microsoft Defender "Security Intelligence Update" entries (all `KB2267602`), which survive the filter and are collapsed later by Go's KB de-dup. Removing that churn is the logical next step (de-dup in PowerShell) and is intentionally **out of scope** here.

Two independent wins per removed entry:
- **On-box CPU / latency:** one skipped `New-Object psobject` + one skipped `Categories` COM round-trip. This helps every connection type, and most on slow/remote WinRM/SSH hosts.
- **Payload:** one fewer JSON record marshaled, transferred over stdout, and parsed in Go. `ConvertTo-Json` pretty-prints, so post-#8327 each entry is ≈ **400 B** serialized.

### Illustrative scenarios

These are **estimates with stated assumptions**, not measured values — the removed fraction is the share of history that is uninstall/failed/aborted, which varies widely by host health and connectivity.

| Scenario | Total history entries | Removed (uninstall + failed) | % removed | JSON saved (~400 B/entry) | Category COM-walks skipped |
|---|---|---|---|---|---|
| **A** — Healthy workstation, ~1 yr, good connectivity | 800 | 60 | ~8% | ~24 KB | 60 |
| **B** — Typical server, 2–3 yr, occasional patch failures | 3,000 | 450 | ~15% | ~180 KB | 450 |
| **C** — Long-lived / flaky, WSUS retries, 4+ yr | 10,000 | 3,000 | ~30% | ~1.2 MB | 3,000 |
| **D** — Pathological, frequent failed installs, constrained bandwidth | 20,000 | 8,000 | ~40% | ~3.1 MB | 8,000 |

The COM-walk and `New-Object` reductions matter most: on a slow WinRM/SSH link the per-entry COM round-trips dominate wall-clock, so cutting 3,000–8,000 of them (scenarios C/D) is a larger real-world win than the raw byte count suggests.

### Not addressed by this PR
- `QueryHistory(0, $count)` still enumerates the full history in COM — that base cost is unchanged (eliminating it would mean a different data source, e.g. `Get-HotFix`, with reduced coverage).
- Duplicate succeeded-install churn (Defender definitions) — survives the filter, collapsed later by Go de-dup. Candidate for a follow-up.

## Test

- `go build ./resources/windows/` — clean
- `go test ./resources/windows/ -run 'TestParseWindowsUpdateHistory|TestFilterInstalledHistory|TestUpdateHistoryQueryFilterMatchesGo'` — pass (incl. the new sync guard)
