### PR TITLE
Fix systemd service reporting enabled/masked/static when not installed

### DIFF
--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -112,6 +112,14 @@ func ParseSystemdListUnits(input io.Reader) (map[string]*Service, error) {
 }
 
 func applySystemdUnitFileState(service *Service, unitFileState string) {
+	// A unit that is not installed (LoadState=not-found or empty) can still
+	// report a leftover UnitFileState such as "enabled" — for example a dangling
+	// enablement symlink left behind by a removed package. Reporting it as
+	// enabled/masked/static would contradict installed=false, so skip applying
+	// the unit-file state for units that are not installed.
+	if !service.Installed {
+		return
+	}
 	service.Enabled = unitFileState == "enabled" || unitFileState == "enabled-runtime"
 	service.Masked = strings.HasPrefix(unitFileState, "masked")
 	service.Static = unitFileState == "static"

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -233,6 +233,34 @@ func TestParseServiceSystemDShow(t *testing.T) {
 	}, services["systemd-journald"])
 }
 
+func TestParseServiceSystemDShowNotFoundIsNotEnabled(t *testing.T) {
+	// A unit whose definition no longer exists (LoadState=not-found) can still
+	// report a leftover UnitFileState such as "enabled" (e.g. a dangling
+	// enablement symlink left behind by a removed package). It must not be
+	// reported as enabled/masked/static, which would contradict installed=false.
+	services, err := ParseServiceSystemDShow(strings.NewReader(strings.Join([]string{
+		"Id=systemd-journal-upload.service",
+		"Description=Journal Remote Upload Service",
+		"LoadState=not-found",
+		"ActiveState=inactive",
+		"UnitFileState=enabled",
+		"",
+	}, "\n")))
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+
+	assert.Equal(t, &Service{
+		Name:        "systemd-journal-upload",
+		Description: "Journal Remote Upload Service",
+		Installed:   false,
+		Running:     false,
+		Enabled:     false,
+		Masked:      false,
+		Static:      false,
+		Type:        "systemd",
+	}, services["systemd-journal-upload"])
+}
+
 func TestSystemDServiceManagerGetUsesTargetedShow(t *testing.T) {
 	const showCmd = "systemctl show --property=Id,LoadState,ActiveState,UnitFileState,Description dbus.service"
 


### PR DESCRIPTION
### What

The systemd `service` resource set `Enabled` / `Masked` / `Static` from `UnitFileState` independently of `Installed` (derived from `LoadState`). A unit whose definition no longer exists (`LoadState=not-found`) but still reports a leftover `UnitFileState` such as `enabled` — for example a dangling enablement symlink left behind by a removed package — was reported as `installed=false` while `enabled=true`, a contradictory state.

This skips applying the unit-file state for units that are not installed, so `enabled`/`masked`/`static` stay `false` when `installed=false`.

### Why

Queries that branch on `service("x").enabled == false` (e.g. "require rsyslog unless a journal uploader is enabled") were misled by the contradictory state and silently skipped dependent logic.

### Test

Added `TestParseServiceSystemDShowNotFoundIsNotEnabled` covering `LoadState=not-found` with `UnitFileState=enabled`. It fails before the change (`Enabled=true`) and passes after (`Enabled=false`). The full `providers/os/resources/services` suite passes.

The `list-unit-files` path is unaffected (it always sets `installed=true`, so the new guard is a no-op there).

Fixes #8464
