### PR TITLE
🐛 gcp: fix swallowed errors and over-strict error handling

### DIFF
--- a/providers/gcp/resources/appengine.go
+++ b/providers/gcp/resources/appengine.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/appengine/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -57,6 +59,13 @@ func (g *mqlGcpProjectAppEngineService) application() (*mqlGcpProjectAppEngineSe
 
 	app, err := svc.Apps.Get(projectId).Do()
 	if err != nil {
+		// App Engine returns 404 when the project has no application and 403
+		// when the API is disabled; treat both as "no application" so a
+		// project-wide scan doesn't fail on the common no-app case.
+		if gerr, ok := err.(*googleapi.Error); ok && (gerr.Code == 403 || gerr.Code == 404) {
+			g.Application.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1077,7 +1077,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				return storage.Error
 			}
 			buckets := storage.Data.GetBuckets()
-			if buckets == nil {
+			if buckets.Error != nil {
 				return buckets.Error
 			}
 			for i := range buckets.Data {

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -352,7 +352,7 @@ func (g *mqlGcpProjectKmsService) keyrings() ([]any, error) {
 					break
 				}
 				if err != nil {
-					log.Error().Err(err)
+					log.Error().Err(err).Str("location", location).Msg("could not list kms keyrings")
 					return
 				}
 
@@ -365,7 +365,7 @@ func (g *mqlGcpProjectKmsService) keyrings() ([]any, error) {
 					"location":     llx.StringData(location),
 				})
 				if err != nil {
-					log.Error().Err(err)
+					log.Error().Err(err).Str("location", location).Msg("could not create kms keyring resource")
 					return
 				}
 				mux.Lock()
@@ -520,6 +520,9 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokey) versions() ([]any, error) {
 		}
 
 		mqlVersion, err := cryptoKeyVersionToMql(g.MqlRuntime, v)
+		if err != nil {
+			return nil, err
+		}
 		versions = append(versions, mqlVersion)
 	}
 	return versions, nil


### PR DESCRIPTION
## What

Four error-handling defects that either silently dropped data or failed a whole query unnecessarily.

### Fixes
- **discovery (storage buckets)** — the guard `if buckets == nil` is always false (`GetBuckets()` returns a `*plugin.TValue` that is never nil), so a bucket-listing error was silently swallowed (and the body would nil-deref if it ever were nil). Now checks `buckets.Error`, so the error flows through `runDiscoveryStep`'s skippable-error handling. (Independently flagged by the `nilness` linter.)
- **kms `keyrings()`** — the two per-location goroutine error paths used `log.Error().Err(err)` with no terminal `.Msg()`/`.Send()`, so the zerolog event was never emitted — a per-location failure silently dropped that location's keyrings with no trace. Added a message.
- **kms cryptokey `versions()`** — the error from `cryptoKeyVersionToMql` was ignored and a nil version appended to the list (other call sites check it), risking a downstream nil-deref. Now returns the error.
- **appEngine `application()`** — `Apps.Get` returned its 404/403 verbatim, so a project with no App Engine application (or the API disabled) failed the whole query. Now tolerates 403/404 and returns a null application, matching the apiGateway/workstations/cloudDomains accessors.

## Test
`go build ./resources/...` passes.