### PR TITLE
🐛 gitlab: stop member listings from poisoning gitlab.user security fields

### DIFF
--- a/providers/gitlab/resources/gitlab_group.go
+++ b/providers/gitlab/resources/gitlab_group.go
@@ -170,21 +170,14 @@ func (g *mqlGitlabGroup) members() ([]any, error) {
 	for _, member := range allMembers {
 		role := mapAccessLevelToRole(int(member.AccessLevel))
 
-		mqlUser, err := CreateResource(g.MqlRuntime, "gitlab.user", map[string]*llx.RawData{
-			"id":               llx.IntData(member.ID),
-			"username":         llx.StringData(member.Username),
-			"name":             llx.StringData(member.Name),
-			"state":            llx.StringData(member.State),
-			"email":            llx.StringData(member.Email),
-			"webURL":           llx.StringData(member.WebURL),
-			"avatarURL":        llx.StringData(member.AvatarURL),
-			"createdAt":        llx.TimeDataPtr(member.CreatedAt),
-			"jobTitle":         llx.StringData(""),
-			"organization":     llx.StringData(""),
-			"location":         llx.StringData(""),
-			"locked":           llx.BoolData(false),
-			"bot":              llx.BoolData(false),
-			"twoFactorEnabled": llx.BoolData(false),
+		// Seed only the id and let initGitlabUser lazily fetch the full record.
+		// Hardcoding zero values for fields the member payload doesn't carry
+		// (twoFactorEnabled, locked, bot, jobTitle, organization, location)
+		// would poison the runtime cache for any later gitlab.user lookup on
+		// the same id — e.g. reporting twoFactorEnabled=false for a user who
+		// actually has it enabled.
+		mqlUser, err := NewResource(g.MqlRuntime, "gitlab.user", map[string]*llx.RawData{
+			"id": llx.IntData(member.ID),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -405,21 +405,14 @@ func (p *mqlGitlabProject) projectMembers() ([]any, error) {
 	for _, member := range allMembers {
 		role := mapAccessLevelToRole(int(member.AccessLevel))
 
-		mqlUser, err := CreateResource(p.MqlRuntime, "gitlab.user", map[string]*llx.RawData{
-			"id":               llx.IntData(int64(member.ID)),
-			"username":         llx.StringData(member.Username),
-			"name":             llx.StringData(member.Name),
-			"state":            llx.StringData(member.State),
-			"email":            llx.StringData(member.Email),
-			"webURL":           llx.StringData(member.WebURL),
-			"avatarURL":        llx.StringData(member.AvatarURL),
-			"createdAt":        llx.TimeDataPtr(member.CreatedAt),
-			"jobTitle":         llx.StringData(""),
-			"organization":     llx.StringData(""),
-			"location":         llx.StringData(""),
-			"locked":           llx.BoolData(false),
-			"bot":              llx.BoolData(false),
-			"twoFactorEnabled": llx.BoolData(false),
+		// Seed only the id and let initGitlabUser lazily fetch the full record.
+		// Hardcoding zero values for fields the member payload doesn't carry
+		// (twoFactorEnabled, locked, bot, jobTitle, organization, location)
+		// would poison the runtime cache for any later gitlab.user lookup on
+		// the same id — e.g. reporting twoFactorEnabled=false for a user who
+		// actually has it enabled.
+		mqlUser, err := NewResource(p.MqlRuntime, "gitlab.user", map[string]*llx.RawData{
+			"id": llx.IntData(int64(member.ID)),
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

`project.projectMembers()` and `group.members()` built each `gitlab.user` via `CreateResource` with **hardcoded `false`** for `twoFactorEnabled`/`locked`/`bot` (and empty `jobTitle`/`organization`/`location`) — fields the member payload doesn't carry. Because `gitlab.user` is cached by id, the first member-listing query **poisons the runtime cache**, so a later `gitlab.user(id)` / `approvalRule.users` lookup returns `twoFactorEnabled=false` even for users who have it enabled — a false-negative MFA finding.

Fix: seed only the `id` via `NewResource` and let `initGitlabUser` fetch the real record lazily, matching the documented `basicUsersToMqlUsers` pattern in the same file.

## Test
`go build ./...` passes.