### PR TITLE
🐛 terraform: stop terraform.files/file.blocks/module.block panicking on plan/state assets

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -37,8 +37,14 @@ type mqlTerraformInternal struct {
 func (t *mqlTerraform) files() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
 
+	// plan and state assets have no HCL parser; there are no files to list.
+	parser := conn.Parser()
+	if parser == nil {
+		return []any{}, nil
+	}
+
 	var mqlTerraformFiles []any
-	files := conn.Parser().Files()
+	files := parser.Files()
 	for path := range files {
 		mqlTerraformFile, err := CreateResource(t.MqlRuntime, "terraform.file", map[string]*llx.RawData{
 			"path": llx.StringData(path),
@@ -882,7 +888,13 @@ func (t *mqlTerraformFile) blocks() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
 	p := t.Path.Data
 
-	files := conn.Parser().Files()
+	// plan and state assets have no HCL parser; there are no blocks to list.
+	parser := conn.Parser()
+	if parser == nil {
+		return []any{}, nil
+	}
+
+	files := parser.Files()
 	file := files[p]
 	return listHclBlocks(t.MqlRuntime, file.Body, file)
 }
@@ -897,7 +909,15 @@ func (t *mqlTerraformModule) id() (string, error) {
 func (t *mqlTerraformModule) block() (*mqlTerraformBlock, error) {
 	key := t.Key.Data
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
-	files := conn.Parser().Files()
+
+	// plan and state assets have no HCL parser; there is no backing block.
+	parser := conn.Parser()
+	if parser == nil {
+		t.Block.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	files := parser.Files()
 
 	var mqlHclBlock *mqlTerraformBlock
 	for k := range files {

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/terraform/connection"
 )
 
 func blockWithLabels(labels ...string) *mqlTerraformBlock {
@@ -55,6 +56,47 @@ func TestBlockResourceTypeAndName(t *testing.T) {
 	rn, err = none.resourceName()
 	require.NoError(t, err)
 	assert.Equal(t, "", rn)
+}
+
+// TestHclResources_NoParser_DoNotPanic is a regression test for
+// https://github.com/mondoohq/mql/issues/2970: the terraform.files,
+// terraform.file.blocks and terraform.module.block resources used to
+// dereference a nil *hclparse.Parser and crash the provider on plan and
+// state assets (which have no HCL parser). They must now return empty
+// results instead of panicking.
+func TestHclResources_NoParser_DoNotPanic(t *testing.T) {
+	// A zero-value Connection mirrors what NewPlanConnection / NewStateConnection
+	// produce: no HCL parser is set, so Parser() returns nil.
+	runtime := &plugin.Runtime{Connection: &connection.Connection{}}
+
+	t.Run("terraform.files", func(t *testing.T) {
+		tf := &mqlTerraform{}
+		tf.MqlRuntime = runtime
+		files, err := tf.files()
+		require.NoError(t, err)
+		assert.Empty(t, files)
+	})
+
+	t.Run("terraform.file.blocks", func(t *testing.T) {
+		file := &mqlTerraformFile{}
+		file.MqlRuntime = runtime
+		file.Path = plugin.TValue[string]{Data: "main.tf", State: plugin.StateIsSet}
+		blocks, err := file.blocks()
+		require.NoError(t, err)
+		assert.Empty(t, blocks)
+	})
+
+	t.Run("terraform.module.block", func(t *testing.T) {
+		module := &mqlTerraformModule{}
+		module.MqlRuntime = runtime
+		module.Key = plugin.TValue[string]{Data: "vpc", State: plugin.StateIsSet}
+		block, err := module.block()
+		require.NoError(t, err)
+		assert.Nil(t, block)
+		// The accessor must mark the field resolved-and-null so the runtime
+		// does not re-fetch indefinitely.
+		assert.True(t, module.Block.State&plugin.StateIsNull != 0)
+	})
 }
 
 // parseAttrs parses an HCL snippet and returns the top-level attributes.


### PR DESCRIPTION
## What

Fixes #2970.

`terraform.files` (and its siblings `terraform.file.blocks` and `terraform.module.block`) crashed the terraform provider with a nil pointer dereference when run against `terraform-plan` and `terraform-state` assets:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/hashicorp/hcl/v2/hclparse.(*Parser).Files(...)
go.mondoo.com/cnquery/.../resources.(*mqlTerraform).files(...) hcl.go
```

## Why

`Connection.Parser()` returns `c.parsed`, which is only set in `NewHclConnection`. `NewPlanConnection` and `NewStateConnection` build the connection without it, leaving `parsed` nil — so `conn.Parser().Files()` dereferences a nil `*hclparse.Parser`. Only `terraform.blocks()` already guarded against this; the three callsites here did not.

## Fix

Add the same `parser == nil` guard to the three unguarded callsites so they return empty/null instead of panicking:

- `terraform.files()` → `[]any{}`
- `terraform.file.blocks()` → `[]any{}`
- `terraform.module.block()` → sets `StateIsNull | StateIsSet` and returns nil

Plan and state assets genuinely have no HCL source files, so empty is the correct and consistent answer (matching the pre-existing `terraform.blocks()` behavior). No runtime warning is emitted: it would only reach provider debug logs, not the query result, and would be noisy for policies iterating these fields across mixed asset types.

## Tests

`TestHclResources_NoParser_DoNotPanic` builds a parser-less `connection.Connection` (exactly what the plan/state constructors produce) and asserts all three resolvers return empty rather than panicking.