### PR TITLE
🐛 network: parse HTTP header directive names case-insensitively

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -214,22 +214,14 @@ func (x *mqlHttpHeader) id() (string, error) {
 	return "", errors.New("http header not initialized")
 }
 
-func (x *mqlHttpHeader) sts() (*mqlHttpHeaderSts, error) {
-	raw, ok := x.Params.Data["Strict-Transport-Security"]
-	if !ok {
-		x.Sts.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-
-	preload := false
-	includeSubDomains := false
-	maxAge := llx.NilData
-
-	parseHeaderFields(raw.([]any), func(key string, value string) {
-		switch key {
+func parseStsDirectives(raw []any) (preload bool, includeSubDomains bool, maxAge *llx.RawData) {
+	maxAge = llx.NilData
+	parseHeaderFields(raw, func(key string, value string) {
+		// RFC 6797 section 6.1: directive names are case-insensitive
+		switch strings.ToLower(key) {
 		case "preload":
 			preload = true
-		case "includeSubDomains":
+		case "includesubdomains":
 			includeSubDomains = true
 		case "max-age":
 			age, err := strconv.Atoi(value)
@@ -241,6 +233,17 @@ func (x *mqlHttpHeader) sts() (*mqlHttpHeaderSts, error) {
 			}
 		}
 	})
+	return preload, includeSubDomains, maxAge
+}
+
+func (x *mqlHttpHeader) sts() (*mqlHttpHeaderSts, error) {
+	raw, ok := x.Params.Data["Strict-Transport-Security"]
+	if !ok {
+		x.Sts.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	preload, includeSubDomains, maxAge := parseStsDirectives(raw.([]any))
 
 	o, err := CreateResource(x.MqlRuntime, "http.header.sts", map[string]*llx.RawData{
 		"preload":           llx.BoolData(preload),
@@ -275,7 +278,8 @@ func (x *mqlHttpHeader) xFrameOptions() (string, error) {
 func parseXssProtectionDirectives(raw []any) (enabled *llx.RawData, mode *llx.RawData, report *llx.RawData) {
 	enabled, mode, report = llx.NilData, llx.NilData, llx.NilData
 	parseHeaderFields(raw, func(key string, value string) {
-		switch key {
+		// directive names are case-insensitive, matching the other parsers
+		switch strings.ToLower(key) {
 		case "0":
 			enabled = llx.BoolFalse
 		case "1":
@@ -340,6 +344,23 @@ func (x *mqlHttpHeader) server() (string, error) {
 	return parseSingleHeaderValue(params, ok, &x.Server)
 }
 
+func parseContentTypeDirectives(raw []any) (typ *llx.RawData, params *llx.RawData) {
+	typ, params = llx.NilData, llx.NilData
+	parseHeaderFields(raw, func(key string, value string) {
+		// RFC 9110 section 8.3.1: media types and parameter names are
+		// case-insensitive; parameter values keep their casing
+		if typ.Value == nil && value == "" {
+			typ = llx.StringData(strings.ToLower(key))
+			return
+		}
+		if params.Value == nil {
+			params = llx.MapData(map[string]any{}, types.String)
+		}
+		params.Value.(map[string]any)[strings.ToLower(key)] = value
+	})
+	return typ, params
+}
+
 func (x *mqlHttpHeader) contentType() (*mqlHttpHeaderContentType, error) {
 	raw, ok := x.Params.Data["Content-Type"]
 	if !ok {
@@ -347,18 +368,7 @@ func (x *mqlHttpHeader) contentType() (*mqlHttpHeaderContentType, error) {
 		return nil, nil
 	}
 
-	typ := llx.NilData
-	params := llx.NilData
-	parseHeaderFields(raw.([]any), func(key string, value string) {
-		if typ.Value == nil && value == "" {
-			typ = llx.StringData(key)
-			return
-		}
-		if params.Value == nil {
-			params = llx.MapData(map[string]any{}, types.String)
-		}
-		params.Value.(map[string]any)[key] = value
-	})
+	typ, params := parseContentTypeDirectives(raw.([]any))
 
 	o, err := CreateResource(x.MqlRuntime, "http.header.contentType", map[string]*llx.RawData{
 		"type":   typ,
@@ -385,6 +395,24 @@ func (x *mqlHttpHeaderContentType) id() (string, error) {
 	return id.String(), nil
 }
 
+func parseSetCookieDirectives(raw []any) (name *llx.RawData, value *llx.RawData, params *llx.RawData) {
+	name, value, params = llx.NilData, llx.NilData, llx.NilData
+	parseHeaderFields(raw, func(key string, val string) {
+		// RFC 6265 section 5.2: attribute names are case-insensitive,
+		// while cookie names and values keep their casing
+		if name.Value == nil && val != "" {
+			name = llx.StringData(key)
+			value = llx.StringData(val)
+			return
+		}
+		if params.Value == nil {
+			params = llx.MapData(map[string]any{}, types.String)
+		}
+		params.Value.(map[string]any)[strings.ToLower(key)] = val
+	})
+	return name, value, params
+}
+
 func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
 	raw, ok := x.Params.Data["Set-Cookie"]
 	if !ok {
@@ -392,20 +420,7 @@ func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
 		return nil, nil
 	}
 
-	cname := llx.NilData
-	cval := llx.NilData
-	params := llx.NilData
-	parseHeaderFields(raw.([]any), func(key string, value string) {
-		if cname.Value == nil && value != "" {
-			cname = llx.StringData(key)
-			cval = llx.StringData(value)
-			return
-		}
-		if params.Value == nil {
-			params = llx.MapData(map[string]any{}, types.String)
-		}
-		params.Value.(map[string]any)[key] = value
-	})
+	cname, cval, params := parseSetCookieDirectives(raw.([]any))
 
 	o, err := CreateResource(x.MqlRuntime, "http.header.setCookie", map[string]*llx.RawData{
 		"name":   cname,
@@ -418,6 +433,16 @@ func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
 	return o.(*mqlHttpHeaderSetCookie), nil
 }
 
+func parseCspDirectives(raw []any) map[string]any {
+	m := map[string]any{}
+	parseHeaderFieldsD(raw, func(key string, value string) {
+		// CSP3: directive names are ASCII case-insensitive; their values
+		// keep their casing
+		m[strings.ToLower(key)] = value
+	}, ";", " ")
+	return m
+}
+
 func (x *mqlHttpHeader) csp() (map[string]any, error) {
 	raw, ok := x.Params.Data["Content-Security-Policy"]
 	if !ok {
@@ -425,12 +450,7 @@ func (x *mqlHttpHeader) csp() (map[string]any, error) {
 		return nil, nil
 	}
 
-	m := map[string]any{}
-	parseHeaderFieldsD(raw.([]any), func(key string, value string) {
-		m[key] = value
-	}, ";", " ")
-
-	return m, nil
+	return parseCspDirectives(raw.([]any)), nil
 }
 
 func (x *mqlHttpHeaderSetCookie) id() (string, error) {

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -59,4 +59,94 @@ func TestParseXssProtectionDirectives(t *testing.T) {
 		assert.Equal(t, llx.BoolTrue, enabled)
 		assert.Equal(t, llx.NilData, report)
 	})
+
+	t.Run("matches directive names case-insensitively", func(t *testing.T) {
+		_, mode, report := parseXssProtectionDirectives([]any{"1; Mode=Block; Report=https://example.com/r"})
+		assert.Equal(t, llx.StringData("Block"), mode)
+		assert.Equal(t, llx.StringData("https://example.com/r"), report)
+	})
+}
+
+func TestParseStsDirectives(t *testing.T) {
+	t.Run("parses max-age, includeSubDomains, and preload", func(t *testing.T) {
+		preload, includeSubDomains, maxAge := parseStsDirectives([]any{"max-age=31536000; includeSubDomains; preload"})
+		assert.True(t, preload)
+		assert.True(t, includeSubDomains)
+		assert.Equal(t, llx.TimeData(llx.DurationToTime(31536000)), maxAge)
+	})
+
+	t.Run("matches directive names case-insensitively", func(t *testing.T) {
+		preload, includeSubDomains, maxAge := parseStsDirectives([]any{"Max-Age=31536000; includeSubdomains; Preload"})
+		assert.True(t, preload)
+		assert.True(t, includeSubDomains)
+		assert.Equal(t, llx.TimeData(llx.DurationToTime(31536000)), maxAge)
+	})
+
+	t.Run("reports an invalid max-age value", func(t *testing.T) {
+		preload, includeSubDomains, maxAge := parseStsDirectives([]any{"max-age=oops"})
+		assert.False(t, preload)
+		assert.False(t, includeSubDomains)
+		require.Error(t, maxAge.Error)
+		assert.Contains(t, maxAge.Error.Error(), "oops")
+	})
+
+	t.Run("leaves absent directives unset", func(t *testing.T) {
+		preload, includeSubDomains, maxAge := parseStsDirectives([]any{"max-age=600"})
+		assert.False(t, preload)
+		assert.False(t, includeSubDomains)
+		assert.Equal(t, llx.TimeData(llx.DurationToTime(600)), maxAge)
+	})
+}
+
+func TestParseContentTypeDirectives(t *testing.T) {
+	t.Run("parses the media type and parameters", func(t *testing.T) {
+		typ, params := parseContentTypeDirectives([]any{"text/html; charset=UTF-8"})
+		assert.Equal(t, llx.StringData("text/html"), typ)
+		assert.Equal(t, map[string]any{"charset": "UTF-8"}, params.Value)
+	})
+
+	t.Run("normalizes the media type and parameter names, keeps values as sent", func(t *testing.T) {
+		typ, params := parseContentTypeDirectives([]any{"Text/HTML; CHARSET=UTF-8"})
+		assert.Equal(t, llx.StringData("text/html"), typ)
+		assert.Equal(t, map[string]any{"charset": "UTF-8"}, params.Value)
+	})
+
+	t.Run("has no parameters when none are sent", func(t *testing.T) {
+		typ, params := parseContentTypeDirectives([]any{"application/json"})
+		assert.Equal(t, llx.StringData("application/json"), typ)
+		assert.Equal(t, llx.NilData, params)
+	})
+}
+
+func TestParseSetCookieDirectives(t *testing.T) {
+	t.Run("parses the cookie name, value, and attributes", func(t *testing.T) {
+		name, value, params := parseSetCookieDirectives([]any{"sid=abc123; Secure; HttpOnly; Max-Age=100"})
+		assert.Equal(t, llx.StringData("sid"), name)
+		assert.Equal(t, llx.StringData("abc123"), value)
+		assert.Equal(t, map[string]any{"secure": "", "httponly": "", "max-age": "100"}, params.Value)
+	})
+
+	t.Run("keeps cookie name and value casing, normalizes attribute names", func(t *testing.T) {
+		name, value, params := parseSetCookieDirectives([]any{"SessionId=AbC123; SECURE; httpOnly"})
+		assert.Equal(t, llx.StringData("SessionId"), name)
+		assert.Equal(t, llx.StringData("AbC123"), value)
+		assert.Equal(t, map[string]any{"secure": "", "httponly": ""}, params.Value)
+	})
+
+	t.Run("keeps attribute value casing", func(t *testing.T) {
+		_, _, params := parseSetCookieDirectives([]any{"sid=1; Domain=Example.COM; SameSite=Strict"})
+		assert.Equal(t, map[string]any{"domain": "Example.COM", "samesite": "Strict"}, params.Value)
+	})
+}
+
+func TestParseCspDirectives(t *testing.T) {
+	t.Run("parses directives into a map", func(t *testing.T) {
+		m := parseCspDirectives([]any{"default-src 'self'; script-src 'none'"})
+		assert.Equal(t, map[string]any{"default-src": "'self'", "script-src": "'none'"}, m)
+	})
+
+	t.Run("normalizes directive names, keeps values as sent", func(t *testing.T) {
+		m := parseCspDirectives([]any{"Default-Src 'self'; SCRIPT-SRC https://CDN.example.com"})
+		assert.Equal(t, map[string]any{"default-src": "'self'", "script-src": "https://CDN.example.com"}, m)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #8342.

The `http.header` sub-resource parsers matched header **directive names** case-sensitively, but the relevant specs make them case-insensitive. Servers sending legal lowercase/mixed-case directives were silently misparsed, which made downstream policy checks (e.g. `mondoo-hsts-include-subdomains` / `mondoo-hsts-max-age` in cnspec's `mondoo-http-security` policy, see mondoohq/cnspec#2836) fail against compliant servers.

## Changes

All directive/parameter **names** now fold to lowercase before matching or storing; **values** keep their casing throughout:

- **Strict-Transport-Security** (RFC 6797 §6.1): `includeSubdomains`, `Max-Age`, `Preload` and any other casing now parse correctly
- **Content-Type** (RFC 9110 §8.3.1): the media type and parameter names normalize to lowercase — `Text/HTML; CHARSET=UTF-8` parses identically to its lowercase form, parameter values (`UTF-8`) stay as sent
- **Set-Cookie** (RFC 6265 §5.2): attribute keys in `params` are lowercased (`secure`, `httponly`, `max-age`, …); cookie **names and values keep their casing**, as do attribute values
- **Content-Security-Policy** (CSP3): directive map keys are lowercased; source lists stay as sent
- **X-XSS-Protection**: `mode`/`report` directive matching is case-insensitive

Each parser is extracted into a runtime-free helper (`parseStsDirectives`, `parseContentTypeDirectives`, `parseSetCookieDirectives`, `parseCspDirectives`), following the precedent from #8344, with unit tests covering canonical input, mixed-case directives, value-casing preservation, and the existing error paths.

## ⚠️ Release note

`contentType.type`, `contentType.params`, `setCookie.params`, and `csp` map keys are now lowercase. Queries that matched the as-sent casing (e.g. `setCookie.params.keys.contains("HttpOnly")`) need to switch to the lowercase key.

## Testing

`go test ./...` in `providers/network` passes; `gofmt` and `go vet` are clean.