### PR TITLE
🐛 gcp: fix nil-deref and panic crashes in resource collection

### DIFF
--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -61,6 +61,9 @@ func initGcpProjectAssetService(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
+	if args == nil {
+		args = make(map[string]*llx.RawData)
+	}
 	args["projectId"] = llx.StringData(conn.ResourceID())
 	return args, nil, nil
 }

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -311,6 +311,7 @@ func (g *mqlGcpProjectCloudRunService) operations() ([]any, error) {
 				}
 				if err != nil {
 					log.Error().Err(err).Send()
+					break
 				}
 				mqlOp, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.operation", map[string]*llx.RawData{
 					"projectId": llx.StringData(projectId),
@@ -429,7 +430,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 						"scaling":                       llx.DictData(scalingCfg),
 						"vpcAccess":                     llx.DictData(vpcCfg),
 						"vpcAccessConfig":               llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
-						"timeout":                       llx.TimeData(llx.DurationToTime((s.Template.Timeout.Seconds))),
+						"timeout":                       llx.TimeData(llx.DurationToTime(s.Template.GetTimeout().GetSeconds())),
 						"serviceAccountEmail":           llx.StringData(s.Template.ServiceAccount),
 						"containers":                    llx.ArrayData(mqlContainers, "gcp.project.cloudRunService.container"),
 						"volumes":                       llx.ArrayData(mqlVolumes(s.Template.Volumes), types.Dict),
@@ -756,7 +757,7 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 							"projectId":            llx.StringData(projectId),
 							"vpcAccess":            llx.DictData(vpcAccess),
 							"vpcAccessConfig":      llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
-							"timeout":              llx.TimeData(llx.DurationToTime((j.Template.Template.Timeout.Seconds))),
+							"timeout":              llx.TimeData(llx.DurationToTime(j.Template.Template.GetTimeout().GetSeconds())),
 							"serviceAccountEmail":  llx.StringData(j.Template.Template.ServiceAccount),
 							"containers":           llx.ArrayData(mqlContainers, types.Resource("gcp.project.cloudRunService.container")),
 							"volumes":              llx.ArrayData(mqlVolumes(j.Template.Template.Volumes), types.Dict),
@@ -941,11 +942,11 @@ func mqlContainers(runtime *plugin.Runtime, containers []*runpb.Container, templ
 		for _, e := range c.Env {
 			valueSource := e.GetValueSource()
 			var mqlValueSource map[string]any
-			if valueSource != nil {
+			if skr := valueSource.GetSecretKeyRef(); skr != nil {
 				mqlValueSource = map[string]any{
 					"secretKeyRef": map[string]any{
-						"secret":  valueSource.SecretKeyRef.Secret,
-						"version": valueSource.SecretKeyRef.Version,
+						"secret":  skr.Secret,
+						"version": skr.Version,
 					},
 				}
 			}

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -107,7 +107,7 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 			userUpdateTime = &t
 		}
 
-		mqlJob, err := CreateResource(g.MqlRuntime, "gcp.project.cloudSchedulerService.job", map[string]*llx.RawData{
+		jobArgs := map[string]*llx.RawData{
 			"projectId":                llx.StringData(projectId),
 			"name":                     llx.StringData(job.Name),
 			"schedule":                 llx.StringData(job.Schedule),
@@ -117,13 +117,19 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 			"lastAttemptTime":          llx.TimeDataPtr(lastAttemptTime),
 			"scheduleTime":             llx.TimeDataPtr(scheduleTime),
 			"userUpdateTime":           llx.TimeDataPtr(userUpdateTime),
-			"retryConfig":              llx.ResourceData(retryConfig, "gcp.retryConfig"),
 			"targetType":               llx.StringData(targetType),
 			"oidcServiceAccountEmail":  llx.StringData(oidcServiceAccountEmail),
 			"oauthServiceAccountEmail": llx.StringData(oauthServiceAccountEmail),
-		})
+		}
+		if retryConfig != nil {
+			jobArgs["retryConfig"] = llx.ResourceData(retryConfig, "gcp.retryConfig")
+		}
+		mqlJob, err := CreateResource(g.MqlRuntime, "gcp.project.cloudSchedulerService.job", jobArgs)
 		if err != nil {
 			return nil, err
+		}
+		if retryConfig == nil {
+			mqlJob.(*mqlGcpProjectCloudSchedulerServiceJob).RetryConfig.State = plugin.StateIsNull | plugin.StateIsSet
 		}
 		res = append(res, mqlJob)
 	}

--- a/providers/gcp/resources/cloudtasks.go
+++ b/providers/gcp/resources/cloudtasks.go
@@ -96,16 +96,22 @@ func (g *mqlGcpProjectCloudTasksService) queues() ([]any, error) {
 				return nil, err
 			}
 
-			mqlQueue, err := CreateResource(g.MqlRuntime, "gcp.project.cloudTasksService.queue", map[string]*llx.RawData{
+			queueArgs := map[string]*llx.RawData{
 				"projectId":                llx.StringData(projectId),
 				"name":                     llx.StringData(queue.Name),
 				"state":                    llx.StringData(queue.State.String()),
 				"rateLimits":               llx.DictData(rateLimits),
-				"retryConfig":              llx.ResourceData(retryConfig, "gcp.retryConfig"),
 				"appEngineRoutingOverride": llx.DictData(appEngineRouting),
-			})
+			}
+			if retryConfig != nil {
+				queueArgs["retryConfig"] = llx.ResourceData(retryConfig, "gcp.retryConfig")
+			}
+			mqlQueue, err := CreateResource(g.MqlRuntime, "gcp.project.cloudTasksService.queue", queueArgs)
 			if err != nil {
 				return nil, err
+			}
+			if retryConfig == nil {
+				mqlQueue.(*mqlGcpProjectCloudTasksServiceQueue).RetryConfig.State = plugin.StateIsNull | plugin.StateIsSet
 			}
 			res = append(res, mqlQueue)
 		}

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -280,7 +280,12 @@ func (g *mqlGcpProjectLoggingserviceMetric) alertPolicies() ([]any, error) {
 }
 
 func parseAlertPolicyConditionFilterMetricName(condition map[string]any) string {
-	filter := condition["filter"].(string)
+	// Not every alert-policy condition carries a "filter" (e.g. monitoringQueryLanguage
+	// conditions only have a "query"), so guard the assertion to avoid a panic.
+	filter, ok := condition["filter"].(string)
+	if !ok {
+		return ""
+	}
 	// The filter is composed of multiple statements split by AND or OR and spaces in between
 	parts := strings.Split(filter, " ")
 	for _, p := range parts {

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -38,8 +38,11 @@ func newMqlRecommendation(runtime *plugin.Runtime, item *recommenderpb.Recommend
 	priority := item.Priority.String()
 	state, _ := convert.JsonToDict(item.StateInfo)
 
-	// /projects/{projectid}/locations/{zone}/recommenders/{recommender}/recommendations/{id}
+	// projects/{projectid}/locations/{zone}/recommenders/{recommender}/recommendations/{id}
 	values := strings.Split(item.Name, "/")
+	if len(values) < 8 {
+		return nil, fmt.Errorf("unexpected recommendation name format: %q", item.Name)
+	}
 
 	res, err := CreateResource(runtime, "gcp.recommendation", map[string]*llx.RawData{
 		"id":               llx.StringData(values[7]),


### PR DESCRIPTION
## What

Fixes several GCP resource accessors that could panic and crash the **entire** scan. The executor runs blocks in goroutines, so an unhandled panic is unrecoverable and takes down the whole run — not just the one field.

All issues were found by a static audit of the provider and verified against the source.

### Fixes
- **cloudrun `operations()`** — on a non-`Done` iterator error the loop logged but did not `break`, then dereferenced a nil `t` (`t.Name`) → panic. (`services()`/`jobs()` already handle this correctly.)
- **cloudrun service/job revision templates** — dereferenced the nullable `Timeout.Seconds` directly; a template without an explicit timeout (common) panicked. Now `GetTimeout().GetSeconds()`.
- **cloudrun container env** — dereferenced `valueSource.SecretKeyRef` which is a nullable oneof; guarded with `GetSecretKeyRef()`.
- **recommendations** — indexed `values[7]/[5]/[3]/[1]` after splitting the resource name with no bounds check, inside a bare goroutine. Now guards the length.
- **cloudTasks queue / cloudScheduler job `retryConfig`** — a queue/job without a retry config stored a typed-nil `*mqlGcpRetryConfig` into a non-nullable field; querying it dereferenced a nil receiver. Now omits the arg and marks the field null (matches the pubsub `schemaSettings` pattern).
- **asset service init** — wrote to a possibly-nil `args` map; now guarded like the other init functions.
- **logging `alertPolicies`** — `parseAlertPolicyConditionFilterMetricName` did an unchecked `condition["filter"].(string)`, but `monitoringQueryLanguage` conditions have no `filter` key → panic. Now comma-ok.

## Test
`go build ./resources/...` passes. Behavioral changes are defensive guards on existing code paths.