### PR TITLE
🐛 os/pam: only treat token-initial # as a comment delimiter

### DIFF
--- a/providers/os/resources/pam/parser.go
+++ b/providers/os/resources/pam/parser.go
@@ -95,8 +95,14 @@ func complicatedParse(fields []string) (*PamLine, error) {
 }
 
 func StripComments(line string) string {
-	if idx := strings.Index(line, "#"); idx >= 0 {
-		line = line[0:idx]
+	// A '#' starts a comment only when it begins a token (start of line or
+	// preceded by whitespace). A '#' embedded in a module option is part of
+	// the option value and must be preserved.
+	for idx := 0; idx < len(line); idx++ {
+		if line[idx] == '#' && (idx == 0 || line[idx-1] == ' ' || line[idx-1] == '\t') {
+			line = line[0:idx]
+			break
+		}
 	}
 	line = strings.Trim(line, " \t\r")
 	return line

--- a/providers/os/resources/pam/parser_test.go
+++ b/providers/os/resources/pam/parser_test.go
@@ -79,6 +79,32 @@ func TestParseLine(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 
+	t.Run("parsing conf lines with a literal # inside an option", func(t *testing.T) {
+		line := "password   required       pam_passwdqc.so config=/etc/passwdqc.conf match=*#*"
+		expected := &PamLine{
+			PamType: "password",
+			Control: "required",
+			Module:  "pam_passwdqc.so",
+			Options: []any{"config=/etc/passwdqc.conf", "match=*#*"},
+		}
+		result, err := ParseLine(line)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("parsing conf lines with a trailing comment", func(t *testing.T) {
+		line := "auth       required       pam_unix.so nullok # comment text"
+		expected := &PamLine{
+			PamType: "auth",
+			Control: "required",
+			Module:  "pam_unix.so",
+			Options: []any{"nullok"},
+		}
+		result, err := ParseLine(line)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
 	t.Run("parsing conf line with include", func(t *testing.T) {
 		line := "@include common-password"
 		expected := &PamLine{
@@ -292,4 +318,26 @@ func TestIncludePamConfigurationFile(t *testing.T) {
 	entries, err := parsePamContent(content)
 	require.NoError(t, err)
 	assert.Equal(t, expected, entries)
+}
+
+func TestStripComments(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected string
+	}{
+		{"full-line comment", "# this is a comment", ""},
+		{"indented full-line comment", "   # indented comment", ""},
+		{"trailing comment", "auth required pam_unix.so # use unix auth", "auth required pam_unix.so"},
+		{"tab before comment", "auth required pam_unix.so\t# use unix auth", "auth required pam_unix.so"},
+		{"hash inside option value", "password required pam_passwdqc.so match=*#*", "password required pam_passwdqc.so match=*#*"},
+		{"hash inside option plus trailing comment", "password required pam_passwdqc.so match=*#* # strict", "password required pam_passwdqc.so match=*#*"},
+		{"no comment", "auth required pam_unix.so nullok", "auth required pam_unix.so nullok"},
+		{"empty line", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, StripComments(tc.line))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #8328.

`StripComments` in the PAM parser cut each line at the first `#`, so a literal `#` embedded inside a module option (e.g. a `pam_passwdqc` `match=*#*` pattern) was silently truncated along with everything after it. This affected both `pam.ParseLine` and the `pam.conf.entries` single-file path in `pam.go`, which routes lines through the same helper.

## Fix

A `#` now starts a comment only when it begins a token — at the start of the line or preceded by a space/tab. A `#` appearing mid-token is data and is preserved. Full-line comments, indented comments, and trailing comments are stripped exactly as before.

## Tests

- `ParseLine` cases: literal `#` inside an option value is retained; a trailing comment after options is still stripped.
- `StripComments` table test covering full-line comments, indented comments, trailing comments (space- and tab-delimited), embedded `#` with and without a trailing comment, and the no-comment/empty-line cases.

`go test ./providers/os/resources/pam/` passes; the new cases fail without the parser change.