### PR TITLE
🐛 network: parse X-XSS-Protection report directive, not max-age

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -272,17 +272,9 @@ func (x *mqlHttpHeader) xFrameOptions() (string, error) {
 	return parseSingleHeaderValue(params, ok, &x.XFrameOptions)
 }
 
-func (x *mqlHttpHeader) xXssProtection() (*mqlHttpHeaderXssProtection, error) {
-	raw, ok := x.Params.Data["X-XSS-Protection"]
-	if !ok {
-		x.XXssProtection.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-
-	enabled := llx.NilData
-	mode := llx.NilData
-	report := llx.NilData
-	parseHeaderFields(raw.([]any), func(key string, value string) {
+func parseXssProtectionDirectives(raw []any) (enabled *llx.RawData, mode *llx.RawData, report *llx.RawData) {
+	enabled, mode, report = llx.NilData, llx.NilData, llx.NilData
+	parseHeaderFields(raw, func(key string, value string) {
 		switch key {
 		case "0":
 			enabled = llx.BoolFalse
@@ -290,10 +282,21 @@ func (x *mqlHttpHeader) xXssProtection() (*mqlHttpHeaderXssProtection, error) {
 			enabled = llx.BoolTrue
 		case "mode":
 			mode = llx.StringData(value)
-		case "max-age":
+		case "report":
 			report = llx.StringData(value)
 		}
 	})
+	return enabled, mode, report
+}
+
+func (x *mqlHttpHeader) xXssProtection() (*mqlHttpHeaderXssProtection, error) {
+	raw, ok := x.Params.Data["X-XSS-Protection"]
+	if !ok {
+		x.XXssProtection.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	enabled, mode, report := parseXssProtectionDirectives(raw.([]any))
 
 	o, err := CreateResource(x.MqlRuntime, "http.header.xssProtection", map[string]*llx.RawData{
 		"enabled": enabled,

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
@@ -35,5 +36,27 @@ func TestHttpHeaderServer(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "", v)
 		assert.NotEqual(t, 0, h.Server.State&plugin.StateIsNull)
+	})
+}
+
+func TestParseXssProtectionDirectives(t *testing.T) {
+	t.Run("parses enabled, mode, and report", func(t *testing.T) {
+		enabled, mode, report := parseXssProtectionDirectives([]any{"1; mode=block; report=https://example.com/r"})
+		assert.Equal(t, llx.BoolTrue, enabled)
+		assert.Equal(t, llx.StringData("block"), mode)
+		assert.Equal(t, llx.StringData("https://example.com/r"), report)
+	})
+
+	t.Run("parses a disabled header", func(t *testing.T) {
+		enabled, mode, report := parseXssProtectionDirectives([]any{"0"})
+		assert.Equal(t, llx.BoolFalse, enabled)
+		assert.Equal(t, llx.NilData, mode)
+		assert.Equal(t, llx.NilData, report)
+	})
+
+	t.Run("ignores directives that are not part of the header syntax", func(t *testing.T) {
+		enabled, _, report := parseXssProtectionDirectives([]any{"1; max-age=99"})
+		assert.Equal(t, llx.BoolTrue, enabled)
+		assert.Equal(t, llx.NilData, report)
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #8343.

The `xXssProtection()` parser populated the `report` field when it saw a `max-age` directive — a copy-paste from the STS parser above it. `max-age` is not part of the X-XSS-Protection header syntax (`X-XSS-Protection: 1; mode=block; report=<reporting-uri>`), so:

- `http.header.xXssProtection.report` was always null for servers that actually send `report=...`
- a nonsensical `X-XSS-Protection: 1; max-age=99` surfaced `report == "99"`

## Changes

- Match on the `report` directive instead of `max-age`
- Extract the directive parsing into a runtime-free `parseXssProtectionDirectives` helper so the logic is unit-testable without a resource runtime
- Add unit tests covering enabled/mode/report parsing, the disabled header, and a regression case asserting `max-age` no longer leaks into `report`

## Testing

`go test ./resources/...` in `providers/network` passes.