### PR TITLE
⭐ aws: computed instance internet-exposure (inPublicSubnet, internetReachable)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15779,6 +15779,12 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   subnet() aws.vpc.subnet
   // Load balancers that route traffic to this instance
   loadBalancers() []aws.elb.loadbalancer
+  // Whether the instance's subnet routes to an internet gateway (a public subnet)
+  inPublicSubnet() bool
+  // Whether the instance is directly reachable from the internet
+  //
+  // True when the instance has a public IP, sits in a public subnet (its subnet's route table has an internet gateway route), and an attached security group permits inbound traffic from 0.0.0.0/0 or ::/0. Exposure through an internet-facing load balancer is a separate path — query `loadBalancers` and their `scheme` for that.
+  internetReachable() bool
   // CloudFormation stack that manages this instance, if any
   cloudformationStack() aws.cloudformation.stack
   // Whether API termination protection is enabled for the instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22083,6 +22083,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
 	},
+	"aws.ec2.instance.inPublicSubnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetInPublicSubnet()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.instance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
 	},
@@ -58233,6 +58239,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.inPublicSubnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).InPublicSubnet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -140125,6 +140139,8 @@ type mqlAwsEc2Instance struct {
 	NetworkInterfaces       plugin.TValue[[]any]
 	Subnet                  plugin.TValue[*mqlAwsVpcSubnet]
 	LoadBalancers           plugin.TValue[[]any]
+	InPublicSubnet          plugin.TValue[bool]
+	InternetReachable       plugin.TValue[bool]
 	CloudformationStack     plugin.TValue[*mqlAwsCloudformationStack]
 	DisableApiTermination   plugin.TValue[bool]
 	BootMode                plugin.TValue[string]
@@ -140448,6 +140464,18 @@ func (c *mqlAwsEc2Instance) GetLoadBalancers() *plugin.TValue[[]any] {
 		}
 
 		return c.loadBalancers()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetInPublicSubnet() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InPublicSubnet, func() (bool, error) {
+		return c.inPublicSubnet()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2978,10 +2978,12 @@ aws.ec2.instance.hypervisor 11.15.2
 aws.ec2.instance.iamInstanceProfile 11.15.2
 aws.ec2.instance.image 11.15.2
 aws.ec2.instance.imdsv2Required 13.29.1
+aws.ec2.instance.inPublicSubnet 13.37.1
 aws.ec2.instance.instanceId 11.15.2
 aws.ec2.instance.instanceLifecycle 11.15.2
 aws.ec2.instance.instanceStatus 11.15.2
 aws.ec2.instance.instanceType 11.15.2
+aws.ec2.instance.internetReachable 13.37.1
 aws.ec2.instance.ipv6Address 11.15.2
 aws.ec2.instance.keypair 11.15.2
 aws.ec2.instance.launchTime 11.15.2

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3849,6 +3849,88 @@ func (i *mqlAwsEc2Instance) subnet() (*mqlAwsVpcSubnet, error) {
 	return res.(*mqlAwsVpcSubnet), nil
 }
 
+// inPublicSubnet reports whether the instance's subnet routes to an internet
+// gateway, which is the defining property of a public subnet.
+func (i *mqlAwsEc2Instance) inPublicSubnet() (bool, error) {
+	subnet := i.GetSubnet()
+	if subnet.Error != nil {
+		return false, subnet.Error
+	}
+	if subnet.Data == nil {
+		return false, nil
+	}
+	rt := subnet.Data.GetRouteTable()
+	if rt.Error != nil {
+		return false, rt.Error
+	}
+	if rt.Data == nil {
+		return false, nil
+	}
+	entries := rt.Data.GetRouteEntries()
+	if entries.Error != nil {
+		return false, entries.Error
+	}
+	for _, e := range entries.Data {
+		route, ok := e.(*mqlAwsVpcRoutetableRoute)
+		if !ok {
+			continue
+		}
+		gw := route.GetGatewayId()
+		if gw.Error == nil && strings.HasPrefix(gw.Data, "igw-") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// internetReachable reports whether the instance is directly reachable from the
+// internet: it has a public IP, sits in a public subnet, and an attached
+// security group permits inbound traffic from 0.0.0.0/0 or ::/0. Load-balancer-
+// fronted exposure is a separate path (see loadBalancers).
+func (i *mqlAwsEc2Instance) internetReachable() (bool, error) {
+	publicIp := i.GetPublicIp()
+	if publicIp.Error != nil {
+		return false, publicIp.Error
+	}
+	if publicIp.Data == "" {
+		return false, nil
+	}
+
+	public := i.GetInPublicSubnet()
+	if public.Error != nil {
+		return false, public.Error
+	}
+	if !public.Data {
+		return false, nil
+	}
+
+	sgs := i.GetSecurityGroups()
+	if sgs.Error != nil {
+		return false, sgs.Error
+	}
+	for _, s := range sgs.Data {
+		sg, ok := s.(*mqlAwsEc2Securitygroup)
+		if !ok {
+			continue
+		}
+		perms := sg.GetIpPermissions()
+		if perms.Error != nil {
+			return false, perms.Error
+		}
+		for _, p := range perms.Data {
+			perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+			if !ok {
+				continue
+			}
+			pub := perm.GetIncludesPublicSource()
+			if pub.Error == nil && pub.Data {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // loadBalancers returns the load balancers that route traffic to this instance.
 // AWS has no "describe load balancers by instance" API, so this scans the
 // account's load balancers (a cross-region list cached after first use) and


### PR DESCRIPTION
## What

The **Approach B** computed-exposure work: fold the multi-hop reachability join into the provider so policy authors get a clean boolean instead of hand-rolling subnet → route-table → gateway → security-group traversal.

Adds two computed fields to `aws.ec2.instance`:

- **`inPublicSubnet()`** — whether the instance's subnet routes to an internet gateway (the defining property of a public subnet). Traverses `subnet → routeTable → routeEntries` looking for an `igw-` gateway route.
- **`internetReachable()`** — directly reachable from the internet: has a public IP **and** is in a public subnet **and** an attached security group permits inbound from `0.0.0.0/0` or `::/0` (reuses the rule-level `includesPublicSource` check).

## Why

The exposure checks shipped in cnspec#2913 hand-roll this join. With this field they collapse:

```
# before: public IP + public subnet + open SG, by hand
# after:
aws.ec2.instances.where(internetReachable)
```

`internetReachable` is deliberately scoped to **direct** reachability. Load-balancer-fronted exposure has different security-group semantics (the LB's SG, not the instance's), so it's a separate path — query `loadBalancers` and their `scheme` for that. Keeping the boolean precise avoids false claims.

## Notes
- Reads cached subnet / route-table / security-group data — **no new API calls or permissions** (912, unchanged).
- New `.lr.versions` entries at `13.37.1`.

## Verification
Run against a live account:
- An instance with a public IP (`54.144.152.249`) in a public subnet behind an SSH-open security group → `internetReachable: true`.
- Instances with no public IP → `internetReachable: false`, while `inPublicSubnet: true` confirms the route-table traversal resolves.
- Build clean; codegen idempotent.

## Follow-up
A natural next step is an `internetReachable`-style field that also accounts for the internet-facing-LB path (using `instance.loadBalancers` + `loadbalancer.scheme` + the LB's security groups) — left out here to keep this boolean's semantics precise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)