### PR TITLE
🐛 inventoryloader: warn when an explicit inventory source yields 0 assets

### DIFF
--- a/cli/inventoryloader/inventory.go
+++ b/cli/inventoryloader/inventory.go
@@ -141,6 +141,15 @@ func parseDomainListInventory(data []byte) (*inventory.Inventory, error) {
 	return inventory.ToV1Inventory(), nil
 }
 
+// explicitInventorySource returns the file path or template path the user
+// asked us to load, or "" if no inventory source was set on the command line.
+func explicitInventorySource() string {
+	if p := viper.GetString("inventory-file"); p != "" {
+		return p
+	}
+	return viper.GetString("inventory-template")
+}
+
 // ParseOrUse tries to load the inventory and if nothing exists it
 // will instead use the provided asset.
 func ParseOrUse(asset *inventory.Asset, insecure bool, annotations map[string]string) (*inventory.Inventory, error) {
@@ -153,8 +162,14 @@ func ParseOrUse(asset *inventory.Asset, insecure bool, annotations map[string]st
 		return nil, errors.Wrap(err, "could not parse inventory")
 	}
 
-	// add asset from cli to inventory
+	// add asset from cli to inventory. When the user explicitly pointed us at
+	// an inventory source that produced zero assets, warn before falling back.
 	if len(v1inventory.Spec.GetAssets()) == 0 && asset != nil {
+		if src := explicitInventorySource(); src != "" {
+			log.Warn().
+				Str("source", src).
+				Msg("inventory source produced 0 assets; falling back to the CLI target.")
+		}
 		v1inventory.AddAssets(asset)
 	}
 


### PR DESCRIPTION
## Summary

`ParseOrUse` falls back to the CLI-provided asset whenever the parsed
inventory has no entries. That fallback is silent — so a user who passes
`--inventory-file` pointing at a file in the wrong format (e.g. an
Ansible-style inventory without `--inventory-format-ansible`, or any YAML
that doesn't match the Mondoo `Inventory` schema) sees the scan run
against `local` with no signal that their inventory was ignored. The
logs show `load inventory inventory-file=...` immediately followed by
`discover related assets for 1 asset(s)`, and that 1 asset is the local
target, not anything from the file.

This PR adds a `Warn` log entry (with the source path) before the
fallback when the user explicitly set `--inventory-file` or
`--inventory-template`. The fallback behavior itself is unchanged so no
existing workflow breaks; users just get a visible hint that their
inventory came back empty.

## Test plan

- [ ] Build cnspec/cnquery against this branch and run `cnspec scan --inventory-file <ansible-format>.yaml` — confirm the new warning appears and the scan still proceeds against the CLI target.
- [ ] Repeat with a valid Mondoo-format inventory — confirm no warning is logged and the inventory assets are used.
- [ ] Run with no `--inventory-file` flag — confirm no warning (helper returns `""`, fallback is the intended path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)