### PR TITLE
⭐ aws: managedBy provenance field for unmanaged-resource detection

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -373,6 +373,10 @@ aws.vpc @defaults("id isDefault cidrBlock region") {
   ipv6CidrBlockAssociations() []dict
   // CloudFormation stack that manages this VPC, if any
   cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this VPC
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the VPC is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon Virtual Private Cloud (VPC) route table
@@ -10101,6 +10105,10 @@ private aws.s3.bucket @defaults("name location public") {
   accessPoints() []aws.s3.bucket.accessPoint
   // CloudFormation stack that manages this bucket, if any
   cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this bucket
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the bucket is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon S3 bucket event notification
@@ -15781,6 +15789,10 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   loadBalancers() []aws.elb.loadbalancer
   // CloudFormation stack that manages this instance, if any
   cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this instance
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the instance is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Whether API termination protection is enabled for the instance
   disableApiTermination() bool
   // Boot mode of the instance (undefined, legacy-bios, uefi, uefi-preferred)
@@ -16092,6 +16104,10 @@ private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   instances() []aws.ec2.instance
   // CloudFormation stack that manages this security group, if any
   cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this security group
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the security group is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon EC2 security group IP permission

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4923,6 +4923,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
 	},
+	"aws.vpc.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.vpc.routetable.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetArn()).ToDataRes(types.String)
 	},
@@ -15690,6 +15693,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
 	},
+	"aws.s3.bucket.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.s3.bucket.eventNotification.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketEventNotification).GetId()).ToDataRes(types.String)
 	},
@@ -22086,6 +22092,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
 	},
+	"aws.ec2.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetDisableApiTermination()).ToDataRes(types.Bool)
 	},
@@ -22466,6 +22475,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.ec2.securitygroup.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Securitygroup).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.ec2.securitygroup.ippermission.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetId()).ToDataRes(types.String)
@@ -33077,6 +33089,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48963,6 +48979,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsS3Bucket).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.eventNotification.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3BucketEventNotification).__id, ok = v.Value.(string)
 		return
@@ -58239,6 +58259,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Instance).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).DisableApiTermination, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -58785,6 +58809,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Securitygroup).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Securitygroup).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.ippermission.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -74615,6 +74643,7 @@ type mqlAwsVpc struct {
 	CidrBlockAssociations     plugin.TValue[[]any]
 	Ipv6CidrBlockAssociations plugin.TValue[[]any]
 	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                 plugin.TValue[string]
 }
 
 // createAwsVpc creates a new instance of this resource
@@ -74965,6 +74994,12 @@ func (c *mqlAwsVpc) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformatio
 		}
 
 		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsVpc) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -117315,6 +117350,7 @@ type mqlAwsS3Bucket struct {
 	MacieCoverage                    plugin.TValue[*mqlAwsMacieBucket]
 	AccessPoints                     plugin.TValue[[]any]
 	CloudformationStack              plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                        plugin.TValue[string]
 }
 
 // createAwsS3Bucket creates a new instance of this resource
@@ -117719,6 +117755,12 @@ func (c *mqlAwsS3Bucket) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudfor
 		}
 
 		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -140126,6 +140168,7 @@ type mqlAwsEc2Instance struct {
 	Subnet                  plugin.TValue[*mqlAwsVpcSubnet]
 	LoadBalancers           plugin.TValue[[]any]
 	CloudformationStack     plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy               plugin.TValue[string]
 	DisableApiTermination   plugin.TValue[bool]
 	BootMode                plugin.TValue[string]
 	SourceDestCheck         plugin.TValue[bool]
@@ -140464,6 +140507,12 @@ func (c *mqlAwsEc2Instance) GetCloudformationStack() *plugin.TValue[*mqlAwsCloud
 		}
 
 		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -141519,6 +141568,7 @@ type mqlAwsEc2Securitygroup struct {
 	NetworkInterfaces            plugin.TValue[[]any]
 	Instances                    plugin.TValue[[]any]
 	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                    plugin.TValue[string]
 }
 
 // createAwsEc2Securitygroup creates a new instance of this resource
@@ -141681,6 +141731,12 @@ func (c *mqlAwsEc2Securitygroup) GetCloudformationStack() *plugin.TValue[*mqlAws
 		}
 
 		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEc2Securitygroup) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2988,6 +2988,7 @@ aws.ec2.instance.launchTime 11.15.2
 aws.ec2.instance.launchedAt 11.15.2
 aws.ec2.instance.loadBalancers 13.37.1
 aws.ec2.instance.maintenanceAutoRecovery 11.15.3
+aws.ec2.instance.managedBy 13.37.1
 aws.ec2.instance.networkInterfaces 11.15.2
 aws.ec2.instance.patchState 11.15.2
 aws.ec2.instance.placement 11.15.3
@@ -3278,6 +3279,7 @@ aws.ec2.securitygroup.ippermission.prefixLists 13.23.2
 aws.ec2.securitygroup.ippermission.toPort 11.15.2
 aws.ec2.securitygroup.ippermission.userIdGroupPairs 11.15.2
 aws.ec2.securitygroup.isAttachedToNetworkInterface 11.15.2
+aws.ec2.securitygroup.managedBy 13.37.1
 aws.ec2.securitygroup.name 11.15.2
 aws.ec2.securitygroup.networkInterfaces 13.37.1
 aws.ec2.securitygroup.region 11.15.2
@@ -7758,6 +7760,7 @@ aws.s3.bucket.lifecycleRules 13.6.3
 aws.s3.bucket.location 11.15.2
 aws.s3.bucket.logging 11.15.2
 aws.s3.bucket.macieCoverage 13.23.2
+aws.s3.bucket.managedBy 13.37.1
 aws.s3.bucket.metricsConfiguration 13.6.3
 aws.s3.bucket.metricsConfiguration.filter 13.6.3
 aws.s3.bucket.metricsConfiguration.id 13.6.3
@@ -9594,6 +9597,7 @@ aws.vpc.internetGatewayBlockMode 11.15.2
 aws.vpc.internetGateways 11.15.2
 aws.vpc.ipv6CidrBlockAssociations 13.6.3
 aws.vpc.isDefault 11.15.2
+aws.vpc.managedBy 13.37.1
 aws.vpc.name 11.15.2
 aws.vpc.natGateways 11.15.2
 aws.vpc.natgateway 11.15.2

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -512,6 +512,29 @@ func (a *mqlAwsCloudformationStackSet) organizationalUnitIds() ([]any, error) {
 	return res, nil
 }
 
+// managedByFromTags infers the infrastructure-management system that owns a
+// resource from the provenance tags AWS injects on managed resources. It returns
+// "" when no known management signal is present — the resource is unmanaged, or
+// managed by a tool that leaves no recognizable tag (raw API calls, or Terraform
+// without a tagging convention).
+func managedByFromTags(tags map[string]any) string {
+	for _, sig := range []struct {
+		key   string
+		owner string
+	}{
+		{"aws:cloudformation:stack-name", "cloudformation"},
+		{"elasticbeanstalk:environment-name", "elasticbeanstalk"},
+		{"eks:cluster-name", "eks"},
+		{"aws:servicecatalog:provisioningPrincipalArn", "servicecatalog"},
+		{"aws:autoscaling:groupName", "autoscaling"},
+	} {
+		if _, ok := tags[sig.key]; ok {
+			return sig.owner
+		}
+	}
+	return ""
+}
+
 // cloudformationStackForTags resolves the CloudFormation stack that manages a
 // resource from the AWS-injected `aws:cloudformation:stack-name` tag. It scans
 // the account's stacks (a cross-region list cached after first use) and matches

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3941,3 +3941,11 @@ func (a *mqlAwsEc2Securitygroup) cloudformationStack() (*mqlAwsCloudformationSta
 	}
 	return stack, nil
 }
+
+func (i *mqlAwsEc2Instance) managedBy() (string, error) {
+	return managedByFromTags(i.Tags.Data), nil
+}
+
+func (a *mqlAwsEc2Securitygroup) managedBy() (string, error) {
+	return managedByFromTags(a.Tags.Data), nil
+}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -587,6 +587,14 @@ func (a *mqlAwsS3Bucket) cloudformationStack() (*mqlAwsCloudformationStack, erro
 	return stack, nil
 }
 
+func (a *mqlAwsS3Bucket) managedBy() (string, error) {
+	tags := a.GetTags()
+	if tags.Error != nil {
+		return "", tags.Error
+	}
+	return managedByFromTags(tags.Data), nil
+}
+
 func (a *mqlAwsS3Bucket) gatherAcl() (*s3.GetBucketAclOutput, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
 	if !a.Exists.Data {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1930,3 +1930,7 @@ func (a *mqlAwsVpc) cloudformationStack() (*mqlAwsCloudformationStack, error) {
 	}
 	return stack, nil
 }
+
+func (a *mqlAwsVpc) managedBy() (string, error) {
+	return managedByFromTags(a.Tags.Data), nil
+}


### PR DESCRIPTION
## What

Adds `managedBy() string` to `aws.ec2.instance`, `aws.ec2.securitygroup`, `aws.vpc`, and `aws.s3.bucket` — the **provenance-depth** follow-up to the `cloudformationStack()` edge.

It infers the infrastructure-management system that owns a resource from the provenance tags AWS injects on managed resources:

| Tag | `managedBy` |
|---|---|
| `aws:cloudformation:stack-name` | `cloudformation` |
| `elasticbeanstalk:environment-name` | `elasticbeanstalk` |
| `eks:cluster-name` | `eks` |
| `aws:servicecatalog:provisioningPrincipalArn` | `servicecatalog` |
| `aws:autoscaling:groupName` | `autoscaling` |
| _(none)_ | `""` |

## Why

`cloudformationStack()` answers "is this CloudFormation-managed" only. `managedBy` generalizes it to the **"unmanaged / shadow-IT resource"** question across management systems:

```
aws.s3.buckets.where(managedBy == "")            # buckets not managed by any known IaC/AWS system
aws.ec2.securityGroups.where(managedBy == "")    # hand-rolled security groups
```

## Notes
- Reads the tags already fetched for each resource — **no new API calls or permissions** (`aws.permissions.json` unchanged).
- Conservative by design: only AWS-injected tags are treated as signals. Terraform/CDK leave no reliable tag by default, so those resources report `""` rather than a guess.
- New `.lr.versions` entries at `13.37.1`.

## Verification
Run against a live account:
- `holori-…` and `vantage-cur-…` buckets correctly report `managedBy: "cloudformation"`.
- Untagged buckets report `""`.
- Build clean; codegen idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)