### PR TITLE
upstream: add retry helpers for transient platform failures

### DIFF
--- a/providers-sdk/v1/upstream/retry.go
+++ b/providers-sdk/v1/upstream/retry.go
@@ -1,0 +1,121 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+// Retry tuning for upstream calls. Transient failures (network blips, 5xx, 429,
+// transient RPC codes) are retried with bounded exponential backoff and full
+// jitter rather than failing the whole operation.
+const (
+	// DefaultRetryAttempts is the maximum number of attempts WithRetry makes.
+	DefaultRetryAttempts = 5
+
+	retryBaseBackoff = 500 * time.Millisecond
+	retryMaxBackoff  = 30 * time.Second
+)
+
+// WithRetry runs fn up to DefaultRetryAttempts times. fn reports whether its
+// error is retryable and an optional explicit wait (e.g. a parsed Retry-After
+// header). Backoff is exponential with full jitter, capped at retryMaxBackoff,
+// and aborts promptly on context cancellation. A nil error returns immediately;
+// `what` labels the operation in the returned error.
+func WithRetry(ctx context.Context, what string, fn func() (retryable bool, retryAfter time.Duration, err error)) error {
+	var lastErr error
+	for attempt := 1; attempt <= DefaultRetryAttempts; attempt++ {
+		retryable, retryAfter, err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryable || attempt == DefaultRetryAttempts {
+			break
+		}
+		wait := retryAfter
+		if wait <= 0 {
+			wait = retryBackoff(attempt)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: %w (after %d attempt(s), last error: %v)", what, ctx.Err(), attempt, lastErr)
+		case <-time.After(wait):
+		}
+	}
+	return fmt.Errorf("%s (after %d attempt(s)): %w", what, DefaultRetryAttempts, lastErr)
+}
+
+// RetryRPC retries a Mondoo upstream RPC on transient errors (see
+// RetryableRPCError) with bounded exponential backoff. Permanent errors
+// (Unauthenticated, PermissionDenied, InvalidArgument, NotFound, …) fail fast
+// without spending the attempt budget. The call must be idempotent — the caller
+// is responsible for only wrapping RPCs that are safe to repeat.
+func RetryRPC(ctx context.Context, what string, fn func() error) error {
+	return WithRetry(ctx, what, func() (bool, time.Duration, error) {
+		err := fn()
+		return RetryableRPCError(err), 0, err
+	})
+}
+
+// RetryableRPCError reports whether a ranger RPC error is transient and worth
+// retrying. A nil error is not retryable. Transient codes (Unavailable,
+// DeadlineExceeded, ResourceExhausted, Aborted) cover backend hiccups and
+// overload; Unknown covers raw transport/network failures that never carry a
+// ranger status. Permanent codes fail fast.
+func RetryableRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted,
+		codes.Aborted, codes.Unknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// RetryableHTTPStatus reports whether an HTTP response status warrants a retry:
+// 429 (rate limited) and any 5xx (transient server/storage error). Other 4xx
+// are permanent (bad request, auth, expired URL) and are not retried.
+func RetryableHTTPStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+// RetryAfter parses a Retry-After header (delay-seconds form) into a duration,
+// returning 0 when absent or unparseable so the caller falls back to backoff.
+func RetryAfter(h http.Header) time.Duration {
+	v := h.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return 0
+}
+
+// retryBackoff returns the exponential-with-full-jitter delay for the given
+// attempt (1-based), capped at retryMaxBackoff. Jitter spreads retries across a
+// fleet so they don't synchronize into a thundering herd.
+func retryBackoff(attempt int) time.Duration {
+	// Guard against shift/multiply overflow (which would wrap to a negative
+	// duration) for large attempts: clamp to retryMaxBackoff.
+	d := retryMaxBackoff
+	if shift := attempt - 1; shift < 62 {
+		if scaled := retryBaseBackoff * (1 << shift); scaled > 0 && scaled < retryMaxBackoff {
+			d = scaled
+		}
+	}
+	return time.Duration(rand.Int64N(int64(d)) + 1) //nolint:gosec // jitter, not security-sensitive
+}

--- a/providers-sdk/v1/upstream/retry_test.go
+++ b/providers-sdk/v1/upstream/retry_test.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upstream
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+func TestRetryableRPCError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unavailable", status.Error(codes.Unavailable, "down"), true},
+		{"deadline", status.Error(codes.DeadlineExceeded, "slow"), true},
+		{"resource exhausted", status.Error(codes.ResourceExhausted, "throttled"), true},
+		{"aborted", status.Error(codes.Aborted, "conflict"), true},
+		{"plain transport error (unknown)", errors.New("connection reset"), true},
+		{"unauthenticated", status.Error(codes.Unauthenticated, "no creds"), false},
+		{"permission denied", status.Error(codes.PermissionDenied, "nope"), false},
+		{"invalid argument", status.Error(codes.InvalidArgument, "bad"), false},
+		{"not found", status.Error(codes.NotFound, "missing"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RetryableRPCError(tt.err))
+		})
+	}
+}
+
+func TestRetryableHTTPStatus(t *testing.T) {
+	assert.True(t, RetryableHTTPStatus(http.StatusTooManyRequests))
+	assert.True(t, RetryableHTTPStatus(http.StatusInternalServerError))
+	assert.True(t, RetryableHTTPStatus(http.StatusBadGateway))
+	assert.False(t, RetryableHTTPStatus(http.StatusOK))
+	assert.False(t, RetryableHTTPStatus(http.StatusBadRequest))
+	assert.False(t, RetryableHTTPStatus(http.StatusUnauthorized))
+	assert.False(t, RetryableHTTPStatus(http.StatusForbidden))
+}
+
+func TestRetryAfter(t *testing.T) {
+	mk := func(v string) http.Header {
+		h := http.Header{}
+		if v != "" {
+			h.Set("Retry-After", v)
+		}
+		return h
+	}
+	assert.Equal(t, 5*time.Second, RetryAfter(mk("5")))
+	assert.Equal(t, time.Duration(0), RetryAfter(mk("")))
+	assert.Equal(t, time.Duration(0), RetryAfter(mk("Wed, 21 Oct 2026 07:28:00 GMT"))) // HTTP-date form unsupported
+	assert.Equal(t, time.Duration(0), RetryAfter(mk("-1")))
+}
+
+func TestWithRetry_SucceedsImmediately(t *testing.T) {
+	calls := 0
+	err := WithRetry(context.Background(), "op", func() (bool, time.Duration, error) {
+		calls++
+		return false, 0, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWithRetry_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	err := WithRetry(context.Background(), "op", func() (bool, time.Duration, error) {
+		calls++
+		if calls < 3 {
+			return true, time.Nanosecond, errors.New("transient")
+		}
+		return false, 0, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestWithRetry_NonRetryableFailsFast(t *testing.T) {
+	calls := 0
+	err := WithRetry(context.Background(), "op", func() (bool, time.Duration, error) {
+		calls++
+		return false, 0, errors.New("permanent")
+	})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "non-retryable error must not retry")
+}
+
+func TestWithRetry_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	err := WithRetry(context.Background(), "op", func() (bool, time.Duration, error) {
+		calls++
+		return true, time.Nanosecond, errors.New("always transient")
+	})
+	require.Error(t, err)
+	assert.Equal(t, DefaultRetryAttempts, calls)
+}
+
+func TestWithRetry_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := WithRetry(ctx, "op", func() (bool, time.Duration, error) {
+		calls++
+		cancel() // cancel before the backoff wait
+		return true, time.Hour, errors.New("transient")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryRPC_FailsFastOnPermanent(t *testing.T) {
+	calls := 0
+	err := RetryRPC(context.Background(), "rpc", func() error {
+		calls++
+		return status.Error(codes.Unauthenticated, "no creds")
+	})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "permanent RPC error must not retry")
+}


### PR DESCRIPTION
Adds small, reusable retry helpers to the `upstream` package so consumers that talk to the Mondoo platform can retry transient failures (network blips, 5xx, 429, transient RPC codes) with bounded exponential backoff + full jitter, instead of each reimplementing it. `ranger-rpc` itself ships no retry.

### API
- `WithRetry(ctx, what, fn)` — generic attempt loop; `fn` reports retryable + an optional explicit wait (e.g. parsed `Retry-After`). Exponential backoff, full jitter, capped, context-aware.
- `RetryRPC(ctx, what, fn)` — retries a ranger RPC on transient codes; the caller is responsible for only wrapping idempotent calls.
- `RetryableRPCError(err)` — classifies against **ranger** status codes: `Unavailable`/`DeadlineExceeded`/`ResourceExhausted`/`Aborted` (transient), `Unknown` (raw transport/network errors that carry no ranger status), everything else permanent → fail fast.
- `RetryableHTTPStatus(code)` — 429 + any 5xx (for signed-URL PUTs etc.).
- `RetryAfter(h)` — parses the delay-seconds form of `Retry-After`.

### Notes
- Classifying against `go.mondoo.com/ranger-rpc/status` (not `grpc/status`) matters: ranger clients return ranger-status errors, so a grpc-based classifier would see every ranger error as `Unknown` and retry even permanent failures. This version fails fast correctly.
- Defaults: 5 attempts, 500ms base, 30s cap. Kept simple; can grow an options struct if needed.
- Unit tests cover classification, backoff exhaustion, fail-fast, and context cancellation.

Factored out of a downstream consumer that was carrying its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)