### PR TITLE
✨ Add expressive debug logging to GCP and Azure providers

### DIFF
--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -111,7 +111,9 @@ func (p *apiTracePolicy) Do(req *policy.Request) (*http.Response, error) {
 	}
 	log.Debug().
 		Str("method", rawReq.Method).
-		Str("url", rawReq.URL.String()).
+		// host+path only: the query string can carry SAS tokens or other
+		// signed-URL credentials that must not leak into debug logs.
+		Str("url", rawReq.URL.Host+rawReq.URL.Path).
 		Int("status", status).
 		Dur("duration", elapsed).
 		Err(err).

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -144,7 +144,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azur
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +199,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 	ctx := context.Background()
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +402,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForApis() (*mqlAzureS
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +432,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderCSPM() (*mqlAzureSubs
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +547,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSub
 	}
 
 	// Check if Defender for Containers is enabled by querying the pricing tier
-	clientFactory, err := armsecurity.NewClientFactory(subId, armConn.token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, armConn.token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +596,9 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers) fetchRaw
 	a.rawExtensionsOnce.Do(func() {
 		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 		subId := a.SubscriptionId.Data
-		clientFactory, err := armsecurity.NewClientFactory(subId, conn.Token(), nil)
+		clientFactory, err := armsecurity.NewClientFactory(subId, conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
 		if err != nil {
 			a.rawExtensionsErr = err
 			return
@@ -623,7 +635,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSecuritySettingsFor(name s
 	ctx := context.Background()
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -701,7 +715,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) securityContacts() ([]any, er
 	ctx := context.Background()
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -841,7 +857,9 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM) extensions() ([]a
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -944,7 +962,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) secureScores() ([]any, error)
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1015,7 +1035,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) secureScoreControls() ([]any,
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1106,7 +1128,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) regulatoryComplianceStandards
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1186,7 +1210,9 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceRegulatoryComplianceStandard) c
 
 	standardName := a.Name.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1383,7 +1409,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1499,7 +1527,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) alerts() ([]any, error) {
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
 
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -240,6 +241,10 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	}
 
 	targets := getDiscoveryTargets(rootConf)
+	log.Debug().
+		Int("subscriptions", len(subsWithConfigs)).
+		Strs("targets", targets).
+		Msg("azure.discovery> starting discovery")
 
 	if stringx.ContainsAnyOf(targets, DiscoverySubscriptions) {
 		// we've already discovered those, simply add them as assets
@@ -280,6 +285,7 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	}
 	assets = append(assets, genericAssets...)
 
+	log.Debug().Int("assets", len(assets)).Msg("azure.discovery> discovery complete")
 	return &inventory.Inventory{
 		Spec: &inventory.InventorySpec{
 			Assets: assets,
@@ -430,6 +436,7 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 	var assets []*inventory.Asset
 	for _, swc := range subsWithConfigs {
 		subId := *swc.sub.SubscriptionID
+		log.Debug().Str("subscription", subId).Str("filter", filter).Msg("azure.discovery> listing resources in subscription")
 		client, err := armresources.NewClient(subId, conn.Token(), &arm.ClientOptions{
 			ClientOptions: conn.ClientOptions(),
 		})

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -45,7 +46,9 @@ func (a *mqlAzureSubscriptionIotService) hubs() ([]any, error) {
 
 	subscriptionID := a.SubscriptionId.Data
 
-	clientFactory, err := armiothub.NewClientFactory(subscriptionID, token, nil)
+	clientFactory, err := armiothub.NewClientFactory(subscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +81,9 @@ func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 	token := conn.Token()
 	subscriptionID := a.SubscriptionId.Data
 
-	clientFactory, err := armiothub.NewClientFactory(subscriptionID, token, nil)
+	clientFactory, err := armiothub.NewClientFactory(subscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/connection/clients.go
+++ b/providers/gcp/connection/clients.go
@@ -19,6 +19,7 @@ import (
 	googleoauth "golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
+	"google.golang.org/grpc"
 )
 
 // scopeCacheKey builds an order-independent cache key from a scope set so that
@@ -144,6 +145,37 @@ func (t *apiTraceTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		Msg("gcp api call")
 
 	return resp, err
+}
+
+// loggingUnaryInterceptor logs every unary gRPC call (method, target, duration,
+// and error) at Debug level. It is the gRPC counterpart of apiTraceTransport:
+// most cloud.google.com/go client libraries (securitycenter, kms, bigquery,
+// etc.) talk gRPC rather than HTTP, so without this their API calls would be
+// invisible under `-v`. The read-only list/get/pager calls these resources make
+// are all unary, so a unary interceptor covers them.
+func loggingUnaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	start := time.Now()
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	log.Debug().
+		Str("method", method).
+		Str("target", cc.Target()).
+		Dur("duration", time.Since(start)).
+		Err(err).
+		Msg("gcp grpc call")
+	return err
+}
+
+// GRPCClientTraceOption returns a client option that installs the Debug-level
+// gRPC tracing interceptor. Pass it alongside option.WithCredentials when
+// constructing a cloud.google.com/go (gRPC) client so its API calls are traced
+// the same way HTTP calls are by apiTraceTransport. Example:
+//
+//	c, err := securitycenter.NewClient(ctx,
+//		option.WithCredentials(creds),
+//		connection.GRPCClientTraceOption(),
+//	)
+func GRPCClientTraceOption() option.ClientOption {
+	return option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(loggingUnaryInterceptor))
 }
 
 // defaultAuth builds an HTTP client from Application Default Credentials.

--- a/providers/gcp/connection/clients.go
+++ b/providers/gcp/connection/clients.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/pkg/errors"
@@ -86,18 +87,63 @@ func (c *GcpConnection) Client(scope ...string) (*http.Client, error) {
 func (c *GcpConnection) buildClient(scope ...string) (*http.Client, error) {
 	ctx := context.Background()
 
+	var client *http.Client
+	var err error
 	// use service account from secret if one is provided
 	if c.opts.cred != nil {
-		data, err := credsServiceAccountData(c.opts.cred)
-		if err != nil {
-			return nil, err
+		data, dataErr := credsServiceAccountData(c.opts.cred)
+		if dataErr != nil {
+			return nil, dataErr
 		}
-		return serviceAccountAuth(ctx, c.opts.serviceAccountSubject, data, scope...)
+		client, err = serviceAccountAuth(ctx, c.opts.serviceAccountSubject, data, scope...)
+	} else {
+		// otherwise fallback to default google sdk authentication
+		log.Debug().Msg("fallback to default google sdk authentication")
+		client, err = defaultAuth(ctx, scope...)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	// otherwise fallback to default google sdk authentication
-	log.Debug().Msg("fallback to default google sdk authentication")
-	return defaultAuth(ctx, scope...)
+	// wrap the transport so every Google API call is traced at Debug level
+	client.Transport = newApiTraceTransport(client.Transport)
+	return client, nil
+}
+
+// apiTraceTransport is an http.RoundTripper that logs every Google API call
+// with its method, URL, status code, and duration at Debug level. It is the GCP
+// analog of the Azure provider's apiTracePolicy, so that `-v` output reveals
+// which APIs are being called (and against which projects/regions/zones) and
+// whether they are failing, rather than presenting GCP discovery as a black box.
+type apiTraceTransport struct {
+	base http.RoundTripper
+}
+
+func newApiTraceTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &apiTraceTransport{base: base}
+}
+
+func (t *apiTraceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	log.Debug().
+		Str("method", req.Method).
+		Str("url", req.URL.String()).
+		Int("status", status).
+		Dur("duration", elapsed).
+		Err(err).
+		Msg("gcp api call")
+
+	return resp, err
 }
 
 // defaultAuth builds an HTTP client from Application Default Credentials.

--- a/providers/gcp/connection/clients.go
+++ b/providers/gcp/connection/clients.go
@@ -138,7 +138,9 @@ func (t *apiTraceTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 	log.Debug().
 		Str("method", req.Method).
-		Str("url", req.URL.String()).
+		// host+path only: the query string can carry signed-URL tokens or
+		// access tokens that must not leak into debug logs.
+		Str("url", req.URL.Host+req.URL.Path).
 		Int("status", status).
 		Dur("duration", elapsed).
 		Err(err).

--- a/providers/gcp/connection/clients_trace_test.go
+++ b/providers/gcp/connection/clients_trace_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// recordingRT is a stub http.RoundTripper that records the request it received
+// and returns a canned response/error.
+type recordingRT struct {
+	resp *http.Response
+	err  error
+	got  *http.Request
+}
+
+func (r *recordingRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.got = req
+	return r.resp, r.err
+}
+
+// The trace transport sits in front of every REST GCP call, so its contract is
+// strict: delegate the request unchanged and return the base response/error
+// verbatim. A regression here would corrupt or hide every REST API result.
+func TestApiTraceTransport_PassesResponseThrough(t *testing.T) {
+	want := &http.Response{StatusCode: http.StatusOK}
+	base := &recordingRT{resp: want}
+	tr := newApiTraceTransport(base)
+
+	req, err := http.NewRequest(http.MethodGet, "https://compute.googleapis.com/x", nil)
+	require.NoError(t, err)
+
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.Same(t, want, resp, "response must be returned unchanged")
+	require.Same(t, req, base.got, "request must be delegated unchanged")
+}
+
+func TestApiTraceTransport_PassesErrorThroughWithNilResponse(t *testing.T) {
+	wantErr := errors.New("transport failure")
+	base := &recordingRT{err: wantErr} // resp is nil
+
+	req, err := http.NewRequest(http.MethodGet, "https://compute.googleapis.com/x", nil)
+	require.NoError(t, err)
+
+	// Must not panic when the base returns a nil response (the status=0 path).
+	resp, err := newApiTraceTransport(base).RoundTrip(req)
+	require.Nil(t, resp)
+	require.Equal(t, wantErr, err)
+}
+
+func TestNewApiTraceTransport_NilBaseFallsBackToDefault(t *testing.T) {
+	tr := newApiTraceTransport(nil).(*apiTraceTransport)
+	require.Equal(t, http.DefaultTransport, tr.base)
+}
+
+// The unary interceptor wraps every gRPC GCP call; it must invoke the real
+// invoker and propagate its error unchanged.
+func TestLoggingUnaryInterceptor_InvokesAndPropagatesError(t *testing.T) {
+	// grpc.NewClient is lazy and does not dial, so this never touches the network.
+	cc, err := grpc.NewClient("passthrough:///unit-test", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer cc.Close()
+
+	wantErr := errors.New("rpc failure")
+	called := false
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		called = true
+		return wantErr
+	}
+
+	got := loggingUnaryInterceptor(context.Background(), "/pkg.Service/Method", "req", "reply", cc, invoker)
+	require.True(t, called, "interceptor must call the underlying invoker")
+	require.Equal(t, wantErr, got, "interceptor must propagate the invoker error")
+}

--- a/providers/gcp/resources/access_approval.go
+++ b/providers/gcp/resources/access_approval.go
@@ -63,7 +63,7 @@ func accessApprovalSettings(runtime *plugin.Runtime, settingsName string) (*mqlG
 	}
 
 	ctx := context.Background()
-	c, err := accessapproval.NewClient(ctx, option.WithCredentials(credentials))
+	c, err := accessapproval.NewClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/access_approval.go
+++ b/providers/gcp/resources/access_approval.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -39,6 +40,7 @@ func (g *mqlGcpProject) accessApprovalSettings() (*mqlGcpAccessApprovalSettings,
 		return nil, err
 	}
 	if !serviceEnabled {
+		log.Debug().Str("service", service_accessapproval).Msg("gcp service is not enabled, skipping")
 		g.AccessApprovalSettings.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -35,7 +35,7 @@ func newACMClient(conn *connection.GcpConnection) (*accesscontextmanager.Client,
 	if err != nil {
 		return nil, err
 	}
-	return accesscontextmanager.NewClient(context.Background(), option.WithCredentials(creds))
+	return accesscontextmanager.NewClient(context.Background(), option.WithCredentials(creds), connection.GRPCClientTraceOption())
 }
 
 func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -66,7 +66,7 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds))
+	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) users() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds))
+	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +366,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) instances() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds))
+	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds))
+	client, err := alloydb.NewAlloyDBAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/artifactregistry.go
+++ b/providers/gcp/resources/artifactregistry.go
@@ -69,7 +69,7 @@ func (g *mqlGcpProjectArtifactRegistryService) repositories() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds))
+	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepository) iamPolicy() ([]any, err
 	}
 
 	ctx := context.Background()
-	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds))
+	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepository) packages() ([]any, erro
 	}
 
 	ctx := context.Background()
-	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds))
+	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepositoryPackage) versions() ([]an
 	}
 
 	ctx := context.Background()
-	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds))
+	client, err := artifactregistry.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -99,7 +99,7 @@ func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := asset.NewClient(ctx, option.WithCredentials(creds))
+	client, err := asset.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := asset.NewClient(ctx, option.WithCredentials(creds))
+	client, err := asset.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/backupdr.go
+++ b/providers/gcp/resources/backupdr.go
@@ -79,7 +79,7 @@ func (g *mqlGcpProjectBackupdrService) managementServers() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds))
+	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (g *mqlGcpProjectBackupdrService) backupVaults() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds))
+	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (g *mqlGcpProjectBackupdrServiceBackupVault) dataSources() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds))
+	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (g *mqlGcpProjectBackupdrService) backupPlans() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds))
+	client, err := backupdr.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -99,7 +99,7 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := batch.NewClient(ctx, option.WithCredentials(creds))
+	client, err := batch.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -68,6 +69,9 @@ func (g *mqlGcpProject) bigquery() (*mqlGcpProjectBigqueryService, error) {
 	}
 	bqService := res.(*mqlGcpProjectBigqueryService)
 	bqService.serviceEnabled = serviceEnabled
+	if !serviceEnabled {
+		log.Debug().Str("service", service_bigquery).Msg("gcp service is not enabled, skipping")
+	}
 
 	return bqService, nil
 }

--- a/providers/gcp/resources/bigquery_connection.go
+++ b/providers/gcp/resources/bigquery_connection.go
@@ -72,7 +72,7 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := bqconnection.NewClient(ctx, option.WithCredentials(creds))
+	client, err := bqconnection.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/bigquery_reservation.go
+++ b/providers/gcp/resources/bigquery_reservation.go
@@ -40,7 +40,7 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := bqreservation.NewClient(ctx, option.WithCredentials(creds))
+	client, err := bqreservation.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -118,7 +118,7 @@ func (g *mqlGcpProjectBigtableService) instances() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds))
+	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds))
+	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds))
+	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	ac, err := bigtable.NewAdminClient(ctx, projectId, instanceName, option.WithCredentials(creds))
+	ac, err := bigtable.NewAdminClient(ctx, projectId, instanceName, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) appProfiles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds))
+	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -581,7 +581,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds))
+	iac, err := bigtable.NewInstanceAdminClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 	}
 
 	// For each cluster, list backups
-	ac, err := bigtable.NewAdminClient(ctx, projectId, instanceName, option.WithCredentials(creds))
+	ac, err := bigtable.NewAdminClient(ctx, projectId, instanceName, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -9,6 +9,7 @@ import (
 
 	binaryauthorization "cloud.google.com/go/binaryauthorization/apiv1"
 	"cloud.google.com/go/binaryauthorization/apiv1/binaryauthorizationpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -28,6 +29,7 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 		return nil, err
 	}
 	if !serviceEnabled {
+		log.Debug().Str("service", service_binaryauthorization).Msg("gcp service is not enabled, skipping")
 		g.BinaryAuthorization.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -41,7 +41,7 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 	}
 
 	ctx := context.Background()
-	c, err := binaryauthorization.NewSystemPolicyClient(ctx, option.WithCredentials(credentials), option.WithQuotaProject(projectId))
+	c, err := binaryauthorization.NewSystemPolicyClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption(), option.WithQuotaProject(projectId))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (g *mqlGcpProjectBinaryAuthorizationControl) attestors() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	c, err := binaryauthorization.NewBinauthzManagementClient(ctx, option.WithCredentials(credentials), option.WithQuotaProject(projectId))
+	c, err := binaryauthorization.NewBinauthzManagementClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption(), option.WithQuotaProject(projectId))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -93,7 +93,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMap) entries() ([]any,
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, err
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +687,7 @@ func initGcpProjectCertificateManagerServiceCertificate(runtime *plugin.Runtime,
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -731,7 +731,7 @@ func initGcpProjectCertificateManagerServiceDnsAuthorization(runtime *plugin.Run
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -792,7 +792,7 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := certificatemanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/gcp/resources/cloud_domains.go
+++ b/providers/gcp/resources/cloud_domains.go
@@ -36,6 +36,9 @@ func (g *mqlGcpProject) cloudDomains() (*mqlGcpProjectCloudDomainsService, error
 	if err != nil {
 		return nil, err
 	}
+	if !serviceEnabled {
+		log.Debug().Str("service", service_clouddomains).Msg("gcp service is not enabled, skipping")
+	}
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.cloudDomainsService", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -50,7 +50,7 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 
 	ctx := context.Background()
 
-	cloudFuncSvc, err := functions.NewCloudFunctionsClient(ctx, option.WithCredentials(creds))
+	cloudFuncSvc, err := functions.NewCloudFunctionsClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (g *mqlGcpProjectCloudFunction) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	cloudFuncSvc, err := functions.NewCloudFunctionsClient(ctx, option.WithCredentials(creds))
+	cloudFuncSvc, err := functions.NewCloudFunctionsClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -35,7 +35,7 @@ func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := functions.NewFunctionClient(ctx, option.WithCredentials(creds))
+	client, err := functions.NewFunctionClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (g *mqlGcpProjectCloudFunctionV2) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := functions.NewFunctionClient(ctx, option.WithCredentials(creds))
+	client, err := functions.NewFunctionClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -55,7 +55,7 @@ func (g *mqlGcpProjectCloudBuildService) triggers() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds))
+	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (g *mqlGcpProjectCloudBuildService) workerPools() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds))
+	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (g *mqlGcpProjectCloudBuildService) builds() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds))
+	client, err := cloudbuild.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/clouddeploy.go
+++ b/providers/gcp/resources/clouddeploy.go
@@ -50,7 +50,7 @@ func (g *mqlGcpProjectCloudDeployService) deliveryPipelines() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds))
+	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (g *mqlGcpProjectCloudDeployService) targets() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds))
+	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (g *mqlGcpProjectCloudDeployServiceDeliveryPipeline) releases() ([]any, err
 	}
 
 	ctx := context.Background()
-	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds))
+	client, err := deploy.NewCloudDeployClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -290,7 +290,7 @@ func (g *mqlGcpProjectCloudRunService) operations() ([]any, error) {
 
 	ctx := context.Background()
 
-	runSvc, err := run.NewServicesClient(ctx, option.WithCredentials(creds))
+	runSvc, err := run.NewServicesClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 
 	ctx := context.Background()
 
-	runSvc, err := run.NewServicesClient(ctx, option.WithCredentials(creds))
+	runSvc, err := run.NewServicesClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +704,7 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	runSvc, err := run.NewJobsClient(ctx, option.WithCredentials(creds))
+	runSvc, err := run.NewJobsClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -50,7 +50,7 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := scheduler.NewCloudSchedulerClient(ctx, option.WithCredentials(creds))
+	client, err := scheduler.NewCloudSchedulerClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloudtasks.go
+++ b/providers/gcp/resources/cloudtasks.go
@@ -54,7 +54,7 @@ func (g *mqlGcpProjectCloudTasksService) queues() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := cloudtasks.NewClient(ctx, option.WithCredentials(creds))
+	client, err := cloudtasks.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (g *mqlGcpProjectCloudTasksServiceQueue) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := cloudtasks.NewClient(ctx, option.WithCredentials(creds))
+	client, err := cloudtasks.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -230,6 +230,7 @@ func (g *mqlGcpProjectComputeService) regions() ([]any, error) {
 		res = append(res, mqlRegion)
 	}
 
+	log.Debug().Str("project", projectId).Int("regions", len(res)).Msg("gcp.compute> listed regions")
 	return res, nil
 }
 
@@ -281,6 +282,7 @@ func (g *mqlGcpProjectComputeService) zones() ([]any, error) {
 		return nil, err
 	}
 
+	log.Debug().Str("project", projectId).Int("zones", len(res)).Msg("gcp.compute> listed zones")
 	return res, nil
 }
 
@@ -924,6 +926,7 @@ func (g *mqlGcpProjectComputeService) instances() ([]any, error) {
 	}); err != nil {
 		return nil, err
 	}
+	log.Debug().Str("project", projectId).Int("instances", len(res)).Msg("gcp.compute> listed instances")
 	return res, nil
 }
 

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -134,7 +134,7 @@ func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := containeranalysis.NewClient(ctx, option.WithCredentials(creds))
+	client, err := containeranalysis.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := containeranalysis.NewClient(ctx, option.WithCredentials(creds))
+	client, err := containeranalysis.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/dataplex.go
+++ b/providers/gcp/resources/dataplex.go
@@ -36,6 +36,9 @@ func (g *mqlGcpProject) dataplex() (*mqlGcpProjectDataplexService, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !serviceEnabled {
+		log.Debug().Str("service", service_dataplex).Msg("gcp service is not enabled, skipping")
+	}
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.dataplexService", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -69,6 +69,9 @@ func (g *mqlGcpProject) dataproc() (*mqlGcpProjectDataprocService, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !serviceEnabled {
+		log.Debug().Str("service", service_dataproc).Msg("gcp service is not enabled, skipping")
+	}
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.dataprocService", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -114,7 +114,7 @@ func (g *mqlGcpProjectDatastreamService) streams() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func initGcpProjectDatastreamServiceConnectionProfile(runtime *plugin.Runtime, a
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -336,7 +336,7 @@ func (g *mqlGcpProjectDatastreamService) connectionProfiles() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +524,7 @@ func initGcpProjectDatastreamServicePrivateConnection(runtime *plugin.Runtime, a
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -554,7 +554,7 @@ func (g *mqlGcpProjectDatastreamService) privateConnections() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func (g *mqlGcpProjectDatastreamServicePrivateConnection) routes() ([]any, error
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := datastream.NewClient(ctx, option.WithCredentials(creds))
+	client, err := datastream.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -206,6 +206,7 @@ var gcpAPIServiceRe = regexp.MustCompile(`([A-Z][A-Za-z0-9 &.,/-]*?) API has not
 // API-not-enabled error is logged on one line and swallowed so the rest
 // of discovery can continue; any other error is propagated unchanged.
 func runDiscoveryStep(target string, fn func() error) error {
+	log.Debug().Str("target", target).Msg("gcp.discovery> running discovery step")
 	err := fn()
 	if err == nil {
 		return nil
@@ -231,6 +232,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 		Assets: []*inventory.Asset{},
 	}}
 	discoveryTargets := getDiscoveryTargets(conn.Conf)
+	log.Debug().Strs("targets", discoveryTargets).Msg("gcp.discovery> resolved discovery targets")
 
 	if conn.ResourceType() == connection.Organization {
 		res, err := NewResource(runtime, "gcp.organization", nil)
@@ -1680,6 +1682,10 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 		}
 	}
 
+	log.Debug().
+		Str("project", gcpProject.Id.Data).
+		Int("assets", len(assetList)).
+		Msg("gcp.discovery> project discovery complete")
 	return assetList, nil
 }
 

--- a/providers/gcp/resources/discoveryengine.go
+++ b/providers/gcp/resources/discoveryengine.go
@@ -125,7 +125,7 @@ func newMqlDiscoveryEngineDataStore(runtime *plugin.Runtime, ds *discoveryengine
 
 func (g *mqlGcpProjectDiscoveryEngineService) listDataStoresInLocation(ctx context.Context, creds *googleoauth.Credentials, projectId, location string) ([]any, error) {
 	client, err := discoveryengine.NewDataStoreClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(discoveryEngineEndpoint(location)),
 	)
 	if err != nil {
@@ -195,7 +195,7 @@ func (a *mqlGcpProjectDiscoveryEngineServiceDataStore) kmsKey() (*mqlGcpProjectK
 
 func (g *mqlGcpProjectDiscoveryEngineService) listEnginesInLocation(ctx context.Context, creds *googleoauth.Credentials, projectId, location string) ([]any, error) {
 	client, err := discoveryengine.NewEngineClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(discoveryEngineEndpoint(location)),
 	)
 	if err != nil {
@@ -296,7 +296,7 @@ func (g *mqlGcpProjectDiscoveryEngineServiceEngine) dataStores() ([]any, error) 
 
 	ctx := context.Background()
 	client, err := discoveryengine.NewDataStoreClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(discoveryEngineEndpoint(location)),
 	)
 	if err != nil {

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -100,7 +100,7 @@ func (g *mqlGcpProjectDlpService) inspectTemplates() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (g *mqlGcpProjectDlpService) deidentifyTemplates() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (g *mqlGcpProjectDlpService) jobTriggers() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func (g *mqlGcpProjectDlpService) dlpJobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ func (g *mqlGcpProjectDlpService) discoveryConfigs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +638,7 @@ func (g *mqlGcpProjectDlpService) connections() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +713,7 @@ func (g *mqlGcpProjectDlpService) projectDataProfiles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func (g *mqlGcpProjectDlpService) tableDataProfiles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -907,7 +907,7 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -1015,7 +1015,7 @@ func (g *mqlGcpProjectDlpService) fileStoreDataProfiles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -1141,7 +1141,7 @@ func (g *mqlGcpProjectStorageServiceBucket) dlpDataProfile() (*mqlGcpProjectDlpS
 	if err != nil {
 		return nil, err
 	}
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -1193,7 +1193,7 @@ func (g *mqlGcpProjectBigqueryServiceTable) dlpDataProfile() (*mqlGcpProjectDlpS
 	if err != nil {
 		return nil, err
 	}
-	client, err := dlp.NewClient(ctx, option.WithCredentials(creds))
+	client, err := dlp.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -112,6 +113,9 @@ func (g *mqlGcpProject) dns() (*mqlGcpProjectDnsService, error) {
 	dnsService := res.(*mqlGcpProjectDnsService)
 	dnsService.serviceEnabled = serviceEnabled
 	dnsService.serviceChecked = true
+	if !serviceEnabled {
+		log.Debug().Str("service", service_dns).Msg("gcp service is not enabled, skipping")
+	}
 
 	return dnsService, nil
 }

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -78,6 +79,7 @@ func (g *mqlGcpProject) essentialContacts() ([]any, error) {
 		return nil, err
 	}
 	if !serviceEnabled {
+		log.Debug().Str("service", service_essential_contacts).Msg("gcp service is not enabled, skipping")
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -135,7 +135,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := eventarc.NewClient(ctx, option.WithCredentials(creds))
+	client, err := eventarc.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := eventarc.NewClient(ctx, option.WithCredentials(creds))
+	client, err := eventarc.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/filestore.go
+++ b/providers/gcp/resources/filestore.go
@@ -77,7 +77,7 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := filestore.NewCloudFilestoreManagerClient(ctx, option.WithCredentials(creds))
+	client, err := filestore.NewCloudFilestoreManagerClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -112,7 +112,7 @@ func (g *mqlGcpProjectFirestoreService) databases() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds))
+	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) indexes() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds))
+	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) backupSchedules() ([]any, error)
 	}
 
 	ctx := context.Background()
-	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds))
+	client, err := firestoreadmin.NewFirestoreAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -54,6 +54,9 @@ func (g *mqlGcpProject) gke() (*mqlGcpProjectGkeService, error) {
 
 	gkeService := res.(*mqlGcpProjectGkeService)
 	gkeService.serviceEnabled = serviceEnabled
+	if !serviceEnabled {
+		log.Debug().Str("service", service_gke).Msg("gcp service is not enabled, skipping")
+	}
 
 	return gkeService, nil
 }

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -301,7 +301,7 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 
 	ctx := context.Background()
 
-	containerSvc, err := container.NewClusterManagerClient(ctx, option.WithCredentials(creds))
+	containerSvc, err := container.NewClusterManagerClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -99,7 +99,7 @@ func (g *mqlGcpProjectGkeBackupService) backupPlans() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := gkebackup.NewBackupForGKEClient(ctx, option.WithCredentials(creds))
+	client, err := gkebackup.NewBackupForGKEClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (g *mqlGcpProjectGkeBackupService) restorePlans() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := gkebackup.NewBackupForGKEClient(ctx, option.WithCredentials(creds))
+	client, err := gkebackup.NewBackupForGKEClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -261,7 +261,7 @@ func (g *mqlGcpProjectIamService) serviceAccounts() ([]any, error) {
 
 	ctx := context.Background()
 
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds))
+	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (g *mqlGcpProjectIamServiceServiceAccount) keys() ([]any, error) {
 
 	ctx := context.Background()
 
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds))
+	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +733,7 @@ func (g *mqlGcpProjectIamService) denyPolicies() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iamv2.NewPoliciesClient(ctx, option.WithCredentials(creds))
+	client, err := iamv2.NewPoliciesClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +815,7 @@ func (g *mqlGcpProjectIamServiceServiceAccount) iamPolicy() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds))
+	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/iam_roles.go
+++ b/providers/gcp/resources/iam_roles.go
@@ -31,7 +31,7 @@ func (g *mqlGcpProjectIamService) roles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds))
+	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (g *mqlGcpOrganization) customRoles() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds))
+	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/iap.go
+++ b/providers/gcp/resources/iap.go
@@ -54,7 +54,7 @@ func (g *mqlGcpProjectIapService) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds))
+	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (g *mqlGcpProjectIapService) settings() (any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds))
+	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (g *mqlGcpProjectIapService) brands() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iap.NewIdentityAwareProxyOAuthClient(ctx, option.WithCredentials(creds))
+	client, err := iap.NewIdentityAwareProxyOAuthClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (g *mqlGcpProjectIapServiceBrand) clients() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iap.NewIdentityAwareProxyOAuthClient(ctx, option.WithCredentials(creds))
+	client, err := iap.NewIdentityAwareProxyOAuthClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (g *mqlGcpProjectIapService) tunnelDestGroups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds))
+	client, err := iap.NewIdentityAwareProxyAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -95,7 +95,7 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := ids.NewClient(ctx, option.WithCredentials(creds))
+	client, err := ids.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -163,7 +163,7 @@ func initGcpProjectKmsServiceKeyringCryptokey(runtime *plugin.Runtime, args map[
 	}
 
 	ctx := context.Background()
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -284,7 +284,7 @@ func (g *mqlGcpProjectKmsService) locations() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (g *mqlGcpProjectKmsService) keyrings() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +393,7 @@ func (g *mqlGcpProjectKmsServiceKeyring) cryptokeys() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +498,7 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokey) versions() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokey) iamPolicy() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -620,7 +620,7 @@ func (g *mqlGcpProjectKmsServiceKeyring) iamPolicy() ([]any, error) {
 
 	ctx := context.Background()
 
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +721,7 @@ func (g *mqlGcpProjectKmsService) retiredResources() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -787,7 +787,7 @@ func (g *mqlGcpProjectKmsService) ekmConnections() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	ekmSvc, err := kms.NewEkmClient(ctx, option.WithCredentials(creds))
+	ekmSvc, err := kms.NewEkmClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -869,7 +869,7 @@ func (g *mqlGcpProjectKmsServiceKeyring) importJobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds))
+	kmsSvc, err := kms.NewKeyManagementClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -196,7 +196,7 @@ func (g *mqlGcpProjectLoggingservice) metrics() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds))
+	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (g *mqlGcpProjectLoggingservice) sinks() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds))
+	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -110,7 +110,7 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := memcache.NewCloudMemcacheClient(ctx, option.WithCredentials(creds))
+	client, err := memcache.NewCloudMemcacheClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,7 +181,7 @@ func (g *mqlGcpProjectMemcacheService) instances() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := memcache.NewCloudMemcacheClient(ctx, option.WithCredentials(creds))
+	client, err := memcache.NewCloudMemcacheClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -106,7 +106,7 @@ func (g *mqlGcpProjectMemorystoreService) instances() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds))
+	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds))
+	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -424,7 +424,7 @@ func (g *mqlGcpProjectMemorystoreService) backupCollections() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds))
+	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func initGcpProjectMemorystoreServiceBackupCollection(runtime *plugin.Runtime, a
 		return nil, nil, err
 	}
 	ctx := context.Background()
-	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds))
+	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -566,7 +566,7 @@ func (g *mqlGcpProjectMemorystoreServiceBackupCollection) backups() ([]any, erro
 		return nil, err
 	}
 	ctx := context.Background()
-	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds))
+	client, err := memorystore.NewRESTClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -89,7 +89,7 @@ func (g *mqlGcpProjectModelArmorService) templates() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := modelarmor.NewClient(ctx, option.WithCredentials(creds))
+	client, err := modelarmor.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (g *mqlGcpProjectModelArmorService) floorSetting() (*mqlGcpProjectModelArmo
 	}
 
 	ctx := context.Background()
-	client, err := modelarmor.NewClient(ctx, option.WithCredentials(creds))
+	client, err := modelarmor.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -148,7 +148,7 @@ func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 
 	ctx := context.Background()
 
-	c, err := monitoring.NewAlertPolicyClient(ctx, option.WithCredentials(creds))
+	c, err := monitoring.NewAlertPolicyClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (g *mqlGcpProjectMonitoringService) notificationChannels() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	c, err := monitoring.NewNotificationChannelClient(ctx, option.WithCredentials(creds))
+	c, err := monitoring.NewNotificationChannelClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (g *mqlGcpProjectMonitoringService) groups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	c, err := monitoring.NewGroupClient(ctx, option.WithCredentials(creds))
+	c, err := monitoring.NewGroupClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +492,7 @@ func (g *mqlGcpProjectMonitoringService) dashboards() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := dashboard.NewDashboardsClient(ctx, option.WithCredentials(creds))
+	client, err := dashboard.NewDashboardsClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func (g *mqlGcpProjectMonitoringService) services() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := monitoring.NewServiceMonitoringClient(ctx, option.WithCredentials(creds))
+	client, err := monitoring.NewServiceMonitoringClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (g *mqlGcpProjectMonitoringServiceService) slos() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := monitoring.NewServiceMonitoringClient(ctx, option.WithCredentials(creds))
+	client, err := monitoring.NewServiceMonitoringClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/orgpolicy.go
+++ b/providers/gcp/resources/orgpolicy.go
@@ -81,7 +81,7 @@ func listOrgPolicies(runtime *plugin.Runtime, conn *connection.GcpConnection, pa
 	}
 
 	ctx := context.Background()
-	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds))
+	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (g *mqlGcpProject) orgPolicyConstraints() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds))
+	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (g *mqlGcpOrganization) customConstraints() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds))
+	client, err := orgpolicy.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -78,7 +78,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds))
+	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities(
 	}
 
 	ctx := context.Background()
-	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds))
+	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 	}
 
 	ctx := context.Background()
-	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds))
+	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -299,7 +299,7 @@ func (g *mqlGcpProjectPubsubService) topics() ([]any, error) {
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (g *mqlGcpProjectPubsubServiceTopic) config() (*mqlGcpProjectPubsubServiceT
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (g *mqlGcpProjectPubsubService) subscriptions() ([]any, error) {
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +499,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (g *mqlGcpProjectPubsubService) snapshots() ([]any, error) {
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +715,7 @@ func (g *mqlGcpProjectPubsubServiceTopic) iamPolicy() ([]any, error) {
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -767,7 +767,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) iamPolicy() ([]any, error) {
 
 	ctx := context.Background()
 
-	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds))
+	pubsubSvc, err := pubsub.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -864,7 +864,7 @@ func (g *mqlGcpProjectPubsubService) schemas() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	schemaClient, err := pubsubadmin.NewSchemaClient(ctx, option.WithCredentials(creds))
+	schemaClient, err := pubsubadmin.NewSchemaClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func initGcpProjectPubsubServiceSchema(runtime *plugin.Runtime, args map[string]
 	}
 
 	ctx := context.Background()
-	schemaClient, err := pubsubadmin.NewSchemaClient(ctx, option.WithCredentials(creds))
+	schemaClient, err := pubsubadmin.NewSchemaClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -127,7 +127,7 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 		return nil, err
 	}
 
-	c, err := recommender.NewClient(ctx, option.WithCredentials(credentials))
+	c, err := recommender.NewClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption())
 	if err != nil {
 		log.Info().Err(err).Msg("could not create client")
 		return nil, err

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -184,7 +184,7 @@ func (g *mqlGcpProjectRedisService) instances() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	redisSvc, err := redis.NewCloudRedisClient(ctx, option.WithCredentials(creds))
+	redisSvc, err := redis.NewCloudRedisClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (g *mqlGcpProjectRedisService) clusters() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	clusterSvc, err := rediscluster.NewCloudRedisClusterClient(ctx, option.WithCredentials(creds))
+	clusterSvc, err := rediscluster.NewCloudRedisClusterClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -1018,7 +1018,7 @@ func (g *mqlGcpProjectRedisServiceCluster) backups() ([]any, error) {
 		return nil, err
 	}
 	ctx := context.Background()
-	clusterSvc, err := rediscluster.NewCloudRedisClusterClient(ctx, option.WithCredentials(creds))
+	clusterSvc, err := rediscluster.NewCloudRedisClusterClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -102,7 +102,7 @@ func (g *mqlGcpProjectSecretmanagerService) secrets() ([]any, error) {
 
 	ctx := context.Background()
 
-	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) versions() ([]any, error) {
 
 	ctx := context.Background()
 
-	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) iamPolicy() ([]any, error) {
 
 	ctx := context.Background()
 
-	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds))
+	client, err := secretmanager.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/securitycenter.go
+++ b/providers/gcp/resources/securitycenter.go
@@ -45,7 +45,7 @@ func newSCCClient(conn *connection.GcpConnection) (*securitycenter.Client, error
 	if err != nil {
 		return nil, err
 	}
-	return securitycenter.NewClient(context.Background(), option.WithCredentials(creds))
+	return securitycenter.NewClient(context.Background(), option.WithCredentials(creds), connection.GRPCClientTraceOption())
 }
 
 // listSCCSources lists Security Command Center sources for a given parent.

--- a/providers/gcp/resources/securitycenter.go
+++ b/providers/gcp/resources/securitycenter.go
@@ -8,6 +8,7 @@ import (
 
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	sccpb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -489,6 +490,7 @@ func (g *mqlGcpProject) sccFindings() ([]any, error) {
 		return nil, err
 	}
 	if !serviceEnabled {
+		log.Debug().Str("service", service_securitycenter).Msg("gcp service is not enabled, skipping")
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -85,7 +85,7 @@ func (g *mqlGcpProject) fetchServices(filter string) ([]any, error) {
 	}
 
 	ctx := context.Background()
-	c, err := serviceusage.NewClient(ctx, option.WithCredentials(credentials))
+	c, err := serviceusage.NewClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption())
 	if err != nil {
 		log.Info().Err(err).Msg("could not create client")
 		return nil, err
@@ -176,7 +176,7 @@ func initGcpService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	}
 
 	ctx := context.Background()
-	c, err := serviceusage.NewClient(ctx, option.WithCredentials(credentials))
+	c, err := serviceusage.NewClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -118,7 +118,7 @@ func (g *mqlGcpProjectSpannerService) instances() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +385,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) ddl() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +542,7 @@ func (g *mqlGcpProjectSpannerService) instanceConfigs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +715,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) iamPolicy() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +745,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) iamPolicy() ([]any, error)
 	}
 
 	ctx := context.Background()
-	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -783,7 +783,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) databaseRoles() ([]any, er
 	}
 
 	ctx := context.Background()
-	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backupSchedules() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	dbClient, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds))
+	dbClient, err := spannerdatabase.NewDatabaseAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +956,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) instancePartitions() ([]any, error
 	}
 
 	ctx := context.Background()
-	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds))
+	client, err := spannerinstance.NewInstanceAdminClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -217,7 +217,7 @@ func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewModelClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -319,7 +319,7 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewEndpointClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -438,7 +438,7 @@ func resolveVertexaiEndpointRef(runtime *plugin.Runtime, field *plugin.TValue[*m
 
 	ctx := context.Background()
 	client, err := aiplatform.NewEndpointClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(vertexaiEndpoint(region)),
 	)
 	if err != nil {
@@ -526,7 +526,7 @@ func resolveVertexaiModelRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlG
 
 	ctx := context.Background()
 	client, err := aiplatform.NewModelClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(vertexaiEndpoint(region)),
 	)
 	if err != nil {
@@ -583,7 +583,7 @@ func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPipelineClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -722,7 +722,7 @@ func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewDatasetClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -798,7 +798,7 @@ func (g *mqlGcpProjectVertexaiService) featureOnlineStores() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewFeatureOnlineStoreAdminClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -890,7 +890,7 @@ func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewTensorboardClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1038,7 +1038,7 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 	}
 	ctx := context.Background()
 	client, err := aiplatform.NewJobClient(ctx,
-		option.WithCredentials(creds),
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 		option.WithEndpoint(vertexaiEndpoint(region)),
 	)
 	if err != nil {
@@ -1119,7 +1119,7 @@ func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1176,7 +1176,7 @@ func (g *mqlGcpProjectVertexaiService) indexes() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewIndexClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1269,7 +1269,7 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewIndexEndpointClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1353,7 +1353,7 @@ func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewMetadataClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1424,7 +1424,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimes() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1533,7 +1533,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimeTemplates() ([]any, error)
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1634,7 +1634,7 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1709,7 +1709,7 @@ func (g *mqlGcpProjectVertexaiService) reasoningEngines() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewReasoningEngineClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1806,7 +1806,7 @@ func (g *mqlGcpProjectVertexaiService) ragCorpora() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewVertexRagDataClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1877,7 +1877,7 @@ func (g *mqlGcpProjectVertexaiService) featureGroups() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewFeatureRegistryClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -1943,7 +1943,7 @@ func (g *mqlGcpProjectVertexaiService) persistentResources() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPersistentResourceClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2028,7 +2028,7 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewScheduleClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2096,7 +2096,7 @@ func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) 
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewDeploymentResourcePoolClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2168,7 +2168,7 @@ func (g *mqlGcpProjectVertexaiService) cachedContents() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewGenAiCacheClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2240,7 +2240,7 @@ func (g *mqlGcpProjectVertexaiService) batchPredictionJobs() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2326,7 +2326,7 @@ func (g *mqlGcpProjectVertexaiService) tuningJobs() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewGenAiTuningClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2411,7 +2411,7 @@ func (g *mqlGcpProjectVertexaiService) trainingPipelines() ([]any, error) {
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPipelineClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2491,7 +2491,7 @@ func (g *mqlGcpProjectVertexaiService) hyperparameterTuningJobs() ([]any, error)
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {
@@ -2573,7 +2573,7 @@ func (g *mqlGcpProjectVertexaiService) modelDeploymentMonitoringJobs() ([]any, e
 
 	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
-			option.WithCredentials(creds),
+			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
 		)
 		if err != nil {

--- a/providers/gcp/resources/workflows.go
+++ b/providers/gcp/resources/workflows.go
@@ -36,6 +36,9 @@ func (g *mqlGcpProject) workflows() (*mqlGcpProjectWorkflowsService, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !serviceEnabled {
+		log.Debug().Str("service", service_workflows).Msg("gcp service is not enabled, skipping")
+	}
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.workflowsService", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),


### PR DESCRIPTION
## Summary

GCP and Azure `-v` (verbose) output was effectively a black box compared to AWS — no visibility into which APIs were being called, against which projects/regions/zones, or whether they were failing. This closes mondoohq/mql#6480 by adding debug logging that covers the issue's four explicit asks (which zones/regions, which resources, which requests, are errors happening) for **both** clouds and **both** transports (REST + gRPC).

## Changes

**1. GCP per-request tracing (REST + gRPC)** — `gcp/connection/clients.go`
- `apiTraceTransport`: an `http.RoundTripper` wrapping the shared HTTP client; logs method/url/status/duration for every `google.golang.org/api` (REST) call. The GCP analog of Azure's `apiTracePolicy`.
- `loggingUnaryInterceptor` / `GRPCClientTraceOption()`: a gRPC unary interceptor logging method/target/duration/error. The ~50 GCP resources built on `cloud.google.com/go` gRPC libraries (securitycenter, kms, bigquery, binaryauthorization, pubsub, …) bypass the HTTP client, so the interceptor is wired into every gRPC client-construction site (188 sites) alongside `option.WithCredentials`. No `go.mod` change — grpc was already a direct dependency.

**2. Azure untraced-client fixes**
- `cloud_defender.go` (15 sites) and `iot.go` (2 sites) passed `nil` ClientOptions to `NewClientFactory`, bypassing the existing `apiTracePolicy` — now pass `&arm.ClientOptions{ClientOptions: conn.ClientOptions()}`.

**3. Lifecycle logging**
- GCP `discovery.go`: per-step target log, resolved-targets log, per-project asset-count summary.
- GCP `compute.go`: region / zone / instance counts.
- Azure `discovery.go`: subscription count + targets, per-subscription resource listing, discovery summary.

**4. Consistent GCP service-disabled skip log**
Added the established `"gcp service is not enabled, skipping"` debug log to the 11 GCP resource files that called `isServiceEnabled` but didn't log the skip.

## Issue asks → coverage

| Ask | Azure | GCP |
|---|---|---|
| Which requests are performed | ✅ apiTracePolicy (all ARM clients) | ✅ REST RoundTripper + gRPC interceptor |
| Are errors happening | ✅ status + err | ✅ status/err (REST) + err (gRPC) |
| Which resources / zones / regions | ✅ discovery + URL paths | ✅ discovery steps + region/zone counts + call targets |

## Notes
- Logging-only change; no behavioral changes to data gathering.
- For #4, completed the existing call-site pattern (one clean log per disabled service) rather than centralizing in the `isServiceEnabled` helper, which would double-log against the 23 files that already log at their call sites.
- gRPC read APIs here are unary (list/get/pager), so a unary interceptor covers them; streaming calls are not used by these resources.

## Test plan
- `go build ./...` and `go vet` pass for both `providers/gcp` and `providers/azure`; `gofmt` clean.
- Manual: `make providers/build/gcp && make providers/install/gcp`, then `mql shell gcp --project-id <proj> -c "gcp.project.compute.instances" -v` — expect `gcp api call` (REST), `gcp grpc call` (gRPC), discovery step/target logs, and service-skip notices. Likewise `azure ... -v` for `azure api call` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)