### PR TITLE
✨ ci: add xgrep security scanning

### DIFF
--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -1,0 +1,35 @@
+name: xgrep
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: xgrep security scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload SARIF to code scanning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # required for diff-aware scanning on pull requests
+      - name: Run xgrep
+        uses: mondoohq/actions/xgrep@b41754752763419780430abef5e35842ba2bec66 # v13.2.0
+        with:
+          path: .
+          output-file: results.sarif
+          fail-on: "off" # report-only for now; surface findings without blocking PRs
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: xgrep


### PR DESCRIPTION
## What

Adds an `xgrep` workflow that runs the shared **`mondoohq/actions/xgrep`** action (released in [actions v13.2.0](https://github.com/mondoohq/actions/releases/tag/v13.2.0)) and uploads results to GitHub code scanning — mirroring the setup added to cnspec.

- Triggers on push/PR to `main`; `security-events: write` to upload SARIF.
- `fetch-depth: 0` so `xgrep ci` can scan diff-aware against the PR base.
- **Report-only** (`fail-on: off`) initially — findings appear in the Security tab without blocking merges. Can flip to `error` once findings are triaged.
- SARIF uploaded with `category: xgrep` (matches the action's default `--sarif-category`).

Actions pinned by SHA per repo convention (`checkout` v6.0.3, `upload-sarif` v4.36.2, `xgrep` v13.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)