### PR TITLE
🎉 aws-13.36.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.35.1",
+	Version:         "13.36.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.36.0)
- ⚡ aws: make ElastiCache kmsKey resolution lazy to speed up cacheClusters (#8369)
- ✨ aws: expose object provenance across EC2, databases, CloudFormation, Backup, ECS, and Signer (#8358)
- ✨ aws: expose AMI provenance watermarks and Neptune networkType (#8354)