### PR TITLE
🐛 report effective version when auto-update staged a newer binary (#7751)

### DIFF
--- a/apps/mql/mql.go
+++ b/apps/mql/mql.go
@@ -30,7 +30,7 @@ func main() {
 	normalizeAutoUpdateFlag()
 
 	// Check for self-update before anything else
-	if shouldTrySelfUpdate() {
+	if run, localOnly := selfUpdateMode(); run {
 		releaseURL := selfupdate.DefaultReleaseURL
 		if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
 			releaseURL = updatesURL + "/mql/latest.json"
@@ -42,7 +42,13 @@ func main() {
 			BinaryName:      "mql",
 			CurrentVersion:  mql.GetVersion(),
 		}
-		if updated, err := selfupdate.CheckAndUpdate(cfg); err != nil {
+		// "version" does only the local switch (no network) so it stays fast while
+		// still reporting the version that other commands transparently exec into.
+		check := selfupdate.CheckAndUpdate
+		if localOnly {
+			check = selfupdate.CheckLocalAndUpdate
+		}
+		if updated, err := check(cfg); err != nil {
 			// Log warning but don't block - only show in debug mode
 			if os.Getenv("DEBUG") != "" {
 				os.Stderr.WriteString("self-update check failed: " + err.Error() + "\n")
@@ -89,23 +95,34 @@ func normalizeAutoUpdateFlag() {
 	os.Args = newArgs
 }
 
-// shouldTrySelfUpdate checks if a self-update should be attempted.
-// This uses viper config and CLI flags to determine if auto-update is enabled.
+// selfUpdateMode decides whether a self-update should be attempted, and whether
+// it must stay local-only (no network). It uses viper config and CLI flags to
+// determine if auto-update is enabled.
+//
+// The "version" command runs a local-only check: it must not pay a network
+// round-trip, but it still has to switch to a newer already-staged binary so it
+// reports the same version every other command transparently execs into (see
+// issue #7751). "help"/"-h" skip self-update entirely.
+//
 // Note: normalizeAutoUpdateFlag() must be called before this function to convert
 // space-separated flags (--auto-update false) to the = format (--auto-update=false).
-func shouldTrySelfUpdate() bool {
+func selfUpdateMode() (run, localOnly bool) {
 	// Skip if disabled via environment variable
 	// This also prevents infinite loops after an update (the updated process
 	// is spawned with MONDOO_AUTO_UPDATE=false)
 	if val := os.Getenv(selfupdate.EnvAutoUpdate); val == "false" || val == "0" {
-		return false
+		return false, false
 	}
 
-	// Skip for version/help commands - these should run fast
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "version", "help", "--help", "-h", "--version":
-			return false
+		case "help", "--help", "-h":
+			// Help output never represents "the version I'm running" and should
+			// be instant, so skip self-update entirely.
+			return false, false
+		case "version", "--version":
+			// Report the effective version without a network round-trip.
+			localOnly = true
 		}
 	}
 
@@ -114,7 +131,7 @@ func shouldTrySelfUpdate() bool {
 
 	// Check if the AutoUpdateEngine feature flag is enabled
 	if !config.GetFeatures().IsActive(mql.AutoUpdateEngine) {
-		return false
+		return false, false
 	}
 
 	// Get auto_update setting from config (defaults to true if not set)
@@ -123,12 +140,12 @@ func shouldTrySelfUpdate() bool {
 	// Check for --auto-update=VALUE flag (already normalized from space-separated format)
 	for _, arg := range os.Args {
 		if arg == "--auto-update=false" || arg == "--auto-update=0" {
-			return false
+			return false, false
 		}
 		if arg == "--auto-update=true" || arg == "--auto-update=1" {
-			return true
+			return true, localOnly
 		}
 	}
 
-	return autoUpdate
+	return autoUpdate, localOnly
 }

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -78,40 +78,68 @@ type ReleaseFile struct {
 	Hash     string `json:"hash"`     // SHA256 hash
 }
 
-// CheckAndUpdate checks for updates and installs them if available.
-// Returns true if an update was installed and the process was replaced.
-func CheckAndUpdate(cfg Config) (bool, error) {
+// updatePreflight runs the guards shared by every self-update entry point and
+// resolves the bin path, platform binary name, and current version. ok is false
+// when self-update must be skipped entirely (disabled via config or environment,
+// or running a dev build); in that case the caller returns (false, err).
+func updatePreflight(cfg Config) (binPath, binName, currentVersion string, ok bool, err error) {
 	if !cfg.Enabled {
-		return false, nil
+		return "", "", "", false, nil
 	}
 
 	// Skip if auto-update is disabled via environment (disables both engine and providers)
 	if val := os.Getenv(EnvAutoUpdate); val == "false" || val == "0" {
 		log.Debug().Msg("self-update: skipping, disabled via " + EnvAutoUpdate)
-		return false, nil
+		return "", "", "", false, nil
 	}
 
 	// Skip if engine auto-update is specifically disabled (e.g., after a binary self-update
 	// to prevent infinite loops, or when the user only wants provider auto-updates)
 	if val := os.Getenv(EnvAutoUpdateEngine); val == "false" || val == "0" {
 		log.Debug().Msg("self-update: skipping, disabled via " + EnvAutoUpdateEngine)
-		return false, nil
+		return "", "", "", false, nil
 	}
 
 	// Skip if version is "rolling" (dev build)
-	currentVersion := cfg.CurrentVersion
+	currentVersion = cfg.CurrentVersion
 	if strings.HasSuffix(currentVersion, "-rolling") {
 		log.Debug().Msg("self-update: skipping, running unstable/dev build")
-		return false, nil
+		return "", "", "", false, nil
 	}
 
 	// Get the bin path for storing updated binaries
-	binPath, err := getBinPath()
+	binPath, err = getBinPath()
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get bin path")
+		return "", "", "", false, errors.Wrap(err, "failed to get bin path")
 	}
 
-	binName := platformBinaryName(cfg.BinaryName)
+	binName = platformBinaryName(cfg.BinaryName)
+	return binPath, binName, currentVersion, true, nil
+}
+
+// CheckLocalAndUpdate runs only the local portion of the self-update flow: if a
+// newer binary has already been staged in the bin path, it execs into it. It
+// performs no network access, so it is fast enough to run on quick commands like
+// "version" that still need to report the effective version after an update has
+// been staged (otherwise they report the stale compiled-in version while every
+// other command transparently execs into the newer binary).
+// Returns true if the process was (or is about to be) replaced by the new binary.
+func CheckLocalAndUpdate(cfg Config) (bool, error) {
+	binPath, binName, currentVersion, ok, err := updatePreflight(cfg)
+	if err != nil || !ok {
+		return false, err
+	}
+
+	return execLocalIfNewer(binPath, binName, currentVersion)
+}
+
+// CheckAndUpdate checks for updates and installs them if available.
+// Returns true if an update was installed and the process was replaced.
+func CheckAndUpdate(cfg Config) (bool, error) {
+	binPath, binName, currentVersion, ok, err := updatePreflight(cfg)
+	if err != nil || !ok {
+		return false, err
+	}
 
 	// First, check if there's already a newer binary installed locally.
 	// This allows us to immediately use an already-downloaded update without

--- a/cli/selfupdate/selfupdate_test.go
+++ b/cli/selfupdate/selfupdate_test.go
@@ -138,6 +138,64 @@ func TestCheckAndUpdate_EnvVarBehavior(t *testing.T) {
 	})
 }
 
+// TestCheckLocalAndUpdate verifies the local-only entry point used by the
+// "version" command (issue #7751): it shares CheckAndUpdate's guards but never
+// performs a network request.
+func TestCheckLocalAndUpdate(t *testing.T) {
+	t.Run("skips when MONDOO_AUTO_UPDATE is false", func(t *testing.T) {
+		t.Setenv(EnvAutoUpdate, "false")
+		t.Setenv(EnvAutoUpdateEngine, "")
+
+		updated, err := CheckLocalAndUpdate(Config{Enabled: true, CurrentVersion: "1.0.0"})
+		assert.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("skips when MONDOO_AUTO_UPDATE_ENGINE is false", func(t *testing.T) {
+		t.Setenv(EnvAutoUpdate, "")
+		t.Setenv(EnvAutoUpdateEngine, "false")
+
+		updated, err := CheckLocalAndUpdate(Config{Enabled: true, CurrentVersion: "1.0.0"})
+		assert.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("skips when config is disabled", func(t *testing.T) {
+		t.Setenv(EnvAutoUpdate, "")
+		t.Setenv(EnvAutoUpdateEngine, "")
+
+		updated, err := CheckLocalAndUpdate(Config{Enabled: false, CurrentVersion: "1.0.0"})
+		assert.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("skips for rolling version", func(t *testing.T) {
+		t.Setenv(EnvAutoUpdate, "")
+		t.Setenv(EnvAutoUpdateEngine, "")
+
+		updated, err := CheckLocalAndUpdate(Config{Enabled: true, CurrentVersion: "1.0.0-rolling"})
+		assert.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("performs no network request", func(t *testing.T) {
+		t.Setenv(EnvAutoUpdate, "")
+		t.Setenv(EnvAutoUpdateEngine, "")
+
+		// A binary name that cannot be staged locally makes execLocalIfNewer
+		// return immediately, and the unroutable ReleaseURL would surface as an
+		// error if the local-only path ever reached the network.
+		updated, err := CheckLocalAndUpdate(Config{
+			Enabled:        true,
+			CurrentVersion: "999.999.999",
+			ReleaseURL:     "https://invalid.invalid/should-never-be-called.json",
+			BinaryName:     "mql-selfupdate-test-nonexistent",
+		})
+		assert.NoError(t, err)
+		assert.False(t, updated)
+	})
+}
+
 // TestEnvVarSeparation verifies that MONDOO_AUTO_UPDATE_ENGINE is separate from
 // MONDOO_AUTO_UPDATE, ensuring that:
 // 1. Engine binary auto-update can be disabled independently of provider auto-update


### PR DESCRIPTION
## Problem

`mql version` / `cnspec version` report the stale **compiled-in** version when auto-update is enabled and a newer binary has already been staged, even though every other command transparently runs the newer one. This makes `version` disagree with `status`:

```
-> % cnspec version
cnspec 13.9.0 (99ea09e9, 2026-05-12T09:00:42Z)

-> % cnspec status
→ auto-update: using the latest installed version installed=13.10.0
→ Version:        13.10.0 (API Version: 13)
```

Fixes #7751.

## Root cause

In `apps/mql/mql.go`, `shouldTrySelfUpdate()` short-circuited the **entire** self-update path for `version` (and `help`) so it would "run fast":

```go
case "version", "help", "--help", "-h", "--version":
    return false
```

But the part that switches into a staged newer binary — `selfupdate.execLocalIfNewer` — is **local-only** (a `stat` + a 5s local `version` call); the network round-trip happens later. By skipping the whole path, `version` never switched into the staged binary and just printed its own old compiled-in version. `status` (and everything else) went through the full path, exec'd into the staged binary, and reported the new version — hence the mismatch.

## Fix

Split the self-update entry point so `version` does a **local-only** check:

- `selfupdate.CheckLocalAndUpdate` — new exported entry point that runs the shared guards and `execLocalIfNewer` only (no network). Common guards are extracted into `updatePreflight`, shared with the existing `CheckAndUpdate` (no behavior change there).
- `selfUpdateMode()` (replaces `shouldTrySelfUpdate()`) returns `(run, localOnly)`. `version`/`--version` → `localOnly` (switch into a staged newer binary, no network); `help`/`-h` → skip entirely. The `MONDOO_AUTO_UPDATE` / `MONDOO_AUTO_UPDATE_ENGINE` env opt-outs, the `AutoUpdateEngine` feature flag, the `auto_update` config setting, and the `--auto-update=` flag are all still honored.

`version` stays network-free; in the common case (nothing staged) it's a single `os.Stat` that returns immediately.

## Verification

Built two binaries stamped `13.9.0` (one from `main`, one from this branch) with a fake newer `13.10.0` staged in an isolated `HOME`:

| Scenario | `main` | this PR |
|---|---|---|
| `version` (13.10.0 staged) | `mql 13.9.0` ❌ | `mql 13.10.0` ✅ |
| `help` | banner | banner, no switch ✅ |
| `version` w/ `MONDOO_AUTO_UPDATE=false` | — | `mql 13.9.0` (opt-out honored) ✅ |

Plus unit tests for `CheckLocalAndUpdate` (guards + network-free path). `go build`, `go vet`, and `gofmt` all clean. (`TestSwapBinaryInPlace/no-op_when_staged_equals_original` fails on `main` too — a pre-existing `/var`→`/private/var` symlink quirk in that test, unrelated to this change.)

## cnspec follow-up

The shared `selfupdate` change lives here and is reused by cnspec. cnspec needs the same one-line wiring in its own `main` (call `CheckLocalAndUpdate` for `version`) once it picks up this release — its `version` command has the identical short-circuit today.
