### PR TITLE
🐛 llx: extend dict.in / dict.notIn to numeric and bool values

### DIFF
--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -1538,24 +1538,85 @@ func dictContainsArrayRegex(e *blockExecutor, bind *RawData, chunk *Chunk, ref u
 }
 
 func dictIn(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolFalse, 0, nil
+	}
 	switch bind.Value.(type) {
-	case string:
-		return stringInArray(e, bind, chunk, ref)
 	case []any:
 		return anyArrayInStringArray(e, bind, chunk, ref)
+	case string, int32, int64, float64, bool:
+		return dictScalarInArray(e, bind, chunk, ref)
 	default:
 		return nil, 0, errors.New("dict value does not support field `in`")
 	}
 }
 
 func dictNotIn(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolTrue, 0, nil
+	}
 	switch bind.Value.(type) {
-	case string:
-		return stringNotInArray(e, bind, chunk, ref)
 	case []any:
 		return anyArrayNotInStringArray(e, bind, chunk, ref)
+	case string, int32, int64, float64, bool:
+		return dictScalarNotInArray(e, bind, chunk, ref)
 	default:
 		return nil, 0, errors.New("dict value does not support field `in`")
+	}
+}
+
+// loose cross-type equality: same semantics as the dict ==/!= operators
+// (e.g. a DWORD-backed int64 matches both 2 and "2").
+func dictScalarInArray(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolFalse, 0, nil
+	}
+	argRef := chunk.Function.Args[0]
+	arg, rref, err := e.resolveValue(argRef, ref)
+	if err != nil || rref > 0 {
+		return nil, rref, err
+	}
+	if arg.Value == nil {
+		return BoolFalse, 0, nil
+	}
+	arr := arg.Value.([]any)
+	for i := range arr {
+		if dictScalarEqual(bind.Value, arr[i]) {
+			return BoolTrue, 0, nil
+		}
+	}
+	return BoolFalse, 0, nil
+}
+
+func dictScalarNotInArray(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	res, rref, err := dictScalarInArray(e, bind, chunk, ref)
+	if res == BoolTrue {
+		return BoolFalse, rref, err
+	}
+	if res == BoolFalse {
+		return BoolTrue, rref, err
+	}
+	return res, rref, err
+}
+
+func dictScalarEqual(bindVal, arrVal any) bool {
+	if bindVal == nil || arrVal == nil {
+		return bindVal == arrVal
+	}
+	switch arrVal.(type) {
+	case string:
+		return opDictCmpString(bindVal, arrVal)
+	case int32, int64:
+		if v, ok := arrVal.(int32); ok {
+			arrVal = int64(v)
+		}
+		return opDictCmpInt(bindVal, arrVal)
+	case float64:
+		return opDictCmpFloat(bindVal, arrVal)
+	case bool:
+		return opDictCmpBool(bindVal, arrVal)
+	default:
+		return false
 	}
 }
 

--- a/llx/builtin_map_test.go
+++ b/llx/builtin_map_test.go
@@ -48,6 +48,77 @@ func TestDictGetIndex_NilValue(t *testing.T) {
 	}
 }
 
+func newArrayArgChunk(elems []*Primitive, elemType types.Type) *Chunk {
+	return &Chunk{
+		Function: &Function{
+			Args: []*Primitive{ArrayPrimitive(elems, elemType)},
+		},
+	}
+}
+
+func runDictInHandler(t *testing.T, bind *RawData, chunk *Chunk, operator string) (*RawData, uint64, error) {
+	t.Helper()
+
+	handler, err := BuiltinFunctionV2(bind.Type, operator)
+	require.NoError(t, err)
+
+	return handler.f(newTestBlockExecutor(), bind, chunk, 0)
+}
+
+func TestDictIn_ScalarValues(t *testing.T) {
+	intArr := newArrayArgChunk([]*Primitive{IntPrimitive(1), IntPrimitive(2)}, types.Int)
+	strArr := newArrayArgChunk([]*Primitive{StringPrimitive("1"), StringPrimitive("2")}, types.String)
+
+	cases := []struct {
+		name  string
+		bind  any
+		chunk *Chunk
+		op    string
+		want  *RawData
+	}{
+		// CIS-style: DWORD (int64) against numeric array — used to error
+		{"int64 bind in int array match", int64(2), intArr, "in", BoolTrue},
+		{"int64 bind in int array miss", int64(3), intArr, "in", BoolFalse},
+		{"int64 bind notIn int array match", int64(2), intArr, "notIn", BoolFalse},
+		{"int64 bind notIn int array miss", int64(3), intArr, "notIn", BoolTrue},
+
+		// Cross-type: DWORD against string array (matches the literal CIS check shape)
+		{"int64 bind in string array match", int64(2), strArr, "in", BoolTrue},
+		{"int64 bind in string array miss", int64(3), strArr, "in", BoolFalse},
+
+		// Existing string-bind path still works through the unified helper
+		{"string bind in string array match", "1", strArr, "in", BoolTrue},
+		{"string bind in string array miss", "9", strArr, "in", BoolFalse},
+
+		// Bool bind
+		{"bool bind in bool array",
+			true,
+			newArrayArgChunk([]*Primitive{BoolPrimitive(false), BoolPrimitive(true)}, types.Bool),
+			"in", BoolTrue},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bind := &RawData{Type: types.Dict, Value: tc.bind}
+			res, ref, err := runDictInHandler(t, bind, tc.chunk, tc.op)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(0), ref)
+			assert.Equal(t, tc.want, res)
+		})
+	}
+}
+
+func TestDictIn_NilBindAndArg(t *testing.T) {
+	intArr := newArrayArgChunk([]*Primitive{IntPrimitive(1)}, types.Int)
+
+	t.Run("nil dict bind", func(t *testing.T) {
+		bind := &RawData{Type: types.Dict, Value: nil}
+		res, _, err := runDictInHandler(t, bind, intArr, "in")
+		require.NoError(t, err)
+		assert.Equal(t, BoolFalse, res)
+	})
+}
+
 func TestMapGetIndex_NilValue(t *testing.T) {
 	for _, operator := range []string{"[]", "[]?"} {
 		t.Run(operator+" returns typed null when parent map is nil", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/mondoo-community/customer-issues/issues/212

## Summary

- `dictIn` / `dictNotIn` previously only dispatched `string` and `[]any` bind values, so calling `.in([...])` on a dict that wraps an `int64` errored with `dict value does not support field 'in'`.
- This silently broke every CIS Windows policy of the shape `registrykey.property(...).data.in(["1","2"])` — `REG_DWORD` values parse to `int64`, so the checks never actually passed; they errored out and were rendered as "not applicable" instead of "fail".
- Add `int32` / `int64` / `float64` / `bool` (and explicit `nil`) dispatch via a new `dictScalarInArray` helper that reuses the existing `opDictCmp{String,Int,Float,Bool}` operators, so cross-type loose equality matches what `dict ==/!=` already does:
  - `dict<int64(2)>.in([2])` → true
  - `dict<int64(2)>.in(["2"])` → true (the literal CIS shape)
  - `dict<"2">.in([2])` → true

The existing `[]any` and `string` cases keep behaving the same for already-working inputs; the only delta is that previously-erroring calls now return a real boolean, consistent with the dict equality semantics already in the codebase.

## Test plan

- [x] `go test ./llx/...` — added `TestDictIn_ScalarValues` and `TestDictIn_NilBindAndArg`; full llx + mqlc suites pass.
- [ ] Re-run a Windows asset against `cis-microsoft-windows-server-2025--2.3.11.11` and confirm the check now evaluates to pass/fail instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)