### PR TITLE
🐛 prefer running provider when resolving cross-provider resource fields

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -938,6 +939,37 @@ func (r *Runtime) lookupFieldProvider(resource string, field string) (*Connected
 		id := priority[i]
 		if s := fieldsPerProvider[id]; s != nil {
 			fieldInfo = s
+		}
+	}
+
+	// Fallback: prefer a provider already running on this runtime over
+	// spawning a new one whose connection type may not match the asset.
+	//
+	// When multiple providers define the same top-level resource (e.g. both
+	// `os` and `vsphere` declare a `vulnmgmt` resource), schema aggregation
+	// is non-deterministic — Schema.LookupField documents that "which
+	// provider becomes the primary [is] non-deterministic". If the loser
+	// gets picked here, Connect() below will be invoked on this runtime's
+	// asset with the wrong provider, which typically rejects with
+	// ErrUnsupportedProvider and surfaces to users as "unsupported platform"
+	// even when the asset is fully supported by the sibling provider.
+	//
+	// A provider that's already in r.providers has been initialized for this
+	// runtime (either as the primary or via a connector's MockConnect — e.g.
+	// the sbom provider initializes the os provider this way), so it is
+	// known-compatible with the asset. Prefer it over an as-yet-unstarted
+	// provider when neither priority entry matched.
+	if r.providers[fieldInfo.Provider] == nil {
+		providerIDs := make([]string, 0, len(fieldsPerProvider))
+		for id := range fieldsPerProvider {
+			providerIDs = append(providerIDs, id)
+		}
+		sort.Strings(providerIDs)
+		for _, id := range providerIDs {
+			if r.providers[id] != nil {
+				fieldInfo = fieldsPerProvider[id]
+				break
+			}
 		}
 	}
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -935,10 +935,12 @@ func (r *Runtime) lookupFieldProvider(resource string, field string) (*Connected
 
 	// prioritize ids
 	priority := []string{BuiltinCoreID, r.Provider.Instance.ID}
+	priorityMatched := false
 	for i := len(priority) - 1; i >= 0; i-- {
 		id := priority[i]
 		if s := fieldsPerProvider[id]; s != nil {
 			fieldInfo = s
+			priorityMatched = true
 		}
 	}
 
@@ -959,7 +961,17 @@ func (r *Runtime) lookupFieldProvider(resource string, field string) (*Connected
 	// the sbom provider initializes the os provider this way), so it is
 	// known-compatible with the asset. Prefer it over an as-yet-unstarted
 	// provider when neither priority entry matched.
-	if r.providers[fieldInfo.Provider] == nil {
+	//
+	// Only runs when the priority loop didn't pick anything — if core or the
+	// active connector was an explicit match, that selection is intentional
+	// and must not be overridden.
+	if !priorityMatched && r.providers[fieldInfo.Provider] == nil {
+		// Sort for determinism only; alphabetical order carries no semantic
+		// preference between sibling providers. The selection still has to
+		// satisfy "already running on this runtime", so the tie-breaker only
+		// matters when two compatible siblings are both initialized — rare in
+		// practice. Schema aggregation should ideally make this case
+		// impossible, but until then a stable order beats map iteration.
 		providerIDs := make([]string, 0, len(fieldsPerProvider))
 		for id := range fieldsPerProvider {
 			providerIDs = append(providerIDs, id)

--- a/providers/runtime_test.go
+++ b/providers/runtime_test.go
@@ -387,6 +387,65 @@ func TestRuntime_LookupFieldProvider_ProviderOverridesOthers_ResourceInfo(t *tes
 	assert.Equal(t, "test", field.Provider)
 }
 
+// When two sibling providers both declare the same top-level resource
+// (e.g. `vulnmgmt` is defined by both `os` and `vsphere`) and the active
+// connector is a third provider whose ID matches neither — for example,
+// the `sbom` connector spawning `os` via MockConnect — the schema merge
+// picks a non-deterministic "primary". If the primary doesn't match an
+// already-running provider on this runtime, lookupFieldProvider would
+// previously fall through to spawning the unrelated provider and calling
+// Connect() on the asset, which gets rejected with ErrUnsupportedProvider.
+// The fix prefers any already-running provider over starting a new one,
+// because a provider in r.providers is known-compatible with the asset.
+func TestRuntime_LookupFieldProvider_PrefersRunningProviderForCrossProviderResource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockC := NewMockProvidersCoordinator(ctrl)
+	mockSchema := NewMockResourcesSchema(ctrl)
+
+	// Active connector ("sbom") does not implement the resource itself; it
+	// has initialized "os" via MockConnect, so "os" is in r.providers.
+	connector := &ConnectedProvider{
+		Instance: &RunningProvider{ID: "sbom", Name: "sbom"},
+	}
+	osProvider := &ConnectedProvider{
+		Instance: &RunningProvider{ID: "os", Name: "os"},
+	}
+	r := &Runtime{
+		coordinator: mockC,
+		recording:   recording.Null{},
+		providers: map[string]*ConnectedProvider{
+			"sbom": connector,
+			"os":   osProvider,
+		},
+		Provider: connector,
+	}
+
+	resName := "vulnmgmt"
+	fieldName := "advisories"
+	// Simulate the non-deterministic case where "vsphere" wins as primary
+	// during schema aggregation. "os" is present as an Other.
+	mockC.EXPECT().Schema().Times(1).Return(mockSchema)
+	mockSchema.EXPECT().Lookup(resName).Times(1).Return(&resources.ResourceInfo{
+		Name:     resName,
+		Provider: "vsphere",
+		Fields: map[string]*resources.Field{
+			fieldName: {
+				Name:     fieldName,
+				Provider: "vsphere",
+				Others: []*resources.Field{
+					{Name: fieldName, Provider: "os"},
+				},
+			},
+		},
+	})
+
+	provider, _, field, err := r.lookupFieldProvider(resName, fieldName)
+	require.NoError(t, err)
+	assert.Equal(t, "os", field.Provider,
+		"should route to the already-running provider, not the non-running primary")
+	assert.Equal(t, osProvider, provider)
+}
+
 func TestRuntime_CriticalErrors_Empty(t *testing.T) {
 	r := &Runtime{}
 	assert.Empty(t, r.CriticalErrors())

--- a/providers/runtime_test.go
+++ b/providers/runtime_test.go
@@ -446,6 +446,193 @@ func TestRuntime_LookupFieldProvider_PrefersRunningProviderForCrossProviderResou
 	assert.Equal(t, osProvider, provider)
 }
 
+// When the priority loop matches an entry (core or the active connector),
+// the running-provider fallback must not override that intentional choice
+// — even if another provider that happens to be in r.providers also
+// implements the field. This guards against the case where core is the
+// declared owner of a field but is handled by the static-provider branch
+// (not via r.providers): without the priorityMatched guard, the fallback
+// would silently swap in the running sibling.
+//
+// We verify by setting up the scenario where the priority pick (core) is
+// not in r.providers, so the function falls through to addProvider. By
+// stubbing GetRunningProvider to error, we can inspect which provider ID
+// the runtime tried to spawn — it must be the priority-matched one, never
+// the running sibling.
+func TestRuntime_LookupFieldProvider_DoesNotOverridePriorityMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockC := NewMockProvidersCoordinator(ctrl)
+	mockSchema := NewMockResourcesSchema(ctrl)
+
+	connector := &ConnectedProvider{
+		Instance: &RunningProvider{ID: "connector", Name: "connector"},
+	}
+	siblingProvider := &ConnectedProvider{
+		Instance: &RunningProvider{ID: "sibling", Name: "sibling"},
+	}
+	r := &Runtime{
+		coordinator: mockC,
+		recording:   recording.Null{},
+		providers: map[string]*ConnectedProvider{
+			"connector": connector,
+			"sibling":   siblingProvider,
+			// BuiltinCoreID intentionally NOT in r.providers — simulates core
+			// being served by the static-provider path.
+		},
+		Provider: connector,
+	}
+
+	resName := "testResource"
+	fieldName := "testField"
+	mockC.EXPECT().Schema().Times(1).Return(mockSchema)
+	mockSchema.EXPECT().Lookup(resName).Times(1).Return(&resources.ResourceInfo{
+		Name:     resName,
+		Provider: "another",
+		Fields: map[string]*resources.Field{
+			fieldName: {
+				Name:     fieldName,
+				Provider: "another",
+				Others: []*resources.Field{
+					{Name: fieldName, Provider: BuiltinCoreID}, // wins priority
+					{Name: fieldName, Provider: "sibling"},     // would win fallback if unguarded
+				},
+			},
+		},
+	})
+	// Capture which provider ID the runtime tries to spawn after priority
+	// resolution. The expectation only matches BuiltinCoreID — if the guard
+	// were missing and "sibling" replaced the priority pick, the call would
+	// be GetRunningProvider("sibling", ...) and the mock would fail with an
+	// unexpected-call error.
+	mockC.EXPECT().
+		GetRunningProvider(BuiltinCoreID, gomock.Any()).
+		Times(1).
+		Return(nil, errors.New("simulated: not exercising real spawn"))
+
+	_, _, _, err := r.lookupFieldProvider(resName, fieldName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start provider '"+BuiltinCoreID+"'",
+		"priority match must not be overridden by the running-provider fallback")
+}
+
+// When two sibling providers are both initialized and neither matches the
+// priority entries, the tie-breaker must be deterministic. We sort by
+// provider ID and pick the first; without the sort, Go map iteration would
+// make the choice randomly per process and reintroduce the exact flake this
+// PR fixes. Run the lookup repeatedly with a fresh controller each iteration
+// to verify the choice is stable across Go's randomized map order.
+//
+// To exercise the fallback, the primary fieldInfo.Provider must NOT itself
+// be running on the runtime — otherwise the early-return at "provider in
+// r.providers" short-circuits before the fallback runs. So the field's
+// declared primary here is `gamma` (unloaded), with `alpha` and `beta` as
+// running siblings; the tie-breaker chooses between them.
+func TestRuntime_LookupFieldProvider_TieBreakerIsDeterministic(t *testing.T) {
+	const iterations = 50
+
+	runOnce := func(t *testing.T) string {
+		ctrl := gomock.NewController(t)
+		mockC := NewMockProvidersCoordinator(ctrl)
+		mockSchema := NewMockResourcesSchema(ctrl)
+
+		connector := &ConnectedProvider{
+			Instance: &RunningProvider{ID: "connector", Name: "connector"},
+		}
+		alpha := &ConnectedProvider{
+			Instance: &RunningProvider{ID: "alpha", Name: "alpha"},
+		}
+		beta := &ConnectedProvider{
+			Instance: &RunningProvider{ID: "beta", Name: "beta"},
+		}
+		r := &Runtime{
+			coordinator: mockC,
+			recording:   recording.Null{},
+			providers: map[string]*ConnectedProvider{
+				"connector": connector,
+				"alpha":     alpha,
+				"beta":      beta,
+				// "gamma" intentionally NOT here — forces the fallback path.
+			},
+			Provider: connector,
+		}
+
+		mockC.EXPECT().Schema().Times(1).Return(mockSchema)
+		mockSchema.EXPECT().Lookup("testResource").Times(1).Return(&resources.ResourceInfo{
+			Name:     "testResource",
+			Provider: "gamma",
+			Fields: map[string]*resources.Field{
+				"testField": {
+					Name:     "testField",
+					Provider: "gamma",
+					Others: []*resources.Field{
+						{Name: "testField", Provider: "alpha"},
+						{Name: "testField", Provider: "beta"},
+					},
+				},
+			},
+		})
+
+		_, _, field, err := r.lookupFieldProvider("testResource", "testField")
+		require.NoError(t, err)
+		return field.Provider
+	}
+
+	for i := range iterations {
+		if got := runOnce(t); got != "alpha" {
+			t.Fatalf("iteration %d: tie-breaker should pick alphabetically-first running sibling, got %q", i, got)
+		}
+	}
+}
+
+// When no entry in fieldsPerProvider corresponds to an already-running
+// provider, the fallback is a no-op: fieldInfo stays as the primary and
+// the existing code path proceeds to spawn the new provider. This verifies
+// the fallback doesn't change behavior in the "actually need to spawn"
+// case — a regression here would silently break previously-working queries.
+func TestRuntime_LookupFieldProvider_FallsThroughWhenNoSiblingRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockC := NewMockProvidersCoordinator(ctrl)
+	mockSchema := NewMockResourcesSchema(ctrl)
+
+	connector := &ConnectedProvider{
+		Instance: &RunningProvider{ID: "connector", Name: "connector"},
+	}
+	r := &Runtime{
+		coordinator: mockC,
+		recording:   recording.Null{},
+		providers: map[string]*ConnectedProvider{
+			"connector": connector,
+			// "needed" provider is NOT in r.providers — fallback should
+			// retain fieldInfo.Provider = "needed" and the existing code
+			// path will try to spawn it.
+		},
+		Provider: connector,
+	}
+
+	mockC.EXPECT().Schema().Times(1).Return(mockSchema)
+	mockSchema.EXPECT().Lookup("testResource").Times(1).Return(&resources.ResourceInfo{
+		Name:     "testResource",
+		Provider: "needed",
+		Fields: map[string]*resources.Field{
+			"testField": {Name: "testField", Provider: "needed"},
+		},
+	})
+
+	// Spawn path: GetRunningProvider is called for "needed". Returning an
+	// error short-circuits the test without exercising real connection
+	// machinery — we just want to confirm fieldInfo wasn't mutated and the
+	// existing addProvider path is reached.
+	mockC.EXPECT().
+		GetRunningProvider("needed", gomock.Any()).
+		Times(1).
+		Return(nil, errors.New("simulated: not exercising real spawn"))
+
+	_, _, _, err := r.lookupFieldProvider("testResource", "testField")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start provider 'needed'",
+		"the fallback should leave fieldInfo.Provider == 'needed' and reach the existing spawn path")
+}
+
 func TestRuntime_CriticalErrors_Empty(t *testing.T) {
 	r := &Runtime{}
 	assert.Empty(t, r.CriticalErrors())


### PR DESCRIPTION
## Summary

When two providers declare the same top-level resource (e.g. both `os` and `vsphere` define a `vulnmgmt` resource), schema aggregation merges their fields and the "primary" is non-deterministic — the existing comment in `Schema.LookupField` already calls this out:

```
// Map iteration during aggregation makes which provider becomes
// the primary non-deterministic
```

If the active connector's provider ID doesn't match either contributor — for example, the `sbom` connector spawning `os` via `MockConnect` — the priority list in `Runtime.lookupFieldProvider` (`[BuiltinCoreID, r.Provider.Instance.ID]`) doesn't apply, and the non-deterministic primary wins. When the loser is picked, the runtime calls `addProvider` on a sibling provider and then `Connect()` on the asset, which the wrong provider rejects with `plugin.ErrUnsupportedProvider`. That error becomes the field's `val.Error`, and the CLI printer renders it as `MsgUnsupported = "unsupported platform"` — even though the asset is fully supported by the sibling that should have been picked.

The symptom is intermittent because it depends on Go map iteration order: identical commands produce different results across runs, and the bug only becomes possible once both colliding providers are installed.

## Fix

Add a fallback after the existing priority loop: if the chosen field's provider isn't already initialized on this runtime, prefer any provider that *is* in `r.providers` (sorted by ID for determinism). A provider already in the map has been started for this runtime — either as the primary connector or via a connector's `MockConnect` — so it is known-compatible with the asset's connection type.

This avoids spawning an incompatible sibling provider, makes the resolution deterministic, and is non-breaking.

## Repro (before the fix)

```
$ mql run sbom alpine-sbom.json --config <sa> -c 'vulnmgmt { advisories { id } }'
vulnmgmt: {
  advisories: unsupported platform
}
```

The same query against the same data in `mql shell` returns the actual advisories. After this fix, both surfaces produce the same result deterministically.

## Test plan

- [x] Added `TestRuntime_LookupFieldProvider_PrefersRunningProviderForCrossProviderResource` that fails on `main` (unexpected `addProvider("vsphere")` call when no entry was queued) and passes with the fix.
- [x] Existing `TestRuntime_LookupFieldProvider_*` cases still pass.
- [x] `go test ./providers/` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)