### PR TITLE
🐛 gcp: sanitize and length-cap snapshot scanner disk names

### DIFF
--- a/providers/gcp/connection/gcpinstancesnapshot/provider.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/provider.go
@@ -140,7 +140,7 @@ func NewGcpSnapshotConnection(id uint32, conf *inventory.Config, asset *inventor
 			} else if err == nil && time.Now().Sub(created).Hours() < 8 {
 				// use the snapshot if it was created less than 8 hours ago
 				log.Debug().Str("snapshot", snapshotUrl).Msg("found latest snapshot")
-				diskUrl, err = sc.createSnapshotDisk(snapshotUrl, scanner.projectID, scanner.zone, "cnspec-"+target.InstanceName+"-snapshot-"+time.Now().Format("2006-01-02t15-04-05z00-00"))
+				diskUrl, err = sc.createSnapshotDisk(snapshotUrl, scanner.projectID, scanner.zone, newDiskName(target.InstanceName))
 				if err != nil {
 					log.Error().Err(err).Str("disk", diskUrl).Msg("could not complete snapshot disk creation")
 					return nil, errors.Wrap(err, "could not create disk from snapshot")
@@ -156,7 +156,7 @@ func NewGcpSnapshotConnection(id uint32, conf *inventory.Config, asset *inventor
 		if mi.diskUrl == "" {
 			// clone the disk of the instance to the zone where the scanner runs
 			// disk name does not allow colons, therefore we need a custom format
-			diskUrl, err = sc.cloneDisk(instanceInfo.BootDiskSourceURL, scanner.projectID, scanner.zone, "cnspec-"+target.InstanceName+"-snapshot-"+time.Now().Format("2006-01-02t15-04-05z00-00"))
+			diskUrl, err = sc.cloneDisk(instanceInfo.BootDiskSourceURL, scanner.projectID, scanner.zone, newDiskName(target.InstanceName))
 			if err != nil {
 				log.Error().Err(err).Str("disk", diskUrl).Msg("could not complete snapshot creation")
 				return nil, errors.Wrap(err, "could not create gcp instance snapshot")
@@ -173,7 +173,7 @@ func NewGcpSnapshotConnection(id uint32, conf *inventory.Config, asset *inventor
 			return nil, err
 		}
 
-		diskUrl, err = sc.createSnapshotDisk(snapshotInfo.SnapshotUrl, scanner.projectID, scanner.zone, "cnspec-"+target.InstanceName+"-snapshot-"+time.Now().Format("2006-01-02t15-04-05z00-00"))
+		diskUrl, err = sc.createSnapshotDisk(snapshotInfo.SnapshotUrl, scanner.projectID, scanner.zone, newDiskName(target.InstanceName))
 		if err != nil {
 			log.Error().Err(err).Str("disk", diskUrl).Msg("could not complete snapshot disk creation")
 			return nil, errors.Wrap(err, "could not create disk from snapshot")

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
@@ -39,6 +39,61 @@ func NewSourceDiskUrl(projectID, zone, diskName string) string {
 	)
 }
 
+// newDiskName builds a GCP-compliant temporary disk name for the scanner's
+// clone/snapshot disk. See buildDiskName.
+func newDiskName(instanceName string) string {
+	return buildDiskName(instanceName, time.Now())
+}
+
+// buildDiskName produces a name matching GCP's rule
+// [a-z]([-a-z0-9]{0,61}[a-z0-9])? with a max length of 63. It lowercases and
+// replaces invalid characters in the instance name and truncates it so the
+// full "cnspec-<instance>-<timestamp>" name fits.
+func buildDiskName(instanceName string, t time.Time) string {
+	const (
+		prefix     = "cnspec-"
+		maxLen     = 63
+		timeLayout = "20060102t150405" // 15 chars, all valid characters
+	)
+	timestamp := t.Format(timeLayout)
+
+	// sanitize the instance name: lowercase, and replace any character that is
+	// not in [a-z0-9-] with '-'
+	sanitized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		default:
+			return '-'
+		}
+	}, instanceName)
+
+	// reserve room for the prefix and the "-"+timestamp suffix, then truncate
+	// the sanitized instance name so the assembled name fits within maxLen
+	avail := maxLen - len(prefix) - 1 - len(timestamp)
+	if avail < 0 {
+		avail = 0
+	}
+	if len(sanitized) > avail {
+		sanitized = sanitized[:avail]
+	}
+
+	// trim trailing '-' from the (possibly truncated) instance name so the
+	// assembled name reads cleanly
+	sanitized = strings.TrimRight(sanitized, "-")
+
+	// the timestamp always ends in a digit, so the assembled name ends in
+	// [a-z0-9] and starts with the "cnspec-" prefix (a letter) — both required
+	// by GCP's rule
+	return prefix + sanitized + "-" + timestamp
+}
+
 func NewSnapshotCreator() (*SnapshotCreator, error) {
 	scope := []string{cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope}
 	client, err := googleoauth.DefaultClient(context.Background(), scope...)

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -26,6 +27,10 @@ const (
 	createdByLabel = "created-by"
 	createdValue   = "cnspec"
 )
+
+// invalidDiskNameChars matches any character that is not allowed in a GCP disk
+// name (i.e. anything outside [a-z0-9-]).
+var invalidDiskNameChars = regexp.MustCompile(`[^a-z0-9-]`)
 
 func NewInstanceUrl(projectID, zone, instanceName string) string {
 	return fmt.Sprintf(
@@ -50,36 +55,16 @@ func newDiskName(instanceName string) string {
 // replaces invalid characters in the instance name and truncates it so the
 // full "cnspec-<instance>-<timestamp>" name fits.
 func buildDiskName(instanceName string, t time.Time) string {
-	const (
-		prefix     = "cnspec-"
-		maxLen     = 63
-		timeLayout = "20060102t150405" // 15 chars, all valid characters
-	)
-	timestamp := t.Format(timeLayout)
+	prefix := "cnspec-"
+	timestamp := t.Format("20060102t150405") // 15 chars, all valid characters
 
 	// sanitize the instance name: lowercase, and replace any character that is
 	// not in [a-z0-9-] with '-'
-	sanitized := strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-		case r >= '0' && r <= '9':
-			return r
-		case r == '-':
-			return r
-		case r >= 'A' && r <= 'Z':
-			return r + ('a' - 'A')
-		default:
-			return '-'
-		}
-	}, instanceName)
+	sanitized := invalidDiskNameChars.ReplaceAllString(strings.ToLower(instanceName), "-")
 
 	// reserve room for the prefix and the "-"+timestamp suffix, then truncate
-	// the sanitized instance name so the assembled name fits within maxLen
-	avail := maxLen - len(prefix) - 1 - len(timestamp)
-	if avail < 0 {
-		avail = 0
-	}
+	// the sanitized instance name so the assembled name fits within 63 chars
+	avail := max(63-len(prefix)-1-len(timestamp), 0)
 	if len(sanitized) > avail {
 		sanitized = sanitized[:avail]
 	}
@@ -87,6 +72,11 @@ func buildDiskName(instanceName string, t time.Time) string {
 	// trim trailing '-' from the (possibly truncated) instance name so the
 	// assembled name reads cleanly
 	sanitized = strings.TrimRight(sanitized, "-")
+
+	// if nothing usable remains, drop the separator to avoid a double dash
+	if sanitized == "" {
+		return prefix + timestamp
+	}
 
 	// the timestamp always ends in a digit, so the assembled name ends in
 	// [a-z0-9] and starts with the "cnspec-" prefix (a letter) — both required

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot_name_test.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot_name_test.go
@@ -1,0 +1,57 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package gcpinstancesnapshot
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestBuildDiskName(t *testing.T) {
+	// GCP disk/snapshot name rule.
+	nameRe := regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
+
+	// fixed timestamp so the test does not depend on the wall clock
+	fixed := time.Date(2026, 6, 14, 13, 45, 7, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		instanceName string
+	}{
+		{"short name", "web-1"},
+		{"very long name (60 chars)", "super-important-server-with-a-really-long-descriptive-name-1"},
+		{"uppercase, underscores, dots", "My_Server.Prod_01"},
+		{"empty name", ""},
+		{"only invalid chars", "____"},
+		{"trailing dashes after truncation", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa--------------------"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDiskName(tc.instanceName, fixed)
+
+			if len(got) > 63 {
+				t.Errorf("buildDiskName(%q) = %q has length %d, want <= 63", tc.instanceName, got, len(got))
+			}
+			if !nameRe.MatchString(got) {
+				t.Errorf("buildDiskName(%q) = %q does not match GCP name rule %s", tc.instanceName, got, nameRe.String())
+			}
+			if got[:7] != "cnspec-" {
+				t.Errorf("buildDiskName(%q) = %q does not start with %q", tc.instanceName, got, "cnspec-")
+			}
+		})
+	}
+}
+
+func TestNewDiskName(t *testing.T) {
+	nameRe := regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
+	got := newDiskName("super-important-server")
+	if len(got) > 63 {
+		t.Errorf("newDiskName produced %q with length %d, want <= 63", got, len(got))
+	}
+	if !nameRe.MatchString(got) {
+		t.Errorf("newDiskName produced %q which does not match GCP name rule", got)
+	}
+}


### PR DESCRIPTION
## Problem

When the GCP snapshot scanner clones a boot disk or materializes a snapshot, it builds the temporary disk name by raw concatenation:

```go
"cnspec-"+target.InstanceName+"-snapshot-"+time.Now().Format("2006-01-02t15-04-05z00-00")
```

For a long instance name (e.g. `super-important-server`) this overflows GCP's 63-character limit, and the instance name itself is never sanitized — uppercase letters, underscores, or dots produce a name that violates GCP's rule `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`. The scanner then fails with `RESOURCE name ... is not a valid disk name`.

## Fix

Add a small, unit-testable helper in `snapshot.go`:

- `newDiskName(instanceName string)` — thin wrapper calling `buildDiskName(instanceName, time.Now())`.
- `buildDiskName(instanceName string, t time.Time)` — lowercases the instance name, replaces any character outside `[a-z0-9-]` with `-`, reserves room for the `cnspec-` prefix and the `-<timestamp>` suffix, truncates the instance portion to fit, and trims trailing dashes.

Invariants guaranteed (and covered by tests):
- result length ≤ 63
- result fully matches `^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`
- result always begins with `cnspec-`
- empty / all-invalid instance names are handled without panic and still produce a valid name

The timestamp uses the layout `20060102t150405` (15 chars, all valid).

## Call sites

All three raw-concatenation expressions in `provider.go` (the snapshot-disk-from-recent-snapshot path, the clone-disk path, and the snapshot-target path) now call `newDiskName(target.InstanceName)`. Surrounding logic is unchanged.

## Test

New `snapshot_name_test.go` uses a fixed `time.Time` and the GCP name regexp, asserting the length and regex invariants across: short name, very long (60-char) name, name with uppercase/underscores/dots, empty name, all-invalid chars, and a name that would leave trailing dashes after truncation.

> Note: `snapshot.go` may lightly conflict with sibling PR #8416 — that's fine, resolved at merge.

Fixes #8417