### PR TITLE
🐛 atlassian: paginate admin users/policies/domains and guard empty org

### DIFF
--- a/providers/atlassian/resources/atlassian_admin.go
+++ b/providers/atlassian/resources/atlassian_admin.go
@@ -45,6 +45,13 @@ func parseAtlassianTime(s string) *time.Time {
 	return &t
 }
 
+// productAccess is one entry of a managed user's product-access list,
+// flattened to the name and the (nullable) last-active timestamp.
+type productAccess struct {
+	Name       string
+	LastActive *time.Time
+}
+
 func initAtlassianAdminOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	conn, ok := runtime.Connection.(*admin.AdminConnection)
 	if !ok {
@@ -62,7 +69,7 @@ func initAtlassianAdminOrganization(runtime *plugin.Runtime, args map[string]*ll
 		return nil, nil, errors.New("no organization found for this API key")
 	}
 	if len(organization.Data) > 1 {
-		return nil, nil, errors.New("Unexpectedly received more than 1 organization")
+		return nil, nil, errors.New("unexpectedly received more than 1 organization")
 	}
 	org := organization.Data[0]
 
@@ -89,15 +96,10 @@ func (a *mqlAtlassianAdminOrganization) managedUsers() ([]any, error) {
 			return nil, err
 		}
 		for _, user := range managedUsers.Data {
-
-			type ProductAccess struct {
-				Name       string
-				LastActive *time.Time
-			}
-			var products []ProductAccess
+			var products []productAccess
 
 			for i := range user.ProductAccess {
-				products = append(products, ProductAccess{
+				products = append(products, productAccess{
 					Name:       user.ProductAccess[i].Name,
 					LastActive: parseAtlassianTime(user.ProductAccess[i].LastActive),
 				})

--- a/providers/atlassian/resources/atlassian_admin.go
+++ b/providers/atlassian/resources/atlassian_admin.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/url"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -14,6 +15,21 @@ import (
 	"go.mondoo.com/mql/v13/providers/atlassian/connection/admin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// extractAtlassianCursor parses the `cursor` query parameter out of a page's
+// Links.Next URL. The admin API paginates by cursor and the SDK list methods
+// take the raw cursor value (re-encoding it as ?cursor=…), so the full Next URL
+// must not be passed back verbatim.
+func extractAtlassianCursor(nextURL string) string {
+	if nextURL == "" {
+		return ""
+	}
+	u, err := url.Parse(nextURL)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get("cursor")
+}
 
 // parseAtlassianTime parses Atlassian Admin API timestamps (RFC3339). Returns
 // nil for empty or unparseable input — the API returns "" for never-active
@@ -42,6 +58,9 @@ func initAtlassianAdminOrganization(runtime *plugin.Runtime, args map[string]*ll
 
 	// We should only ever receive one organization that is scoped to the api key
 	// https://community.atlassian.com/t5/Atlassian-Access-questions/Can-we-access-multiple-organisations-using-one-API-Token/qaq-p/1541337
+	if len(organization.Data) == 0 {
+		return nil, nil, errors.New("no organization found for this API key")
+	}
 	if len(organization.Data) > 1 {
 		return nil, nil, errors.New("Unexpectedly received more than 1 organization")
 	}
@@ -62,48 +81,58 @@ func (a *mqlAtlassianAdminOrganization) managedUsers() ([]any, error) {
 
 	admin := conn.Client()
 
-	managedUsers, _, err := admin.Organization.Users(context.Background(), a.Id.Data, "")
-	if err != nil {
-		return nil, err
-	}
 	res := []any{}
-	for _, user := range managedUsers.Data {
-
-		type ProductAccess struct {
-			Name       string
-			LastActive *time.Time
-		}
-		var products []ProductAccess
-
-		for i := range user.ProductAccess {
-			products = append(products, ProductAccess{
-				Name:       user.ProductAccess[i].Name,
-				LastActive: parseAtlassianTime(user.ProductAccess[i].LastActive),
-			})
-		}
-
-		lastActive := parseAtlassianTime(user.LastActive)
-
-		productArray, err := convert.JsonToDictSlice(products)
+	cursor := ""
+	for {
+		managedUsers, _, err := admin.Organization.Users(context.Background(), a.Id.Data, cursor)
 		if err != nil {
 			return nil, err
 		}
+		for _, user := range managedUsers.Data {
 
-		mqlAtlassianAdminManagedUser, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.managedUser",
-			map[string]*llx.RawData{
-				"id":             llx.StringData(user.AccountID),
-				"name":           llx.StringData(user.Name),
-				"type":           llx.StringData(user.AccountType),
-				"status":         llx.StringData(user.AccountStatus),
-				"email":          llx.StringData(user.Email),
-				"lastActive":     llx.TimeDataPtr(lastActive),
-				"productAccess":  llx.ArrayData(productArray, types.Dict),
-				"organizationId": llx.StringData(a.Id.Data),
-			})
-		if err != nil {
-			return nil, err
+			type ProductAccess struct {
+				Name       string
+				LastActive *time.Time
+			}
+			var products []ProductAccess
+
+			for i := range user.ProductAccess {
+				products = append(products, ProductAccess{
+					Name:       user.ProductAccess[i].Name,
+					LastActive: parseAtlassianTime(user.ProductAccess[i].LastActive),
+				})
+			}
+
+			lastActive := parseAtlassianTime(user.LastActive)
+
+			productArray, err := convert.JsonToDictSlice(products)
+			if err != nil {
+				return nil, err
+			}
+
+			mqlAtlassianAdminManagedUser, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.managedUser",
+				map[string]*llx.RawData{
+					"id":             llx.StringData(user.AccountID),
+					"name":           llx.StringData(user.Name),
+					"type":           llx.StringData(user.AccountType),
+					"status":         llx.StringData(user.AccountStatus),
+					"email":          llx.StringData(user.Email),
+					"lastActive":     llx.TimeDataPtr(lastActive),
+					"productAccess":  llx.ArrayData(productArray, types.Dict),
+					"organizationId": llx.StringData(a.Id.Data),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlAtlassianAdminManagedUser)
 		}
-		res = append(res, mqlAtlassianAdminManagedUser)
+		if managedUsers.Links == nil || managedUsers.Links.Next == "" {
+			break
+		}
+		cursor = extractAtlassianCursor(managedUsers.Links.Next)
+		if cursor == "" {
+			break
+		}
 	}
 	return res, nil
 }
@@ -119,46 +148,56 @@ func (a *mqlAtlassianAdminOrganization) policies() ([]any, error) {
 	}
 	admin := conn.Client()
 	orgId := a.Id.Data
-	policies, _, err := admin.Organization.Policy.Gets(context.Background(), orgId, "", "")
-	if err != nil {
-		return nil, err
-	}
 	res := []any{}
-	for _, policy := range policies.Data {
-		var createdAt *time.Time
-		if !policy.Attributes.CreatedAt.IsZero() {
-			createdAt = &policy.Attributes.CreatedAt
-		}
-		var updatedAt *time.Time
-		if !policy.Attributes.UpdatedAt.IsZero() {
-			updatedAt = &policy.Attributes.UpdatedAt
-		}
-		resources := make([]any, 0, len(policy.Attributes.Resources))
-		for _, r := range policy.Attributes.Resources {
-			if r == nil {
-				continue
-			}
-			resources = append(resources, map[string]any{
-				"id":                r.ID,
-				"applicationStatus": r.ApplicationStatus,
-			})
-		}
-
-		mqlAtlassianAdminPolicy, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.policy",
-			map[string]*llx.RawData{
-				"id":         llx.StringData(policy.ID),
-				"type":       llx.StringData(policy.Type),
-				"name":       llx.StringData(policy.Attributes.Name),
-				"status":     llx.StringData(policy.Attributes.Status),
-				"policyType": llx.StringData(policy.Attributes.Type),
-				"createdAt":  llx.TimeDataPtr(createdAt),
-				"updatedAt":  llx.TimeDataPtr(updatedAt),
-				"resources":  llx.ArrayData(resources, types.Dict),
-			})
+	cursor := ""
+	for {
+		policies, _, err := admin.Organization.Policy.Gets(context.Background(), orgId, "", cursor)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, mqlAtlassianAdminPolicy)
+		for _, policy := range policies.Data {
+			var createdAt *time.Time
+			if !policy.Attributes.CreatedAt.IsZero() {
+				createdAt = &policy.Attributes.CreatedAt
+			}
+			var updatedAt *time.Time
+			if !policy.Attributes.UpdatedAt.IsZero() {
+				updatedAt = &policy.Attributes.UpdatedAt
+			}
+			resources := make([]any, 0, len(policy.Attributes.Resources))
+			for _, r := range policy.Attributes.Resources {
+				if r == nil {
+					continue
+				}
+				resources = append(resources, map[string]any{
+					"id":                r.ID,
+					"applicationStatus": r.ApplicationStatus,
+				})
+			}
+
+			mqlAtlassianAdminPolicy, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.policy",
+				map[string]*llx.RawData{
+					"id":         llx.StringData(policy.ID),
+					"type":       llx.StringData(policy.Type),
+					"name":       llx.StringData(policy.Attributes.Name),
+					"status":     llx.StringData(policy.Attributes.Status),
+					"policyType": llx.StringData(policy.Attributes.Type),
+					"createdAt":  llx.TimeDataPtr(createdAt),
+					"updatedAt":  llx.TimeDataPtr(updatedAt),
+					"resources":  llx.ArrayData(resources, types.Dict),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlAtlassianAdminPolicy)
+		}
+		if policies.Links == nil || policies.Links.Next == "" {
+			break
+		}
+		cursor = extractAtlassianCursor(policies.Links.Next)
+		if cursor == "" {
+			break
+		}
 	}
 	return res, nil
 }
@@ -170,31 +209,41 @@ func (a *mqlAtlassianAdminOrganization) domains() ([]any, error) {
 	}
 	admin := conn.Client()
 	orgId := a.Id.Data
-	domains, resp, err := admin.Organization.Domains(context.Background(), orgId, "")
-	// A 404 means the org has no verified domains — that's a valid empty
-	// state, not an error. Anything else (transport failure, 5xx, 403) should
-	// surface so callers can't mistake it for "no domains."
-	if resp != nil && resp.StatusCode == 404 {
-		return []any{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	if domains == nil {
-		return []any{}, nil
-	}
 	res := []any{}
-	for _, domain := range domains.Data {
-		mqlAtlassianAdminDomain, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.domain",
-			map[string]*llx.RawData{
-				"id":   llx.StringData(domain.ID),
-				"name": llx.StringData(domain.Attributes.Name),
-				"type": llx.StringData(domain.Type),
-			})
+	cursor := ""
+	for {
+		domains, resp, err := admin.Organization.Domains(context.Background(), orgId, cursor)
+		// A 404 means the org has no verified domains — that's a valid empty
+		// state, not an error. Anything else (transport failure, 5xx, 403) should
+		// surface so callers can't mistake it for "no domains."
+		if resp != nil && resp.StatusCode == 404 {
+			return []any{}, nil
+		}
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, mqlAtlassianAdminDomain)
+		if domains == nil {
+			break
+		}
+		for _, domain := range domains.Data {
+			mqlAtlassianAdminDomain, err := CreateResource(a.MqlRuntime, "atlassian.admin.organization.domain",
+				map[string]*llx.RawData{
+					"id":   llx.StringData(domain.ID),
+					"name": llx.StringData(domain.Attributes.Name),
+					"type": llx.StringData(domain.Type),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlAtlassianAdminDomain)
+		}
+		if domains.Links == nil || domains.Links.Next == "" {
+			break
+		}
+		cursor = extractAtlassianCursor(domains.Links.Next)
+		if cursor == "" {
+			break
+		}
 	}
 	return res, nil
 }

--- a/providers/atlassian/resources/atlassian_admin_test.go
+++ b/providers/atlassian/resources/atlassian_admin_test.go
@@ -36,3 +36,16 @@ func TestParseAtlassianTime(t *testing.T) {
 		assert.True(t, got.Equal(time.Date(2026, 4, 27, 20, 0, 0, 0, time.UTC)))
 	})
 }
+
+// TestExtractAtlassianCursor verifies we extract the raw cursor value from a
+// page's Links.Next URL — the SDK list methods re-encode it as ?cursor=, so the
+// full Next URL must not be passed back verbatim (which would break paging and
+// silently truncate managed users / policies / domains to the first page).
+func TestExtractAtlassianCursor(t *testing.T) {
+	assert.Equal(t, "abc123",
+		extractAtlassianCursor("https://api.atlassian.com/admin/v1/orgs/org-1/users?cursor=abc123"))
+	assert.Equal(t, "x=y/z+w",
+		extractAtlassianCursor("https://api.atlassian.com/admin/v1/orgs/org-1/domains?cursor=x%3Dy%2Fz%2Bw"))
+	assert.Equal(t, "", extractAtlassianCursor(""))
+	assert.Equal(t, "", extractAtlassianCursor("https://api.atlassian.com/admin/v1/orgs/org-1/policies"))
+}


### PR DESCRIPTION
## What

The admin organization accessors read only the **first page**:

- `managedUsers()`, `policies()`, and `domains()` each called the cursor-paginated SDK method once with an empty cursor and **never followed `Links.Next`**, silently dropping every record past the first page (~100 items). For an access review this under-reports managed users and org security policies.
- `initAtlassianAdminOrganization` checked `len(Data) > 1` but then indexed `Data[0]`, **panicking** the connection init when zero organizations are returned (revoked / mis-scoped API token).

## Fix

- Loop each accessor until `Links.Next` is empty, extracting the **raw cursor value** from the Next URL via `extractAtlassianCursor` (the SDK re-encodes it as `?cursor=`, so the full URL must not be passed back).
- Guard the empty-organization case before indexing.

## Test

`TestExtractAtlassianCursor` covers raw/encoded/empty/no-cursor URLs. `go build ./...` and `go test ./resources/` pass.