### PR TITLE
🐛 os: recover macOS package versions from Info.plist when system_profiler omits them

### DIFF
--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -32,6 +32,13 @@ type sysProfiler struct {
 	Items []sysProfilerItem `plist:"_items"`
 }
 
+// infoPlist holds the version keys we care about from an app bundle's
+// Contents/Info.plist.
+type infoPlist struct {
+	ShortVersion  string `plist:"CFBundleShortVersionString"`
+	BundleVersion string `plist:"CFBundleVersion"`
+}
+
 // parse macos system version property list
 func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, input io.Reader) ([]Package, error) {
 	var r io.ReadSeeker
@@ -61,13 +68,23 @@ func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, in
 	for i, entry := range data[0].Items {
 		// We need a special handling for Firefox to determine ESR installations
 		purlQualifiers := getPurlQualifiers(conn, entry)
+
+		// system_profiler only surfaces CFBundleShortVersionString as the
+		// version. Some bundles (e.g. PWAs) ship a version only in
+		// CFBundleVersion, so fall back to the bundle's Info.plist when
+		// system_profiler reports no version.
+		version := entry.Version
+		if version == "" {
+			version = bundleVersionFromInfoPlist(conn, entry.Path)
+		}
+
 		pkgs[i].Name = entry.Name
-		pkgs[i].Version = entry.Version
+		pkgs[i].Version = version
 		pkgs[i].Format = MacosPkgFormat
 		pkgs[i].FilesAvailable = PkgFilesIncluded
 		pkgs[i].Arch = platform.Arch
 		pkgs[i].PUrl = purl.NewPackageURL(
-			platform, purl.TypeMacos, entry.Name, entry.Version, purl.WithQualifiers(purlQualifiers),
+			platform, purl.TypeMacos, entry.Name, version, purl.WithQualifiers(purlQualifiers),
 		).String()
 		if entry.Path != "" {
 			pkgs[i].Files = []FileRecord{
@@ -111,6 +128,42 @@ func (mpm *MacOSPkgManager) Available() (map[string]PackageUpdate, error) {
 func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
 	// nothing extra to be done here since the list is already included in the package list
 	return nil, nil
+}
+
+// bundleVersionFromInfoPlist recovers an app's version from its
+// Contents/Info.plist when system_profiler did not report one. It prefers
+// CFBundleShortVersionString (the user-facing version) and falls back to
+// CFBundleVersion (the build version). Returns an empty string when no bundle
+// Info.plist exists (e.g. bare ".app" daemons) or it carries no version.
+func bundleVersionFromInfoPlist(conn shared.Connection, path string) string {
+	if path == "" {
+		return ""
+	}
+
+	infoPath := filepath.Join(path, "Contents", "Info.plist")
+	f, err := conn.FileSystem().Open(infoPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", infoPath).Msg("could not open Info.plist")
+		return ""
+	}
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		log.Debug().Err(err).Str("path", infoPath).Msg("could not read Info.plist")
+		return ""
+	}
+
+	var info infoPlist
+	if _, err := plist.Unmarshal(content, &info); err != nil {
+		log.Debug().Err(err).Str("path", infoPath).Msg("could not parse Info.plist")
+		return ""
+	}
+
+	if info.ShortVersion != "" {
+		return info.ShortVersion
+	}
+	return info.BundleVersion
 }
 
 func getPurlQualifiers(conn shared.Connection, entry sysProfilerItem) map[string]string {

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -31,7 +31,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	}
 	m, err := packages.ParseMacOSPackages(mock, pf, c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(m), "detected the right amount of packages")
+	assert.Equal(t, 5, len(m), "detected the right amount of packages")
 
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
@@ -53,4 +53,16 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, packages.MacosPkgFormat, m[2].Format, "pkg format detected")
 	assert.Equal(t, "pkg:macos/macos/Firefox@128.12.0?arch=x86_64&remoting-name=firefox-esr", m[2].PUrl)
 	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Firefox.app"}}, m[2].Files)
+
+	// system_profiler only surfaces CFBundleShortVersionString; when that is
+	// absent (e.g. a PWA that ships only a CFBundleVersion) we recover the
+	// version from the bundle's Info.plist.
+	assert.Equal(t, "Microsoft Teams (PWA)", m[3].Name, "pkg name detected")
+	assert.Equal(t, "7778.181", m[3].Version, "pkg version recovered from Info.plist")
+	assert.Equal(t, "pkg:macos/macos/Microsoft%20Teams%20%28PWA%29@7778.181?arch=x86_64", m[3].PUrl)
+
+	// A bare ".app" directory with no Info.plist (a system daemon) genuinely
+	// has no version anywhere, so the version stays empty.
+	assert.Equal(t, "liquiddetectiond", m[4].Name, "pkg name detected")
+	assert.Equal(t, "", m[4].Version, "no version available for a bare .app daemon")
 }

--- a/providers/os/resources/packages/testdata/packages_macos.toml
+++ b/providers/os/resources/packages/testdata/packages_macos.toml
@@ -91,11 +91,50 @@ stdout = """<?xml version="1.0" encoding="UTF-8"?>
 				<key>version</key>
 				<string>128.12.0</string>
 			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Microsoft Teams (PWA)</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2025-07-02T08:20:57Z</date>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Microsoft Teams (PWA).app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>liquiddetectiond</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>apple</string>
+				<key>path</key>
+				<string>/System/Library/CoreServices/liquiddetectiond.app</string>
+			</dict>
 		</array>
 		<key>_parentDataType</key>
 		<string>SPSoftwareDataType</string>
 	</dict>
 </array>
+</plist>
+"""
+
+[files."/Applications/Microsoft Teams (PWA).app/Contents/Info.plist"]
+content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.microsoft.teams2.pwa</string>
+	<key>CFBundleName</key>
+	<string>Microsoft Teams (PWA)</string>
+	<key>CFBundleVersion</key>
+	<string>7778.181</string>
+</dict>
 </plist>
 """
 


### PR DESCRIPTION
## What

Fixes #4738 — some macOS packages report an empty `Version`.

## Root cause

`system_profiler SPApplicationsDataType -xml` only surfaces **`CFBundleShortVersionString`** as a package's `version`, and omits the key entirely when that string is absent. On a test Mac, 116 of 503 app entries had no version. They split into two groups:

- **Genuinely versionless** (~111): bare `.app` directories with no `Contents/Info.plist` at all (e.g. `liquiddetectiond.app` — just an executable + a PDF), system daemons on the sealed system volume, and non-app entries like `com.apple.ctcategories` (an `~/Library/HTTPStorages/…service` dir) and Firefox profile storage dirs (`https+++….app`). These carry no version *anywhere* — nothing can recover one.
- **Recoverable**: real app bundles that ship a version only in **`CFBundleVersion`** (e.g. a Microsoft Teams PWA at `7778.181`, with no `CFBundleShortVersionString`). `system_profiler` reports these blank even though the version is right there in the bundle.

## Fix

When `system_profiler` reports no version, fall back to reading the bundle's `Contents/Info.plist` via the connection filesystem (works over SSH too — same pattern as the existing Firefox `application.ini` read), preferring `CFBundleShortVersionString`, then `CFBundleVersion`. The resolved version feeds both `pkg.Version` and the PURL.

## Tests

- New Teams-PWA-style fixture (blank `version`, Info.plist with only `CFBundleVersion`) — version now recovered to `7778.181`.
- New bare-daemon `liquiddetectiond` fixture (no Info.plist) — version correctly stays empty.
- Full `./resources/packages` suite + `go vet` pass.

## Note

The two examples in the issue (`liquiddetectiond`, `com.apple.ctcategories`) are unfixable by definition — they have no version metadata at all. A related observation: a chunk of those 116 entries aren't applications at all (HTTPStorages, browser-profile storage dirs ending in `.app`). Filtering that noise out of the package list would be a reasonable separate follow-up if desired.