### PR TITLE
🐛 cloudflare: guard nil zone account in r2/workers/stream accessors

### DIFF
--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -4,6 +4,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -14,6 +15,20 @@ import (
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
 
+// zoneAccountID returns the parent account id, guarding the nullable account
+// field so the R2/Workers/Stream accessors don't nil-deref on a zone whose
+// account wasn't resolved (e.g. a zone reached by id without discovery).
+func (c *mqlCloudflareZone) zoneAccountID() (string, error) {
+	acc := c.GetAccount()
+	if acc.Error != nil {
+		return "", acc.Error
+	}
+	if acc.Data == nil {
+		return "", errors.New("cloudflare zone has no associated account")
+	}
+	return acc.Data.GetId().Data, nil
+}
+
 func (c *mqlCloudflareR2) id() (string, error) {
 	return "cloudflare.r2", nil
 }
@@ -23,15 +38,19 @@ type mqlCloudflareR2Internal struct {
 }
 
 func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
 	res, err := CreateResource(c.MqlRuntime, "cloudflare.r2", map[string]*llx.RawData{
-		"__id": llx.StringData("cloudflare.r2@" + c.GetAccount().Data.GetId().Data),
+		"__id": llx.StringData("cloudflare.r2@" + accountID),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	r2 := res.(*mqlCloudflareR2)
-	r2.AccountID = c.GetAccount().Data.GetId().Data
+	r2.AccountID = accountID
 
 	return r2, nil
 }

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -54,7 +54,11 @@ func (c *mqlCloudflareStreamsVideo) id() (string, error) {
 }
 
 func (c *mqlCloudflareZone) liveInputs() ([]any, error) {
-	return fetchLiveInputs(c.MqlRuntime, c.Account.Data.GetId().Data)
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
+	return fetchLiveInputs(c.MqlRuntime, accountID)
 }
 
 func (c *mqlCloudflareAccount) liveInputs() ([]any, error) {
@@ -97,7 +101,11 @@ func fetchLiveInputs(runtime *plugin.Runtime, accountID string) ([]any, error) {
 }
 
 func (c *mqlCloudflareZone) videos() ([]any, error) {
-	return fetchVideos(c.MqlRuntime, c.Account.Data.GetId().Data)
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
+	return fetchVideos(c.MqlRuntime, accountID)
 }
 
 func (c *mqlCloudflareAccount) videos() ([]any, error) {

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -13,15 +13,19 @@ import (
 )
 
 func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
 	res, err := CreateResource(c.MqlRuntime, "cloudflare.workers", map[string]*llx.RawData{
-		"__id": llx.StringData("cloudflare.workers@" + c.GetAccount().Data.GetId().Data),
+		"__id": llx.StringData("cloudflare.workers@" + accountID),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	workers := res.(*mqlCloudflareWorkers)
-	workers.AccountID = c.GetAccount().Data.GetId().Data
+	workers.AccountID = accountID
 
 	return workers, nil
 }


### PR DESCRIPTION
## What

`zone.r2()`, `zone.workers()`, `zone.liveInputs()`, and `zone.videos()` dereferenced `GetAccount().Data.GetId()` without checking the account field's `Error` or that `Data != nil` — unlike the guarded siblings (`tunnels`, `mtls`, `one`). A zone materialized without a resolved account (e.g. reached by id outside the normal discovery flow, or where the field resolved to an error) would **panic the scan** instead of returning the error.

## Fix

Added a shared `zoneAccountID()` helper that guards both `Error` and a nil `Data`, and routed all four accessors through it (also removes the duplicated `GetAccount().Data.GetId().Data` chains).

## Test
`go build ./...` passes. (Behavioral guard on existing accessors; exercised via the provider's interactive tests.)