### PR TITLE
🐛 ms365: clear error for direct authenticationMethodConfiguration query

### DIFF
--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -619,6 +620,20 @@ func newMqlAuthenticationMethodsPolicy(runtime *plugin.Runtime, policy models.Au
 	}
 
 	return resource.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy), nil
+}
+
+// initMicrosoftConditionalAccessAuthenticationMethodConfiguration rejects a
+// direct query of this resource. It is a member of
+// authenticationMethodsPolicy.authenticationMethodConfigurations and has no
+// standalone identity, so a bare binding resolves to an empty husk whose plain
+// fields (id, state) then fail with "cannot convert primitive with NO type
+// information". When it is built as a list element (with an __id), it passes
+// through unchanged.
+func initMicrosoftConditionalAccessAuthenticationMethodConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	return nil, nil, errors.New("microsoft.conditionalAccess.authenticationMethodConfiguration cannot be queried directly; read it through microsoft.conditionalAccess.authenticationMethodsPolicy.authenticationMethodConfigurations")
 }
 
 func newMqlAuthenticationMethodConfiguration(runtime *plugin.Runtime, config models.AuthenticationMethodConfigurationable) (*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration, error) {

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -333,7 +333,7 @@ func init() {
 			Create: createMicrosoftConditionalAccessAuthenticationMethodsPolicy,
 		},
 		"microsoft.conditionalAccess.authenticationMethodConfiguration": {
-			// to override args, implement: initMicrosoftConditionalAccessAuthenticationMethodConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMicrosoftConditionalAccessAuthenticationMethodConfiguration,
 			Create: createMicrosoftConditionalAccessAuthenticationMethodConfiguration,
 		},
 		"microsoft.conditionalAccess.namedLocations": {


### PR DESCRIPTION
## Summary

Closes the last open item from #7712. While smoke-testing the ms365 provider, four resources were reported failing with `cannot convert primitive with NO type information` when used as a query **subject** (vs. traversed through the parent). Verifying against the live tenant on current `main` shows **three of the four are already fixed**:

| Reported resource | State on `main` | Fixed by |
|---|---|---|
| `identitySecurityDefaultsEnforcementPolicy` | ✅ works | #8180 (init delegation) |
| `conditionalAccess.authenticationMethodsPolicy` | ✅ works | #8180 (init delegation) |
| `conditionalAccess.namedLocations` | ✅ works | #7713 (computed field) |
| `conditionalAccess.authenticationMethodConfiguration` | ❌ still husks | **this PR** |

Both fixing PRs merged weeks after the issue was filed.

## The remaining case

`microsoft.conditionalAccess.authenticationMethodConfiguration` is a **list-element** resource — a row of `authenticationMethodsPolicy.authenticationMethodConfigurations`. It has no standalone identity, so a bare binding builds an empty husk whose plain `id`/`state` fields fail with the cryptic conversion error. (The same generic behavior affects any list-row type queried directly, e.g. `microsoft.conditionalAccess.policy`; `namedLocations` escapes it only because its fields are computed accessors.)

This adds an `init` that rejects a bare direct query with an actionable message pointing at the list accessor, while passing through unchanged when the resource is built as a list element (carries an `__id`). No schema changes — the only `*.lr.go` change is wiring the new init into the factory; `.lr.versions` and `*.json` are unchanged.

## Verification

Built and installed the provider, run against the live lunalectric tenant:

| Query | Before | After |
|---|---|---|
| `...authenticationMethodConfiguration { id state }` (direct) | `cannot convert primitive with NO type information` | clear error pointing at the list accessor |
| `...authenticationMethodsPolicy.authenticationMethodConfigurations { id state }` (proper path) | works | works (unchanged) |

`go build ./resources/...` and the ms365 resources test suite pass; `gofmt` clean.