### PR TITLE
🐛 os: registrykey.property fails gracefully on a missing property

### DIFF
--- a/providers/os/resources/registrykey.go
+++ b/providers/os/resources/registrykey.go
@@ -239,10 +239,12 @@ func initRegistrykeyProperty(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 	key := obj.(*mqlRegistrykey)
 
+	// An unreadable key (exists.Error != nil) is intentionally treated the same
+	// as a missing one: the defaults below mark the property absent so the
+	// lookup fails cleanly instead of erroring the whole check. (The previous
+	// `if err != nil` here inspected a stale, always-nil err from the
+	// CreateResource above and was dead code.)
 	exists := key.GetExists()
-	if err != nil {
-		return nil, nil, err
-	}
 
 	// set default values
 	args["exists"] = llx.BoolFalse
@@ -273,22 +275,26 @@ func initRegistrykeyProperty(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	return args, nil, nil
 }
 
+// The fields below are normally populated by initRegistrykeyProperty. These
+// compute fallbacks are only reached when the resource was created without
+// those fields pre-set — e.g. replaying a recording that did not capture them.
+// In that case the property is treated as absent and the fields fail cleanly
+// (false / null) rather than erroring the whole check, mirroring the leniency
+// of init (which already defaults a missing property to exists=false, data=nil)
+// and matching how a missing key on an array/map now fails gracefully.
+
 func (p *mqlRegistrykeyProperty) exists() (bool, error) {
-	// NOTE: will not be called since it will always be set in init
-	return false, errors.New("could not determine if the property exists")
+	return false, nil
 }
 
 func (p *mqlRegistrykeyProperty) compute_type() (string, error) {
-	// NOTE: if we reach here the value has not been set in init, therefore we return an error
-	return "", errors.New("requested property does not exist")
+	return "", nil
 }
 
 func (p *mqlRegistrykeyProperty) data() (any, error) {
-	// NOTE: if we reach here the value has not been set in init, therefore we return an error
-	return "", errors.New("requested property does not exist")
+	return nil, nil
 }
 
 func (p *mqlRegistrykeyProperty) value() (string, error) {
-	// NOTE: if we reach here the value has not been set in init, therefore we return an error
-	return "", errors.New("requested property does not exist")
+	return "", nil
 }

--- a/providers/os/resources/registrykey_internal_test.go
+++ b/providers/os/resources/registrykey_internal_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// When a registrykey.property is created without its fields pre-populated by
+// initRegistrykeyProperty — e.g. replaying a recording that did not capture
+// them — the compute fallbacks must fail cleanly (false / empty / null) rather
+// than erroring, so that policies querying a missing property fail gracefully
+// instead of erroring the whole check.
+func TestRegistrykeyProperty_FallbacksFailGracefully(t *testing.T) {
+	p := &mqlRegistrykeyProperty{}
+
+	exists, err := p.exists()
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	data, err := p.data()
+	require.NoError(t, err)
+	require.Nil(t, data)
+
+	val, err := p.value()
+	require.NoError(t, err)
+	require.Equal(t, "", val)
+
+	typ, err := p.compute_type()
+	require.NoError(t, err)
+	require.Equal(t, "", typ)
+}

--- a/providers/os/resources/registrykey_test.go
+++ b/providers/os/resources/registrykey_test.go
@@ -60,4 +60,29 @@ func TestResource_Registrykey(t *testing.T) {
 		assert.Empty(t, res[0].Result().Error)
 		assert.Nil(t, res[0].Data.Value)
 	})
+
+	// A missing registry property must not error when its fields are read or
+	// compared — this is what lets policies drop the
+	// `switch(x) { case _ != empty: ... default: false }` workaround around
+	// registrykey.property(...).data.
+	t.Run("missing property does not error on field access or comparison", func(t *testing.T) {
+		existPath := "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+		queries := []string{
+			// missing property on an existing key path
+			"registrykey.property(path: '" + existPath + "', name: 'DoesNotExist').exists",
+			"registrykey.property(path: '" + existPath + "', name: 'DoesNotExist').data > 0",
+			"registrykey.property(path: '" + existPath + "', name: 'DoesNotExist').data > 0 && registrykey.property(path: '" + existPath + "', name: 'DoesNotExist').data <= 30",
+			// missing property on a non-existent key path
+			"registrykey.property(path: 'HKEY_LOCAL_MACHINE\\Nope\\Nope', name: 'DoesNotExist').data > 0",
+		}
+		for _, q := range queries {
+			t.Run(q, func(t *testing.T) {
+				res := testWindowsQuery(t, q)
+				assert.NotEmpty(t, res)
+				last := res[len(res)-1]
+				assert.NoError(t, last.Data.Error)
+				assert.Equal(t, false, last.Data.Value)
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Reading a field of a **missing `registrykey.property`** can raise a hard **error** instead of failing the check gracefully. The standalone compute methods on `registrykey.property` return errors when the field wasn't pre-populated by `initRegistrykeyProperty`:

```go
func (p *mqlRegistrykeyProperty) exists() (bool, error) {
	return false, errors.New("could not determine if the property exists")
}
func (p *mqlRegistrykeyProperty) data() (any, error) {
	return "", errors.New("requested property does not exist")
}
func (p *mqlRegistrykeyProperty) value() (string, error) { /* errors */ }
func (p *mqlRegistrykeyProperty) compute_type() (string, error) { /* errors */ }
```

This forces policy authors into the same `switch` workaround we are removing elsewhere:

```mql
maximumPasswordAge = registrykey.property(path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters', name: 'MaximumPasswordAge').data;
switch(maximumPasswordAge) {
  case _ != empty:
      maximumPasswordAge > 0 && maximumPasswordAge <= 30;
  default:
      false;   # <- only here to stop .data erroring when the property is absent
}
```

## Analysis

The common **live-query** path is already lenient: `initRegistrykeyProperty` defaults a missing property to `exists=false`, `data=nil`, `value=null`, `type=null` (added in #2324, "be more lenient with errors on registrykey"). Verified end-to-end against the Windows secpol/registry mock — `registrykey.property(path:…, name:'Missing').data > 0` already returns a clean `false`.

The remaining landmine is the **compute fallbacks above**, which are reached when the resource is created *without* those fields pre-set — most realistically when **replaying a recording** that didn't capture them (`ResourceFromRecording("registrykey.property", …)`). There the property is treated as absent, but the field read **errors** rather than failing cleanly.

There is also a dead `if err != nil` check in `initRegistrykeyProperty` that inspects a stale, always-nil `err` from the preceding `CreateResource` (it was clearly meant to inspect `exists.Error`).

## Proposed fix

- Make `exists()` / `data()` / `value()` / `compute_type()` fail cleanly (`false` / `nil` / `""`) instead of erroring, treating an un-pre-populated property as absent — consistent with init's leniency and with the array/map null-handling work.
- Replace the dead `if err != nil` check with a comment documenting that an unreadable key is intentionally treated as missing (so the lookup stays graceful rather than erroring the whole check).

Policies can then drop the `switch` wrapper around `registrykey.property(...).data`.
