### PR TITLE
🐛 ms365: fix filter caching collision on microsoft.identityAndAccess

### DIFF
--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -67,9 +67,7 @@ func (a *mqlMicrosoftIdentityAndAccess) organization() (*mqlMicrosoftTenant, err
 }
 
 func (pim *mqlMicrosoftIdentityAndAccessPrivilegedIdentityManagement) policies() (*mqlMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies, error) {
-	resource, err := CreateResource(pim.MqlRuntime, ResourceMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies, map[string]*llx.RawData{
-		"__id": llx.StringData(identityAndAccessPrivilegedIdentityManagementPoliciesID),
-	})
+	resource, err := CreateResource(pim.MqlRuntime, ResourceMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +80,22 @@ func initMicrosoftIdentityAndAccess(runtime *plugin.Runtime, args map[string]*ll
 
 func initMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	return args, nil, nil
+}
+
+// id derives the resource cache key from the filter so that querying the same
+// resource with different filters yields distinct instances. Without the
+// filter in the __id, the runtime caches the first result and reuses it for
+// every later filter.
+func (a *mqlMicrosoftIdentityAndAccess) id() (string, error) {
+	return "microsoft.identityAndAccess/filter/" + a.Filter.Data, nil
+}
+
+func (a *mqlMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies) id() (string, error) {
+	return identityAndAccessPrivilegedIdentityManagementPoliciesID + "/filter/" + a.Filter.Data, nil
+}
+
+func (a *mqlMicrosoftIdentityAndAccessAccessReviews) id() (string, error) {
+	return "microsoft.identityAndAccess.accessReviews/filter/" + a.Filter.Data, nil
 }
 
 func (a *mqlMicrosoftIdentityAndAccess) list() ([]any, error) {

--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -82,20 +82,30 @@ func initMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies(runtime 
 	return args, nil, nil
 }
 
+// filterID renders a filter value for embedding in a resource __id, using an
+// explicit sentinel for the empty (no-filter) case so unfiltered instances
+// share one deliberate cache key rather than an empty-suffixed one.
+func filterID(filter string) string {
+	if filter == "" {
+		return "<none>"
+	}
+	return filter
+}
+
 // id derives the resource cache key from the filter so that querying the same
 // resource with different filters yields distinct instances. Without the
 // filter in the __id, the runtime caches the first result and reuses it for
 // every later filter.
 func (a *mqlMicrosoftIdentityAndAccess) id() (string, error) {
-	return "microsoft.identityAndAccess/filter/" + a.Filter.Data, nil
+	return "microsoft.identityAndAccess/filter/" + filterID(a.Filter.Data), nil
 }
 
 func (a *mqlMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies) id() (string, error) {
-	return identityAndAccessPrivilegedIdentityManagementPoliciesID + "/filter/" + a.Filter.Data, nil
+	return identityAndAccessPrivilegedIdentityManagementPoliciesID + "/filter/" + filterID(a.Filter.Data), nil
 }
 
 func (a *mqlMicrosoftIdentityAndAccessAccessReviews) id() (string, error) {
-	return "microsoft.identityAndAccess.accessReviews/filter/" + a.Filter.Data, nil
+	return "microsoft.identityAndAccess.accessReviews/filter/" + filterID(a.Filter.Data), nil
 }
 
 func (a *mqlMicrosoftIdentityAndAccess) list() ([]any, error) {

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -12868,7 +12868,12 @@ func createMicrosoftIdentityAndAccessAccessReviews(runtime *plugin.Runtime, args
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.identityAndAccess.accessReviews", res.__id)
@@ -13880,7 +13885,12 @@ func createMicrosoftIdentityAndAccess(runtime *plugin.Runtime, args map[string]*
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.identityAndAccess", res.__id)
@@ -14061,7 +14071,12 @@ func createMicrosoftIdentityAndAccessPrivilegedIdentityManagementPolicies(runtim
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.identityAndAccess.privilegedIdentityManagement.policies", res.__id)


### PR DESCRIPTION
## What

`microsoft.identityAndAccess(filter:)`, `…privilegedIdentityManagement.policies(filter:)`, and `…accessReviews(filter:)` all accept a `filter` argument but created their resource with an **empty `__id`**. Because the runtime caches resources by `resourceName + \x00 + __id`, two queries that differ only by filter resolved to the **same cached instance**, so the second filter silently returned the first filter's results.

Reported in #5705:

```mql
microsoft.identityAndAccess(filter: "scopeId eq '/' and scopeType eq 'Directory'")
microsoft.identityAndAccess(filter: "scopeId eq '/' and scopeType eq 'DirectoryRole'")
# → identical results
```

## Fix

Add `id()` overrides that fold the `filter` value into the `__id`, so each distinct filter produces a distinct cache key (the generated `create` calls `id()` whenever `__id == ""`, covering both the accessor path and the direct `(filter:)` query path). The PIM `policies()` accessor no longer hardcodes a constant `__id`, so it stays consistent with the filtered path.

No schema change — `id()` is Go-only; the only generated delta is the `__id` wiring in `ms365.lr.go`.

## Verification

Live against a tenant, both filters in a single process (so the cache is actually exercised):

```mql
{
  directoryScopeType:     microsoft.identityAndAccess(filter: "scopeId eq '/' and scopeType eq 'Directory'").list.first.scopeType,
  directoryRoleScopeType: microsoft.identityAndAccess(filter: "scopeId eq '/' and scopeType eq 'DirectoryRole'").list.first.scopeType
}
```

```
directoryScopeType:     "Directory"
directoryRoleScopeType: "DirectoryRole"
```

Before the fix both returned `"Directory"` (the first result, served from cache).

Fixes #5705