### PR TITLE
🐛 azure: fix swallowed errors and a discovery-target loop bug

### DIFF
--- a/providers/azure/resources/advisor.go
+++ b/providers/azure/resources/advisor.go
@@ -180,9 +180,15 @@ func (a *mqlAzureSubscriptionAdvisorService) averageScore() (float64, error) {
 	if scores.Error != nil {
 		return 0, scores.Error
 	}
+	if len(scores.Data) == 0 {
+		return 0, nil
+	}
 	avg := float64(0)
 	for _, s := range scores.Data {
 		score := s.(*mqlAzureSubscriptionAdvisorServiceScore)
+		if score.CurrentScore.Data == nil {
+			continue
+		}
 		avg += score.CurrentScore.Data.Score.Data
 	}
 

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -202,12 +202,9 @@ func getDiscoveryTargets(config *inventory.Config) []string {
 		return All
 	}
 	if stringx.ContainsAnyOf(targets, DiscoveryAuto) {
-		for i, target := range targets {
-			if target == DiscoveryAuto {
-				// remove the auto keyword
-				targets = slices.Delete(targets, i, i+1)
-			}
-		}
+		// remove the auto keyword (DeleteFunc handles every occurrence; mutating
+		// the slice inside a range loop would skip elements after a deletion)
+		targets = slices.DeleteFunc(targets, func(s string) bool { return s == DiscoveryAuto })
 		// add in the required discovery targets
 		return append(targets, Auto...)
 	}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1353,7 +1353,7 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 	azureSub := sub.(*mqlAzureSubscription)
 	rgs := azureSub.GetResourceGroups()
 	if rgs.Error != nil {
-		return nil, err
+		return nil, rgs.Error
 	}
 	res := []any{}
 	for _, rg := range rgs.Data {
@@ -2714,7 +2714,7 @@ func (a *mqlAzureSubscriptionNetworkServiceSubnet) ipConfigurations() ([]any, er
 	// no API to fetch this so we fetch the gateways and iterate through them
 	gateways := mqlNetwork.GetVirtualNetworkGateways()
 	if gateways.Error != nil {
-		return nil, err
+		return nil, gateways.Error
 	}
 	for _, gw := range gateways.Data {
 		mqlGw := gw.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway)

--- a/providers/azure/resources/postgresql.go
+++ b/providers/azure/resources/postgresql.go
@@ -265,7 +265,7 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceServer) databases() ([]any, error)
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
-		return nil, &json.MarshalerError{}
+		return nil, err
 	}
 	pager := dbDatabaseClient.NewListByServerPager(resourceID.ResourceGroup, server, &postgresql.DatabasesClientListByServerOptions{})
 	res := []any{}
@@ -312,7 +312,7 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) databases() ([]any
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
-		return nil, &json.MarshalerError{}
+		return nil, err
 	}
 	pager := dbDatabaseClient.NewListByServerPager(resourceID.ResourceGroup, server, &flexible.DatabasesClientListByServerOptions{})
 	res := []any{}


### PR DESCRIPTION
## What

- **network `virtualNetworkGateways` / `…ipConfigurations()`** — two error paths returned the (already-nil) `err` variable instead of the sub-resource's `rgs.Error` / `gateways.Error`, silently swallowing a real failure as success.
- **postgresql `databases()`** (single-server and flexible) — on a `NewDatabasesClient` failure both returned `&json.MarshalerError{}`, an empty struct literal that discards the real error and whose `Error()` can itself nil-deref. Now returns the actual error.
- **advisor `averageScore()`** — divided by `len(scores)` with no zero guard (NaN on a subscription with no advisor scores) and dereferenced `CurrentScore.Data` without a nil check. Guards both.
- **discovery `getDiscoveryTargets()`** — removed the "auto" keyword with `slices.Delete` inside a `range` over the same slice, which skips the element after a deletion. Now uses `slices.DeleteFunc`.

## Test
`go build ./...` passes.