### PR TITLE
🐛 aws: fix wrong resource name and swallowed errors

### DIFF
--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -147,7 +147,7 @@ func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	rawResources := gw.GetRestApis()
 	if rawResources.Error != nil {
-		return nil, nil, err
+		return nil, nil, rawResources.Error
 	}
 
 	arnVal := args["arn"].Value.(string)

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -108,7 +108,7 @@ func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return args, nil, nil
 	}
 
-	if args["name"] == nil && args["region"] == nil {
+	if args["name"] == nil || args["region"] == nil {
 		return nil, nil, errors.New("name and region required to fetch codebuild project")
 	}
 

--- a/providers/aws/resources/aws_eventbridge_scheduler.go
+++ b/providers/aws/resources/aws_eventbridge_scheduler.go
@@ -525,7 +525,7 @@ func (a *mqlAwsEventbridgeScheduleTargetEcsParameters) taskDefinition() (*mqlAws
 		a.TaskDefinition.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	res, err := NewResource(a.MqlRuntime, "aws.ecs.taskdefinition", map[string]*llx.RawData{
+	res, err := NewResource(a.MqlRuntime, "aws.ecs.taskDefinition", map[string]*llx.RawData{
 		"arn": llx.StringData(a.cacheTaskDefArn),
 	})
 	if err != nil {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -124,6 +124,11 @@ func (a *mqlAwsIam) credentialReport() ([]any, error) {
 			if maxRetries == 5 {
 				return nil, errors.Wrap(err, "timed out trying to gather aws iam credential report")
 			}
+			// re-extract the API error so the loop condition reflects the latest
+			// response; without this it keeps testing the original error code.
+			if !errors.As(err, &ae) {
+				return nil, errors.Wrap(err, "could not gather aws iam credential report")
+			}
 			time.Sleep(200 * time.Millisecond)
 			maxRetries++
 		}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -188,6 +188,9 @@ func (a *mqlAwsSqsQueue) createdAt() (*time.Time, error) {
 		return nil, err
 	}
 	i, err := strconv.ParseInt(atts["CreatedTimestamp"], 10, 64)
+	if err != nil {
+		return nil, err
+	}
 	t := time.Unix(i, 0)
 	return &t, nil
 }
@@ -210,6 +213,9 @@ func (a *mqlAwsSqsQueue) lastModified() (*time.Time, error) {
 		return nil, err
 	}
 	i, err := strconv.ParseInt(atts["LastModifiedTimestamp"], 10, 64)
+	if err != nil {
+		return nil, err
+	}
 	t := time.Unix(i, 0)
 	return &t, nil
 }


### PR DESCRIPTION
## What

Fixes a wrong resource-name reference plus several swallowed/mishandled errors found during a deep audit of the AWS provider.

## Fixes

- **`aws_eventbridge_scheduler.go` (Critical)** — `taskDefinition()` resolved `"aws.ecs.taskdefinition"` (lowercase `d`), but the registered resource is `"aws.ecs.taskDefinition"` (every other call site uses the capital-D form). `NewResource` couldn't resolve it, so querying a scheduler ECS target's `taskDefinition` errored outright.
- **`aws_apigateway.go` (Critical)** — `initAwsApigatewayRestapi` checked `rawResources.Error` but returned the `err` from the *preceding successful* `CreateResource` (which is `nil`), swallowing the real `GetRestApis` failure and reporting "restapi does not exist" instead. Returns `rawResources.Error`.
- **`aws_codebuild.go` (Critical)** — `initAwsCodebuildProject` guarded with `name == nil && region == nil`, then unconditionally dereferenced both args, so fetching a project by name *or* region alone (`aws.codebuild.project(name: "x")`) panicked. Uses `||`.
- **`aws_iam.go` (High)** — the credential-report retry loop extracted the API error once before the loop and never refreshed it, so the loop condition kept testing the original error code. Re-extracts with `errors.As` each iteration and surfaces a non-API error instead of spinning to the retry cap.
- **`aws_sqs.go` (Medium)** — `createdAt()` / `lastModified()` ignored the `strconv.ParseInt` error and silently returned the Unix epoch (1970) on a missing/blank timestamp. Returns the error.

## Testing

- `go build ./...` passes in `providers/aws`.
- No `.lr` schema changes, so no codegen.