### PR TITLE
🌟 os: add windows.auditPolicy with language-stable subcategory lookup

### DIFF
--- a/providers/os/resources/auditpol.go
+++ b/providers/os/resources/auditpol.go
@@ -4,31 +4,13 @@
 package resources
 
 import (
-	"fmt"
 	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers/os/resources/windows"
 )
 
 func (p *mqlAuditpol) list() ([]any, error) {
-	o, err := CreateResource(p.MqlRuntime, "powershell", map[string]*llx.RawData{
-		"script": llx.StringData("[Console]::OutputEncoding = [Text.Encoding]::UTF8;auditpol /get /category:* /r"),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	cmd := o.(*mqlPowershell)
-	out := cmd.GetStdout()
-	if out.Error != nil {
-		return nil, fmt.Errorf("could not run auditpol: %w", out.Error)
-	}
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, fmt.Errorf("could not run auditpol: %s", strings.TrimSpace(cmd.Stderr.Data))
-	}
-
-	entries, err := windows.ParseAuditpol(strings.NewReader(out.Data))
+	entries, err := fetchAuditpolEntries(p.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/auditpol_test.go
+++ b/providers/os/resources/auditpol_test.go
@@ -18,6 +18,13 @@ func TestResource_Auditpol(t *testing.T) {
 		assert.NotEmpty(t, res)
 	})
 
+	t.Run("list contains the policy rows, not the CSV header", func(t *testing.T) {
+		res := testWindowsQuery(t, "auditpol.length")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, int64(59), res[0].Data.Value)
+	})
+
 	t.Run("test a specific secpol systemaccess entry", func(t *testing.T) {
 		res := testWindowsQuery(t, "auditpol.where(subcategory == 'Credential Validation')[0].subcategory")
 		assert.NotEmpty(t, res)

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3787,20 +3787,21 @@ ports {
 
 // Windows audit policies
 //
-// Examine inclusion and exclusion settings for every audit subcategory
-auditpol {
+// Deprecated in favor of windows.auditPolicy, which reports subcategory
+// names and categories in English regardless of the OS display language
+// and supports looking up a single subcategory by name or GUID.
+auditpol @maturity("deprecated") {
   []auditpol.entry
 }
 
 // Windows audit policy entry
 //
-// Examine a single Windows audit-policy entry: the machine name, policy
-// target, subcategory name and GUID, inclusion setting, and exclusion
-// setting, plus the `success` and `failure` booleans derived from the
-// inclusion setting. Iterated from `auditpol` to assert that specific
-// subcategories (e.g., Logon, Account Management) have the expected audit
-// settings.
-auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") {
+// Deprecated in favor of windows.auditPolicy.subcategory, which reports
+// subcategory names and categories in English regardless of the OS display
+// language. This entry carries the subcategory name, GUID, inclusion
+// setting, and exclusion setting as reported by the system, plus the
+// `success` and `failure` booleans derived from the inclusion setting.
+auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") @maturity("deprecated") {
   // Machine name
   machinename string
   // Policy target
@@ -6916,6 +6917,55 @@ windows.tpm {
   specVersion() string
   // TPM manufacturer version string
   manufacturerVersion() string
+}
+
+// Windows advanced audit policy
+//
+// Examine the effective Windows advanced audit policy: every audit
+// subcategory together with whether success and failure events are
+// audited. Subcategory names and categories are reported in English
+// regardless of the OS display language, so the same audit works
+// unchanged on localized systems. Iterate the subcategories to assert
+// audit coverage — for example
+// `windows.auditPolicy.where(category == "Account Logon").all(success)` —
+// or select a single subcategory with windows.auditPolicy.subcategory.
+windows.auditPolicy {
+  []windows.auditPolicy.subcategory
+}
+
+// Windows audit policy subcategory
+//
+// Examine the audit settings of a single advanced audit policy
+// subcategory. The `name` field selects the subcategory by its English
+// name — for example `windows.auditPolicy.subcategory(name: "Logon")` —
+// and also accepts a subcategory GUID or the localized name the system
+// reports. `success` and `failure` indicate whether the subcategory
+// audits success and failure events, derived from the reported audit
+// setting independent of the OS display language. A subcategory that is
+// not present on the system audits nothing — `success` and `failure` are
+// false and the reported fields are null — so checks against it fail
+// rather than error.
+windows.auditPolicy.subcategory @defaults("name success failure") {
+  init(name string)
+  // Subcategory name in English (e.g. `Logon`), stable across OS display languages
+  name string
+  // GUID that identifies the subcategory across Windows versions and languages
+  guid string
+  // Audit category the subcategory belongs to (e.g. `Logon/Logoff`)
+  category string
+  // Subcategory name as reported by the system in its display language
+  localizedName string
+  // Whether success events are audited
+  success bool
+  // Whether failure events are audited
+  failure bool
+  // Audit setting as reported by the system in its display language
+  //
+  // One of `Success`, `Failure`, `Success and Failure`, or `No Auditing`,
+  // localized to the OS display language.
+  inclusionSetting string
+  // Per-user audit exclusion setting as reported by the system
+  exclusionSetting string
 }
 
 // Windows Firewall (Advanced Security)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -336,6 +336,8 @@ const (
 	ResourceWindowsEventlog               string = "windows.eventlog"
 	ResourceWindowsRdp                    string = "windows.rdp"
 	ResourceWindowsTpm                    string = "windows.tpm"
+	ResourceWindowsAuditPolicy            string = "windows.auditPolicy"
+	ResourceWindowsAuditPolicySubcategory string = "windows.auditPolicy.subcategory"
 	ResourceWindowsFirewall               string = "windows.firewall"
 	ResourceWindowsFirewallProfile        string = "windows.firewall.profile"
 	ResourceWindowsFirewallRule           string = "windows.firewall.rule"
@@ -1727,6 +1729,14 @@ func init() {
 		"windows.tpm": {
 			// to override args, implement: initWindowsTpm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsTpm,
+		},
+		"windows.auditPolicy": {
+			// to override args, implement: initWindowsAuditPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsAuditPolicy,
+		},
+		"windows.auditPolicy.subcategory": {
+			Init:   initWindowsAuditPolicySubcategory,
+			Create: createWindowsAuditPolicySubcategory,
 		},
 		"windows.firewall": {
 			// to override args, implement: initWindowsFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -8195,6 +8205,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.tpm.manufacturerVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsTpm).GetManufacturerVersion()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicy).GetList()).ToDataRes(types.Array(types.Resource("windows.auditPolicy.subcategory")))
+	},
+	"windows.auditPolicy.subcategory.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetName()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.subcategory.guid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetGuid()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.subcategory.category": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetCategory()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.subcategory.localizedName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetLocalizedName()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.subcategory.success": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetSuccess()).ToDataRes(types.Bool)
+	},
+	"windows.auditPolicy.subcategory.failure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetFailure()).ToDataRes(types.Bool)
+	},
+	"windows.auditPolicy.subcategory.inclusionSetting": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetInclusionSetting()).ToDataRes(types.String)
+	},
+	"windows.auditPolicy.subcategory.exclusionSetting": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsAuditPolicySubcategory).GetExclusionSetting()).ToDataRes(types.String)
 	},
 	"windows.firewall.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsFirewall).GetSettings()).ToDataRes(types.Dict)
@@ -19289,6 +19326,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.tpm.manufacturerVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsTpm).ManufacturerVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.auditPolicy.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicy).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.auditPolicy.subcategory.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.guid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).Guid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.category": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).Category, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.localizedName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).LocalizedName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.success": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).Success, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.failure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).Failure, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.inclusionSetting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).InclusionSetting, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.auditPolicy.subcategory.exclusionSetting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsAuditPolicySubcategory).ExclusionSetting, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51175,6 +51256,146 @@ func (c *mqlWindowsTpm) GetManufacturerVersion() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManufacturerVersion, func() (string, error) {
 		return c.manufacturerVersion()
 	})
+}
+
+// mqlWindowsAuditPolicy for the windows.auditPolicy resource
+type mqlWindowsAuditPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlWindowsAuditPolicyInternal it will be used here
+	List plugin.TValue[[]any]
+}
+
+// createWindowsAuditPolicy creates a new instance of this resource
+func createWindowsAuditPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsAuditPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.auditPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsAuditPolicy) MqlName() string {
+	return "windows.auditPolicy"
+}
+
+func (c *mqlWindowsAuditPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsAuditPolicy) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows.auditPolicy", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlWindowsAuditPolicySubcategory for the windows.auditPolicy.subcategory resource
+type mqlWindowsAuditPolicySubcategory struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlWindowsAuditPolicySubcategoryInternal it will be used here
+	Name             plugin.TValue[string]
+	Guid             plugin.TValue[string]
+	Category         plugin.TValue[string]
+	LocalizedName    plugin.TValue[string]
+	Success          plugin.TValue[bool]
+	Failure          plugin.TValue[bool]
+	InclusionSetting plugin.TValue[string]
+	ExclusionSetting plugin.TValue[string]
+}
+
+// createWindowsAuditPolicySubcategory creates a new instance of this resource
+func createWindowsAuditPolicySubcategory(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsAuditPolicySubcategory{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.auditPolicy.subcategory", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) MqlName() string {
+	return "windows.auditPolicy.subcategory"
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetGuid() *plugin.TValue[string] {
+	return &c.Guid
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetCategory() *plugin.TValue[string] {
+	return &c.Category
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetLocalizedName() *plugin.TValue[string] {
+	return &c.LocalizedName
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetSuccess() *plugin.TValue[bool] {
+	return &c.Success
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetFailure() *plugin.TValue[bool] {
+	return &c.Failure
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetInclusionSetting() *plugin.TValue[string] {
+	return &c.InclusionSetting
+}
+
+func (c *mqlWindowsAuditPolicySubcategory) GetExclusionSetting() *plugin.TValue[string] {
+	return &c.ExclusionSetting
 }
 
 // mqlWindowsFirewall for the windows.firewall resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2693,6 +2693,17 @@ warp.skill.sha256 13.13.1
 warp.skill.source 13.13.1
 warp.skills 13.13.1
 windows 9.0.1
+windows.auditPolicy 13.28.2
+windows.auditPolicy.list 13.28.2
+windows.auditPolicy.subcategory 13.28.2
+windows.auditPolicy.subcategory.category 13.28.2
+windows.auditPolicy.subcategory.exclusionSetting 13.28.2
+windows.auditPolicy.subcategory.failure 13.28.2
+windows.auditPolicy.subcategory.guid 13.28.2
+windows.auditPolicy.subcategory.inclusionSetting 13.28.2
+windows.auditPolicy.subcategory.localizedName 13.28.2
+windows.auditPolicy.subcategory.name 13.28.2
+windows.auditPolicy.subcategory.success 13.28.2
 windows.bitlocker 9.0.1
 windows.bitlocker.volume 9.0.1
 windows.bitlocker.volume.conversionStatus 9.0.1

--- a/providers/os/resources/windows/auditpol.go
+++ b/providers/os/resources/windows/auditpol.go
@@ -6,6 +6,7 @@ package windows
 import (
 	"encoding/csv"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -19,6 +20,101 @@ type AuditpolEntry struct {
 	InclusionSetting string
 	ExclusionSetting string
 }
+
+// AuditpolSubcategory carries the canonical English name of a well-known
+// audit subcategory and the audit category it belongs to. auditpol localizes
+// subcategory names to the OS display language, while the GUIDs stay stable
+// across Windows versions and languages.
+type AuditpolSubcategory struct {
+	Name     string
+	Category string
+}
+
+// auditpolKnownSubcategories maps subcategory GUIDs (uppercase, no braces) to
+// their canonical English name and audit category. It covers the 59
+// subcategories of MS-GPAC / `auditpol /list /subcategory:*`.
+var auditpolKnownSubcategories = map[string]AuditpolSubcategory{
+	// System
+	"0CCE9210-69AE-11D9-BED3-505054503030": {"Security State Change", "System"},
+	"0CCE9211-69AE-11D9-BED3-505054503030": {"Security System Extension", "System"},
+	"0CCE9212-69AE-11D9-BED3-505054503030": {"System Integrity", "System"},
+	"0CCE9213-69AE-11D9-BED3-505054503030": {"IPsec Driver", "System"},
+	"0CCE9214-69AE-11D9-BED3-505054503030": {"Other System Events", "System"},
+	// Logon/Logoff
+	"0CCE9215-69AE-11D9-BED3-505054503030": {"Logon", "Logon/Logoff"},
+	"0CCE9216-69AE-11D9-BED3-505054503030": {"Logoff", "Logon/Logoff"},
+	"0CCE9217-69AE-11D9-BED3-505054503030": {"Account Lockout", "Logon/Logoff"},
+	"0CCE9218-69AE-11D9-BED3-505054503030": {"IPsec Main Mode", "Logon/Logoff"},
+	"0CCE9219-69AE-11D9-BED3-505054503030": {"IPsec Quick Mode", "Logon/Logoff"},
+	"0CCE921A-69AE-11D9-BED3-505054503030": {"IPsec Extended Mode", "Logon/Logoff"},
+	"0CCE921B-69AE-11D9-BED3-505054503030": {"Special Logon", "Logon/Logoff"},
+	"0CCE921C-69AE-11D9-BED3-505054503030": {"Other Logon/Logoff Events", "Logon/Logoff"},
+	"0CCE9243-69AE-11D9-BED3-505054503030": {"Network Policy Server", "Logon/Logoff"},
+	"0CCE9247-69AE-11D9-BED3-505054503030": {"User / Device Claims", "Logon/Logoff"},
+	"0CCE9249-69AE-11D9-BED3-505054503030": {"Group Membership", "Logon/Logoff"},
+	// Object Access
+	"0CCE921D-69AE-11D9-BED3-505054503030": {"File System", "Object Access"},
+	"0CCE921E-69AE-11D9-BED3-505054503030": {"Registry", "Object Access"},
+	"0CCE921F-69AE-11D9-BED3-505054503030": {"Kernel Object", "Object Access"},
+	"0CCE9220-69AE-11D9-BED3-505054503030": {"SAM", "Object Access"},
+	"0CCE9221-69AE-11D9-BED3-505054503030": {"Certification Services", "Object Access"},
+	"0CCE9222-69AE-11D9-BED3-505054503030": {"Application Generated", "Object Access"},
+	"0CCE9223-69AE-11D9-BED3-505054503030": {"Handle Manipulation", "Object Access"},
+	"0CCE9224-69AE-11D9-BED3-505054503030": {"File Share", "Object Access"},
+	"0CCE9225-69AE-11D9-BED3-505054503030": {"Filtering Platform Packet Drop", "Object Access"},
+	"0CCE9226-69AE-11D9-BED3-505054503030": {"Filtering Platform Connection", "Object Access"},
+	"0CCE9227-69AE-11D9-BED3-505054503030": {"Other Object Access Events", "Object Access"},
+	"0CCE9244-69AE-11D9-BED3-505054503030": {"Detailed File Share", "Object Access"},
+	"0CCE9245-69AE-11D9-BED3-505054503030": {"Removable Storage", "Object Access"},
+	"0CCE9246-69AE-11D9-BED3-505054503030": {"Central Policy Staging", "Object Access"},
+	// Privilege Use
+	"0CCE9228-69AE-11D9-BED3-505054503030": {"Sensitive Privilege Use", "Privilege Use"},
+	"0CCE9229-69AE-11D9-BED3-505054503030": {"Non Sensitive Privilege Use", "Privilege Use"},
+	"0CCE922A-69AE-11D9-BED3-505054503030": {"Other Privilege Use Events", "Privilege Use"},
+	// Detailed Tracking
+	"0CCE922B-69AE-11D9-BED3-505054503030": {"Process Creation", "Detailed Tracking"},
+	"0CCE922C-69AE-11D9-BED3-505054503030": {"Process Termination", "Detailed Tracking"},
+	"0CCE922D-69AE-11D9-BED3-505054503030": {"DPAPI Activity", "Detailed Tracking"},
+	"0CCE922E-69AE-11D9-BED3-505054503030": {"RPC Events", "Detailed Tracking"},
+	"0CCE9248-69AE-11D9-BED3-505054503030": {"Plug and Play Events", "Detailed Tracking"},
+	"0CCE924A-69AE-11D9-BED3-505054503030": {"Token Right Adjusted Events", "Detailed Tracking"},
+	// Policy Change
+	"0CCE922F-69AE-11D9-BED3-505054503030": {"Audit Policy Change", "Policy Change"},
+	"0CCE9230-69AE-11D9-BED3-505054503030": {"Authentication Policy Change", "Policy Change"},
+	"0CCE9231-69AE-11D9-BED3-505054503030": {"Authorization Policy Change", "Policy Change"},
+	"0CCE9232-69AE-11D9-BED3-505054503030": {"MPSSVC Rule-Level Policy Change", "Policy Change"},
+	"0CCE9233-69AE-11D9-BED3-505054503030": {"Filtering Platform Policy Change", "Policy Change"},
+	"0CCE9234-69AE-11D9-BED3-505054503030": {"Other Policy Change Events", "Policy Change"},
+	// Account Management
+	"0CCE9235-69AE-11D9-BED3-505054503030": {"User Account Management", "Account Management"},
+	"0CCE9236-69AE-11D9-BED3-505054503030": {"Computer Account Management", "Account Management"},
+	"0CCE9237-69AE-11D9-BED3-505054503030": {"Security Group Management", "Account Management"},
+	"0CCE9238-69AE-11D9-BED3-505054503030": {"Distribution Group Management", "Account Management"},
+	"0CCE9239-69AE-11D9-BED3-505054503030": {"Application Group Management", "Account Management"},
+	"0CCE923A-69AE-11D9-BED3-505054503030": {"Other Account Management Events", "Account Management"},
+	// DS Access
+	"0CCE923B-69AE-11D9-BED3-505054503030": {"Directory Service Access", "DS Access"},
+	"0CCE923C-69AE-11D9-BED3-505054503030": {"Directory Service Changes", "DS Access"},
+	"0CCE923D-69AE-11D9-BED3-505054503030": {"Directory Service Replication", "DS Access"},
+	"0CCE923E-69AE-11D9-BED3-505054503030": {"Detailed Directory Service Replication", "DS Access"},
+	// Account Logon
+	"0CCE923F-69AE-11D9-BED3-505054503030": {"Credential Validation", "Account Logon"},
+	"0CCE9240-69AE-11D9-BED3-505054503030": {"Kerberos Service Ticket Operations", "Account Logon"},
+	"0CCE9241-69AE-11D9-BED3-505054503030": {"Other Account Logon Events", "Account Logon"},
+	"0CCE9242-69AE-11D9-BED3-505054503030": {"Kerberos Authentication Service", "Account Logon"},
+}
+
+// LookupAuditpolSubcategory resolves a subcategory GUID (braces optional,
+// case-insensitive) to its canonical English name and audit category.
+func LookupAuditpolSubcategory(guid string) (AuditpolSubcategory, bool) {
+	guid = strings.ToUpper(strings.TrimSpace(guid))
+	guid = strings.TrimPrefix(guid, "{")
+	guid = strings.TrimSuffix(guid, "}")
+	sub, ok := auditpolKnownSubcategories[guid]
+	return sub, ok
+}
+
+var auditpolGuidRe = regexp.MustCompile(`^[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$`)
 
 // see https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpac/77878370-0712-47cd-997d-b07053429f6d
 func ParseAuditpol(r io.Reader) ([]AuditpolEntry, error) {
@@ -45,6 +141,12 @@ func ParseAuditpol(r io.Reader) ([]AuditpolEntry, error) {
 		guid := strings.TrimSpace(record[3])
 		guid = strings.TrimPrefix(guid, "{")
 		guid = strings.TrimSuffix(guid, "}")
+
+		// every policy row carries a subcategory GUID; this skips the CSV
+		// header row regardless of the OS display language
+		if !auditpolGuidRe.MatchString(guid) {
+			continue
+		}
 
 		res = append(res, AuditpolEntry{
 			MachineName:      strings.TrimSpace(record[0]),

--- a/providers/os/resources/windows/auditpol_test.go
+++ b/providers/os/resources/windows/auditpol_test.go
@@ -24,7 +24,8 @@ func TestParseAuditpol(t *testing.T) {
 	auditpol, err := windows.ParseAuditpol(f.Stdout)
 	require.NoError(t, err)
 
-	assert.Equal(t, 60, len(auditpol))
+	// 59 policy rows; the CSV header row is not an entry
+	assert.Equal(t, 59, len(auditpol))
 
 	expected := &windows.AuditpolEntry{
 		MachineName:      "Test",
@@ -53,6 +54,61 @@ func TestParseAuditpol_NonCSVOutput(t *testing.T) {
 			_, err := windows.ParseAuditpol(strings.NewReader(in))
 			require.NoError(t, err)
 		})
+	}
+}
+
+// The header row is six comma-separated column titles and previously parsed
+// as a policy entry with subcategory "Subcategory".
+func TestParseAuditpol_SkipsHeaderRow(t *testing.T) {
+	in := "Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting\n" +
+		"Test,System,Logon,{0CCE9215-69AE-11D9-BED3-505054503030},Success,\n"
+	auditpol, err := windows.ParseAuditpol(strings.NewReader(in))
+	require.NoError(t, err)
+	require.Len(t, auditpol, 1)
+	assert.Equal(t, "Logon", auditpol[0].Subcategory)
+}
+
+func TestLookupAuditpolSubcategory(t *testing.T) {
+	cases := []struct {
+		guid     string
+		name     string
+		category string
+	}{
+		{"0CCE9215-69AE-11D9-BED3-505054503030", "Logon", "Logon/Logoff"},
+		{"{0CCE922B-69AE-11D9-BED3-505054503030}", "Process Creation", "Detailed Tracking"},
+		{"0cce923f-69ae-11d9-bed3-505054503030", "Credential Validation", "Account Logon"},
+		{"0CCE9245-69AE-11D9-BED3-505054503030", "Removable Storage", "Object Access"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.guid, func(t *testing.T) {
+			sub, ok := windows.LookupAuditpolSubcategory(tc.guid)
+			require.True(t, ok)
+			assert.Equal(t, tc.name, sub.Name)
+			assert.Equal(t, tc.category, sub.Category)
+		})
+	}
+
+	_, ok := windows.LookupAuditpolSubcategory("00000000-0000-0000-0000-000000000000")
+	assert.False(t, ok)
+}
+
+// Every subcategory the auditpol recording reports must resolve through the
+// well-known table, and vice versa — the table and a real system agree on
+// all 59 subcategories and their English names.
+func TestAuditpolSubcategoryTableMatchesSystem(t *testing.T) {
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/auditpol.toml"))
+	require.NoError(t, err)
+	f, err := mock.RunCommand("auditpol /get /category:* /r")
+	require.NoError(t, err)
+	auditpol, err := windows.ParseAuditpol(f.Stdout)
+	require.NoError(t, err)
+	require.Len(t, auditpol, 59)
+
+	for _, entry := range auditpol {
+		sub, ok := windows.LookupAuditpolSubcategory(entry.SubcategoryGUID)
+		require.True(t, ok, "GUID %s missing from table", entry.SubcategoryGUID)
+		assert.Equal(t, entry.Subcategory, sub.Name, "name mismatch for %s", entry.SubcategoryGUID)
+		assert.NotEmpty(t, sub.Category)
 	}
 }
 

--- a/providers/os/resources/windows_auditpolicy.go
+++ b/providers/os/resources/windows_auditpolicy.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/resources/windows"
+)
+
+// fetchAuditpolEntries runs `auditpol /get /category:* /r` and parses its CSV
+// output. Shared by the windows.auditPolicy and (deprecated) auditpol
+// resources so both replay the same command.
+func fetchAuditpolEntries(runtime *plugin.Runtime) ([]windows.AuditpolEntry, error) {
+	o, err := CreateResource(runtime, "powershell", map[string]*llx.RawData{
+		"script": llx.StringData("[Console]::OutputEncoding = [Text.Encoding]::UTF8;auditpol /get /category:* /r"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := o.(*mqlPowershell)
+	out := cmd.GetStdout()
+	if out.Error != nil {
+		return nil, fmt.Errorf("could not run auditpol: %w", out.Error)
+	}
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return nil, fmt.Errorf("could not run auditpol: %s", strings.TrimSpace(cmd.Stderr.Data))
+	}
+
+	return windows.ParseAuditpol(strings.NewReader(out.Data))
+}
+
+func (p *mqlWindowsAuditPolicy) list() ([]any, error) {
+	entries, err := fetchAuditpolEntries(p.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	subcategories := make([]any, len(entries))
+	for i := range entries {
+		entry := entries[i]
+		known, _ := windows.LookupAuditpolSubcategory(entry.SubcategoryGUID)
+		name := known.Name
+		if name == "" {
+			name = entry.Subcategory
+		}
+		flags := auditpolInclusionAudits(entry.InclusionSetting)
+		o, err := CreateResource(p.MqlRuntime, "windows.auditPolicy.subcategory", map[string]*llx.RawData{
+			"name":             llx.StringData(name),
+			"guid":             llx.StringData(entry.SubcategoryGUID),
+			"category":         llx.StringData(known.Category),
+			"localizedName":    llx.StringData(entry.Subcategory),
+			"success":          llx.BoolData(flags.success),
+			"failure":          llx.BoolData(flags.failure),
+			"inclusionSetting": llx.StringData(entry.InclusionSetting),
+			"exclusionSetting": llx.StringData(entry.ExclusionSetting),
+		})
+		if err != nil {
+			return nil, err
+		}
+		subcategories[i] = o.(*mqlWindowsAuditPolicySubcategory)
+	}
+
+	return subcategories, nil
+}
+
+func (p *mqlWindowsAuditPolicySubcategory) id() (string, error) {
+	// a subcategory missing from the system has no GUID; key it by the
+	// requested name instead
+	if p.Guid.Data != "" {
+		return "windows.auditPolicy.subcategory/" + p.Guid.Data, nil
+	}
+	return "windows.auditPolicy.subcategory/" + p.Name.Data, nil
+}
+
+func initWindowsAuditPolicySubcategory(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// we only look up the subcategory if it is selected by name and nothing else
+	raw, ok := args["name"]
+	if !ok || len(args) != 1 {
+		return args, nil, nil
+	}
+	name, ok := raw.Value.(string)
+	if !ok {
+		return nil, nil, errors.New("name must be a string")
+	}
+
+	o, err := CreateResource(runtime, "windows.auditPolicy", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	policy := o.(*mqlWindowsAuditPolicy)
+	list := policy.GetList()
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+
+	// the key may be the English name, the localized name the system reports,
+	// or a GUID with or without braces
+	want := strings.ToLower(strings.TrimSpace(name))
+	want = strings.TrimPrefix(want, "{")
+	want = strings.TrimSuffix(want, "}")
+	for i := range list.Data {
+		sub := list.Data[i].(*mqlWindowsAuditPolicySubcategory)
+		if strings.ToLower(sub.Name.Data) == want ||
+			strings.ToLower(sub.Guid.Data) == want ||
+			strings.ToLower(sub.LocalizedName.Data) == want {
+			return nil, sub, nil
+		}
+	}
+
+	// The subcategory is not present on the system: nothing about it is
+	// audited, so success and failure are explicitly false. (Null would make
+	// `subcategory(...) { success && failure }` pass, since null && null is
+	// true in MQL.) The fields auditpol would have reported stay null.
+	res := &mqlWindowsAuditPolicySubcategory{}
+	res.MqlRuntime = runtime
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Success = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Failure = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Guid.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Category.State = plugin.StateIsSet | plugin.StateIsNull
+	res.LocalizedName.State = plugin.StateIsSet | plugin.StateIsNull
+	res.InclusionSetting.State = plugin.StateIsSet | plugin.StateIsNull
+	res.ExclusionSetting.State = plugin.StateIsSet | plugin.StateIsNull
+	res.__id, _ = res.id()
+	return nil, res, nil
+}

--- a/providers/os/resources/windows_auditpolicy_test.go
+++ b/providers/os/resources/windows_auditpolicy_test.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+)
+
+func TestResource_WindowsAuditPolicy(t *testing.T) {
+	// one tester for all subtests, so lookups, list iteration, and the
+	// missing-subcategory stub share a runtime and exercise resource caching
+	win := testutils.InitTester(testutils.WindowsMock())
+
+	t.Run("list all subcategories", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.length")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, int64(59), res[0].Data.Value)
+	})
+
+	t.Run("lookup by English name", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('Logon') { success && failure }")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		truthy, found := res[0].Data.IsTruthy()
+		assert.True(t, found)
+		assert.True(t, truthy)
+	})
+
+	t.Run("lookup is case-insensitive", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('logon').guid")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "0CCE9215-69AE-11D9-BED3-505054503030", res[0].Data.Value)
+	})
+
+	t.Run("lookup by GUID", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('0CCE922B-69AE-11D9-BED3-505054503030').name")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Process Creation", res[0].Data.Value)
+	})
+
+	t.Run("lookup by braced GUID", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('{0CCE922B-69AE-11D9-BED3-505054503030}').name")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Process Creation", res[0].Data.Value)
+	})
+
+	t.Run("category from the well-known table", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('Credential Validation').category")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Account Logon", res[0].Data.Value)
+	})
+
+	t.Run("filter by category", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.where(category == 'Detailed Tracking').length")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, int64(6), res[0].Data.Value)
+	})
+
+	t.Run("success and failure derive from the inclusion setting", func(t *testing.T) {
+		cases := []struct {
+			name             string // its inclusion setting in the recording
+			success, failure bool
+		}{
+			{"System Integrity", true, true},            // "Success and Failure"
+			{"Security State Change", true, false},      // "Success"
+			{"Security System Extension", false, false}, // "No Auditing"
+		}
+		for _, tc := range cases {
+			res := win.TestQuery(t, "windows.auditPolicy.subcategory('"+tc.name+"').success")
+			require.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.success, res[0].Data.Value, "success for %s", tc.name)
+
+			res = win.TestQuery(t, "windows.auditPolicy.subcategory('"+tc.name+"').failure")
+			require.NotEmpty(t, res)
+			assert.Empty(t, res[0].Result().Error)
+			assert.Equal(t, tc.failure, res[0].Data.Value, "failure for %s", tc.name)
+		}
+	})
+
+	t.Run("raw settings pass through unchanged", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('Logon').inclusionSetting")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Success and Failure", res[0].Data.Value)
+
+		// on an English system the localized name is the English name
+		res = win.TestQuery(t, "windows.auditPolicy.subcategory('Logon').localizedName")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Logon", res[0].Data.Value)
+	})
+
+	t.Run("missing subcategory audits nothing and fails checks cleanly", func(t *testing.T) {
+		res := win.TestQuery(t, "windows.auditPolicy.subcategory('No Such Subcategory').success")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, false, res[0].Data.Value)
+
+		res = win.TestQuery(t, "windows.auditPolicy.subcategory('No Such Subcategory').guid")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Nil(t, res[0].Data.Value)
+
+		res = win.TestQuery(t, "windows.auditPolicy.subcategory('No Such Subcategory') { success && failure }")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		truthy, found := res[0].Data.IsTruthy()
+		assert.True(t, found)
+		assert.False(t, truthy)
+
+		// a missed lookup must not poison the cache for present subcategories
+		res = win.TestQuery(t, "windows.auditPolicy.subcategory('Logon').success")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, true, res[0].Data.Value)
+	})
+}
+
+// TestResource_WindowsAuditPolicyGerman exercises the resource end-to-end
+// against a recording of a German-localized `auditpol /r`: subcategory names
+// and inclusion settings arrive localized, while name, category, and the
+// success/failure booleans must come out language-stable.
+func TestResource_WindowsAuditPolicyGerman(t *testing.T) {
+	abs, err := filepath.Abs("testdata/auditpol_windows_de.json")
+	require.NoError(t, err)
+	de := testutils.InitTester(testutils.RecordingMock(abs))
+
+	// "Richtlinienänderungen überwachen" / "Erfolg" on GUID 0CCE922F
+	t.Run("English name resolves on a German system", func(t *testing.T) {
+		res := de.TestQuery(t, "windows.auditPolicy.subcategory('Audit Policy Change').success")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, true, res[0].Data.Value)
+
+		res = de.TestQuery(t, "windows.auditPolicy.subcategory('Audit Policy Change').failure")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, false, res[0].Data.Value)
+
+		res = de.TestQuery(t, "windows.auditPolicy.subcategory('Audit Policy Change').localizedName")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Richtlinienänderungen überwachen", res[0].Data.Value)
+	})
+
+	t.Run("localized name resolves too", func(t *testing.T) {
+		res := de.TestQuery(t, "windows.auditPolicy.subcategory('Richtlinienänderungen überwachen').guid")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "0CCE922F-69AE-11D9-BED3-505054503030", res[0].Data.Value)
+	})
+
+	t.Run("names and categories are reported in English", func(t *testing.T) {
+		res := de.TestQuery(t, "windows.auditPolicy.subcategory('0CCE9217-69AE-11D9-BED3-505054503030').name")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Account Lockout", res[0].Data.Value)
+
+		res = de.TestQuery(t, "windows.auditPolicy.subcategory('Account Lockout').category")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "Logon/Logoff", res[0].Data.Value)
+	})
+
+	// the issue's motivating check shape: "Success and Failure" on a
+	// localized system, asserted without GUIDs or props
+	t.Run("audit check pattern", func(t *testing.T) {
+		res := de.TestQuery(t, "windows.auditPolicy.subcategory('Account Lockout') { success && failure }")
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		truthy, found := res[0].Data.IsTruthy()
+		assert.True(t, found)
+		assert.True(t, truthy)
+	})
+}


### PR DESCRIPTION
## Summary

Closes #8056 with the rework discussed there: instead of bolting a lookup onto `auditpol`, this introduces `windows.auditPolicy` shaped like our modern resources, and deprecates `auditpol` / `auditpol.entry` in place.

```coffeescript
windows.auditPolicy {
  []windows.auditPolicy.subcategory
}

windows.auditPolicy.subcategory @defaults("name success failure") {
  init(name string)
  name string              // canonical English name, language-stable
  guid string
  category string          // e.g. "Logon/Logoff", from the built-in table
  localizedName string     // what the system actually reported
  success bool
  failure bool
  inclusionSetting string  // raw localized setting text
  exclusionSetting string
}
```

The checks from `mondoo-windows-security` collapse from a GUID + props pair to:

```coffeescript
windows.auditPolicy.subcategory("Logon") { success && failure }
windows.auditPolicy.subcategory("Process Creation").success
windows.auditPolicy.where(category == "Account Logon").all(success)
```

## Design notes

- **Language stability.** `auditpol /r` localizes subcategory names and settings to the OS display language (the class of bug #8286 fixed for the booleans). `name` and `category` are resolved from a built-in table of the 59 well-known subcategory GUIDs (MS-GPAC), verified 1:1 against the English real-system recording, so name-based queries behave identically on a German box. The lookup accepts the English name, the localized name, or a GUID (braces optional, case-insensitive).
- **The issue's `subcategory(name string)` field syntax** isn't expressible in the `.lr` grammar (field args are dependency refs), so the lookup is an `init` on the element resource — the `package(name:)` / `service(name:)` pattern.
- **Missing subcategory → explicit false, not null.** The issue asked for null settings so checks fail rather than error. It turns out `null && null` evaluates to **true** in MQL (`llx.boolAndOpV2` returns `v.Value == nil` when the left side is nil), so a null stub would make `subcategory("typo") { success && failure }` *pass*. A missing subcategory audits nothing, so `success`/`failure` are a real `false` (mirroring `package(...).installed`); the fields auditpol would have reported stay null.
- **Header-row parser fix.** `ParseAuditpol` parsed the CSV header as a 60th entry (`subcategory == "Subcategory"`), which `auditpol` has been emitting as a bogus row. Rows are now required to carry a GUID-shaped subcategory GUID, which drops the header in any display language. This is the one observable change to the deprecated resource.
- **Deprecation.** `auditpol` and `auditpol.entry` are marked `@maturity("deprecated")` and share the fetch path with the new resource; their `.lr.versions` entries are untouched. New entries land at 13.28.2.

## Testing

- `windows` package: parser header-skip case, GUID lookup forms, and a consistency test proving the 59-entry table matches the real-system recording name-for-name.
- `resources` package (English recording, shared runtime to exercise caching): list length, lookup by name / case-insensitive / GUID / braced GUID, category + category filtering, success/failure for all three inclusion settings, raw-field passthrough, and the miss behavior — `success == false`, `guid == null`, block check falsy, and no cache poisoning of subsequent good lookups.
- German recording end-to-end: English-name lookup on a localized system, localized-name lookup, English name/category output, and the motivating `{ success && failure }` check pattern.
- Existing `auditpol` tests (including the German ones from #8286) pass unchanged, plus a new length assertion locking in the header fix.

`go test ./providers/os/resources/... ` is green; `gofmt`, `go vet`, and a second `mqlr generate` pass produce no diffs. (The `connection/device/linux` build failure under `go test ./...` is a pre-existing missing-mockgen-artifact issue, untouched here.)