### PR TITLE
🌟 aws: add aws.backup.plan.selection with assigned resource ARNs (#3512)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -10815,8 +10815,47 @@ private aws.backup.plan @defaults("name region") {
   rules() []aws.backup.plan.rule
   // Advanced backup settings for the plan
   advancedBackupSettings []aws.backup.plan.advancedBackupSetting
-  // Resource selections (which resources are backed up by this plan)
-  selections() []dict
+  // Backup selection summaries (selection ID, name, and IAM role)
+  //
+  // Deprecated in favor of `resourceSelections`, which additionally exposes
+  // the assigned resource ARNs, exclusions, and tag-based conditions.
+  selections() @maturity("deprecated") []dict
+  // Resource selections that assign resources to this backup plan
+  resourceSelections() []aws.backup.plan.selection
+}
+
+// AWS Backup plan resource selection
+//
+// Examine which resources a backup plan protects. The `resources` and
+// `notResources` lists hold the resource ARNs explicitly assigned to or
+// excluded from the plan, while `listOfTags` and `conditions` capture the
+// tag-based rules that assign matching resources. Use it to audit backup
+// coverage — for example, confirm that production databases are targeted by
+// a plan with `aws.backup.plan.selections.any(resources.any(_ == /arn:aws:rds:/))`.
+private aws.backup.plan.selection @defaults("name") {
+  // Selection ID
+  id string
+  // Display name of the resource selection
+  name string
+  // Date the selection was created
+  createdAt time
+  // IAM role that Backup assumes to back up the selected resources
+  iamRole() aws.iam.role
+  // ARNs of the resources assigned to the backup plan
+  resources []string
+  // ARNs of the resources excluded from the backup plan
+  notResources []string
+  // Tag-based conditions that assign resources to the plan
+  //
+  // Each entry has keys `conditionType` (always STRINGEQUALS), `conditionKey`,
+  // and `conditionValue`. Multiple entries are combined with OR logic.
+  listOfTags []dict
+  // Tag-based conditions that assign resources to the plan
+  //
+  // Has keys `stringEquals`, `stringNotEquals`, `stringLike`, and
+  // `stringNotLike`, each a list of `{conditionKey, conditionValue}` pairs.
+  // Multiple conditions are combined with AND logic.
+  conditions dict
 }
 
 // AWS Backup plan advanced backup setting

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -439,6 +439,7 @@ const (
 	ResourceAwsBackupVaultRecoveryPoint                                         string = "aws.backup.vaultRecoveryPoint"
 	ResourceAwsBackupLifecycle                                                  string = "aws.backup.lifecycle"
 	ResourceAwsBackupPlan                                                       string = "aws.backup.plan"
+	ResourceAwsBackupPlanSelection                                              string = "aws.backup.plan.selection"
 	ResourceAwsBackupPlanAdvancedBackupSetting                                  string = "aws.backup.plan.advancedBackupSetting"
 	ResourceAwsBackupPlanRule                                                   string = "aws.backup.plan.rule"
 	ResourceAwsBackupPlanRuleCopyAction                                         string = "aws.backup.plan.rule.copyAction"
@@ -2612,6 +2613,10 @@ func init() {
 		"aws.backup.plan": {
 			// to override args, implement: initAwsBackupPlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsBackupPlan,
+		},
+		"aws.backup.plan.selection": {
+			// to override args, implement: initAwsBackupPlanSelection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsBackupPlanSelection,
 		},
 		"aws.backup.plan.advancedBackupSetting": {
 			// to override args, implement: initAwsBackupPlanAdvancedBackupSetting(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -16464,6 +16469,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.backup.plan.selections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupPlan).GetSelections()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.backup.plan.resourceSelections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlan).GetResourceSelections()).ToDataRes(types.Array(types.Resource("aws.backup.plan.selection")))
+	},
+	"aws.backup.plan.selection.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetId()).ToDataRes(types.String)
+	},
+	"aws.backup.plan.selection.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetName()).ToDataRes(types.String)
+	},
+	"aws.backup.plan.selection.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.backup.plan.selection.iamRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
+	"aws.backup.plan.selection.resources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetResources()).ToDataRes(types.Array(types.String))
+	},
+	"aws.backup.plan.selection.notResources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetNotResources()).ToDataRes(types.Array(types.String))
+	},
+	"aws.backup.plan.selection.listOfTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetListOfTags()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.backup.plan.selection.conditions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlanSelection).GetConditions()).ToDataRes(types.Dict)
 	},
 	"aws.backup.plan.advancedBackupSetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupPlanAdvancedBackupSetting).GetId()).ToDataRes(types.String)
@@ -50047,6 +50079,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.backup.plan.selections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupPlan).Selections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.resourceSelections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlan).ResourceSelections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.backup.plan.selection.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.resources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.notResources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).NotResources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.listOfTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).ListOfTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.selection.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlanSelection).Conditions, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"aws.backup.plan.advancedBackupSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -120381,6 +120453,7 @@ type mqlAwsBackupPlan struct {
 	Rules                  plugin.TValue[[]any]
 	AdvancedBackupSettings plugin.TValue[[]any]
 	Selections             plugin.TValue[[]any]
+	ResourceSelections     plugin.TValue[[]any]
 }
 
 // createAwsBackupPlan creates a new instance of this resource
@@ -120476,6 +120549,113 @@ func (c *mqlAwsBackupPlan) GetSelections() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Selections, func() ([]any, error) {
 		return c.selections()
 	})
+}
+
+func (c *mqlAwsBackupPlan) GetResourceSelections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ResourceSelections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.backup.plan", c.__id, "resourceSelections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resourceSelections()
+	})
+}
+
+// mqlAwsBackupPlanSelection for the aws.backup.plan.selection resource
+type mqlAwsBackupPlanSelection struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAwsBackupPlanSelectionInternal
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	CreatedAt    plugin.TValue[*time.Time]
+	IamRole      plugin.TValue[*mqlAwsIamRole]
+	Resources    plugin.TValue[[]any]
+	NotResources plugin.TValue[[]any]
+	ListOfTags   plugin.TValue[[]any]
+	Conditions   plugin.TValue[any]
+}
+
+// createAwsBackupPlanSelection creates a new instance of this resource
+func createAwsBackupPlanSelection(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsBackupPlanSelection{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.backup.plan.selection", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsBackupPlanSelection) MqlName() string {
+	return "aws.backup.plan.selection"
+}
+
+func (c *mqlAwsBackupPlanSelection) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsBackupPlanSelection) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsBackupPlanSelection) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsBackupPlanSelection) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsBackupPlanSelection) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.IamRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.backup.plan.selection", c.__id, "iamRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.iamRole()
+	})
+}
+
+func (c *mqlAwsBackupPlanSelection) GetResources() *plugin.TValue[[]any] {
+	return &c.Resources
+}
+
+func (c *mqlAwsBackupPlanSelection) GetNotResources() *plugin.TValue[[]any] {
+	return &c.NotResources
+}
+
+func (c *mqlAwsBackupPlanSelection) GetListOfTags() *plugin.TValue[[]any] {
+	return &c.ListOfTags
+}
+
+func (c *mqlAwsBackupPlanSelection) GetConditions() *plugin.TValue[any] {
+	return &c.Conditions
 }
 
 // mqlAwsBackupPlanAdvancedBackupSetting for the aws.backup.plan.advancedBackupSetting resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -754,6 +754,7 @@ aws.backup.plan.id 11.15.2
 aws.backup.plan.lastExecutionDate 11.15.2
 aws.backup.plan.name 11.15.2
 aws.backup.plan.region 11.15.2
+aws.backup.plan.resourceSelections 13.35.2
 aws.backup.plan.rule 11.15.2
 aws.backup.plan.rule.completionWindowMinutes 11.15.2
 aws.backup.plan.rule.copyAction 11.15.2
@@ -775,6 +776,15 @@ aws.backup.plan.rule.scheduleExpressionTimezone 11.15.2
 aws.backup.plan.rule.startWindowMinutes 11.15.2
 aws.backup.plan.rule.targetBackupVaultName 11.15.2
 aws.backup.plan.rules 11.15.2
+aws.backup.plan.selection 13.35.2
+aws.backup.plan.selection.conditions 13.35.2
+aws.backup.plan.selection.createdAt 13.35.2
+aws.backup.plan.selection.iamRole 13.35.2
+aws.backup.plan.selection.id 13.35.2
+aws.backup.plan.selection.listOfTags 13.35.2
+aws.backup.plan.selection.name 13.35.2
+aws.backup.plan.selection.notResources 13.35.2
+aws.backup.plan.selection.resources 13.35.2
 aws.backup.plan.selections 13.6.3
 aws.backup.plan.versionId 11.15.2
 aws.backup.plans 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.35.1",
-  "generated_at": "2026-06-12T17:40:19-07:00",
+  "generated_at": "2026-06-13T14:21:33-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -60,6 +60,7 @@
     "autoscaling:DescribeAutoScalingGroups",
     "autoscaling:DescribeLaunchConfigurations",
     "backup:GetBackupPlan",
+    "backup:GetBackupSelection",
     "backup:GetBackupVaultAccessPolicy",
     "backup:ListBackupPlans",
     "backup:ListBackupSelections",
@@ -1262,6 +1263,12 @@
       "permission": "backup:GetBackupPlan",
       "service": "backup",
       "action": "GetBackupPlan",
+      "source_file": "aws_backups.go"
+    },
+    {
+      "permission": "backup:GetBackupSelection",
+      "service": "backup",
+      "action": "GetBackupSelection",
       "source_file": "aws_backups.go"
     },
     {

--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
@@ -336,6 +337,139 @@ func (a *mqlAwsBackupPlan) selections() ([]any, error) {
 		nextToken = resp.NextToken
 	}
 	return res, nil
+}
+
+type mqlAwsBackupPlanSelectionInternal struct {
+	cacheIamRoleArn string
+}
+
+func (a *mqlAwsBackupPlan) resourceSelections() ([]any, error) {
+	planId := a.Id.Data
+	planArn := a.Arn.Data
+
+	region, err := GetRegionFromArn(planArn)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Backup(region)
+	ctx := context.Background()
+
+	res := []any{}
+	var nextToken *string
+	for {
+		resp, err := svc.ListBackupSelections(ctx, &backup.ListBackupSelectionsInput{
+			BackupPlanId: &planId,
+			NextToken:    nextToken,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		for _, sel := range resp.BackupSelectionsList {
+			detail, err := svc.GetBackupSelection(ctx, &backup.GetBackupSelectionInput{
+				BackupPlanId: &planId,
+				SelectionId:  sel.SelectionId,
+			})
+			if err != nil {
+				if Is400AccessDeniedError(err) {
+					continue
+				}
+				return nil, err
+			}
+			if detail.BackupSelection == nil {
+				continue
+			}
+			mqlSel, err := newMqlBackupPlanSelection(a.MqlRuntime, planArn, convert.ToValue(detail.SelectionId), detail.CreationDate, *detail.BackupSelection)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlSel)
+		}
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+	return res, nil
+}
+
+func newMqlBackupPlanSelection(runtime *plugin.Runtime, planArn, selectionId string, creationDate *time.Time, sel backuptypes.BackupSelection) (*mqlAwsBackupPlanSelection, error) {
+	uniqueId := planArn + "\x00" + selectionId
+
+	resources := make([]any, 0, len(sel.Resources))
+	for _, r := range sel.Resources {
+		resources = append(resources, r)
+	}
+	notResources := make([]any, 0, len(sel.NotResources))
+	for _, r := range sel.NotResources {
+		notResources = append(notResources, r)
+	}
+
+	listOfTags := make([]any, 0, len(sel.ListOfTags))
+	for _, c := range sel.ListOfTags {
+		listOfTags = append(listOfTags, map[string]any{
+			"conditionType":  string(c.ConditionType),
+			"conditionKey":   convert.ToValue(c.ConditionKey),
+			"conditionValue": convert.ToValue(c.ConditionValue),
+		})
+	}
+
+	var conditions any
+	if sel.Conditions != nil {
+		conditions = map[string]any{
+			"stringEquals":    conditionParametersToList(sel.Conditions.StringEquals),
+			"stringNotEquals": conditionParametersToList(sel.Conditions.StringNotEquals),
+			"stringLike":      conditionParametersToList(sel.Conditions.StringLike),
+			"stringNotLike":   conditionParametersToList(sel.Conditions.StringNotLike),
+		}
+	}
+
+	resource, err := CreateResource(runtime, ResourceAwsBackupPlanSelection,
+		map[string]*llx.RawData{
+			"__id":         llx.StringData(uniqueId),
+			"id":           llx.StringData(selectionId),
+			"name":         llx.StringDataPtr(sel.SelectionName),
+			"createdAt":    llx.TimeDataPtr(creationDate),
+			"resources":    llx.ArrayData(resources, types.String),
+			"notResources": llx.ArrayData(notResources, types.String),
+			"listOfTags":   llx.ArrayData(listOfTags, types.Dict),
+			"conditions":   llx.DictData(conditions),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	mqlSel := resource.(*mqlAwsBackupPlanSelection)
+	mqlSel.cacheIamRoleArn = convert.ToValue(sel.IamRoleArn)
+	return mqlSel, nil
+}
+
+func conditionParametersToList(params []backuptypes.ConditionParameter) []any {
+	res := make([]any, 0, len(params))
+	for _, p := range params {
+		res = append(res, map[string]any{
+			"conditionKey":   convert.ToValue(p.ConditionKey),
+			"conditionValue": convert.ToValue(p.ConditionValue),
+		})
+	}
+	return res
+}
+
+func (a *mqlAwsBackupPlanSelection) iamRole() (*mqlAwsIamRole, error) {
+	if a.cacheIamRoleArn == "" {
+		a.IamRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringData(a.cacheIamRoleArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
 }
 
 // ========================


### PR DESCRIPTION
## What

Closes #3512.

Backup plan resource selections previously surfaced only the `ListBackupSelections` summary (selection ID, name, IAM role) as a `[]dict`, so the resource ARNs a plan actually protects were not queryable. This made the issue's whole motivating goal — auditing backup coverage, e.g. "is this RDS instance targeted by some plan?" — impossible.

This data wasn't available on the individual resources either: `aws.rds.dbinstance.backupSettings` is the RDS-native automated-backup retention window, not AWS Backup plan coverage.

## Changes

Add a typed **`aws.backup.plan.selection`** resource backed by `GetBackupSelection`, reached via a new **`aws.backup.plan.resourceSelections`** field:

| field | source |
|---|---|
| `id`, `name`, `createdAt` | selection metadata |
| `iamRole() aws.iam.role` | `IamRoleArn` (typed reference) |
| `resources []string` | assigned resource ARNs |
| `notResources []string` | excluded resource ARNs |
| `listOfTags []dict` | `StringEquals`-only tag conditions (OR logic) |
| `conditions dict` | `stringEquals` / `stringNotEquals` / `stringLike` / `stringNotLike` (AND logic) |

The motivating query now works:

```mql
aws.backup.plans.where(
  resourceSelections.any(resources.any(_ == /arn:aws:rds:/))
)
```

`resources` / `notResources` are kept as `[]string` rather than typed refs because the ARNs are heterogeneous (RDS, EBS, EFS, …) and may contain wildcards (`arn:aws:ec2:*:*:volume/*`, `*`).

## Backward compatibility

The existing `selections() []dict` field is **kept** (returning the identical summary shape) and marked `@maturity("deprecated")` in favor of `resourceSelections`. Existing queries against `selections` continue to work unchanged.

## Permissions

Adds `backup:GetBackupSelection` to `aws.permissions.json`.

## Verification

Tested against a live AWS account (us-west-2):
- New `resourceSelections` returns `iamRole`, `conditions`, `listOfTags`, `resources`/`notResources` (verified on the AWS-managed EFS auto-backup plan, which selects by tag).
- The coverage query above compiles and runs.
- The deprecated `selections` still returns the original dict shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)