### PR TITLE
🐛 os: make native files.find match `find -L` (symlinks + perm 0)

### DIFF
--- a/providers/os/fsutil/find_files.go
+++ b/providers/os/fsutil/find_files.go
@@ -13,6 +13,12 @@ import (
 func FindFiles(iofs fs.FS, from string, r *regexp.Regexp, typ string, perm *uint32, depth *int) ([]string, error) {
 	matcher := createFindFilesMatcher(iofs, typ, from, r, perm, depth)
 	matchedPaths := []string{}
+	// Note: matcher.Match resolves a symlink to its target type so a symlink is
+	// reported under the type it points at (mirroring `find -L`), but WalkDir
+	// itself does not follow symlinks during traversal. So a symlinked directory
+	// is reported for type:"directory" yet its contents are not walked. Full
+	// `find -L` recursion would need explicit symlink following with loop
+	// detection; it isn't required for the config-file discovery this powers.
 	err := fs.WalkDir(iofs, from, func(p string, d fs.DirEntry, err error) error {
 		if d != nil && d.IsDir() && matcher.DepthReached(p) {
 			return fs.SkipDir

--- a/providers/os/fsutil/find_files.go
+++ b/providers/os/fsutil/find_files.go
@@ -62,7 +62,7 @@ func (m findFilesMatcher) DepthReached(p string) bool {
 }
 
 func (m findFilesMatcher) Match(path string, t fs.FileMode) bool {
-	matchesType := m.matchesType(t)
+	matchesType := m.matchesType(path, t)
 	matchesRegex := m.matchesRegex(path)
 	matchesPerm := m.matchesPerm(path)
 
@@ -80,24 +80,45 @@ func (m findFilesMatcher) matchesRegex(path string) bool {
 	return match == path
 }
 
-func (m findFilesMatcher) matchesType(entryType fs.FileMode) bool {
+func (m findFilesMatcher) matchesType(path string, entryType fs.FileMode) bool {
 	if len(m.types) == 0 {
 		return true
 	}
+
+	// WalkDir reports lstat info, so a symlink keeps fs.ModeSymlink and never
+	// matches file/dir/etc. on its own. The command-based backend uses
+	// `find -L`, which follows symlinks and tests the target's type; mirror
+	// that here by resolving the symlink's target. Without this, a symlinked
+	// regular file (e.g. authselect manages /etc/pam.d service files as
+	// symlinks into /etc/authselect) is skipped by type:"file".
+	// See https://github.com/mondoohq/mql/issues/8467
+	// This is purely additive: a symlink still matches type:"link" (handled
+	// against the original lstat mode below), it now ALSO matches the type of
+	// whatever it points at. Broken symlinks fail to resolve and keep their
+	// symlink type.
+	resolvedType := entryType
+	if entryType&fs.ModeSymlink != 0 && m.wantsNonSymlinkType() {
+		if info, err := fs.Stat(m.iofs, path); err == nil {
+			resolvedType = info.Mode()
+		}
+	}
+
 	for _, at := range m.types {
 		var matches bool
 		switch at {
 		case 'b':
-			matches = (entryType&fs.ModeDevice) != 0 && (entryType&fs.ModeCharDevice) == 0
+			matches = (resolvedType&fs.ModeDevice) != 0 && (resolvedType&fs.ModeCharDevice) == 0
 		case 'c':
-			matches = (entryType&fs.ModeDevice) != 0 && (entryType&fs.ModeCharDevice) != 0
+			matches = (resolvedType&fs.ModeDevice) != 0 && (resolvedType&fs.ModeCharDevice) != 0
 		case 'd':
-			matches = entryType.IsDir()
+			matches = resolvedType.IsDir()
 		case 'p':
-			matches = (entryType & fs.ModeNamedPipe) != 0
+			matches = (resolvedType & fs.ModeNamedPipe) != 0
 		case 'f':
-			matches = entryType.IsRegular()
+			matches = resolvedType.IsRegular()
 		case 'l':
+			// match against the original mode so any symlink matches, including
+			// one that points at a regular file or directory.
 			matches = (entryType & fs.ModeSymlink) != 0
 		}
 		if matches {
@@ -107,8 +128,31 @@ func (m findFilesMatcher) matchesType(entryType fs.FileMode) bool {
 	return false
 }
 
+// wantsNonSymlinkType reports whether any requested type other than "link" is
+// set, i.e. whether resolving a symlink's target type could change the result.
+// It lets us skip the extra stat for plain type:"link" lookups.
+func (m findFilesMatcher) wantsNonSymlinkType() bool {
+	for _, at := range m.types {
+		if at != 'l' {
+			return true
+		}
+	}
+	return false
+}
+
 func (m findFilesMatcher) matchesPerm(path string) bool {
 	if m.perm == nil {
+		return true
+	}
+	// A zero permission mask is "no permission filter", matching `find -perm -0`
+	// (every file has all of zero bits set) and the command-based find backend.
+	// files.find created via CreateResource without a `permissions` argument
+	// arrives here with a 0 mask (initFilesFind's 0o777 default only applies to
+	// MQL-instantiated resources), and the pam/sudoers/modprobe/rsyslog/... `*.d`
+	// discoveries all rely on that. Without this guard a 0 mask matched nothing
+	// (`mode & 0 == 0`), so those lookups returned no files on filesystem and
+	// tar connections. See https://github.com/mondoohq/mql/issues/8467
+	if *m.perm == 0 {
 		return true
 	}
 	info, err := fs.Stat(m.iofs, path)

--- a/providers/os/fsutil/find_files_unix_test.go
+++ b/providers/os/fsutil/find_files_unix_test.go
@@ -6,6 +6,8 @@
 package fsutil
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -33,4 +35,68 @@ func TestFindFilesPermissionFilter(t *testing.T) {
 	permFiles, err := FindFiles(afero.NewIOFS(fs), "root", nil, "f", &perm, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, permFiles, []string{"root/c/file4"})
+}
+
+// TestFindFilesZeroPermissionMatchesAll is a regression test for
+// https://github.com/mondoohq/mql/issues/8467
+//
+// files.find built via CreateResource without a permissions argument reaches
+// the native walker with a 0 mask (initFilesFind's 0o777 default only applies
+// to MQL-instantiated resources). A 0 mask must mean "no permission filter"
+// (like `find -perm -0`), not "match nothing" — otherwise the pam/sudoers/
+// modprobe/rsyslog/... `*.d` discoveries return no files on filesystem/tar
+// connections.
+func TestFindFilesZeroPermissionMatchesAll(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	mkDir(t, fs, "root")
+	mkFile(t, fs, "root/a")
+	mkFile(t, fs, "root/b")
+	require.NoError(t, fs.Chmod("root/a", 0o644))
+	require.NoError(t, fs.Chmod("root/b", 0o600))
+
+	zero := uint32(0)
+	files, err := FindFiles(afero.NewIOFS(fs), "root", nil, "f", &zero, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"root/a", "root/b"}, files,
+		"a 0 permission mask must match all files, not none")
+}
+
+// TestFindFilesFollowsSymlinks is a regression test for
+// https://github.com/mondoohq/mql/issues/8467
+//
+// authselect manages key /etc/pam.d service files (system-auth, password-auth,
+// ...) as symlinks into /etc/authselect. The command-based backend runs
+// `find -L` and follows them, but the native walker reported lstat info and
+// skipped symlinks, so type:"file" missed those service files and pam.module
+// resolved to an empty husk. A real filesystem is needed here because afero's
+// MemMapFs has no symlink support.
+func TestFindFilesFollowsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.conf"), []byte("x"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.Symlink("real.conf", filepath.Join(dir, "link.conf"))) // -> regular file
+	require.NoError(t, os.Symlink("sub", filepath.Join(dir, "dirlink")))         // -> directory
+	require.NoError(t, os.Symlink("missing", filepath.Join(dir, "broken")))      // dangling
+
+	iofs := os.DirFS(dir)
+
+	// type:"file" follows symlinks to regular files (mirrors `find -L`).
+	files, err := FindFiles(iofs, ".", nil, "file", nil, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"real.conf", "link.conf"}, files,
+		"type:file must include a symlink that points at a regular file")
+
+	// type:"link" still matches every symlink (additive), including the one
+	// that resolves to a file/dir and the dangling one.
+	links, err := FindFiles(iofs, ".", nil, "link", nil, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"link.conf", "dirlink", "broken"}, links,
+		"type:link must still match all symlinks")
+
+	// type:"directory" follows a symlink that points at a directory.
+	dirs, err := FindFiles(iofs, ".", nil, "directory", nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, dirs, "sub")
+	assert.Contains(t, dirs, "dirlink",
+		"type:directory must include a symlink that points at a directory")
 }


### PR DESCRIPTION
## Summary

Fixes #8467.

On RHEL systems managed by **authselect**, `pam.module("pam_unix")` (and `pam.conf`) report the module as not present / `enabled = false` even though it is configured, because the key `/etc/pam.d` service files (`system-auth`, `password-auth`, …) are **symlinks** into `/etc/authselect` and PAM file discovery skipped them.

While verifying the fix on a filesystem scan I found the native `files.find` walker (used by the **filesystem** and **tar** connections) diverges from the command-based `find -L` backend in *two* ways, which together break PAM discovery on those connections. Both are needed for the authselect case to work.

## Root cause

`pam.conf` discovers service files via `getSortedPathFiles` → `files.find(from: "/etc/pam.d", type: "file")`. On filesystem/tar connections that runs the native Go walker (`fsutil.FindFiles`), which differs from `find -L` (what the local/SSH command backend runs):

1. **Symlinks are skipped.** `fs.WalkDir` reports lstat info, so a symlink keeps `fs.ModeSymlink` and never satisfies `type:"file"` (`IsRegular()` is false). The authselect-managed service files are symlinks, so `pam_unix` (defined only there) is never parsed and `pam.module("pam_unix")` resolves to the empty husk.

2. **A `0` permission mask matches nothing.** `files.find` built via `CreateResource` (as pam, sudoers, modprobe, rsyslog, logrotate, limits, apt, … all do) never runs `initFilesFind`, so `permissions` stays at the Go zero `0`. The walker then filtered out *every* file (`mode & 0 == 0`). The command backend treats the same value as `-perm -0`, which matches everything — hence local/SSH worked but filesystem/tar returned nothing.

## Fix (`providers/os/fsutil/find_files.go`)

Make the native walker mirror `find -L`:

- Resolve a symlink to its target type for type matching, so a symlink to a regular file matches `type:"file"` (and a symlink to a dir matches `type:"directory"`). This is **additive** — a symlink still matches `type:"link"`, and a broken symlink keeps its symlink type. A small guard skips the extra `stat` for plain `type:"link"` lookups.
- Treat a `0` permission mask as "no filter" (like `find -perm -0`).

No call sites change, so this fixes the `*.d` discovery for pam **and** sudoers/modprobe/rsyslog/… on filesystem/tar connections in one place.

## Tests

`providers/os/fsutil/find_files_unix_test.go`:
- `TestFindFilesFollowsSymlinks` — a symlink to a file matches `type:"file"`, a symlink to a dir matches `type:"directory"`, all symlinks (incl. broken) still match `type:"link"`. Verified it fails without the fix.
- `TestFindFilesZeroPermissionMatchesAll` — a `0` mask matches all files instead of none.

End-to-end against an authselect-style rootfs (`system-auth`/`password-auth` as symlinks into `/etc/authselect`, `pam_unix` without `nullok`) via `mql run filesystem --path …`:

- before: `pam.conf.files` empty → `pam.module("pam_unix").enabled` = `false`
- after: `pam.conf.files` lists the symlinked services → the issue's exact check `pam.module("pam_unix").enabled && pam.module("pam_unix").entries.none(options.contains("nullok"))` returns `true`

Confirmed each fix is independently required: with only the perm fix, `pam.conf.files` still drops the symlinks and `pam_unix` stays a husk.

`go test ./providers/os/fsutil/... ./providers/os/resources/...` passes.