### PR TITLE
🐛 azure: re-land stranded review fixes + add regression tests

### DIFF
--- a/providers/azure/resources/advisor.go
+++ b/providers/azure/resources/advisor.go
@@ -175,24 +175,40 @@ func (a *mqlAzureSubscriptionAdvisorService) scores() ([]any, error) {
 	return res, nil
 }
 
+// meanOfPresentScores averages the non-nil values, dividing by the count of
+// values actually summed (not the input length) so the average isn't skewed
+// toward zero by unresolved/absent scores. Returns 0 when none are present.
+func meanOfPresentScores(values []*float64) float64 {
+	sum := float64(0)
+	count := 0
+	for _, v := range values {
+		if v == nil {
+			continue
+		}
+		sum += *v
+		count++
+	}
+	if count == 0 {
+		return 0
+	}
+	return sum / float64(count)
+}
+
 func (a *mqlAzureSubscriptionAdvisorService) averageScore() (float64, error) {
 	scores := a.GetScores()
 	if scores.Error != nil {
 		return 0, scores.Error
 	}
-	if len(scores.Data) == 0 {
-		return 0, nil
-	}
-	avg := float64(0)
+	values := make([]*float64, 0, len(scores.Data))
 	for _, s := range scores.Data {
 		score := s.(*mqlAzureSubscriptionAdvisorServiceScore)
 		if score.CurrentScore.Data == nil {
 			continue
 		}
-		avg += score.CurrentScore.Data.Score.Data
+		v := score.CurrentScore.Data.Score.Data
+		values = append(values, &v)
 	}
-
-	return avg / float64(len(scores.Data)), nil
+	return meanOfPresentScores(values), nil
 }
 
 func (a *mqlAzureSubscriptionAdvisorServiceRecommendation) id() (string, error) {

--- a/providers/azure/resources/advisor_test.go
+++ b/providers/azure/resources/advisor_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMeanOfPresentScores verifies the average divides by the count of scores
+// actually present (non-nil), not the input length — otherwise unresolved
+// scores skew the average toward zero.
+func TestMeanOfPresentScores(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	// 10 + 20 over 2 present (the nil is skipped in BOTH sum and denominator)
+	assert.Equal(t, 15.0, meanOfPresentScores([]*float64{f(10), nil, f(20)}))
+	// all present
+	assert.Equal(t, 20.0, meanOfPresentScores([]*float64{f(10), f(30)}))
+	// single
+	assert.Equal(t, 7.0, meanOfPresentScores([]*float64{f(7)}))
+	// none present / empty
+	assert.Equal(t, 0.0, meanOfPresentScores([]*float64{nil, nil}))
+	assert.Equal(t, 0.0, meanOfPresentScores(nil))
+}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -466,19 +466,25 @@ func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {
 	return res, nil
 }
 
-func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
-	type mqlRetentionPolicy struct {
-		Enabled       bool `json:"enabled"`
-		RetentionDays int  `json:"retentionDays"`
-	}
-	type mqlFlowLogAnalytics struct {
-		Enabled             bool   `json:"enabled"`
-		AnalyticsInterval   int    `json:"analyticsInterval"`
-		WorkspaceId         string `json:"workspaceId"`
-		WorkspaceResourceId string `json:"workspaceResourceId"`
-		WorkspaceRegion     string `json:"workspaceRegion"`
-	}
+// flowLogRetentionPolicy and flowLogAnalyticsConfig mirror the Azure flow-log
+// sub-objects, carrying the JSON tags used to build the resource's dict fields.
+// They are package-level (not function-local) so the tag mapping can be
+// unit-tested — the tags were previously scrambled, serializing values under
+// the wrong keys.
+type flowLogRetentionPolicy struct {
+	Enabled       bool `json:"enabled"`
+	RetentionDays int  `json:"retentionDays"`
+}
 
+type flowLogAnalyticsConfig struct {
+	Enabled             bool   `json:"enabled"`
+	AnalyticsInterval   int    `json:"analyticsInterval"`
+	WorkspaceId         string `json:"workspaceId"`
+	WorkspaceResourceId string `json:"workspaceResourceId"`
+	WorkspaceRegion     string `json:"workspaceRegion"`
+}
+
+func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSubscriptionNetworkServiceWatcherFlowlog, error) {
 	args := map[string]*llx.RawData{
 		"id":       llx.StringDataPtr(flowLog.ID),
 		"name":     llx.StringDataPtr(flowLog.Name),
@@ -489,9 +495,9 @@ func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSu
 	}
 
 	if props := flowLog.Properties; props != nil {
-		var retentionPolicy mqlRetentionPolicy
+		var retentionPolicy flowLogRetentionPolicy
 		if rp := props.RetentionPolicy; rp != nil {
-			retentionPolicy = mqlRetentionPolicy{
+			retentionPolicy = flowLogRetentionPolicy{
 				Enabled:       convert.ToValue(rp.Enabled),
 				RetentionDays: int(convert.ToValue(rp.Days)),
 			}
@@ -500,10 +506,10 @@ func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSu
 		if err != nil {
 			return nil, err
 		}
-		var flowLogAnalytics mqlFlowLogAnalytics
+		var flowLogAnalytics flowLogAnalyticsConfig
 		if fac := props.FlowAnalyticsConfiguration; fac != nil && fac.NetworkWatcherFlowAnalyticsConfiguration != nil {
 			nwfac := fac.NetworkWatcherFlowAnalyticsConfiguration
-			flowLogAnalytics = mqlFlowLogAnalytics{
+			flowLogAnalytics = flowLogAnalyticsConfig{
 				Enabled:             convert.ToValue(nwfac.Enabled),
 				AnalyticsInterval:   int(convert.ToValue(nwfac.TrafficAnalyticsInterval)),
 				WorkspaceRegion:     convert.ToValue(nwfac.WorkspaceRegion),

--- a/providers/azure/resources/network_flowlog_test.go
+++ b/providers/azure/resources/network_flowlog_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFlowLogAnalyticsConfigJSONTags guards the JSON tags on the flow-log
+// analytics struct. They were previously scrambled — `enabled` serialized
+// under `allowedApplications`, and `workspaceId`/`workspaceResourceId` swapped
+// — so any audit reading those dict fields got the wrong value.
+func TestFlowLogAnalyticsConfigJSONTags(t *testing.T) {
+	cfg := flowLogAnalyticsConfig{
+		Enabled:             true,
+		AnalyticsInterval:   10,
+		WorkspaceId:         "ws-id",
+		WorkspaceResourceId: "ws-resource-id",
+		WorkspaceRegion:     "westus",
+	}
+	b, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	assert.Equal(t, true, m["enabled"])
+	assert.Equal(t, float64(10), m["analyticsInterval"])
+	assert.Equal(t, "ws-id", m["workspaceId"])
+	assert.Equal(t, "ws-resource-id", m["workspaceResourceId"])
+	assert.Equal(t, "westus", m["workspaceRegion"])
+
+	// none of the old/scrambled keys should be present
+	for _, badKey := range []string{"allowedApplications"} {
+		_, present := m[badKey]
+		assert.False(t, present, "unexpected scrambled key %q", badKey)
+	}
+}

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -587,11 +587,12 @@ func (a *mqlAzureSubscriptionSqlServiceServer) azureAdOnlyAuthentication() (bool
 	}
 	result, err := client.Get(ctx, resourceID.ResourceGroup, server, sql.AuthenticationNameDefault, &sql.ServerAzureADOnlyAuthenticationsClientGetOptions{})
 	if err != nil {
-		// Only tolerate access-denied: swallowing every error would report a
-		// transient/permission failure as Azure-AD-only-auth disabled, which is
-		// the insecure value for a security check.
+		// Only tolerate access-denied / not-found: swallowing every error would
+		// report a transient/permission failure as Azure-AD-only-auth disabled,
+		// which is the insecure value for a security check. Some server SKUs
+		// don't support the endpoint and return 404 rather than 403.
 		var rerr *azcore.ResponseError
-		if errors.As(err, &rerr) && rerr.StatusCode == http.StatusForbidden {
+		if errors.As(err, &rerr) && (rerr.StatusCode == http.StatusForbidden || rerr.StatusCode == http.StatusNotFound) {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
## What

Two review-follow-up fixes were pushed to their PR branches **after** those PRs had already merged (#8489, #8488), so they never reached `main`. This re-lands them with regression tests:

- **advisor `averageScore`** (correctness) — now divides by the count of scores actually summed (skipping nil `currentScore`), not the full list length, so unresolved scores don't skew the average toward zero. Extracted `meanOfPresentScores` as a pure, tested helper.
- **sql `azureAdOnlyAuthentication`** — also tolerates 404 (some server SKUs return 404 rather than 403 for the unsupported endpoint), while still surfacing other errors.
- **network flow-log analytics** — lifted the JSON-tagged struct to package level and added a test asserting the tag names, guarding the previously-scrambled `enabled`/`workspaceId`/`workspaceResourceId` tags from regressing.

## Test
`go test ./resources/ -run 'TestFlowLogAnalyticsConfigJSONTags|TestMeanOfPresentScores'` passes; `go build ./...` clean.