### PR TITLE
✨ ms365: add microsoft.user.isAdministrator

### DIFF
--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sync"
 
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	errors "github.com/cockroachdb/errors"
@@ -36,6 +37,30 @@ type Ms365Connection struct {
 	clientId      string
 	organization  string
 	sharepointUrl string
+
+	adminPrincipalsMu sync.Mutex
+	adminPrincipals   map[string]struct{}
+}
+
+// AdminPrincipalIDs returns the set of principal IDs that hold an active
+// Microsoft Entra directory role. The set is computed once per connection via
+// load and cached for the connection's lifetime, so it is not recomputed for
+// every user. Errors are not cached, so a transient failure is retried on the
+// next call.
+func (p *Ms365Connection) AdminPrincipalIDs(load func() (map[string]struct{}, error)) (map[string]struct{}, error) {
+	p.adminPrincipalsMu.Lock()
+	defer p.adminPrincipalsMu.Unlock()
+
+	if p.adminPrincipals != nil {
+		return p.adminPrincipals, nil
+	}
+
+	set, err := load()
+	if err != nil {
+		return nil, err
+	}
+	p.adminPrincipals = set
+	return set, nil
 }
 
 func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*Ms365Connection, error) {

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -851,6 +851,12 @@ private microsoft.user @defaults("id displayName userPrincipalName") {
   id string
   // Whether the user account is enabled
   accountEnabled bool
+  // Administrator status
+  //
+  // True when the user is directly assigned at least one active Microsoft
+  // Entra directory role. Roles held only through group membership or as
+  // not-yet-activated PIM-eligible assignments are not reflected.
+  isAdministrator() bool
   // User city
   city string
   // User company name

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1736,6 +1736,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.user.accountEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUser).GetAccountEnabled()).ToDataRes(types.Bool)
 	},
+	"microsoft.user.isAdministrator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUser).GetIsAdministrator()).ToDataRes(types.Bool)
+	},
 	"microsoft.user.city": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUser).GetCity()).ToDataRes(types.String)
 	},
@@ -6856,6 +6859,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.user.accountEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftUser).AccountEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.user.isAdministrator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUser).IsAdministrator, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.user.city": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16441,6 +16448,7 @@ type mqlMicrosoftUser struct {
 	// optional: if you define mqlMicrosoftUserInternal it will be used here
 	Id                         plugin.TValue[string]
 	AccountEnabled             plugin.TValue[bool]
+	IsAdministrator            plugin.TValue[bool]
 	City                       plugin.TValue[string]
 	CompanyName                plugin.TValue[string]
 	Country                    plugin.TValue[string]
@@ -16523,6 +16531,12 @@ func (c *mqlMicrosoftUser) GetId() *plugin.TValue[string] {
 
 func (c *mqlMicrosoftUser) GetAccountEnabled() *plugin.TValue[bool] {
 	return &c.AccountEnabled
+}
+
+func (c *mqlMicrosoftUser) GetIsAdministrator() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsAdministrator, func() (bool, error) {
+		return c.isAdministrator()
+	})
 }
 
 func (c *mqlMicrosoftUser) GetCity() *plugin.TValue[string] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1161,6 +1161,7 @@ microsoft.user.identity 11.1.0
 microsoft.user.identity.issuer 11.1.0
 microsoft.user.identity.issuerAssignedId 11.1.0
 microsoft.user.identity.signInType 11.1.0
+microsoft.user.isAdministrator 13.7.2
 microsoft.user.job 9.0.0
 microsoft.user.jobTitle 9.0.0
 microsoft.user.lastPasswordChangeDateTime 11.2.1

--- a/providers/ms365/resources/user_isadministrator.go
+++ b/providers/ms365/resources/user_isadministrator.go
@@ -5,57 +5,45 @@ package resources
 
 import (
 	"context"
-	"sync"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/ms365/connection"
 )
 
-var (
-	adminPrincipalsMu    sync.Mutex
-	adminPrincipalsCache = map[*connection.Ms365Connection]map[string]struct{}{}
-)
-
 // adminPrincipalIDs returns the set of principal IDs (users, groups, or service
 // principals) that hold at least one active Microsoft Entra directory role
-// assignment. The set is fetched once per connection and cached so that
-// microsoft.user.isAdministrator resolves from memory instead of issuing a
-// request per user.
+// assignment. The set is fetched once per connection (cached on the connection,
+// so it is freed with it) so that microsoft.user.isAdministrator resolves from
+// memory instead of issuing a request per user.
 // requires RoleManagement.Read.Directory permission
 func adminPrincipalIDs(runtime *plugin.Runtime) (map[string]struct{}, error) {
 	conn := runtime.Connection.(*connection.Ms365Connection)
 
-	adminPrincipalsMu.Lock()
-	defer adminPrincipalsMu.Unlock()
-	if set, ok := adminPrincipalsCache[conn]; ok {
-		return set, nil
-	}
-
-	graphClient, err := conn.GraphClient()
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	resp, err := graphClient.RoleManagement().Directory().RoleAssignments().Get(ctx, nil)
-	if err != nil {
-		return nil, transformError(err)
-	}
-	assignments, err := iterate[models.UnifiedRoleAssignmentable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleAssignmentCollectionResponseFromDiscriminatorValue)
-	if err != nil {
-		return nil, err
-	}
-
-	set := make(map[string]struct{}, len(assignments))
-	for _, assignment := range assignments {
-		if principalID := assignment.GetPrincipalId(); principalID != nil {
-			set[*principalID] = struct{}{}
+	return conn.AdminPrincipalIDs(func() (map[string]struct{}, error) {
+		graphClient, err := conn.GraphClient()
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	adminPrincipalsCache[conn] = set
-	return set, nil
+		ctx := context.Background()
+		resp, err := graphClient.RoleManagement().Directory().RoleAssignments().Get(ctx, nil)
+		if err != nil {
+			return nil, transformError(err)
+		}
+		assignments, err := iterate[models.UnifiedRoleAssignmentable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleAssignmentCollectionResponseFromDiscriminatorValue)
+		if err != nil {
+			return nil, err
+		}
+
+		set := make(map[string]struct{}, len(assignments))
+		for _, assignment := range assignments {
+			if principalID := assignment.GetPrincipalId(); principalID != nil {
+				set[*principalID] = struct{}{}
+			}
+		}
+		return set, nil
+	})
 }
 
 // isAdministrator reports whether the user is directly assigned at least one

--- a/providers/ms365/resources/user_isadministrator.go
+++ b/providers/ms365/resources/user_isadministrator.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"sync"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/ms365/connection"
+)
+
+var (
+	adminPrincipalsMu    sync.Mutex
+	adminPrincipalsCache = map[*connection.Ms365Connection]map[string]struct{}{}
+)
+
+// adminPrincipalIDs returns the set of principal IDs (users, groups, or service
+// principals) that hold at least one active Microsoft Entra directory role
+// assignment. The set is fetched once per connection and cached so that
+// microsoft.user.isAdministrator resolves from memory instead of issuing a
+// request per user.
+// requires RoleManagement.Read.Directory permission
+func adminPrincipalIDs(runtime *plugin.Runtime) (map[string]struct{}, error) {
+	conn := runtime.Connection.(*connection.Ms365Connection)
+
+	adminPrincipalsMu.Lock()
+	defer adminPrincipalsMu.Unlock()
+	if set, ok := adminPrincipalsCache[conn]; ok {
+		return set, nil
+	}
+
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	resp, err := graphClient.RoleManagement().Directory().RoleAssignments().Get(ctx, nil)
+	if err != nil {
+		return nil, transformError(err)
+	}
+	assignments, err := iterate[models.UnifiedRoleAssignmentable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleAssignmentCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		if principalID := assignment.GetPrincipalId(); principalID != nil {
+			set[*principalID] = struct{}{}
+		}
+	}
+
+	adminPrincipalsCache[conn] = set
+	return set, nil
+}
+
+// isAdministrator reports whether the user is directly assigned at least one
+// active Microsoft Entra directory role.
+func (a *mqlMicrosoftUser) isAdministrator() (bool, error) {
+	if a.Id.Data == "" {
+		return false, nil
+	}
+
+	admins, err := adminPrincipalIDs(a.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	_, ok := admins[a.Id.Data]
+	return ok, nil
+}


### PR DESCRIPTION
## What

Adds `isAdministrator` to `microsoft.user` — `true` when the user is directly assigned at least one **active** Microsoft Entra directory role.

This replaces the verbose cross-reference users have to write today (from #5581):

```mql
principalIds = microsoft.rolemanagement.roleDefinitions.where(displayName == "Global Administrator").list.first.assignments.map(principalId)
rootDomain   = "@" + microsoft.domains.where(isRoot == true && authenticationType == "Managed").map(id).first
microsoft.users.where(_.id.in(principalIds)).all(_.userPrincipalName.contains(rootDomain))
```

with simply:

```mql
microsoft.users.where(isAdministrator)
```

## Semantics

True when the user is the principal of at least one assignment in `roleManagement.directory.roleAssignments`. Roles held only through group membership, or as not-yet-activated PIM-eligible assignments, are intentionally not counted (those aren't *active* direct admin grants). This is documented on the field.

## Performance

The admin principal-ID set is fetched **once per connection** (a single `roleManagement.directory.roleAssignments` call) and cached, so `microsoft.users { isAdministrator }` over the whole tenant issues one request, not one per user.

## Verification

Live against a 24-user tenant:

```
microsoft.users.length                              => 24
microsoft.users.where(isAdministrator == true)      => 6  (incl. the Global Administrator)
microsoft.users.where(isAdministrator == false)     => 18
```

6 + 18 = 24; the known Global Admin resolves `true`, a sample standard user resolves `false`.

Closes #5581