### PR TITLE
🐛 github: fix headCommit nil-owner panic and unchecked connection hash error

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -124,6 +124,9 @@ func NewGithubConnection(id uint32, asset *inventory.Asset) (*GithubConnection, 
 
 	// store the hash of the config options used to generate this client
 	hash, err := hashstructure.Hash(connectionOpts, hashstructure.FormatV2, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return &GithubConnection{
 		Connection:  plugin.NewConnection(id, asset),

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -808,9 +808,24 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 }
 
 func (g *mqlGithubBranch) headCommit() (*mqlGithubCommit, error) {
+	if g.Owner.Error != nil {
+		return nil, g.Owner.Error
+	}
+	// newMqlGithubRepository sets owner to null for owner-less repos, so
+	// g.Owner.Data can be nil; guard before dereferencing it.
 	ownerName := g.Owner.Data
+	if ownerName == nil {
+		g.HeadCommit.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	if ownerName.Login.Error != nil {
 		return nil, ownerName.Login.Error
+	}
+	if g.HeadCommitSha.Error != nil {
+		return nil, g.HeadCommitSha.Error
+	}
+	if g.RepoName.Error != nil {
+		return nil, g.RepoName.Error
 	}
 	ownerLogin := ownerName.Login.Data
 


### PR DESCRIPTION
## What

- **`branch.headCommit()` nil-owner panic** — it read `g.Owner.Data` and dereferenced `.Login` without checking `g.Owner.Error` or `Data != nil`. `newMqlGithubRepository` explicitly sets the owner to null for owner-less repos, so `branch.headCommit` panicked and (since the executor runs blocks in goroutines) crashed the whole scan. Now guards `g.Owner` (and `HeadCommitSha`/`RepoName`), returning a null commit when the owner is absent.
- **connection hash error ignored** — `hashstructure.Hash(...)` error was dropped; a hash failure would silently yield `OptionsHash == 0`, collapsing distinct connections onto one key and defeating the client-verification dedup. Now returns the error.

## Test
`go build ./...` passes.