### PR TITLE
🐛 ms365: fix nil-pointer derefs that crash the scan

### DIFF
--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -239,7 +239,7 @@ func (a *mqlMicrosoftConditionalAccess) createPolicyResource(policy models.Condi
 			"displayName":      llx.StringDataPtr(policy.GetDisplayName()),
 			"createdDateTime":  llx.TimeDataPtr(policy.GetCreatedDateTime()),
 			"modifiedDateTime": llx.TimeDataPtr(policy.GetModifiedDateTime()),
-			"state":            llx.StringData(policy.GetState().String()),
+			"state":            llx.StringDataPtr(enumPtrString(policy.GetState())),
 			"sessionControls":  llx.ResourceData(sessionControls, "microsoft.conditionalAccess.policy.sessionControls"),
 			"conditions":       llx.ResourceData(conditions, "microsoft.conditionalAccess.policy.conditions"),
 			"grantControls":    llx.ResourceData(grantControls, "microsoft.conditionalAccess.policy.grantControls"),
@@ -269,7 +269,7 @@ func (a *mqlMicrosoftConditionalAccess) createConditionsResource(
 		authenticationFlows := conditions.GetAuthenticationFlows()
 		usersData := map[string]*llx.RawData{
 			"__id":            llx.StringData(policyId + "_conditions_authflows"),
-			"transferMethods": llx.StringData(authenticationFlows.GetTransferMethods().String()),
+			"transferMethods": llx.StringDataPtr(enumPtrString(authenticationFlows.GetTransferMethods())),
 		}
 
 		mqlAuthenticationFlows, err = CreateResource(a.MqlRuntime, "microsoft.conditionalAccess.policy.conditions.authenticationFlows", usersData)
@@ -406,8 +406,8 @@ func (a *mqlMicrosoftConditionalAccess) createGrantControlsResource(
 			"id":                    llx.StringDataPtr(authStrength.GetId()),
 			"displayName":           llx.StringDataPtr(authStrength.GetDisplayName()),
 			"description":           llx.StringDataPtr(authStrength.GetDescription()),
-			"policyType":            llx.StringData(authStrength.GetPolicyType().String()),
-			"requirementsSatisfied": llx.StringData(authStrength.GetRequirementsSatisfied().String()),
+			"policyType":            llx.StringDataPtr(enumPtrString(authStrength.GetPolicyType())),
+			"requirementsSatisfied": llx.StringDataPtr(enumPtrString(authStrength.GetRequirementsSatisfied())),
 			"allowedCombinations":   llx.ArrayData(convert.SliceAnyToInterface(convertEnumCollectionToStrings(authStrength.GetAllowedCombinations())), types.String),
 			"createdDateTime":       llx.TimeDataPtr(authStrength.GetCreatedDateTime()),
 			"modifiedDateTime":      llx.TimeDataPtr(authStrength.GetModifiedDateTime()),
@@ -458,8 +458,8 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 		}
 		signInFreqData := map[string]*llx.RawData{
 			"__id":               llx.StringData(policyId + "_session_signInFrequency"),
-			"authenticationType": llx.StringData(signInFreq.GetAuthenticationType().String()),
-			"frequencyInterval":  llx.StringData(signInFreq.GetFrequencyInterval().String()),
+			"authenticationType": llx.StringDataPtr(enumPtrString(signInFreq.GetAuthenticationType())),
+			"frequencyInterval":  llx.StringDataPtr(enumPtrString(signInFreq.GetFrequencyInterval())),
 			"isEnabled":          llx.BoolDataPtr(signInFreq.GetIsEnabled()),
 			"type":               llx.StringDataPtr(freqType),
 			"value":              llx.IntDataPtr(signInFreq.GetValue()),
@@ -476,7 +476,7 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 		cloudAppSecurity := sessionControls.GetCloudAppSecurity()
 		cloudAppSecurityData := map[string]*llx.RawData{
 			"__id":                 llx.StringData(policyId + "_session_cloudAppSecurity"),
-			"cloudAppSecurityType": llx.StringData(cloudAppSecurity.GetCloudAppSecurityType().String()),
+			"cloudAppSecurityType": llx.StringDataPtr(enumPtrString(cloudAppSecurity.GetCloudAppSecurityType())),
 			"isEnabled":            llx.BoolDataPtr(cloudAppSecurity.GetIsEnabled()),
 		}
 		var err error
@@ -491,7 +491,7 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 		persistentBrowser := sessionControls.GetPersistentBrowser()
 		persistentBrowserData := map[string]*llx.RawData{
 			"__id":      llx.StringData(policyId + "_session_persistentBrowser"),
-			"mode":      llx.StringData(persistentBrowser.GetMode().String()),
+			"mode":      llx.StringDataPtr(enumPtrString(persistentBrowser.GetMode())),
 			"isEnabled": llx.BoolDataPtr(persistentBrowser.GetIsEnabled()),
 		}
 		var err error
@@ -640,7 +640,7 @@ func newMqlAuthenticationMethodConfiguration(runtime *plugin.Runtime, config mod
 	resource, err := CreateResource(runtime, "microsoft.conditionalAccess.authenticationMethodConfiguration", map[string]*llx.RawData{
 		"__id":  llx.StringDataPtr(config.GetId()),
 		"id":    llx.StringDataPtr(config.GetId()),
-		"state": llx.StringData(config.GetState().String()),
+		"state": llx.StringDataPtr(enumPtrString(config.GetState())),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/ms365/resources/errors.go
+++ b/providers/ms365/resources/errors.go
@@ -27,7 +27,14 @@ func transformError(err error) error {
 	oDataErr, ok := err.(*odataerrors.ODataError)
 	if ok && oDataErr != nil {
 		if err := oDataErr.GetErrorEscaped(); err != nil {
-			return errors.Newf("error while performing request. Code: %s, Message: %s", *err.GetCode(), *err.GetMessage())
+			code, msg := "", ""
+			if c := err.GetCode(); c != nil {
+				code = *c
+			}
+			if m := err.GetMessage(); m != nil {
+				msg = *m
+			}
+			return errors.Newf("error while performing request. Code: %s, Message: %s", code, msg)
 		}
 	}
 	return err

--- a/providers/ms365/resources/security_securescores.go
+++ b/providers/ms365/resources/security_securescores.go
@@ -114,7 +114,11 @@ func (a *mqlMicrosoftSecurity) latestSecureScores() (*mqlMicrosoftSecuritySecuri
 	latest := secureScores.Data[0].(*mqlMicrosoftSecuritySecurityscore)
 	for _, s := range secureScores.Data {
 		mqlS := s.(*mqlMicrosoftSecuritySecurityscore)
-		if mqlS.CreatedDateTime.Data.After(*latest.CreatedDateTime.Data) {
+		// createdDateTime is nilable; guard before dereferencing to avoid a panic.
+		if mqlS.CreatedDateTime.Data == nil {
+			continue
+		}
+		if latest.CreatedDateTime.Data == nil || mqlS.CreatedDateTime.Data.After(*latest.CreatedDateTime.Data) {
 			latest = mqlS
 		}
 	}

--- a/providers/ms365/resources/serviceprincipals.go
+++ b/providers/ms365/resources/serviceprincipals.go
@@ -319,7 +319,7 @@ func fetchServicePrincipals(runtime *plugin.Runtime, conn *connection.Ms365Conne
 
 		// also fill up the index
 		if permissionIndexer != nil {
-			permissionIndexer.IndexAppName(convert.ToValue(sp.GetId()), *sp.GetDisplayName())
+			permissionIndexer.IndexAppName(convert.ToValue(sp.GetId()), convert.ToValue(sp.GetDisplayName()))
 			permissionIndexer.IndexAppRole(convert.ToValue(sp.GetId()), sp.GetAppRoles()...)
 			permissionIndexer.IndexOauthScope(convert.ToValue(sp.GetId()), sp.GetOauth2PermissionScopes()...)
 		}

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -36,7 +36,7 @@ func newAssignedPlan(p models.AssignedPlanable) AssignedPlan {
 		AssignedDateTime: p.GetAssignedDateTime(),
 		CapabilityStatus: convert.ToValue(p.GetCapabilityStatus()),
 		Service:          convert.ToValue(p.GetService()),
-		ServicePlanId:    p.GetServicePlanId().String(),
+		ServicePlanId:    convert.ToValue(newUuidString(p.GetServicePlanId())),
 	}
 }
 
@@ -557,7 +557,13 @@ type PermissionGrantConditionSet struct {
 }
 
 func newPermissionGrantConditionSet(p models.PermissionGrantConditionSetable) PermissionGrantConditionSet {
-	t := PermissionType(*p.GetPermissionType())
+	if p == nil {
+		return PermissionGrantConditionSet{}
+	}
+	var t PermissionType
+	if pt := p.GetPermissionType(); pt != nil {
+		t = PermissionType(*pt)
+	}
 
 	return PermissionGrantConditionSet{
 		Entity: Entity{

--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -234,8 +234,9 @@ func (a *mqlMicrosoftUser) microsoftParent() (*mqlMicrosoft, error) {
 
 func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicrosoftUser, error) {
 	identities := []any{}
+	uid := convert.ToValue(u.GetId())
 	for idx, userId := range u.GetIdentities() {
-		id := fmt.Sprintf("%s-%d", *u.GetId(), idx)
+		id := fmt.Sprintf("%s-%d", uid, idx)
 		identity, err := CreateResource(runtime, "microsoft.user.identity", map[string]*llx.RawData{
 			"signInType":       llx.StringDataPtr(userId.GetSignInType()),
 			"issuer":           llx.StringDataPtr(userId.GetIssuer()),
@@ -252,9 +253,10 @@ func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicros
 
 	if u.GetAssignedLicenses() != nil {
 		for _, license := range u.GetAssignedLicenses() {
-			if license == nil {
+			if license == nil || license.GetSkuId() == nil {
 				continue
 			}
+			skuId := license.GetSkuId().String()
 
 			var disabledPlanStrings []string
 			if license.GetDisabledPlans() != nil {
@@ -265,9 +267,9 @@ func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicros
 
 			mqlAssignedLicenses, err := CreateResource(runtime, "microsoft.user.assignedLicense",
 				map[string]*llx.RawData{
-					"__id":          llx.StringData(license.GetSkuId().String()),
+					"__id":          llx.StringData(skuId),
 					"disabledPlans": llx.ArrayData(convert.SliceAnyToInterface(disabledPlanStrings), types.String),
-					"skuId":         llx.StringData(license.GetSkuId().String()),
+					"skuId":         llx.StringData(skuId),
 				})
 			if err != nil {
 				return nil, err
@@ -1260,7 +1262,7 @@ func newMqlMicrosoftUserLicenseDetail(runtime *plugin.Runtime, d models.LicenseD
 				"__id":               llx.StringData(planId),
 				"appliesTo":          llx.StringDataPtr(sp.GetAppliesTo()),
 				"provisioningStatus": llx.StringDataPtr(sp.GetProvisioningStatus()),
-				"servicePlanId":      llx.StringData(sp.GetServicePlanId().String()),
+				"servicePlanId":      llx.StringDataPtr(newUuidString(sp.GetServicePlanId())),
 				"servicePlanName":    llx.StringDataPtr(sp.GetServicePlanName()),
 			})
 		if err != nil {


### PR DESCRIPTION
## What

Several resource converters dereferenced nilable Microsoft Graph getter pointers unconditionally. A single object with the field unset (common in real tenants) panics, and because the executor runs blocks in goroutines the panic is unrecoverable and kills the **whole** scan.

### Fixes
- **conditional-access** — 7 enum getters (`state`, `transferMethods`, `policyType`, `requirementsSatisfied`, `authenticationType`, `frequencyInterval`, `cloudAppSecurityType`, persistentBrowser `mode`, auth-method-config `state`) were `.GetX().String()`-dereferenced. Routed through the nil-safe `enumPtrString` helper.
- **structs `newPermissionGrantConditionSet`** — deref of `*GetPermissionType()` with no nil guard (and no top-level `p == nil` guard like its siblings).
- **structs `newAssignedPlan` / users servicePlanInfo** — `GetServicePlanId().String()` on a nilable `*uuid.UUID`; use the nil-safe `newUuidString` helper.
- **users `newMqlMicrosoftUser`** — `*u.GetId()` and `license.GetSkuId().String()` dereferenced raw; use `convert.ToValue` and skip licenses with no skuId.
- **serviceprincipals** — `*sp.GetDisplayName()` deref when indexing; use `ToValue`.
- **security `latestSecureScores`** — compared `CreatedDateTime.Data` without a nil check; guard before the `.After()` deref.
- **errors `transformError`** — `*GetCode()`/`*GetMessage()` deref in the v1 error path (the beta path already guards); nil-check both.

## Test
`go build ./...` passes.