### PR TITLE
🐛 llx: guard isTruthy type assertions against mismatched values

### DIFF
--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -265,22 +265,45 @@ func isTruthy(data any, typ types.Type) (bool, bool) {
 		return false, true
 
 	case types.Bool:
-		return data.(bool), true
+		b, ok := data.(bool)
+		if !ok {
+			return false, false
+		}
+		return b, true
 
 	case types.Int:
-		return data.(int64) != 0, true
+		i, ok := data.(int64)
+		if !ok {
+			return false, false
+		}
+		return i != 0, true
 
 	case types.Float:
-		return data.(float64) != 0, true
+		f, ok := data.(float64)
+		if !ok {
+			return false, false
+		}
+		return f != 0, true
 
 	case types.String:
-		return data.(string) != "", true
+		s, ok := data.(string)
+		if !ok {
+			return false, false
+		}
+		return s != "", true
 
 	case types.Regex:
-		return data.(string) != "", true
+		s, ok := data.(string)
+		if !ok {
+			return false, false
+		}
+		return s != "", true
 
 	case types.Time:
-		dt := data.(*time.Time)
+		dt, ok := data.(*time.Time)
+		if !ok {
+			return false, false
+		}
 
 		// needs separate testing due to: https://go.dev/doc/faq#nil_error
 		if dt == nil {
@@ -292,7 +315,10 @@ func isTruthy(data any, typ types.Type) (bool, bool) {
 	case types.Block:
 		res := true
 
-		m := data.(map[string]any)
+		m, ok := data.(map[string]any)
+		if !ok {
+			return false, false
+		}
 		if m != nil {
 			if bif, ok := m["__t"]; ok {
 				if rd, ok := bif.(*RawData); ok {
@@ -310,14 +336,24 @@ func isTruthy(data any, typ types.Type) (bool, bool) {
 		return res, true
 
 	case types.Version:
-		return data.(string) != "", true
+		s, ok := data.(string)
+		if !ok {
+			return false, false
+		}
+		return s != "", true
 
 	case types.IP:
-		d := data.(RawIP)
+		d, ok := data.(RawIP)
+		if !ok {
+			return false, false
+		}
 		return len(d.IP) != 0, true
 
 	case types.ArrayLike:
-		arr := data.([]any)
+		arr, ok := data.([]any)
+		if !ok {
+			return false, false
+		}
 
 		// Empty arrays count as false here, this is because users
 		// frequently write statements like:
@@ -346,7 +382,10 @@ func isTruthy(data any, typ types.Type) (bool, bool) {
 
 		switch typ.Key() {
 		case types.String:
-			m := data.(map[string]any)
+			m, ok := data.(map[string]any)
+			if !ok {
+				return false, false
+			}
 			for _, v := range m {
 				t1, f1 := isTruthy(v, typ.Child())
 				if f1 {
@@ -355,7 +394,10 @@ func isTruthy(data any, typ types.Type) (bool, bool) {
 			}
 
 		case types.Int:
-			m := data.(map[int64]any)
+			m, ok := data.(map[int64]any)
+			if !ok {
+				return false, false
+			}
 			for _, v := range m {
 				t1, f1 := isTruthy(v, typ.Child())
 				if f1 {
@@ -400,9 +442,16 @@ func isSuccess(data any, typ types.Type) (bool, bool) {
 		}
 		return false, false
 	case types.Bool:
-		return data.(bool), true
+		b, ok := data.(bool)
+		if !ok {
+			return false, false
+		}
+		return b, true
 	case types.Block:
-		m := data.(map[string]any)
+		m, ok := data.(map[string]any)
+		if !ok {
+			return false, false
+		}
 		if m != nil {
 			if bif, ok := m["__s"]; ok {
 				if rd, ok := bif.(*RawData); ok {
@@ -415,7 +464,10 @@ func isSuccess(data any, typ types.Type) (bool, bool) {
 		return false, false
 
 	case types.ArrayLike:
-		arr := data.([]any)
+		arr, ok := data.([]any)
+		if !ok {
+			return false, false
+		}
 		res := true
 		valid := false
 

--- a/llx/rawdata_test.go
+++ b/llx/rawdata_test.go
@@ -105,6 +105,40 @@ func TestTruthy(t *testing.T) {
 	}
 }
 
+// TestTruthyTypeMismatch ensures that a RawData whose declared type disagrees
+// with the Go type of its value does not panic in IsTruthy; instead it returns
+// (false, false) — "could not determine". See issue #8430.
+func TestTruthyTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name string
+		data *RawData
+	}{
+		{"int type with string value", &RawData{Type: types.Int, Value: "not-an-int"}},
+		{"string type with int value", &RawData{Type: types.String, Value: int64(1)}},
+		{"bool type with string value", &RawData{Type: types.Bool, Value: "nope"}},
+		{"float type with string value", &RawData{Type: types.Float, Value: "nope"}},
+		{"regex type with int value", &RawData{Type: types.Regex, Value: int64(1)}},
+		{"version type with int value", &RawData{Type: types.Version, Value: int64(1)}},
+		{"time type with string value", &RawData{Type: types.Time, Value: "nope"}},
+		{"ip type with string value", &RawData{Type: types.IP, Value: "nope"}},
+		{"array type with string value", &RawData{Type: types.Array(types.Bool), Value: "nope"}},
+		{"map type with string value", &RawData{Type: types.Map(types.String, types.Bool), Value: "nope"}},
+		{"block type with string value", &RawData{Type: types.Block, Value: "nope"}},
+	}
+
+	for i := range tests {
+		o := tests[i]
+		t.Run(o.name, func(t *testing.T) {
+			var truthy, valid bool
+			require.NotPanics(t, func() {
+				truthy, valid = o.data.IsTruthy()
+			})
+			assert.False(t, truthy)
+			assert.False(t, valid)
+		})
+	}
+}
+
 func TestSuccess(t *testing.T) {
 	tests := []struct {
 		data    *RawData


### PR DESCRIPTION
## Problem

Scanning certain assets (e.g. a GitHub repo with workflows) could crash the entire scan with a panic like:

```
interface conversion: string is not int64
```

The panic originated in `isTruthy` / `IsTruthy` in `llx/rawdata.go`, reached via `arrayBlockCallResult.isTruthy`. Because the executor runs blocks in goroutines, this panic is unrecoverable and kills the whole scan.

## Root cause

`isTruthy` performed **unchecked** single-value type assertions keyed off the declared `types.Type` — e.g. `data.(int64)` for `types.Int`, `data.(string)` for `types.String`, `data.(map[string]any)` for `types.Block`, etc. When a value's declared type disagreed with its actual Go runtime type, the assertion panicked instead of returning a value.

This is the same class of bug already fixed for other llx builtins in #8320 / #8321; the established fix is comma-ok / guarded assertions.

## Fix

Convert the unchecked concrete-type assertions in `isTruthy` to comma-ok form. On a type mismatch we return `(false, false)` — the second bool is the "valid/determined" flag, and `false` means "could not determine", the safe non-panicking outcome. The happy-path semantics (including the empty-array-is-false rule) are unchanged.

Guarded cases in `isTruthy`:
- `types.Bool` (`bool`)
- `types.Int` (`int64`)
- `types.Float` (`float64`)
- `types.String` (`string`)
- `types.Regex` (`string`)
- `types.Version` (`string`)
- `types.Time` (`*time.Time`)
- `types.IP` (`RawIP`)
- `types.Block` (`map[string]any`)
- `types.ArrayLike` (`[]any`)
- `types.MapLike` (`map[string]any` / `map[int64]any`)

The `types.Any` / `types.Nil` cases already use comma-ok or are inherently safe and were left unchanged.

`isSuccess` in the same file had the identical unchecked pattern (`data.(bool)`, `data.(map[string]any)`, `data.([]any)`), so it was guarded the same way.

## Test

Added `TestTruthyTypeMismatch` to `llx/rawdata_test.go`, covering each guarded type with a deliberately mismatched value (e.g. `RawData{Type: types.Int, Value: "not-an-int"}`, `RawData{Type: types.String, Value: int64(1)}`). Each case asserts `IsTruthy()` does **not** panic and returns `(false, false)`.

Verified: `gofmt` clean, `go build ./llx/...`, and `go test ./llx/` all pass.

Fixes #8430