### PR TITLE
🐛 aws: fix __id collisions for EIPs and network ACL associations

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -97,7 +97,11 @@ func initAwsEc2Eip(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 }
 
 func (a *mqlAwsEc2Eip) id() (string, error) {
-	return a.NetworkInterfaceId.Data, nil
+	// publicIp is always present and globally unique for an Elastic IP, whereas
+	// networkInterfaceId is empty for unattached EIPs (which would collide them
+	// all to a single cache entry). region+publicIp also matches the key used
+	// when EIPs are resolved by cross-references (nat gateway, network interface).
+	return "aws.ec2.eip/" + a.Region.Data + "/" + a.PublicIp.Data, nil
 }
 
 type mqlAwsEc2EipInternal struct {
@@ -274,6 +278,7 @@ func (a *mqlAwsEc2) getNetworkACLs(conn *connection.AwsConnection) []*jobpool.Jo
 					for _, association := range acl.Associations {
 						mqlNetworkAclAssoc, err := CreateResource(a.MqlRuntime, ResourceAwsEc2NetworkaclAssociation,
 							map[string]*llx.RawData{
+								"__id":          llx.StringDataPtr(association.NetworkAclAssociationId),
 								"associationId": llx.StringDataPtr(association.NetworkAclAssociationId),
 								"networkAclId":  llx.StringDataPtr(association.NetworkAclId),
 								"subnetId":      llx.StringDataPtr(association.SubnetId),

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -278,7 +278,7 @@ func (a *mqlAwsEc2) getNetworkACLs(conn *connection.AwsConnection) []*jobpool.Jo
 					for _, association := range acl.Associations {
 						mqlNetworkAclAssoc, err := CreateResource(a.MqlRuntime, ResourceAwsEc2NetworkaclAssociation,
 							map[string]*llx.RawData{
-								"__id":          llx.StringDataPtr(association.NetworkAclAssociationId),
+								"__id":          llx.StringData("aws.ec2.networkacl.association/" + convert.ToValue(association.NetworkAclAssociationId)),
 								"associationId": llx.StringDataPtr(association.NetworkAclAssociationId),
 								"networkAclId":  llx.StringDataPtr(association.NetworkAclId),
 								"subnetId":      llx.StringDataPtr(association.SubnetId),


### PR DESCRIPTION
## What

Two EC2 resources used non-unique cache keys, so distinct objects collapsed onto a single cached instance and returned duplicated/incorrect data. Resource cache keys are `resourceName + "\x00" + __id`, so an empty/duplicate `__id` makes the runtime hand back the first-created instance for every subsequent one.

Found during a deep audit of the AWS provider.

## Fixes

- **`aws.ec2.eip` (High)** — `id()` returned `networkInterfaceId`, which is empty for *unattached* Elastic IPs. Every unattached EIP shared one empty `__id` and collapsed to a single object, under-reporting dangling public IPs (a common security finding). Now keyed on `region + publicIp`, which is always present, unique, and already matches the key used when EIPs are resolved via cross-references (nat gateway address, network interface `elasticIp`).
- **`aws.ec2.networkacl.association` (Critical)** — `CreateResource` was called with no `__id` and the resource has no `id()` method, so every association in the account shared the key `"aws.ec2.networkacl.association\x00"` and the runtime returned the *first* association for all of them — wrong subnet/associationId everywhere. Now passes the association id as `__id`.

## Testing

- `go build ./...` passes in `providers/aws`.
- No `.lr` schema changes, so no codegen.