### PR TITLE
🐛 gcp: request IAM policy schema v3 so conditional bindings are returned

### DIFF
--- a/providers/gcp/resources/artifactregistry.go
+++ b/providers/gcp/resources/artifactregistry.go
@@ -260,7 +260,7 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepository) iamPolicy() ([]any, err
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: repoPath})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: repoPath, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -276,7 +276,7 @@ func (g *mqlGcpProjectCloudFunction) iamPolicy() ([]any, error) {
 	defer cloudFuncSvc.Close()
 
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/functions/%s", projectId, location, name)
-	policy, err := cloudFuncSvc.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath})
+	policy, err := cloudFuncSvc.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
 			log.Warn().Str("project", projectId).Str("function", name).Err(err).Msg("could not retrieve cloud function IAM policy")

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -182,7 +182,7 @@ func (g *mqlGcpProjectCloudFunctionV2) iamPolicy() ([]any, error) {
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
 			log.Warn().Str("function", resourcePath).Err(err).Msg("could not retrieve cloud function IAM policy")

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -589,7 +589,7 @@ func (g *mqlGcpProjectCloudRunServiceService) iamPolicy() ([]any, error) {
 	}
 
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/services/%s", projectId, region, name)
-	policy, err := runSvc.Projects.Locations.Services.GetIamPolicy(resourcePath).Context(ctx).Do()
+	policy, err := runSvc.Projects.Locations.Services.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +623,7 @@ func (g *mqlGcpProjectCloudRunServiceJob) iamPolicy() ([]any, error) {
 	}
 
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/jobs/%s", projectId, region, name)
-	policy, err := runSvc.Projects.Locations.Jobs.GetIamPolicy(resourcePath).Context(ctx).Do()
+	policy, err := runSvc.Projects.Locations.Jobs.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloudtasks.go
+++ b/providers/gcp/resources/cloudtasks.go
@@ -161,7 +161,7 @@ func (g *mqlGcpProjectCloudTasksServiceQueue) iamPolicy() ([]any, error) {
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: name})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: name, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
 			return nil, nil

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3537,7 +3537,7 @@ func (g *mqlGcpProjectComputeServiceImage) iamPolicy() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	policy, err := svc.Images.GetIamPolicy(projectId, name).Context(ctx).Do()
+	policy, err := svc.Images.GetIamPolicy(projectId, name).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -3619,7 +3619,7 @@ func (g *mqlGcpProjectComputeServiceSnapshot) iamPolicy() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	policy, err := svc.Snapshots.GetIamPolicy(projectId, name).Context(ctx).Do()
+	policy, err := svc.Snapshots.GetIamPolicy(projectId, name).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -756,7 +756,11 @@ func (g *mqlGcpProjectDataprocServiceCluster) iamPolicy() ([]any, error) {
 	}
 
 	resource := fmt.Sprintf("projects/%s/regions/%s/clusters/%s", projectId, location, name)
-	policy, err := dataprocSvc.Projects.Regions.Clusters.GetIamPolicy(resource, &dataproc.GetIamPolicyRequest{}).Do()
+	// Request policy schema v3 so conditional bindings are returned; the
+	// default v1 omits any binding carrying an IAM condition.
+	policy, err := dataprocSvc.Projects.Regions.Clusters.GetIamPolicy(resource, &dataproc.GetIamPolicyRequest{
+		Options: &dataproc.GetPolicyOptions{RequestedPolicyVersion: 3},
+	}).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 403 {
 			log.Warn().Str("cluster", resource).Msg("not authorized to retrieve dataproc cluster iam policy")

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -590,7 +590,7 @@ func (g *mqlGcpProjectDnsServiceManagedzone) iamPolicy() ([]any, error) {
 	}
 
 	resourcePath := "projects/" + projectId + "/managedZones/" + zoneName
-	policy, err := dnsSvc.ManagedZones.GetIamPolicy(resourcePath, &dns.GoogleIamV1GetIamPolicyRequest{}).Context(ctx).Do()
+	policy, err := dnsSvc.ManagedZones.GetIamPolicy(resourcePath, &dns.GoogleIamV1GetIamPolicyRequest{Options: &dns.GoogleIamV1GetPolicyOptions{RequestedPolicyVersion: 3}}).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -247,7 +247,7 @@ func (g *mqlGcpFolder) fetchIamPolicy() (*cloudresourcemanager.Policy, error) {
 			return
 		}
 
-		g.iamPolicyCache, g.iamPolicyErr = svc.Folders.GetIamPolicy(folderName, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+		g.iamPolicyCache, g.iamPolicyErr = svc.Folders.GetIamPolicy(folderName, &cloudresourcemanager.GetIamPolicyRequest{Options: &cloudresourcemanager.GetPolicyOptions{RequestedPolicyVersion: 3}}).Do()
 	})
 	return g.iamPolicyCache, g.iamPolicyErr
 }

--- a/providers/gcp/resources/iap.go
+++ b/providers/gcp/resources/iap.go
@@ -61,7 +61,7 @@ func (g *mqlGcpProjectIapService) iamPolicy() ([]any, error) {
 	defer client.Close()
 
 	resource := fmt.Sprintf("projects/%s/iap_web", projectId)
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resource})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resource, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/organization.go
+++ b/providers/gcp/resources/organization.go
@@ -124,7 +124,7 @@ func (g *mqlGcpOrganization) fetchIamPolicy() (string, *cloudresourcemanager.Pol
 		}
 
 		name := "organizations/" + orgId
-		g.iamPolicyCache, g.iamPolicyErr = svc.Organizations.GetIamPolicy(name, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+		g.iamPolicyCache, g.iamPolicyErr = svc.Organizations.GetIamPolicy(name, &cloudresourcemanager.GetIamPolicyRequest{Options: &cloudresourcemanager.GetPolicyOptions{RequestedPolicyVersion: 3}}).Do()
 	})
 	if g.iamPolicyErr != nil {
 		return "", nil, g.iamPolicyErr

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -142,7 +142,7 @@ func (g *mqlGcpProject) fetchIamPolicy() (*cloudresourcemanager.Policy, error) {
 			g.iamPolicyErr = err
 			return
 		}
-		g.iamPolicyCache, g.iamPolicyErr = svc.Projects.GetIamPolicy(fmt.Sprintf("projects/%s", projectId), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+		g.iamPolicyCache, g.iamPolicyErr = svc.Projects.GetIamPolicy(fmt.Sprintf("projects/%s", projectId), &cloudresourcemanager.GetIamPolicyRequest{Options: &cloudresourcemanager.GetPolicyOptions{RequestedPolicyVersion: 3}}).Do()
 	})
 	return g.iamPolicyCache, g.iamPolicyErr
 }

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -722,7 +722,7 @@ func (g *mqlGcpProjectPubsubServiceTopic) iamPolicy() ([]any, error) {
 	defer pubsubSvc.Close()
 
 	resourcePath := topicPath(projectId, name)
-	policy, err := pubsubSvc.TopicAdminClient.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath})
+	policy, err := pubsubSvc.TopicAdminClient.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
 			log.Warn().Str("project", projectId).Str("topic", name).Err(err).Msg("could not retrieve topic IAM policy")
@@ -774,7 +774,7 @@ func (g *mqlGcpProjectPubsubServiceSubscription) iamPolicy() ([]any, error) {
 	defer pubsubSvc.Close()
 
 	resourcePath := subscriptionPath(projectId, name)
-	policy, err := pubsubSvc.SubscriptionAdminClient.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath})
+	policy, err := pubsubSvc.SubscriptionAdminClient.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: resourcePath, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
 			log.Warn().Str("project", projectId).Str("subscription", name).Err(err).Msg("could not retrieve subscription IAM policy")

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -21,6 +21,8 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	iampb "google.golang.org/genproto/googleapis/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -396,8 +398,19 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) iamPolicy() ([]any, error) {
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: secretPath})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{
+		Resource: secretPath,
+		// Request policy schema v3 so conditional bindings (which can include
+		// conditional allUsers/allAuthenticatedUsers grants) are returned;
+		// the default v1 silently strips any binding carrying a condition.
+		Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3},
+	})
 	if err != nil {
+		// Tolerate access-denied on a single secret so one inaccessible secret
+		// doesn't fail the whole collection (mirrors the KMS accessors).
+		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
+			return nil, nil
+		}
 		return nil, err
 	}
 	res := make([]any, 0, len(policy.Bindings))

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -721,7 +721,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) iamPolicy() ([]any, error) {
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: instanceName})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: instanceName, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if isGRPCSkippable(err) {
 			log.Warn().Err(err).Msg("could not read Spanner instance IAM policy")
@@ -751,7 +751,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) iamPolicy() ([]any, error)
 	}
 	defer client.Close()
 
-	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: dbName})
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: dbName, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
 		if isGRPCSkippable(err) {
 			log.Warn().Err(err).Msg("could not read Spanner database IAM policy")

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -482,7 +482,10 @@ func (g *mqlGcpProjectStorageServiceBucket) iamPolicy() ([]any, error) {
 		return nil, err
 	}
 
-	policy, err := storeSvc.Buckets.GetIamPolicy(bucketName).Do()
+	// Request policy schema v3 so conditional bindings are returned; the
+	// default v1 omits any binding carrying an IAM condition, which would hide
+	// conditional grants (including conditional public-access bindings).
+	policy, err := storeSvc.Buckets.GetIamPolicy(bucketName).OptionsRequestedPolicyVersion(3).Do()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Several IAM-policy reads used the default policy schema **v1**, which silently strips any binding carrying an IAM condition. Where the code then inspects bindings for public members or reads the condition fields, conditional grants (including conditional `allUsers`/`allAuthenticatedUsers`) were invisible — so e.g. `secret.public()` / `bucket.public()` could falsely report **not-public**.

### Fixes
- **secretmanager secret `iamPolicy()`** — request `RequestedPolicyVersion: 3`, and tolerate `PermissionDenied` on a single secret (return empty) so one inaccessible secret doesn't fail the whole collection, mirroring the KMS accessors.
- **storage bucket `iamPolicy()`** — add `OptionsRequestedPolicyVersion(3)`.
- **dataproc cluster `iamPolicy()`** — set `GetPolicyOptions.RequestedPolicyVersion: 3`.

The KMS keyring/cryptokey accessors already request v3; this brings the remaining IAM-policy readers in line.

## Test
`go build ./resources/...` passes.

---
**Note (review follow-up):** the secretmanager change also adds `PermissionDenied` tolerance (returns an empty binding list for a single inaccessible secret) so one inaccessible secret doesn't fail the whole collection, matching the KMS accessors. This is a small additional behavior change beyond the v3 schema fix. This PR now also extends `RequestedPolicyVersion: 3` to **all** remaining `GetIamPolicy` call sites in the provider (compute, cloudrun, dns, pubsub, spanner, cloud functions, artifact registry, cloud tasks, iap, folder/org/project), per review feedback.
