### PR TITLE
🐛 stackit: fix client region config, region field, object storage 404, mongodb listing

### DIFF
--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.0.4",
+	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/stackit/connection/connection.go
+++ b/providers/stackit/connection/connection.go
@@ -238,14 +238,19 @@ func (c *StackitConnection) Verify(ctx context.Context) error {
 
 func (c *StackitConnection) IaaS() (*iaas.APIClient, error) {
 	c.iaasOnce.Do(func() {
-		c.iaasClient, c.iaasErr = iaas.NewAPIClient(c.configOpts...)
+		// The IaaS API rejects WithRegion in the client config and requires the
+		// region as a per-call function parameter (which every IaaS resource
+		// method supplies), so build the client without a bound region.
+		c.iaasClient, c.iaasErr = iaas.NewAPIClient(c.configOptsGlobal...)
 	})
 	return c.iaasClient, c.iaasErr
 }
 
 func (c *StackitConnection) SKE() (*ske.APIClient, error) {
 	c.skeOnce.Do(func() {
-		c.skeClient, c.skeErr = ske.NewAPIClient(c.configOpts...)
+		// SKE likewise rejects WithRegion in the client config; the region is
+		// passed as a per-call function parameter.
+		c.skeClient, c.skeErr = ske.NewAPIClient(c.configOptsGlobal...)
 	})
 	return c.skeClient, c.skeErr
 }
@@ -287,7 +292,9 @@ func (c *StackitConnection) PostgresFlex() (*postgresflex.APIClient, error) {
 
 func (c *StackitConnection) MongoDbFlex() (*mongodbflex.APIClient, error) {
 	c.mongoDbFlexOnce.Do(func() {
-		c.mongoDbFlexClient, c.mongoDbFlexErr = mongodbflex.NewAPIClient(c.configOpts...)
+		// MongoDB Flex rejects WithRegion in the client config; the region is
+		// passed as a per-call function parameter.
+		c.mongoDbFlexClient, c.mongoDbFlexErr = mongodbflex.NewAPIClient(c.configOptsGlobal...)
 	})
 	return c.mongoDbFlexClient, c.mongoDbFlexErr
 }
@@ -357,7 +364,9 @@ func (c *StackitConnection) ServiceAccount() (*serviceaccount.APIClient, error) 
 
 func (c *StackitConnection) Sfs() (*sfs.APIClient, error) {
 	c.sfsOnce.Do(func() {
-		c.sfsClient, c.sfsErr = sfs.NewAPIClient(c.configOpts...)
+		// SFS rejects WithRegion in the client config; every SFS resource method
+		// passes the region as a per-call function parameter.
+		c.sfsClient, c.sfsErr = sfs.NewAPIClient(c.configOptsGlobal...)
 	})
 	return c.sfsClient, c.sfsErr
 }

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -172,7 +172,11 @@ func (r *mqlStackitMongoDbFlex) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	// Unlike the other Flex engines, the MongoDB Flex ListInstances endpoint
+	// requires a `tag` query parameter. An empty tag returns all instances in
+	// the project, so use the request builder rather than the convenience
+	// ListInstancesExecute (which cannot set a tag).
+	resp, err := client.ListInstances(bgctx(), c.ProjectID(), c.Region()).Tag("").Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -26,7 +26,9 @@ func (r *mqlStackitObjectStorage) buckets() ([]any, error) {
 	}
 	resp, err := client.ListBucketsExecute(bgctx(), c.ProjectID(), c.Region())
 	if err != nil {
-		if isAccessDenied(err) {
+		// A 404 here means the project is not onboarded to Object Storage
+		// (the service returns "project.not_found"); treat it as no buckets.
+		if isAccessDenied(err) || isNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -24,7 +24,7 @@ stackit {
   // STACKIT project the connection is scoped to
   project() stackit.project
   // Region the connection targets (e.g., eu01)
-  region string
+  region() string
   // Compute servers (virtual machines)
   servers() []stackit.server
   // Block storage volumes

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -4356,7 +4356,9 @@ func (c *mqlStackit) GetProject() *plugin.TValue[*mqlStackitProject] {
 }
 
 func (c *mqlStackit) GetRegion() *plugin.TValue[string] {
-	return &c.Region
+	return plugin.GetOrCompute[string](&c.Region, func() (string, error) {
+		return c.region()
+	})
 }
 
 func (c *mqlStackit) GetServers() *plugin.TValue[[]any] {


### PR DESCRIPTION
## What

The **first live test** of the STACKIT provider (running a scan against a real project) surfaced several bugs that prevented core resources from returning any data. This fixes them.

| Bug | Symptom | Fix |
|---|---|---|
| IaaS / SKE / SFS / MongoDB Flex clients built with `WithRegion` | `this API does not support setting a region in the client configuration` → servers, volumes, security groups, SKE clusters, SFS pools, mongo instances all returned no data | build those clients with `configOptsGlobal`; their methods already pass region as a per-call parameter |
| Root `region` declared as a stored field but never populated | `stackit.region` → "cannot convert primitive with NO type information" | make it a computed `region()` wired to the existing resolver |
| Object Storage 404 when project not onboarded | `project.not_found` errored the whole resource | treat 404 as "no buckets" (`isNotFound`) |
| MongoDB Flex `ListInstances` requires a `tag` query param (unlike other Flex engines) | `tag is required and must be specified` | use the request builder with an empty tag to list all instances |

Of these, the region-config bugs in IaaS/SKE and the region field and object-storage handling are pre-existing (provider introduced in #7670, never live-tested); the SFS one was a regression from #8471.

## Why it matters

Before this change the provider does not work against a live STACKIT project — most resources error out. After it, a full security scan runs cleanly.

## Testing

- `make providers/build/stackit` + `make providers/install/stackit` ✅
- `go test ./providers/stackit/...` ✅
- Generated code regenerated; `.lr.versions` unchanged (no new/changed field entries — `stackit.region` stays `13.0.0`) ✅
- **Verified end-to-end against a live STACKIT project**: servers, volumes, security groups, SFS, SKE, object storage, and MongoDB Flex all resolve; a 31-check security policy scans with 0 resource errors.
- Provider version `13.0.4` → `13.0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)