### PR TITLE
✨ ms365: expose tenant-wide Intune device management settings

### DIFF
--- a/providers/ms365/resources/devicemanagement_tenantsettings.go
+++ b/providers/ms365/resources/devicemanagement_tenantsettings.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/devicemanagement"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/ms365/connection"
+)
+
+const devicemanagementSettingsID = "microsoft.devicemanagement/settings"
+
+// settings exposes the tenant-wide Intune device management settings. When the
+// tenant has no Intune device management configuration the Graph settings
+// object is null, in which case every field resolves to null rather than a
+// fabricated zero value.
+// requires DeviceManagementConfiguration.Read.All permission
+func (a *mqlMicrosoftDevicemanagement) settings() (*mqlMicrosoftDevicemanagementSettings, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	dm, err := graphClient.DeviceManagement().Get(ctx, &devicemanagement.DeviceManagementRequestBuilderGetRequestConfiguration{
+		QueryParameters: &devicemanagement.DeviceManagementRequestBuilderGetQueryParameters{
+			Select: []string{"settings"},
+		},
+	})
+	if err != nil {
+		return nil, transformError(err)
+	}
+
+	// nil pointers (no Intune settings configured, or a field omitted) flow
+	// through the *DataPtr helpers as null rather than a fabricated zero value
+	var secureByDefault, scheduledActionEnabled *bool
+	var checkinThresholdDays *int32
+	if dm != nil && dm.GetSettings() != nil {
+		settings := dm.GetSettings()
+		secureByDefault = settings.GetSecureByDefault()
+		checkinThresholdDays = settings.GetDeviceComplianceCheckinThresholdDays()
+		scheduledActionEnabled = settings.GetIsScheduledActionEnabled()
+	}
+
+	resource, err := CreateResource(a.MqlRuntime, "microsoft.devicemanagement.settings", map[string]*llx.RawData{
+		"__id":                                 llx.StringData(devicemanagementSettingsID),
+		"secureByDefault":                      llx.BoolDataPtr(secureByDefault),
+		"deviceComplianceCheckinThresholdDays": llx.IntDataPtr(checkinThresholdDays),
+		"isScheduledActionEnabled":             llx.BoolDataPtr(scheduledActionEnabled),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resource.(*mqlMicrosoftDevicemanagementSettings), nil
+}
+
+// initMicrosoftDevicemanagementSettings rebuilds the parent chain so that the
+// settings resource can be queried by its full dotted path
+// (microsoft.devicemanagement.settings) and not just nested under
+// microsoft.devicemanagement. Without it, the dotted form is built as a bare
+// husk with no data.
+func initMicrosoftDevicemanagementSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	dm, err := CreateResource(runtime, "microsoft.devicemanagement", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	settings, err := dm.(*mqlMicrosoftDevicemanagement).settings()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, settings, nil
+}

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -2513,6 +2513,25 @@ microsoft.devicemanagement {
   windowsQualityUpdateProfiles() []microsoft.devicemanagement.windowsQualityUpdateProfile
   // Group policy (administrative template) configurations
   groupPolicyConfigurations() []microsoft.devicemanagement.groupPolicyConfiguration
+  // Tenant-wide Intune device management settings
+  settings() microsoft.devicemanagement.settings
+}
+
+// Intune tenant-wide device management settings
+//
+// Examine the tenant-level Intune settings: whether devices are marked
+// noncompliant when no compliance policy targets them (`secureByDefault`),
+// how many days a device may go without checking in before it is treated as
+// noncompliant, and whether scheduled actions for noncompliant devices are
+// enabled. This is null when no Intune device management settings are
+// configured for the tenant.
+private microsoft.devicemanagement.settings @defaults("secureByDefault deviceComplianceCheckinThresholdDays isScheduledActionEnabled") {
+  // Whether devices are marked noncompliant when no compliance policy targets them
+  secureByDefault bool
+  // Number of days a device may go without checking in before it is treated as noncompliant
+  deviceComplianceCheckinThresholdDays int
+  // Whether scheduled actions for noncompliant devices are enabled tenant-wide
+  isScheduledActionEnabled bool
 }
 
 // Microsoft Intune group policy configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -130,6 +130,7 @@ const (
 	ResourceMicrosoftRolemanagementRoledefinition                                                        string = "microsoft.rolemanagement.roledefinition"
 	ResourceMicrosoftRolemanagementRoleassignment                                                        string = "microsoft.rolemanagement.roleassignment"
 	ResourceMicrosoftDevicemanagement                                                                    string = "microsoft.devicemanagement"
+	ResourceMicrosoftDevicemanagementSettings                                                            string = "microsoft.devicemanagement.settings"
 	ResourceMicrosoftDevicemanagementGroupPolicyConfiguration                                            string = "microsoft.devicemanagement.groupPolicyConfiguration"
 	ResourceMicrosoftDevicemanagementGroupPolicyDefinitionValue                                          string = "microsoft.devicemanagement.groupPolicyDefinitionValue"
 	ResourceMicrosoftDevicemanagementWindowsUpdateRing                                                   string = "microsoft.devicemanagement.windowsUpdateRing"
@@ -655,6 +656,10 @@ func init() {
 		"microsoft.devicemanagement": {
 			// to override args, implement: initMicrosoftDevicemanagement(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftDevicemanagement,
+		},
+		"microsoft.devicemanagement.settings": {
+			Init:   initMicrosoftDevicemanagementSettings,
+			Create: createMicrosoftDevicemanagementSettings,
 		},
 		"microsoft.devicemanagement.groupPolicyConfiguration": {
 			// to override args, implement: initMicrosoftDevicemanagementGroupPolicyConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3448,6 +3453,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.devicemanagement.groupPolicyConfigurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagement).GetGroupPolicyConfigurations()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.groupPolicyConfiguration")))
+	},
+	"microsoft.devicemanagement.settings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagement).GetSettings()).ToDataRes(types.Resource("microsoft.devicemanagement.settings"))
+	},
+	"microsoft.devicemanagement.settings.secureByDefault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementSettings).GetSecureByDefault()).ToDataRes(types.Bool)
+	},
+	"microsoft.devicemanagement.settings.deviceComplianceCheckinThresholdDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementSettings).GetDeviceComplianceCheckinThresholdDays()).ToDataRes(types.Int)
+	},
+	"microsoft.devicemanagement.settings.isScheduledActionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementSettings).GetIsScheduledActionEnabled()).ToDataRes(types.Bool)
 	},
 	"microsoft.devicemanagement.groupPolicyConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementGroupPolicyConfiguration).GetId()).ToDataRes(types.String)
@@ -9384,6 +9401,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.devicemanagement.groupPolicyConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagement).GroupPolicyConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagement).Settings, ok = plugin.RawToTValue[*mqlMicrosoftDevicemanagementSettings](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.settings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementSettings).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.devicemanagement.settings.secureByDefault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementSettings).SecureByDefault, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.settings.deviceComplianceCheckinThresholdDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementSettings).DeviceComplianceCheckinThresholdDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.settings.isScheduledActionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementSettings).IsScheduledActionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.groupPolicyConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22406,6 +22443,7 @@ type mqlMicrosoftDevicemanagement struct {
 	WindowsFeatureUpdateProfiles       plugin.TValue[[]any]
 	WindowsQualityUpdateProfiles       plugin.TValue[[]any]
 	GroupPolicyConfigurations          plugin.TValue[[]any]
+	Settings                           plugin.TValue[*mqlMicrosoftDevicemanagementSettings]
 }
 
 // createMicrosoftDevicemanagement creates a new instance of this resource
@@ -22790,6 +22828,76 @@ func (c *mqlMicrosoftDevicemanagement) GetGroupPolicyConfigurations() *plugin.TV
 
 		return c.groupPolicyConfigurations()
 	})
+}
+
+func (c *mqlMicrosoftDevicemanagement) GetSettings() *plugin.TValue[*mqlMicrosoftDevicemanagementSettings] {
+	return plugin.GetOrCompute[*mqlMicrosoftDevicemanagementSettings](&c.Settings, func() (*mqlMicrosoftDevicemanagementSettings, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement", c.__id, "settings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftDevicemanagementSettings), nil
+			}
+		}
+
+		return c.settings()
+	})
+}
+
+// mqlMicrosoftDevicemanagementSettings for the microsoft.devicemanagement.settings resource
+type mqlMicrosoftDevicemanagementSettings struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDevicemanagementSettingsInternal it will be used here
+	SecureByDefault                      plugin.TValue[bool]
+	DeviceComplianceCheckinThresholdDays plugin.TValue[int64]
+	IsScheduledActionEnabled             plugin.TValue[bool]
+}
+
+// createMicrosoftDevicemanagementSettings creates a new instance of this resource
+func createMicrosoftDevicemanagementSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDevicemanagementSettings{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.devicemanagement.settings", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDevicemanagementSettings) MqlName() string {
+	return "microsoft.devicemanagement.settings"
+}
+
+func (c *mqlMicrosoftDevicemanagementSettings) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDevicemanagementSettings) GetSecureByDefault() *plugin.TValue[bool] {
+	return &c.SecureByDefault
+}
+
+func (c *mqlMicrosoftDevicemanagementSettings) GetDeviceComplianceCheckinThresholdDays() *plugin.TValue[int64] {
+	return &c.DeviceComplianceCheckinThresholdDays
+}
+
+func (c *mqlMicrosoftDevicemanagementSettings) GetIsScheduledActionEnabled() *plugin.TValue[bool] {
+	return &c.IsScheduledActionEnabled
 }
 
 // mqlMicrosoftDevicemanagementGroupPolicyConfiguration for the microsoft.devicemanagement.groupPolicyConfiguration resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -575,6 +575,10 @@ microsoft.devicemanagement.roleScopeTag.displayName 13.0.12
 microsoft.devicemanagement.roleScopeTag.id 13.0.12
 microsoft.devicemanagement.roleScopeTag.isBuiltIn 13.0.12
 microsoft.devicemanagement.roleScopeTags 13.0.12
+microsoft.devicemanagement.settings 13.7.2
+microsoft.devicemanagement.settings.deviceComplianceCheckinThresholdDays 13.7.2
+microsoft.devicemanagement.settings.isScheduledActionEnabled 13.7.2
+microsoft.devicemanagement.settings.secureByDefault 13.7.2
 microsoft.devicemanagement.windowsAutopilotDeploymentProfile 13.0.12
 microsoft.devicemanagement.windowsAutopilotDeploymentProfile.assignedDeviceCount 13.0.12
 microsoft.devicemanagement.windowsAutopilotDeploymentProfile.createdDateTime 13.0.12


### PR DESCRIPTION
## What

Adds `microsoft.devicemanagement.settings`, backed by the Graph `GET /deviceManagement?$select=settings` endpoint (`deviceManagementSettings`):

| Field | Meaning |
|---|---|
| `secureByDefault` | Devices are marked noncompliant when no compliance policy targets them |
| `deviceComplianceCheckinThresholdDays` | Days a device may go without checking in before it's treated as noncompliant |
| `isScheduledActionEnabled` | Whether scheduled actions for noncompliant devices are enabled tenant-wide |

Resolves #5632 (the `secureByDefault` setting the issue asked for, plus the two sibling settings on the same object).

## Notes

- **Null, not fabricated zero.** When a tenant has no Intune device management settings configured, Graph returns `settings: null`. Each field resolves to `null` rather than `false`/`0`, so a policy can distinguish "secure-by-default is off" from "not configured". Verified against a tenant whose `settings` is null:

  ```
  microsoft.devicemanagement.settings.secureByDefault            => null
  microsoft.devicemanagement.settings { secureByDefault, deviceComplianceCheckinThresholdDays, isScheduledActionEnabled }
                                                                 => all null
  microsoft.devicemanagement { settings { secureByDefault } }    => settings.secureByDefault: null
  ```

- **Dotted-path init.** Because `settings` is both a field and a resource name, the resource carries an `init` that rebuilds the parent chain so the full dotted path (`microsoft.devicemanagement.settings…`) resolves instead of building an empty husk.

- Populated values weren't exercised live (the verification tenant has no Intune settings configured); the field mapping is a direct `*DataPtr` deref of the SDK getters.

Closes #5632