### PR TITLE
🎉 gcp-13.24.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.23.1",
+	Version: "13.24.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.24.0)
- 🐛 gcp/azure: fix provenance accessors silently returning empty (#8380)
- ✨ gcp: expose object provenance (asset inventory, build history, artifact lineage, container analysis) (#8356)
- ✨ gcp: expand pubsub with bigtable sink, push wrapper, snapshot labels (#8350)