### PR TITLE
🐛 ms365: fix index map data race and swallowed/nil-policy errors

### DIFF
--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -195,53 +195,46 @@ func (a *mqlMicrosoft) loadMfaResp() *mfaResp {
 	return &a.mfaResp
 }
 
-// initIndex ensures the user indexes are initialized,
-// can be called multiple times without side effects
-func (a *mqlMicrosoft) initIndex() {
+// indexUser adds a user to the internal indexes. The map is created lazily
+// under the write lock so concurrent indexing can't race on the nil check.
+func (a *mqlMicrosoft) indexUser(user *mqlMicrosoftUser) {
+	idxUsersById.Lock()
 	if a.idxUsersById == nil {
 		a.idxUsersById = make(map[string]*mqlMicrosoftUser)
 	}
-	if a.idxDevicesById == nil {
-		a.idxDevicesById = make(map[string]*mqlMicrosoftDevice)
-	}
-}
-
-// indexUser adds a user to the internal indexes
-func (a *mqlMicrosoft) indexUser(user *mqlMicrosoftUser) {
-	a.initIndex()
-	idxUsersById.Lock()
 	a.idxUsersById[user.Id.Data] = user
 	idxUsersById.Unlock()
 }
 
 // userById returns a user by id if it exists in the indexUser
 func (a *mqlMicrosoft) userById(id string) (*mqlMicrosoftUser, bool) {
+	idxUsersById.RLock()
+	defer idxUsersById.RUnlock()
 	if a.idxUsersById == nil {
 		return nil, false
 	}
-
-	idxUsersById.RLock()
 	res, ok := a.idxUsersById[id]
-	idxUsersById.RUnlock()
 	return res, ok
 }
 
-// indexDevice adds a device to the internal indexes
+// indexDevice adds a device to the internal indexes. The map is created lazily
+// under the write lock so concurrent indexing can't race on the nil check.
 func (a *mqlMicrosoft) indexDevice(device *mqlMicrosoftDevice) {
-	a.initIndex()
 	idxDevicesById.Lock()
+	if a.idxDevicesById == nil {
+		a.idxDevicesById = make(map[string]*mqlMicrosoftDevice)
+	}
 	a.idxDevicesById[device.Id.Data] = device
 	idxDevicesById.Unlock()
 }
 
 // deviceById returns a device by id if it exists in the indexDevice
 func (a *mqlMicrosoft) deviceById(id string) (*mqlMicrosoftDevice, bool) {
+	idxDevicesById.RLock()
+	defer idxDevicesById.RUnlock()
 	if a.idxDevicesById == nil {
 		return nil, false
 	}
-
-	idxDevicesById.RLock()
 	res, ok := a.idxDevicesById[id]
-	idxDevicesById.RUnlock()
 	return res, ok
 }

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -172,7 +172,10 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 	}
 
 	tenant, err := r.getTenant()
-	if tenant == "" || err != nil {
+	if err != nil {
+		return errHandler(fmt.Errorf("cannot fetch sharepoint online report: %w", err))
+	}
+	if tenant == "" {
 		return errHandler(fmt.Errorf("tenant cannot be empty, cannot fetch sharepoint online report"))
 	}
 

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -367,6 +367,9 @@ func (a *mqlMicrosoftPolicies) externalIdentitiesPolicy() (*mqlMicrosoftExternal
 	if err != nil {
 		return nil, transformError(err)
 	}
+	if policy == nil {
+		return nil, fmt.Errorf("external identities policy not found")
+	}
 
 	mqlPolicy, err := CreateResource(a.MqlRuntime, ResourceMicrosoftExternalIdentitiesPolicy,
 		map[string]*llx.RawData{
@@ -451,6 +454,9 @@ func (a *mqlMicrosoftCrossTenantAccessPolicyDefault) getCrossTenantAccessPolicy(
 	policy, err := graphClient.Policies().CrossTenantAccessPolicy().DefaultEscaped().Get(context.Background(), nil)
 	if err != nil {
 		return errHandler(transformError(err))
+	}
+	if policy == nil {
+		return errHandler(fmt.Errorf("cross-tenant access policy not found"))
 	}
 
 	a.policy = policy
@@ -631,6 +637,9 @@ func (a *mqlMicrosoftPolicies) defaultAppManagementPolicy() (*mqlMicrosoftDefaul
 	policy, err := graphClient.Policies().DefaultAppManagementPolicy().Get(context.Background(), nil)
 	if err != nil {
 		return nil, transformError(err)
+	}
+	if policy == nil {
+		return nil, fmt.Errorf("default app management policy not found")
 	}
 
 	policyId := ""


### PR DESCRIPTION
## What

- **microsoft user/device index** — `initIndex()` created the index maps under **no** lock (the package mutexes only guarded map contents, taken afterward), and `userById`/`deviceById` read the nil-check unlocked — a data race under concurrent indexing (`-race` flags it). Now each map is created lazily under its write lock and read under the read lock.
- **policies `crossTenantAccessPolicy` / `externalIdentitiesPolicy` / `defaultAppManagementPolicy`** — each used the `Get` result without a nil check, so a nil-without-error response would panic. Guard `policy == nil`.
- **sharepoint `getSharepointOnlineReport`** — a non-empty error from `getTenant()` was collapsed into a generic "tenant cannot be empty" message, hiding the real cause. Surface the underlying error.

## Test
`go build ./...` passes.