### PR TITLE
🐛 mqlc: keep resource type through map(...).flat()

### DIFF
--- a/mqlc/builtin_array.go
+++ b/mqlc/builtin_array.go
@@ -520,9 +520,7 @@ func compileArrayMap(c *compiler, typ types.Type, ref uint64, id string, call *p
 	// display-expand a resource(-list) entrypoint into an anonymous `{}` block,
 	// which would otherwise make the mapped elements lose their resource type.
 	// See https://github.com/mondoohq/mql/issues/8474
-	if c.valueBodyBlocks != nil {
-		c.valueBodyBlocks[refs.block] = struct{}{}
-	}
+	c.valueBodyBlocks[refs.block] = struct{}{}
 
 	args := []*llx.Primitive{
 		llx.RefPrimitiveV2(ref),

--- a/mqlc/builtin_array.go
+++ b/mqlc/builtin_array.go
@@ -515,6 +515,15 @@ func compileArrayMap(c *compiler, typ types.Type, ref uint64, id string, call *p
 	}
 	mappedType := c.Result.CodeV2.DereferencedBlockType(block)
 
+	// The map body's entrypoint is the value this map collects, not something
+	// that gets rendered on its own. Mark the block so postCompile won't
+	// display-expand a resource(-list) entrypoint into an anonymous `{}` block,
+	// which would otherwise make the mapped elements lose their resource type.
+	// See https://github.com/mondoohq/mql/issues/8474
+	if c.valueBodyBlocks != nil {
+		c.valueBodyBlocks[refs.block] = struct{}{}
+	}
+
 	args := []*llx.Primitive{
 		llx.RefPrimitiveV2(ref),
 		argExpectation,

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -281,6 +281,13 @@ func compileResourceMap(c *compiler, typ types.Type, ref uint64, id string, call
 		return types.Nil, multierr.Wrap(err, "called '"+id+"' with a bad function block, types don't match")
 	}
 
+	// The map body's entrypoint is the value this map collects, not something
+	// that gets rendered on its own. Mark the block so postCompile won't
+	// display-expand a resource(-list) entrypoint into an anonymous `{}` block,
+	// which would otherwise make the mapped elements lose their resource type.
+	// See https://github.com/mondoohq/mql/issues/8474
+	c.valueBodyBlocks[refs.block] = struct{}{}
+
 	listType, err := compileResourceDefault(c, typ, ref, "list", nil)
 	if err != nil {
 		return listType, err

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -201,6 +201,17 @@ type compiler struct {
 	// overrideTailDataRef is set by `having` so that subsequent chained calls
 	// bind to the where-filtered list instead of the $any boolean chunk.
 	overrideTailDataRef uint64
+
+	// valueBodyBlocks holds the refs of blocks whose single entrypoint is a
+	// value consumed by a parent builtin (the function body of `.map(...)`).
+	// postCompile must not display-expand those entrypoints: replacing the real
+	// value (e.g. the `[]file` from `.list`) with an anonymous `{}` display
+	// block (`[]block`) makes the parent collect `block`-typed elements, which
+	// breaks any later field access on the result.
+	// See https://github.com/mondoohq/mql/issues/8474
+	// The map is shared across the whole compiler tree (allocated once on the
+	// root compiler and handed to every newBlockCompiler).
+	valueBodyBlocks map[uint64]struct{}
 }
 
 func (c *compiler) isInMyBlock(ref uint64) bool {
@@ -249,16 +260,17 @@ func (c *compiler) newBlockCompiler(binding *variable) compiler {
 	}
 
 	return compiler{
-		CompilerConfig: c.CompilerConfig,
-		Result:         c.Result,
-		Binding:        binding,
-		blockDeps:      blockDeps,
-		vars:           newvarmap(ref, c.vars),
-		parent:         c,
-		block:          block,
-		blockRef:       ref,
-		props:          c.props,
-		standalone:     true,
+		CompilerConfig:  c.CompilerConfig,
+		Result:          c.Result,
+		Binding:         binding,
+		blockDeps:       blockDeps,
+		vars:            newvarmap(ref, c.vars),
+		parent:          c,
+		block:           block,
+		blockRef:        ref,
+		props:           c.props,
+		standalone:      true,
+		valueBodyBlocks: c.valueBodyBlocks,
 	}
 }
 
@@ -1742,6 +1754,15 @@ func (c *compiler) postCompile() {
 	// expandResourceFields (nested @defaults) are visited in the same pass.
 	for i := 0; i < len(code.Blocks); i++ {
 		block := code.Blocks[i]
+
+		// Skip blocks whose entrypoint is a value consumed by a parent builtin
+		// (e.g. a `.map(...)` body). Display-expanding such an entrypoint would
+		// replace the collected value with an anonymous `{}` block and strip its
+		// resource type. See https://github.com/mondoohq/mql/issues/8474
+		if _, ok := c.valueBodyBlocks[uint64(i+1)<<32]; ok {
+			continue
+		}
+
 		eps := block.Entrypoints
 
 		for _, ref := range eps {
@@ -2219,14 +2240,15 @@ func CompileAST(ast *parser.AST, props PropsHandler, conf CompilerConfig) (*llx.
 	}
 
 	c := compiler{
-		CompilerConfig: conf,
-		Result:         codeBundle,
-		vars:           newvarmap(1<<32, nil),
-		parent:         nil,
-		blockRef:       1 << 32,
-		block:          codeBundle.CodeV2.Blocks[0],
-		props:          props,
-		standalone:     true,
+		CompilerConfig:  conf,
+		Result:          codeBundle,
+		vars:            newvarmap(1<<32, nil),
+		parent:          nil,
+		blockRef:        1 << 32,
+		block:           codeBundle.CodeV2.Blocks[0],
+		props:           props,
+		standalone:      true,
+		valueBodyBlocks: map[uint64]struct{}{},
 	}
 
 	return c.Result, c.CompileParsed(ast)

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1021,6 +1021,52 @@ func TestCompiler_NamedBindingScope(t *testing.T) {
 	})
 }
 
+// TestCompiler_MapBodyKeepsResourceType is a regression test for
+// https://github.com/mondoohq/mql/issues/8474
+//
+// The body of `.map(...)` returns a value the map collects; it is not rendered
+// on its own. postCompile used to display-expand a resource(-list) entrypoint
+// into an anonymous `{}` block, flipping the body's type from `[]file` to
+// `[]block`. The mapped (and later flattened) elements then lost their `file`
+// type, so a `.path`/`.size`/`.permissions` access on the result failed at
+// runtime with "cannot find functions for type 'block'".
+func TestCompiler_MapBodyKeepsResourceType(t *testing.T) {
+	compileT(t, `["/etc/pam.d"].map(files.find(from: _, type: "file").list).flat()`, func(res *llx.CodeBundle) {
+		code := res.CodeV2
+
+		var mapChunk *llx.Chunk
+		for _, b := range code.Blocks {
+			for _, ch := range b.Chunks {
+				if ch.Id == "map" && ch.Call == llx.Chunk_FUNCTION {
+					mapChunk = ch
+				}
+			}
+		}
+		require.NotNil(t, mapChunk, "expected a map chunk")
+
+		// map over a list of dirs, each body yielding []file, is [][]file. The
+		// innermost element type must stay a resource, never anonymous `block`.
+		mapType := types.Type(mapChunk.Function.Type)
+		require.True(t, mapType.IsArray() && mapType.Child().IsArray(),
+			"map result should be a nested array, got "+mapType.Label())
+		assert.True(t, mapType.Child().Child().IsResource(),
+			"map element type must stay a resource array, got "+mapType.Label())
+
+		// The map body block's single entrypoint must still be the collected
+		// value (`list`), not a display `{}` block that strips the type.
+		bodyRef, ok := mapChunk.Function.Args[1].RefV2()
+		require.True(t, ok, "map should carry a function block reference")
+		body := code.Block(bodyRef)
+		require.Len(t, body.Entrypoints, 1)
+		ep := code.Chunk(body.Entrypoints[0])
+		assert.NotEqual(t, "{}", ep.Id,
+			"map body entrypoint must not be an auto-expanded display block")
+		epType := ep.Type()
+		assert.True(t, epType.IsArray() && epType.Child().IsResource(),
+			"map body entrypoint must stay []file, got "+epType.Label())
+	})
+}
+
 func TestCompiler_ArrayContains(t *testing.T) {
 	compileT(t, "[1,2,3].contains(_ == 2)", func(res *llx.CodeBundle) {
 		assertPrimitive(t, &llx.Primitive{

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1029,42 +1029,59 @@ func TestCompiler_NamedBindingScope(t *testing.T) {
 // into an anonymous `{}` block, flipping the body's type from `[]file` to
 // `[]block`. The mapped (and later flattened) elements then lost their `file`
 // type, so a `.path`/`.size`/`.permissions` access on the result failed at
-// runtime with "cannot find functions for type 'block'".
+// runtime with "cannot find functions for type 'block'". This covers both the
+// array map (compileArrayMap) and the resource-list map (compileResourceMap).
 func TestCompiler_MapBodyKeepsResourceType(t *testing.T) {
-	compileT(t, `["/etc/pam.d"].map(files.find(from: _, type: "file").list).flat()`, func(res *llx.CodeBundle) {
-		code := res.CodeV2
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"array map", `["/etc/pam.d"].map(files.find(from: _, type: "file").list).flat()`},
+		{"resource-list map", `users.map(file("/etc/hosts")).flat()`},
+	}
 
-		var mapChunk *llx.Chunk
-		for _, b := range code.Blocks {
-			for _, ch := range b.Chunks {
-				if ch.Id == "map" && ch.Call == llx.Chunk_FUNCTION {
-					mapChunk = ch
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			compileT(t, tc.query, func(res *llx.CodeBundle) {
+				code := res.CodeV2
+
+				var mapChunk *llx.Chunk
+				for _, b := range code.Blocks {
+					for _, ch := range b.Chunks {
+						if ch.Id == "map" && ch.Call == llx.Chunk_FUNCTION {
+							mapChunk = ch
+						}
+					}
 				}
-			}
-		}
-		require.NotNil(t, mapChunk, "expected a map chunk")
+				require.NotNil(t, mapChunk, "expected a map chunk")
 
-		// map over a list of dirs, each body yielding []file, is [][]file. The
-		// innermost element type must stay a resource, never anonymous `block`.
-		mapType := types.Type(mapChunk.Function.Type)
-		require.True(t, mapType.IsArray() && mapType.Child().IsArray(),
-			"map result should be a nested array, got "+mapType.Label())
-		assert.True(t, mapType.Child().Child().IsResource(),
-			"map element type must stay a resource array, got "+mapType.Label())
+				// The mapped element type must stay a resource (the map collects
+				// `file`/`[]file`), never the anonymous `block` type.
+				elem := types.Type(mapChunk.Function.Type).Child()
+				for elem.IsArray() {
+					elem = elem.Child()
+				}
+				assert.True(t, elem.IsResource(),
+					"map element type must stay a resource, got "+types.Type(mapChunk.Function.Type).Label())
 
-		// The map body block's single entrypoint must still be the collected
-		// value (`list`), not a display `{}` block that strips the type.
-		bodyRef, ok := mapChunk.Function.Args[1].RefV2()
-		require.True(t, ok, "map should carry a function block reference")
-		body := code.Block(bodyRef)
-		require.Len(t, body.Entrypoints, 1)
-		ep := code.Chunk(body.Entrypoints[0])
-		assert.NotEqual(t, "{}", ep.Id,
-			"map body entrypoint must not be an auto-expanded display block")
-		epType := ep.Type()
-		assert.True(t, epType.IsArray() && epType.Child().IsResource(),
-			"map body entrypoint must stay []file, got "+epType.Label())
-	})
+				// The map body block's single entrypoint must still be the
+				// collected value, not a display `{}` block that strips the type.
+				bodyRef, ok := mapChunk.Function.Args[1].RefV2()
+				require.True(t, ok, "map should carry a function block reference")
+				body := code.Block(bodyRef)
+				require.Len(t, body.Entrypoints, 1)
+				ep := code.Chunk(body.Entrypoints[0])
+				assert.NotEqual(t, "{}", ep.Id,
+					"map body entrypoint must not be an auto-expanded display block")
+				epType := ep.Type()
+				for epType.IsArray() {
+					epType = epType.Child()
+				}
+				assert.True(t, epType.IsResource(),
+					"map body entrypoint must keep its resource type, got "+ep.Type().Label())
+			})
+		})
+	}
 }
 
 func TestCompiler_ArrayContains(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #8474.

A query of the form `list.map(files.find(...).list.where(...)).flat()` errors at scan time with:

```
cannot find functions for type 'block' (called 'size')
cannot find functions for type 'block' (called 'path')
cannot find functions for type 'block' (called 'permissions')
```

The nested `.map(...).flat()` loses the `file` type — the flattened elements come out typed as an anonymous `block`, so `.where(path == …)` / `.path` / `.size` / `.permissions` can't resolve.

## Root cause

The compiled chunk types are actually correct (`map` → `[][]file`, `flat` → `[]file`). The bug is that **`postCompile` rewrites the entrypoint of the `map` body block**.

The body of `.map(...)` returns a value the map *collects* — it is not rendered on its own. But `postCompile` runs `expandResourceFields` over the entrypoints of *every* block, and when an entrypoint is a resource(-list) it appends an auto-expand `{}` display block and **replaces the entrypoint with it** (`mqlc.go: expandResourceFields`). For the map body that flips the entrypoint from `.list` (`[]file`) to `{}` (`[]block`).

At runtime `arrayMapV2` derives the mapped element type (and value) from that entrypoint, so it collects `block`-typed elements. `flat` then yields `[]block`, and the trailing display block binds each element as `block` → the field lookups fail.

## Fix

Mark `.map(...)` body blocks as value-producing (`valueBodyBlocks`, shared across the compiler tree) and skip display expansion for them in `postCompile`. The body keeps its real entrypoint, so the map collects the actual `file` resources and the type survives `.flat()`.

Display expansion for the *result* still happens normally at the outer level, so report output is unchanged.

## Test

`mqlc_test.go: TestCompiler_MapBodyKeepsResourceType` compiles the repro and asserts the map body's entrypoint stays `[]file` (not an auto-expanded `{}`/`[]block`). Verified it fails without the fix (`got []block`) and passes with it.

Manually verified end-to-end with `mql run local`:

- `["/etc/pam.d"].map(files.find(from: _, type: "file").list).flat() { path }` — now returns paths (was erroring)
- the original issue's `moduleFiles == empty || kernel.module("cramfs").disabled` shape — now resolves `path`/`size`/`permissions`
- single-level `files.find(...).list { path }`, scalar maps, explicit inner blocks, and nested `map().flat()` all still work

`go test ./mqlc/... ./llx/...` passes.