### PR TITLE
⚡ aws: make ElastiCache kmsKey resolution lazy to speed up cacheClusters

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -124078,7 +124078,7 @@ func (c *mqlAwsRdsParameterGroupParameter) GetSupportedEngineModes() *plugin.TVa
 type mqlAwsElasticache struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElasticacheInternal it will be used here
+	mqlAwsElasticacheInternal
 	CacheClusters    plugin.TValue[[]any]
 	ServerlessCaches plugin.TValue[[]any]
 	ParameterGroups  plugin.TValue[[]any]

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
@@ -82,30 +83,6 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 				}
 			}
 
-			// Batch-fetch replication groups to cache KMS key IDs (avoids N+1 on kmsKey()).
-			rgKmsKeys := map[string]*string{}
-			rgPaginator := elasticache.NewDescribeReplicationGroupsPaginator(svc, &elasticache.DescribeReplicationGroupsInput{})
-			for rgPaginator.HasMorePages() {
-				page, err := rgPaginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
-						break
-					}
-					return nil, err
-				}
-				for _, rg := range page.ReplicationGroups {
-					if rg.ReplicationGroupId != nil {
-						rgKmsKeys[*rg.ReplicationGroupId] = rg.KmsKeyId
-					}
-				}
-			}
-			for _, r := range res {
-				mqlCluster := r.(*mqlAwsElasticacheCluster)
-				if mqlCluster.cacheReplicationGroupId != nil {
-					mqlCluster.cacheKmsKeyId = rgKmsKeys[*mqlCluster.cacheReplicationGroupId]
-				}
-			}
-
 			return jobpool.JobResult(res), nil
 		}
 		tasks = append(tasks, jobpool.NewJob(f))
@@ -113,10 +90,51 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 	return tasks
 }
 
+type mqlAwsElasticacheInternal struct {
+	rgKmsLock     sync.Mutex
+	rgKmsByRegion map[string]map[string]*string
+}
+
+// kmsKeyIdForReplicationGroup resolves the KMS key ID for a replication group,
+// fetching all replication groups for a region with a single call the first time
+// the region is queried and caching the result. Queries that never access a
+// cluster's kmsKey pay nothing, while a scan that walks every cluster's kmsKey
+// still makes at most one DescribeReplicationGroups call per region.
+func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConnection, region, replicationGroupId string) (*string, error) {
+	a.rgKmsLock.Lock()
+	defer a.rgKmsLock.Unlock()
+
+	if a.rgKmsByRegion == nil {
+		a.rgKmsByRegion = map[string]map[string]*string{}
+	}
+	regionMap, ok := a.rgKmsByRegion[region]
+	if !ok {
+		regionMap = map[string]*string{}
+		svc := conn.Elasticache(region)
+		ctx := context.Background()
+		paginator := elasticache.NewDescribeReplicationGroupsPaginator(svc, &elasticache.DescribeReplicationGroupsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+					break
+				}
+				return nil, err
+			}
+			for _, rg := range page.ReplicationGroups {
+				if rg.ReplicationGroupId != nil {
+					regionMap[*rg.ReplicationGroupId] = rg.KmsKeyId
+				}
+			}
+		}
+		a.rgKmsByRegion[region] = regionMap
+	}
+	return regionMap[replicationGroupId], nil
+}
+
 type mqlAwsElasticacheClusterInternal struct {
 	securityGroupIdHandler
 	cacheReplicationGroupId *string
-	cacheKmsKeyId           *string
 	region                  string
 }
 
@@ -220,13 +238,26 @@ func (a *mqlAwsElasticacheCluster) tags() (map[string]any, error) {
 }
 
 func (a *mqlAwsElasticacheCluster) kmsKey() (*mqlAwsKmsKey, error) {
-	if a.cacheKmsKeyId == nil || *a.cacheKmsKeyId == "" {
+	if a.cacheReplicationGroupId == nil || *a.cacheReplicationGroupId == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	parent, err := CreateResource(a.MqlRuntime, "aws.elasticache", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	kmsKeyId, err := parent.(*mqlAwsElasticache).kmsKeyIdForReplicationGroup(conn, a.region, *a.cacheReplicationGroupId)
+	if err != nil {
+		return nil, err
+	}
+	if kmsKeyId == nil || *kmsKeyId == "" {
 		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
 		map[string]*llx.RawData{
-			"arn": llx.StringDataPtr(a.cacheKmsKeyId),
+			"arn": llx.StringDataPtr(kmsKeyId),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -91,25 +91,29 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 }
 
 type mqlAwsElasticacheInternal struct {
-	rgKmsLock     sync.Mutex
-	rgKmsByRegion map[string]map[string]*string
+	// rgKms holds one *rgKmsRegion per region, each resolved at most once.
+	// Keying per region (rather than a single mutex) keeps DescribeReplicationGroups
+	// calls for different regions running concurrently when kmsKey is queried.
+	rgKms sync.Map
+}
+
+type rgKmsRegion struct {
+	once sync.Once
+	keys map[string]*string
+	err  error
 }
 
 // kmsKeyIdForReplicationGroup resolves the KMS key ID for a replication group,
 // fetching all replication groups for a region with a single call the first time
 // the region is queried and caching the result. Queries that never access a
 // cluster's kmsKey pay nothing, while a scan that walks every cluster's kmsKey
-// still makes at most one DescribeReplicationGroups call per region.
+// makes at most one DescribeReplicationGroups call per region, concurrently
+// across regions.
 func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConnection, region, replicationGroupId string) (*string, error) {
-	a.rgKmsLock.Lock()
-	defer a.rgKmsLock.Unlock()
-
-	if a.rgKmsByRegion == nil {
-		a.rgKmsByRegion = map[string]map[string]*string{}
-	}
-	regionMap, ok := a.rgKmsByRegion[region]
-	if !ok {
-		regionMap = map[string]*string{}
+	v, _ := a.rgKms.LoadOrStore(region, &rgKmsRegion{})
+	entry := v.(*rgKmsRegion)
+	entry.once.Do(func() {
+		keys := map[string]*string{}
 		svc := conn.Elasticache(region)
 		ctx := context.Background()
 		paginator := elasticache.NewDescribeReplicationGroupsPaginator(svc, &elasticache.DescribeReplicationGroupsInput{})
@@ -119,17 +123,21 @@ func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConn
 				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 					break
 				}
-				return nil, err
+				entry.err = err
+				return
 			}
 			for _, rg := range page.ReplicationGroups {
 				if rg.ReplicationGroupId != nil {
-					regionMap[*rg.ReplicationGroupId] = rg.KmsKeyId
+					keys[*rg.ReplicationGroupId] = rg.KmsKeyId
 				}
 			}
 		}
-		a.rgKmsByRegion[region] = regionMap
+		entry.keys = keys
+	})
+	if entry.err != nil {
+		return nil, entry.err
 	}
-	return regionMap[replicationGroupId], nil
+	return entry.keys[replicationGroupId], nil
 }
 
 type mqlAwsElasticacheClusterInternal struct {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -91,16 +91,16 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 }
 
 type mqlAwsElasticacheInternal struct {
-	// rgKms holds one *rgKmsRegion per region, each resolved at most once.
-	// Keying per region (rather than a single mutex) keeps DescribeReplicationGroups
-	// calls for different regions running concurrently when kmsKey is queried.
+	// rgKms holds one *rgKmsRegion per region. Keying per region (rather than a
+	// single mutex) keeps DescribeReplicationGroups calls for different regions
+	// running concurrently when kmsKey is queried.
 	rgKms sync.Map
 }
 
 type rgKmsRegion struct {
-	once sync.Once
-	keys map[string]*string
-	err  error
+	mu      sync.Mutex
+	fetched bool
+	keys    map[string]*string
 }
 
 // kmsKeyIdForReplicationGroup resolves the KMS key ID for a replication group,
@@ -108,11 +108,15 @@ type rgKmsRegion struct {
 // the region is queried and caching the result. Queries that never access a
 // cluster's kmsKey pay nothing, while a scan that walks every cluster's kmsKey
 // makes at most one DescribeReplicationGroups call per region, concurrently
-// across regions.
+// across regions. A transient failure is not cached, so a later access retries.
 func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConnection, region, replicationGroupId string) (*string, error) {
 	v, _ := a.rgKms.LoadOrStore(region, &rgKmsRegion{})
 	entry := v.(*rgKmsRegion)
-	entry.once.Do(func() {
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if !entry.fetched {
 		keys := map[string]*string{}
 		svc := conn.Elasticache(region)
 		ctx := context.Background()
@@ -123,8 +127,8 @@ func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConn
 				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 					break
 				}
-				entry.err = err
-				return
+				// Leave fetched=false so a later access retries the transient failure.
+				return nil, err
 			}
 			for _, rg := range page.ReplicationGroups {
 				if rg.ReplicationGroupId != nil {
@@ -133,9 +137,7 @@ func (a *mqlAwsElasticache) kmsKeyIdForReplicationGroup(conn *connection.AwsConn
 			}
 		}
 		entry.keys = keys
-	})
-	if entry.err != nil {
-		return nil, entry.err
+		entry.fetched = true
 	}
 	return entry.keys[replicationGroupId], nil
 }

--- a/providers/aws/resources/aws_elasticache_test.go
+++ b/providers/aws/resources/aws_elasticache_test.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestElasticacheClusterKmsKey covers the early-return null-state paths of
+// kmsKey(), which resolve before any connection or API call. A cluster without
+// a replication group (the KMS key only ever comes from the replication group)
+// must report a set-but-null field rather than returning a bare nil, which would
+// panic the runtime. The populated path requires a live API and is covered by
+// interactive testing.
+func TestElasticacheClusterKmsKey(t *testing.T) {
+	t.Run("nil replication group ID sets null state", func(t *testing.T) {
+		c := &mqlAwsElasticacheCluster{}
+		result, err := c.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, c.KmsKey.IsNull())
+		assert.True(t, c.KmsKey.IsSet())
+	})
+
+	t.Run("empty replication group ID sets null state", func(t *testing.T) {
+		c := &mqlAwsElasticacheCluster{}
+		empty := ""
+		c.cacheReplicationGroupId = &empty
+		result, err := c.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, c.KmsKey.IsNull())
+		assert.True(t, c.KmsKey.IsSet())
+	})
+}


### PR DESCRIPTION
## Problem

Issue #5115 reports a slow `aws.elasticache` query that only filters on snapshot retention:

```
aws.elasticache.cacheClusters.all(snapshotRetentionLimit > ...)
```

`getCacheClusters` eagerly called `DescribeReplicationGroups` in **every region** — a second paginated API round-trip per region — solely to pre-populate KMS-key IDs for the `kmsKey()` accessor (added in #7158 to avoid an N+1). Any query that never touches `kmsKey` still paid that cost, roughly doubling the latency of the whole multi-region `cacheClusters` walk.

## Fix

Make the KMS resolution lazy **without** reintroducing an N+1:

- Removed the eager per-region `DescribeReplicationGroups` from `getCacheClusters`.
- Added a mutex-guarded, per-region cache (`kmsKeyIdForReplicationGroup`) on the parent `aws.elasticache` resource. The first `kmsKey()` access in a region issues one `DescribeReplicationGroups` call for that region; subsequent clusters reuse the cached map.

Net effect:
- Queries that don't access `kmsKey` (the reported case) → **zero** replication-group calls.
- A full KMS scan → at most one `DescribeReplicationGroups` per region, same as before.

`CacheCluster` carries no KMS key of its own (only `ReplicationGroup` does), so behavior is unchanged.

## Verification

Built and installed the provider, then ran against live AWS using a temporary encrypted Redis replication group (one AWS-owned key, one customer-managed key), now torn down:

| Cluster | Encryption | `kmsKey` |
|---|---|---|
| `mql-test-5115-001` | AWS-owned (`sse-elasticache`) | `null` ✓ |
| `mql-test-5115-cmk-001` | customer-managed key | resolves to the CMK ARN ✓ |

- `make providers/build/aws` — builds, `aws.permissions.json` unchanged (911)
- `gofmt` clean, `golangci-lint` 0 issues
- Generated `aws.lr.go` diff limited to embedding the new internal struct; no `.lr.versions` changes

Fixes #5115