### PR TITLE
📄 os: document authorizedkeys init syntax with examples

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -793,12 +793,16 @@ users {
 // SSH authorized_keys file
 //
 // Examine a single `authorized_keys` file: its path, the typed `file`
-// reference, the raw `content` string, and the parsed `[]entry` list
-// where each entry surfaces the line number, key type, key material,
-// label, and any `command=` / `from=` / `no-port-forwarding` SSH
-// options. Used to audit which keys actually grant SSH access to a
-// given user and to detect entries with no source / command
-// restrictions.
+// reference, the raw `content` string, and the parsed `entry` list where
+// each entry surfaces the line number, key type, key material, label, and
+// any `command=` / `from=` / `no-port-forwarding` SSH options. Select the
+// file by absolute path — for example
+// `authorizedkeys(path: "/root/.ssh/authorized_keys")` — or reach it per
+// account through the `user` resource, whose `authorizedkeys` field
+// resolves each user's `~/.ssh/authorized_keys` automatically (for
+// example `users.where(name == "root") { authorizedkeys { list { key } } }`).
+// Used to audit which keys actually grant SSH access to a given user and
+// to detect entries with no source or command restrictions.
 authorizedkeys {
   []authorizedkeys.entry(file, content)
   init(path string)


### PR DESCRIPTION
## What

The `authorizedkeys` resource requires a `path` init argument, but its [docs page](https://mondoo.com/docs/mql/resources/core-pack/authorizedkeys/) never showed the call syntax — only field descriptions. A user can't tell from the docs that they must write `authorizedkeys(path: '/root/.ssh/authorized_keys')`.

This rewrites the resource doc-comment (the source the website resource docs are generated from) to show how to select a file:

- **By path:** `authorizedkeys(path: "/root/.ssh/authorized_keys")` — the exact syntax the reporter asked for.
- **Per user:** `users.where(name == "root") { authorizedkeys { list { key } } }` — how most real audits reach it, via the `user` resource which resolves `~/.ssh/authorized_keys` automatically.

This follows the repo's own doc-comment convention for selection-keyed resources (mention the selection field with a concrete example), which `authorizedkeys` was missing.

## Notes

- Doc-comment only; no schema/field changes, no `.lr.versions` bumps.
- `mqlr generate` runs clean (two-part doc-comment validates).

Fixes #1186