### PR TITLE
🎉 aws-13.37.0, google-workspace-13.1.4, helm-13.3.0, os-13.29.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.36.0",
+	Version:         "13.37.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.1.3",
+	Version:         "13.1.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.2.4",
+	Version:         "13.3.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.28.1",
+	Version: "13.29.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Release version bumps for four providers.

| Provider | Bump | Old → New |
|---|---|---|
| aws | minor | 13.36.0 → 13.37.0 |
| os | minor | 13.28.1 → 13.29.0 |
| helm | minor | 13.2.4 → 13.3.0 |
| google-workspace | patch | 13.1.3 → 13.1.4 |

## aws — 13.36.0 → 13.37.0
- 🌟 aws: add `aws.backup.plan.selection` with assigned resource ARNs (#8379)
- ⭐ aws.ecr: retry DescribeRepositories/DescribeImages on throttling (#8450)
- 🐎 aws: fix data race on account org-description cache (#8460)
- 🐛 aws: fix `__id` collisions for EIPs and network ACL associations (#8458)
- 🐛 aws: guard nil SDK pointer derefs and harden crash-safety (#8457)
- 🧹 ci: replace check-spelling with typos (#8461)
- 🧹 Update deps for mql and providers 20260615 (#8443)

## os — 13.28.1 → 13.29.0
- 🌟 os: add `windows.auditPolicy` with language-stable subcategory lookup (#8349)
- ⭐ os: detect CirrOS container base OS (#8374)
- ⚡ os/windows.update: pre-filter update history to succeeded installs in PowerShell (#8339)
- 🐛 os: make native `files.find` match `find -L` (symlinks + perm 0) (#8476)
- 🐛 os: filter placeholder serial numbers from platform ID detection (#8466)
- 🐛 os: fix systemd service reporting enabled/masked/static when not installed (#8465)
- 🐛 os: recover macOS package versions from Info.plist when system_profiler omits them (#8371)
- 🐛 os/pam: only treat token-initial `#` as a comment delimiter (#8347)
- 🧹 os: refactor container/docker scan handling (#8044)
- 🧹 ci: replace check-spelling with typos (#8461)
- 📄 os: document authorizedkeys init syntax with examples (#8377)

## helm — 13.2.4 → 13.3.0
- ✨ helm: parse chart provenance (.prov) for fetched charts (#8040)
- 🧹 Update deps for mql and providers 20260615 (#8443)

## google-workspace — 13.1.3 → 13.1.4
- 🐛 google-workspace: pass member-read scope when listing group members (#8373)
- 🧹 Update deps for mql and providers 20260615 (#8443)