### PR TITLE
🐛 mqlc/llx: fix switch with constant-boolean case conditions

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -72,6 +72,36 @@ func TestMqlSimple(t *testing.T) {
 	}
 }
 
+// Regression test for https://github.com/mondoohq/mql/issues/1174: a case whose
+// condition is a constant boolean (`case true:` / `case false:`) used to compile
+// to the same Bool primitive the compiler emits for `default`, so the runtime
+// misidentified it as the default case and fell through to the last default-looking
+// arg. These must now match by their actual truthiness.
+func TestMqlSwitch(t *testing.T) {
+	tests := []struct {
+		query     string
+		assertion any
+	}{
+		{"switch { case true: 1; case false: 2; }", int64(1)},
+		{"switch { case false: 1; case true: 2; }", int64(2)},
+		{"switch { case true: 1; default: 2; }", int64(1)},
+		{"switch { case false: 1; default: 2; }", int64(2)},
+		{"switch { case false: 1; case false: 2; default: 3; }", int64(3)},
+		{`switch(1) { case _ > 0: "pos"; default: "neg" }`, "pos"},
+		{`switch(1) { case _ < 0: "neg"; default: "other" }`, "other"},
+	}
+
+	for i := range tests {
+		one := tests[i]
+		t.Run(one.query, func(t *testing.T) {
+			res, err := exec.Exec(one.query, runtime(), testutils.Features, nil)
+			require.NoError(t, err)
+			require.NoError(t, res.Error)
+			assert.Equal(t, one.assertion, res.Value)
+		})
+	}
+}
+
 func TestCustomData(t *testing.T) {
 	query := "{ \"a\": \"valuea\", \"b\": \"valueb\"}"
 

--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -128,7 +128,10 @@ func switchCallV2(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, 
 	max := len(f.Args)
 	defaultCaseIdx := -1
 	for idx+2 < max {
-		if types.Type(f.Args[idx].Type) == types.Bool {
+		// the default case is marked with an unset condition primitive by the
+		// compiler, so it can be told apart from a real case with a constant
+		// boolean condition (`case true:` / `case false:`). See mondoohq/mql#1174.
+		if types.Type(f.Args[idx].Type) == types.Unset {
 			defaultCaseIdx = idx
 			idx += 3
 			continue

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -545,9 +545,12 @@ func (c *compiler) compileIfBlock(expressions []*parser.Expression, chunk *llx.C
 }
 
 func (c *compiler) compileSwitchCase(expression *parser.Expression, bind *variable, chunk *llx.Chunk) error {
-	// for the default case, we get a nil expression
+	// for the default case, we get a nil expression. We mark it with an unset
+	// primitive (not `BoolPrimitive(true)`) so the runtime can tell the default
+	// apart from a real case whose condition happens to be a constant boolean,
+	// e.g. `case true:` / `case false:`. See mondoohq/mql#1174.
 	if expression == nil {
-		chunk.Function.Args = append(chunk.Function.Args, llx.BoolPrimitive(true))
+		chunk.Function.Args = append(chunk.Function.Args, llx.UnsetPrimitive)
 		return nil
 	}
 

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -873,7 +873,7 @@ func TestCompiler_Switch(t *testing.T) {
 					// will already be available for any blocks
 					llx.RefPrimitiveV2((1 << 32) | 1),
 				}, types.Ref),
-				llx.BoolPrimitive(true),
+				llx.UnsetPrimitive,
 				llx.FunctionPrimitive(3 << 32),
 				llx.ArrayPrimitive([]*llx.Primitive{
 					// TODO: this shouldn't be needed


### PR DESCRIPTION
## What

`switch` returned the wrong result whenever a case condition was a constant boolean:

```
switch { case true: 1; case false: 2; }   → 2   (should be 1)
switch { case true: 1; default: 2; }       → 2   (should be 1)
```

Reported in #1174.

## Root cause

The compiler encodes the `default` case with a synthetic condition of `BoolPrimitive(true)` (`mqlc/mqlc.go`), and the runtime identifies the default case by checking whether a case's condition arg is `Bool`-typed (`llx/builtin_global.go`). A real `case true:` / `case false:` *also* compiles to a `Bool` primitive, so the runtime misidentified those cases as the default, skipped them in the match loop, and fell through to the last default-looking arg.

Non-constant conditions (`case _ > 0:`, `case 1 == 1:`) compile to a `Ref`, not a `Bool` primitive, so everyday `switch` usage was unaffected — only literal-boolean cases broke.

## Fix

- Compiler now marks the `default` case with `UnsetPrimitive` instead of `BoolPrimitive(true)`. A real case condition never compiles to an unset type, so the marker is unambiguous.
- Runtime detects the default case by that unset sentinel rather than by `== types.Bool`. Constant-boolean cases now flow through the normal truthy evaluation like any other case.

## Tests

- Added `TestMqlSwitch` (`exec/exec_test.go`) covering literal-bool cases, default fall-through, and non-constant conditions — fails before the fix, passes after.
- Updated `TestCompiler_Switch` to expect the new `UnsetPrimitive` default encoding.
- `mqlc`, `llx`, and `exec` suites all pass.

Fixes #1174