### PR TITLE
🐛 status: add an implicit timeout to network calls

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -33,6 +33,10 @@ func init() {
 	rootCmd.AddCommand(StatusCmd)
 }
 
+// statusTimeout bounds the total time the status command spends on network
+// calls so it cannot hang indefinitely when the API is unreachable.
+const statusTimeout = 30 * time.Second
+
 // StatusCmd represents the version command
 var StatusCmd = &cobra.Command{
 	Use:   "status",
@@ -48,7 +52,12 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 
 		config.DisplayUsedConfig()
 
-		s, err := checkStatus()
+		// Bound all network calls with a deadline so the command cannot hang
+		// indefinitely when the API is unreachable.
+		ctx, cancel := context.WithTimeout(cmd.Context(), statusTimeout)
+		defer cancel()
+
+		s, err := checkStatus(ctx)
 		if err != nil {
 			return err
 		}
@@ -59,7 +68,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		case "json":
 			s.RenderJson()
 		default:
-			s.RenderCliStatus()
+			s.RenderCliStatus(ctx)
 		}
 
 		if !s.Client.Registered || s.Client.PingPongError != nil {
@@ -71,7 +80,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 	},
 }
 
-func checkStatus() (Status, error) {
+func checkStatus(ctx context.Context) (Status, error) {
 	s := Status{
 		Client: ClientStatus{
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -98,7 +107,7 @@ func checkStatus() (Status, error) {
 	}
 
 	// check server health and clock skew
-	upstreamStatus, err := health.CheckApiHealth(httpClient, opts.UpstreamApiEndpoint())
+	upstreamStatus, err := health.CheckApiHealthContext(ctx, httpClient, opts.UpstreamApiEndpoint())
 	if err != nil {
 		log.Error().Err(err).Msg("could not check upstream health")
 	}
@@ -113,7 +122,7 @@ func checkStatus() (Status, error) {
 
 	// Fetch latest version using the configured updates URL
 	releaseURL := s.Client.UpdatesURL + "/mql/latest.json?ignoreCache=1"
-	latestVersion, err := mql.GetLatestReleaseName(releaseURL, httpClient)
+	latestVersion, err := mql.GetLatestReleaseNameContext(ctx, releaseURL, httpClient)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to get latest version")
 	}
@@ -143,7 +152,7 @@ func checkStatus() (Status, error) {
 		// try to ping the server
 		client, err := upstream.NewAgentManagerClient(s.Upstream.API.Endpoint, httpClient, plugins...)
 		if err == nil {
-			_, err = client.PingPong(context.Background(), &upstream.Ping{})
+			_, err = client.PingPong(ctx, &upstream.Ping{})
 			if err != nil {
 				s.Client.PingPongError = err
 			}
@@ -192,7 +201,7 @@ type ClientStatus struct {
 	ProvidersURL   string              `json:"providersUrl,omitempty"`
 }
 
-func (s Status) RenderCliStatus() {
+func (s Status) RenderCliStatus(ctx context.Context) {
 	if s.Client.Platform != nil {
 		agent := s.Client
 		log.Info().Msg("Platform:\t\t" + agent.Platform.Name)
@@ -217,7 +226,7 @@ func (s Status) RenderCliStatus() {
 	log.Info().Msg("Updates URL:\t\t" + s.Client.UpdatesURL)
 	log.Info().Msg("Providers URL:\t" + s.Client.ProvidersURL)
 
-	installed, outdated, err := getProviders()
+	installed, outdated, err := getProviders(ctx)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to get provider info")
 	}
@@ -281,7 +290,7 @@ func (s Status) RenderYaml() {
 	os.Stdout.Write(output)
 }
 
-func getProviders() ([]string, []string, error) {
+func getProviders(ctx context.Context) ([]string, []string, error) {
 	var installed []string
 	var outdated []string
 
@@ -293,11 +302,13 @@ func getProviders() ([]string, []string, error) {
 	for _, provider := range allProviders {
 		installed = append(installed, provider.Name)
 		if errCircuitBreaker == nil {
-			latestVersion, err := providers.LatestVersion(context.Background(), provider.Name)
+			latestVersion, err := providers.LatestVersion(ctx, provider.Name)
 			if err != nil {
-				// If we get a connection refused, we assume this will happen for all providers
-				// so we will return early
-				if errors.Is(err, syscall.ECONNREFUSED) {
+				// If we get a connection refused or the deadline expires, we assume
+				// this will happen for all providers, so we stop checking versions.
+				if errors.Is(err, syscall.ECONNREFUSED) ||
+					errors.Is(err, context.DeadlineExceeded) ||
+					errors.Is(err, context.Canceled) {
 					errCircuitBreaker = err
 				}
 				continue

--- a/mql.go
+++ b/mql.go
@@ -4,6 +4,7 @@
 package mql
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -62,7 +63,18 @@ var mqlLatestReleaseUrl = "https://releases.mondoo.com/mql/latest.json?ignoreCac
 
 // GetLatestReleaseName fetches the name of the latest release from releases.mondoo.com
 func GetLatestReleaseName(releaseUrl string, client *http.Client) (string, error) {
-	resp, err := client.Get(releaseUrl)
+	return GetLatestReleaseNameContext(context.Background(), releaseUrl, client)
+}
+
+// GetLatestReleaseNameContext behaves like GetLatestReleaseName but honors the
+// provided context, so callers can bound the request with a deadline or cancel it.
+func GetLatestReleaseNameContext(ctx context.Context, releaseUrl string, client *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseUrl, nil)
+	if err != nil {
+		return "", fmt.Errorf("error building latest release request: %v", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error fetching latest release: %v", err)
 	}

--- a/providers-sdk/v1/upstream/health/health.go
+++ b/providers-sdk/v1/upstream/health/health.go
@@ -23,6 +23,12 @@ type Status struct {
 }
 
 func CheckApiHealth(httpClient *http.Client, endpoint string) (Status, error) {
+	return CheckApiHealthContext(context.Background(), httpClient, endpoint)
+}
+
+// CheckApiHealthContext behaves like CheckApiHealth but honors the provided
+// context, so callers can bound the health check with a deadline or cancel it.
+func CheckApiHealthContext(ctx context.Context, httpClient *http.Client, endpoint string) (Status, error) {
 	status := Status{}
 	status.API.Endpoint = endpoint
 
@@ -31,7 +37,7 @@ func CheckApiHealth(httpClient *http.Client, endpoint string) (Status, error) {
 	if err != nil {
 		return status, err
 	}
-	healthResp, err := healthClient.Check(context.Background(), &HealthCheckRequest{})
+	healthResp, err := healthClient.Check(ctx, &HealthCheckRequest{})
 	if err != nil {
 		return status, err
 	} else {

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -82,7 +82,12 @@ func (r *MondooProviderRegistry) GetLatestVersion(ctx context.Context, name stri
 		return "", errors.Wrap(err, "failed to construct latest version URL")
 	}
 
-	res, err := client.Get(latestURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to build latest version request")
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

The `status` command can hang indefinitely when the Mondoo API is unreachable — for example, behind a corporate proxy with no proxy settings in `mondoo.yml`. This was observed in the installer (mondoohq/installer#694), where `cnspec status` blocked forever after a successful install. A 10s timeout was added in the install script as a workaround (mondoohq/installer#696), but the root fix belongs in the `status` command itself.

Fixes #7357.

## Root cause

`status` makes several network calls with no overall deadline:

- `health.CheckApiHealth`, `mql.GetLatestReleaseName`, and `PingPong` each rely only on the HTTP client's 30s timeout, so their sum can run well past what callers expect.
- The worst offender is the provider-version check (`getProviders` → `providers.LatestVersion`): it retries each provider (`RetryMax=3`) and only circuit-broke on `ECONNREFUSED`. Behind a blackholed proxy you get *timeouts*, not connection-refused, so it looped over every installed provider — effectively hanging.

## Fix

Bound the entire command with a single **30s deadline** and thread a `context.Context` through every network call so they all share it:

- `checkStatus`, `RenderCliStatus`, and `getProviders` now take a `context.Context`.
- The health check, latest-release fetch, and `PingPong` use the shared deadline.
- `providers.GetLatestVersion` now honors its `context` (it previously ignored it) via `http.NewRequestWithContext`.
- `getProviders` also circuit-breaks on `context.DeadlineExceeded`/`Canceled`, so it stops checking the moment the deadline expires.

To avoid breaking external callers (e.g. cnspec), the SDK-exported helpers gained backward-compatible context variants: `health.CheckApiHealthContext` and `mql.GetLatestReleaseNameContext`. The original `CheckApiHealth` / `GetLatestReleaseName` now delegate with `context.Background()`.

When the API is unreachable, `status` now returns within ~30s with a non-zero exit code instead of hanging.

## Testing

- `go build` of the affected packages passes.
- `go vet` clean on changed packages (the pre-existing `providers/*_test.go` mockgen failures are unrelated).