### PR TITLE
⭐ vsphere: add vsphere.host.lockdownExceptions

### DIFF
--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -728,6 +728,19 @@ func (v *mqlVsphereHost) services() ([]any, error) {
 	return mqlServices, nil
 }
 
+func (v *mqlVsphereHost) lockdownExceptions() ([]any, error) {
+	_, host, err := v.pathAndHost()
+	if err != nil {
+		return nil, err
+	}
+
+	exceptions, err := resourceclient.HostLockdownExceptions(host)
+	if err != nil {
+		return nil, err
+	}
+	return convert.SliceAnyToInterface(exceptions), nil
+}
+
 func (v *mqlVsphereHost) timezone() (*mqlVsphereHostTimezone, error) {
 	path, host, err := v.pathAndHost()
 	if err != nil {

--- a/providers/vsphere/resources/resourceclient/host.go
+++ b/providers/vsphere/resources/resourceclient/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware/govmomi/license"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -52,6 +53,26 @@ func HostOptions(host *object.HostSystem) (map[string]any, error) {
 		advancedProps[key] = value
 	}
 	return advancedProps, nil
+}
+
+// HostLockdownExceptions returns the user and service accounts that are exempt
+// from lockdown mode on the given host. It reads the host's HostAccessManager
+// reference from the config manager and calls QueryLockdownExceptions on it.
+func HostLockdownExceptions(host *object.HostSystem) ([]string, error) {
+	ctx := context.Background()
+	var props mo.HostSystem
+	if err := host.Properties(ctx, host.Reference(), []string{"configManager.hostAccessManager"}, &props); err != nil {
+		return nil, err
+	}
+	ref := props.ConfigManager.HostAccessManager
+	if ref == nil {
+		return nil, nil
+	}
+	res, err := methods.QueryLockdownExceptions(ctx, host.Client(), &types.QueryLockdownExceptions{This: *ref})
+	if err != nil {
+		return nil, err
+	}
+	return res.Returnval, nil
 }
 
 func HostServices(host *object.HostSystem) ([]types.HostService, error) {

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -492,6 +492,8 @@ private vsphere.host @defaults("moid name") {
   tags []string
   // Lockdown mode (lockdownDisabled, lockdownNormal, lockdownStrict)
   lockdownMode string
+  // User and service accounts exempt from lockdown mode; these accounts retain direct host access even while lockdown mode is enabled
+  lockdownExceptions() []string
   // Whether the host firewall blocks unsolicited incoming traffic by default (the host firewall service itself is always running on ESXi)
   firewallIncomingBlocked bool
   // Whether the host firewall blocks unsolicited outgoing traffic by default

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -870,6 +870,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.host.lockdownMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetLockdownMode()).ToDataRes(types.String)
 	},
+	"vsphere.host.lockdownExceptions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetLockdownExceptions()).ToDataRes(types.Array(types.String))
+	},
 	"vsphere.host.firewallIncomingBlocked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetFirewallIncomingBlocked()).ToDataRes(types.Bool)
 	},
@@ -2727,6 +2730,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.lockdownMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).LockdownMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.lockdownExceptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).LockdownExceptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vsphere.host.firewallIncomingBlocked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6304,6 +6311,7 @@ type mqlVsphereHost struct {
 	Snmp                        plugin.TValue[map[string]any]
 	Tags                        plugin.TValue[[]any]
 	LockdownMode                plugin.TValue[string]
+	LockdownExceptions          plugin.TValue[[]any]
 	FirewallIncomingBlocked     plugin.TValue[bool]
 	FirewallOutgoingBlocked     plugin.TValue[bool]
 	SecureBootEnabled           plugin.TValue[bool]
@@ -6560,6 +6568,12 @@ func (c *mqlVsphereHost) GetTags() *plugin.TValue[[]any] {
 
 func (c *mqlVsphereHost) GetLockdownMode() *plugin.TValue[string] {
 	return &c.LockdownMode
+}
+
+func (c *mqlVsphereHost) GetLockdownExceptions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LockdownExceptions, func() ([]any, error) {
+		return c.lockdownExceptions()
+	})
 }
 
 func (c *mqlVsphereHost) GetFirewallIncomingBlocked() *plugin.TValue[bool] {

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -244,6 +244,7 @@ vsphere.host.kernelModule.signedStatus 13.1.1
 vsphere.host.kernelModule.version 13.1.1
 vsphere.host.kernelModule.vibAcceptanceLevel 13.1.1
 vsphere.host.kernelModules 9.0.0
+vsphere.host.lockdownExceptions 13.5.2
 vsphere.host.lockdownMode 13.0.10
 vsphere.host.memShareForceSalting 13.4.3
 vsphere.host.mobEnabled 13.4.3


### PR DESCRIPTION
## What

Adds a `lockdownExceptions` field to the `vsphere.host` resource, resolving #5948.

When an ESXi host is in lockdown mode, a set of user and service accounts can be configured to retain direct host access. This field exposes that exemption list — the equivalent of:

```powershell
(Get-View (Get-VMHost -Name $ESXi | Get-View).ConfigManager.HostAccessManager).QueryLockdownExceptions()
```

## How

- `vsphere.lr`: new `lockdownExceptions() []string` computed field on `vsphere.host`, sitting alongside the existing `lockdownMode` hardening field.
- `resourceclient/host.go`: `HostLockdownExceptions` reads `ConfigManager.hostAccessManager` from the host and calls govmomi's `QueryLockdownExceptions`, returning the account list (`nil` when the host reports no HostAccessManager).
- `host.go`: thin lazy accessor wiring the resourceclient helper to the resource.

It's a computed accessor rather than an eagerly-populated discovery field because `QueryLockdownExceptions` is a separate SOAP call (not part of the cached `mo.HostSystem` properties); making it lazy keeps host discovery free of an extra round-trip per host.

Example query:

```mql
vsphere.host.lockdownExceptions
```

## Testing

- `make providers/build/vsphere` compiles cleanly.
- Existing `providers/vsphere/resources/...` unit tests pass.

The accessor is a thin govmomi wrapper with no branching logic to unit-test, and the govmomi vCenter simulator does not implement `QueryLockdownExceptions`, so live verification against a real vCenter is recommended before release.