### PR TITLE
⭐ os: detect platform arch from ELF header on command-less fs scans

### DIFF
--- a/providers/os/detector/arch.go
+++ b/providers/os/detector/arch.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"debug/elf"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+// archBinaryCandidates is an ordered list of well-known binaries that are
+// present on virtually every Linux installation. The first one that exists and
+// parses as an ELF file is used to determine the machine architecture.
+var archBinaryCandidates = []string{
+	"/bin/ls",
+	"/usr/bin/ls",
+	"/bin/sh",
+	"/sbin/init",
+	"/usr/lib/systemd/systemd",
+	"/bin/busybox",
+}
+
+// archFromELF determines the platform architecture by inspecting the ELF header
+// of a well-known binary on the target filesystem. It is used as a fallback for
+// command-less scans (e.g. filesystem scans of k8s nodes) where `uname -m` is
+// not available. It returns an empty string if the architecture could not be
+// determined.
+func archFromELF(fs afero.Fs) string {
+	if fs == nil {
+		return ""
+	}
+
+	for _, path := range archBinaryCandidates {
+		arch := archFromBinary(fs, path)
+		if arch != "" {
+			log.Debug().Str("path", path).Str("arch", arch).Msg("detected platform architecture from ELF header")
+			return arch
+		}
+	}
+
+	log.Debug().Msg("could not determine platform architecture from filesystem")
+	return ""
+}
+
+// archFromBinary opens a single file and returns its ELF machine architecture,
+// or an empty string if the file does not exist or is not a recognized ELF
+// binary.
+func archFromBinary(fs afero.Fs, path string) string {
+	f, err := fs.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	ef, err := elf.NewFile(f)
+	if err != nil {
+		return ""
+	}
+
+	return elfMachineToArch(ef.Machine, ef.Data)
+}
+
+// elfMachineToArch maps an ELF machine type to the uname-style architecture
+// string used throughout platform detection (i.e. the value `uname -m` would
+// report). Unknown machine types return an empty string.
+func elfMachineToArch(machine elf.Machine, data elf.Data) string {
+	switch machine {
+	case elf.EM_X86_64:
+		return "x86_64"
+	case elf.EM_AARCH64:
+		return "aarch64"
+	case elf.EM_386:
+		return "i386"
+	case elf.EM_ARM:
+		return "arm"
+	case elf.EM_PPC64:
+		// ppc64 (big endian) and ppc64le (little endian) share a machine type
+		// and are distinguished by the ELF data encoding.
+		if data == elf.ELFDATA2LSB {
+			return "ppc64le"
+		}
+		return "ppc64"
+	case elf.EM_PPC:
+		return "ppc"
+	case elf.EM_S390:
+		return "s390x"
+	case elf.EM_RISCV:
+		return "riscv64"
+	case elf.EM_MIPS:
+		return "mips"
+	default:
+		return ""
+	}
+}

--- a/providers/os/detector/arch_test.go
+++ b/providers/os/detector/arch_test.go
@@ -1,0 +1,84 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalELF64 builds a minimal but valid 64-bit ELF header for the given
+// machine type and data encoding. It has no program or section headers, which
+// is enough for debug/elf to parse the machine type.
+func minimalELF64(machine elf.Machine, data elf.Data) []byte {
+	var order binary.ByteOrder = binary.LittleEndian
+	if data == elf.ELFDATA2MSB {
+		order = binary.BigEndian
+	}
+
+	b := make([]byte, 64)
+	// e_ident
+	b[0], b[1], b[2], b[3] = 0x7f, 'E', 'L', 'F'
+	b[4] = byte(elf.ELFCLASS64)
+	b[5] = byte(data)
+	b[6] = byte(elf.EV_CURRENT)
+
+	order.PutUint16(b[16:], uint16(elf.ET_EXEC)) // e_type
+	order.PutUint16(b[18:], uint16(machine))     // e_machine
+	order.PutUint32(b[20:], uint32(elf.EV_CURRENT))
+	// e_entry, e_phoff, e_shoff all zero -> no program/section headers
+	order.PutUint16(b[52:], 64) // e_ehsize
+	return b
+}
+
+func TestElfMachineToArch(t *testing.T) {
+	tests := []struct {
+		machine elf.Machine
+		data    elf.Data
+		want    string
+	}{
+		{elf.EM_X86_64, elf.ELFDATA2LSB, "x86_64"},
+		{elf.EM_AARCH64, elf.ELFDATA2LSB, "aarch64"},
+		{elf.EM_386, elf.ELFDATA2LSB, "i386"},
+		{elf.EM_ARM, elf.ELFDATA2LSB, "arm"},
+		{elf.EM_PPC64, elf.ELFDATA2LSB, "ppc64le"},
+		{elf.EM_PPC64, elf.ELFDATA2MSB, "ppc64"},
+		{elf.EM_S390, elf.ELFDATA2MSB, "s390x"},
+		{elf.EM_RISCV, elf.ELFDATA2LSB, "riscv64"},
+		{elf.EM_AVR, elf.ELFDATA2LSB, ""}, // unknown -> empty
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, elfMachineToArch(tt.machine, tt.data), tt.machine.String())
+	}
+}
+
+func TestArchFromELF(t *testing.T) {
+	t.Run("x86_64 binary at /bin/ls", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/bin/ls", minimalELF64(elf.EM_X86_64, elf.ELFDATA2LSB), 0o755))
+		assert.Equal(t, "x86_64", archFromELF(fs))
+	})
+
+	t.Run("falls through to a later candidate", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		// /bin/ls is not an ELF file; /sbin/init is.
+		require.NoError(t, afero.WriteFile(fs, "/bin/ls", []byte("#!/bin/sh\n"), 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/sbin/init", minimalELF64(elf.EM_AARCH64, elf.ELFDATA2LSB), 0o755))
+		assert.Equal(t, "aarch64", archFromELF(fs))
+	})
+
+	t.Run("no candidates present", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		assert.Equal(t, "", archFromELF(fs))
+	})
+
+	t.Run("nil filesystem", func(t *testing.T) {
+		assert.Equal(t, "", archFromELF(nil))
+	})
+}

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -58,6 +58,15 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 		}
 	}
 
+	// If architecture could not be determined via command-based detection
+	// (e.g. a filesystem-only scan with no command capability), fall back to
+	// inspecting the ELF header of a well-known binary on the target.
+	if resolved && pi.Arch == "" {
+		if arch := archFromELF(conn.FileSystem()); arch != "" {
+			pi.Arch = arch
+		}
+	}
+
 	log.Debug().Str("platform", pi.Name).Strs("family", pi.Family).Msg("platform> detected os")
 	return pi, resolved
 }


### PR DESCRIPTION
## Problem

Fixes #983.

A pure filesystem scan (e.g. the mondoo-operator scanning k8s nodes) has no command capability — `RunCommand` returns `ErrRunCommandNotImplemented` — so every `pf.Arch = unamem` detector path silently leaves `Platform Arch` empty/`null`. There was no filesystem-based fallback.

## Fix

- **`providers/os/detector/arch.go`** (new): `archFromELF()` opens the first existing well-known binary (`/bin/ls`, `/usr/bin/ls`, `/bin/sh`, `/sbin/init`, `/usr/lib/systemd/systemd`, `/bin/busybox`), parses its ELF header via `debug/elf`, and maps `e_machine` (with endianness for ppc64/ppc64le) to the uname-style arch string the detector already uses (`x86_64`, `aarch64`, `i386`, `arm`, `ppc64le`, `ppc64`, `s390x`, `riscv64`, `mips`, `ppc`). Unknown machines return `""` so we never write garbage.
- **`providers/os/detector/platform_resolver.go`**: the fallback is wired into the single chokepoint in `Resolve()` — when detection succeeds but `Arch` is still empty, it tries `archFromELF(conn.FileSystem())`. Command-based detection (`uname -m`) still wins whenever available; this only fills the gap. The 6 existing `pf.Arch = unamem` sites are untouched.

This fixes the operator's k8s-node case and every other command-less filesystem scan with **zero operator-side changes**.

## Tests

- `arch_test.go`: table tests for the machine→arch mapping plus `archFromELF` (candidate fall-through, missing binaries, nil FS) using in-memory ELF headers.
- Full `providers/os/detector` suite passes; `gofmt` and `go vet` clean.