### PR TITLE
🐛 github: surface workflow access errors instead of returning empty

### DIFF
--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -1438,8 +1438,15 @@ func (g *mqlGithubRepository) workflows() ([]any, error) {
 	for {
 		workflows, resp, err := conn.Client().Actions.ListWorkflows(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				return nil, nil
+			// The Actions API returns 404/403 when the token lacks the "Actions"
+			// (read) permission on a fine-grained PAT, or the full "repo" scope on
+			// a classic PAT (and also when Actions is disabled on the repository).
+			// Surface this instead of returning an empty list: an empty list makes
+			// a security check (e.g. "packages are scanned for vulnerabilities")
+			// silently FAIL as if no scanning workflow were configured, when in
+			// fact the scanner simply could not read the workflows.
+			if isAccessDeniedOrNotFound(err) {
+				return nil, fmt.Errorf("cannot list workflows for %q: %w; grant the scanning token the \"Actions\" read permission (fine-grained PAT) or the full \"repo\" scope (classic PAT)", fullName, err)
 			}
 			return nil, err
 		}


### PR DESCRIPTION
## Problem

`github.repository.workflows` is backed by the GitHub **List repository workflows** API (`GET /repos/{owner}/{repo}/actions/workflows`). That endpoint requires the **Actions** permission:

- **Fine-grained PAT:** `Actions: Read`
- **Classic PAT:** the full `repo` scope (`public_repo` alone can't list workflows on private repos)

When the token lacks it, GitHub returns **404** for this endpoint. The resource caught the 404 with a fragile `strings.Contains(err.Error(), "404")` check and returned an **empty list**.

For a security check such as *"packages are automatically scanned for known vulnerabilities (via a workflow)"*, this silently turns a **permission gap** into a confident **FAIL** — indistinguishable from *"no scanning workflow configured"*. The operator sees a failing control and has no signal that the scanner simply couldn't read the workflows.

## Change

In `providers/github/resources/github_repo.go` (`workflows()`):

- Detect the access error with the existing typed `isAccessDeniedOrNotFound()` helper (404/403 via `*github.ErrorResponse`) instead of string matching.
- Return an **actionable error** instead of an empty list, so the check is reported as un-evaluatable rather than failing, and the message tells the operator which permission to grant.

```go
if isAccessDeniedOrNotFound(err) {
    return nil, fmt.Errorf("cannot list workflows for %q: %w; grant the scanning token the \"Actions\" read permission (fine-grained PAT) or the full \"repo\" scope (classic PAT)", fullName, err)
}
return nil, err
```

## Tradeoff

Repositories with GitHub Actions **legitimately disabled** also return 404, so they now error rather than silently reporting an empty workflow list. For a security tool, surfacing *"couldn't read workflows"* is preferable to a false FAIL, but flagging it for reviewers in case the desired behavior differs.

## Testing

- `go build ./resources/` and `go vet ./resources/` pass from the provider module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)