### PR TITLE
🐛 ansible: tolerate non-integer max_fail_percentage

### DIFF
--- a/providers/ansible/play/playbook.go
+++ b/providers/ansible/play/playbook.go
@@ -6,6 +6,7 @@ package play
 import (
 	"maps"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -52,9 +53,13 @@ type Play struct {
 	// see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_strategies.html
 	Strategy string `yaml:"strategy,omitempty"`
 
-	// MaxFailPercentage sets a maximum failure percentage
+	// MaxFailPercentage sets a maximum failure percentage. Ansible types this
+	// field as a percent, so beyond a plain integer it also accepts a float
+	// (33.3) or a percent-suffixed string ("30%"). Decode it as any and
+	// normalize with MaxFailPercentageValue so one of those forms can't fail
+	// the whole playbook decode.
 	// see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_error_handling.html#maximum-failure-percentage
-	MaxFailPercentage int `yaml:"max_fail_percentage,omitempty"`
+	MaxFailPercentage any `yaml:"max_fail_percentage,omitempty"`
 
 	// IgnoreUnreachable sets to true to ignore unreachable hosts
 	// see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_error_handling.html#ignore-unreachable
@@ -111,6 +116,32 @@ type Play struct {
 	Handlers []*Handler `yaml:"handlers,omitempty"`
 
 	GatherFacts string `yaml:"gather_facts,omitempty"`
+}
+
+// MaxFailPercentageValue normalizes the play's max_fail_percentage into an
+// integer percentage. Ansible types the field as a percent, so it may arrive
+// from YAML as an int, a float (33.3), or a string with an optional trailing
+// "%" ("30%"). Unrecognized or absent values yield 0, Ansible's default.
+func (p *Play) MaxFailPercentageValue() int64 {
+	switch v := p.MaxFailPercentage.(type) {
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case string:
+		s := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(v), "%"))
+		if s == "" {
+			return 0
+		}
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return int64(f)
+		}
+		return 0
+	default:
+		return 0
+	}
 }
 
 // Tasks is a list of tasks to be executed

--- a/providers/ansible/play/playbook_test.go
+++ b/providers/ansible/play/playbook_test.go
@@ -215,3 +215,38 @@ func TestTaskDecoding(t *testing.T) {
 		assert.Equal(t, 5, len(task.Vars))
 	})
 }
+
+func TestMaxFailPercentageValue(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want int64
+	}{
+		{"absent", nil, 0},
+		{"plain int", 30, 30},
+		{"int64", int64(45), 45},
+		{"float", 33.3, 33},
+		{"percent string", "30%", 30},
+		{"percent string with spaces", " 50 % ", 50},
+		{"bare numeric string", "20", 20},
+		{"empty string", "", 0},
+		{"garbage string", "abc", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Play{MaxFailPercentage: tt.raw}
+			assert.Equal(t, tt.want, p.MaxFailPercentageValue())
+		})
+	}
+}
+
+// A percent-suffixed max_fail_percentage is valid Ansible (the field is typed
+// as a percent). It must not fail the whole playbook decode the way it would
+// when the struct field was a plain int.
+func TestMaxFailPercentagePercentStringDecodes(t *testing.T) {
+	data := []byte("- name: percent play\n  hosts: all\n  max_fail_percentage: 30%\n")
+	pb, err := DecodePlaybook(data)
+	require.NoError(t, err)
+	require.Len(t, pb, 1)
+	assert.Equal(t, int64(30), pb[0].MaxFailPercentageValue())
+}

--- a/providers/ansible/resources/ansible.go
+++ b/providers/ansible/resources/ansible.go
@@ -53,7 +53,7 @@ func newMqlAnsiblePlay(runtime *plugin.Runtime, id, baseDir string, p *play.Play
 		"becomeFlags":       llx.StringData(p.BecomeFlags),
 		"serial":            dictData(p.Serial),
 		"strategy":          llx.StringData(p.Strategy),
-		"maxFailPercentage": llx.IntData(p.MaxFailPercentage),
+		"maxFailPercentage": llx.IntData(p.MaxFailPercentageValue()),
 		"ignoreUnreachable": llx.BoolData(p.IgnoreUnreachable),
 		"anyErrorsFatal":    llx.BoolData(p.AnyErrorsFatal),
 		"gatherFacts":       llx.StringData(p.GatherFacts),


### PR DESCRIPTION
## Summary

`Play.MaxFailPercentage` was decoded into a plain `int`:

```go
MaxFailPercentage int `yaml:"max_fail_percentage,omitempty"`
```

But Ansible types `max_fail_percentage` as a **percent**, so beyond a plain integer it also accepts a float (`33.3`) or a percent-suffixed string (`30%`). The playbook is unmarshalled non-strictly with `yaml.Unmarshal`, so when a real-world playbook used one of those valid forms, the type mismatch failed the decode of the **entire playbook** — `DecodePlaybook` returned an error and every play was dropped, not just that one field.

This mirrors a problem the codebase already solved for `serial` (`Serial any` — "Can be an integer or a string").

## Fix

- Decode `max_fail_percentage` as `any`.
- Add `Play.MaxFailPercentageValue() int64`, which normalizes int / int64 / float64 / percent-string (`"30%"`, `" 50 % "`, `"20"`) into an integer percentage, falling back to `0` (Ansible's default) for absent or unparseable values.
- Build the `maxFailPercentage` field from that helper.

The `.lr` schema is unchanged (`maxFailPercentage int`), so this is **not** a breaking change to the resource API.

## Tests

`TestMaxFailPercentageValue` covers int/int64/float/percent-string/bare-string/empty/garbage/absent. `TestMaxFailPercentagePercentStringDecodes` decodes a real `max_fail_percentage: 30%` playbook and asserts it no longer fails the whole-playbook parse. Full `ansible/play` and `ansible/resources` suites pass.