### PR TITLE
🐛 digitalocean: consistent error handling for scans, spaces keys, pagination

### DIFF
--- a/providers/digitalocean/resources/digitalocean_images.go
+++ b/providers/digitalocean/resources/digitalocean_images.go
@@ -76,7 +76,7 @@ func (r *mqlDigitalocean) images() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -130,7 +130,7 @@ func (r *mqlDigitalocean) snapshots() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}

--- a/providers/digitalocean/resources/digitalocean_security_scan.go
+++ b/providers/digitalocean/resources/digitalocean_security_scan.go
@@ -49,6 +49,12 @@ func (r *mqlDigitalocean) securityScans() ([]interface{}, error) {
 	for {
 		scans, resp, err := client.Security.ListScans(context.Background(), opt)
 		if err != nil {
+			// CSPM scan endpoints 404 on accounts that have never run a scan;
+			// treat that as an empty list rather than failing (mirrors the
+			// container-registry accessors).
+			if isDoNotFound(err) {
+				return []interface{}{}, nil
+			}
 			return nil, err
 		}
 		for _, s := range scans {
@@ -78,6 +84,11 @@ func (r *mqlDigitalocean) latestSecurityScan() (*mqlDigitaloceanSecurityScan, er
 
 	scan, _, err := client.Security.GetLatestScan(context.Background(), nil)
 	if err != nil {
+		// 404 when no scan has ever run; return a null field rather than error.
+		if isDoNotFound(err) {
+			r.LatestSecurityScan.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	if scan == nil {

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -891,8 +891,13 @@ func (r *mqlDigitalocean) spacesKeys() ([]interface{}, error) {
 	for {
 		keys, resp, err := client.SpacesKeys.List(context.Background(), opt)
 		if err != nil {
-			// Spaces Keys API may not be available if Spaces is not enabled
-			return []interface{}{}, nil
+			// Spaces Keys API 404s if Spaces isn't enabled; tolerate that, but
+			// surface real failures (auth, rate-limit, network) instead of
+			// masking them as "no keys".
+			if isDoNotFound(err) {
+				return []interface{}{}, nil
+			}
+			return nil, err
 		}
 		for _, k := range keys {
 			grants := make([]interface{}, len(k.Grants))


### PR DESCRIPTION
## What

digitalocean is otherwise clean (no panics, no inverted security booleans, pagination handled). Three error-handling consistency fixes:

- **`securityScans()` / `latestSecurityScan()`** — the CSPM scan endpoints 404 on accounts that have never run a scan, so these fields **errored** on accounts without CSPM, while the container-registry accessors tolerate 404 via `isDoNotFound`. Now treat `isDoNotFound` as an empty list / null field.
- **`spacesKeys()`** — blanket-swallowed **every** `List` error as "no keys", masking real auth/rate-limit/network failures. Now only tolerates `isDoNotFound`; propagates the rest.
- **`images()` / `snapshots()`** — a `CurrentPage()` parse error did `break`, silently truncating the inventory with no error. Now returns the error, like every other list in the provider.

## Test
`go build ./...` passes.