### PR TITLE
🐛 google-workspace: pass member-read scope when listing group members

### DIFF
--- a/providers/google-workspace/resources/group.go
+++ b/providers/google-workspace/resources/group.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"strings"
 
 	"go.mondoo.com/mql/v13/providers/google-workspace/connection"
@@ -16,7 +15,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	directory "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/cloudidentity/v1"
-	"google.golang.org/api/option"
 )
 
 func (g *mqlGoogleworkspace) groups() ([]any, error) {
@@ -73,12 +71,7 @@ func (g *mqlGoogleworkspaceGroup) id() (string, error) {
 
 func (g *mqlGoogleworkspaceGroup) members() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
-	client, err := conn.Client()
-	if err != nil {
-		return nil, err
-	}
-
-	directoryService, err := directory.NewService(context.Background(), option.WithHTTPClient(client))
+	directoryService, err := directoryService(conn, directory.AdminDirectoryGroupMemberReadonlyScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

`googleworkspace.group.members` returned an OAuth error even with all read-only scopes configured (issue #697):

```
members: Get ".../members?...": oauth2: cannot fetch token: 400 Bad Request
Response: { "error": "invalid_scope", "error_description": "Empty or missing scope not allowed." }
```

The `members()` method called `conn.Client()` with **no scope**, so the token request had an empty scope and was rejected. It was the only remaining no-scope `Client()` call in the provider — the other fields reported in the issue (`settings`, `securitySettings`, `orgUnits`, `roles`, `user.tokens`) were already migrated to scoped service helpers.

## Fix

Use the scoped `directoryService` helper with `directory.AdminDirectoryGroupMemberReadonlyScope`, mirroring the sibling `settings()` and `securitySettings()` methods. The scope is already part of `DefaultWorkspaceClientScopes`, so no scope-configuration change is required. The now-unused `context` and `option` imports were dropped.

## Verification

Provider-only change. Build is clean (`go build ./resources/`). Against a live tenant:

```
mql shell google-workspace -c "googleworkspace.groups[1].members { * }"
```

Fixes #697