### PR TITLE
🐛 azure: fix security-posture detections returning wrong values

### DIFF
--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -31,8 +31,12 @@ const (
 	arcClusterDefenderExtensionDefinitionId        string = "/providers/Microsoft.Authorization/policyDefinitions/708b60a6-d253-4fe0-9114-4be4c00f012c"
 	kubernetesClusterDefenderExtensionDefinitionId string = "/providers/Microsoft.Authorization/policyDefinitions/64def556-fbad-4622-930e-72d1d5589bf5"
 
+	// 0adc5395-... is the Arc-enabled Kubernetes "Azure Policy extension" definition;
+	// a8eff44f-... is the AKS "Azure Policy Add-on" definition. They were previously
+	// both set to the Arc GUID, so azurePolicyForKubernetes never reflected the AKS
+	// add-on assignment.
 	arcClusterPolicyExtensionDefinitionId        string = "/providers/Microsoft.Authorization/policyDefinitions/0adc5395-9169-4b9b-8687-af838d69410a"
-	kubernetesClusterPolicyExtensionDefinitionId string = "/providers/Microsoft.Authorization/policyDefinitions/0adc5395-9169-4b9b-8687-af838d69410a"
+	kubernetesClusterPolicyExtensionDefinitionId string = "/providers/Microsoft.Authorization/policyDefinitions/a8eff44f-8c92-45c3-a3fb-9880802d67a7"
 )
 
 func (a *mqlAzureSubscriptionCloudDefenderService) id() (string, error) {
@@ -220,7 +224,12 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 	// Override enabled based on policy assignments and vulnerability assessment settings
 	vulnToolName := ""
 	for _, it := range list.PolicyAssignments {
-		if it.Properties.PolicyDefinitionID == vaQualysPolicyDefinitionId {
+		// Scope the assignment to this subscription; the unfiltered list also
+		// returns management-group-inherited assignments, which would otherwise
+		// report enabled even when VA is not configured on this subscription
+		// (mirrors the scope check in the Defender-for-Containers detection).
+		if it.Properties.PolicyDefinitionID == vaQualysPolicyDefinitionId &&
+			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
 			args["enabled"] = llx.BoolData(true)
 			vulnToolName = "Microsoft Defender for Cloud integrated Qualys scanner"
 		}

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -582,7 +582,14 @@ func (a *mqlAzureSubscriptionSqlServiceServer) azureAdOnlyAuthentication() (bool
 	}
 	result, err := client.Get(ctx, resourceID.ResourceGroup, server, sql.AuthenticationNameDefault, &sql.ServerAzureADOnlyAuthenticationsClientGetOptions{})
 	if err != nil {
-		return false, nil
+		// Only tolerate access-denied: swallowing every error would report a
+		// transient/permission failure as Azure-AD-only-auth disabled, which is
+		// the insecure value for a security check.
+		var rerr *azcore.ResponseError
+		if errors.As(err, &rerr) && rerr.StatusCode == http.StatusForbidden {
+			return false, nil
+		}
+		return false, err
 	}
 	if result.Properties != nil && result.Properties.AzureADOnlyAuthentication != nil {
 		return *result.Properties.AzureADOnlyAuthentication, nil


### PR DESCRIPTION
## What

Three security signals could report the insecure/wrong value:

- **`defenderForServers()`** — the Qualys VA policy check did not scope the assignment to the subscription, so a Qualys policy inherited from a parent management group made `enabled` report true even when Defender-for-Servers VA was not configured here. Added the same `Scope == /subscriptions/{subId}` filter the Containers detection uses.
- **`defenderForContainers()`** — `arcClusterPolicyExtensionDefinitionId` and `kubernetesClusterPolicyExtensionDefinitionId` were **both** set to the Arc GUID (`0adc5395-…`), so `azurePolicyForKubernetes` never reflected the AKS Azure Policy Add-on. Pointed the AKS constant at its real definition (`a8eff44f-…`, "Azure Policy Add-on for Kubernetes service (AKS)…"). *Reviewers: please sanity-check this GUID.*
- **sql `azureAdOnlyAuthentication()`** — the accessor swallowed **every** error as `false` (Azure-AD-only-auth disabled — the insecure value). Now only tolerates access-denied (403) and surfaces other errors.

## Test
`go build ./...` passes.