### PR TITLE
✨ aws: add EKS control plane egress mode and Cognito domain TLS policy

### DIFF
--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.36.4
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.4
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.34.4
-	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.6
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.65.1
@@ -57,7 +57,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.6
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/eks v1.86.0
+	github.com/aws/aws-sdk-go-v2/service/eks v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.4
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.6

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -183,8 +183,8 @@ github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.4 h1:v/pmsep1Vs+QfSghyBH
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.47.4/go.mod h1:WX3sF7RcrXTLTXld80dBMBD0AvtZfWeloP8iX8VaGdw=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.34.4 h1:xsQKaFhM90DS2gTAyNhG29xZ2tT/utyCmF1k2G7QJ4g=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.34.4/go.mod h1:bCX6lcNB2cluVdICB1gzNckz2GH3V6lwrD2cVTMo9fY=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4 h1:KDPcknxnbdpcAU04wq+9wfDW4Yoo9h0tsO8Uv+oES4c=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4/go.mod h1:fhiInRlq2MkbUqzDYoWLF+dE/NdEg24s9TML5FcSwhA=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.62.0 h1:gkhS82QWXx9E2Y1Mimks8P50JTtlEQGR+bWamli5PE0=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.62.0/go.mod h1:fhiInRlq2MkbUqzDYoWLF+dE/NdEg24s9TML5FcSwhA=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.64.1 h1:CJ6YcGJiXPJIz6ICOcGBumi2TcUSldUESHeF243WvVo=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.64.1/go.mod h1:oqVF/7XFqk3GY0/zlvY3Dj2+42ynOx4x/Sp875yKcxE=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.6 h1:SRziHSEbM6suFdIB8veHXWzj7Uw2pkOfSiFHDuyLik4=
@@ -221,8 +221,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0 h1:LQKIHuVHqdbU9LUt5c2G9f+CcQAz
 github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0/go.mod h1:0vahPCh3slyORHbSuAP8YDyJKLEUQAMX7+bzYGxEnVI=
 github.com/aws/aws-sdk-go-v2/service/efs v1.42.1 h1:Ii4N3TQ2wa18cOlFR2Kxcji4wVsaySku+ygiBeKGqTU=
 github.com/aws/aws-sdk-go-v2/service/efs v1.42.1/go.mod h1:AMhRvE41tgqPUU9hqtyCw8ektaKSnKbm10kyX9xL+FQ=
-github.com/aws/aws-sdk-go-v2/service/eks v1.86.0 h1:RYiM/XcRljyvfTKlrldQCAZ0iL3sGmI4JuiJMbiKa+M=
-github.com/aws/aws-sdk-go-v2/service/eks v1.86.0/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0 h1:bftLltXNWmNr9ed3CaQnVlzNPTNTFdHguNhIsZF6DxM=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3 h1:KZDlMf8V5riU8xBCMJLWhfa+RP/MIagz2qJFwRg/b1g=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3/go.mod h1:nsMdHtF/ned4F5GCAfoerJaa/Q6cx+G+WYNsb/TFN7Q=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.4 h1:hS5ilJrr1xgHvrw0pwb+xKwZDx0KA1LULHbN+OzwBDM=

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -16435,6 +16435,13 @@ aws.eks.cluster @defaults("arn version status") {
   logging() dict
   // Kubernetes network configuration
   networkConfig() dict
+  // Control plane egress routing mode
+  //
+  // `AWS_MANAGED` lets Amazon EKS manage the egress path from the control
+  // plane. `CUSTOMER_ROUTED` means egress is routed through your VPC subnets,
+  // making you responsible for ensuring the control plane can reach endpoints
+  // such as webhook servers and OIDC providers.
+  controlPlaneEgressMode() string
   // Raw VPC configuration dict for the cluster resources
   //
   // Deprecated in favor of `vpc()`, `clusterSubnets()`,
@@ -17067,6 +17074,13 @@ private aws.cognito.userPoolDomain @defaults("domain userPoolId status") {
   s3Bucket string
   // Configuration for a custom domain (ACM cert ARN), or null for prefix-style domains
   customDomainConfig dict
+  // Minimum TLS version enforced on a custom domain
+  //
+  // Defines the lowest TLS version and cipher suites CloudFront accepts from
+  // clients connecting to the custom-domain login endpoint. One of `TLS_V1`,
+  // `TLS_V1_2_2021`, or `TLS_V1_3_2025`. Empty for prefix-style domains, which
+  // do not carry a configurable security policy.
+  tlsSecurityPolicy string
   // Hosted UI version configured on the domain
   version string
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22836,6 +22836,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.eks.cluster.networkConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetNetworkConfig()).ToDataRes(types.Dict)
 	},
+	"aws.eks.cluster.controlPlaneEgressMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetControlPlaneEgressMode()).ToDataRes(types.String)
+	},
 	"aws.eks.cluster.resourcesVpcConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetResourcesVpcConfig()).ToDataRes(types.Dict)
 	},
@@ -23579,6 +23582,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cognito.userPoolDomain.customDomainConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCognitoUserPoolDomain).GetCustomDomainConfig()).ToDataRes(types.Dict)
+	},
+	"aws.cognito.userPoolDomain.tlsSecurityPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCognitoUserPoolDomain).GetTlsSecurityPolicy()).ToDataRes(types.String)
 	},
 	"aws.cognito.userPoolDomain.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCognitoUserPoolDomain).GetVersion()).ToDataRes(types.String)
@@ -59301,6 +59307,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEksCluster).NetworkConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.eks.cluster.controlPlaneEgressMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).ControlPlaneEgressMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.eks.cluster.resourcesVpcConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).ResourcesVpcConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -60351,6 +60361,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cognito.userPoolDomain.customDomainConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCognitoUserPoolDomain).CustomDomainConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.cognito.userPoolDomain.tlsSecurityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCognitoUserPoolDomain).TlsSecurityPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.cognito.userPoolDomain.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -142945,6 +142959,7 @@ type mqlAwsEksCluster struct {
 	EncryptionResources     plugin.TValue[[]any]
 	Logging                 plugin.TValue[any]
 	NetworkConfig           plugin.TValue[any]
+	ControlPlaneEgressMode  plugin.TValue[string]
 	ResourcesVpcConfig      plugin.TValue[any]
 	CreatedAt               plugin.TValue[*time.Time]
 	NodeGroups              plugin.TValue[[]any]
@@ -143091,6 +143106,12 @@ func (c *mqlAwsEksCluster) GetLogging() *plugin.TValue[any] {
 func (c *mqlAwsEksCluster) GetNetworkConfig() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.NetworkConfig, func() (any, error) {
 		return c.networkConfig()
+	})
+}
+
+func (c *mqlAwsEksCluster) GetControlPlaneEgressMode() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ControlPlaneEgressMode, func() (string, error) {
+		return c.controlPlaneEgressMode()
 	})
 }
 
@@ -145390,6 +145411,7 @@ type mqlAwsCognitoUserPoolDomain struct {
 	CloudFrontDistribution plugin.TValue[string]
 	S3Bucket               plugin.TValue[string]
 	CustomDomainConfig     plugin.TValue[any]
+	TlsSecurityPolicy      plugin.TValue[string]
 	Version                plugin.TValue[string]
 }
 
@@ -145472,6 +145494,10 @@ func (c *mqlAwsCognitoUserPoolDomain) GetS3Bucket() *plugin.TValue[string] {
 
 func (c *mqlAwsCognitoUserPoolDomain) GetCustomDomainConfig() *plugin.TValue[any] {
 	return &c.CustomDomainConfig
+}
+
+func (c *mqlAwsCognitoUserPoolDomain) GetTlsSecurityPolicy() *plugin.TValue[string] {
+	return &c.TlsSecurityPolicy
 }
 
 func (c *mqlAwsCognitoUserPoolDomain) GetVersion() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2113,6 +2113,7 @@ aws.cognito.userPoolDomain.domain 13.21.4
 aws.cognito.userPoolDomain.region 13.21.4
 aws.cognito.userPoolDomain.s3Bucket 13.21.4
 aws.cognito.userPoolDomain.status 13.21.4
+aws.cognito.userPoolDomain.tlsSecurityPolicy 13.37.1
 aws.cognito.userPoolDomain.userPool 13.21.4
 aws.cognito.userPoolDomain.userPoolId 13.21.4
 aws.cognito.userPoolDomain.version 13.21.4
@@ -3889,6 +3890,7 @@ aws.eks.cluster.clusterSecurityGroup 13.12.1
 aws.eks.cluster.clusterSecurityGroups 13.12.1
 aws.eks.cluster.clusterSubnets 13.12.1
 aws.eks.cluster.computeConfig 13.12.1
+aws.eks.cluster.controlPlaneEgressMode 13.37.1
 aws.eks.cluster.createdAt 11.15.2
 aws.eks.cluster.deletionProtection 11.15.2
 aws.eks.cluster.encryptionConfig 11.15.2

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -737,6 +737,11 @@ func (a *mqlAwsCognitoUserPool) domain() (*mqlAwsCognitoUserPoolDomain, error) {
 	dd := detail.DomainDescription
 	customConfig, _ := convert.JsonToDict(dd.CustomDomainConfig)
 
+	tlsSecurityPolicy := ""
+	if dd.CustomDomainConfig != nil {
+		tlsSecurityPolicy = string(dd.CustomDomainConfig.SecurityPolicy)
+	}
+
 	res, err := CreateResource(a.MqlRuntime, "aws.cognito.userPoolDomain", map[string]*llx.RawData{
 		"domain":                 llx.StringData(name),
 		"userPoolId":             llx.StringDataPtr(dd.UserPoolId),
@@ -745,6 +750,7 @@ func (a *mqlAwsCognitoUserPool) domain() (*mqlAwsCognitoUserPoolDomain, error) {
 		"cloudFrontDistribution": llx.StringDataPtr(dd.CloudFrontDistribution),
 		"s3Bucket":               llx.StringDataPtr(dd.S3Bucket),
 		"customDomainConfig":     llx.DictData(customConfig),
+		"tlsSecurityPolicy":      llx.StringData(tlsSecurityPolicy),
 		"version":                llx.StringDataPtr(dd.Version),
 	})
 	if err != nil {

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -194,6 +194,12 @@ func (a *mqlAwsEksCluster) populateFromDescribe(cluster *ekstypes.Cluster) error
 	kubernetesNetworkConfig, _ := convert.JsonToDict(cluster.KubernetesNetworkConfig)
 	a.NetworkConfig = plugin.TValue[any]{Data: kubernetesNetworkConfig, State: plugin.StateIsSet}
 
+	controlPlaneEgressMode := ""
+	if cluster.ResourcesVpcConfig != nil {
+		controlPlaneEgressMode = string(cluster.ResourcesVpcConfig.ControlPlaneEgressMode)
+	}
+	a.ControlPlaneEgressMode = plugin.TValue[string]{Data: controlPlaneEgressMode, State: plugin.StateIsSet}
+
 	vpcConfig, _ := convert.JsonToDict(cluster.ResourcesVpcConfig)
 	a.ResourcesVpcConfig = plugin.TValue[any]{Data: vpcConfig, State: plugin.StateIsSet}
 
@@ -360,6 +366,10 @@ func (a *mqlAwsEksCluster) logging() (map[string]any, error) {
 
 func (a *mqlAwsEksCluster) networkConfig() (map[string]any, error) {
 	return nil, a.fetchDetail()
+}
+
+func (a *mqlAwsEksCluster) controlPlaneEgressMode() (string, error) {
+	return "", a.fetchDetail()
 }
 
 func (a *mqlAwsEksCluster) resourcesVpcConfig() (map[string]any, error) {


### PR DESCRIPTION
## What

Surface two security-relevant fields newly exposed by the bumped AWS SDKs:

| Field | Resource | SDK source |
|---|---|---|
| `controlPlaneEgressMode string` | `aws.eks.cluster` | `VpcConfigResponse.ControlPlaneEgressMode` (eks `1.86.0` → `1.87.0`) |
| `tlsSecurityPolicy string` | `aws.cognito.userPoolDomain` | `CustomDomainConfigType.SecurityPolicy` (cognitoidentityprovider `1.61.4` → `1.62.0`) |

- `controlPlaneEgressMode` reports whether EKS manages control-plane egress (`AWS_MANAGED`) or it is routed through your VPC subnets (`CUSTOMER_ROUTED`).
- `tlsSecurityPolicy` reports the minimum TLS version / cipher suite policy CloudFront enforces on a Cognito custom-domain login endpoint (`TLS_V1`, `TLS_V1_2_2021`, `TLS_V1_3_2025`); empty for prefix-style domains.

Both values were previously only reachable as raw keys inside the existing `networkConfig` / `customDomainConfig` dicts; this promotes them to typed, documented, queryable fields.

## Why

The bumped SDKs added these to Describe responses we already populate. Promoting them gives clean audit queries, e.g.:

```mql
aws.eks.clusters.where(controlPlaneEgressMode == "CUSTOMER_ROUTED")
aws.cognito.userPools.flatMap(domain).where(tlsSecurityPolicy == "TLS_V1")
```

## Notes

- Read from Describe calls we already make → **no new IAM permissions** (`permissions.json` unchanged).
- `.lr.versions` entries added at `13.37.1` (next patch after the `13.37.0` provider version).
- Only the two SDKs these fields require are bumped; the broader multi-provider dep bump is left out of scope.

## Verification

- `mqlr generate` clean, `go build ./...` passes, `gofmt` + `go mod tidy` clean.
- Not yet exercised against live AWS (needs an EKS cluster + a Cognito user pool with a custom domain).