### PR TITLE
:star: add `mql inventory validate` to catch unknown connection options

### DIFF
--- a/apps/mql/cmd/inventory.go
+++ b/apps/mql/cmd/inventory.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.mondoo.com/mql/v13/cli/inventoryvalidate"
+	"go.mondoo.com/mql/v13/cli/theme"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func init() {
+	rootCmd.AddCommand(inventoryCmd)
+	inventoryCmd.AddCommand(inventoryValidateCmd)
+	inventoryValidateCmd.Flags().Bool("strict", false,
+		"Treat warnings (unknown options, uninstalled connection types) as errors")
+}
+
+var inventoryCmd = &cobra.Command{
+	Use:   "inventory",
+	Short: "Work with inventory files",
+	Long:  "Inspect and validate inventory files.",
+}
+
+var inventoryValidateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Short: "Validate an inventory file against installed provider schemas",
+	Long: `Validate parses an inventory file and checks each asset connection against
+the provider that handles it. Connection types that no installed provider
+provides, and option keys that the provider's connectors do not declare, are
+reported — these are typically typos that would otherwise be silently ignored
+when the scan runs.
+
+Option keys are matched against each provider's connector flag names, so the
+set of valid options always reflects the providers you have installed.`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		strict, _ := cmd.Flags().GetBool("strict")
+		path := args[0]
+
+		inv, err := inventory.InventoryFromFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to load inventory %q: %w", path, err)
+		}
+
+		all, err := providers.ListAll()
+		if err != nil {
+			return fmt.Errorf("failed to list installed providers: %w", err)
+		}
+		plugins := make([]*plugin.Provider, 0, len(all))
+		for _, p := range all {
+			if p != nil && p.Provider != nil {
+				plugins = append(plugins, p.Provider)
+			}
+		}
+
+		schema := inventoryvalidate.BuildSchema(plugins)
+		findings := inventoryvalidate.Check(inv, schema, strict)
+
+		errCount := 0
+		for _, f := range findings {
+			line := fmt.Sprintf("%s: %s (asset %s, connection %d)",
+				f.Severity, f.Message, f.Asset, f.Connection)
+			if f.Severity == inventoryvalidate.SeverityError {
+				errCount++
+				line = theme.DefaultTheme.Error(line)
+			} else {
+				line = theme.DefaultTheme.Secondary(line)
+			}
+			cmd.PrintErrln(line)
+		}
+
+		switch {
+		case len(findings) == 0:
+			cmd.Printf("inventory %q is valid\n", path)
+			return nil
+		case errCount > 0:
+			return fmt.Errorf("inventory %q has %d error(s)", path, errCount)
+		default:
+			cmd.Printf("inventory %q passed with %d warning(s); use --strict to fail on warnings\n",
+				path, len(findings))
+			return nil
+		}
+	},
+}

--- a/apps/mql/cmd/inventory.go
+++ b/apps/mql/cmd/inventory.go
@@ -38,6 +38,8 @@ when the scan runs.
 
 Option keys are matched against each provider's connector flag names, so the
 set of valid options always reflects the providers you have installed.`,
+	Example: `  mql inventory validate inventory.yml
+  mql inventory validate inventory.yml --strict`,
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/inventoryvalidate/validate.go
+++ b/cli/inventoryvalidate/validate.go
@@ -1,0 +1,186 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package inventoryvalidate checks an inventory file against the schema of the
+// providers that handle its connections. A connection's option keys must match
+// the long names of the flags its provider declares; an option key that no
+// provider accepts is almost always a typo (e.g. "tenantId" instead of
+// "tenant-id") that would otherwise be silently ignored at connect time.
+package inventoryvalidate
+
+import (
+	"fmt"
+	"sort"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Severity classifies a finding. Unknown option keys and uninstalled
+// connection types are warnings by default and become errors under strict mode.
+type Severity int
+
+const (
+	SeverityWarning Severity = iota
+	SeverityError
+)
+
+func (s Severity) String() string {
+	if s == SeverityError {
+		return "error"
+	}
+	return "warning"
+}
+
+// Finding is a single validation problem with one connection.
+type Finding struct {
+	// Asset is a human-readable label for the asset (its id, name, or index).
+	Asset string
+	// Connection is the index of the connection within the asset.
+	Connection int
+	// Type is the connection type that was validated.
+	Type string
+	// Severity is error or warning.
+	Severity Severity
+	// Message describes the problem.
+	Message string
+}
+
+// Schema is the set of option keys each connection type accepts, derived from
+// installed providers' static plugin metadata. It is built once and reused
+// across connections.
+type Schema struct {
+	// optionKeys maps a connection type to the set of option keys (flag long
+	// names) the resolving provider accepts. The value is the union of the
+	// provider's connector flags, which avoids false positives when a provider
+	// exposes several connectors for the same type.
+	optionKeys map[string]map[string]struct{}
+}
+
+// BuildSchema derives the option-key schema from the given providers' static
+// metadata. No provider is connected to; only the declared connectors and
+// flags are read, so this works offline.
+//
+// A connection type is associated with a provider through the provider's
+// ConnectionTypes list and through each connector's Name and Aliases — the
+// same resolution the CLI uses to attach a provider to a connection.
+func BuildSchema(provs []*plugin.Provider) *Schema {
+	s := &Schema{optionKeys: map[string]map[string]struct{}{}}
+	for _, p := range provs {
+		if p == nil {
+			continue
+		}
+
+		// The union of every connector flag long name this provider declares.
+		keys := map[string]struct{}{}
+		for i := range p.Connectors {
+			for _, f := range p.Connectors[i].Flags {
+				if f.Long != "" {
+					keys[f.Long] = struct{}{}
+				}
+			}
+		}
+
+		// Every connection type string this provider answers to.
+		types := map[string]struct{}{}
+		for _, t := range p.ConnectionTypes {
+			if t != "" {
+				types[t] = struct{}{}
+			}
+		}
+		for i := range p.Connectors {
+			if p.Connectors[i].Name != "" {
+				types[p.Connectors[i].Name] = struct{}{}
+			}
+			for _, a := range p.Connectors[i].Aliases {
+				if a != "" {
+					types[a] = struct{}{}
+				}
+			}
+		}
+
+		for t := range types {
+			allowed, ok := s.optionKeys[t]
+			if !ok {
+				allowed = map[string]struct{}{}
+				s.optionKeys[t] = allowed
+			}
+			for k := range keys {
+				allowed[k] = struct{}{}
+			}
+		}
+	}
+	return s
+}
+
+// Check validates every connection in the inventory against the schema. Option
+// keys not accepted by the connection's provider, and connection types not
+// handled by any installed provider, are returned as findings. Findings are
+// warnings unless strict is set, in which case they are errors. The result is
+// ordered (by asset, then connection, then message) for stable output.
+func Check(inv *inventory.Inventory, schema *Schema, strict bool) []Finding {
+	var findings []Finding
+	if inv == nil || inv.Spec == nil || schema == nil {
+		return findings
+	}
+
+	sev := SeverityWarning
+	if strict {
+		sev = SeverityError
+	}
+
+	for ai, asset := range inv.Spec.Assets {
+		if asset == nil {
+			continue
+		}
+		label := assetLabel(asset, ai)
+		for ci, conn := range asset.Connections {
+			if conn == nil {
+				continue
+			}
+
+			allowed, known := schema.optionKeys[conn.Type]
+			if !known {
+				findings = append(findings, Finding{
+					Asset:      label,
+					Connection: ci,
+					Type:       conn.Type,
+					Severity:   sev,
+					Message: fmt.Sprintf(
+						"connection type %q is not provided by any installed provider; its options cannot be validated (is the provider installed?)",
+						conn.Type),
+				})
+				continue
+			}
+
+			// Sort the keys so the findings are deterministic.
+			keys := make([]string, 0, len(conn.Options))
+			for k := range conn.Options {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				if _, ok := allowed[k]; !ok {
+					findings = append(findings, Finding{
+						Asset:      label,
+						Connection: ci,
+						Type:       conn.Type,
+						Severity:   sev,
+						Message:    fmt.Sprintf("unknown option %q for connection type %q", k, conn.Type),
+					})
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func assetLabel(asset *inventory.Asset, idx int) string {
+	if asset.Id != "" {
+		return asset.Id
+	}
+	if asset.Name != "" {
+		return asset.Name
+	}
+	return fmt.Sprintf("#%d", idx)
+}

--- a/cli/inventoryvalidate/validate_test.go
+++ b/cli/inventoryvalidate/validate_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package inventoryvalidate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// testProviders mirrors the relevant shape of real provider metadata: a k8s
+// provider whose connector declares "namespaces"/"context", and an azure
+// provider with "subscriptions". The schema is derived from these without
+// touching any installed provider.
+func testProviders() []*plugin.Provider {
+	return []*plugin.Provider{
+		{
+			Name:            "k8s",
+			ConnectionTypes: []string{"k8s"},
+			Connectors: []plugin.Connector{
+				{
+					Name:    "k8s",
+					Aliases: []string{"kubernetes"},
+					Flags: []plugin.Flag{
+						{Long: "namespaces", Type: plugin.FlagType_String},
+						{Long: "context", Type: plugin.FlagType_String},
+					},
+				},
+			},
+		},
+		{
+			Name:            "azure",
+			ConnectionTypes: []string{"azure"},
+			Connectors: []plugin.Connector{
+				{
+					Name: "azure",
+					Flags: []plugin.Flag{
+						{Long: "subscriptions", Type: plugin.FlagType_String},
+					},
+				},
+			},
+		},
+	}
+}
+
+func inv(conns ...*inventory.Config) *inventory.Inventory {
+	return &inventory.Inventory{
+		Spec: &inventory.InventorySpec{
+			Assets: []*inventory.Asset{{Id: "test-asset", Connections: conns}},
+		},
+	}
+}
+
+func TestBuildSchema_resolvesTypesAndAliases(t *testing.T) {
+	s := BuildSchema(testProviders())
+
+	// Connection types are reachable by ConnectionTypes, connector name, and alias.
+	_, k8s := s.optionKeys["k8s"]
+	_, kubernetes := s.optionKeys["kubernetes"]
+	_, azure := s.optionKeys["azure"]
+	assert.True(t, k8s, "k8s type resolves")
+	assert.True(t, kubernetes, "k8s alias resolves")
+	assert.True(t, azure, "azure type resolves")
+
+	_, unknown := s.optionKeys["aws"]
+	assert.False(t, unknown, "uninstalled type does not resolve")
+}
+
+func TestCheck_validOptions(t *testing.T) {
+	s := BuildSchema(testProviders())
+	findings := Check(inv(&inventory.Config{
+		Type:    "k8s",
+		Options: map[string]string{"namespaces": "default", "context": "prod"},
+	}), s, false)
+	assert.Empty(t, findings, "known options produce no findings")
+}
+
+func TestCheck_unknownOption(t *testing.T) {
+	s := BuildSchema(testProviders())
+	findings := Check(inv(&inventory.Config{
+		Type: "k8s",
+		// "namespace" (singular) is a typo for "namespaces"; "subscriptions"
+		// belongs to a different provider.
+		Options: map[string]string{"namespace": "default", "subscriptions": "x"},
+	}), s, false)
+
+	require.Len(t, findings, 2)
+	for _, f := range findings {
+		assert.Equal(t, SeverityWarning, f.Severity)
+		assert.Equal(t, "k8s", f.Type)
+		assert.Equal(t, "test-asset", f.Asset)
+	}
+	// Deterministic order: keys are sorted, so "namespace" precedes "subscriptions".
+	assert.Contains(t, findings[0].Message, `"namespace"`)
+	assert.Contains(t, findings[1].Message, `"subscriptions"`)
+}
+
+func TestCheck_strictPromotesToError(t *testing.T) {
+	s := BuildSchema(testProviders())
+	findings := Check(inv(&inventory.Config{
+		Type:    "k8s",
+		Options: map[string]string{"bogus": "1"},
+	}), s, true)
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityError, findings[0].Severity)
+}
+
+func TestCheck_unknownConnectionType(t *testing.T) {
+	s := BuildSchema(testProviders())
+	findings := Check(inv(&inventory.Config{
+		Type:    "made-up",
+		Options: map[string]string{"anything": "1"},
+	}), s, false)
+
+	// Only the type finding — options are not validated for an unknown type.
+	require.Len(t, findings, 1)
+	assert.Equal(t, "made-up", findings[0].Type)
+	assert.Contains(t, findings[0].Message, "not provided by any installed provider")
+}
+
+func TestCheck_nilSafe(t *testing.T) {
+	s := BuildSchema(testProviders())
+	assert.Empty(t, Check(nil, s, false))
+	assert.Empty(t, Check(&inventory.Inventory{}, s, false))
+	assert.Empty(t, Check(inv(), nil, false))
+}
+
+func TestCheck_assetLabelFallback(t *testing.T) {
+	s := BuildSchema(testProviders())
+	in := &inventory.Inventory{Spec: &inventory.InventorySpec{
+		Assets: []*inventory.Asset{
+			{Name: "named", Connections: []*inventory.Config{{Type: "made-up"}}},
+			{Connections: []*inventory.Config{{Type: "made-up"}}},
+		},
+	}}
+	findings := Check(in, s, false)
+	require.Len(t, findings, 2)
+	assert.Equal(t, "named", findings[0].Asset)
+	assert.Equal(t, "#1", findings[1].Asset)
+}

--- a/test/commands/testdata/mql.ct
+++ b/test/commands/testdata/mql.ct
@@ -14,6 +14,7 @@ Available Commands:
   completion    Generate the autocompletion script for the specified shell
   discover      Discover assets
   help          Help about any command
+  inventory     Work with inventory files
   login         Register with Mondoo Platform
   logout        Log out from Mondoo Platform
   providers     Providers add connectivity to all assets


### PR DESCRIPTION
## Problem

A connection's `options` in an inventory file are a free-form `map[string]string`. A mistyped key — `namespace` instead of `namespaces`, `tenantId` instead of `tenant-id`, `subscription-id` (no such flag) instead of `subscription` — is **silently ignored**. There is no way to check an inventory before a scan, so the mistake only surfaces as a confusing connect-time failure, or as a setting that quietly never took effect.

## What this adds

A new `mql inventory validate <file>` command. It parses the inventory and checks each asset connection against the providers installed on the system:

- **Unknown connection type** — a `type` no installed provider provides is reported.
- **Unknown option key** — an `options` key not declared by the resolving provider's connector flags is reported. The flag `Long` names are the authoritative set of option keys, since providers read `conf.Options[flag.Long]`.

```
$ mql inventory validate prod.yaml
warning: unknown option "namespace" for connection type "k8s" (asset cluster, connection 0)
warning: unknown option "tenntid" for connection type "azure" (asset cluster, connection 1)
inventory "prod.yaml" passed with 2 warning(s); use --strict to fail on warnings
```

Findings are **warnings by default** and become **errors under `--strict`** (non-zero exit), so the command can gate inventories in CI without false-failing on a provider that simply isn't installed on the local machine. Validation is **offline** — it reads each provider's static plugin metadata via `providers.ListAll()` and never connects to a target.

## Design

- The check logic lives in a new `cli/inventoryvalidate` package, driven by a `Schema` built from provider metadata (`BuildSchema([]*plugin.Provider)`). Keeping the schema as an input makes `Check` unit-testable with hand-built providers — **no provider needs to be installed to run the tests**.
- A type's allowed option keys are the **union** of its provider's connector flags, which avoids false positives for providers that expose several connectors. The default warning severity is a deliberate hedge: if a provider ever reads an option it doesn't declare as a flag, the user sees a warning rather than a hard failure.

## Tests

`cli/inventoryvalidate/validate_test.go` covers schema resolution (type, connector name, alias), valid options, unknown options, `--strict` promotion, unknown types, nil-safety, and asset-label fallback. `go vet` and `golangci-lint` are clean; manually smoke-tested against good/typo'd/unknown-type inventories and a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
