### PR TITLE
🐛 proxmox: fix cluster storage enabled=false and vm.updates agent failure

### DIFF
--- a/providers/proxmox/connection/storage.go
+++ b/providers/proxmox/connection/storage.go
@@ -15,10 +15,8 @@ type StorageInfo struct {
 	Content string `json:"content"`
 	Path    string `json:"path"`
 	Enabled int    `json:"enabled"`
-	// Disable is the cluster /storage config key (1 = disabled). The
-	// cluster endpoint reports config (disable), while /nodes/<n>/storage
-	// reports runtime status (enabled); GetStorages normalizes Enabled from
-	// Disable so the shared mapper is correct for both.
+	// Disable is the cluster /storage config key (1 = disabled); /nodes/<n>/storage
+	// uses "enabled" instead. GetStorages normalizes Enabled from Disable.
 	Disable  int     `json:"disable"`
 	Shared   int     `json:"shared"`
 	Total    int64   `json:"total"`
@@ -39,11 +37,13 @@ func (c *PveConnection) GetStorages() ([]StorageInfo, error) {
 	// The cluster /storage endpoint reports config (a "disable" key), not the
 	// runtime "enabled" key that /nodes/<n>/storage returns. Normalize Enabled
 	// from Disable so the shared mapper reports a correct value — without this,
-	// every cluster-level storage was reported as enabled=false.
+	// every cluster-level storage was reported as enabled=false. Only infer
+	// Enabled when the response didn't already provide it, so a future endpoint
+	// that returns both keys keeps its explicit value.
 	for i := range storages {
 		if storages[i].Disable != 0 {
 			storages[i].Enabled = 0
-		} else {
+		} else if storages[i].Enabled == 0 {
 			storages[i].Enabled = 1
 		}
 	}

--- a/providers/proxmox/connection/storage.go
+++ b/providers/proxmox/connection/storage.go
@@ -10,11 +10,16 @@ import "fmt"
 // ---------------------------------------------------------------------------
 
 type StorageInfo struct {
-	Storage  string  `json:"storage"`
-	Type     string  `json:"type"`
-	Content  string  `json:"content"`
-	Path     string  `json:"path"`
-	Enabled  int     `json:"enabled"`
+	Storage string `json:"storage"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	Path    string `json:"path"`
+	Enabled int    `json:"enabled"`
+	// Disable is the cluster /storage config key (1 = disabled). The
+	// cluster endpoint reports config (disable), while /nodes/<n>/storage
+	// reports runtime status (enabled); GetStorages normalizes Enabled from
+	// Disable so the shared mapper is correct for both.
+	Disable  int     `json:"disable"`
 	Shared   int     `json:"shared"`
 	Total    int64   `json:"total"`
 	Used     int64   `json:"used"`
@@ -30,6 +35,17 @@ func (c *PveConnection) GetStorages() ([]StorageInfo, error) {
 	var storages []StorageInfo
 	if err := c.apiGet("/storage", &storages); err != nil {
 		return nil, fmt.Errorf("failed to get storages: %w", err)
+	}
+	// The cluster /storage endpoint reports config (a "disable" key), not the
+	// runtime "enabled" key that /nodes/<n>/storage returns. Normalize Enabled
+	// from Disable so the shared mapper reports a correct value — without this,
+	// every cluster-level storage was reported as enabled=false.
+	for i := range storages {
+		if storages[i].Disable != 0 {
+			storages[i].Enabled = 0
+		} else {
+			storages[i].Enabled = 1
+		}
 	}
 	return storages, nil
 }

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -305,7 +305,11 @@ func (r *mqlProxmoxVm) updates() ([]any, error) {
 	})
 	if r.osInfoErr != nil {
 		if errors.Is(r.osInfoErr, connection.ErrQGANotRunning) {
-			return nil, fmt.Errorf("guest agent not reachable for VM %d", vmid)
+			// Without the guest agent we can't enumerate updates; return an
+			// empty list rather than failing the field, so iterating
+			// `vms { updates }` doesn't error on the first agent-less VM
+			// (consistent with the Windows-update path).
+			return []any{}, nil
 		}
 		return nil, r.osInfoErr
 	}

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/proxmox/connection"
@@ -308,7 +309,9 @@ func (r *mqlProxmoxVm) updates() ([]any, error) {
 			// Without the guest agent we can't enumerate updates; return an
 			// empty list rather than failing the field, so iterating
 			// `vms { updates }` doesn't error on the first agent-less VM
-			// (consistent with the Windows-update path).
+			// (consistent with the Windows-update path). Warn so operators can
+			// still see which VMs are agent-less.
+			log.Warn().Int("vmid", vmid).Msg("guest agent not reachable, returning empty updates list")
 			return []any{}, nil
 		}
 		return nil, r.osInfoErr


### PR DESCRIPTION
## What

- **`proxmox.storages` enabled always false** — the cluster `/storage` endpoint reports config (a `disable` key), not the runtime `enabled` key that `/nodes/<n>/storage` returns. `StorageInfo.Enabled` was therefore always `0`, so `proxmox.storages` (and every storage resolved via `initProxmoxStorage` typed refs) reported `enabled=false` for all storages — and `enabled` is a `@defaults` field. Added a `Disable` field and normalize `Enabled` from it in `GetStorages`; the node path keeps its genuine `enabled` value, so `proxmox.node.storages` is unchanged.
- **`vm.updates()` fails on agent-less VMs** — a running VM without the QEMU guest agent returned a hard error, failing the field for the whole list during `vms { updates }`. Now returns an empty list, consistent with the Windows-update path.

## Test
`go build ./...` passes.