### PR TITLE
🐛 os: file.user/file.group fail gracefully on an unknown owner uid/gid

### DIFF
--- a/providers/os/resources/file.go
+++ b/providers/os/resources/file.go
@@ -174,11 +174,22 @@ func (s *mqlFile) cacheOwnership(stat shared.FileInfoDetails) error {
 
 	user, err := users.findID(stat.Uid)
 	if err != nil {
-		return err
-	}
-	s.User = plugin.TValue[*mqlUser]{
-		Data:  user,
-		State: plugin.StateIsSet,
+		// A file owned by a uid with no passwd entry (a deleted user, or a
+		// minimal container image) resolves the owner to null and fails
+		// cleanly, rather than erroring the whole check. Other errors (e.g. the
+		// users list could not be loaded) still propagate.
+		var notFound resources.NotFoundError
+		if !errors.As(err, &notFound) {
+			return err
+		}
+		s.User = plugin.TValue[*mqlUser]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+	} else {
+		s.User = plugin.TValue[*mqlUser]{
+			Data:  user,
+			State: plugin.StateIsSet,
+		}
 	}
 
 	raw, err = CreateResource(s.MqlRuntime, "groups", nil)
@@ -189,11 +200,20 @@ func (s *mqlFile) cacheOwnership(stat shared.FileInfoDetails) error {
 
 	group, err := groups.findID(stat.Gid)
 	if err != nil {
-		return err
-	}
-	s.Group = plugin.TValue[*mqlGroup]{
-		Data:  group,
-		State: plugin.StateIsSet,
+		// See the user lookup above: an unknown gid resolves to a null group
+		// rather than erroring the whole check.
+		var notFound resources.NotFoundError
+		if !errors.As(err, &notFound) {
+			return err
+		}
+		s.Group = plugin.TValue[*mqlGroup]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+	} else {
+		s.Group = plugin.TValue[*mqlGroup]{
+			Data:  group,
+			State: plugin.StateIsSet,
+		}
 	}
 
 	return nil

--- a/providers/os/resources/file_owner_internal_test.go
+++ b/providers/os/resources/file_owner_internal_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// A file that exists but is owned by a uid/gid with no passwd/group entry
+// (common on minimal containers, or files left by a deleted user) must resolve
+// file.user / file.group to null and fail cleanly, rather than erroring the
+// whole check with "cannot find user for uid N".
+func TestFileOwnership_UnknownUidGid(t *testing.T) {
+	fixturePath, err := filepath.Abs("testdata/file_orphan_owner.toml")
+	require.NoError(t, err)
+
+	asset := &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "centos",
+			Family: []string{"linux", "unix"},
+		},
+	}
+	conn, err := mock.New(0, asset, mock.WithPath(fixturePath))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	raw, err := CreateResource(runtime, "file", map[string]*llx.RawData{
+		"path": llx.StringData("/orphan"),
+	})
+	require.NoError(t, err)
+
+	file := raw.(*mqlFile)
+	// Simulate an existing file owned by a uid/gid that is not in passwd/group.
+	file.Exists = plugin.TValue[bool]{Data: true, State: plugin.StateIsSet}
+	file.statInfo = &shared.FileInfoDetails{
+		Mode: shared.FileModeDetails{FileMode: os.FileMode(0o644)},
+		Size: 10,
+		Uid:  4242,
+		Gid:  4242,
+	}
+
+	user := file.GetUser()
+	require.NoError(t, user.Error, "file.user must not error for an unknown uid")
+	assert.True(t, user.State&plugin.StateIsNull != 0, "file.user should be null for an unknown uid")
+
+	group := file.GetGroup()
+	require.NoError(t, group.Error, "file.group must not error for an unknown gid")
+	assert.True(t, group.State&plugin.StateIsNull != 0, "file.group should be null for an unknown gid")
+}

--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -10,6 +10,7 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/resources/groups"
 )
@@ -179,7 +180,7 @@ func (x *mqlGroups) findID(id int64) (*mqlGroup, error) {
 
 	res, ok := x.groupsByID[id]
 	if !ok {
-		return nil, errors.New("cannot find group for uid " + strconv.Itoa(int(id)))
+		return nil, resources.NotFoundError{Resource: "group", ID: strconv.Itoa(int(id))}
 	}
 	return res, nil
 }

--- a/providers/os/resources/testdata/file_orphan_owner.toml
+++ b/providers/os/resources/testdata/file_orphan_owner.toml
@@ -1,0 +1,15 @@
+[commands."getent passwd"]
+stdout = """root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+"""
+
+[commands."getent group"]
+stdout = """root:x:0:
+bin:x:1:
+"""
+
+[files."/etc/group"]
+path = "/etc/group"
+content = """root:x:0:
+bin:x:1:
+"""

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/resources/users"
 	"go.mondoo.com/mql/v13/utils/multierr"
@@ -181,7 +182,7 @@ func (x *mqlUsers) findID(id int64) (*mqlUser, error) {
 
 	res, ok := x.usersByID[id]
 	if !ok {
-		return nil, errors.New("cannot find user for uid " + strconv.Itoa(int(id)))
+		return nil, resources.NotFoundError{Resource: "user", ID: strconv.Itoa(int(id))}
 	}
 	return res, nil
 }


### PR DESCRIPTION
## Summary

`file.user` / `file.group` raise a hard **error** when a file **exists** but is owned by a **uid/gid that has no `/etc/passwd` / `/etc/group` entry** — common on minimal/container images, or for files left behind by a deleted user. The error is:

```
cannot find user for uid <N>
cannot find group for uid <N>
```

Because this errors the whole datapoint (and `file.user`/`file.group` are resolved together in `cacheOwnership`), file ownership/permission checks fail with an *error* instead of a clean pass/fail — forcing the same defensive wrappers we are removing elsewhere.

Note: the *missing-file* case already fails gracefully (since #7491). This issue is specifically the **existing file, orphaned owner** case, which the `.where(file(_).exists)` guard does not protect against.

## Root cause

`mqlFile.cacheOwnership` (`providers/os/resources/file.go`) calls `users.findID(uid)` / `groups.findID(gid)` and propagates any error. `findID` returns a plain `errors.New("cannot find user for uid N")` when the id isn't in the resolved list, so a legitimately-absent owner is indistinguishable from a genuine failure (e.g. the users list could not be loaded) and both error out.

## Fix

- `mqlUsers.findID` / `mqlGroups.findID` now return a typed `resources.NotFoundError` when the id isn't present (instead of a generic error).
- `cacheOwnership` treats a `NotFoundError` from `findID` as "owner not resolvable" → sets `file.user` / `file.group` to **null** (`StateIsSet | StateIsNull`) and fails cleanly. Any other error (e.g. the users/groups list could not be loaded) still propagates, so genuine failures are not masked.

This mirrors the missing-file null handling (#7491) and the array/map/registrykey null-handling work, and lets policies write `file('/path') { user.name == '...'; permissions.user_readable == ... }` without erroring on orphaned ownership.

## Testing

- Added a deterministic internal regression test (`TestFileOwnership_UnknownUidGid`) with a mock connection whose passwd/group does not contain the file's uid/gid; it errored before the fix (`cannot find user for uid 4242`) and now resolves `file.user`/`file.group` to null with no error.
- `go test ./providers/os/resources/...` (including the `users` and `groups` packages) passes.

## Related (out of scope)

`user.group` (a user's primary group) still errors for an unknown gid via the same `findID`; it now returns the typed `NotFoundError` but the field still surfaces it. Aligning that to null can be a follow-up.
