### PR TITLE
⭐ os: detect CirrOS container base OS (#438)

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -979,6 +979,19 @@ var euleros = &PlatformResolver{
 	},
 }
 
+// CirrOS is a minimal Buildroot-based cloud test image; it self-identifies via
+// /etc/os-release (ID=cirros), populated by the generic linux family detection.
+var cirros = &PlatformResolver{
+	Name:     "cirros",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "cirros" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 // fallback linux detection, since we do not know the system, the family detection may not be correct
 var defaultLinux = &PlatformResolver{
 	Name:     "generic-linux",
@@ -1260,7 +1273,7 @@ var eulerFamily = &PlatformResolver{
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, defaultLinux},
+	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -698,6 +698,17 @@ func TestGentooLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+func TestCirrOSLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-cirros.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "cirros", di.Name, "os name should be identified")
+	assert.Equal(t, "CirrOS 0.6.0", di.Title, "os title should be identified")
+	assert.Equal(t, "0.6.0", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestAlpineLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-alpine.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-cirros.toml
+++ b/providers/os/detector/testdata/detect-cirros.toml
@@ -1,0 +1,18 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.0.0"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="CirrOS 0.6.0"
+NAME="CirrOS"
+VERSION_ID="0.6.0"
+ID=cirros
+HOME_URL="https://cirros-cloud.net"
+BUG_REPORT_URL="https://github.com/cirros-dev/cirros/issues"
+"""


### PR DESCRIPTION
## Summary

Apps built on the CirrOS base container image are now detected as the `cirros` OS instead of falling through to generic Linux detection.

CirrOS is a minimal Buildroot-based cloud test image that self-identifies via `/etc/os-release` (`ID=cirros`). The generic linux family detection already populates `pf.Name` from that ID, so this adds an explicit `cirros` `PlatformResolver` under the linux family that matches on it — giving CirrOS a recognized platform entry with the `linux → unix → os` family lineage. It follows the same pattern as the existing `gentoo`/`photon`/`flatcar` resolvers.

```
/ # cat /etc/os-release
PRETTY_NAME="CirrOS 0.6.0"
NAME="CirrOS"
VERSION_ID="0.6.0"
ID=cirros
HOME_URL="https://cirros-cloud.net"
BUG_REPORT_URL="https://github.com/cirros-dev/cirros/issues"
```

## Changes

- `providers/os/detector/detector_all.go` — new `cirros` resolver, registered in the `linuxFamily` children before the `defaultLinux` fallback
- `providers/os/detector/testdata/detect-cirros.toml` — fixture with the os-release from the issue
- `providers/os/detector/detector_platform_test.go` — `TestCirrOSLinuxDetector` asserting name/title/version/arch/family

## Testing

- `go test ./detector/` passes (new test + no regressions)
- `gofmt` clean

Resolves #438