### PR TITLE
fex: add FindingDocument constructor helpers to the SDK

### DIFF
--- a/providers-sdk/v1/upstream/fex/fex.go
+++ b/providers-sdk/v1/upstream/fex/fex.go
@@ -4,3 +4,46 @@
 package fex
 
 //go:generate protoc --plugin=protoc-gen-go=../../../../scripts/protoc/protoc-gen-go --plugin=protoc-gen-go-vtproto=../../../../scripts/protoc/protoc-gen-go-vtproto --go_out=. --go_opt=paths=source_relative --go-vtproto_out=. --go-vtproto_opt=paths=source_relative --go-vtproto_opt=features=marshal+unmarshal+size fex.proto
+
+// FexToDocument wraps a FindingExchange in a FindingDocument.
+func FexToDocument(f *FindingExchange) *FindingDocument {
+	return &FindingDocument{
+		Finding: &FindingDocument_Fex{Fex: f},
+	}
+}
+
+// FexToDocuments wraps each FindingExchange in a FindingDocument.
+func FexToDocuments(fexes []*FindingExchange) []*FindingDocument {
+	docs := make([]*FindingDocument, 0, len(fexes))
+	for _, f := range fexes {
+		docs = append(docs, FexToDocument(f))
+	}
+	return docs
+}
+
+// VexToDocument wraps a VulnerabilityExchange in a FindingDocument.
+func VexToDocument(v *VulnerabilityExchange) *FindingDocument {
+	return &FindingDocument{
+		Finding: &FindingDocument_Vex{Vex: v},
+	}
+}
+
+// VexToDocuments wraps each VulnerabilityExchange in a FindingDocument.
+func VexToDocuments(vexes []*VulnerabilityExchange) []*FindingDocument {
+	docs := make([]*FindingDocument, 0, len(vexes))
+	for _, v := range vexes {
+		docs = append(docs, VexToDocument(v))
+	}
+	return docs
+}
+
+// NewRemediation builds a Remediation with the Fix category and the given
+// summary, details, and optional URL.
+func NewRemediation(summary, details, url string) *Remediation {
+	return &Remediation{
+		Category: Remediation_Fix,
+		Summary:  summary,
+		Details:  details,
+		Url:      url,
+	}
+}

--- a/providers-sdk/v1/upstream/fex/fex_test.go
+++ b/providers-sdk/v1/upstream/fex/fex_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package fex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFexToDocument(t *testing.T) {
+	f := &FindingExchange{Id: "finding-1"}
+
+	doc := FexToDocument(f)
+
+	require.NotNil(t, doc)
+	require.Same(t, f, doc.GetFex())
+	assert.Nil(t, doc.GetVex())
+}
+
+func TestFexToDocuments(t *testing.T) {
+	fexes := []*FindingExchange{{Id: "a"}, {Id: "b"}}
+
+	docs := FexToDocuments(fexes)
+
+	require.Len(t, docs, 2)
+	assert.Equal(t, "a", docs[0].GetFex().GetId())
+	assert.Equal(t, "b", docs[1].GetFex().GetId())
+
+	assert.Empty(t, FexToDocuments(nil))
+}
+
+func TestVexToDocument(t *testing.T) {
+	v := &VulnerabilityExchange{Id: "CVE-2026-0001"}
+
+	doc := VexToDocument(v)
+
+	require.NotNil(t, doc)
+	require.Same(t, v, doc.GetVex())
+	assert.Nil(t, doc.GetFex())
+}
+
+func TestVexToDocuments(t *testing.T) {
+	vexes := []*VulnerabilityExchange{{Id: "CVE-1"}, {Id: "CVE-2"}}
+
+	docs := VexToDocuments(vexes)
+
+	require.Len(t, docs, 2)
+	assert.Equal(t, "CVE-1", docs[0].GetVex().GetId())
+	assert.Equal(t, "CVE-2", docs[1].GetVex().GetId())
+
+	assert.Empty(t, VexToDocuments(nil))
+}
+
+func TestNewRemediation(t *testing.T) {
+	r := NewRemediation("upgrade", "bump to 1.2.3", "https://example.com/advisory")
+
+	require.NotNil(t, r)
+	assert.Equal(t, Remediation_Fix, r.GetCategory())
+	assert.Equal(t, "upgrade", r.GetSummary())
+	assert.Equal(t, "bump to 1.2.3", r.GetDetails())
+	assert.Equal(t, "https://example.com/advisory", r.GetUrl())
+}


### PR DESCRIPTION
Follow-up to #8478, which published the Finding Exchange (FEX) / Vulnerability Exchange (VEX) proto contract in the provider SDK.

Adds small, contract-generic constructors next to the proto so every producer of the contract shares them instead of each reimplementing the oneof wrappers:

- `FexToDocument` / `FexToDocuments` — wrap `FindingExchange` values in `FindingDocument`
- `VexToDocument` / `VexToDocuments` — wrap `VulnerabilityExchange` values in `FindingDocument`
- `NewRemediation` — build a `Remediation` with the `Fix` category

Scope is intentionally limited to unopinionated wrappers/constructors. Helpers that bake in producer-specific policy (default finding status/timestamp/severity-string conventions, protocol string parsing, source aggregation, asset binding) are deliberately left out so they don't constrain other consumers of the contract.

Added in `fex.go`, with unit tests in `fex_test.go`. Package builds, vets, and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)