### PR TITLE
fix(sbom): import Windows packages and avoid hotfix id collisions

### DIFF
--- a/providers/sbom.go
+++ b/providers/sbom.go
@@ -283,7 +283,12 @@ func newRecording(asset *inventory.Asset, s *sbom.Sbom) (*recording.Asset, error
 	for i := range s.Packages {
 		pkg := s.Packages[i]
 
-		if pkg.Type == "deb" || pkg.Type == "rpm" || pkg.Type == "apk" {
+		// windows/app, windows/appx and windows/hotfix mirror what a live scan's
+		// packages resource returns on Windows (WinPkgManager.List includes
+		// hotfixes alongside apps). They feed Windows advisory matching
+		// (OS build + KB list + application packages).
+		if pkg.Type == "deb" || pkg.Type == "rpm" || pkg.Type == "apk" ||
+			pkg.Type == "windows/app" || pkg.Type == "windows/appx" || pkg.Type == "windows/hotfix" {
 			pkgResource, otherResources := newOsPackage(pkg)
 			r.Resources = append(r.Resources, pkgResource)
 			r.Resources = append(r.Resources, otherResources...)
@@ -375,9 +380,17 @@ func newOsPackage(pkg *sbom.Package) (recording.Resource, []recording.Resource) 
 		})
 	}
 
+	// Some package types carry no purl (e.g. windows/hotfix). Fall back to
+	// the package name so each recording resource keeps a unique, stable id
+	// instead of all colliding on "".
+	id := pkg.Purl
+	if id == "" {
+		id = pkg.Name
+	}
+
 	return recording.Resource{
 		Resource: "package",
-		ID:       pkg.Purl,
+		ID:       id,
 		Fields: map[string]*llx.RawData{
 			"name": {
 				Type:  types.String,

--- a/providers/sbom_test.go
+++ b/providers/sbom_test.go
@@ -63,12 +63,14 @@ func TestNewRecording_WindowsPackages(t *testing.T) {
 
 	seenIDs := map[string]bool{}
 	for i, pkg := range doc.Packages {
-		// Each input package must produce a package recording resource with a
-		// unique, non-empty ID. Hotfixes without purl must fall back to name.
-		pkgRes, ok := rec.GetResource("package", pkg.Purl)
-		if pkg.Purl == "" {
-			pkgRes, ok = rec.GetResource("package", pkg.Name)
+		// Mirror the production fallback (newOsPackage): use purl when set,
+		// else name. Hotfixes have no purl so the recording must key them by
+		// name to keep IDs unique.
+		lookupKey := pkg.Purl
+		if lookupKey == "" {
+			lookupKey = pkg.Name
 		}
+		pkgRes, ok := rec.GetResource("package", lookupKey)
 		require.Truef(t, ok, "package %d (%s) missing from recording", i, pkg.Name)
 		assert.NotEmptyf(t, pkgRes.ID, "package %s recording ID must not be empty", pkg.Name)
 		assert.Falsef(t, seenIDs[pkgRes.ID], "package ID %q collides between two recording resources", pkgRes.ID)

--- a/providers/sbom_test.go
+++ b/providers/sbom_test.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// Imported Windows SBOMs need windows/app, windows/appx and windows/hotfix
+// packages in the recording, otherwise packages.list comes back empty and
+// vulnerability matching has nothing to chew on. Hotfix entries also carry
+// no purl, so the recording ID must fall back to the package name.
+func TestNewRecording_WindowsPackages(t *testing.T) {
+	asset := &inventory.Asset{
+		Name: "WIN-TEST01",
+		Platform: &inventory.Platform{
+			Name:    "windows",
+			Title:   "Microsoft Windows Server 2012 R2 Standard",
+			Version: "9600",
+			Arch:    "AMD64",
+			Family:  []string{"windows", "os"},
+		},
+	}
+
+	doc := &sbom.Sbom{
+		Asset: &sbom.Asset{
+			Name: asset.Name,
+			Platform: &sbom.Platform{
+				Name:    asset.Platform.Name,
+				Title:   asset.Platform.Title,
+				Version: asset.Platform.Version,
+				Arch:    asset.Platform.Arch,
+				Family:  asset.Platform.Family,
+			},
+		},
+		Packages: []*sbom.Package{
+			{Name: "alpine-baselayout", Version: "3.4.3-r2", Purl: "pkg:apk/alpine/alpine-baselayout@3.4.3-r2", Type: "apk"},
+			{Name: "VMware Tools", Version: "12.1.5.20735119", Purl: "pkg:windows/windows/VMware%20Tools@12.1.5.20735119", Type: "windows/app"},
+			{Name: "Microsoft.UI.Xaml.2.4", Version: "2.42007.9001.0", Purl: "pkg:windows/windows/Microsoft.UI.Xaml.2.4@2.42007.9001.0", Type: "windows/appx"},
+			{Name: "KB2919355", Type: "windows/hotfix"},
+			{Name: "KB2999226", Type: "windows/hotfix"},
+		},
+	}
+
+	rec, err := newRecording(asset, doc)
+	require.NoError(t, err)
+
+	packages, ok := rec.GetResource("packages", "")
+	require.True(t, ok, "packages resource must exist")
+
+	list, ok := packages.Fields["list"]
+	require.True(t, ok, "packages.list field must exist")
+
+	refs, ok := list.Value.([]any)
+	require.True(t, ok, "packages.list must be an array")
+	assert.Len(t, refs, 5, "every supported os package type must show up in packages.list")
+
+	seenIDs := map[string]bool{}
+	for i, pkg := range doc.Packages {
+		// Each input package must produce a package recording resource with a
+		// unique, non-empty ID. Hotfixes without purl must fall back to name.
+		pkgRes, ok := rec.GetResource("package", pkg.Purl)
+		if pkg.Purl == "" {
+			pkgRes, ok = rec.GetResource("package", pkg.Name)
+		}
+		require.Truef(t, ok, "package %d (%s) missing from recording", i, pkg.Name)
+		assert.NotEmptyf(t, pkgRes.ID, "package %s recording ID must not be empty", pkg.Name)
+		assert.Falsef(t, seenIDs[pkgRes.ID], "package ID %q collides between two recording resources", pkgRes.ID)
+		seenIDs[pkgRes.ID] = true
+	}
+}


### PR DESCRIPTION
## Summary

The SBOM provider's recording filter at \`providers/sbom.go:286\` only mapped \`deb\`, \`rpm\`, and \`apk\` package types. Windows imports (\`windows/app\`, \`windows/appx\`, \`windows/hotfix\`) were silently dropped, so \`packages.list\` came back empty and vulnerability matching had nothing to chew on.

Hotfix entries also carry no purl, so \`newOsPackage\` assigned every hotfix the same empty resource ID. \`Asset.RefreshCache\` keys resources by \`name+sep+id\`, so two hotfixes silently overwrote each other in the lookup cache.

## Changes

- Expand the type filter to also map \`windows/app\`, \`windows/appx\` and \`windows/hotfix\` — same shape \`WinPkgManager.List\` emits on a live Windows scan.
- In \`newOsPackage\`, fall back to \`pkg.Name\` for the recording resource ID when \`pkg.Purl\` is empty.
- Add \`providers/sbom_test.go\` covering all three Windows types + an \`apk\` control. The test asserts every package shows up in \`packages.list\` with a unique non-empty resource ID.

## Reproduction (before this PR)

\`\`\`shell
$ mql run sbom win-sbom.json -c "packages.list { name version format }"
packages.list: []
\`\`\`

The same SBOM with \`apk\` packages instead returned a fully populated list, confirming the recording mechanism works — the type filter was the only thing dropping Windows entries.

## Refs

- #8336

## Test plan

- [x] \`go test ./providers/ -run TestNewRecording_WindowsPackages -v\` passes
- [x] \`go vet ./providers/\` clean for changed files (one pre-existing warning in \`runtime.go:689\` unrelated)
- [x] \`mql run sbom win-sbom.json -c "packages.list { name version format }"\` returns all 5 packages including the two hotfixes after applying this branch