### PR TITLE
✨ github: configure App private key via content flag and env var

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -35,7 +35,7 @@ Examples:
 Notes:
   Mondoo needs a personal access token to scan a GitHub organization, public repo, or private repo. The token's level of access determines how much information Mondoo can retrieve. Supply your personal access token to Mondoo by setting the GITHUB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/github/.
 
-	If you have very large GitHub organizations, consider giving Mondoo access using custom GitHub app credentials. To learn how, read https://mondoo.com/docs/cnspec/saas/gh-app/.
+	If you have very large GitHub organizations, consider giving Mondoo access using custom GitHub app credentials. To learn how, read https://mondoo.com/docs/cnspec/saas/gh-app/. Provide the app's private key as a file path with --app-private-key, as inline PEM content with --app-private-key-content, or by setting the GITHUB_APP_PRIVATE_KEY environment variable.
 
 	If you have a GitHub Enterprise Server account, you must provide the URL for the account using the --enterprise-url flag.
 `,
@@ -84,6 +84,12 @@ Notes:
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "GitHub App private key file path",
+				},
+				{
+					Long:    "app-private-key-content",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "GitHub App private key PEM content (alternative to --app-private-key; also settable via GITHUB_APP_PRIVATE_KEY)",
 				},
 				{
 					Long:    "enterprise-url",

--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -25,13 +25,14 @@ import (
 )
 
 const (
-	OPTION_TOKEN               = "token"
-	OPTION_REPOS               = "repos"
-	OPTION_REPOS_EXCLUDE       = "repos-exclude"
-	OPTION_APP_ID              = "app-id"
-	OPTION_APP_INSTALLATION_ID = "app-installation-id"
-	OPTION_APP_PRIVATE_KEY     = "app-private-key"
-	OPTION_ENTERPRISE_URL      = "enterprise-url"
+	OPTION_TOKEN                   = "token"
+	OPTION_REPOS                   = "repos"
+	OPTION_REPOS_EXCLUDE           = "repos-exclude"
+	OPTION_APP_ID                  = "app-id"
+	OPTION_APP_INSTALLATION_ID     = "app-installation-id"
+	OPTION_APP_PRIVATE_KEY         = "app-private-key"
+	OPTION_APP_PRIVATE_KEY_CONTENT = "app-private-key-content"
+	OPTION_ENTERPRISE_URL          = "enterprise-url"
 )
 
 type GithubConnection struct {

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -74,8 +74,27 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		installId := req.Flags[connection.OPTION_APP_INSTALLATION_ID]
 		conf.Options[connection.OPTION_APP_INSTALLATION_ID] = string(installId.Value)
 
-		pk := req.Flags[connection.OPTION_APP_PRIVATE_KEY]
-		conf.Options[connection.OPTION_APP_PRIVATE_KEY] = string(pk.Value)
+		// The GitHub App private key may be provided three ways: as a file path
+		// (--app-private-key), as inline PEM content (--app-private-key-content),
+		// or via the GITHUB_APP_PRIVATE_KEY environment variable. Inline content
+		// takes precedence and is passed as a private_key credential so the
+		// connection can authenticate without reading from the filesystem.
+		appPrivateKey := ""
+		if x, ok := flags[connection.OPTION_APP_PRIVATE_KEY_CONTENT]; ok && len(x.Value) != 0 {
+			appPrivateKey = string(x.Value)
+			log.Debug().Msg("loaded GitHub App private key from flag")
+		}
+		if appPrivateKey == "" && len(os.Getenv("GITHUB_APP_PRIVATE_KEY")) != 0 {
+			appPrivateKey = os.Getenv("GITHUB_APP_PRIVATE_KEY")
+			log.Debug().Msg("loaded GitHub App private key from GITHUB_APP_PRIVATE_KEY env variable")
+		}
+		if appPrivateKey != "" {
+			conf.Credentials = append(conf.Credentials,
+				vault.NewPrivateKeyCredential("", []byte(appPrivateKey), ""))
+		} else if pk, ok := flags[connection.OPTION_APP_PRIVATE_KEY]; ok && len(pk.Value) != 0 {
+			conf.Options[connection.OPTION_APP_PRIVATE_KEY] = string(pk.Value)
+		}
+
 		isAppAuth = true
 		log.Debug().Msg("application credentials provided")
 	}

--- a/providers/github/provider/provider_test.go
+++ b/providers/github/provider/provider_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/v13/providers/github/connection"
+)
+
+const testPEM = "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
+
+func appFlags(extra map[string]*llx.Primitive) map[string]*llx.Primitive {
+	flags := map[string]*llx.Primitive{
+		connection.OPTION_APP_ID:              llx.StringPrimitive("123"),
+		connection.OPTION_APP_INSTALLATION_ID: llx.StringPrimitive("456"),
+	}
+	maps.Copy(flags, extra)
+	return flags
+}
+
+func TestParseCLI_AppPrivateKeyContentFlag(t *testing.T) {
+	s := Init()
+	res, err := s.ParseCLI(&plugin.ParseCLIReq{
+		Connector: ConnectionType,
+		Args:      []string{"org", "my-org"},
+		Flags: appFlags(map[string]*llx.Primitive{
+			connection.OPTION_APP_PRIVATE_KEY_CONTENT: llx.StringPrimitive(testPEM),
+		}),
+	})
+	require.NoError(t, err)
+
+	conf := res.Asset.Connections[0]
+	// content must not leak into the path option
+	assert.Empty(t, conf.Options[connection.OPTION_APP_PRIVATE_KEY])
+
+	require.Len(t, conf.Credentials, 1)
+	cred := conf.Credentials[0]
+	assert.Equal(t, vault.CredentialType_private_key, cred.Type)
+	assert.Equal(t, testPEM, string(cred.Secret))
+}
+
+func TestParseCLI_AppPrivateKeyContentEnv(t *testing.T) {
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", testPEM)
+
+	s := Init()
+	res, err := s.ParseCLI(&plugin.ParseCLIReq{
+		Connector: ConnectionType,
+		Args:      []string{"org", "my-org"},
+		Flags:     appFlags(nil),
+	})
+	require.NoError(t, err)
+
+	conf := res.Asset.Connections[0]
+	assert.Empty(t, conf.Options[connection.OPTION_APP_PRIVATE_KEY])
+	require.Len(t, conf.Credentials, 1)
+	assert.Equal(t, vault.CredentialType_private_key, conf.Credentials[0].Type)
+	assert.Equal(t, testPEM, string(conf.Credentials[0].Secret))
+}
+
+func TestParseCLI_AppPrivateKeyContentFlagBeatsEnv(t *testing.T) {
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", "env-key")
+
+	s := Init()
+	res, err := s.ParseCLI(&plugin.ParseCLIReq{
+		Connector: ConnectionType,
+		Args:      []string{"org", "my-org"},
+		Flags: appFlags(map[string]*llx.Primitive{
+			connection.OPTION_APP_PRIVATE_KEY_CONTENT: llx.StringPrimitive(testPEM),
+		}),
+	})
+	require.NoError(t, err)
+
+	conf := res.Asset.Connections[0]
+	require.Len(t, conf.Credentials, 1)
+	assert.Equal(t, testPEM, string(conf.Credentials[0].Secret))
+}
+
+func TestParseCLI_AppPrivateKeyPathStillWorks(t *testing.T) {
+	s := Init()
+	res, err := s.ParseCLI(&plugin.ParseCLIReq{
+		Connector: ConnectionType,
+		Args:      []string{"org", "my-org"},
+		Flags: appFlags(map[string]*llx.Primitive{
+			connection.OPTION_APP_PRIVATE_KEY: llx.StringPrimitive("/path/to/key.pem"),
+		}),
+	})
+	require.NoError(t, err)
+
+	conf := res.Asset.Connections[0]
+	assert.Equal(t, "/path/to/key.pem", conf.Options[connection.OPTION_APP_PRIVATE_KEY])
+	assert.Empty(t, conf.Credentials)
+}


### PR DESCRIPTION
## What

The GitHub provider's App private key could previously only be supplied as a **file path** (`--app-private-key`). When the key lives in a secret manager (e.g. Google Cloud Secret Manager with Cloud Build), that forces an extra step of materializing the PEM to a file before scanning.

This adds two filesystem-free ways to provide the key, mirroring the existing token handling:

- `--app-private-key-content` — inline PEM content
- `GITHUB_APP_PRIVATE_KEY` — environment variable

**Precedence:** content flag → env var → file path. Inline content is passed through as a `private_key` vault credential, which the connection already consumes into `ghinstallation.New` (`connection.go`) — so no connection-layer change was required. This matches the suggested fix approach in the triage comment.

## Why

Closes #4854. Users running scans in CI/CD where secrets come from a secret manager can now pipe the PEM contents straight into an env var or flag rather than writing it to disk first.

## Changes

- `config/config.go` — new `--app-private-key-content` flag + updated help text
- `connection/connection.go` — `OPTION_APP_PRIVATE_KEY_CONTENT` constant
- `provider/provider.go` — `ParseCLI` reads the flag/env var and appends a `NewPrivateKeyCredential`
- `provider/provider_test.go` — unit tests covering the content flag, env var, flag-beats-env precedence, and the existing path behavior

## Testing

- `go build ./...` and `go test ./provider/...` pass (4 new tests)
- `gofmt` and `go vet` clean
- No `.lr` resource/field changes, so no `.lr.versions` bumps