### PR TITLE
:star: k8s: filter discovery by label selectors

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -69,6 +69,18 @@ Examples:
 					Desc:    "Only include Kubernetes objects in the matching namespaces",
 				},
 				{
+					Long:    "namespace-label-selector",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Only include Kubernetes namespaces matching the label selector, along with all objects discovered within those namespaces",
+				},
+				{
+					Long:    "object-label-selector",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Only include Kubernetes objects matching the label selector; for container image discovery this matches the pod that references the image",
+				},
+				{
 					Long:    "container-proxy",
 					Type:    plugin.FlagType_String,
 					Default: "",

--- a/providers/k8s/connection/shared/connection.go
+++ b/providers/k8s/connection/shared/connection.go
@@ -17,18 +17,20 @@ import (
 )
 
 const (
-	OPTION_GIT_HTTP          = "http-url"
-	OPTION_MANIFEST          = "path"
-	OPTION_IMMEMORY_CONTENT  = "manifest-content"
-	OPTION_NAMESPACE         = "namespaces"
-	OPTION_NAMESPACE_EXCLUDE = "namespaces-exclude"
-	OPTION_IMAGES            = "images"
-	OPTION_IMAGES_EXCLUDE    = "images-exclude"
-	OPTION_ADMISSION         = "k8s-admission-review"
-	OPTION_OBJECT_KIND       = "object-kind"
-	OPTION_CONTEXT           = "context"
-	OPTION_KUBELOGIN         = "kubelogin"
-	IdPrefix                 = "//platformid.api.mondoo.app/runtime/k8s/uid/"
+	OPTION_GIT_HTTP                 = "http-url"
+	OPTION_MANIFEST                 = "path"
+	OPTION_IMMEMORY_CONTENT         = "manifest-content"
+	OPTION_NAMESPACE                = "namespaces"
+	OPTION_NAMESPACE_EXCLUDE        = "namespaces-exclude"
+	OPTION_NAMESPACE_LABEL_SELECTOR = "namespace-label-selector"
+	OPTION_OBJECT_LABEL_SELECTOR    = "object-label-selector"
+	OPTION_IMAGES                   = "images"
+	OPTION_IMAGES_EXCLUDE           = "images-exclude"
+	OPTION_ADMISSION                = "k8s-admission-review"
+	OPTION_OBJECT_KIND              = "object-kind"
+	OPTION_CONTEXT                  = "context"
+	OPTION_KUBELOGIN                = "kubelogin"
+	IdPrefix                        = "//platformid.api.mondoo.app/runtime/k8s/uid/"
 )
 
 type ConnectionType string

--- a/providers/k8s/provider/provider.go
+++ b/providers/k8s/provider/provider.go
@@ -86,6 +86,14 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options[shared.OPTION_IMAGES_EXCLUDE] = string(img.Value)
 	}
 
+	if selector, ok := req.Flags[shared.OPTION_NAMESPACE_LABEL_SELECTOR]; ok {
+		conf.Options[shared.OPTION_NAMESPACE_LABEL_SELECTOR] = string(selector.Value)
+	}
+
+	if selector, ok := req.Flags[shared.OPTION_OBJECT_LABEL_SELECTOR]; ok {
+		conf.Options[shared.OPTION_OBJECT_LABEL_SELECTOR] = string(selector.Value)
+	}
+
 	if val, ok := req.Flags[shared.OPTION_KUBELOGIN]; ok {
 		conf.Options[shared.OPTION_KUBELOGIN] = strconv.FormatBool(val.RawData().Value.(bool))
 	}

--- a/providers/k8s/provider/provider_test.go
+++ b/providers/k8s/provider/provider_test.go
@@ -267,6 +267,12 @@ func TestParseCLI(t *testing.T) {
 				"namespaces": {
 					Value: []byte("my-namespace"),
 				},
+				"namespace-label-selector": {
+					Value: []byte("tenant=t1"),
+				},
+				"object-label-selector": {
+					Value: []byte("app in (api,worker)"),
+				},
 			},
 		}
 
@@ -279,8 +285,10 @@ func TestParseCLI(t *testing.T) {
 			},
 			Type: "k8s",
 			Options: map[string]string{
-				shared.OPTION_NAMESPACE:         "my-namespace",
-				shared.OPTION_NAMESPACE_EXCLUDE: "excluded-namespace",
+				shared.OPTION_NAMESPACE:                "my-namespace",
+				shared.OPTION_NAMESPACE_EXCLUDE:        "excluded-namespace",
+				shared.OPTION_NAMESPACE_LABEL_SELECTOR: "tenant=t1",
+				shared.OPTION_OBJECT_LABEL_SELECTOR:    "app in (api,worker)",
 			},
 		}
 

--- a/providers/k8s/resources/admission.go
+++ b/providers/k8s/resources/admission.go
@@ -73,19 +73,19 @@ func (k *mqlK8sAdmissionreview) request() (*mqlK8sAdmissionrequest, error) {
 		args["object"] = llx.NilData
 	}
 
-	oldObj, err := resources.ResourcesFromManifest(bytes.NewReader(aRequest.OldObject.Raw))
-	if err != nil {
-		return nil, err
-	}
-
-	if len(oldObj) == 1 {
-		oldObjDict, err := convert.JsonToDict(oldObj[0])
+	args["oldObject"] = llx.NilData
+	if len(aRequest.OldObject.Raw) > 0 {
+		oldObj, err := resources.ResourcesFromManifest(bytes.NewReader(aRequest.OldObject.Raw))
 		if err != nil {
 			return nil, err
 		}
-		args["oldObject"] = llx.DictData(oldObjDict)
-	} else {
-		args["oldObject"] = llx.NilData
+		if len(oldObj) == 1 {
+			oldObjDict, err := convert.JsonToDict(oldObj[0])
+			if err != nil {
+				return nil, err
+			}
+			args["oldObject"] = llx.DictData(oldObjDict)
+		}
 	}
 
 	r, err := CreateResource(k.MqlRuntime, "k8s.admissionrequest", args)

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -22,6 +22,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -72,6 +73,36 @@ func (f *FilterOpts) skip(value string) bool {
 		return !matchesAny(f.include, value)
 	}
 	return matchesAny(f.exclude, value)
+}
+
+// LabelSelectorFilters filters discovered Kubernetes objects by labels.
+// Object selectors match the Kubernetes object being discovered; for container
+// image discovery this is the pod that references the image, not the image asset.
+type LabelSelectorFilters struct {
+	namespace labels.Selector
+	object    labels.Selector
+}
+
+func (f *LabelSelectorFilters) MatchNamespace(obj metav1.Object) bool {
+	if f == nil || f.namespace == nil || f.namespace.Empty() {
+		return true
+	}
+	return f.namespace.Matches(labels.Set(obj.GetLabels()))
+}
+
+func (f *LabelSelectorFilters) HasNamespaceSelector() bool {
+	return f != nil && f.namespace != nil && !f.namespace.Empty()
+}
+
+func (f *LabelSelectorFilters) IsEmpty() bool {
+	return f == nil || ((f.namespace == nil || f.namespace.Empty()) && (f.object == nil || f.object.Empty()))
+}
+
+func (f *LabelSelectorFilters) MatchObject(obj metav1.Object) bool {
+	if f == nil || f.object == nil || f.object.Empty() {
+		return true
+	}
+	return f.object.Matches(labels.Set(obj.GetLabels()))
 }
 
 // Discover routes to the appropriate discovery path based on whether the client
@@ -130,11 +161,16 @@ func discoverLegacy(runtime *plugin.Runtime, conn shared.Connection, invConfig *
 		return nil, err
 	}
 
+	labelFilters, err := labelSelectorFilters(invConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// If we can discover the cluster asset, then we use that as root and build all
 	// platform IDs for the assets based on it. If we cannot discover the cluster, we
 	// discover the individual namespaces according to the ns filter and then build
 	// the platform IDs for the assets based on the namespace.
-	if len(nsFilter.include) == 0 && len(nsFilter.exclude) == 0 {
+	if len(nsFilter.include) == 0 && len(nsFilter.exclude) == 0 && labelFilters.IsEmpty() {
 		assetId, err := conn.AssetId()
 		if err == nil {
 			root := &inventory.Asset{
@@ -150,7 +186,7 @@ func discoverLegacy(runtime *plugin.Runtime, conn shared.Connection, invConfig *
 			log.Warn().Err(err).Msg("failed to discover cluster asset")
 		}
 	}
-	nss, err := discoverNamespaces(conn, invConfig, "", nil, nsFilter)
+	nss, err := discoverNamespaces(conn, invConfig, "", nil, nsFilter, labelFilters)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +203,7 @@ func discoverLegacy(runtime *plugin.Runtime, conn shared.Connection, invConfig *
 		od := NewPlatformIdOwnershipIndex(ns.PlatformIds[0])
 
 		// We don't want to discover the namespaces again since we have already done this above
-		assets, err := discoverAssets(runtime, conn, invConfig, ns.PlatformIds[0], k8s, nsFilter, resFilters, od, imgFilter)
+		assets, err := discoverAssets(runtime, conn, invConfig, ns.PlatformIds[0], k8s, nsFilter, resFilters, labelFilters, od, imgFilter)
 		if err != nil {
 			return nil, err
 		}
@@ -204,11 +240,16 @@ func discoverClusterStage(runtime *plugin.Runtime, conn shared.Connection, invCo
 		return nil, err
 	}
 
+	labelFilters, err := labelSelectorFilters(invConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// If we can discover the cluster asset, then we use that as root and build all
 	// platform IDs for the assets based on it. If we cannot discover the cluster, we
 	// discover the individual namespaces according to the ns filter and then build
 	// the platform IDs for the assets based on the namespace.
-	if len(nsFilter.include) == 0 && len(nsFilter.exclude) == 0 {
+	if len(nsFilter.include) == 0 && len(nsFilter.exclude) == 0 && labelFilters.IsEmpty() {
 		assetId, err := conn.AssetId()
 		if err == nil {
 			root := &inventory.Asset{
@@ -228,7 +269,7 @@ func discoverClusterStage(runtime *plugin.Runtime, conn shared.Connection, invCo
 	// Discover namespaces and emit them as scannable assets with platform IDs
 	// and discovery targets. Override each namespace's connection config to
 	// route to stage 2 when the client connects to it later.
-	nss, err := discoverNamespaces(conn, invConfig, "", nil, nsFilter)
+	nss, err := discoverNamespaces(conn, invConfig, "", nil, nsFilter, labelFilters)
 	if err != nil {
 		return nil, err
 	}
@@ -294,6 +335,11 @@ func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, inv
 		return nil, err
 	}
 
+	labelFilters, err := labelSelectorFilters(invConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// Resolve the namespace's platform ID for use as the ownership root
 	basePlatformId, err := conn.BasePlatformId()
 	if err != nil {
@@ -303,11 +349,14 @@ func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, inv
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespace %q: %w", nsName, err)
 	}
+	if !labelFilters.MatchNamespace(nsObj) {
+		return in, nil
+	}
 	namespacePlatformId := shared.NewNamespacePlatformId(basePlatformId, nsName, string(nsObj.UID))
 
 	od := NewPlatformIdOwnershipIndex(namespacePlatformId)
 
-	assets, err := discoverAssets(runtime, conn, invConfig, namespacePlatformId, k8s, nsFilter, resFilters, od, imgFilter)
+	assets, err := discoverAssets(runtime, conn, invConfig, namespacePlatformId, k8s, nsFilter, resFilters, labelFilters, od, imgFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -324,6 +373,7 @@ func discoverAssets(
 	k8s *mqlK8s,
 	nsFilter FilterOpts,
 	resFilters *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 	od *PlatformIdOwnershipIndex,
 	imgFilter FilterOpts,
 ) ([]*inventory.Asset, error) {
@@ -332,77 +382,77 @@ func discoverAssets(
 	for _, target := range invConfig.Discover.Targets {
 		var list []*inventory.Asset
 		if target == DiscoveryPods || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverPods(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverPods(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryJobs || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverJobs(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverJobs(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryCronJobs || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverCronJobs(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverCronJobs(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryServices || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverServices(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverServices(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryStatefulSets || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverStatefulSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverStatefulSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryDeployments || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverDeployments(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverDeployments(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryReplicaSets || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverReplicaSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverReplicaSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryDaemonSets || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverDaemonSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverDaemonSets(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryIngresses || target == DiscoveryAuto || target == DiscoveryAll {
-			list, err = discoverIngresses(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters)
+			list, err = discoverIngresses(conn, invConfig, clusterId, k8s, od, nsFilter, resFilters, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryAdmissionReviews {
-			list, err = discoverAdmissionReviews(conn, invConfig, clusterId, k8s, od, nsFilter)
+			list, err = discoverAdmissionReviews(conn, invConfig, clusterId, k8s, od, nsFilter, labelFilters)
 			if err != nil {
 				return nil, err
 			}
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryContainerImages || target == DiscoveryAll {
-			list, err = discoverContainerImages(conn, runtime, invConfig, k8s, nsFilter, imgFilter)
+			list, err = discoverContainerImages(conn, runtime, invConfig, k8s, nsFilter, labelFilters, imgFilter)
 			if err != nil {
 				return nil, err
 			}
@@ -420,6 +470,7 @@ func discoverPods(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	pods := k8s.GetPods()
 	if pods.Error != nil {
@@ -446,6 +497,10 @@ func discoverPods(
 
 		k8sMeta, err := meta.Accessor(pod.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -489,6 +544,7 @@ func discoverJobs(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	jobs := k8s.GetJobs()
 	if jobs.Error != nil {
@@ -515,6 +571,10 @@ func discoverJobs(
 
 		k8sMeta, err := meta.Accessor(job.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -558,6 +618,7 @@ func discoverServices(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	cjs := k8s.GetServices()
 	if cjs.Error != nil {
@@ -588,6 +649,10 @@ func discoverServices(
 
 		k8sMeta, err := meta.Accessor(serv.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -623,6 +688,7 @@ func discoverCronJobs(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	cjs := k8s.GetCronjobs()
 	if cjs.Error != nil {
@@ -653,6 +719,10 @@ func discoverCronJobs(
 
 		k8sMeta, err := meta.Accessor(cjob.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -688,6 +758,7 @@ func discoverStatefulSets(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	ss := k8s.GetStatefulsets()
 	if ss.Error != nil {
@@ -718,6 +789,10 @@ func discoverStatefulSets(
 
 		k8sMeta, err := meta.Accessor(statefulset.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -753,6 +828,7 @@ func discoverDeployments(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	ds := k8s.GetDeployments()
 	if ds.Error != nil {
@@ -783,6 +859,10 @@ func discoverDeployments(
 
 		k8sMeta, err := meta.Accessor(deployment.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -818,6 +898,7 @@ func discoverReplicaSets(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	rs := k8s.GetReplicasets()
 	if rs.Error != nil {
@@ -844,6 +925,10 @@ func discoverReplicaSets(
 
 		k8sMeta, err := meta.Accessor(replicaset.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -887,6 +972,7 @@ func discoverDaemonSets(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	ds := k8s.GetDaemonsets()
 	if ds.Error != nil {
@@ -917,6 +1003,10 @@ func discoverDaemonSets(
 
 		k8sMeta, err := meta.Accessor(daemonset.obj)
 		if err != nil {
+			continue
+		}
+
+		if !labelFilters.MatchObject(k8sMeta) {
 			continue
 		}
 
@@ -951,6 +1041,7 @@ func discoverAdmissionReviews(
 	k8s *mqlK8s,
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	admissionReviews, err := conn.AdmissionReviews()
 	if err != nil {
@@ -961,9 +1052,12 @@ func discoverAdmissionReviews(
 	for i := range admissionReviews {
 		aReview := admissionReviews[i]
 
-		asset, err := assetFromAdmissionReview(conn, aReview, conn.Runtime(), invConfig, clusterId)
+		asset, matched, err := assetFromAdmissionReview(conn, aReview, conn.Runtime(), invConfig, clusterId, nsFilter, labelFilters)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from admission review")
+		}
+		if !matched {
+			continue
 		}
 
 		log.Debug().Str("connection", asset.Connections[0].Host).Msg("resolved AdmissionReview")
@@ -982,6 +1076,7 @@ func discoverIngresses(
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
 	resFilter *ResourceFilters,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	is := k8s.GetIngresses()
 	if is.Error != nil {
@@ -1015,6 +1110,10 @@ func discoverIngresses(
 			continue
 		}
 
+		if !labelFilters.MatchObject(k8sMeta) {
+			continue
+		}
+
 		labels := map[string]string{}
 		for k, v := range ingress.GetLabels().Data {
 			labels[k] = v.(string)
@@ -1045,6 +1144,7 @@ func discoverNamespaces(
 	clusterId string,
 	od *PlatformIdOwnershipIndex,
 	nsFilter FilterOpts,
+	labelFilters *LabelSelectorFilters,
 ) ([]*inventory.Asset, error) {
 	// We don't use MQL here since we need to handle k8s permission errors
 	nss, err := conn.Namespaces()
@@ -1077,6 +1177,10 @@ func discoverNamespaces(
 			continue
 		}
 
+		if !labelFilters.MatchNamespace(&ns) {
+			continue
+		}
+
 		labels := map[string]string{}
 		for k, v := range ns.Labels {
 			labels[k] = v
@@ -1103,7 +1207,7 @@ func discoverNamespaces(
 	return assetList, nil
 }
 
-func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, invConfig *inventory.Config, k8s *mqlK8s, nsFilter FilterOpts, imgFilter FilterOpts) ([]*inventory.Asset, error) {
+func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, invConfig *inventory.Config, k8s *mqlK8s, nsFilter FilterOpts, labelFilters *LabelSelectorFilters, imgFilter FilterOpts) ([]*inventory.Asset, error) {
 	pods := k8s.GetPods()
 	if pods.Error != nil {
 		return nil, pods.Error
@@ -1119,6 +1223,9 @@ func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, in
 
 		podObj, err := pod.getPod()
 		if err != nil {
+			continue
+		}
+		if !labelFilters.MatchObject(podObj) {
 			continue
 		}
 
@@ -1184,34 +1291,62 @@ func addMondooAssetLabels(assetLabels map[string]string, objMeta metav1.Object, 
 	}
 }
 
-func assetFromAdmissionReview(conn shared.Connection, a admissionv1.AdmissionReview, runtime string, connection *inventory.Config, clusterIdentifier string) (*inventory.Asset, error) {
+func assetFromAdmissionReview(conn shared.Connection, a admissionv1.AdmissionReview, runtime string, connection *inventory.Config, clusterIdentifier string, nsFilter FilterOpts, labelFilters *LabelSelectorFilters) (*inventory.Asset, bool, error) {
 	// Use the meta from the request object.
+	if a.Request == nil {
+		return nil, false, errors.New("admission review request is nil")
+	}
+	if len(a.Request.Object.Raw) == 0 {
+		return nil, false, errors.New("admission review request object is empty")
+	}
 	obj, err := resources.ResourcesFromManifest(bytes.NewReader(a.Request.Object.Raw))
 	if err != nil {
 		log.Error().Err(err).Msg("failed to parse object from admission review")
-		return nil, err
+		return nil, false, err
+	}
+	if len(obj) == 0 {
+		return nil, false, errors.New("admission review request object did not contain any resources")
 	}
 	objMeta, err := meta.Accessor(obj[0])
 	if err != nil {
 		log.Error().Err(err).Msg("could not access object attributes")
-		return nil, err
+		return nil, false, err
 	}
-	objType, err := meta.TypeAccessor(&a)
+	objType, err := meta.TypeAccessor(obj[0])
 	if err != nil {
 		log.Error().Err(err).Msg("could not access object attributes")
-		return nil, err
+		return nil, false, err
+	}
+	objNamespace := admissionReviewObjectNamespace(a, objMeta)
+	if skip := nsFilter.skip(objNamespace); skip {
+		return nil, false, nil
+	}
+	if labelFilters.HasNamespaceSelector() {
+		switch {
+		case objType.GetKind() == "Namespace":
+			if !labelFilters.MatchNamespace(objMeta) {
+				return nil, false, nil
+			}
+		case objNamespace != "":
+			log.Warn().
+				Str("namespace", objNamespace).
+				Str("kind", objType.GetKind()).
+				Str("object", objMeta.GetName()).
+				Msg("skipping admission review object because namespace labels are unavailable for namespace-label-selector filtering")
+			return nil, false, nil
+		}
+	}
+	if !labelFilters.MatchObject(objMeta) {
+		return nil, false, nil
 	}
 
 	basePlatformId, err := conn.BasePlatformId()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	objectKind := objType.GetKind()
-	platformData, err := createPlatformData(a.Kind, runtime)
-	if err != nil {
-		return nil, err
-	}
+	platformData := createAdmissionReviewObjectPlatformData(objectKind, runtime)
 	platformData.Version = objType.GetAPIVersion()
 	platformData.Build = objMeta.GetResourceVersion()
 	platformData.Labels = map[string]string{
@@ -1243,7 +1378,34 @@ func assetFromAdmissionReview(conn shared.Connection, a admissionv1.AdmissionRev
 		Category:    conn.Asset().Category,
 	}
 
-	return asset, nil
+	return asset, true, nil
+}
+
+func createAdmissionReviewObjectPlatformData(objectKind, runtime string) *inventory.Platform {
+	platformData, err := createPlatformData(objectKind, runtime)
+	if err == nil {
+		return platformData
+	}
+
+	platformName := "k8s-object"
+	return &inventory.Platform{
+		Family:                []string{"k8s"},
+		Kind:                  "k8s-object",
+		Runtime:               runtime,
+		Name:                  platformName,
+		Title:                 "Kubernetes " + objectKind,
+		TechnologyUrlSegments: []string{"k8s", platformName},
+	}
+}
+
+func admissionReviewObjectNamespace(a admissionv1.AdmissionReview, objMeta metav1.Object) string {
+	if objMeta != nil && objMeta.GetNamespace() != "" {
+		return objMeta.GetNamespace()
+	}
+	if a.Request != nil {
+		return a.Request.Namespace
+	}
+	return ""
 }
 
 func createPlatformData(objectKind, runtime string) (*inventory.Platform, error) {
@@ -1416,6 +1578,44 @@ func setImageFilters(cfg *inventory.Config) (FilterOpts, error) {
 		return FilterOpts{}, fmt.Errorf("--images and --images-exclude are mutually exclusive")
 	}
 	return newFilterOpts(includeVals, excludeVals)
+}
+
+func labelSelectorFilters(cfg *inventory.Config) (*LabelSelectorFilters, error) {
+	filters := &LabelSelectorFilters{
+		namespace: labels.Everything(),
+		object:    labels.Everything(),
+	}
+
+	if raw, ok := cfg.Options[shared.OPTION_NAMESPACE_LABEL_SELECTOR]; ok {
+		selector, err := parseLabelSelectorOption(shared.OPTION_NAMESPACE_LABEL_SELECTOR, raw)
+		if err != nil {
+			return nil, err
+		}
+		filters.namespace = selector
+	}
+
+	if raw, ok := cfg.Options[shared.OPTION_OBJECT_LABEL_SELECTOR]; ok {
+		selector, err := parseLabelSelectorOption(shared.OPTION_OBJECT_LABEL_SELECTOR, raw)
+		if err != nil {
+			return nil, err
+		}
+		filters.object = selector
+	}
+
+	return filters, nil
+}
+
+func parseLabelSelectorOption(option, raw string) (labels.Selector, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return labels.Everything(), nil
+	}
+
+	selector, err := labels.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s label selector: %w", option, err)
+	}
+	return selector, nil
 }
 
 func setNamespaceFilters(cfg *inventory.Config) (FilterOpts, error) {

--- a/providers/k8s/resources/discovery_test.go
+++ b/providers/k8s/resources/discovery_test.go
@@ -4,20 +4,25 @@
 package resources
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	admissionconn "go.mondoo.com/mql/v13/providers/k8s/connection/admission"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/shared"
 	sharedres "go.mondoo.com/mql/v13/providers/k8s/connection/shared/resources"
 	"go.mondoo.com/mql/v13/utils/syncx"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -146,3 +151,234 @@ func (c *namespaceDiscoveryConnection) InventoryConfig() *inventory.Config {
 }
 
 var _ shared.Connection = (*namespaceDiscoveryConnection)(nil)
+
+func TestLabelSelectorFilters(t *testing.T) {
+	cfg := &inventory.Config{
+		Options: map[string]string{
+			shared.OPTION_NAMESPACE_LABEL_SELECTOR: "tenant=t1",
+			shared.OPTION_OBJECT_LABEL_SELECTOR:    "app in (api,worker)",
+		},
+	}
+
+	filters, err := labelSelectorFilters(cfg)
+	require.NoError(t, err)
+
+	assert.False(t, filters.IsEmpty())
+	assert.True(t, filters.MatchNamespace(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"tenant": "t1"}},
+	}))
+	assert.False(t, filters.MatchNamespace(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"tenant": "t2"}},
+	}))
+	assert.True(t, filters.MatchObject(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+	}))
+	assert.False(t, filters.MatchObject(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "db"}},
+	}))
+}
+
+func TestLabelSelectorFilters_EmptySelectorsMatchAll(t *testing.T) {
+	filters, err := labelSelectorFilters(&inventory.Config{Options: map[string]string{}})
+	require.NoError(t, err)
+
+	assert.True(t, filters.IsEmpty())
+	assert.True(t, filters.MatchNamespace(&corev1.Namespace{}))
+	assert.True(t, filters.MatchObject(&corev1.Pod{}))
+}
+
+func TestLabelSelectorFilters_InvalidSelector(t *testing.T) {
+	_, err := labelSelectorFilters(&inventory.Config{
+		Options: map[string]string{
+			shared.OPTION_OBJECT_LABEL_SELECTOR: "app in (",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), shared.OPTION_OBJECT_LABEL_SELECTOR)
+}
+
+func TestAdmissionReviewObjectNamespace(t *testing.T) {
+	assert.Equal(t, "object-ns", admissionReviewObjectNamespace(admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{Namespace: "request-ns"},
+	}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "object-ns"}}))
+
+	assert.Equal(t, "request-ns", admissionReviewObjectNamespace(admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{Namespace: "request-ns"},
+	}, &corev1.Pod{}))
+
+	assert.Empty(t, admissionReviewObjectNamespace(admissionv1.AdmissionReview{}, &corev1.Namespace{}))
+}
+
+func TestAssetFromAdmissionReviewRejectsMalformedRequestObject(t *testing.T) {
+	tests := []struct {
+		name       string
+		review     admissionv1.AdmissionReview
+		wantErrMsg string
+	}{
+		{
+			name:       "nil request",
+			review:     admissionv1.AdmissionReview{},
+			wantErrMsg: "admission review request is nil",
+		},
+		{
+			name: "empty object",
+			review: admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{},
+			},
+			wantErrMsg: "admission review request object is empty",
+		},
+		{
+			name: "no resources",
+			review: admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{Raw: []byte("# no resources\n")},
+				},
+			},
+			wantErrMsg: "admission review request object did not contain any resources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset, matched, err := assetFromAdmissionReview(nil, tt.review, "k8s-admission", &inventory.Config{}, "", FilterOpts{}, nil)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+			assert.False(t, matched)
+			assert.Nil(t, asset)
+		})
+	}
+}
+
+func TestAssetFromAdmissionReviewUsesAdmittedObjectPlatform(t *testing.T) {
+	podRaw := []byte(`{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "admitted-pod",
+    "namespace": "default",
+    "uid": "pod-uid",
+    "resourceVersion": "42",
+    "labels": {
+      "app": "api"
+    }
+  }
+}`)
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       types.UID("review-uid"),
+			Namespace: "default",
+			Object:    runtime.RawExtension{Raw: podRaw},
+		},
+	}
+	reviewJSON, err := json.Marshal(review)
+	require.NoError(t, err)
+
+	connection := &inventory.Config{Options: map[string]string{}}
+	parent := &inventory.Asset{
+		Name:        "admission-review",
+		Connections: []*inventory.Config{connection},
+	}
+	conn, err := admissionconn.NewConnection(1, parent, base64.StdEncoding.EncodeToString(reviewJSON))
+	require.NoError(t, err)
+
+	asset, matched, err := assetFromAdmissionReview(conn, review, conn.Runtime(), connection, "cluster-id", FilterOpts{}, nil)
+
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.NotNil(t, asset)
+	assert.Equal(t, "default/admitted-pod", asset.Name)
+	assert.Equal(t, "k8s-pod", asset.Platform.Name)
+	assert.Equal(t, "Kubernetes Pod", asset.Platform.Title)
+	assert.Equal(t, "v1", asset.Platform.Version)
+	assert.Equal(t, "42", asset.Platform.Build)
+	assert.Equal(t, "Pod", asset.Labels["k8s.mondoo.com/kind"])
+	assert.Equal(t, "v1", asset.Labels["k8s.mondoo.com/apiVersion"])
+	assert.NotContains(t, asset.PlatformIds[0], "admissionreview")
+	assert.Contains(t, asset.PlatformIds[0], "pod")
+}
+
+func TestAssetFromAdmissionReviewAppliesNamespaceLabelSelector(t *testing.T) {
+	podRaw := []byte(`{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "admitted-pod",
+    "namespace": "default",
+    "uid": "pod-uid",
+    "labels": {
+      "app": "api"
+    }
+  }
+}`)
+	review := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Namespace: "default",
+			Object:    runtime.RawExtension{Raw: podRaw},
+		},
+	}
+	filters, err := labelSelectorFilters(&inventory.Config{Options: map[string]string{
+		shared.OPTION_NAMESPACE_LABEL_SELECTOR: "tenant=t1",
+	}})
+	require.NoError(t, err)
+
+	asset, matched, err := assetFromAdmissionReview(nil, review, "k8s-admission", &inventory.Config{}, "", FilterOpts{}, filters)
+
+	require.NoError(t, err)
+	assert.False(t, matched)
+	assert.Nil(t, asset)
+}
+
+func TestAssetFromAdmissionReviewUsesGenericPlatformForUnsupportedObjectKind(t *testing.T) {
+	configMapRaw := []byte(`{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "admitted-config",
+    "namespace": "default",
+    "uid": "configmap-uid",
+    "resourceVersion": "43",
+    "labels": {
+      "app": "api"
+    }
+  }
+}`)
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       types.UID("review-uid"),
+			Namespace: "default",
+			Object:    runtime.RawExtension{Raw: configMapRaw},
+		},
+	}
+	reviewJSON, err := json.Marshal(review)
+	require.NoError(t, err)
+
+	connection := &inventory.Config{Options: map[string]string{}}
+	parent := &inventory.Asset{
+		Name:        "admission-review",
+		Connections: []*inventory.Config{connection},
+	}
+	conn, err := admissionconn.NewConnection(1, parent, base64.StdEncoding.EncodeToString(reviewJSON))
+	require.NoError(t, err)
+
+	asset, matched, err := assetFromAdmissionReview(conn, review, conn.Runtime(), connection, "cluster-id", FilterOpts{}, nil)
+
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.NotNil(t, asset)
+	assert.Equal(t, "default/admitted-config", asset.Name)
+	assert.Equal(t, "k8s-object", asset.Platform.Name)
+	assert.Equal(t, "Kubernetes ConfigMap", asset.Platform.Title)
+	assert.Equal(t, "ConfigMap", asset.Labels["k8s.mondoo.com/kind"])
+	assert.Contains(t, asset.PlatformIds[0], "configmap")
+	assert.NotContains(t, asset.PlatformIds[0], "admissionreview")
+}


### PR DESCRIPTION
## Summary
- add k8s provider flags for namespace and object label selectors
- apply namespace selectors before namespace assets are emitted and before staged namespace discovery continues
- apply object selectors to discovered workload assets, admission-review objects, and pod-backed container image discovery
- avoid emitting the cluster root asset when discovery is scoped by label selectors

## Review fixes
- admission-review discovery now honors namespace label selectors for Namespace objects
- admission-review discovery fails closed for namespaced non-Namespace objects when namespace labels are required but unavailable
- log a warning when a namespaced admission-review object is skipped because namespace labels are unavailable for selector evaluation

## Tests
- `git diff --check`
- `cd providers/k8s && go test ./resources -run 'TestAssetFromAdmissionReview|TestLabelSelectorFilters'`
- `cd providers/k8s && go test ./provider ./resources`
- `go test ./provider ./resources -count=1`
- `go test ./... -count=1`
- `git -c core.fsmonitor=false diff --check`