### PR TITLE
⭐ aws: CloudFormation provenance, instance→LB backref, faster role usage

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -371,6 +371,8 @@ aws.vpc @defaults("id isDefault cidrBlock region") {
   cidrBlockAssociations() []dict
   // IPv6 CIDR block associations for the VPC
   ipv6CidrBlockAssociations() []dict
+  // CloudFormation stack that manages this VPC, if any
+  cloudformationStack() aws.cloudformation.stack
 }
 
 // Amazon Virtual Private Cloud (VPC) route table
@@ -10097,6 +10099,8 @@ private aws.s3.bucket @defaults("name location public") {
   macieCoverage() aws.macie.bucket
   // S3 access points attached to the bucket
   accessPoints() []aws.s3.bucket.accessPoint
+  // CloudFormation stack that manages this bucket, if any
+  cloudformationStack() aws.cloudformation.stack
 }
 
 // Amazon S3 bucket event notification
@@ -15773,6 +15777,10 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   networkInterfaces() []aws.ec2.networkinterface
   // Subnet the instance is launched in
   subnet() aws.vpc.subnet
+  // Load balancers that route traffic to this instance
+  loadBalancers() []aws.elb.loadbalancer
+  // CloudFormation stack that manages this instance, if any
+  cloudformationStack() aws.cloudformation.stack
   // Whether API termination protection is enabled for the instance
   disableApiTermination() bool
   // Boot mode of the instance (undefined, legacy-bios, uefi, uefi-preferred)
@@ -16082,6 +16090,8 @@ private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   networkInterfaces() []aws.ec2.networkinterface
   // EC2 instances this security group is attached to, resolved through their network interfaces
   instances() []aws.ec2.instance
+  // CloudFormation stack that manages this security group, if any
+  cloudformationStack() aws.cloudformation.stack
 }
 
 // Amazon EC2 security group IP permission

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4920,6 +4920,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.ipv6CidrBlockAssociations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetIpv6CidrBlockAssociations()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.vpc.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
 	"aws.vpc.routetable.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetArn()).ToDataRes(types.String)
 	},
@@ -15684,6 +15687,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.accessPoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetAccessPoints()).ToDataRes(types.Array(types.Resource("aws.s3.bucket.accessPoint")))
 	},
+	"aws.s3.bucket.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
 	"aws.s3.bucket.eventNotification.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketEventNotification).GetId()).ToDataRes(types.String)
 	},
@@ -22074,6 +22080,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
 	},
+	"aws.ec2.instance.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
+	},
+	"aws.ec2.instance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
 	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetDisableApiTermination()).ToDataRes(types.Bool)
 	},
@@ -22451,6 +22463,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetInstances()).ToDataRes(types.Array(types.Resource("aws.ec2.instance")))
+	},
+	"aws.ec2.securitygroup.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Securitygroup).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
 	},
 	"aws.ec2.securitygroup.ippermission.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetId()).ToDataRes(types.String)
@@ -33058,6 +33073,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.ipv6CidrBlockAssociations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).Ipv6CidrBlockAssociations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48940,6 +48959,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsS3Bucket).AccessPoints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.eventNotification.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3BucketEventNotification).__id, ok = v.Value.(string)
 		return
@@ -58208,6 +58231,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Instance).Subnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instance.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).DisableApiTermination, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -58750,6 +58781,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.instances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Securitygroup).Instances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Securitygroup).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.ippermission.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -74579,6 +74614,7 @@ type mqlAwsVpc struct {
 	EnableDnsHostnames        plugin.TValue[bool]
 	CidrBlockAssociations     plugin.TValue[[]any]
 	Ipv6CidrBlockAssociations plugin.TValue[[]any]
+	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
 }
 
 // createAwsVpc creates a new instance of this resource
@@ -74913,6 +74949,22 @@ func (c *mqlAwsVpc) GetCidrBlockAssociations() *plugin.TValue[[]any] {
 func (c *mqlAwsVpc) GetIpv6CidrBlockAssociations() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Ipv6CidrBlockAssociations, func() ([]any, error) {
 		return c.ipv6CidrBlockAssociations()
+	})
+}
+
+func (c *mqlAwsVpc) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
 	})
 }
 
@@ -117262,6 +117314,7 @@ type mqlAwsS3Bucket struct {
 	TransferAcceleration             plugin.TValue[string]
 	MacieCoverage                    plugin.TValue[*mqlAwsMacieBucket]
 	AccessPoints                     plugin.TValue[[]any]
+	CloudformationStack              plugin.TValue[*mqlAwsCloudformationStack]
 }
 
 // createAwsS3Bucket creates a new instance of this resource
@@ -117650,6 +117703,22 @@ func (c *mqlAwsS3Bucket) GetAccessPoints() *plugin.TValue[[]any] {
 		}
 
 		return c.accessPoints()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
 	})
 }
 
@@ -140055,6 +140124,8 @@ type mqlAwsEc2Instance struct {
 	TpmSupport              plugin.TValue[string]
 	NetworkInterfaces       plugin.TValue[[]any]
 	Subnet                  plugin.TValue[*mqlAwsVpcSubnet]
+	LoadBalancers           plugin.TValue[[]any]
+	CloudformationStack     plugin.TValue[*mqlAwsCloudformationStack]
 	DisableApiTermination   plugin.TValue[bool]
 	BootMode                plugin.TValue[string]
 	SourceDestCheck         plugin.TValue[bool]
@@ -140361,6 +140432,38 @@ func (c *mqlAwsEc2Instance) GetSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
 		}
 
 		return c.subnet()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetLoadBalancers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.instance", c.__id, "loadBalancers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.loadBalancers()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.instance", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
 	})
 }
 
@@ -141415,6 +141518,7 @@ type mqlAwsEc2Securitygroup struct {
 	IsAttachedToNetworkInterface plugin.TValue[bool]
 	NetworkInterfaces            plugin.TValue[[]any]
 	Instances                    plugin.TValue[[]any]
+	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
 }
 
 // createAwsEc2Securitygroup creates a new instance of this resource
@@ -141561,6 +141665,22 @@ func (c *mqlAwsEc2Securitygroup) GetInstances() *plugin.TValue[[]any] {
 		}
 
 		return c.instances()
+	})
+}
+
+func (c *mqlAwsEc2Securitygroup) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.securitygroup", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2955,6 +2955,7 @@ aws.ec2.instance 11.15.2
 aws.ec2.instance.architecture 11.15.2
 aws.ec2.instance.arn 11.15.2
 aws.ec2.instance.bootMode 11.15.2
+aws.ec2.instance.cloudformationStack 13.37.1
 aws.ec2.instance.cpuCoreCount 11.15.3
 aws.ec2.instance.cpuThreadsPerCore 11.15.3
 aws.ec2.instance.currentInstanceBootMode 11.15.3
@@ -2985,6 +2986,7 @@ aws.ec2.instance.ipv6Address 11.15.2
 aws.ec2.instance.keypair 11.15.2
 aws.ec2.instance.launchTime 11.15.2
 aws.ec2.instance.launchedAt 11.15.2
+aws.ec2.instance.loadBalancers 13.37.1
 aws.ec2.instance.maintenanceAutoRecovery 11.15.3
 aws.ec2.instance.networkInterfaces 11.15.2
 aws.ec2.instance.patchState 11.15.2
@@ -3256,6 +3258,7 @@ aws.ec2.placementGroups 13.6.3
 aws.ec2.securityGroups 11.15.2
 aws.ec2.securitygroup 11.15.2
 aws.ec2.securitygroup.arn 11.15.2
+aws.ec2.securitygroup.cloudformationStack 13.37.1
 aws.ec2.securitygroup.description 11.15.2
 aws.ec2.securitygroup.id 11.15.2
 aws.ec2.securitygroup.instances 13.37.1
@@ -7703,6 +7706,7 @@ aws.s3.bucket.analyticsConfigurations 13.29.1
 aws.s3.bucket.arn 11.15.2
 aws.s3.bucket.blockPublicAcls 13.32.2
 aws.s3.bucket.blockPublicPolicy 13.32.2
+aws.s3.bucket.cloudformationStack 13.37.1
 aws.s3.bucket.cors 11.15.2
 aws.s3.bucket.corsrule 11.15.2
 aws.s3.bucket.corsrule.allowedHeaders 11.15.2
@@ -9539,6 +9543,7 @@ aws.vpc.arn 11.15.2
 aws.vpc.blockPublicAccessOptions 13.29.1
 aws.vpc.cidrBlock 11.15.2
 aws.vpc.cidrBlockAssociations 13.6.3
+aws.vpc.cloudformationStack 13.37.1
 aws.vpc.defaultNetworkAcl 13.29.1
 aws.vpc.defaultSecurityGroup 13.29.1
 aws.vpc.dhcpOptions 13.6.3

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.37.0",
-  "generated_at": "2026-06-18T18:56:52-06:00",
+  "generated_at": "2026-06-18T22:07:05-06:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -471,7 +471,6 @@
     "iam:ListGroups",
     "iam:ListGroupsForUser",
     "iam:ListInstanceProfiles",
-    "iam:ListInstanceProfilesForRole",
     "iam:ListMFADevices",
     "iam:ListOpenIDConnectProviders",
     "iam:ListPolicies",
@@ -3784,12 +3783,6 @@
       "permission": "iam:ListInstanceProfiles",
       "service": "iam",
       "action": "ListInstanceProfiles",
-      "source_file": "aws_iam.go"
-    },
-    {
-      "permission": "iam:ListInstanceProfilesForRole",
-      "service": "iam",
-      "action": "ListInstanceProfilesForRole",
       "source_file": "aws_iam.go"
     },
     {

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -511,3 +511,38 @@ func (a *mqlAwsCloudformationStackSet) organizationalUnitIds() ([]any, error) {
 	}
 	return res, nil
 }
+
+// cloudformationStackForTags resolves the CloudFormation stack that manages a
+// resource from the AWS-injected `aws:cloudformation:stack-name` tag. It scans
+// the account's stacks (a cross-region list cached after first use) and matches
+// on stack name and region. Returns (nil, nil) when the resource is not part of
+// a stack; callers set the field's null state before returning.
+func cloudformationStackForTags(runtime *plugin.Runtime, region string, tags map[string]any) (*mqlAwsCloudformationStack, error) {
+	raw, ok := tags["aws:cloudformation:stack-name"]
+	if !ok {
+		return nil, nil
+	}
+	name, ok := raw.(string)
+	if !ok || name == "" {
+		return nil, nil
+	}
+
+	obj, err := CreateResource(runtime, ResourceAwsCloudformation, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	stacks := obj.(*mqlAwsCloudformation).GetStacks()
+	if stacks.Error != nil {
+		return nil, stacks.Error
+	}
+	for _, s := range stacks.Data {
+		st, ok := s.(*mqlAwsCloudformationStack)
+		if !ok {
+			continue
+		}
+		if st.Name.Data == name && st.Region.Data == region {
+			return st, nil
+		}
+	}
+	return nil, nil
+}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3852,7 +3852,8 @@ func (i *mqlAwsEc2Instance) subnet() (*mqlAwsVpcSubnet, error) {
 // loadBalancers returns the load balancers that route traffic to this instance.
 // AWS has no "describe load balancers by instance" API, so this scans the
 // account's load balancers (a cross-region list cached after first use) and
-// matches on the instances each one targets.
+// matches on the instances each one targets — directly for classic ELBs, and
+// through target groups for Application and Network Load Balancers.
 func (i *mqlAwsEc2Instance) loadBalancers() ([]any, error) {
 	obj, err := CreateResource(i.MqlRuntime, ResourceAwsElb, map[string]*llx.RawData{})
 	if err != nil {
@@ -3869,19 +3870,52 @@ func (i *mqlAwsEc2Instance) loadBalancers() ([]any, error) {
 		if !ok {
 			continue
 		}
-		insts := lb.GetInstances()
-		if insts.Error != nil {
-			return nil, insts.Error
+		targets, err := loadBalancerTargetsInstance(lb, instanceArn)
+		if err != nil {
+			return nil, err
 		}
-		for _, x := range insts.Data {
-			inst, ok := x.(*mqlAwsEc2Instance)
-			if ok && inst.Arn.Data == instanceArn {
-				res = append(res, lb)
-				break
-			}
+		if targets {
+			res = append(res, lb)
 		}
 	}
 	return res, nil
+}
+
+// loadBalancerTargetsInstance reports whether a load balancer routes traffic to
+// the given instance. Classic ELBs register instances directly; Application and
+// Network Load Balancers register them through target groups, so both paths are
+// checked.
+func loadBalancerTargetsInstance(lb *mqlAwsElbLoadbalancer, instanceArn string) (bool, error) {
+	insts := lb.GetInstances()
+	if insts.Error != nil {
+		return false, insts.Error
+	}
+	for _, x := range insts.Data {
+		if inst, ok := x.(*mqlAwsEc2Instance); ok && inst.Arn.Data == instanceArn {
+			return true, nil
+		}
+	}
+
+	tgs := lb.GetTargetGroups()
+	if tgs.Error != nil {
+		return false, tgs.Error
+	}
+	for _, t := range tgs.Data {
+		tg, ok := t.(*mqlAwsElbTargetgroup)
+		if !ok {
+			continue
+		}
+		ec2Targets := tg.GetEc2Targets()
+		if ec2Targets.Error != nil {
+			return false, ec2Targets.Error
+		}
+		for _, x := range ec2Targets.Data {
+			if inst, ok := x.(*mqlAwsEc2Instance); ok && inst.Arn.Data == instanceArn {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (i *mqlAwsEc2Instance) cloudformationStack() (*mqlAwsCloudformationStack, error) {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3848,3 +3848,62 @@ func (i *mqlAwsEc2Instance) subnet() (*mqlAwsVpcSubnet, error) {
 	}
 	return res.(*mqlAwsVpcSubnet), nil
 }
+
+// loadBalancers returns the load balancers that route traffic to this instance.
+// AWS has no "describe load balancers by instance" API, so this scans the
+// account's load balancers (a cross-region list cached after first use) and
+// matches on the instances each one targets.
+func (i *mqlAwsEc2Instance) loadBalancers() ([]any, error) {
+	obj, err := CreateResource(i.MqlRuntime, ResourceAwsElb, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	lbs := obj.(*mqlAwsElb).GetLoadBalancers()
+	if lbs.Error != nil {
+		return nil, lbs.Error
+	}
+	instanceArn := i.Arn.Data
+	res := []any{}
+	for _, l := range lbs.Data {
+		lb, ok := l.(*mqlAwsElbLoadbalancer)
+		if !ok {
+			continue
+		}
+		insts := lb.GetInstances()
+		if insts.Error != nil {
+			return nil, insts.Error
+		}
+		for _, x := range insts.Data {
+			inst, ok := x.(*mqlAwsEc2Instance)
+			if ok && inst.Arn.Data == instanceArn {
+				res = append(res, lb)
+				break
+			}
+		}
+	}
+	return res, nil
+}
+
+func (i *mqlAwsEc2Instance) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	stack, err := cloudformationStackForTags(i.MqlRuntime, i.Region.Data, i.Tags.Data)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		i.CloudformationStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}
+
+func (a *mqlAwsEc2Securitygroup) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	stack, err := cloudformationStackForTags(a.MqlRuntime, a.Region.Data, a.Tags.Data)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		a.CloudformationStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1809,25 +1809,32 @@ func (a *mqlAwsIamRole) inlinePolicies() ([]any, error) {
 
 // usedByInstances returns the EC2 instances that use this role through an
 // instance profile. EC2 references an instance *profile*, which in turn contains
-// roles, so this first resolves the role's instance profiles, then scans the
-// account's instances (a cross-region list, cached after first use) for ones
-// whose instance profile is among them.
+// roles. It derives the role's instance profiles from the account-wide instance
+// profile list (a single ListInstanceProfiles call cached and shared across all
+// role evaluations, rather than a per-role ListInstanceProfilesForRole call),
+// then scans the cached instance list for ones whose profile is among them.
 func (a *mqlAwsIamRole) usedByInstances() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Iam("")
-	ctx := context.Background()
-	rolename := a.Name.Data
+	roleArn := a.Arn.Data
+
+	iamObj, err := CreateResource(a.MqlRuntime, ResourceAwsIam, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	profiles := iamObj.(*mqlAwsIam).GetInstanceProfiles()
+	if profiles.Error != nil {
+		return nil, profiles.Error
+	}
 
 	profileArns := map[string]struct{}{}
-	paginator := iam.NewListInstanceProfilesForRolePaginator(svc, &iam.ListInstanceProfilesForRoleInput{RoleName: &rolename})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
+	for _, p := range profiles.Data {
+		prof, ok := p.(*mqlAwsIamInstanceProfile)
+		if !ok {
+			continue
 		}
-		for i := range page.InstanceProfiles {
-			if page.InstanceProfiles[i].Arn != nil {
-				profileArns[*page.InstanceProfiles[i].Arn] = struct{}{}
+		for _, role := range prof.rolesCache {
+			if role.Arn != nil && *role.Arn == roleArn {
+				profileArns[prof.Arn.Data] = struct{}{}
+				break
 			}
 		}
 	}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -567,6 +567,26 @@ func (a *mqlAwsS3Bucket) location() (string, error) {
 	return region, nil
 }
 
+func (a *mqlAwsS3Bucket) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	tags := a.GetTags()
+	if tags.Error != nil {
+		return nil, tags.Error
+	}
+	loc := a.GetLocation()
+	if loc.Error != nil {
+		return nil, loc.Error
+	}
+	stack, err := cloudformationStackForTags(a.MqlRuntime, loc.Data, tags.Data)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		a.CloudformationStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}
+
 func (a *mqlAwsS3Bucket) gatherAcl() (*s3.GetBucketAclOutput, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
 	if !a.Exists.Data {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1918,3 +1918,15 @@ func (a *mqlAwsVpcVpnGateway) vpnConnections() ([]any, error) {
 	}
 	return vpnConns, nil
 }
+
+func (a *mqlAwsVpc) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	stack, err := cloudformationStackForTags(a.MqlRuntime, a.Region.Data, a.Tags.Data)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		a.CloudformationStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}


### PR DESCRIPTION
## What

Three follow-ups to the cross-resource edges (#8513), all in the AWS provider.

### 1. Provenance — `cloudformationStack()`
Adds `cloudformationStack() aws.cloudformation.stack` to `aws.ec2.instance`, `aws.ec2.securitygroup`, `aws.vpc`, and `aws.s3.bucket`. Resolved from the AWS-injected `aws:cloudformation:stack-name` tag via a shared helper that scans the cached cross-region stack list. Enables **"unmanaged / drifted resource"** checks (resource has no managing stack → not IaC-managed).

### 2. Reverse edge — `aws.ec2.instance.loadBalancers()`
The load balancers that route traffic to an instance (the forward `loadbalancer.instances()` already existed). Lets a policy express *"this instance is internet-reachable via an internet-facing ALB/NLB even though it has no public IP"* — the exposure case the public-IP checks miss.

### 3. Perf — `aws.iam.role.usedByInstances`
Reworked to derive the role's instance profiles from the account-wide `ListInstanceProfiles` list (one call, **cached and shared across all role evaluations**) instead of a per-role `ListInstanceProfilesForRole` call. The `aws.iam.roles.where(usedByInstances.length > 0)` pattern now makes a single IAM list call total instead of one per role. Drops the `iam:ListInstanceProfilesForRole` permission (permissions regenerated: 913 → 912).

## Notes
- New `.lr.versions` entries at `13.37.1`.
- The `aws:cloudformation:stack-name` correlation is a runtime tag relationship with no static-IaC analog, consistent with the other cross-resource edges.

## Verification
Built and run against a live account:
- All six new fields resolve without error and return correct negatives for resources not managed by CloudFormation / not behind a load balancer.
- `usedByInstances` returns the same correct result (`EC2-SSM`) via the faster path.
- `go build ./...` clean; codegen idempotent; permissions regenerated.

## Follow-up
The `#6 hardening` item also called for dedicated unit tests on these edges. They aren't included here: the resolvers call into the MQL runtime (`GetInstances`, `GetLoadBalancers`, `GetStacks`), and the provider's existing tests cover only pure helpers (e.g. `TestShouldExcludeInstance`) — there's no mock-runtime harness for resolver-level tests. Verified interactively instead, per the repo's stated norm. Happy to add a mock-runtime test scaffold as a separate change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)