### PR TITLE
🐛 azure: fix nil-deref and panic crashes in resource collection

### DIFF
--- a/providers/azure/connection/client_subscriptions.go
+++ b/providers/azure/connection/client_subscriptions.go
@@ -33,13 +33,13 @@ func (client *subscriptionsClient) GetSubscriptions(filter SubscriptionsFilter) 
 	subscriptionsC, err := subscriptions.NewClient(client.token, &arm.ClientOptions{
 		ClientOptions: client.clientOptions,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	ctx := context.Background()
 	subs := []subscriptions.Subscription{}
 	res := subscriptionsC.NewListPager(&subscriptions.ClientListOptions{})
-	if err != nil {
-		return nil, err
-	}
 	for res.More() {
 		page, err := res.NextPage(ctx)
 		if err != nil {

--- a/providers/azure/connection/client_subscriptions.go
+++ b/providers/azure/connection/client_subscriptions.go
@@ -36,7 +36,6 @@ func (client *subscriptionsClient) GetSubscriptions(filter SubscriptionsFilter) 
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
 	subs := []subscriptions.Subscription{}
 	res := subscriptionsC.NewListPager(&subscriptions.ClientListOptions{})

--- a/providers/azure/resources/automation.go
+++ b/providers/azure/resources/automation.go
@@ -92,7 +92,13 @@ func (a *mqlAzureSubscriptionAutomationService) accounts() ([]any, error) {
 }
 
 func automationAccountToMql(runtime *plugin.Runtime, acct *armautomation.Account) (*mqlAzureSubscriptionAutomationServiceAccount, error) {
-	sku, err := convert.JsonToDict(acct.Properties.SKU)
+	// Properties is a nullable pointer; guard before reading SKU (the nil guard
+	// for the remaining property reads is already below).
+	var skuRaw any
+	if acct.Properties != nil {
+		skuRaw = acct.Properties.SKU
+	}
+	sku, err := convert.JsonToDict(skuRaw)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -198,6 +198,12 @@ type mqlAzureSubscriptionAuthorizationServiceRoleAssignmentInternal struct {
 }
 
 func newMqlRoleAssignment(runtime *plugin.Runtime, roleAssignment *authorization.RoleAssignment) (*mqlAzureSubscriptionAuthorizationServiceRoleAssignment, error) {
+	// Properties is a nullable pointer; the args map dereferences it throughout,
+	// so normalize to an empty struct to avoid a panic (mirrors the
+	// denyAssignments/classicAdministrators paths below).
+	if roleAssignment.Properties == nil {
+		roleAssignment.Properties = &authorization.RoleAssignmentProperties{}
+	}
 	principalType := string(convert.ToValue(roleAssignment.Properties.PrincipalType))
 	r, err := CreateResource(runtime, "azure.subscription.authorizationService.roleAssignment",
 		map[string]*llx.RawData{
@@ -373,13 +379,21 @@ type mqlAzureSubscriptionManagedIdentityInternal struct {
 }
 
 func newMqlManagedIdentity(runtime *plugin.Runtime, managedIdentity *armmsi.Identity) (*mqlAzureSubscriptionManagedIdentity, error) {
+	// Properties (and the *TenantID inside it) are nullable; guard before
+	// dereferencing to avoid a panic on a partially-populated identity.
+	var clientID, principalID, tenantID *string
+	if p := managedIdentity.Properties; p != nil {
+		clientID = p.ClientID
+		principalID = p.PrincipalID
+		tenantID = (*string)(p.TenantID)
+	}
 	r, err := CreateResource(runtime, "azure.subscription.managedIdentity",
 		map[string]*llx.RawData{
 			"__id":        llx.StringDataPtr(managedIdentity.ID),
 			"name":        llx.StringDataPtr(managedIdentity.Name),
-			"clientId":    llx.StringDataPtr(managedIdentity.Properties.ClientID),
-			"principalId": llx.StringDataPtr(managedIdentity.Properties.PrincipalID),
-			"tenantId":    llx.StringData(string(*managedIdentity.Properties.TenantID)),
+			"clientId":    llx.StringDataPtr(clientID),
+			"principalId": llx.StringDataPtr(principalID),
+			"tenantId":    llx.StringDataPtr(tenantID),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -104,6 +104,9 @@ func (a *mqlAzureSubscriptionMonitorService) logProfiles() ([]any, error) {
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil || entry.Properties == nil {
+				continue
+			}
 
 			properties, err := convert.JsonToDict(entry.Properties)
 			if err != nil {
@@ -304,17 +307,26 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]any, error) 
 		}
 
 		for _, entry := range page.Value {
+			if entry == nil || entry.Properties == nil {
+				continue
+			}
 			actions := []mqlAlertAction{}
 			conditions := []mqlAlertCondition{}
 
-			for _, act := range entry.Properties.Actions.ActionGroups {
-				mqlAction := mqlAlertAction{
-					ActionGroupId:     convert.ToValue(act.ActionGroupID),
-					WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
+			if entry.Properties.Actions != nil {
+				for _, act := range entry.Properties.Actions.ActionGroups {
+					mqlAction := mqlAlertAction{
+						ActionGroupId:     convert.ToValue(act.ActionGroupID),
+						WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
+					}
+					actions = append(actions, mqlAction)
 				}
-				actions = append(actions, mqlAction)
 			}
-			for _, cond := range entry.Properties.Condition.AllOf {
+			var allOf []*monitor.AlertRuleAnyOfOrLeafCondition
+			if entry.Properties.Condition != nil {
+				allOf = entry.Properties.Condition.AllOf
+			}
+			for _, cond := range allOf {
 				anyOf := []mqlAlertLeafCondition{}
 				for _, leaf := range cond.AnyOf {
 					mqlAnyOfLeaf := mqlAlertLeafCondition{

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1365,6 +1365,16 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 				return nil, err
 			}
 			for _, vng := range page.Value {
+				// Properties and the nested SKU are nullable pointers; a gateway
+				// in a transient/failed state can return either as nil. The args
+				// map below dereferences them throughout, so normalize to empty
+				// structs to avoid a scan-killing panic.
+				if vng.Properties == nil {
+					vng.Properties = &network.VirtualNetworkGatewayPropertiesFormat{}
+				}
+				if vng.Properties.SKU == nil {
+					vng.Properties.SKU = &network.VirtualNetworkGatewaySKU{}
+				}
 				props, err := convert.JsonToDict(vng.Properties)
 				if err != nil {
 					return nil, err
@@ -2506,15 +2516,18 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) connections() 
 			return nil, err
 		}
 		for _, c := range page.Value {
+			if c.Properties == nil {
+				continue
+			}
 			// the API does not let us get connections, applicable to a given gateway.
 			// Therefore we filter them manually here.
 			filter := []string{}
 			// primary gateway
-			if c.Properties.VirtualNetworkGateway1 != nil {
+			if c.Properties.VirtualNetworkGateway1 != nil && c.Properties.VirtualNetworkGateway1.ID != nil {
 				filter = append(filter, *c.Properties.VirtualNetworkGateway1.ID)
 			}
 			// secondary, optional (only if Vnet2Vnet connection)
-			if c.Properties.VirtualNetworkGateway2 != nil {
+			if c.Properties.VirtualNetworkGateway2 != nil && c.Properties.VirtualNetworkGateway2.ID != nil {
 				filter = append(filter, *c.Properties.VirtualNetworkGateway2.ID)
 			}
 			if !stringx.Contains(filter, id) {

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -147,7 +147,9 @@ func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {
 				return nil, err
 			}
 			mqlRedis := cacheData.(*mqlAzureSubscriptionCacheServiceRedisInstance)
-			mqlRedis.cachePrivateEndpointConnections = cache.Properties.PrivateEndpointConnections
+			if cache.Properties != nil {
+				mqlRedis.cachePrivateEndpointConnections = cache.Properties.PrivateEndpointConnections
+			}
 			caches = append(caches, mqlRedis)
 		}
 	}

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -158,6 +158,13 @@ func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {
 }
 
 func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.ResourceInfo) (map[string]*llx.RawData, error) {
+	// Properties is a nullable pointer that the field reads below dereference
+	// throughout; normalize to an empty struct so a cache returned without
+	// properties doesn't panic here (the callers reach this before their own
+	// nil guards).
+	if cache.Properties == nil {
+		cache.Properties = &armredis.Properties{}
+	}
 	properties, err := convert.JsonToDict(cache)
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -243,6 +243,11 @@ func (a *mqlAzureSubscriptionSqlServiceServer) databases() ([]any, error) {
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			// Properties is a nullable pointer; the args map below dereferences
+			// it throughout, so normalize to an empty struct to avoid a panic.
+			if entry.Properties == nil {
+				entry.Properties = &sql.DatabaseProperties{}
+			}
 			var editionTier *string
 			if entry.SKU != nil {
 				editionTier = entry.SKU.Tier
@@ -614,6 +619,15 @@ func (a *mqlAzureSubscriptionSqlServiceServer) vulnerabilityAssessmentSettings()
 	vaSettings, err := serverClient.Get(ctx, resourceID.ResourceGroup, server, sql.VulnerabilityAssessmentNameDefault, &sql.ServerVulnerabilityAssessmentsClientGetOptions{})
 	if err != nil {
 		return nil, err
+	}
+	// Properties and the nested RecurringScans are nullable; a server with VA
+	// configured but no recurring scans returns RecurringScans == nil. The args
+	// map dereferences both, so normalize to empty structs to avoid a panic.
+	if vaSettings.Properties == nil {
+		vaSettings.Properties = &sql.ServerVulnerabilityAssessmentProperties{}
+	}
+	if vaSettings.Properties.RecurringScans == nil {
+		vaSettings.Properties.RecurringScans = &sql.VulnerabilityAssessmentRecurringScansProperties{}
 	}
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.server.vulnerabilityassessmentsettings",
 		map[string]*llx.RawData{

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -429,13 +429,17 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) dataProtection() (*mqlAzureS
 	var blobRetentionDays *int32
 	var containerSoftDeletionEnabled bool
 	var containerRetentionDays *int32
-	if properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy != nil {
-		blobSoftDeletionEnabled = convert.ToValue(properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy.Enabled)
-		blobRetentionDays = properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy.Days
-	}
-	if properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy != nil {
-		containerSoftDeletionEnabled = convert.ToValue(properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy.Enabled)
-		containerRetentionDays = properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy.Days
+	// The inner BlobServiceProperties pointer is nullable (empty body for an
+	// account with no blob service settings); guard before dereferencing.
+	if inner := properties.BlobServiceProperties.BlobServiceProperties; inner != nil {
+		if inner.DeleteRetentionPolicy != nil {
+			blobSoftDeletionEnabled = convert.ToValue(inner.DeleteRetentionPolicy.Enabled)
+			blobRetentionDays = inner.DeleteRetentionPolicy.Days
+		}
+		if inner.ContainerDeleteRetentionPolicy != nil {
+			containerSoftDeletionEnabled = convert.ToValue(inner.ContainerDeleteRetentionPolicy.Enabled)
+			containerRetentionDays = inner.ContainerDeleteRetentionPolicy.Days
+		}
 	}
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionStorageServiceAccountDataProtection,
@@ -573,7 +577,33 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) getServiceStorageProperties(
 	return props, nil
 }
 
+// normalizeServiceProperties fills in empty structs for the nullable
+// logging/metrics pointers (and their retention policies) so the callers that
+// dereference them unconditionally cannot panic on an account whose analytics
+// settings were never configured.
+func normalizeServiceProperties(props *table.ServiceProperties) {
+	if props.Logging == nil {
+		props.Logging = &table.Logging{}
+	}
+	if props.Logging.RetentionPolicy == nil {
+		props.Logging.RetentionPolicy = &table.RetentionPolicy{}
+	}
+	if props.MinuteMetrics == nil {
+		props.MinuteMetrics = &table.Metrics{}
+	}
+	if props.MinuteMetrics.RetentionPolicy == nil {
+		props.MinuteMetrics.RetentionPolicy = &table.RetentionPolicy{}
+	}
+	if props.HourMetrics == nil {
+		props.HourMetrics = &table.Metrics{}
+	}
+	if props.HourMetrics.RetentionPolicy == nil {
+		props.HourMetrics.RetentionPolicy = &table.RetentionPolicy{}
+	}
+}
+
 func toMqlServiceStorageProperties(runtime *plugin.Runtime, props table.ServiceProperties, serviceType, parentId string) (*mqlAzureSubscriptionStorageServiceAccountServiceProperties, error) {
+	normalizeServiceProperties(&props)
 	loggingRetentionPolicy, err := CreateResource(runtime, "azure.subscription.storageService.account.service.properties.retentionPolicy",
 		map[string]*llx.RawData{
 			"id":            llx.StringData(fmt.Sprintf("%s/%s/properties/logging/retentionPolicy", parentId, serviceType)),
@@ -649,6 +679,7 @@ func toMqlServiceStorageProperties(runtime *plugin.Runtime, props table.ServiceP
 }
 
 func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.ServiceProperties, blobProps storage.BlobServiceProperties, serviceType, parentId string) (*mqlAzureSubscriptionStorageServiceAccountServiceBlobProperties, error) {
+	normalizeServiceProperties(&props)
 	loggingRetentionPolicy, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesRetentionPolicy,
 		map[string]*llx.RawData{
 			"id":            llx.StringData(fmt.Sprintf("%s/%s/properties/logging/retentionPolicy", parentId, serviceType)),


### PR DESCRIPTION
## What

Fixes accessors that dereferenced nullable Azure SDK pointers unconditionally. Because the executor runs blocks in goroutines, an unhandled panic is unrecoverable and crashes the **entire** scan. Found by a static audit and verified against the SDK pointer shapes.

### Fixes
- **network `virtualNetworkGateways()`** — `Properties` and the nested `SKU` are nullable (transient/failed gateways); normalized to empty structs.
- **network `connections()`** — guard `c.Properties` and the gateway-ref `.ID` before dereferencing.
- **sql `vulnerabilityAssessmentSettings()`** — `RecurringScans` (and `Properties`) are nullable; a VA config without recurring scans panicked.
- **sql `databases()`** — guard nullable `entry.Properties`.
- **storage queue/table/blob service properties** — `Logging`/`Metrics` and their `RetentionPolicy` are nullable; added `normalizeServiceProperties()`.
- **storage `dataProtection()`** — guard the nullable inner `BlobServiceProperties`.
- **monitor `logProfiles()` / `alerts()`** — guard nullable `entry.Properties` and nested `Actions`/`Condition`.
- **automation `accounts()`** — read SKU only after guarding `acct.Properties`.
- **iam `roleAssignment` / `managedIdentity`** — guard nullable `Properties` (and the raw `*TenantID` deref, now `StringDataPtr`).
- **redis `instances()`** — guard nullable `cache.Properties`.
- **connection `GetSubscriptions()`** — the `NewClient` error was checked only after the returned (nil) client was already used to build the pager; moved the check before first use.

## Test
`go build ./...` passes.