### PR TITLE
✨ gcp: expand pubsub with bigtable sink, push wrapper, snapshot labels

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -4709,6 +4709,15 @@ private gcp.project.pubsubService.subscription.config @defaults("topic.name ackD
   // that do not deliver to Cloud Storage. A populated value persists topic
   // data into object storage, so it widens the data's exposure surface.
   cloudStorageConfig dict
+  // Bigtable delivery sink
+  //
+  // When the subscription writes messages directly to a Cloud Bigtable table
+  // this dict holds the destination `table`, the `appProfileId` used for
+  // routing, the `serviceAccountEmail` the export runs as, the `writeMetadata`
+  // flag, and the delivery `state`. Null for subscriptions that do not deliver
+  // to Bigtable. A populated value is an egress path that moves topic data into
+  // a queryable store, so it widens the data's exposure surface.
+  bigtableConfig dict
 }
 
 // Google Cloud (GCP) Pub/Sub configuration for subscriptions that operate in push mode
@@ -4723,6 +4732,13 @@ private gcp.project.pubsubService.subscription.config.pushconfig @defaults("attr
   oidcTokenServiceAccountEmail string
   // Audience used when generating the OIDC token for authenticated push
   oidcTokenAudience string
+  // How the Pub/Sub message is wrapped before it is delivered to the endpoint
+  //
+  // PUBSUB wraps the message in the standard Pub/Sub envelope (message data plus
+  // metadata such as attributes and the message ID); NONE delivers the raw
+  // message payload with metadata moved to HTTP headers. Empty when push
+  // delivery is not configured.
+  wrapper string
 }
 
 // Google Cloud (GCP) Pub/Sub snapshot
@@ -4740,6 +4756,8 @@ private gcp.project.pubsubService.snapshot @defaults("name") {
   topic gcp.project.pubsubService.topic
   // When the snapshot expires
   expiration time
+  // Labels associated with this snapshot
+  labels map[string]string
 }
 
 // Google Cloud (GCP) Pub/Sub schema

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -7022,6 +7022,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.pubsubService.subscription.config.cloudStorageConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetCloudStorageConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.pubsubService.subscription.config.bigtableConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetBigtableConfig()).ToDataRes(types.Dict)
+	},
 	"gcp.project.pubsubService.subscription.config.pushconfig.configId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).GetConfigId()).ToDataRes(types.String)
 	},
@@ -7037,6 +7040,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.pubsubService.subscription.config.pushconfig.oidcTokenAudience": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).GetOidcTokenAudience()).ToDataRes(types.String)
 	},
+	"gcp.project.pubsubService.subscription.config.pushconfig.wrapper": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).GetWrapper()).ToDataRes(types.String)
+	},
 	"gcp.project.pubsubService.snapshot.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSnapshot).GetProjectId()).ToDataRes(types.String)
 	},
@@ -7048,6 +7054,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.pubsubService.snapshot.expiration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSnapshot).GetExpiration()).ToDataRes(types.Time)
+	},
+	"gcp.project.pubsubService.snapshot.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSnapshot).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"gcp.project.pubsubService.schema.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSchema).GetProjectId()).ToDataRes(types.String)
@@ -23417,6 +23426,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).CloudStorageConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.pubsubService.subscription.config.bigtableConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).BigtableConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.pubsubService.subscription.config.pushconfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).__id, ok = v.Value.(string)
 		return
@@ -23441,6 +23454,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).OidcTokenAudience, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.pubsubService.subscription.config.pushconfig.wrapper": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).Wrapper, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.pubsubService.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSnapshot).__id, ok = v.Value.(string)
 		return
@@ -23459,6 +23476,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.pubsubService.snapshot.expiration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSnapshot).Expiration, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.snapshot.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSnapshot).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.pubsubService.schema.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -53498,6 +53519,7 @@ type mqlGcpProjectPubsubServiceSubscriptionConfig struct {
 	RetryPolicy                   plugin.TValue[any]
 	BigqueryConfig                plugin.TValue[any]
 	CloudStorageConfig            plugin.TValue[any]
+	BigtableConfig                plugin.TValue[any]
 }
 
 // createGcpProjectPubsubServiceSubscriptionConfig creates a new instance of this resource
@@ -53613,6 +53635,10 @@ func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetCloudStorageConfig() *
 	return &c.CloudStorageConfig
 }
 
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetBigtableConfig() *plugin.TValue[any] {
+	return &c.BigtableConfig
+}
+
 // mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig for the gcp.project.pubsubService.subscription.config.pushconfig resource
 type mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig struct {
 	MqlRuntime *plugin.Runtime
@@ -53623,6 +53649,7 @@ type mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig struct {
 	Attributes                   plugin.TValue[map[string]any]
 	OidcTokenServiceAccountEmail plugin.TValue[string]
 	OidcTokenAudience            plugin.TValue[string]
+	Wrapper                      plugin.TValue[string]
 }
 
 // createGcpProjectPubsubServiceSubscriptionConfigPushconfig creates a new instance of this resource
@@ -53682,6 +53709,10 @@ func (c *mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig) GetOidcTokenAud
 	return &c.OidcTokenAudience
 }
 
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig) GetWrapper() *plugin.TValue[string] {
+	return &c.Wrapper
+}
+
 // mqlGcpProjectPubsubServiceSnapshot for the gcp.project.pubsubService.snapshot resource
 type mqlGcpProjectPubsubServiceSnapshot struct {
 	MqlRuntime *plugin.Runtime
@@ -53691,6 +53722,7 @@ type mqlGcpProjectPubsubServiceSnapshot struct {
 	Name       plugin.TValue[string]
 	Topic      plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	Expiration plugin.TValue[*time.Time]
+	Labels     plugin.TValue[map[string]any]
 }
 
 // createGcpProjectPubsubServiceSnapshot creates a new instance of this resource
@@ -53744,6 +53776,10 @@ func (c *mqlGcpProjectPubsubServiceSnapshot) GetTopic() *plugin.TValue[*mqlGcpPr
 
 func (c *mqlGcpProjectPubsubServiceSnapshot) GetExpiration() *plugin.TValue[*time.Time] {
 	return &c.Expiration
+}
+
+func (c *mqlGcpProjectPubsubServiceSnapshot) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 // mqlGcpProjectPubsubServiceSchema for the gcp.project.pubsubService.schema resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3928,6 +3928,7 @@ gcp.project.pubsubService.schema.type 13.7.2
 gcp.project.pubsubService.schemas 13.7.2
 gcp.project.pubsubService.snapshot 9.0.0
 gcp.project.pubsubService.snapshot.expiration 9.0.0
+gcp.project.pubsubService.snapshot.labels 13.23.2
 gcp.project.pubsubService.snapshot.name 9.0.0
 gcp.project.pubsubService.snapshot.projectId 9.0.0
 gcp.project.pubsubService.snapshot.topic 9.0.0
@@ -3936,6 +3937,7 @@ gcp.project.pubsubService.subscription 9.0.0
 gcp.project.pubsubService.subscription.config 9.0.0
 gcp.project.pubsubService.subscription.config.ackDeadline 9.0.0
 gcp.project.pubsubService.subscription.config.bigqueryConfig 13.21.2
+gcp.project.pubsubService.subscription.config.bigtableConfig 13.23.2
 gcp.project.pubsubService.subscription.config.cloudStorageConfig 13.21.2
 gcp.project.pubsubService.subscription.config.deadLetterPolicy 13.7.2
 gcp.project.pubsubService.subscription.config.detached 11.0.146
@@ -3952,6 +3954,7 @@ gcp.project.pubsubService.subscription.config.pushconfig.configId 9.0.0
 gcp.project.pubsubService.subscription.config.pushconfig.endpoint 9.0.0
 gcp.project.pubsubService.subscription.config.pushconfig.oidcTokenAudience 13.18.1
 gcp.project.pubsubService.subscription.config.pushconfig.oidcTokenServiceAccountEmail 13.18.1
+gcp.project.pubsubService.subscription.config.pushconfig.wrapper 13.23.2
 gcp.project.pubsubService.subscription.config.retainAckedMessages 9.0.0
 gcp.project.pubsubService.subscription.config.retentionDuration 9.0.0
 gcp.project.pubsubService.subscription.config.retryPolicy 13.7.2

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.21.1",
-  "generated_at": "2026-06-07T20:20:08-07:00",
+  "version": "13.23.1",
+  "generated_at": "2026-06-12T14:27:21-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -520,7 +520,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 		return nil, err
 	}
 
-	var pushEndpoint, oidcServiceAccountEmail, oidcAudience string
+	var pushEndpoint, oidcServiceAccountEmail, oidcAudience, pushWrapper string
 	var pushAttributes map[string]string
 	if cfg.PushConfig != nil {
 		pushEndpoint = cfg.PushConfig.PushEndpoint
@@ -529,6 +529,12 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 			oidcServiceAccountEmail = oidc.ServiceAccountEmail
 			oidcAudience = oidc.Audience
 		}
+		switch cfg.PushConfig.Wrapper.(type) {
+		case *pubsubpb.PushConfig_PubsubWrapper_:
+			pushWrapper = "PUBSUB"
+		case *pubsubpb.PushConfig_NoWrapper_:
+			pushWrapper = "NONE"
+		}
 	}
 	pushConfig, err := CreateResource(g.MqlRuntime, "gcp.project.pubsubService.subscription.config.pushconfig", map[string]*llx.RawData{
 		"configId":                     llx.StringData(pubsubConfigId(projectId, name)),
@@ -536,6 +542,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 		"attributes":                   llx.MapData(convert.MapToInterfaceMap(pushAttributes), types.String),
 		"oidcTokenServiceAccountEmail": llx.StringData(oidcServiceAccountEmail),
 		"oidcTokenAudience":            llx.StringData(oidcAudience),
+		"wrapper":                      llx.StringData(pushWrapper),
 	})
 	if err != nil {
 		return nil, err
@@ -569,7 +576,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 		}
 	}
 
-	var bigqueryConfigDict, cloudStorageConfigDict map[string]any
+	var bigqueryConfigDict, cloudStorageConfigDict, bigtableConfigDict map[string]any
 	if bq := cfg.GetBigqueryConfig(); bq != nil {
 		bigqueryConfigDict, err = protoToDict(bq)
 		if err != nil {
@@ -578,6 +585,12 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 	}
 	if cs := cfg.GetCloudStorageConfig(); cs != nil {
 		cloudStorageConfigDict, err = protoToDict(cs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if bt := cfg.GetBigtableConfig(); bt != nil {
+		bigtableConfigDict, err = protoToDict(bt)
 		if err != nil {
 			return nil, err
 		}
@@ -603,6 +616,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 		"retryPolicy":                   llx.DictData(retryDict),
 		"bigqueryConfig":                llx.DictData(bigqueryConfigDict),
 		"cloudStorageConfig":            llx.DictData(cloudStorageConfigDict),
+		"bigtableConfig":                llx.DictData(bigtableConfigDict),
 	})
 	if err != nil {
 		return nil, err
@@ -670,6 +684,7 @@ func (g *mqlGcpProjectPubsubService) snapshots() ([]any, error) {
 			"name":       llx.StringData(snapshotName),
 			"topic":      llx.ResourceData(topic, "gcp.project.pubsubService.topic"),
 			"expiration": llx.TimeData(expiration),
+			"labels":     llx.MapData(convert.MapToInterfaceMap(s.Labels), types.String),
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Resolves #7457 — fills the remaining **Tier 1 / Tier 2** audit-relevant Pub/Sub fields that the `pubsub/v2` proto-direct admin clients make cheap to surface. Most of the issue's fields were already added in prior work; this PR closes the last three gaps.

## Added

| Tier | Resource | Field | Type | Source |
|---|---|---|---|---|
| 1 | `subscription.config` | `bigtableConfig` | `dict` | `pubsubpb.Subscription.BigtableConfig` |
| 1 | `subscription.config.pushconfig` | `wrapper` | `string` (`PUBSUB`/`NONE`) | `PushConfig` wrapper oneof |
| 2 | `snapshot` | `labels` | `map[string]string` | `Snapshot.Labels` |

- **`bigtableConfig`** — Bigtable export sink; an egress path that moves topic data into a queryable store, so it widens the data's exposure surface (same audit framing as the existing `bigqueryConfig` / `cloudStorageConfig` sinks). Modeled as a `dict` via `protoToDict`, consistent with those siblings. The current SDK's `BigtableConfig` exposes `table` / `appProfileId` / `serviceAccountEmail` / `writeMetadata` / `state`; `protoToDict` serializes whatever the SDK provides.
- **`wrapper`** — `PUBSUB` wraps the message in the standard Pub/Sub envelope; `NONE` delivers the raw payload with metadata in HTTP headers. Extracted via a type-switch on the `PushConfig.Wrapper` oneof.
- **`labels`** — already exposed on topics and subscriptions, was missing on snapshots. Set on the snapshot creator; the init path inherits it from the list.

## Notes

- Additive only — no MQL schema breaks.
- No new API calls: all three reuse existing `ListSnapshots` / `ListSubscriptions` data, so `gcp.permissions.json` gains no permissions (only its stale version/timestamp header caught up to the current `13.23.1`).
- New `.lr.versions` entries at `13.23.2` (next patch after the current provider version).
- Already present from earlier work (verified, unchanged): `bigqueryConfig`, `cloudStorageConfig`, `oidcToken*`, `ingestionDataSourceSettings`, `satisfiesPzs`, `enforceInTransit`.

## Verification

- `mqlr generate` clean, `go build ./resources/` passes, `gofmt` applied.
- Interactive verification against a project with Bigtable-sink subscriptions / labeled snapshots still recommended (`make providers/install/gcp` + `mql shell gcp`).