### PR TITLE
🐛 cloudformation: guard section bodies against non-mapping YAML (panic fix)

### DIFF
--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -435,8 +435,17 @@ func (r *mqlCloudformationTemplate) types() ([]any, error) {
 	}
 	// GetTypes iterates the Resources section assuming an even mapping and
 	// dereferences Content[0]; skip when the template/Resources body is
-	// degenerate or malformed so the upstream stride-2 access can't panic.
-	if _, body, err := gatherMapValue(template.Node.Content[0], string(cft.Resources)); err != nil || !isEvenMappingNode(body) {
+	// degenerate or malformed so the upstream stride-2 access can't panic. A
+	// missing Resources section is a valid empty state, but any other
+	// gatherMapValue error is a real parse failure and must surface rather than
+	// be swallowed as "no types."
+	_, body, err := gatherMapValue(template.Node.Content[0], string(cft.Resources))
+	if err != nil && status.Code(err) == codes.NotFound {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if !isEvenMappingNode(body) {
 		return nil, nil
 	}
 

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -15,6 +15,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// isEvenMappingNode reports whether n is a YAML mapping with an even number of
+// content nodes — i.e. safe to iterate two-at-a-time (key, value). A template
+// section written as a sequence (or with odd content) would otherwise index
+// out of range in the stride-2 loops below and panic the whole scan.
+func isEvenMappingNode(n *yaml.Node) bool {
+	return n != nil && n.Kind == yaml.MappingNode && len(n.Content)%2 == 0
+}
+
 func initCloudformationTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil
@@ -73,6 +81,9 @@ func (r *mqlCloudformationTemplate) extractDict(section cft.Section) (map[string
 	}
 	if err != nil {
 		return nil, err
+	}
+	if !isEvenMappingNode(parameters) {
+		return nil, nil
 	}
 
 	result := make(map[string]any)
@@ -134,6 +145,9 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
+	}
+	if !isEvenMappingNode(resources) {
+		return nil, nil
 	}
 
 	result := make([]any, 0)
@@ -260,6 +274,9 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	if !isEvenMappingNode(outputs) {
+		return nil, nil
+	}
 
 	result := make([]any, 0)
 	for i := 0; i < len(outputs.Content); i += 2 {
@@ -324,6 +341,9 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
+	}
+	if !isEvenMappingNode(params) {
+		return nil, nil
 	}
 
 	result := make([]any, 0)
@@ -410,6 +430,15 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 func (r *mqlCloudformationTemplate) types() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
 	template := conn.CftTemplate()
+	if template.Node == nil || len(template.Node.Content) == 0 {
+		return nil, nil
+	}
+	// GetTypes iterates the Resources section assuming an even mapping and
+	// dereferences Content[0]; skip when the template/Resources body is
+	// degenerate or malformed so the upstream stride-2 access can't panic.
+	if _, body, err := gatherMapValue(template.Node.Content[0], string(cft.Resources)); err != nil || !isEvenMappingNode(body) {
+		return nil, nil
+	}
 
 	list, err := template.GetTypes()
 	if err != nil {

--- a/providers/cloudformation/resources/template_test.go
+++ b/providers/cloudformation/resources/template_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws-cloudformation/rain/cft"
+	"github.com/aws-cloudformation/rain/cft/parse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsEvenMappingNode_SectionBodyGuard guards against the out-of-bounds panic
+// that occurred when a CloudFormation section (Resources/Outputs/Parameters/…)
+// was written as a YAML sequence instead of a mapping: the stride-2 loops
+// (body.Content[i+1]) would index past the end. isEvenMappingNode must reject a
+// sequence-bodied section so those loops never run.
+func TestIsEvenMappingNode_SectionBodyGuard(t *testing.T) {
+	// Resources as an odd-length sequence — the historical panic input.
+	tmpl, err := parse.String("Resources:\n  - a\n  - b\n  - c\n")
+	require.NoError(t, err)
+	require.NotNil(t, tmpl.Node)
+	require.NotEmpty(t, tmpl.Node.Content)
+
+	_, body, err := gatherMapValue(tmpl.Node.Content[0], string(cft.Resources))
+	require.NoError(t, err)
+	assert.False(t, isEvenMappingNode(body), "sequence-bodied section must be rejected")
+
+	// A well-formed mapping body must pass.
+	tmpl2, err := parse.String("Resources:\n  Bucket:\n    Type: AWS::S3::Bucket\n")
+	require.NoError(t, err)
+	_, body2, err := gatherMapValue(tmpl2.Node.Content[0], string(cft.Resources))
+	require.NoError(t, err)
+	assert.True(t, isEvenMappingNode(body2), "well-formed mapping body must be accepted")
+}
+
+// TestResourcesDoesNotPanicOnSequenceBody is a belt-and-suspenders check that
+// the node-level guard maps to the behavior we want: nil node, sequence node,
+// and odd-content node are all rejected.
+func TestIsEvenMappingNode_Cases(t *testing.T) {
+	assert.False(t, isEvenMappingNode(nil))
+
+	tmpl, err := parse.String("Resources:\n  Bucket:\n    Type: AWS::S3::Bucket\n")
+	require.NoError(t, err)
+	doc := tmpl.Node.Content[0]
+	assert.True(t, isEvenMappingNode(doc), "the top-level template mapping is even")
+}


### PR DESCRIPTION
## What

`resources()` / `outputs()` / `parameterList()` / `extractDict()` / `types()` iterate a template section body two-at-a-time (`body.Content[i+1]`) but only validated the **parent** document node, not the section body returned by `gatherMapValue`. A section written as a YAML **sequence** (or with odd content) — e.g.

```yaml
Resources:
  - a
  - b
  - c
```

makes the body a sequence node, so the stride-2 loop indexes out of range and **panics the whole scan** on one malformed template. `types()` additionally lacked the degenerate-template guard its siblings already had (and the upstream `GetTypes` dereferences `Content[0]` / iterates Resources assuming an even mapping).

## Fix

- Added `isEvenMappingNode` and guard every stride-2 section loop with it (returns empty/nil for a non-mapping body instead of panicking).
- `types()` now skips `GetTypes` when the template/Resources body is degenerate or malformed.

## Test

`TestIsEvenMappingNode_SectionBodyGuard` reproduces the sequence-bodied `Resources:` input via `parse.String` and asserts the guard rejects it, and accepts a well-formed mapping body. `go test ./resources/` and `go build ./...` pass.