### PR TITLE
🐛 github: fix 2FA false-negative and swallowed/over-strict error handling

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -88,7 +88,7 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	if userId == "" {
 		userId = conf.Options["owner"]
 	}
-	if conf.Options["user"] != "" {
+	if userId != "" {
 		userAssets, err := user(runtime, userId, conn)
 		if err != nil {
 			return nil, err

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -81,7 +81,10 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	plan, _ := convert.JsonToDict(org.Plan)
 	args["plan"] = llx.MapData(plan, types.Any)
 
-	args["twoFactorRequirementEnabled"] = llx.BoolData(convert.ToValue(org.TwoFactorRequirementEnabled))
+	// Use BoolDataPtr so an unset value (GitHub returns null when the caller
+	// lacks org-admin scope) reads as MQL null rather than false — otherwise a
+	// scoped-down token would report 2FA-not-required for an org that enforces it.
+	args["twoFactorRequirementEnabled"] = llx.BoolDataPtr(org.TwoFactorRequirementEnabled)
 	args["isVerified"] = llx.BoolData(convert.ToValue(org.IsVerified))
 
 	args["hasOrganizationProjects"] = llx.BoolData(convert.ToValue(org.HasOrganizationProjects))

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -623,6 +623,9 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 	var err error
 
 	// if the branch is not protected, we don't need to fetch the protection rules
+	if g.IsProtected.Error != nil {
+		return nil, g.IsProtected.Error
+	}
 	if !g.IsProtected.Data {
 		g.ProtectionRules.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -97,6 +97,12 @@ func (g *mqlGithubTeam) members() ([]any, error) {
 	for {
 		members, resp, err := conn.Client().Teams.ListTeamMembersByID(conn.Context(), orgID, teamID, listOpts)
 		if err != nil {
+			// A team that's gone (deleted between list and access) or not
+			// visible to the token 404s; degrade to an empty member list
+			// rather than failing the whole query, like team.repositories().
+			if strings.Contains(err.Error(), "404") {
+				return nil, nil
+			}
 			return nil, err
 		}
 		allMembers = append(allMembers, members...)


### PR DESCRIPTION
## What

- **`org.twoFactorRequirementEnabled` false-negative** — used `convert.ToValue`, so a nil pointer (GitHub returns `null` when the caller lacks org-admin scope) collapsed to `false`, reporting 2FA-not-required for an org that actually enforces it. Now uses `BoolDataPtr` so unset reads as MQL null (audits can distinguish "not required" from "unknown/unauthorized").
- **`branch.protectionRules()` swallowed error** — read `g.IsProtected.Data` without checking `g.IsProtected.Error`, so a field-resolution error was rendered as "branch unprotected". Now surfaces the error.
- **`team.members()` over-strict** — returned the raw error on any failure; a 404 (team deleted or not visible to the token) failed the whole query. Now tolerates 404 → empty, matching `team.repositories()`.
- **discovery dead owner-fallback** — user discovery guarded on `conf.Options["user"]` instead of the computed `userId`, so the `owner` fallback was dead code and an owner-only config never discovered the user asset. Now guards on `userId`.

## Test
`go build ./...` passes.