### PR TITLE
🐛 fix: improve handling of config binding for provider flags to avoid key collisions

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -505,12 +505,25 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 				continue
 			}
 
-			// Flags with no explicit config entry or opted-out ("-") are
-			// read directly from cobra to avoid viper key collisions with
-			// top-level config fields (see PreRun comment above).
-			if flag.ConfigEntry == "-" || flag.ConfigEntry == "" {
+			if flag.ConfigEntry == "-" {
+				// Opted out of config entirely — read from cobra only.
 				if v := getFlagValueFromCobra(flag, cmd); v != nil {
 					flagVals[flag.Long] = v
+				}
+			} else if flag.ConfigEntry == "" {
+				// No explicit config mapping. Use cobra when the user
+				// passed the flag on the CLI; otherwise fall back to
+				// viper so that env vars (MONDOO_<FLAG>) still work.
+				// We do NOT bind the cobra flag to viper (see PreRun)
+				// to avoid overwriting top-level config keys.
+				if cmd.Flags().Changed(flag.Long) {
+					if v := getFlagValueFromCobra(flag, cmd); v != nil {
+						flagVals[flag.Long] = v
+					}
+				} else {
+					if v := getFlagValueFromConfig(flag); v != nil {
+						flagVals[flag.Long] = v
+					}
 				}
 			} else {
 				if v := getFlagValueFromConfig(flag); v != nil {

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -437,17 +437,18 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		// Flags are provided by the connector.
 		for i := range allFlags {
 			flag := allFlags[i]
-			if flag.ConfigEntry == "-" {
+			// Skip flags that opt out of config binding ("-") and flags
+			// that have no explicit config entry. Binding flags with no
+			// ConfigEntry would use the flag name as the viper key, which
+			// can collide with top-level config keys (e.g. a provider's
+			// --token flag overwrites the platform service-account token,
+			// causing 401 on upstream API calls).
+			if flag.ConfigEntry == "-" || flag.ConfigEntry == "" {
 				log.Debug().Msg("skipping config binding for " + flag.Long)
 				continue
 			}
 
-			flagName := flag.ConfigEntry
-			if flagName == "" {
-				flagName = flag.Long
-			}
-
-			_ = viper.BindPFlag(flagName, cmd.Flags().Lookup(flag.Long))
+			_ = viper.BindPFlag(flag.ConfigEntry, cmd.Flags().Lookup(flag.Long))
 		}
 	}
 
@@ -504,9 +505,10 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 				continue
 			}
 
-			// if the provider flag was configured to avoid using the config,
-			// we should instead fetch the flag value from `cobra` directly.
-			if flag.ConfigEntry == "-" {
+			// Flags with no explicit config entry or opted-out ("-") are
+			// read directly from cobra to avoid viper key collisions with
+			// top-level config fields (see PreRun comment above).
+			if flag.ConfigEntry == "-" || flag.ConfigEntry == "" {
 				if v := getFlagValueFromCobra(flag, cmd); v != nil {
 					flagVals[flag.Long] = v
 				}


### PR DESCRIPTION
## Summary

When a provider defines a connector flag whose name matches a top-level config key (most commonly `--token`), the viper binding in `setConnector` overwrites the config value. This causes `config.Read()` to return the provider's API token in place of the Mondoo platform service-account token, leading to 401 Unauthenticated on upstream API calls like `PolicyHub/GetBundle`.

Affected providers: fortios, github, gitlab, cloudflare, digitalocean, equinix, grafana, huggingface, okta, ollama, openai, proxmox, shodan, slack, claude — any provider declaring `--token` without `ConfigEntry: "-"`. Triggered when the flag is passed on the CLI and the scan is platform-connected (not incognito).

### Root cause

1. `setConnector` PreRun binds connector flags to viper. Flags with empty `ConfigEntry` fall back to `flag.Long` as the viper key.
2. Provider's `--token <api-token>` binds to viper key `"token"`, overriding the config file's SA token.
3. `config.Read()` → `viper.Unmarshal()` picks up the overridden value.
4. `GetServiceCredential()` returns creds with the wrong token.
5. `NewServiceAccountRangerPlugin` sees `Token != ""` and uses static-token auth instead of cert-based auth → Platform returns 401.

`scan local` is unaffected because no `--token` flag is passed, so viper keeps the config file value.

### Fix

Skip viper binding and read directly from cobra for flags with empty `ConfigEntry` (not just `"-"`). Only flags with an explicit `ConfigEntry` (like `"sudo.active"`) get bound to viper.

### History

| When | Commit | What happened |
|------|--------|---------------|
| Jun 2023 | `e17c6bc8d` | Viper binding introduced in PreRun. Flags were still read from cobra in Run, so the collision only affected `viper.Unmarshal()` callers — latent bug. |
| Nov 25, 2024 | `9cf319817` (PR #4863) | Flag reading switched from cobra to viper for env-var support. Guard added for `ConfigEntry == "-"` but `ConfigEntry == ""` (default) was missed, making the collision fully active. |

### Compatibility

| Area | Impact |
|------|--------|
| login, logout, status, vault, serve | None — these have their own `viper.BindPFlag` calls and don't go through `setConnector`. |
| CLI-passed provider flags | None — cobra returns the same value. |
| Env-var-backed provider flags | Minor regression: viper's automatic env binding no longer applies to flags with empty `ConfigEntry`. In practice, providers handle env vars internally with provider-specific names (e.g. `GITHUB_TOKEN`, `CLOUDFLARE_API_TOKEN`), not viper's generic `TOKEN`. |
| Config-file-backed provider flags | Intentionally removed — setting `token: xyz` in `mondoo.yml` to pass a provider API token was never correct since it collided with the SA token. |
| Flags with explicit `ConfigEntry` | None — still bound to viper under their explicit key. |

## Test plan

- [X] `cnspec scan fortios --hostname X --token Y --insecure` succeeds (requires FortiOS target + platform creds)
- [X] `cnspec scan local` continues to work with platform upload
- [X] `cnspec scan github --token $GITHUB_TOKEN` returns results (token reaches provider via cobra)
- [X] `cnspec login` / `cnspec status` unaffected
- [X] `mql shell github --token X` unaffected
- [X] Provider flags with explicit `ConfigEntry` (e.g. `--sudo`) still read from config

