### PR TITLE
🐛 vsphere: populate vulnmgmt.packages and fix disk-group id collision

### DIFF
--- a/providers/vsphere/resources/vsan.go
+++ b/providers/vsphere/resources/vsan.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -223,7 +224,7 @@ func (v *mqlVsphereHost) vsan() (*mqlVsphereHostVsan, error) {
 // cache-disk UUID appearing on two hosts can't collide in the resource cache.
 func (v *mqlVsphereHostVsan) diskGroups() ([]any, error) {
 	mqlDiskGroups := make([]any, 0, len(v.cacheDiskMappings))
-	for _, dm := range v.cacheDiskMappings {
+	for i, dm := range v.cacheDiskMappings {
 		capacityDisks := make([]any, 0, len(dm.NonSsd))
 		var capacityBytes int64
 		for _, disk := range dm.NonSsd {
@@ -231,8 +232,15 @@ func (v *mqlVsphereHostVsan) diskGroups() ([]any, error) {
 			capacityBytes += scsiDiskCapacityBytes(disk)
 		}
 
+		// The cache SSD UUID is the natural key, but it can be empty on
+		// all-flash/ESA topologies with no dedicated cache disk; fall back to
+		// the mapping index so disk groups don't collide on one cache __id.
+		dgKey := dm.Ssd.Uuid
+		if dgKey == "" {
+			dgKey = "dg" + strconv.Itoa(i)
+		}
 		res, err := CreateResource(v.MqlRuntime, "vsphere.host.vsan.diskGroup", map[string]*llx.RawData{
-			"__id":              llx.StringData(v.cacheHostMoid + "/vsanDiskGroup/" + dm.Ssd.Uuid),
+			"__id":              llx.StringData(v.cacheHostMoid + "/vsanDiskGroup/" + dgKey),
 			"cacheDiskUuid":     llx.StringData(dm.Ssd.Uuid),
 			"cacheDisk":         llx.StringData(scsiDiskName(dm.Ssd)),
 			"capacityDisks":     llx.ArrayData(capacityDisks, types.String),

--- a/providers/vsphere/resources/vulnmgmt.go
+++ b/providers/vsphere/resources/vulnmgmt.go
@@ -54,18 +54,13 @@ func (v *mqlVulnmgmt) lastAssessment() (*time.Time, error) {
 		return v.setUnavailableLastAssessment(errors.New("no update time available"))
 	}
 
-	var lastUpdateTime *time.Time
-	if lastUpdate != "" {
-		parsedLastUpdateTime, err := time.Parse(time.RFC3339, lastUpdate)
-		if err != nil {
-			return nil, errors.New("could not parse last update time: " + lastUpdate)
-		}
-		lastUpdateTime = &parsedLastUpdateTime
-	} else {
-		lastUpdateTime = &llx.NeverFutureTime
+	// lastUpdate is guaranteed non-empty here (the empty case returned above).
+	parsedLastUpdateTime, err := time.Parse(time.RFC3339, lastUpdate)
+	if err != nil {
+		return nil, errors.New("could not parse last update time: " + lastUpdate)
 	}
 
-	return lastUpdateTime, nil
+	return &parsedLastUpdateTime, nil
 }
 
 func (v *mqlVulnmgmt) cves() ([]any, error) {
@@ -178,6 +173,20 @@ func (v *mqlVulnmgmt) populateData() error {
 		mqlVulnCves[i] = mqlVulnCve
 	}
 
+	mqlVulnPackages := make([]any, len(vulnReport.Packages))
+	for i, p := range vulnReport.Packages {
+		mqlVulnPackage, err := CreateResource(v.MqlRuntime, "vuln.package", map[string]*llx.RawData{
+			"name":      llx.StringData(p.Name),
+			"version":   llx.StringData(p.Version),
+			"available": llx.StringData(p.Available),
+			"arch":      llx.StringData(p.Arch),
+		})
+		if err != nil {
+			return err
+		}
+		mqlVulnPackages[i] = mqlVulnPackage
+	}
+
 	id := fmt.Sprintf("%d-%s", vulnReport.Stats.Score.Value, vulnReport.Stats.Score.Vector)
 	res, err := CreateResource(v.MqlRuntime, "audit.cvss", map[string]*llx.RawData{
 		"__id":   llx.StringData(id),
@@ -191,6 +200,7 @@ func (v *mqlVulnmgmt) populateData() error {
 
 	v.Advisories = plugin.TValue[[]any]{Data: mqlVulAdvisories, State: plugin.StateIsSet}
 	v.Cves = plugin.TValue[[]any]{Data: mqlVulnCves, State: plugin.StateIsSet}
+	v.Packages = plugin.TValue[[]any]{Data: mqlVulnPackages, State: plugin.StateIsSet}
 	v.Stats = plugin.TValue[*mqlAuditCvss]{Data: statsCvssScore, State: plugin.StateIsSet}
 
 	return nil


### PR DESCRIPTION
## What

vsphere is otherwise very clean. Three real fixes:

- **vulnmgmt `populateData()`** — the success path built advisories/cves/stats but **never** read `vulnReport.Packages` or set `v.Packages`, so `vulnmgmt.packages` silently resolved empty even when the report listed affected packages (only the unavailable/error path set it, to an empty slice). Now builds `vuln.package` resources like the os provider does.
- **vsan `diskGroups()`** — the `__id` used the cache SSD UUID, which is empty on all-flash/ESA topologies with no dedicated cache disk, collapsing all such groups onto one cache key (silent data loss). Fall back to the mapping index.
- **vulnmgmt `lastAssessment()`** — drop a dead `else` branch (the empty-`lastUpdate` case already returned earlier).

## Test
`go build ./...` passes.