### PR TITLE
🧹 Slim cloud-provider SDKs out of the MQL embedding path

### DIFF
--- a/apps/mql/mql.go
+++ b/apps/mql/mql.go
@@ -17,6 +17,17 @@ import (
 	// self-register with the vault registry. The in-memory backend is always
 	// available via the SDK.
 	_ "go.mondoo.com/mql/v13/vault/register"
+
+	// Link in the cloud token providers (AWS, GCP, Azure, GitHub) so they
+	// self-register for external token exchange (workload identity
+	// federation). They depend on cloud SDKs, so upstream does not import
+	// them directly; the binary opts in here.
+	_ "go.mondoo.com/mql/v13/providers-sdk/v1/upstream/tokenauth"
+
+	// Link in the AWS SSM Parameter Store config loader so "aws-ssm-ps://"
+	// config paths work. It depends on the AWS SDK, so cli/config does not
+	// import it directly; the binary opts in here.
+	_ "go.mondoo.com/mql/v13/cli/config/awsssm"
 )
 
 func main() {

--- a/cli/config/awsssm/awsssm.go
+++ b/cli/config/awsssm/awsssm.go
@@ -1,7 +1,12 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-package config
+// Package awsssm loads mql/cnspec configuration from AWS SSM Parameter Store
+// for config paths prefixed with "aws-ssm-ps://". It depends on the AWS SDK,
+// so it is a separate package that registers itself with cli/config from
+// init(); blank-import it from a binary to enable AWS SSM config loading. This
+// keeps the AWS SDK out of cli/config's import graph.
+package awsssm
 
 import (
 	"context"
@@ -11,16 +16,21 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	cliconfig "go.mondoo.com/mql/v13/cli/config"
 )
 
 const AWS_SSM_PARAMETERSTORE_PREFIX = "aws-ssm-ps://"
 
-// loads the configuration from aws ssm parameter store
+func init() {
+	cliconfig.RegisterRemoteConfigLoader(AWS_SSM_PARAMETERSTORE_PREFIX, loadAwsSSMParameterStore)
+}
+
+// loadAwsSSMParameterStore loads the configuration from aws ssm parameter store
 func loadAwsSSMParameterStore(key string) error {
 	viper.RemoteConfig = &awsSSMParamConfigFactory{}
 	viper.SupportedRemoteProviders = []string{"aws-ssm-ps"}
@@ -48,7 +58,7 @@ func (a *awsSSMParamConfigFactory) Get(rp viper.RemoteProvider) (io.Reader, erro
 	}
 	ctx := context.Background()
 
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/config/awsssm/awsssm_test.go
+++ b/cli/config/awsssm/awsssm_test.go
@@ -1,7 +1,7 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-package config
+package awsssm
 
 import (
 	"testing"

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,11 +95,10 @@ func InitViperConfig() {
 	} else {
 		Source = "default"
 	}
-	if strings.HasPrefix(Path, AWS_SSM_PARAMETERSTORE_PREFIX) {
-		err := loadAwsSSMParameterStore(Path)
+	if matched, err := loadRemoteConfig(Path); matched {
 		if err != nil {
 			LoadedConfig = false
-			log.Error().Err(err).Str("path", Path).Msg("could not load aws parameter store config")
+			log.Error().Err(err).Str("path", Path).Msg("could not load remote config")
 		} else {
 			LoadedConfig = true
 		}

--- a/cli/config/remote.go
+++ b/cli/config/remote.go
@@ -1,0 +1,37 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import "strings"
+
+// RemoteConfigLoader loads configuration from a remote source identified by a
+// URI scheme prefix (for example "aws-ssm-ps://"). It loads the resolved
+// configuration into the global viper instance, mirroring the local config
+// path.
+type RemoteConfigLoader func(path string) error
+
+// remoteConfigLoaders maps a scheme prefix to the loader that handles it.
+var remoteConfigLoaders = map[string]RemoteConfigLoader{}
+
+// RegisterRemoteConfigLoader associates a loader with a config path prefix.
+//
+// Remote backends depend on cloud SDKs (e.g. the AWS SDK for SSM Parameter
+// Store), so they live in subpackages that register themselves from init().
+// Binaries blank-import the backends they need; this keeps those SDKs out of
+// the import graph of this package — and therefore out of every package that
+// transitively imports cli/config, including the query evaluation path.
+func RegisterRemoteConfigLoader(prefix string, loader RemoteConfigLoader) {
+	remoteConfigLoaders[prefix] = loader
+}
+
+// loadRemoteConfig dispatches to the registered loader whose prefix matches
+// path. matched reports whether any loader handled it.
+func loadRemoteConfig(path string) (matched bool, err error) {
+	for prefix, loader := range remoteConfigLoaders {
+		if strings.HasPrefix(path, prefix) {
+			return true, loader(path)
+		}
+	}
+	return false, nil
+}

--- a/providers-sdk/v1/upstream/sts.go
+++ b/providers-sdk/v1/upstream/sts.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"time"
 
-	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/tokenauth"
 	"go.mondoo.com/mql/v13/providers/os/connection/ssh/signers"
 	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/crypto/ssh"
@@ -66,7 +65,7 @@ func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string, to
 
 	if jwtToken == "" {
 		// Try to resolve a token provider from the issuer URI
-		provider, err := tokenauth.Resolve(issuerURI)
+		provider, err := resolveTokenProvider(issuerURI)
 		if err != nil {
 			return nil, err
 		}

--- a/providers-sdk/v1/upstream/tokenauth/provider.go
+++ b/providers-sdk/v1/upstream/tokenauth/provider.go
@@ -4,15 +4,18 @@
 package tokenauth
 
 import (
-	"context"
 	"fmt"
 	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 )
 
 // TokenProvider fetches an identity token from a cloud provider.
-type TokenProvider interface {
-	GetToken(ctx context.Context, audience string) (string, error)
-}
+//
+// It is an alias for upstream.TokenProvider: this package implements the
+// cloud-specific providers (which pull in cloud SDKs) and registers them with
+// upstream from init(), so upstream itself stays free of those dependencies.
+type TokenProvider = upstream.TokenProvider
 
 // providers maps issuer URI substrings to their TokenProvider implementation.
 var providers = map[string]TokenProvider{
@@ -21,6 +24,13 @@ var providers = map[string]TokenProvider{
 	"token.actions.githubusercontent.com": &GitHubTokenProvider{},
 	"login.microsoftonline.com":           &AzureTokenProvider{},
 	"sts.windows.net":                     &AzureTokenProvider{},
+}
+
+// init registers Resolve with upstream so external token exchange can find the
+// cloud token providers without upstream importing this package (and its cloud
+// SDKs). Binaries enable token exchange by blank-importing this package.
+func init() {
+	upstream.RegisterTokenResolver(Resolve)
 }
 
 // Resolve returns the TokenProvider matching the given issuer URI.

--- a/providers-sdk/v1/upstream/tokenresolver.go
+++ b/providers-sdk/v1/upstream/tokenresolver.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upstream
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+)
+
+// TokenProvider fetches an identity token from a cloud provider, used by
+// external token exchange (workload identity federation).
+type TokenProvider interface {
+	GetToken(ctx context.Context, audience string) (string, error)
+}
+
+// TokenResolver returns the TokenProvider matching a given issuer URI.
+type TokenResolver func(issuerURI string) (TokenProvider, error)
+
+var (
+	tokenResolverMu sync.RWMutex
+	tokenResolver   TokenResolver
+)
+
+// RegisterTokenResolver installs the resolver used by external token exchange.
+//
+// The cloud token providers depend on cloud SDKs (e.g. the AWS SigV4 signer),
+// so they live in a separate implementation package that registers itself from
+// init(). Blank-import go.mondoo.com/mql/v13/providers-sdk/v1/upstream/tokenauth
+// to enable external token exchange. Keeping the registration in that package
+// keeps the cloud SDKs out of the import graph of this package — and therefore
+// out of inventory, which embeds upstream's protobuf types and is imported by
+// any consumer of the llx.Runtime interface.
+func RegisterTokenResolver(r TokenResolver) {
+	tokenResolverMu.Lock()
+	defer tokenResolverMu.Unlock()
+	tokenResolver = r
+}
+
+// resolveTokenProvider returns the registered TokenProvider for the issuer, or
+// an error explaining how to enable external token exchange.
+func resolveTokenProvider(issuerURI string) (TokenProvider, error) {
+	tokenResolverMu.RLock()
+	r := tokenResolver
+	tokenResolverMu.RUnlock()
+	if r == nil {
+		return nil, errors.New("external token exchange is unavailable: blank-import go.mondoo.com/mql/v13/providers-sdk/v1/upstream/tokenauth to enable it")
+	}
+	return r(issuerURI)
+}


### PR DESCRIPTION
## Summary

Embedding the MQL evaluator dragged ~50+ AWS/cloud-SDK packages into a consumer's build graph even when no vault, asset, or cloud feature is used. The vault half of this was fixed in v13.21.1; this PR removes the two remaining edges, both via the same registry pattern.

After this change, a consumer importing only `llx + mqlc + exec + resources + inventory` builds with **zero cloud-provider SDK packages**.

## The two edges

**1. `inventory → upstream → tokenauth → AWS`** (the reported edge)

`upstream/sts.go` imported `upstream/tokenauth` for external token exchange, and `tokenauth` pulls the AWS SigV4 signer. Since `inventory` embeds `upstream`'s protobuf types, and `llx.Runtime` requires `AssetUpdated(*inventory.Asset)`, every embedder inherited the AWS SDK. Now the `TokenProvider` interface and a resolver hook live in `upstream`; `tokenauth` self-registers from `init()`.

**2. `exec → upstream/health → cli/config → AWS`** (a second, independent edge)

`cli/config` directly imported the AWS SDK for its `aws-ssm-ps://` config loader, and the eval path reaches `cli/config` through `health`'s panic reporting. Moved the AWS SSM backend into `cli/config/awsssm`, dispatched via a new remote-config-loader registry; it self-registers from `init()`.

The `mql` binary blank-imports both implementations in `main` (alongside the existing `vault/register`), so the CLI is unchanged. Other binaries opt in as needed; if external token exchange or `aws-ssm-ps://` is used without the import, a clear error explains how to enable it.

## Before / after (cloud-SDK package count via `go list -deps`)

| package | before | after |
|---|---|---|
| `providers-sdk/v1/inventory` | 54 | **0** |
| `exec` | 57 | **0** |
| `cli/config` | 57 | **0** |
| `llx`, `mqlc`, `resources` | 0 | 0 |
| `apps/mql` (the binary) | 71 | 71 |

## Notes for reviewers

- Pattern mirrors the existing `vault` registry (`providers-sdk/v1/vault/registry.go`) and `vault/register`.
- Behavior change: binaries that perform external token exchange or load `aws-ssm-ps://` config must blank-import the relevant package. The `mql` binary does; cnquery/cnspec mains should add the same imports. The runtime error message names the package to import.
- No public type removed: `tokenauth.TokenProvider` is retained as an alias of `upstream.TokenProvider`.

## Test plan

- `go build ./...` — clean.
- `go test ./cli/config/awsssm/ ./providers-sdk/v1/upstream/...` — pass (SSM path parsing, token resolver, health).
- `go mod tidy` — no change.
- `go list -deps` counts above verified.
- Pre-existing, environment-specific `cli/config.Test_autodetectConfig/test_systemConfig_returned` fails identically on `main` (depends on absence of a local `~/.config/mondoo/mondoo.yml`); untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)