### PR TITLE
🐛 google-workspace: fix over-strict usage-report error, app merge, ACL id

### DIFF
--- a/providers/google-workspace/resources/calendars.go
+++ b/providers/google-workspace/resources/calendars.go
@@ -74,7 +74,7 @@ func (g *mqlGoogleworkspaceCalendar) acl() ([]any, error) {
 				scopeValue = a.Scope.Value
 			}
 			scope, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule.scope", map[string]*llx.RawData{
-				"__id":  llx.StringData(a.Id + scopeType + scopeValue),
+				"__id":  llx.StringData(a.Id + "/" + scopeType + "/" + scopeValue),
 				"type":  llx.StringData(scopeType),
 				"value": llx.StringData(scopeValue),
 			})

--- a/providers/google-workspace/resources/connected_apps.go
+++ b/providers/google-workspace/resources/connected_apps.go
@@ -69,6 +69,11 @@ func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
 				return nil, tk.ClientId.Error
 			}
 			clientID := tk.ClientId.Data
+			// Skip tokens without a clientId: they would all collapse into one
+			// phantom connected-app under the empty-string key.
+			if clientID == "" {
+				continue
+			}
 
 			cApp, ok := connectedApps[clientID]
 			if !ok {

--- a/providers/google-workspace/resources/users.go
+++ b/providers/google-workspace/resources/users.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -468,7 +467,7 @@ func (g *mqlGoogleworkspaceUser) usageReport() (*mqlGoogleworkspaceReportUsage, 
 	if err != nil {
 		return nil, err
 	}
-	reportsByEmail, date, err := parent.loadUsageReports()
+	reportsByEmail, _, err := parent.loadUsageReports()
 	if err != nil {
 		return nil, err
 	}
@@ -479,9 +478,9 @@ func (g *mqlGoogleworkspaceUser) usageReport() (*mqlGoogleworkspaceReportUsage, 
 		// users. Surface this as a null field rather than an error so audits
 		// can still iterate the user list.
 		g.UsageReport.State = plugin.StateIsSet | plugin.StateIsNull
-		if date == "" {
-			return nil, errors.New("no usage reports published yet for this customer")
-		}
+		// A customer with no published reports at all (date == "") is not an
+		// error condition — return a null field so `users { usageReport }`
+		// doesn't fail for every user on a new/report-disabled tenant.
 		return nil, nil
 	}
 	return newMqlGoogleWorkspaceUsageReport(g.MqlRuntime, report)


### PR DESCRIPTION
## What

google-workspace is otherwise clean (no panics; the suspect non-paginated `domains`/`orgUnits` calls are correct — those Directory APIs don't paginate). Three real correctness/robustness fixes:

- **user `usageReport()`** — on a customer that has never published usage reports (`date == ""`), the accessor set the field null but then returned an error, which `GetOrCompute` stores — failing `users { usageReport }` for **every** user on a new/report-disabled tenant. Return a null field instead.
- **`connectedApps()`** — tokens with an empty `clientId` all collapsed into one phantom connected-app under the `""` map key (and a non-unique `__id`). Skip tokens without a clientId.
- **calendar aclRule scope `__id`** — built as `id+type+value` with no separators, so distinct rules could collide in the cache. Join with `/`.

## Test
`go build ./...` passes.