### PR TITLE
✨ Retry DescribeRepositories/DescribeImages on throttling

### DIFF
--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -51,6 +51,19 @@ type ecrLifecyclePolicyAction struct {
 	Type string `json:"type"`
 }
 
+// the max amount of retries for the ECR Describe* calls (1 initial + 7 retries).
+const ecrDescribeMaxAttempts = 8
+
+// raises the per-operation retry ceiling for private ECR Describe* calls.
+func withEcrDescribeRetries(o *ecr.Options) {
+	o.RetryMaxAttempts = ecrDescribeMaxAttempts
+}
+
+// raises the per-operation retry ceiling for public ECR Describe* calls.
+func withEcrPublicDescribeRetries(o *ecrpublic.Options) {
+	o.RetryMaxAttempts = ecrDescribeMaxAttempts
+}
+
 func (a *mqlAwsEcr) id() (string, error) {
 	return "aws.ecr", nil
 }
@@ -175,7 +188,7 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 
 				paginator := ecr.NewDescribeRepositoriesPaginator(svc, req)
 				for paginator.HasMorePages() {
-					repoResp, err := paginator.NextPage(ctx)
+					repoResp, err := paginator.NextPage(ctx, withEcrDescribeRetries)
 					if err != nil {
 						if Is400AccessDeniedError(err) {
 							log.Warn().Str("region", region).Msg("error accessing region for AWS API")
@@ -263,7 +276,7 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 		svc := conn.EcrPublic(region)
 		paginator := ecrpublic.NewDescribeImagesPaginator(svc, &ecrpublic.DescribeImagesInput{RepositoryName: &name})
 		for paginator.HasMorePages() {
-			res, err := paginator.NextPage(ctx)
+			res, err := paginator.NextPage(ctx, withEcrPublicDescribeRetries)
 			if err != nil {
 				if Is400AccessDeniedError(err) {
 					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
@@ -301,7 +314,7 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 	svc := conn.Ecr(region)
 	paginator := ecr.NewDescribeImagesPaginator(svc, &ecr.DescribeImagesInput{RepositoryName: &name})
 	for paginator.HasMorePages() {
-		res, err := paginator.NextPage(ctx)
+		res, err := paginator.NextPage(ctx, withEcrDescribeRetries)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
 				log.Warn().Str("region", region).Msg("error accessing region for AWS API")
@@ -553,7 +566,7 @@ func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 
 		paginator := ecrpublic.NewDescribeRepositoriesPaginator(svc, req)
 		for paginator.HasMorePages() {
-			repoResp, err := paginator.NextPage(context.TODO())
+			repoResp, err := paginator.NextPage(context.TODO(), withEcrPublicDescribeRetries)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## What

Make the ECR `DescribeRepositories` and `DescribeImages` calls in `aws_ecr.go` more resilient to **transient / throttling** errors by raising the per-operation retry ceiling from the SDK default of **3 attempts** to **8** (1 initial call + 7 retries).

ECR's `Describe*` APIs have low per-second throttle limits, so listing repositories and images in accounts with many of them frequently hits `ThrottlingException`. We don't hand-roll a retry loop — the AWS SDK v2 **standard retryer** already retries throttle/transient errors (`ThrottlingException`, `TooManyRequestsException`, 5xx, connection errors, …) with exponential backoff + jitter, and a token-bucket rate limiter that prevents retry storms. The only weak spot is the attempt ceiling, so we raise just that, leaving all detection/backoff logic intact.

A one-field per-request option wraps the client's existing default retryer:

```go
const ecrDescribeMaxAttempts = 8

func withEcrDescribeRetries(o *ecr.Options)             { o.RetryMaxAttempts = ecrDescribeMaxAttempts }
func withEcrPublicDescribeRetries(o *ecrpublic.Options) { o.RetryMaxAttempts = ecrDescribeMaxAttempts }
```

Applied to all four matching call sites — `DescribeRepositories` and `DescribeImages`, in both **private** and **public** scope.

## Backoff per retry

The SDK's default ("standard"/legacy) retry mode computes the delay before each retry as `rand[0,1) × 2^attempt` seconds, flat-capped at `MaxBackoff` (20s) once `attempt > floor(log₂20) = 4`. With 8 attempts, that's **7 retries**:

| Retry | Before attempt # | Backoff formula | Wait window (jittered) |
|------:|:----------------:|:----------------|:-----------------------|
| 1 | 2 | `rand × 2¹` s | **0 – 2 s** |
| 2 | 3 | `rand × 2²` s | **0 – 4 s** |
| 3 | 4 | `rand × 2³` s | **0 – 8 s** |
| 4 | 5 | `rand × 2⁴` s | **0 – 16 s** |
| 5 | 6 | capped at `MaxBackoff` | **20 s** (flat, no jitter) |
| 6 | 7 | capped at `MaxBackoff` | **20 s** (flat, no jitter) |
| 7 | 8 | capped at `MaxBackoff` | **20 s** (flat, no jitter) |

- Retries 1–4 are uniformly jittered in `[0, 2^attempt)` seconds.
- Retries 5–7 hit the 20s `MaxBackoff` cap and are returned flat (no jitter).
- **Worst-case** added latency before the final attempt ≈ `2+4+8+16+20+20+20 = 90 s`; **expected** ≈ `1+2+4+8+20+20+20 = 75 s`. In practice throttling usually clears within the first couple of retries.
- The retry token bucket (capacity 500, 5 tokens/retry) easily covers these 7 retries for a single operation while still capping retry storms across concurrent calls.

> Values reflect the SDK's default retry mode. If `AWS_NEW_RETRIES_2026=true` is set in the environment, the SDK switches to a throttle-aware backoff with a smaller base delay; the attempt ceiling of 8 still applies.

## Scope

Limited to the two operations requested (`DescribeRepositories`, `DescribeImages`). The same option could later be extended to other throttle-prone ECR calls (`DescribeImageScanFindings`, `ListTagsForResource`, `BatchGetRepositoryScanningConfiguration`, `GetRepositoryCatalogData`) or hoisted to the client constructor if we want account-wide coverage.

## Test plan

- [x] `gofmt` clean, `go build ./resources/` passes
- [ ] `make providers/build/aws && make providers/install/aws`, then `mql shell aws` → `aws.ecr.images { __id }` against an account with many repos/images

🤖 Generated with [Claude Code](https://claude.com/claude-code)
