### PR TITLE
🧹 ci: pin spell-check (typos) actions to commit SHAs

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -7,5 +7,5 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: crate-ci/typos@v1.46.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0


### PR DESCRIPTION
The typos spell-check workflow (#8461) merged with tag refs (`actions/checkout@v5`, `crate-ci/typos@v1.46.0`). This pins them to commit SHAs via `pinact`, matching the repo's action-pinning policy.

```yaml
- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
- uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
```

Ran `pinact run` on the workflow; a repo-wide grep confirms no other unpinned actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)