### PR TITLE
🎉 network-13.2.2

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.2.1",
+	Version:         "13.2.2",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	CrossProviderTypes: []string{
 		"go.mondoo.com/mql/providers/os",


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### network (13.2.2)
- 🐛 network: parse HTTP header directive names case-insensitively (#8345)
- 🐛 network: parse X-XSS-Protection report directive, not max-age (#8344)