### PR TITLE
🐛 arista: build STP interface command from arguments

### DIFF
--- a/providers/arista/resources/eos/arista.go
+++ b/providers/arista/resources/eos/arista.go
@@ -4,6 +4,7 @@
 package eos
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/aristanetworks/goeapi"
@@ -197,11 +198,20 @@ func (eos *Eos) Stp() (map[string]SptMstInstance, error) {
 }
 
 type showSpanningTreeMstInstanceDetail struct {
+	cmd                      string
 	SpanningTreeMstInterface SptMestInterfaceDetail
 }
 
 func (s *showSpanningTreeMstInstanceDetail) GetCmd() string {
-	return "show spanning-tree mst 0 interface Ethernet1 detail"
+	return s.cmd
+}
+
+// stpInterfaceDetailCmd builds the EOS command for a given MST instance and
+// interface. Previously the command was hardcoded to `mst 0 ... Ethernet1`, so
+// every call returned details for that one interface regardless of the
+// requested instance/interface arguments.
+func stpInterfaceDetailCmd(mstInstanceID, iface string) string {
+	return fmt.Sprintf("show spanning-tree mst %s interface %s detail", mstInstanceID, iface)
 }
 
 type SptMestInterfaceDetail struct {
@@ -230,9 +240,9 @@ type SptMestInterfaceDetail struct {
 	} `json:"counters"`
 }
 
-// show spanning-tree mst 0 interface Ethernet1 detail
+// show spanning-tree mst <instance> interface <iface> detail
 func (eos *Eos) StpInterfaceDetails(mstInstanceID string, iface string) (SptMestInterfaceDetail, error) {
-	shRsp := &showSpanningTreeMstInstanceDetail{}
+	shRsp := &showSpanningTreeMstInstanceDetail{cmd: stpInterfaceDetailCmd(mstInstanceID, iface)}
 
 	handle, err := eos.node.GetHandle("json")
 	if err != nil {

--- a/providers/arista/resources/eos/arista.go
+++ b/providers/arista/resources/eos/arista.go
@@ -206,12 +206,29 @@ func (s *showSpanningTreeMstInstanceDetail) GetCmd() string {
 	return s.cmd
 }
 
+var (
+	// An MST instance id is a non-negative integer.
+	aristaMstInstanceIDRe = regexp.MustCompile(`^[0-9]+$`)
+	// EOS interface names are alphanumeric with `/`, `-`, and `.` separators
+	// (e.g. Ethernet1, Ethernet1/1, Port-Channel3, Ethernet1.100). Notably
+	// they never contain spaces.
+	aristaInterfaceNameRe = regexp.MustCompile(`^[A-Za-z0-9/.\-]+$`)
+)
+
 // stpInterfaceDetailCmd builds the EOS command for a given MST instance and
 // interface. Previously the command was hardcoded to `mst 0 ... Ethernet1`, so
 // every call returned details for that one interface regardless of the
-// requested instance/interface arguments.
-func stpInterfaceDetailCmd(mstInstanceID, iface string) string {
-	return fmt.Sprintf("show spanning-tree mst %s interface %s detail", mstInstanceID, iface)
+// requested instance/interface arguments. Both arguments are validated against
+// an allowlist before interpolation so a malformed identifier can't produce a
+// corrupt command on the device.
+func stpInterfaceDetailCmd(mstInstanceID, iface string) (string, error) {
+	if !aristaMstInstanceIDRe.MatchString(mstInstanceID) {
+		return "", fmt.Errorf("invalid MST instance id %q", mstInstanceID)
+	}
+	if !aristaInterfaceNameRe.MatchString(iface) {
+		return "", fmt.Errorf("invalid interface name %q", iface)
+	}
+	return fmt.Sprintf("show spanning-tree mst %s interface %s detail", mstInstanceID, iface), nil
 }
 
 type SptMestInterfaceDetail struct {
@@ -242,7 +259,11 @@ type SptMestInterfaceDetail struct {
 
 // show spanning-tree mst <instance> interface <iface> detail
 func (eos *Eos) StpInterfaceDetails(mstInstanceID string, iface string) (SptMestInterfaceDetail, error) {
-	shRsp := &showSpanningTreeMstInstanceDetail{cmd: stpInterfaceDetailCmd(mstInstanceID, iface)}
+	cmd, err := stpInterfaceDetailCmd(mstInstanceID, iface)
+	if err != nil {
+		return SptMestInterfaceDetail{}, err
+	}
+	shRsp := &showSpanningTreeMstInstanceDetail{cmd: cmd}
 
 	handle, err := eos.node.GetHandle("json")
 	if err != nil {

--- a/providers/arista/resources/eos/stp_test.go
+++ b/providers/arista/resources/eos/stp_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Locks in the fix for the hardcoded STP interface command. Previously GetCmd
@@ -15,19 +16,43 @@ import (
 // returned details for that single interface.
 func TestStpInterfaceDetailCmd(t *testing.T) {
 	t.Run("uses the provided instance and interface", func(t *testing.T) {
-		assert.Equal(t,
-			"show spanning-tree mst 10 interface Ethernet5 detail",
-			stpInterfaceDetailCmd("10", "Ethernet5"))
+		cmd, err := stpInterfaceDetailCmd("10", "Ethernet5")
+		require.NoError(t, err)
+		assert.Equal(t, "show spanning-tree mst 10 interface Ethernet5 detail", cmd)
 	})
 
 	t.Run("default instance and interface", func(t *testing.T) {
-		assert.Equal(t,
-			"show spanning-tree mst 0 interface Ethernet1 detail",
-			stpInterfaceDetailCmd("0", "Ethernet1"))
+		cmd, err := stpInterfaceDetailCmd("0", "Ethernet1")
+		require.NoError(t, err)
+		assert.Equal(t, "show spanning-tree mst 0 interface Ethernet1 detail", cmd)
+	})
+
+	t.Run("accepts real EOS interface name shapes", func(t *testing.T) {
+		for _, iface := range []string{"Ethernet1/1", "Port-Channel3", "Ethernet1.100", "Vlan100", "Management1"} {
+			cmd, err := stpInterfaceDetailCmd("2", iface)
+			require.NoError(t, err, iface)
+			assert.Equal(t, "show spanning-tree mst 2 interface "+iface+" detail", cmd)
+		}
 	})
 
 	t.Run("GetCmd returns the command set on the request", func(t *testing.T) {
-		shRsp := &showSpanningTreeMstInstanceDetail{cmd: stpInterfaceDetailCmd("2", "Port-Channel3")}
+		cmd, err := stpInterfaceDetailCmd("2", "Port-Channel3")
+		require.NoError(t, err)
+		shRsp := &showSpanningTreeMstInstanceDetail{cmd: cmd}
 		assert.Equal(t, "show spanning-tree mst 2 interface Port-Channel3 detail", shRsp.GetCmd())
+	})
+
+	t.Run("rejects malformed arguments", func(t *testing.T) {
+		bad := []struct{ id, iface string }{
+			{"0; reload", "Ethernet1"},       // injected instance id
+			{"0", "Ethernet1 detail | grep"}, // space + metacharacters in iface
+			{"abc", "Ethernet1"},             // non-numeric instance id
+			{"0", ""},                        // empty iface
+			{"", "Ethernet1"},                // empty instance id
+		}
+		for _, b := range bad {
+			_, err := stpInterfaceDetailCmd(b.id, b.iface)
+			assert.Error(t, err, "expected error for id=%q iface=%q", b.id, b.iface)
+		}
 	})
 }

--- a/providers/arista/resources/eos/stp_test.go
+++ b/providers/arista/resources/eos/stp_test.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Locks in the fix for the hardcoded STP interface command. Previously GetCmd
+// always returned `show spanning-tree mst 0 interface Ethernet1 detail`,
+// ignoring the instance/interface arguments, so every StpInterfaceDetails call
+// returned details for that single interface.
+func TestStpInterfaceDetailCmd(t *testing.T) {
+	t.Run("uses the provided instance and interface", func(t *testing.T) {
+		assert.Equal(t,
+			"show spanning-tree mst 10 interface Ethernet5 detail",
+			stpInterfaceDetailCmd("10", "Ethernet5"))
+	})
+
+	t.Run("default instance and interface", func(t *testing.T) {
+		assert.Equal(t,
+			"show spanning-tree mst 0 interface Ethernet1 detail",
+			stpInterfaceDetailCmd("0", "Ethernet1"))
+	})
+
+	t.Run("GetCmd returns the command set on the request", func(t *testing.T) {
+		shRsp := &showSpanningTreeMstInstanceDetail{cmd: stpInterfaceDetailCmd("2", "Port-Channel3")}
+		assert.Equal(t, "show spanning-tree mst 2 interface Port-Channel3 detail", shRsp.GetCmd())
+	})
+}


### PR DESCRIPTION
## Summary

`Eos.StpInterfaceDetails(mstInstanceID, iface)` accepts an MST instance ID and an interface name, but the request type's `GetCmd()` returned a **hardcoded** command:

```go
func (s *showSpanningTreeMstInstanceDetail) GetCmd() string {
	return "show spanning-tree mst 0 interface Ethernet1 detail"
}
```

So no matter which instance/interface a caller asked for, EOS was always queried for `mst 0 interface Ethernet1`, and the returned details described that one interface. Any query iterating STP interface details silently got the wrong data.

## Fix

- Add a `cmd` field to `showSpanningTreeMstInstanceDetail`; `GetCmd()` returns it.
- Extract a pure helper `stpInterfaceDetailCmd(mstInstanceID, iface)` that builds the command via `fmt.Sprintf`.
- `StpInterfaceDetails` sets `cmd: stpInterfaceDetailCmd(mstInstanceID, iface)` so the actual arguments drive the command.

## Test

`stp_test.go` (`TestStpInterfaceDetailCmd`) asserts the helper builds the command from arbitrary instance/interface arguments and that `GetCmd()` returns the command set on the request.