### PR TITLE
🐛 gcp: require --project-id/--zone for instance and snapshot scanning

### DIFF
--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -187,8 +188,15 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 // validateInstanceTarget ensures the required flags for instance scanning are
 // present. Both project-id and zone are needed to locate the instance.
 func validateInstanceTarget(projectId, zone string) error {
-	if projectId == "" || zone == "" {
-		return status.Error(codes.InvalidArgument, "the --project-id and --zone flags are required for gcp instance scanning")
+	var missing []string
+	if projectId == "" {
+		missing = append(missing, "--project-id")
+	}
+	if zone == "" {
+		missing = append(missing, "--zone")
+	}
+	if len(missing) > 0 {
+		return status.Errorf(codes.InvalidArgument, "the %s flag(s) are required for gcp instance scanning", strings.Join(missing, " and "))
 	}
 	return nil
 }

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -155,6 +155,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options["repository"] = string(flags["repository"].Value)
 		conf.Runtime = "gcp-gcr"
 	case "snapshot":
+		if err := validateSnapshotTarget(projectId); err != nil {
+			return nil, err
+		}
 		conf.Options["snapshot-name"] = req.Args[1]
 		conf.Options["project-id"] = projectId
 		conf.Options["zone"] = zone
@@ -162,6 +165,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Type = string(gcpinstancesnapshot.SnapshotConnectionType)
 		conf.Discover = nil
 	case "instance":
+		if err := validateInstanceTarget(projectId, zone); err != nil {
+			return nil, err
+		}
 		conf.Options["instance-name"] = req.Args[1]
 		conf.Options["type"] = "instance"
 		conf.Options["project-id"] = projectId
@@ -176,6 +182,24 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	return &plugin.ParseCLIRes{Asset: &asset}, nil
+}
+
+// validateInstanceTarget ensures the required flags for instance scanning are
+// present. Both project-id and zone are needed to locate the instance.
+func validateInstanceTarget(projectId, zone string) error {
+	if projectId == "" || zone == "" {
+		return status.Error(codes.InvalidArgument, "the --project-id and --zone flags are required for gcp instance scanning")
+	}
+	return nil
+}
+
+// validateSnapshotTarget ensures the required flags for snapshot scanning are
+// present. The project-id is needed to locate the snapshot.
+func validateSnapshotTarget(projectId string) error {
+	if projectId == "" {
+		return status.Error(codes.InvalidArgument, "the --project-id flag is required for gcp snapshot scanning")
+	}
+	return nil
 }
 
 func (s *Service) MockConnect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {

--- a/providers/gcp/provider/provider_test.go
+++ b/providers/gcp/provider/provider_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+func TestParseCLI_InstanceRequiresProjectAndZone(t *testing.T) {
+	_, err := (&Service{}).ParseCLI(&plugin.ParseCLIReq{
+		Connector: "gcp",
+		Args:      []string{"instance", "my-vm"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "--project-id")
+	assert.Contains(t, err.Error(), "--zone")
+}
+
+func TestParseCLI_SnapshotRequiresProject(t *testing.T) {
+	_, err := (&Service{}).ParseCLI(&plugin.ParseCLIReq{
+		Connector: "gcp",
+		Args:      []string{"snapshot", "my-snapshot"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "--project-id")
+}
+
+func TestValidateInstanceTarget(t *testing.T) {
+	assert.Error(t, validateInstanceTarget("", ""))
+	assert.Error(t, validateInstanceTarget("my-project", ""))
+	assert.Error(t, validateInstanceTarget("", "us-central1-a"))
+	assert.NoError(t, validateInstanceTarget("my-project", "us-central1-a"))
+}
+
+func TestValidateSnapshotTarget(t *testing.T) {
+	assert.Error(t, validateSnapshotTarget(""))
+	assert.NoError(t, validateSnapshotTarget("my-project"))
+}


### PR DESCRIPTION
## Problem

The `gcp instance <name>` and `gcp snapshot <name>` subcommands read `--project-id` and `--zone` into local variables that default to the empty string when the flags are absent, then assigned them straight into `conf.Options` with no validation. Running e.g. `gcp instance my-vm` without `--project-id`/`--zone` produced empty connection options and a confusing, downstream `RESOURCE_PROJECT_INVALID` failure with no hint about what the user actually got wrong.

## Fix

Validate the required flags in `ParseCLI` before building the asset:

- **`instance`** — both `--project-id` and `--zone` are required (both feed `InstanceInfo(projectID, zone, instanceName)`). If either is empty:
  > `the --project-id and --zone flags are required for gcp instance scanning`
- **`snapshot`** — `--project-id` is required (feeds `SnapshotInfo(projectID, snapshotName)`). If empty:
  > `the --project-id flag is required for gcp snapshot scanning`

Both return a clear `codes.InvalidArgument` error. The two checks are factored into small pure helpers (`validateInstanceTarget`, `validateSnapshotTarget`) called from their respective `case` blocks.

## Test

Added `providers/gcp/provider/provider_test.go`:
- `ParseCLI` for `instance`/`snapshot` with empty flags returns an `InvalidArgument` error mentioning the required flags.
- Direct unit tests for the two validation helpers across present/absent flag combinations.

`gofmt`, `go test ./provider/...`, and `go build ./...` all pass in the gcp provider module.

Fixes #8418