### PR TITLE
🐛 aws: guard nil SDK pointer derefs and harden crash-safety

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -370,6 +370,9 @@ func (h *AwsConnection) Regions() ([]string, error) {
 		regions = enabledRegions
 	} else {
 		for _, region := range res.Regions {
+			if region.RegionName == nil {
+				continue
+			}
 			regions = append(regions, *region.RegionName)
 		}
 	}

--- a/providers/aws/resources/aws_appsync.go
+++ b/providers/aws/resources/aws_appsync.go
@@ -46,6 +46,9 @@ func (a *mqlAwsAppsync) apis() ([]any, error) {
 		return nil, pool.GetErrors()
 	}
 	for i := range pool.Jobs {
+		if pool.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, pool.Jobs[i].Result.([]any)...)
 	}
 	return res, nil

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -50,6 +50,9 @@ func (a *mqlAwsCloudfront) distributions() ([]any, error) {
 			return nil, errors.Wrap(err, "could not gather aws cloudfront distributions")
 		}
 
+		if distributions.DistributionList == nil {
+			continue
+		}
 		for _, distribution := range distributions.DistributionList.Items {
 			origins := []any{}
 			if or := distribution.Origins; or != nil {

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -319,7 +319,7 @@ func (a *mqlAwsConfigRule) complianceStatus() (string, error) {
 		}
 		return "", err
 	}
-	if len(resp.ComplianceByConfigRules) > 0 {
+	if len(resp.ComplianceByConfigRules) > 0 && resp.ComplianceByConfigRules[0].Compliance != nil {
 		return string(resp.ComplianceByConfigRules[0].Compliance.ComplianceType), nil
 	}
 	return "INSUFFICIENT_DATA", nil

--- a/providers/aws/resources/aws_drs.go
+++ b/providers/aws/resources/aws_drs.go
@@ -94,6 +94,9 @@ func (a *mqlAwsDrs) sourceServers() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 
@@ -481,6 +484,9 @@ func (a *mqlAwsDrs) recoveryInstances() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 
@@ -698,6 +704,9 @@ func (a *mqlAwsDrs) jobs() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 
@@ -825,6 +834,9 @@ func (a *mqlAwsDrs) replicationConfigurationTemplates() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -70,6 +70,10 @@ func (a *mqlAwsDynamodbExport) fetchExport() (*ddtypes.ExportDescription, error)
 	svc := conn.Dynamodb(a.region)
 	desc, err := svc.DescribeExport(ctx, &dynamodb.DescribeExportInput{ExportArn: aws.String(a.arn)})
 	if err != nil {
+		if Is400AccessDeniedError(err) {
+			a.fetched = true
+			return nil, nil
+		}
 		return nil, err
 	}
 	a.exportCache = desc.ExportDescription
@@ -134,7 +138,7 @@ func (a *mqlAwsDynamodbExport) s3Prefix() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if exp.S3Prefix != nil {
+	if exp != nil && exp.S3Prefix != nil {
 		return *exp.S3Prefix, nil
 	}
 	return "", nil
@@ -145,7 +149,7 @@ func (a *mqlAwsDynamodbExport) itemCount() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if exp.ItemCount != nil {
+	if exp != nil && exp.ItemCount != nil {
 		return *exp.ItemCount, nil
 	}
 	return 0, nil
@@ -156,6 +160,9 @@ func (a *mqlAwsDynamodbExport) format() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if exp == nil {
+		return "", nil
+	}
 	return string(exp.ExportFormat), nil
 }
 
@@ -163,6 +170,9 @@ func (a *mqlAwsDynamodbExport) startTime() (*time.Time, error) {
 	exp, err := a.fetchExport()
 	if err != nil {
 		return nil, err
+	}
+	if exp == nil {
+		return nil, nil
 	}
 	return exp.StartTime, nil
 }
@@ -172,6 +182,9 @@ func (a *mqlAwsDynamodbExport) endTime() (*time.Time, error) {
 	if err != nil {
 		return nil, err
 	}
+	if exp == nil {
+		return nil, nil
+	}
 	return exp.EndTime, nil
 }
 
@@ -179,6 +192,9 @@ func (a *mqlAwsDynamodbExport) s3SseAlgorithm() (string, error) {
 	exp, err := a.fetchExport()
 	if err != nil {
 		return "", err
+	}
+	if exp == nil {
+		return "", nil
 	}
 	return string(exp.S3SseAlgorithm), nil
 }
@@ -188,7 +204,7 @@ func (a *mqlAwsDynamodbExport) s3Bucket() (*mqlAwsS3Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	if exp.S3Bucket == nil || *exp.S3Bucket == "" {
+	if exp == nil || exp.S3Bucket == nil || *exp.S3Bucket == "" {
 		a.S3Bucket.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
@@ -207,7 +223,7 @@ func (a *mqlAwsDynamodbExport) kmsKey() (*mqlAwsKmsKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	if exp.S3SseKmsKeyId == nil {
+	if exp == nil || exp.S3SseKmsKeyId == nil {
 		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -639,14 +639,18 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 func getContainerIP(eniPublicIPs map[string]string, attachments []ecstypes.Attachment, c ecstypes.Container) string {
 	containerAttachmentIds := []string{}
 	for _, ca := range c.NetworkInterfaces {
-		containerAttachmentIds = append(containerAttachmentIds, *ca.AttachmentId)
+		if ca.AttachmentId != nil {
+			containerAttachmentIds = append(containerAttachmentIds, *ca.AttachmentId)
+		}
 	}
 	for _, a := range attachments {
-		if stringx.Contains(containerAttachmentIds, *a.Id) {
+		if a.Id != nil && stringx.Contains(containerAttachmentIds, *a.Id) {
 			for _, detail := range a.Details {
-				if *detail.Name == "networkInterfaceId" {
-					if ip, ok := eniPublicIPs[*detail.Value]; ok {
-						return ip
+				if detail.Name != nil && *detail.Name == "networkInterfaceId" {
+					if detail.Value != nil {
+						if ip, ok := eniPublicIPs[*detail.Value]; ok {
+							return ip
+						}
 					}
 				}
 			}

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -164,7 +164,8 @@ func (a *mqlAwsEksCluster) fetchDetail() error {
 	}
 	if descResp.Cluster == nil {
 		a.fetched = true
-		return nil
+		a.fetchErr = fmt.Errorf("eks DescribeCluster returned no cluster for %q in %q", a.Name.Data, a.Region.Data)
+		return a.fetchErr
 	}
 	if err := a.populateFromDescribe(descResp.Cluster); err != nil {
 		a.fetched = true

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -162,6 +162,10 @@ func (a *mqlAwsEksCluster) fetchDetail() error {
 		a.fetchErr = err
 		return err
 	}
+	if descResp.Cluster == nil {
+		a.fetched = true
+		return nil
+	}
 	if err := a.populateFromDescribe(descResp.Cluster); err != nil {
 		a.fetched = true
 		a.fetchErr = err

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -193,6 +193,10 @@ func (a *mqlAwsEmrCluster) fetchClusterDetails() error {
 	if err != nil {
 		return err
 	}
+	if resp.Cluster == nil {
+		a.clusterDetailsFetched = true
+		return nil
+	}
 
 	if resp.Cluster.SecurityConfiguration != nil {
 		a.cacheSecurityConfig = *resp.Cluster.SecurityConfiguration

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -303,7 +303,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 				}
 				for _, dbInstance := range dbInstances.DBInstances {
 					// we cannot filter it in the api call since the api does not support it negative filters
-					if slices.Contains(nonRdsEngines, *dbInstance.Engine) {
+					if dbInstance.Engine != nil && slices.Contains(nonRdsEngines, *dbInstance.Engine) {
 						log.Debug().Str("engine", *dbInstance.Engine).Msg("skipping non-RDS engine")
 						continue
 					}
@@ -999,7 +999,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 
 				for _, cluster := range dbClusters.DBClusters {
 					// we cannot filter it in the api call since the api does not support it negative filters
-					if slices.Contains(nonRdsEngines, *cluster.Engine) {
+					if cluster.Engine != nil && slices.Contains(nonRdsEngines, *cluster.Engine) {
 						log.Debug().Str("engine", *cluster.Engine).Msg("skipping non-RDS engine")
 						continue
 					}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -252,7 +252,15 @@ func (a *mqlAwsS3Bucket) accessPoints() ([]any, error) {
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	bucketName := a.Name.Data
-	region := a.GetLocation().Data
+	// surface a location lookup failure instead of silently defaulting to
+	// us-east-1, which would list access points in the wrong region and miss
+	// them for buckets that actually live elsewhere. An empty (but error-free)
+	// location is legitimately us-east-1.
+	location := a.GetLocation()
+	if location.Error != nil {
+		return nil, location.Error
+	}
+	region := location.Data
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -794,6 +794,9 @@ func (a *mqlAwsS3Bucket) public() (bool, error) {
 
 	for i := range acl.Grants {
 		grant := acl.Grants[i]
+		if grant.Grantee == nil {
+			continue
+		}
 		if grant.Grantee.Type == s3types.TypeGroup && (convert.ToValue(grant.Grantee.URI) == s3AuthenticatedUsersGroup || convert.ToValue(grant.Grantee.URI) == s3AllUsersGroup) {
 			return true, nil
 		}

--- a/providers/aws/resources/aws_signer.go
+++ b/providers/aws/resources/aws_signer.go
@@ -30,6 +30,9 @@ func (a *mqlAwsSigner) signingProfiles() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -477,9 +478,8 @@ func createActionResource(runtime *plugin.Runtime, ruleAction *waftypes.RuleActi
 
 		if ruleAction.Block != nil {
 			action = "block"
-			if ruleAction.Block.CustomResponse != nil {
-				responseCodeNumber := *ruleAction.Block.CustomResponse.ResponseCode
-				responseCode = string(responseCodeNumber)
+			if ruleAction.Block.CustomResponse != nil && ruleAction.Block.CustomResponse.ResponseCode != nil {
+				responseCode = strconv.Itoa(int(*ruleAction.Block.CustomResponse.ResponseCode))
 			} else {
 				responseCode = "403" // Default for Block
 			}

--- a/providers/aws/resources/aws_workdocs.go
+++ b/providers/aws/resources/aws_workdocs.go
@@ -61,6 +61,9 @@ func (a *mqlAwsWorkdocs) users() ([]any, error) {
 		return nil, poolOfJobs.GetErrors()
 	}
 	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
 		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
 	}
 


### PR DESCRIPTION
## What

Adds nil guards around AWS SDK pointer dereferences (and a couple of jobpool result type-assertions) that could panic, plus an S3 location error-handling fix. The executor runs resource blocks in goroutines, so an unrecovered panic kills the whole scan — a single malformed API record or a transient resource state was enough to crash a healthy collection.

Found during a deep audit of the AWS provider.

## Fixes

| Area | Bug | Severity |
|---|---|---|
| `aws_waf.go` | Block custom-response code rendered via `string(int32)` (rune cast → garbage like `"Ɠ"`) **and** unchecked `*int32` deref. Now `strconv.Itoa` behind a nil guard. | Critical |
| `aws_cloudfront.go` | `distributions.DistributionList.Items` iterated without nil-checking the pointer list. | Critical |
| `aws_emr.go` / `aws_eks.go` | `resp.Cluster` / `descResp.Cluster` dereferenced without a nil check after DescribeCluster. | Critical |
| `aws_rds.go` | `*dbInstance.Engine` / `*cluster.Engine` (omitted by the API in transient states) dereferenced in the engine filter. | Critical |
| `connection.go` | `*region.RegionName` from DescribeRegions dereferenced unconditionally. | High |
| `aws_ecs.go` | `*ca.AttachmentId` / `*detail.Name` / `*detail.Value` dereferenced in `getContainerIP`. | Medium |
| `aws_config.go` | `Compliance.ComplianceType` read without nil-checking `Compliance` (nil for `INSUFFICIENT_DATA`). | Medium |
| `aws_s3.go` | `grant.Grantee` dereferenced in the bucket-public ACL scan; `accessPoints()` silently fell back to us-east-1 when the bucket-location lookup *errored* (missing access points for other-region buckets). | Medium |
| `aws_dynamodb.go` | `DescribeExport` didn't tolerate access-denied, and a nil `ExportDescription` was dereferenced in every export accessor. | Medium |
| `aws_appsync.go` / `aws_signer.go` / `aws_workdocs.go` / `aws_drs.go` | jobpool `Result.([]any)` asserted without a nil guard (crash-safety hardening). | Medium |

## Testing

- `go build ./...` passes in `providers/aws`.
- No `.lr` schema changes, so no codegen.