### PR TITLE
✨ vsphere: expose esxcli system security (TPM key persistence + cert store)

### DIFF
--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -795,6 +795,59 @@ func (v *mqlVsphereHost) snmp() (map[string]any, error) {
 	return esxiClient.Snmp()
 }
 
+func (v *mqlVsphereHost) security() (*mqlVsphereHostSecurity, error) {
+	esxiClient, err := v.esxiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := CreateResource(v.MqlRuntime, "vsphere.host.security", map[string]*llx.RawData{
+		"__id": llx.StringData(esxiClient.InventoryPath + "/security"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	security := res.(*mqlVsphereHostSecurity)
+	security.hostInventoryPath = esxiClient.InventoryPath
+	return security, nil
+}
+
+type mqlVsphereHostSecurityInternal struct {
+	hostInventoryPath string
+}
+
+func (v *mqlVsphereHostSecurity) esxiClient() (*resourceclient.Esxi, error) {
+	conn := v.MqlRuntime.Connection.(*connection.VsphereConnection)
+	return esxiClient(conn, v.hostInventoryPath)
+}
+
+func (v *mqlVsphereHostSecurity) keyPersistenceEnabled() (bool, error) {
+	esxiClient, err := v.esxiClient()
+	if err != nil {
+		return false, err
+	}
+	return esxiClient.KeyPersistenceEnabled()
+}
+
+func (v *mqlVsphereHostSecurity) certificateStore() ([]any, error) {
+	esxiClient, err := v.esxiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := esxiClient.CertificateStore()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]any, len(store))
+	for i := range store {
+		res[i] = store[i]
+	}
+	return res, nil
+}
+
 // firewallRulesets exposes the per-service ESXi firewall ruleset definitions
 // from mo.HostSystem.Config.Firewall (already fetched via HostInfo). Each
 // ruleset bundles a per-service rule list, an enabled flag, and the

--- a/providers/vsphere/resources/resourceclient/esxi.go
+++ b/providers/vsphere/resources/resourceclient/esxi.go
@@ -783,3 +783,65 @@ func (esxi *Esxi) Snmp() (map[string]any, error) {
 	}
 	return snmp, nil
 }
+
+// keyPersistenceUnsupportedRegex matches the esxcli error returned by hosts
+// that predate TPM-backed key persistence (added in ESXi 7.0 Update 2) or that
+// boot without a TPM. On those hosts the `system security keypersistence get`
+// namespace is either absent or reports the feature as unavailable.
+var keyPersistenceUnsupportedRegex = regexp.MustCompile(`(?i)(not supported|unknown command|invalid namespace|tpm)`)
+
+// KeyPersistenceEnabled reports whether TPM-backed key persistence is enabled
+// on the host.
+//
+// ($ESXCli).system.security.keypersistence.get()
+//
+//	Enabled: false
+//
+// Hosts that do not support the feature (pre-7.0 Update 2 or no TPM) make the
+// namespace unavailable; we treat that as "not enabled" rather than failing the
+// whole host query.
+func (esxi *Esxi) KeyPersistenceEnabled() (bool, error) {
+	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
+	if err != nil {
+		return false, err
+	}
+
+	res, err := e.Run(context.Background(), []string{"system", "security", "keypersistence", "get"})
+	if err != nil {
+		if keyPersistenceUnsupportedRegex.MatchString(err.Error()) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, val := range res.Values {
+		for k := range val {
+			if !strings.EqualFold(k, "Enabled") {
+				continue
+			}
+			if len(val[k]) > 0 {
+				return strings.EqualFold(val[k][0], "true"), nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// CertificateStore lists the trusted CA certificates installed in the host
+// certificate store.
+//
+// ($ESXCli).system.security.certificatestore.list()
+func (esxi *Esxi) CertificateStore() ([]map[string]any, error) {
+	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := e.Run(context.Background(), []string{"system", "security", "certificatestore", "list"})
+	if err != nil {
+		return nil, err
+	}
+
+	return esxiValuesSliceToDict(res.Values), nil
+}

--- a/providers/vsphere/resources/resourceclient/esxi_test.go
+++ b/providers/vsphere/resources/resourceclient/esxi_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resourceclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyPersistenceUnsupportedRegex(t *testing.T) {
+	// Errors from hosts that lack the keypersistence namespace (pre-7.0 Update 2
+	// or no TPM) should be treated as "feature not enabled", not propagated.
+	unsupported := []string{
+		"Error: Not supported on this host",
+		"Unknown command or namespace system security keypersistence get",
+		"Invalid namespace: keypersistence",
+		"This host does not have a TPM",
+	}
+	for _, msg := range unsupported {
+		assert.True(t, keyPersistenceUnsupportedRegex.MatchString(msg), "expected match: %q", msg)
+	}
+
+	// Genuine failures (auth, connectivity) must surface as real errors.
+	realErrors := []string{
+		"connection refused",
+		"401 Unauthorized",
+		"context deadline exceeded",
+	}
+	for _, msg := range realErrors {
+		assert.False(t, keyPersistenceUnsupportedRegex.MatchString(msg), "expected no match: %q", msg)
+	}
+}

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -511,6 +511,23 @@ private vsphere.host @defaults("moid name") {
   ipRouteConfig() vsphere.host.ipRouteConfig
   // vSAN host configuration; null when the host does not participate in vSAN
   vsan() vsphere.host.vsan
+  // Host security configuration: TPM key persistence and the trusted certificate store
+  security() vsphere.host.security
+}
+
+// ESXi Host Security Configuration
+//
+// Examine host-level security settings exposed through the esxcli
+// `system security` namespace. `keyPersistenceEnabled` reports whether
+// TPM-backed key persistence is active — available on ESXi 7.0 Update 2
+// and later, and false on hosts that predate or otherwise do not support
+// it. `certificateStore` lists the trusted CA certificates installed in
+// the host certificate store.
+private vsphere.host.security @defaults("keyPersistenceEnabled") {
+  // Whether TPM-backed key persistence is enabled (ESXi 7.0 Update 2 and later); false on hosts that do not support it
+  keyPersistenceEnabled() bool
+  // Trusted CA certificates installed in the host certificate store
+  certificateStore() []dict
 }
 
 // vSAN Cluster Configuration

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -34,6 +34,7 @@ const (
 	ResourceVsphereDatastore                  string = "vsphere.datastore"
 	ResourceVsphereCluster                    string = "vsphere.cluster"
 	ResourceVsphereHost                       string = "vsphere.host"
+	ResourceVsphereHostSecurity               string = "vsphere.host.security"
 	ResourceVsphereClusterVsan                string = "vsphere.cluster.vsan"
 	ResourceVsphereHostVsan                   string = "vsphere.host.vsan"
 	ResourceVsphereHostVsanDiskGroup          string = "vsphere.host.vsan.diskGroup"
@@ -157,6 +158,10 @@ func init() {
 		"vsphere.host": {
 			Init:   initVsphereHost,
 			Create: createVsphereHost,
+		},
+		"vsphere.host.security": {
+			// to override args, implement: initVsphereHostSecurity(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createVsphereHostSecurity,
 		},
 		"vsphere.cluster.vsan": {
 			// to override args, implement: initVsphereClusterVsan(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -904,6 +909,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"vsphere.host.vsan": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetVsan()).ToDataRes(types.Resource("vsphere.host.vsan"))
+	},
+	"vsphere.host.security": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetSecurity()).ToDataRes(types.Resource("vsphere.host.security"))
+	},
+	"vsphere.host.security.keyPersistenceEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHostSecurity).GetKeyPersistenceEnabled()).ToDataRes(types.Bool)
+	},
+	"vsphere.host.security.certificateStore": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHostSecurity).GetCertificateStore()).ToDataRes(types.Array(types.Dict))
 	},
 	"vsphere.cluster.vsan.uuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereClusterVsan).GetUuid()).ToDataRes(types.String)
@@ -2690,6 +2704,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.vsan": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).Vsan, ok = plugin.RawToTValue[*mqlVsphereHostVsan](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.security": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).Security, ok = plugin.RawToTValue[*mqlVsphereHostSecurity](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.security.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHostSecurity).__id, ok = v.Value.(string)
+		return
+	},
+	"vsphere.host.security.keyPersistenceEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHostSecurity).KeyPersistenceEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.security.certificateStore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHostSecurity).CertificateStore, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vsphere.cluster.vsan.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5939,6 +5969,7 @@ type mqlVsphereHost struct {
 	DnsConfig                   plugin.TValue[*mqlVsphereHostDnsConfig]
 	IpRouteConfig               plugin.TValue[*mqlVsphereHostIpRouteConfig]
 	Vsan                        plugin.TValue[*mqlVsphereHostVsan]
+	Security                    plugin.TValue[*mqlVsphereHostSecurity]
 }
 
 // createVsphereHost creates a new instance of this resource
@@ -6421,6 +6452,75 @@ func (c *mqlVsphereHost) GetVsan() *plugin.TValue[*mqlVsphereHostVsan] {
 		}
 
 		return c.vsan()
+	})
+}
+
+func (c *mqlVsphereHost) GetSecurity() *plugin.TValue[*mqlVsphereHostSecurity] {
+	return plugin.GetOrCompute[*mqlVsphereHostSecurity](&c.Security, func() (*mqlVsphereHostSecurity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.host", c.__id, "security")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlVsphereHostSecurity), nil
+			}
+		}
+
+		return c.security()
+	})
+}
+
+// mqlVsphereHostSecurity for the vsphere.host.security resource
+type mqlVsphereHostSecurity struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlVsphereHostSecurityInternal
+	KeyPersistenceEnabled plugin.TValue[bool]
+	CertificateStore      plugin.TValue[[]any]
+}
+
+// createVsphereHostSecurity creates a new instance of this resource
+func createVsphereHostSecurity(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlVsphereHostSecurity{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("vsphere.host.security", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlVsphereHostSecurity) MqlName() string {
+	return "vsphere.host.security"
+}
+
+func (c *mqlVsphereHostSecurity) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlVsphereHostSecurity) GetKeyPersistenceEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KeyPersistenceEnabled, func() (bool, error) {
+		return c.keyPersistenceEnabled()
+	})
+}
+
+func (c *mqlVsphereHostSecurity) GetCertificateStore() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.CertificateStore, func() ([]any, error) {
+		return c.certificateStore()
 	})
 }
 

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -259,6 +259,9 @@ vsphere.host.packages 9.0.0
 vsphere.host.properties 9.0.0
 vsphere.host.rebootRequired 13.2.5
 vsphere.host.secureBootEnabled 13.0.10
+vsphere.host.security 13.5.2
+vsphere.host.security.certificateStore 13.5.2
+vsphere.host.security.keyPersistenceEnabled 13.5.2
 vsphere.host.service 13.1.1
 vsphere.host.service.key 13.1.1
 vsphere.host.service.label 13.1.1


### PR DESCRIPTION
## What

Adds a `vsphere.host.security` resource exposing the `esxcli system security` namespace requested in #5876:

```
vsphere.host.security {
  keyPersistenceEnabled  bool      // TPM-backed key persistence (ESXi 7.0 Update 2+)
  certificateStore       []dict    // trusted CA certs in the host store
}
```

Reached via `vsphere.hosts { security { keyPersistenceEnabled certificateStore } }`.

`keyPersistenceEnabled` is exactly the value requested in #5879 (`$ESXcli.system.security.keypersistence.get.invoke() | Select Enabled`).

## How

Backed by the govmomi **API-based esxcli executor** (`esx.NewExecutor(...).Run(...)`) — the same path the provider already uses for `network`/`software`/`system` esxcli data. This deliberately avoids the `esxi.command` / vmware-tools-binary route, per the maintainer discussion on the issue (that binary may be absent and would error the whole query).

`keyPersistenceEnabled` carries the version guard called out in #5879: `get` is only available on ESXi 8.x / 7.0 Update 2+, and hosts that predate it — or that boot without a TPM — make the `system security keypersistence` namespace unavailable. A matching esxcli error degrades to `false` rather than failing the host query; genuine auth/connectivity errors still propagate.

## Notes

- New `.lr.versions` entries at `13.5.2` (next patch after `13.5.1`); `config.go` `Version` left for the release flow.
- The grouping sub-resource uses a synthetic hidden `__id` (`<inventoryPath>/security`), matching existing host config singletons (`ntpConfig`, `dnsConfig`).

## Testing

- ✅ builds, `go vet`, `golangci-lint` clean on changed files
- ✅ `go test ./resources/...` passes, incl. a new unit test for the version-detection regex (unsupported-host errors degrade; auth/network errors propagate)
- ⚠️ **Not yet verified against a live ESXi host** — no reachable host in the dev environment, and the vSim simulator doesn't implement esxcli (see the existing `TestESXi` TODO). Implemented against documented esxcli output (`Enabled: false`). A reviewer with ESXi 7.x+ access should confirm the exact `certificatestore list` output keys before merge.

Closes #5876
Closes #5879