### PR TITLE
🎉 azure-13.20.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.19.1",
+	Version: "13.20.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.20.0)
- 🐛 gcp/azure: fix provenance accessors silently returning empty (#8380)
- 🐛 azure: guard management-group-inherited policy assignments (#5812) (#8362)
- ✨ azure: expose object provenance (systemData, activity log events, deployments) (#8355)