### PR TITLE
fix(sbom): preserve asset identity and platform labels on import

### DIFF
--- a/providers/sbom.go
+++ b/providers/sbom.go
@@ -106,8 +106,16 @@ func (s *sbomProviderService) Connect(req *plugin.ConnectReq, callback plugin.Pr
 			Build:   sbomReport.Asset.Platform.Build,
 			Arch:    sbomReport.Asset.Platform.Arch,
 			Family:  sbomReport.Asset.Platform.Family,
+			Labels:  sbomReport.Asset.Platform.Labels,
 		}
-		asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/sbom/uuid/" + uuid.New().String()}
+		// Keep the identity the SBOM declares (e.g. the hostname / bios-uuid
+		// platform ids a live scan emits) so re-importing the same document
+		// updates the same asset instead of spawning a new one on every run.
+		// Only fall back to a random UUID when the document carries no
+		// identity at all.
+		if len(asset.PlatformIds) == 0 {
+			asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/sbom/uuid/" + uuid.New().String()}
+		}
 	}
 
 	// generate recording from sbom and store it into the provider


### PR DESCRIPTION
## Summary

\`Connect()\` in \`providers/sbom.go\` copied \`platform_ids\` from the SBOM into the asset at line 101, then unconditionally replaced them at line 110 with a fresh \`//platformid.api.mondoo.app/runtime/sbom/uuid/<random uuid>\`. Importing the same document twice produced two distinct assets in the platform, and re-imports could never update an existing asset.

\`Platform.Labels\` from the document was also never copied into the runtime \`inventory.Platform\`. Labels like \`windows.mondoo.com/product-type\` (used to distinguish workstation vs server SKUs) were lost on import.

## Changes

- Only fall back to a random UUID when \`asset.PlatformIds\` is empty. Documents that already declare identity (live-scan output, repeat imports) now keep it.
- Copy \`sbomReport.Asset.Platform.Labels\` into the new \`inventory.Platform\` struct.

## Refs

- #8336

## Test plan

- [x] \`go build ./providers/...\` clean
- [x] \`go vet ./providers/\` clean for changed code (one pre-existing warning in \`runtime.go:689\` unrelated)
- [ ] Manual: \`cnspec scan sbom win-sbom.json\` twice in a row — assert the same asset MRN is produced, asset name carries through, and \`windows.mondoo.com/product-type\` label appears in the asset metadata.