### PR TITLE
🐛 os: filter placeholder serial numbers from platform ID detection

### DIFF
--- a/providers/os/id/serialnumber/serial.go
+++ b/providers/os/id/serialnumber/serial.go
@@ -36,8 +36,8 @@ var knownSentinels = []string{
 }
 
 // isValidSerialNumber checks that the serial is not empty and not a known placeholder.
+// It expects a pre-trimmed value.
 func isValidSerialNumber(serial string) bool {
-	serial = strings.TrimSpace(serial)
 	if len(serial) == 0 {
 		return false
 	}
@@ -58,6 +58,10 @@ func SerialNumber(conn shared.Connection, p *inventory.Platform) (string, error)
 		return "", errors.New("cannot determine platform serial number")
 	}
 
+	// A placeholder or empty serial returns ("", nil) — not an error — so the
+	// caller (gatherPlatformInfo) treats it the same as "no serial available"
+	// and falls through to the next ID strategy, rather than building a
+	// non-unique platform ID from an OEM default. This matches biosuuid.BiosUUID.
 	serial := strings.TrimSpace(info.SysInfo.SerialNumber)
 	if !isValidSerialNumber(serial) {
 		return "", nil

--- a/providers/os/id/serialnumber/serial.go
+++ b/providers/os/id/serialnumber/serial.go
@@ -4,11 +4,45 @@
 package serialnumber
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/pkg/errors"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/resources/smbios"
 )
+
+// knownSentinels are SMBIOS serial number values that indicate the serial is not
+// set or not usable. OEMs frequently ship hardware (and many hypervisors ship VMs)
+// with these placeholder strings left in the DMI fields, so they are not unique and
+// must not be used as a platform identifier.
+var knownSentinels = []string{
+	"system serial number",
+	"base board serial number",
+	"chassis serial number",
+	"to be filled by o.e.m.",
+	"default string",
+	"not specified",
+	"not available",
+	"not applicable",
+	"not present",
+	"not settable",
+	"none",
+	"oem",
+	"invalid",
+	"0",
+	"00000000",
+}
+
+// isValidSerialNumber checks that the serial is not empty and not a known placeholder.
+func isValidSerialNumber(serial string) bool {
+	serial = strings.TrimSpace(serial)
+	if len(serial) == 0 {
+		return false
+	}
+	return !slices.Contains(knownSentinels, strings.ToLower(serial))
+}
 
 func SerialNumber(conn shared.Connection, p *inventory.Platform) (string, error) {
 	mgr, err := smbios.ResolveManager(conn, p)
@@ -24,5 +58,10 @@ func SerialNumber(conn shared.Connection, p *inventory.Platform) (string, error)
 		return "", errors.New("cannot determine platform serial number")
 	}
 
-	return info.SysInfo.SerialNumber, nil
+	serial := strings.TrimSpace(info.SysInfo.SerialNumber)
+	if !isValidSerialNumber(serial) {
+		return "", nil
+	}
+
+	return serial, nil
 }

--- a/providers/os/id/serialnumber/serial_test.go
+++ b/providers/os/id/serialnumber/serial_test.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package serialnumber
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidSerialNumber(t *testing.T) {
+	tests := []struct {
+		serial string
+		valid  bool
+	}{
+		{"", false},
+		{"   ", false},
+		{"System Serial Number", false},
+		{"system serial number", false},
+		{"  System Serial Number  ", false},
+		{"Base Board Serial Number", false},
+		{"Chassis Serial Number", false},
+		{"To Be Filled By O.E.M.", false},
+		{"Default string", false},
+		{"Not Specified", false},
+		{"None", false},
+		{"0", false},
+		{"00000000", false},
+		{"OEM", false},
+		// genuine-looking serials
+		{"VMware-56 4d 1a 2b", true},
+		{"PF2ABCDE", true},
+		{"5CG1234ABC", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.serial, func(t *testing.T) {
+			assert.Equal(t, tt.valid, isValidSerialNumber(tt.serial))
+		})
+	}
+}

--- a/providers/os/id/serialnumber/serial_test.go
+++ b/providers/os/id/serialnumber/serial_test.go
@@ -15,10 +15,8 @@ func TestIsValidSerialNumber(t *testing.T) {
 		valid  bool
 	}{
 		{"", false},
-		{"   ", false},
 		{"System Serial Number", false},
 		{"system serial number", false},
-		{"  System Serial Number  ", false},
 		{"Base Board Serial Number", false},
 		{"Chassis Serial Number", false},
 		{"To Be Filled By O.E.M.", false},


### PR DESCRIPTION
## Problem

On Linux, the serial-number ID detector reads `/sys/class/dmi/id/product_serial` and used the value verbatim with **no validation**. Many OEMs/firmware (and some hypervisors) leave placeholder strings in the DMI tables, so machines reported IDs like:

```
//platformid.api.mondoo.app/serialnumber/System Serial Number
```

These placeholders (`System Serial Number`, `To be filled by O.E.M.`, `Default string`, `None`, `0`, …) are **not unique** — every machine with unprogrammed firmware collides on the same platform ID.

The neighboring **BIOS-UUID** detector (`providers/os/id/biosuuid/biosuuid.go`) already filters exactly these sentinels; the serial-number detector did not.

## Fix

Add `isValidSerialNumber()` to `providers/os/id/serialnumber/serial.go`, mirroring the `biosuuid` sentinel pattern. Placeholder serials now produce **no** `serialnumber/...` ID (the asset falls back to hostname / BIOS-UUID) instead of a bogus colliding one.

Added `serial_test.go` covering placeholders and genuine-looking serials.

## Notes

- The "only works with `sudo`" behavior the reporter also saw is expected: `/sys/class/dmi/id/product_serial` is mode `0400` (root-only), so serial-based identification on Linux inherently requires root. Not changed here.
- Real serial-based identity for affected machines still requires correct firmware programming — software can't invent a serial.

## Test plan

- [x] `go test ./id/serialnumber/...`
- [x] `gofmt` clean, builds
- [ ] `make providers/build/os && make providers/install/os` then `mql run local -c 'asset.ids'` — placeholder serial ID no longer emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)