### PR TITLE
🐛 gcp/azure: fix provenance accessors silently returning empty

### DIFF
--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -118,6 +118,25 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) fetchVault() (*keyvault.Vault
 	return a.fetchVaultResp, a.fetchVaultErr
 }
 
+// systemDataRaw returns the vault's systemData dict. The vaults() list pager
+// does not return systemData on its entries, so when the cached value is empty
+// fall back to the per-vault Get (shared via fetchVault), which does include it.
+func (a *mqlAzureSubscriptionKeyVaultServiceVault) systemDataRaw() any {
+	if m, ok := a.cacheSystemData.(map[string]any); ok && len(m) > 0 {
+		return a.cacheSystemData
+	}
+	resp, err := a.fetchVault()
+	if err != nil || resp == nil {
+		return a.cacheSystemData
+	}
+	sysData, err := convert.JsonToDict(resp.SystemData)
+	if err != nil {
+		return a.cacheSystemData
+	}
+	a.cacheSystemData = sysData
+	return sysData
+}
+
 func (a *mqlAzureSubscriptionKeyVaultServiceKey) id() (string, error) {
 	return a.Kid.Data, nil
 }

--- a/providers/azure/resources/systemdata.go
+++ b/providers/azure/resources/systemdata.go
@@ -95,7 +95,7 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) systemMetadata() (*mqlAzureS
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.systemDataRaw(), &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionAksServiceCluster) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -23,6 +23,7 @@ import (
 
 type mqlGcpProjectContainerAnalysisServiceInternal struct {
 	serviceEnabled bool
+	serviceChecked bool
 }
 
 func (g *mqlGcpProject) containerAnalysis() (*mqlGcpProjectContainerAnalysisService, error) {
@@ -45,11 +46,40 @@ func (g *mqlGcpProject) containerAnalysis() (*mqlGcpProjectContainerAnalysisServ
 
 	svc := res.(*mqlGcpProjectContainerAnalysisService)
 	svc.serviceEnabled = serviceEnabled
+	svc.serviceChecked = true
 	if !serviceEnabled {
 		log.Debug().Str("service", service_containeranalysis).Msg("gcp service is not enabled, skipping")
 	}
 
 	return svc, nil
+}
+
+// isEnabled reports whether the Container Analysis API is enabled for the
+// project. When the service is reached through gcp.project.containerAnalysis the
+// flag is set by that accessor, but a direct query of
+// gcp.project.containerAnalysisService is built through the init function, which
+// cannot set it. Resolve it lazily here so the direct-query path doesn't
+// silently return empty occurrences/notes.
+func (g *mqlGcpProjectContainerAnalysisService) isEnabled() (bool, error) {
+	if g.serviceChecked {
+		return g.serviceEnabled, nil
+	}
+	if g.ProjectId.Error != nil {
+		return false, g.ProjectId.Error
+	}
+	proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(g.ProjectId.Data),
+	})
+	if err != nil {
+		return false, err
+	}
+	enabled, err := proj.(*mqlGcpProject).isServiceEnabled(service_containeranalysis)
+	if err != nil {
+		return false, err
+	}
+	g.serviceEnabled = enabled
+	g.serviceChecked = true
+	return enabled, nil
 }
 
 func initGcpProjectContainerAnalysisService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -84,7 +114,11 @@ func (g *mqlGcpProjectContainerAnalysisServiceNote) id() (string, error) {
 }
 
 func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -167,7 +201,11 @@ func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
 }
 
 func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## What

Fixes two object-provenance accessors (added in the recent provenance work — gcp #8356, azure #8355) that returned empty results against **real** infrastructure. Both were found by running the new fields against live cloud accounts during provider verification.

### gcp: `containerAnalysisService.occurrences` / `.notes` empty on direct query

`gcp.project.containerAnalysisService.occurrences` (and `.notes`) returned `[]` whenever the service resource was built through its own `init` — i.e. a direct `gcp.project.containerAnalysisService.occurrences` query — instead of through the `gcp.project.containerAnalysis` accessor. The init path never set the `serviceEnabled` flag, so the gate short-circuited to empty even when the Container Analysis API was enabled and occurrences existed.

Fix: resolve enablement lazily (`isEnabled()`), so both entry paths behave the same. The `gcp.project.containerAnalysis` accessor still sets the flag eagerly; the direct path now resolves it on demand.

**Verified** against a project with 34 occurrences (BUILD / ATTESTATION / PACKAGE): the direct path went from `0` → `34`, parent path unchanged at `34`, direct `notes` → `1`.

### azure: `keyVaultService.vault.systemMetadata` always null

`azure.subscription.keyVaultService.vault.systemMetadata` was always `null` because the `vaults()` list pager does not return `systemData` on its entries — only the per-vault `Get` does. (Cross-checked against the raw ARM REST API: the list omits `systemData`, the GET includes it.)

Fix: back the accessor with the existing `fetchVault()` GET (already shared across the vault's other lazy fields via `sync.Once`) when the cached list value is empty.

**Verified** live: `systemMetadata` went from `null` → fully populated (`createdBy`, `createdAt`, `createdByType`, `lastModified*`).

## Test

Both fixes re-verified with `mql run` against live GCP and Azure infrastructure before this PR was opened. No schema (`.lr`) changes, so no `.lr.versions` changes. No permissions changes.