### PR TITLE
🐛 helm: split rendered manifests on real YAML separators only

### DIFF
--- a/providers/helm/resources/resource.go
+++ b/providers/helm/resources/resource.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// yamlDocSeparator matches a YAML document separator: `---` alone on a line
+// (optionally with trailing whitespace), at column 0.
+var yamlDocSeparator = regexp.MustCompile(`(?m)^---[ \t]*$`)
+
+// splitYAMLDocuments splits a multi-document YAML stream on real document
+// separators only. The previous strings.Split(content, "---") split on ANY
+// occurrence of "---" — including inside a string value, an indented block
+// scalar (e.g. a ConfigMap data payload), or a comment — which silently
+// corrupted or dropped valid Kubernetes resources.
+func splitYAMLDocuments(content string) []string {
+	return yamlDocSeparator.Split(content, -1)
+}
+
 type mqlHelmResourceInternal struct {
 	cacheTemplateKey string
 }
@@ -25,8 +39,8 @@ type mqlHelmResourceInternal struct {
 func parseK8sResources(runtime *plugin.Runtime, templateKey string, content string, isCRD bool) ([]any, error) {
 	var mqlResources []any
 
-	// Split on YAML document separator
-	docs := strings.Split(content, "---")
+	// Split on YAML document separators only (not on `---` inside values)
+	docs := splitYAMLDocuments(content)
 	docIndex := 0
 	for _, doc := range docs {
 		doc = strings.TrimSpace(doc)

--- a/providers/helm/resources/resource_test.go
+++ b/providers/helm/resources/resource_test.go
@@ -391,3 +391,38 @@ metadata:
 		assert.NotEqual(t, id0, id1, "duplicate resources should have different IDs due to docIndex")
 	})
 }
+
+func TestParseK8sResourcesDocumentSeparatorInValue(t *testing.T) {
+	t.Run("--- inside a quoted scalar must not split the document", func(t *testing.T) {
+		// The previous strings.Split(content, "---") split this into an
+		// unterminated-quote chunk that failed to unmarshal, dropping the whole
+		// resource (0 results). Splitting only on real separators keeps it whole.
+		yaml := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: inline-sep\ndata:\n  note: \"a --- b\"\n"
+
+		runtime := newTestRuntime()
+		resources, err := parseK8sResources(runtime, "mychart/templates/cm.yaml", yaml, false)
+		require.NoError(t, err)
+		require.Len(t, resources, 1, "a `---` inside a quoted value must not split (or drop) the document")
+		assert.Equal(t, "inline-sep", resources[0].(*mqlHelmResource).Name.Data)
+	})
+
+	t.Run("--- inside an indented block scalar must not split the document", func(t *testing.T) {
+		// strings.Split would cut the block scalar at the indented `---`,
+		// truncating the resource. Real separators are column-0 only.
+		yaml := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: block-sep\ndata:\n  readme: |\n    intro\n    ---\n    outro\n"
+
+		runtime := newTestRuntime()
+		resources, err := parseK8sResources(runtime, "mychart/templates/cm.yaml", yaml, false)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assert.Equal(t, "block-sep", resources[0].(*mqlHelmResource).Name.Data)
+	})
+
+	t.Run("genuine separators still split", func(t *testing.T) {
+		yaml := "kind: ConfigMap\nmetadata:\n  name: a\n---\nkind: ConfigMap\nmetadata:\n  name: b\n"
+		runtime := newTestRuntime()
+		resources, err := parseK8sResources(runtime, "mychart/templates/cm.yaml", yaml, false)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+	})
+}


### PR DESCRIPTION
## What

`parseK8sResources` split rendered chart output with `strings.Split(content, "---")`, which splits on **any** occurrence of `---`, not just YAML document separators. A `---` inside:
- a quoted value (`note: "a --- b"`) — left an **unterminated quote** chunk that failed to unmarshal, silently **dropping the whole resource**,
- an indented block scalar (e.g. a ConfigMap `data` payload), or
- a comment

...corrupted or dropped valid Kubernetes resources from scan output, on entirely valid charts.

## Fix

Split on `(?m)^---[ \t]*$` (a `---` alone on a line, at column 0) via the extracted `splitYAMLDocuments` helper.

## Test

Added regression tests (in the existing `parseK8sResources` harness): a `---` inside a quoted scalar and inside an indented block scalar must each stay **one** document (the quoted case yielded **0** resources before the fix), while genuine `---` separators still split. `go test ./resources/` and `go build ./...` pass.