### PR TITLE
⭐ aws: NACL-aware reachability, Lambda Function URL + API Gateway exposure

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13907,7 +13907,7 @@ private aws.apigatewayv2.route @defaults("routeKey apiId authorizationType") {
   requestModels map[string]string
   // Whether the route is owned and managed by another AWS service
   apiGatewayManaged bool
-  // Whether the route is publicly invokable (no authorizer — authorization type NONE)
+  // Whether the route is publicly invocable (no authorizer — authorization type NONE)
   isPublic() bool
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13907,6 +13907,8 @@ private aws.apigatewayv2.route @defaults("routeKey apiId authorizationType") {
   requestModels map[string]string
   // Whether the route is owned and managed by another AWS service
   apiGatewayManaged bool
+  // Whether the route is publicly invokable (no authorizer — authorization type NONE)
+  isPublic() bool
 }
 
 // Authorizer in an API Gateway v2 API

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -19923,6 +19923,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.apigatewayv2.route.apiGatewayManaged": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayv2Route).GetApiGatewayManaged()).ToDataRes(types.Bool)
 	},
+	"aws.apigatewayv2.route.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayv2Route).GetIsPublic()).ToDataRes(types.Bool)
+	},
 	"aws.apigatewayv2.authorizer.authorizerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayv2Authorizer).GetAuthorizerId()).ToDataRes(types.String)
 	},
@@ -55112,6 +55115,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apigatewayv2.route.apiGatewayManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayv2Route).ApiGatewayManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.apigatewayv2.route.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayv2Route).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.apigatewayv2.authorizer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -132467,6 +132474,7 @@ type mqlAwsApigatewayv2Route struct {
 	OperationName       plugin.TValue[string]
 	RequestModels       plugin.TValue[map[string]any]
 	ApiGatewayManaged   plugin.TValue[bool]
+	IsPublic            plugin.TValue[bool]
 }
 
 // createAwsApigatewayv2Route creates a new instance of this resource
@@ -132568,6 +132576,12 @@ func (c *mqlAwsApigatewayv2Route) GetRequestModels() *plugin.TValue[map[string]a
 
 func (c *mqlAwsApigatewayv2Route) GetApiGatewayManaged() *plugin.TValue[bool] {
 	return &c.ApiGatewayManaged
+}
+
+func (c *mqlAwsApigatewayv2Route) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
+	})
 }
 
 // mqlAwsApigatewayv2Authorizer for the aws.apigatewayv2.authorizer resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -210,6 +210,7 @@ aws.apigatewayv2.route.apiKeyRequired 13.21.4
 aws.apigatewayv2.route.authorizationScopes 13.21.4
 aws.apigatewayv2.route.authorizationType 13.21.4
 aws.apigatewayv2.route.authorizerId 13.21.4
+aws.apigatewayv2.route.isPublic 13.37.1
 aws.apigatewayv2.route.operationName 13.21.4
 aws.apigatewayv2.route.region 13.21.4
 aws.apigatewayv2.route.requestModels 13.21.4

--- a/providers/aws/resources/aws_apigatewayv2.go
+++ b/providers/aws/resources/aws_apigatewayv2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	apigwv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
@@ -525,4 +526,23 @@ func newMqlAwsApigatewayv2DomainName(runtime *plugin.Runtime, region string, dn 
 
 func (a *mqlAwsApigatewayv2DomainName) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// isPublic reports whether the route can be invoked without authentication —
+// its authorization type is NONE (or unset), meaning no IAM signature, JWT, or
+// custom authorizer is required.
+func (a *mqlAwsApigatewayv2Route) isPublic() (bool, error) {
+	authType := a.GetAuthorizationType()
+	if authType.Error != nil {
+		return false, authType.Error
+	}
+	return routeAuthIsPublic(authType.Data), nil
+}
+
+// routeAuthIsPublic reports whether an API Gateway v2 route authorization type
+// leaves the route open. NONE (the default when no authorizer is attached) means
+// unauthenticated public access; AWS_IAM, JWT, and CUSTOM all require a caller
+// identity.
+func routeAuthIsPublic(authorizationType string) bool {
+	return authorizationType == "" || strings.EqualFold(authorizationType, "NONE")
 }

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3917,9 +3917,10 @@ func (i *mqlAwsEc2Instance) inPublicSubnet() (bool, error) {
 }
 
 // internetReachable reports whether the instance is directly reachable from the
-// internet: it has a public IP, sits in a public subnet, and an attached
-// security group permits inbound traffic from 0.0.0.0/0 or ::/0. Load-balancer-
-// fronted exposure is a separate path (see loadBalancers).
+// internet: it has a public IP, sits in a public subnet, an attached security
+// group permits inbound traffic from 0.0.0.0/0 or ::/0, and the subnet's network
+// ACL does not block that traffic. Load-balancer-fronted exposure is a separate
+// path (see loadBalancers).
 func (i *mqlAwsEc2Instance) internetReachable() (bool, error) {
 	publicIp := i.GetPublicIp()
 	if publicIp.Error != nil {
@@ -3937,7 +3938,85 @@ func (i *mqlAwsEc2Instance) internetReachable() (bool, error) {
 		return false, nil
 	}
 
-	return securityGroupsAllowPublicIngress(i.GetSecurityGroups())
+	sgOpen, err := securityGroupsAllowPublicIngress(i.GetSecurityGroups())
+	if err != nil {
+		return false, err
+	}
+	if !sgOpen {
+		return false, nil
+	}
+
+	// The subnet's network ACL must also permit inbound traffic from the
+	// internet — a restrictive NACL blocks reachability even when the security
+	// group is open. Missing subnet/NACL data does not override the positive
+	// public-IP + public-subnet + open-SG signal.
+	subnet := i.GetSubnet()
+	if subnet.Error != nil {
+		return false, subnet.Error
+	}
+	if subnet.Data == nil {
+		return true, nil
+	}
+	nacl := subnet.Data.GetNetworkAcl()
+	if nacl.Error != nil {
+		return false, nacl.Error
+	}
+	if nacl.Data == nil {
+		return true, nil
+	}
+	return networkAclAllowsPublicIngress(nacl.Data)
+}
+
+// naclIngressRule is the minimal shape of a network ACL inbound rule needed to
+// decide public reachability.
+type naclIngressRule struct {
+	ruleNumber int
+	allow      bool
+	public     bool // source is 0.0.0.0/0 or ::/0
+}
+
+// naclAllowsPublicIngress reports whether a network ACL permits inbound traffic
+// from the internet. Network ACL rules are evaluated in ascending rule-number
+// order and the first match wins, so the lowest-numbered rule whose source is
+// public decides the outcome. When no rule matches a public source the implicit
+// final deny blocks the traffic.
+func naclAllowsPublicIngress(rules []naclIngressRule) bool {
+	found := false
+	bestNum := 0
+	allow := false
+	for _, r := range rules {
+		if !r.public {
+			continue
+		}
+		if !found || r.ruleNumber < bestNum {
+			found = true
+			bestNum = r.ruleNumber
+			allow = r.allow
+		}
+	}
+	return found && allow
+}
+
+// networkAclAllowsPublicIngress evaluates a network ACL's inbound rules for
+// reachability from the internet.
+func networkAclAllowsPublicIngress(nacl *mqlAwsEc2Networkacl) (bool, error) {
+	entries := nacl.GetEntries()
+	if entries.Error != nil {
+		return false, entries.Error
+	}
+	rules := make([]naclIngressRule, 0, len(entries.Data))
+	for _, e := range entries.Data {
+		entry, ok := e.(*mqlAwsEc2NetworkaclEntry)
+		if !ok || entry.Egress.Data {
+			continue
+		}
+		rules = append(rules, naclIngressRule{
+			ruleNumber: int(entry.RuleNumber.Data),
+			allow:      strings.EqualFold(entry.RuleAction.Data, "allow"),
+			public:     cidrEntryIsPublic(entry.CidrBlock.Data, entry.Ipv6CidrBlock.Data),
+		})
+	}
+	return naclAllowsPublicIngress(rules), nil
 }
 
 // loadBalancers returns the load balancers that route traffic to this instance.

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -341,6 +341,35 @@ func (a *mqlAwsEcrRepository) isPublic() (bool, error) {
 	return resourceIsPublic(a.GetPolicyStatements())
 }
 
+// isPublic reports whether the function is exposed publicly — either its
+// resource policy grants a wildcard principal, or it has a Function URL whose
+// auth type is NONE (unauthenticated invocation over the internet).
 func (a *mqlAwsLambdaFunction) isPublic() (bool, error) {
-	return resourceIsPublic(a.GetPolicyStatements())
+	policyPublic, err := resourceIsPublic(a.GetPolicyStatements())
+	if err != nil {
+		return false, err
+	}
+	if policyPublic {
+		return true, nil
+	}
+
+	url := a.GetUrlConfig()
+	if url.Error != nil {
+		return false, url.Error
+	}
+	if url.Data == nil {
+		return false, nil
+	}
+	authType := url.Data.GetAuthType()
+	if authType.Error != nil {
+		return false, authType.Error
+	}
+	return functionUrlIsPublic(authType.Data), nil
+}
+
+// functionUrlIsPublic reports whether a Lambda Function URL auth type permits
+// unauthenticated public invocation. AWS_IAM requires a signed request; NONE
+// allows anyone on the internet.
+func functionUrlIsPublic(authType string) bool {
+	return strings.EqualFold(authType, "NONE")
 }

--- a/providers/aws/resources/aws_internet_exposure_test.go
+++ b/providers/aws/resources/aws_internet_exposure_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNaclAllowsPublicIngress(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []naclIngressRule
+		want  bool
+	}{
+		{
+			name:  "default nacl allows all",
+			rules: []naclIngressRule{{ruleNumber: 100, allow: true, public: true}},
+			want:  true,
+		},
+		{
+			name: "lower-numbered deny shadows allow",
+			rules: []naclIngressRule{
+				{ruleNumber: 90, allow: false, public: true},
+				{ruleNumber: 100, allow: true, public: true},
+			},
+			want: false,
+		},
+		{
+			name: "lower-numbered allow wins over later deny",
+			rules: []naclIngressRule{
+				{ruleNumber: 200, allow: false, public: true},
+				{ruleNumber: 100, allow: true, public: true},
+			},
+			want: true,
+		},
+		{
+			name: "only specific-cidr allow, no public rule",
+			rules: []naclIngressRule{
+				{ruleNumber: 100, allow: true, public: false},
+			},
+			want: false,
+		},
+		{
+			name:  "no rules",
+			rules: []naclIngressRule{},
+			want:  false,
+		},
+		{
+			name: "non-public rules ignored, public deny decides",
+			rules: []naclIngressRule{
+				{ruleNumber: 50, allow: true, public: false},
+				{ruleNumber: 100, allow: false, public: true},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, naclAllowsPublicIngress(tt.rules))
+		})
+	}
+}
+
+func TestFunctionUrlIsPublic(t *testing.T) {
+	assert.True(t, functionUrlIsPublic("NONE"))
+	assert.True(t, functionUrlIsPublic("none"))
+	assert.False(t, functionUrlIsPublic("AWS_IAM"))
+	assert.False(t, functionUrlIsPublic(""))
+}
+
+func TestRouteAuthIsPublic(t *testing.T) {
+	assert.True(t, routeAuthIsPublic("NONE"))
+	assert.True(t, routeAuthIsPublic("none"))
+	assert.True(t, routeAuthIsPublic(""), "unset authorization type defaults to no auth")
+	assert.False(t, routeAuthIsPublic("AWS_IAM"))
+	assert.False(t, routeAuthIsPublic("JWT"))
+	assert.False(t, routeAuthIsPublic("CUSTOM"))
+}


### PR DESCRIPTION
Stacked on #8526 (bases on `aws-internet-exposure-predicates`; rebase to main once that merges).

Sharpens and extends the internet-exposure analysis along three vectors, each with unit tests.

### #3 — NACL-aware reachability
`aws.ec2.instance.internetReachable` now also requires the subnet's **network ACL** to permit inbound from the internet. A restrictive NACL blocks reachability even when the security group is open, so this removes a false-positive class. Adds `naclAllowsPublicIngress` (rules evaluated in rule-number order, first match wins) + `networkAclAllowsPublicIngress`.

### #4 — Lambda Function URL
`aws.lambda.function.isPublic` now also returns true when the function has a **Function URL with auth type `NONE`** (unauthenticated public invocation). Previously it inspected only the resource policy, missing the most common Lambda exposure vector. Adds `functionUrlIsPublic`.

### #5 — API Gateway
`aws.apigatewayv2.route.isPublic` — the route's authorization type is `NONE` (or unset), so it is invokable without IAM / JWT / custom auth. Adds `routeAuthIsPublic`.

## Tests
`aws_internet_exposure_test.go` — pure unit tests (no runtime):
- `naclAllowsPublicIngress`: default-allow, shadowing deny, allow-wins-over-later-deny, specific-cidr-only, ordering, empty.
- `functionUrlIsPublic`, `routeAuthIsPublic`: NONE/unset vs AWS_IAM/JWT/CUSTOM.

## Notes
- Reads cached data — **no new API calls or permissions** (912, unchanged). Versions `13.37.1`.
- **Data gap flagged:** REST (v1) API Gateway *method-level* authorization isn't modeled in the provider, so v1 method exposure can't be computed yet — a follow-up.

## Verification
- `go test ./resources/ -run 'Nacl|FunctionUrl|RouteAuth'` → pass.
- Live: `internetReachable` positive case preserved under the new NACL gate (reachable instance has a default-allow NACL); `route.isPublic` resolves (no v2 APIs in the test account — unit tests cover the logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)