### PR TITLE
🐛 Fix debug log output interleaving with shell spinner

### DIFF
--- a/cli/shell/model.go
+++ b/cli/shell/model.go
@@ -20,6 +20,7 @@ import (
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/exec"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/mqlc"
 	"go.mondoo.com/mql/v13/mqlc/parser"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
@@ -240,6 +241,10 @@ func (m *shellModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case queryResultMsg:
 		// Query finished executing
 		m.executing = false
+		// Resume log output, flushing any buffered debug logs
+		if bw, ok := logger.LogOutputWriter.(*logger.BufferedWriter); ok {
+			bw.Resume()
+		}
 		// Print results directly to terminal (outside of Bubble Tea's view)
 		if msg.err != nil {
 			output := m.theme.ErrorText("failed to compile: " + msg.err.Error())
@@ -560,6 +565,11 @@ func (m *shellModel) executeQuery(input string) (tea.Model, tea.Cmd) {
 	m.input.SetHeight(1)
 	m.isMultiline = false
 	m.executing = true
+
+	// Pause log output to prevent debug logs from interleaving with the spinner
+	if bw, ok := logger.LogOutputWriter.(*logger.BufferedWriter); ok {
+		bw.Pause()
+	}
 
 	// Execute the query
 	queryToRun := m.query


### PR DESCRIPTION
## What

Running the interactive shell at `--log-level debug` (or with `DEBUG=1`) produced unreadable output: zerolog writes formatted log lines directly to stderr while the Bubble Tea spinner is animating, so the two fight over the terminal. Debug lines interleave with spinner frames and the query results.

Example from #6399:

```
> containers

DBG starting query execution qrid=/C2uGiu1QQA=lp
                                              DBG resource containers has no MQL ID defined ...                                       > containers
⣽  Executing query...

DBG detected docker container runtime manager=docker                                                         ⣻  Executing query...
```

## Fix

Wrap query execution in the existing `logger.BufferedWriter` `Pause`/`Resume` mechanism:

- **Pause** direct log output in `executeQuery`, right before the spinner starts.
- **Resume** in the `queryResultMsg` handler once the query finishes, flushing any buffered debug lines.

The spinner now animates cleanly during execution, and buffered debug logs are emitted as a block before the results. The `*logger.BufferedWriter` type assertion uses comma-ok, so the shell degrades gracefully (logs flow as before) rather than panicking if the global log writer is ever swapped.

## Testing

- `go build ./cli/shell/`
- `go test ./cli/shell/`
- `go vet ./cli/shell/`
- `gofmt` clean

Interactive verification (debug spinner rendering) requires a TTY and was not run in CI.

Fixes #6399