### PR TITLE
🐛 kustomize: keep no-fieldPaths replacement targets and unique image ids

### DIFF
--- a/providers/kustomize/resources/image.go
+++ b/providers/kustomize/resources/image.go
@@ -4,13 +4,19 @@
 package resources
 
 import (
+	"strconv"
+
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
 )
 
-func newMqlKustomizeImage(runtime *plugin.Runtime, kustPath string, img kustomizeTypes.Image) (*mqlKustomizeImage, error) {
-	id := "kustomize.image:" + kustPath + ":" + img.Name
+func newMqlKustomizeImage(runtime *plugin.Runtime, kustPath string, idx int, img kustomizeTypes.Image) (*mqlKustomizeImage, error) {
+	// Include the list index in the __id: an images: list can legally contain
+	// two entries with the same name (e.g. one overriding the tag, one the
+	// digest); without the index the second collides with the first in the
+	// resource cache and is lost.
+	id := "kustomize.image:" + kustPath + ":" + strconv.Itoa(idx) + ":" + img.Name
 
 	res, err := CreateResource(runtime, "kustomize.image", map[string]*llx.RawData{
 		"__id":    llx.StringData(id),

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -223,8 +223,8 @@ func (k *mqlKustomizeKustomization) images() ([]any, error) {
 		return nil, err
 	}
 	var mqlImages []any
-	for _, img := range kust.Images {
-		mqlImg, err := newMqlKustomizeImage(k.MqlRuntime, kustPath, img)
+	for i, img := range kust.Images {
+		mqlImg, err := newMqlKustomizeImage(k.MqlRuntime, kustPath, i, img)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/kustomize/resources/kustomize_test.go
+++ b/providers/kustomize/resources/kustomize_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
+)
+
+func newTestRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+// TestNewMqlKustomizeImageUniqueID ensures two images that share a name (legal
+// in kustomize — e.g. one overrides the tag, one the digest) get distinct
+// __ids, so the second isn't dropped by a resource-cache collision.
+func TestNewMqlKustomizeImageUniqueID(t *testing.T) {
+	rt := newTestRuntime()
+
+	a, err := newMqlKustomizeImage(rt, "kustomization.yaml", 0, kustomizeTypes.Image{Name: "nginx", NewTag: "1.0"})
+	require.NoError(t, err)
+	b, err := newMqlKustomizeImage(rt, "kustomization.yaml", 1, kustomizeTypes.Image{Name: "nginx", Digest: "sha256:abc"})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a.__id, b.__id, "same-name images must have distinct __ids")
+}
+
+// TestReplacementTargetsWithoutFieldPaths ensures a target that specifies a
+// Select but omits fieldPaths still produces a target row (it was previously
+// dropped because the only emission happened inside the fieldPaths loop).
+func TestReplacementTargetsWithoutFieldPaths(t *testing.T) {
+	r := &mqlKustomizeReplacement{MqlRuntime: newTestRuntime()}
+	r.kustPath = "kustomization.yaml"
+	r.replacementTargets = []*kustomizeTypes.TargetSelector{
+		{Select: &kustomizeTypes.Selector{}, FieldPaths: nil},                          // no fieldPaths -> 1 row
+		{Select: &kustomizeTypes.Selector{}, FieldPaths: []string{"spec.a", "spec.b"}}, // -> 2 rows
+		nil, // a bare `- ` list entry -> skipped
+	}
+
+	targets, err := r.targets()
+	require.NoError(t, err)
+	assert.Len(t, targets, 3, "target with no fieldPaths must still emit one row")
+}

--- a/providers/kustomize/resources/replacement.go
+++ b/providers/kustomize/resources/replacement.go
@@ -68,7 +68,13 @@ func (r *mqlKustomizeReplacement) targets() ([]any, error) {
 			name = t.Select.Name
 		}
 
-		for j, fp := range t.FieldPaths {
+		// A target may specify a Select but omit fieldPaths; emit one target
+		// row with an empty fieldPath rather than dropping the target entirely.
+		fieldPaths := t.FieldPaths
+		if len(fieldPaths) == 0 {
+			fieldPaths = []string{""}
+		}
+		for j, fp := range fieldPaths {
 			id := "kustomize.replacementTarget:" + r.kustPath + ":" + strconv.Itoa(i) + ":" + kind + ":" + name + ":" + strconv.Itoa(j) + ":" + fp
 
 			res, err := CreateResource(r.MqlRuntime, "kustomize.replacementTarget", map[string]*llx.RawData{


### PR DESCRIPTION
## What

- **`replacementTarget.targets()`** — a target that specified a `Select` but omitted `fieldPaths` was **silently dropped**, because the only `CreateResource` happened inside the `for _, fp := range t.FieldPaths` loop. Now emits one target row with an empty `fieldPath` when none are given.
- **`newMqlKustomizeImage`** — the `__id` was `kustomize.image:<path>:<name>`, so two images sharing a name (legal in kustomize — e.g. one overriding the tag, one the digest) **collided** in the resource cache and the second was lost. The `__id` now includes the list index.

## Test

Added unit tests: two same-name images get distinct `__id`s; a target with no `fieldPaths` still yields one row (plus a nil list entry is skipped). `go test ./resources/` and `go build ./...` pass.