### PR TITLE
🧹 proxmox: regression test for cluster storage enabled normalization

### DIFF
--- a/providers/proxmox/connection/storage.go
+++ b/providers/proxmox/connection/storage.go
@@ -34,12 +34,17 @@ func (c *PveConnection) GetStorages() ([]StorageInfo, error) {
 	if err := c.apiGet("/storage", &storages); err != nil {
 		return nil, fmt.Errorf("failed to get storages: %w", err)
 	}
-	// The cluster /storage endpoint reports config (a "disable" key), not the
-	// runtime "enabled" key that /nodes/<n>/storage returns. Normalize Enabled
-	// from Disable so the shared mapper reports a correct value — without this,
-	// every cluster-level storage was reported as enabled=false. Only infer
-	// Enabled when the response didn't already provide it, so a future endpoint
-	// that returns both keys keeps its explicit value.
+	normalizeClusterStorageEnabled(storages)
+	return storages, nil
+}
+
+// normalizeClusterStorageEnabled derives Enabled from the cluster /storage
+// "disable" config key. That endpoint reports config (disable), not the runtime
+// "enabled" key that /nodes/<n>/storage returns, so without this every
+// cluster-level storage reads as enabled=false. Enabled is only inferred when
+// the response didn't already provide it, so an endpoint returning both keys
+// keeps its explicit value.
+func normalizeClusterStorageEnabled(storages []StorageInfo) {
 	for i := range storages {
 		if storages[i].Disable != 0 {
 			storages[i].Enabled = 0
@@ -47,7 +52,6 @@ func (c *PveConnection) GetStorages() ([]StorageInfo, error) {
 			storages[i].Enabled = 1
 		}
 	}
-	return storages, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/connection/storage_test.go
+++ b/providers/proxmox/connection/storage_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "testing"
+
+// TestNormalizeClusterStorageEnabled verifies Enabled is derived from the
+// cluster "disable" config key. The cluster /storage endpoint omits the runtime
+// "enabled" key, so without normalization every cluster storage read as
+// enabled=false.
+func TestNormalizeClusterStorageEnabled(t *testing.T) {
+	storages := []StorageInfo{
+		{Storage: "cluster-enabled", Disable: 0, Enabled: 0},  // no disable key -> enabled
+		{Storage: "cluster-disabled", Disable: 1, Enabled: 0}, // disable=1 -> disabled
+		{Storage: "node-enabled", Disable: 0, Enabled: 1},     // explicit enabled preserved
+		{Storage: "disable-wins", Disable: 1, Enabled: 1},     // disable overrides explicit enabled
+	}
+
+	normalizeClusterStorageEnabled(storages)
+
+	want := []int{1, 0, 1, 0}
+	for i, s := range storages {
+		if s.Enabled != want[i] {
+			t.Errorf("%s: Enabled = %d, want %d", s.Storage, s.Enabled, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## What

Regression test for the storage `enabled` fix in #8497 (merged). The cluster `/storage` endpoint reports a `disable` config key rather than the runtime `enabled` key, so without normalization every cluster-level storage read as `enabled=false`. Extracted the logic into `normalizeClusterStorageEnabled` and added a table test covering: cluster-enabled (no `disable`), cluster-disabled (`disable=1`), node path (explicit `enabled` preserved), and disable-wins.

## Test
`go test ./connection/ -run TestNormalizeClusterStorageEnabled` passes; `go build ./...` clean.