### PR TITLE
⭐ digitalocean: discover specific assets (database, k8s, lb, firewall, spaces)

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
 	"go.mondoo.com/mql/v13/providers/digitalocean/provider"
 )
 
@@ -27,9 +28,17 @@ Examples:
 Notes:
   If you set the DIGITALOCEAN_TOKEN environment variable, you can omit the token flag.
 `,
-			MinArgs:   0,
-			MaxArgs:   0,
-			Discovery: []string{},
+			MinArgs: 0,
+			MaxArgs: 0,
+			Discovery: []string{
+				connection.DiscoveryAuto,
+				connection.DiscoveryAll,
+				connection.DiscoveryDatabases,
+				connection.DiscoveryKubernetes,
+				connection.DiscoveryLoadBalancers,
+				connection.DiscoveryFirewalls,
+				connection.DiscoverySpacesBuckets,
+			},
 			Flags: []plugin.Flag{
 				{
 					Long:    "token",

--- a/providers/digitalocean/connection/connection.go
+++ b/providers/digitalocean/connection/connection.go
@@ -30,6 +30,24 @@ type DigitaloceanConnection struct {
 	spacesRegion    string // optional — when set, restricts bucket listing to one region
 	spacesClients   map[string]*s3.Client
 	spacesClientsMu sync.Mutex
+
+	accountUUID     string
+	accountUUIDOnce sync.Once
+}
+
+// AccountUUID returns the owning account's UUID, fetching it once and
+// caching the result. It anchors both the account platform id and the
+// discovered child platform ids, so detect() and Discover() share a
+// single Account.Get round-trip. Returns "" when the token can't read
+// the account.
+func (c *DigitaloceanConnection) AccountUUID() string {
+	c.accountUUIDOnce.Do(func() {
+		acct, _, err := c.client.Account.Get(context.Background())
+		if err == nil && acct != nil {
+			c.accountUUID = acct.UUID
+		}
+	})
+	return c.accountUUID
 }
 
 func NewDigitaloceanConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*DigitaloceanConnection, error) {

--- a/providers/digitalocean/connection/platform.go
+++ b/providers/digitalocean/connection/platform.go
@@ -1,0 +1,143 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// Discovery targets. "auto" and "all" both expand to every specific
+// child-asset type the provider knows how to split an account into.
+const (
+	DiscoveryAuto          = "auto"
+	DiscoveryAll           = "all"
+	DiscoveryDatabases     = "databases"
+	DiscoveryKubernetes    = "kubernetes"
+	DiscoveryLoadBalancers = "loadbalancers"
+	DiscoveryFirewalls     = "firewalls"
+	DiscoverySpacesBuckets = "spaces-buckets"
+)
+
+// Connection options that scope a connection to a single discovered
+// sub-asset. When one of these is set on the connection config, the
+// connection represents that specific resource (not the whole account),
+// and the matching singular MQL resource (e.g. digitalocean.database)
+// binds to it.
+const (
+	// OptionAccount carries the owning account UUID so child platform
+	// ids stay stable and unique without an extra Account.Get at
+	// child-connect time.
+	OptionAccount      = "account"
+	OptionDatabase     = "database"
+	OptionKubernetes   = "kubernetes-cluster"
+	OptionLoadBalancer = "loadbalancer"
+	OptionFirewall     = "firewall"
+	OptionSpacesBucket = "spaces-bucket"
+	// OptionSpacesRegion is paired with OptionSpacesBucket because a
+	// bucket is addressed by (region, name) on the S3-compatible API.
+	OptionSpacesRegion = "spaces-region"
+)
+
+const platformIDBase = "//platformid.api.mondoo.app/runtime/digitalocean"
+
+func basePlatform(name, title string) *inventory.Platform {
+	return &inventory.Platform{
+		Name:    name,
+		Title:   title,
+		Family:  []string{"digitalocean"},
+		Kind:    "api",
+		Runtime: "digitalocean",
+	}
+}
+
+// AccountPlatform is the root DigitalOcean account asset.
+func AccountPlatform() *inventory.Platform {
+	return basePlatform("digitalocean", "DigitalOcean")
+}
+
+// DatabasePlatform is a single managed database cluster.
+func DatabasePlatform() *inventory.Platform {
+	return basePlatform("digitalocean-database", "DigitalOcean Database")
+}
+
+// KubernetesPlatform is a single DOKS cluster.
+func KubernetesPlatform() *inventory.Platform {
+	return basePlatform("digitalocean-kubernetes-cluster", "DigitalOcean Kubernetes Cluster")
+}
+
+// LoadBalancerPlatform is a single load balancer.
+func LoadBalancerPlatform() *inventory.Platform {
+	return basePlatform("digitalocean-loadbalancer", "DigitalOcean Load Balancer")
+}
+
+// FirewallPlatform is a single cloud firewall.
+func FirewallPlatform() *inventory.Platform {
+	return basePlatform("digitalocean-firewall", "DigitalOcean Cloud Firewall")
+}
+
+// SpacesBucketPlatform is a single Spaces bucket.
+func SpacesBucketPlatform() *inventory.Platform {
+	return basePlatform("digitalocean-spaces-bucket", "DigitalOcean Spaces Bucket")
+}
+
+// NewAccountIdentifier builds the platform id for the account root. The
+// UUID may be empty when the token isn't permitted to read the account.
+func NewAccountIdentifier(accountUUID string) string {
+	if accountUUID == "" {
+		return platformIDBase
+	}
+	return platformIDBase + "/account/" + accountUUID
+}
+
+func childIdentifier(accountUUID, kind, id string) string {
+	return NewAccountIdentifier(accountUUID) + "/" + kind + "/" + id
+}
+
+func NewDatabaseIdentifier(accountUUID, id string) string {
+	return childIdentifier(accountUUID, "database", id)
+}
+
+func NewKubernetesIdentifier(accountUUID, id string) string {
+	return childIdentifier(accountUUID, "kubernetes", id)
+}
+
+func NewLoadBalancerIdentifier(accountUUID, id string) string {
+	return childIdentifier(accountUUID, "loadbalancer", id)
+}
+
+func NewFirewallIdentifier(accountUUID, id string) string {
+	return childIdentifier(accountUUID, "firewall", id)
+}
+
+func NewSpacesBucketIdentifier(accountUUID, region, name string) string {
+	return childIdentifier(accountUUID, "spaces-bucket", region+"/"+name)
+}
+
+// SubAssetPlatform reports the specific platform, platform id, and asset
+// name when this connection is scoped to a single discovered sub-asset.
+// It returns (nil, "", "") for a plain account connection. The account
+// UUID is read from the OptionAccount the discovery step stamped on the
+// child config.
+func (c *DigitaloceanConnection) SubAssetPlatform() (*inventory.Platform, string, string) {
+	opts := c.Conf.Options
+	accountUUID := opts[OptionAccount]
+
+	if id := opts[OptionDatabase]; id != "" {
+		return DatabasePlatform(), NewDatabaseIdentifier(accountUUID, id), "DigitalOcean Database " + id
+	}
+	if id := opts[OptionKubernetes]; id != "" {
+		return KubernetesPlatform(), NewKubernetesIdentifier(accountUUID, id), "DigitalOcean Kubernetes Cluster " + id
+	}
+	if id := opts[OptionLoadBalancer]; id != "" {
+		return LoadBalancerPlatform(), NewLoadBalancerIdentifier(accountUUID, id), "DigitalOcean Load Balancer " + id
+	}
+	if id := opts[OptionFirewall]; id != "" {
+		return FirewallPlatform(), NewFirewallIdentifier(accountUUID, id), "DigitalOcean Cloud Firewall " + id
+	}
+	if name := opts[OptionSpacesBucket]; name != "" {
+		region := opts[OptionSpacesRegion]
+		return SpacesBucketPlatform(), NewSpacesBucketIdentifier(accountUUID, region, name), "DigitalOcean Spaces Bucket " + name
+	}
+	return nil, "", ""
+}

--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -170,12 +170,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.DigitaloceanCo
 	asset.Id = conn.Conf.Type
 	asset.Name = "DigitalOcean Account"
 	asset.Platform = connection.AccountPlatform()
-
-	accountUUID := ""
-	if acct, _, err := conn.Client().Account.Get(context.Background()); err == nil {
-		accountUUID = acct.UUID
-	}
-	asset.PlatformIds = []string{connection.NewAccountIdentifier(accountUUID)}
+	asset.PlatformIds = []string{connection.NewAccountIdentifier(conn.AccountUUID())}
 	return nil
 }
 

--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -38,9 +38,8 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	conf := &inventory.Config{
-		Type:     req.Connector,
-		Options:  map[string]string{},
-		Discover: &inventory.Discovery{},
+		Type:    req.Connector,
+		Options: map[string]string{},
 	}
 
 	token := ""

--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -38,8 +38,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	conf := &inventory.Config{
-		Type:    req.Connector,
-		Options: map[string]string{},
+		Type:     req.Connector,
+		Options:  map[string]string{},
+		Discover: &inventory.Discovery{},
 	}
 
 	token := ""
@@ -52,6 +53,19 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	if token != "" {
 		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential("", token))
 	}
+
+	// Discovery expands the account into specific child assets
+	// (databases, Kubernetes clusters, load balancers, firewalls, and
+	// Spaces buckets). Default to "auto" so a plain `digitalocean` scan
+	// surfaces per-resource assets alongside the account.
+	discoverTargets := []string{connection.DiscoveryAuto}
+	if x, ok := flags["discover"]; ok && len(x.Array) != 0 {
+		discoverTargets = discoverTargets[:0]
+		for i := range x.Array {
+			discoverTargets = append(discoverTargets, string(x.Array[i].Value))
+		}
+	}
+	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
 
 	asset := inventory.Asset{
 		Connections: []*inventory.Config{conf},
@@ -76,12 +90,30 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
+	inv, err := s.discover(conn)
+	if err != nil {
+		return nil, err
+	}
+
 	return &plugin.ConnectRes{
 		Id:        conn.ID(),
 		Name:      conn.Name(),
 		Asset:     req.Asset,
-		Inventory: nil,
+		Inventory: inv,
 	}, nil
+}
+
+func (s *Service) discover(conn *connection.DigitaloceanConnection) (*inventory.Inventory, error) {
+	conf := conn.Asset().Connections[0]
+	if conf.Discover == nil {
+		return nil, nil
+	}
+
+	runtime, err := s.GetRuntime(conn.ID())
+	if err != nil {
+		return nil, err
+	}
+	return resources.Discover(runtime)
 }
 
 func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*connection.DigitaloceanConnection, error) {
@@ -124,23 +156,26 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.DigitaloceanConnection) error {
+	// A connection scoped to a single discovered sub-asset carries its
+	// type and id in the connection options; surface the specific
+	// platform for it instead of the account root.
+	if platform, platformID, name := conn.SubAssetPlatform(); platform != nil {
+		asset.Id = platformID
+		asset.Name = name
+		asset.Platform = platform
+		asset.PlatformIds = []string{platformID}
+		return nil
+	}
+
 	asset.Id = conn.Conf.Type
 	asset.Name = "DigitalOcean Account"
+	asset.Platform = connection.AccountPlatform()
 
-	asset.Platform = &inventory.Platform{
-		Name:    "digitalocean",
-		Family:  []string{"digitalocean"},
-		Kind:    "api",
-		Runtime: "digitalocean",
-		Title:   "DigitalOcean",
+	accountUUID := ""
+	if acct, _, err := conn.Client().Account.Get(context.Background()); err == nil {
+		accountUUID = acct.UUID
 	}
-
-	platformId := "//platformid.api.mondoo.app/runtime/digitalocean"
-	acct, _, err := conn.Client().Account.Get(context.Background())
-	if err == nil && acct.UUID != "" {
-		platformId += "/account/" + acct.UUID
-	}
-	asset.PlatformIds = []string{platformId}
+	asset.PlatformIds = []string{connection.NewAccountIdentifier(accountUUID)}
 	return nil
 }
 

--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -219,56 +219,7 @@ func (r *mqlDigitalocean) firewalls() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, fw := range firewalls {
-			inbound := make([]interface{}, len(fw.InboundRules))
-			for i, rule := range fw.InboundRules {
-				m := map[string]interface{}{
-					"protocol": rule.Protocol,
-					"ports":    rule.PortRange,
-				}
-				if rule.Sources != nil {
-					m["sourceAddresses"] = toStringSlice(rule.Sources.Addresses)
-					m["sourceDropletIds"] = toIntSlice(rule.Sources.DropletIDs)
-					m["sourceLoadBalancerUids"] = toStringSlice(rule.Sources.LoadBalancerUIDs)
-					m["sourceKubernetesIds"] = toStringSlice(rule.Sources.KubernetesIDs)
-					m["sourceTags"] = toStringSlice(rule.Sources.Tags)
-				}
-				inbound[i] = m
-			}
-			outbound := make([]interface{}, len(fw.OutboundRules))
-			for i, rule := range fw.OutboundRules {
-				m := map[string]interface{}{
-					"protocol": rule.Protocol,
-					"ports":    rule.PortRange,
-				}
-				if rule.Destinations != nil {
-					m["destinationAddresses"] = toStringSlice(rule.Destinations.Addresses)
-					m["destinationDropletIds"] = toIntSlice(rule.Destinations.DropletIDs)
-					m["destinationLoadBalancerUids"] = toStringSlice(rule.Destinations.LoadBalancerUIDs)
-					m["destinationKubernetesIds"] = toStringSlice(rule.Destinations.KubernetesIDs)
-					m["destinationTags"] = toStringSlice(rule.Destinations.Tags)
-				}
-				outbound[i] = m
-			}
-
-			dropletIds := make([]interface{}, len(fw.DropletIDs))
-			for i, id := range fw.DropletIDs {
-				dropletIds[i] = int64(id)
-			}
-			tags := make([]interface{}, len(fw.Tags))
-			for i, t := range fw.Tags {
-				tags[i] = t
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", map[string]*llx.RawData{
-				"id":            llx.StringData(fw.ID),
-				"name":          llx.StringData(fw.Name),
-				"status":        llx.StringData(fw.Status),
-				"createdAt":     llx.TimeDataPtr(parseDoTime(fw.Created)),
-				"inboundRules":  llx.ArrayData(inbound, "\x13"),
-				"outboundRules": llx.ArrayData(outbound, "\x13"),
-				"dropletIds":    llx.ArrayData(dropletIds, "\x05"),
-				"tags":          llx.ArrayData(tags, "\x02"),
-			})
+			res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", firewallArgs(&fw))
 			if err != nil {
 				return nil, err
 			}
@@ -302,60 +253,7 @@ func (r *mqlDigitalocean) databases() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, db := range dbs {
-			tags := make([]interface{}, len(db.Tags))
-			for i, t := range db.Tags {
-				tags[i] = t
-			}
-
-			mw := map[string]interface{}{}
-			if db.MaintenanceWindow != nil {
-				mw["day"] = db.MaintenanceWindow.Day
-				mw["hour"] = db.MaintenanceWindow.Hour
-				mw["pending"] = db.MaintenanceWindow.Pending
-			}
-
-			// The DigitalOcean API returns connection URIs that embed the admin
-			// password, so we deliberately do not surface them on the resource.
-			// Host/port are exposed separately for connectivity checks.
-			connHost := ""
-			connPort := int64(0)
-			if db.Connection != nil {
-				connHost = db.Connection.Host
-				connPort = int64(db.Connection.Port)
-			}
-			privConnHost := ""
-			privConnPort := int64(0)
-			if db.PrivateConnection != nil {
-				privConnHost = db.PrivateConnection.Host
-				privConnPort = int64(db.PrivateConnection.Port)
-			}
-
-			dbNames := make([]interface{}, len(db.DBNames))
-			for i, n := range db.DBNames {
-				dbNames[i] = n
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.database", map[string]*llx.RawData{
-				"id":                    llx.StringData(db.ID),
-				"name":                  llx.StringData(db.Name),
-				"engine":                llx.StringData(db.EngineSlug),
-				"version":               llx.StringData(db.VersionSlug),
-				"numNodes":              llx.IntData(int64(db.NumNodes)),
-				"size":                  llx.StringData(db.SizeSlug),
-				"region":                llx.StringData(db.RegionSlug),
-				"status":                llx.StringData(db.Status),
-				"storageSizeMib":        llx.IntData(int64(db.StorageSizeMib)),
-				"dbNames":               llx.ArrayData(dbNames, "\x02"),
-				"createdAt":             llx.TimeData(db.CreatedAt),
-				"projectId":             llx.StringData(db.ProjectID),
-				"privateNetworkUuid":    llx.StringData(db.PrivateNetworkUUID),
-				"tags":                  llx.ArrayData(tags, "\x02"),
-				"maintenanceWindow":     llx.DictData(mw),
-				"connectionHost":        llx.StringData(connHost),
-				"connectionPort":        llx.IntData(connPort),
-				"privateConnectionHost": llx.StringData(privConnHost),
-				"privateConnectionPort": llx.IntData(privConnPort),
-			})
+			res, err := CreateResource(r.MqlRuntime, "digitalocean.database", databaseArgs(&db))
 			if err != nil {
 				return nil, err
 			}
@@ -550,68 +448,7 @@ func (r *mqlDigitalocean) loadBalancers() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, lb := range lbs {
-			dropletIds := make([]interface{}, len(lb.DropletIDs))
-			for i, id := range lb.DropletIDs {
-				dropletIds[i] = int64(id)
-			}
-			tags := make([]interface{}, len(lb.Tags))
-			for i, t := range lb.Tags {
-				tags[i] = t
-			}
-
-			fwdRules := make([]interface{}, len(lb.ForwardingRules))
-			for i, rule := range lb.ForwardingRules {
-				fwdRules[i] = map[string]interface{}{
-					"entryProtocol":  rule.EntryProtocol,
-					"entryPort":      float64(rule.EntryPort),
-					"targetProtocol": rule.TargetProtocol,
-					"targetPort":     float64(rule.TargetPort),
-					"certificateId":  rule.CertificateID,
-					"tlsPassthrough": rule.TlsPassthrough,
-				}
-			}
-
-			hc := map[string]interface{}{}
-			if lb.HealthCheck != nil {
-				hc["protocol"] = lb.HealthCheck.Protocol
-				hc["port"] = float64(lb.HealthCheck.Port)
-				hc["path"] = lb.HealthCheck.Path
-				hc["checkIntervalSeconds"] = float64(lb.HealthCheck.CheckIntervalSeconds)
-				hc["responseTimeoutSeconds"] = float64(lb.HealthCheck.ResponseTimeoutSeconds)
-				hc["unhealthyThreshold"] = float64(lb.HealthCheck.UnhealthyThreshold)
-				hc["healthyThreshold"] = float64(lb.HealthCheck.HealthyThreshold)
-			}
-
-			ss := map[string]interface{}{}
-			if lb.StickySessions != nil {
-				ss["type"] = lb.StickySessions.Type
-				ss["cookieName"] = lb.StickySessions.CookieName
-				ss["cookieTtlSeconds"] = float64(lb.StickySessions.CookieTtlSeconds)
-			}
-
-			lbRegion := ""
-			if lb.Region != nil {
-				lbRegion = lb.Region.Slug
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", map[string]*llx.RawData{
-				"id":                           llx.StringData(lb.ID),
-				"name":                         llx.StringData(lb.Name),
-				"ip":                           llx.StringData(lb.IP),
-				"status":                       llx.StringData(lb.Status),
-				"region":                       llx.StringData(lbRegion),
-				"createdAt":                    llx.TimeDataPtr(parseDoTime(lb.Created)),
-				"algorithm":                    llx.StringData(lb.Algorithm),
-				"redirectHttpToHttps":          llx.BoolData(lb.RedirectHttpToHttps),
-				"enableProxyProtocol":          llx.BoolData(lb.EnableProxyProtocol),
-				"enableBackendKeepalive":       llx.BoolData(lb.EnableBackendKeepalive),
-				"vpcUuid":                      llx.StringData(lb.VPCUUID),
-				"dropletIds":                   llx.ArrayData(dropletIds, "\x05"),
-				"tags":                         llx.ArrayData(tags, "\x02"),
-				"forwardingRules":              llx.ArrayData(fwdRules, "\x13"),
-				"healthCheck":                  llx.DictData(hc),
-				"stickySessions":               llx.DictData(ss),
-				"disableLetsEncryptDnsRecords": llx.BoolDataPtr(lb.DisableLetsEncryptDNSRecords),
-			})
+			res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", loadBalancerArgs(&lb))
 			if err != nil {
 				return nil, err
 			}
@@ -687,52 +524,7 @@ func (r *mqlDigitalocean) kubernetesClusters() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, c := range clusters {
-			tags := make([]interface{}, len(c.Tags))
-			for i, t := range c.Tags {
-				tags[i] = t
-			}
-
-			mp := map[string]interface{}{}
-			if c.MaintenancePolicy != nil {
-				mp["startTime"] = c.MaintenancePolicy.StartTime
-				mp["day"] = float64(c.MaintenancePolicy.Day)
-			}
-
-			status := ""
-			if c.Status != nil {
-				status = string(c.Status.State)
-			}
-
-			var ssoEnabled, ssoRequired bool
-			var ssoIssuerURL, ssoClientID string
-			if c.SSO != nil {
-				ssoEnabled = c.SSO.Enabled
-				ssoRequired = c.SSO.Required
-				ssoIssuerURL = c.SSO.IssuerURL
-				ssoClientID = c.SSO.ClientID
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", map[string]*llx.RawData{
-				"id":                llx.StringData(c.ID),
-				"name":              llx.StringData(c.Name),
-				"version":           llx.StringData(c.VersionSlug),
-				"region":            llx.StringData(c.RegionSlug),
-				"status":            llx.StringData(status),
-				"createdAt":         llx.TimeData(c.CreatedAt),
-				"updatedAt":         llx.TimeData(c.UpdatedAt),
-				"clusterSubnet":     llx.StringData(c.ClusterSubnet),
-				"serviceSubnet":     llx.StringData(c.ServiceSubnet),
-				"vpcUuid":           llx.StringData(c.VPCUUID),
-				"autoUpgrade":       llx.BoolData(c.AutoUpgrade),
-				"surgeUpgrade":      llx.BoolData(c.SurgeUpgrade),
-				"ha":                llx.BoolData(c.HA),
-				"ssoEnabled":        llx.BoolData(ssoEnabled),
-				"ssoRequired":       llx.BoolData(ssoRequired),
-				"ssoIssuerUrl":      llx.StringData(ssoIssuerURL),
-				"ssoClientId":       llx.StringData(ssoClientID),
-				"tags":              llx.ArrayData(tags, "\x02"),
-				"maintenancePolicy": llx.DictData(mp),
-			})
+			res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
 			if err != nil {
 				return nil, err
 			}

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -99,7 +99,7 @@ func init() {
 			Create: createDigitaloceanDroplet,
 		},
 		"digitalocean.firewall": {
-			// to override args, implement: initDigitaloceanFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanFirewall,
 			Create: createDigitaloceanFirewall,
 		},
 		"digitalocean.firewall.ingressRule": {
@@ -111,7 +111,7 @@ func init() {
 			Create: createDigitaloceanFirewallEgressRule,
 		},
 		"digitalocean.database": {
-			// to override args, implement: initDigitaloceanDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanDatabase,
 			Create: createDigitaloceanDatabase,
 		},
 		"digitalocean.database.backup": {
@@ -151,7 +151,7 @@ func init() {
 			Create: createDigitaloceanVolume,
 		},
 		"digitalocean.loadBalancer": {
-			// to override args, implement: initDigitaloceanLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanLoadBalancer,
 			Create: createDigitaloceanLoadBalancer,
 		},
 		"digitalocean.vpc": {
@@ -163,7 +163,7 @@ func init() {
 			Create: createDigitaloceanVpcPeering,
 		},
 		"digitalocean.kubernetes.cluster": {
-			// to override args, implement: initDigitaloceanKubernetesCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanKubernetesCluster,
 			Create: createDigitaloceanKubernetesCluster,
 		},
 		"digitalocean.kubernetes.nodePool": {
@@ -231,7 +231,7 @@ func init() {
 			Create: createDigitaloceanSpacesKey,
 		},
 		"digitalocean.spacesBucket": {
-			// to override args, implement: initDigitaloceanSpacesBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanSpacesBucket,
 			Create: createDigitaloceanSpacesBucket,
 		},
 		"digitalocean.image": {

--- a/providers/digitalocean/resources/digitalocean_assets.go
+++ b/providers/digitalocean/resources/digitalocean_assets.go
@@ -1,0 +1,338 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// This file holds the shared resource arg-builders and the singular
+// init functions for the resources the provider splits an account into
+// (databases, Kubernetes clusters, load balancers, firewalls). Each
+// builder maps a godo object to the MQL field set, and is used by both
+// the account-level list accessor and the singular init — so a resource
+// fetched on its own (digitalocean.database(id: "...") or a connected
+// digitalocean-database asset) is populated identically to one listed
+// from the account.
+
+// databaseArgs maps a managed database cluster to its MQL fields.
+func databaseArgs(db *godo.Database) map[string]*llx.RawData {
+	tags := make([]interface{}, len(db.Tags))
+	for i, t := range db.Tags {
+		tags[i] = t
+	}
+
+	mw := map[string]interface{}{}
+	if db.MaintenanceWindow != nil {
+		mw["day"] = db.MaintenanceWindow.Day
+		mw["hour"] = db.MaintenanceWindow.Hour
+		mw["pending"] = db.MaintenanceWindow.Pending
+	}
+
+	// The DigitalOcean API returns connection URIs that embed the admin
+	// password, so we deliberately do not surface them on the resource.
+	// Host/port are exposed separately for connectivity checks.
+	connHost := ""
+	connPort := int64(0)
+	if db.Connection != nil {
+		connHost = db.Connection.Host
+		connPort = int64(db.Connection.Port)
+	}
+	privConnHost := ""
+	privConnPort := int64(0)
+	if db.PrivateConnection != nil {
+		privConnHost = db.PrivateConnection.Host
+		privConnPort = int64(db.PrivateConnection.Port)
+	}
+
+	dbNames := make([]interface{}, len(db.DBNames))
+	for i, n := range db.DBNames {
+		dbNames[i] = n
+	}
+
+	return map[string]*llx.RawData{
+		"id":                    llx.StringData(db.ID),
+		"name":                  llx.StringData(db.Name),
+		"engine":                llx.StringData(db.EngineSlug),
+		"version":               llx.StringData(db.VersionSlug),
+		"numNodes":              llx.IntData(int64(db.NumNodes)),
+		"size":                  llx.StringData(db.SizeSlug),
+		"region":                llx.StringData(db.RegionSlug),
+		"status":                llx.StringData(db.Status),
+		"storageSizeMib":        llx.IntData(int64(db.StorageSizeMib)),
+		"dbNames":               llx.ArrayData(dbNames, "\x02"),
+		"createdAt":             llx.TimeData(db.CreatedAt),
+		"projectId":             llx.StringData(db.ProjectID),
+		"privateNetworkUuid":    llx.StringData(db.PrivateNetworkUUID),
+		"tags":                  llx.ArrayData(tags, "\x02"),
+		"maintenanceWindow":     llx.DictData(mw),
+		"connectionHost":        llx.StringData(connHost),
+		"connectionPort":        llx.IntData(connPort),
+		"privateConnectionHost": llx.StringData(privConnHost),
+		"privateConnectionPort": llx.IntData(privConnPort),
+	}
+}
+
+func initDigitaloceanDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	id := stringArg(args, "id")
+	if id == "" {
+		id = conn.Conf.Options[connection.OptionDatabase]
+	}
+	if id == "" {
+		return nil, nil, errors.New("digitalocean.database requires an id or a connected digitalocean-database asset")
+	}
+	db, _, err := conn.Client().Databases.Get(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return databaseArgs(db), nil, nil
+}
+
+// firewallArgs maps a cloud firewall to its MQL fields.
+func firewallArgs(fw *godo.Firewall) map[string]*llx.RawData {
+	inbound := make([]interface{}, len(fw.InboundRules))
+	for i, rule := range fw.InboundRules {
+		m := map[string]interface{}{
+			"protocol": rule.Protocol,
+			"ports":    rule.PortRange,
+		}
+		if rule.Sources != nil {
+			m["sourceAddresses"] = toStringSlice(rule.Sources.Addresses)
+			m["sourceDropletIds"] = toIntSlice(rule.Sources.DropletIDs)
+			m["sourceLoadBalancerUids"] = toStringSlice(rule.Sources.LoadBalancerUIDs)
+			m["sourceKubernetesIds"] = toStringSlice(rule.Sources.KubernetesIDs)
+			m["sourceTags"] = toStringSlice(rule.Sources.Tags)
+		}
+		inbound[i] = m
+	}
+	outbound := make([]interface{}, len(fw.OutboundRules))
+	for i, rule := range fw.OutboundRules {
+		m := map[string]interface{}{
+			"protocol": rule.Protocol,
+			"ports":    rule.PortRange,
+		}
+		if rule.Destinations != nil {
+			m["destinationAddresses"] = toStringSlice(rule.Destinations.Addresses)
+			m["destinationDropletIds"] = toIntSlice(rule.Destinations.DropletIDs)
+			m["destinationLoadBalancerUids"] = toStringSlice(rule.Destinations.LoadBalancerUIDs)
+			m["destinationKubernetesIds"] = toStringSlice(rule.Destinations.KubernetesIDs)
+			m["destinationTags"] = toStringSlice(rule.Destinations.Tags)
+		}
+		outbound[i] = m
+	}
+
+	dropletIds := make([]interface{}, len(fw.DropletIDs))
+	for i, id := range fw.DropletIDs {
+		dropletIds[i] = int64(id)
+	}
+	tags := make([]interface{}, len(fw.Tags))
+	for i, t := range fw.Tags {
+		tags[i] = t
+	}
+
+	return map[string]*llx.RawData{
+		"id":            llx.StringData(fw.ID),
+		"name":          llx.StringData(fw.Name),
+		"status":        llx.StringData(fw.Status),
+		"createdAt":     llx.TimeDataPtr(parseDoTime(fw.Created)),
+		"inboundRules":  llx.ArrayData(inbound, "\x13"),
+		"outboundRules": llx.ArrayData(outbound, "\x13"),
+		"dropletIds":    llx.ArrayData(dropletIds, "\x05"),
+		"tags":          llx.ArrayData(tags, "\x02"),
+	}
+}
+
+func initDigitaloceanFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	id := stringArg(args, "id")
+	if id == "" {
+		id = conn.Conf.Options[connection.OptionFirewall]
+	}
+	if id == "" {
+		return nil, nil, errors.New("digitalocean.firewall requires an id or a connected digitalocean-firewall asset")
+	}
+	fw, _, err := conn.Client().Firewalls.Get(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return firewallArgs(fw), nil, nil
+}
+
+// loadBalancerArgs maps a load balancer to its MQL fields.
+func loadBalancerArgs(lb *godo.LoadBalancer) map[string]*llx.RawData {
+	dropletIds := make([]interface{}, len(lb.DropletIDs))
+	for i, id := range lb.DropletIDs {
+		dropletIds[i] = int64(id)
+	}
+	tags := make([]interface{}, len(lb.Tags))
+	for i, t := range lb.Tags {
+		tags[i] = t
+	}
+
+	fwdRules := make([]interface{}, len(lb.ForwardingRules))
+	for i, rule := range lb.ForwardingRules {
+		fwdRules[i] = map[string]interface{}{
+			"entryProtocol":  rule.EntryProtocol,
+			"entryPort":      float64(rule.EntryPort),
+			"targetProtocol": rule.TargetProtocol,
+			"targetPort":     float64(rule.TargetPort),
+			"certificateId":  rule.CertificateID,
+			"tlsPassthrough": rule.TlsPassthrough,
+		}
+	}
+
+	hc := map[string]interface{}{}
+	if lb.HealthCheck != nil {
+		hc["protocol"] = lb.HealthCheck.Protocol
+		hc["port"] = float64(lb.HealthCheck.Port)
+		hc["path"] = lb.HealthCheck.Path
+		hc["checkIntervalSeconds"] = float64(lb.HealthCheck.CheckIntervalSeconds)
+		hc["responseTimeoutSeconds"] = float64(lb.HealthCheck.ResponseTimeoutSeconds)
+		hc["unhealthyThreshold"] = float64(lb.HealthCheck.UnhealthyThreshold)
+		hc["healthyThreshold"] = float64(lb.HealthCheck.HealthyThreshold)
+	}
+
+	ss := map[string]interface{}{}
+	if lb.StickySessions != nil {
+		ss["type"] = lb.StickySessions.Type
+		ss["cookieName"] = lb.StickySessions.CookieName
+		ss["cookieTtlSeconds"] = float64(lb.StickySessions.CookieTtlSeconds)
+	}
+
+	lbRegion := ""
+	if lb.Region != nil {
+		lbRegion = lb.Region.Slug
+	}
+
+	return map[string]*llx.RawData{
+		"id":                           llx.StringData(lb.ID),
+		"name":                         llx.StringData(lb.Name),
+		"ip":                           llx.StringData(lb.IP),
+		"status":                       llx.StringData(lb.Status),
+		"region":                       llx.StringData(lbRegion),
+		"createdAt":                    llx.TimeDataPtr(parseDoTime(lb.Created)),
+		"algorithm":                    llx.StringData(lb.Algorithm),
+		"redirectHttpToHttps":          llx.BoolData(lb.RedirectHttpToHttps),
+		"enableProxyProtocol":          llx.BoolData(lb.EnableProxyProtocol),
+		"enableBackendKeepalive":       llx.BoolData(lb.EnableBackendKeepalive),
+		"vpcUuid":                      llx.StringData(lb.VPCUUID),
+		"dropletIds":                   llx.ArrayData(dropletIds, "\x05"),
+		"tags":                         llx.ArrayData(tags, "\x02"),
+		"forwardingRules":              llx.ArrayData(fwdRules, "\x13"),
+		"healthCheck":                  llx.DictData(hc),
+		"stickySessions":               llx.DictData(ss),
+		"disableLetsEncryptDnsRecords": llx.BoolDataPtr(lb.DisableLetsEncryptDNSRecords),
+	}
+}
+
+func initDigitaloceanLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	id := stringArg(args, "id")
+	if id == "" {
+		id = conn.Conf.Options[connection.OptionLoadBalancer]
+	}
+	if id == "" {
+		return nil, nil, errors.New("digitalocean.loadBalancer requires an id or a connected digitalocean-loadbalancer asset")
+	}
+	lb, _, err := conn.Client().LoadBalancers.Get(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return loadBalancerArgs(lb), nil, nil
+}
+
+// kubernetesClusterArgs maps a DOKS cluster to its MQL fields.
+func kubernetesClusterArgs(c *godo.KubernetesCluster) map[string]*llx.RawData {
+	tags := make([]interface{}, len(c.Tags))
+	for i, t := range c.Tags {
+		tags[i] = t
+	}
+
+	mp := map[string]interface{}{}
+	if c.MaintenancePolicy != nil {
+		mp["startTime"] = c.MaintenancePolicy.StartTime
+		mp["day"] = float64(c.MaintenancePolicy.Day)
+	}
+
+	status := ""
+	if c.Status != nil {
+		status = string(c.Status.State)
+	}
+
+	var ssoEnabled, ssoRequired bool
+	var ssoIssuerURL, ssoClientID string
+	if c.SSO != nil {
+		ssoEnabled = c.SSO.Enabled
+		ssoRequired = c.SSO.Required
+		ssoIssuerURL = c.SSO.IssuerURL
+		ssoClientID = c.SSO.ClientID
+	}
+
+	return map[string]*llx.RawData{
+		"id":                llx.StringData(c.ID),
+		"name":              llx.StringData(c.Name),
+		"version":           llx.StringData(c.VersionSlug),
+		"region":            llx.StringData(c.RegionSlug),
+		"status":            llx.StringData(status),
+		"createdAt":         llx.TimeData(c.CreatedAt),
+		"updatedAt":         llx.TimeData(c.UpdatedAt),
+		"clusterSubnet":     llx.StringData(c.ClusterSubnet),
+		"serviceSubnet":     llx.StringData(c.ServiceSubnet),
+		"vpcUuid":           llx.StringData(c.VPCUUID),
+		"autoUpgrade":       llx.BoolData(c.AutoUpgrade),
+		"surgeUpgrade":      llx.BoolData(c.SurgeUpgrade),
+		"ha":                llx.BoolData(c.HA),
+		"ssoEnabled":        llx.BoolData(ssoEnabled),
+		"ssoRequired":       llx.BoolData(ssoRequired),
+		"ssoIssuerUrl":      llx.StringData(ssoIssuerURL),
+		"ssoClientId":       llx.StringData(ssoClientID),
+		"tags":              llx.ArrayData(tags, "\x02"),
+		"maintenancePolicy": llx.DictData(mp),
+	}
+}
+
+func initDigitaloceanKubernetesCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	id := stringArg(args, "id")
+	if id == "" {
+		id = conn.Conf.Options[connection.OptionKubernetes]
+	}
+	if id == "" {
+		return nil, nil, errors.New("digitalocean.kubernetes.cluster requires an id or a connected digitalocean-kubernetes-cluster asset")
+	}
+	c, _, err := conn.Client().Kubernetes.Get(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return kubernetesClusterArgs(c), nil, nil
+}
+
+// stringArg returns the string value of args[key], or "" when absent.
+func stringArg(args map[string]*llx.RawData, key string) string {
+	if a, ok := args[key]; ok {
+		if s, ok := a.Value.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -97,11 +97,7 @@ func initDigitaloceanSpacesBucket(runtime *plugin.Runtime, args map[string]*llx.
 		}
 	}
 
-	parent, err := parentDigitalocean(runtime)
-	if err != nil {
-		return nil, nil, err
-	}
-	res, err := newSpacesBucket(parent, client, region, summary)
+	res, err := newSpacesBucket(runtime, client, region, summary)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -187,7 +183,7 @@ func fetchSpacesBucketDetails(r *mqlDigitalocean, refs []bucketRef) ([]interface
 	for i, ref := range refs {
 		idx, ref := i, ref
 		jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
-			res, err := newSpacesBucket(r, ref.client, ref.region, ref.b)
+			res, err := newSpacesBucket(r.MqlRuntime, ref.client, ref.region, ref.b)
 			if err != nil {
 				return nil, err
 			}
@@ -214,7 +210,7 @@ func fetchSpacesBucketDetails(r *mqlDigitalocean, refs []bucketRef) ([]interface
 // Each call tolerates the "not configured" S3 error codes so an
 // un-customized bucket still produces a resource with sensible nil
 // defaults.
-func newSpacesBucket(r *mqlDigitalocean, client *s3.Client, region string, b s3types.Bucket) (interface{}, error) {
+func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, b s3types.Bucket) (interface{}, error) {
 	ctx := context.Background()
 	name := aws.ToString(b.Name)
 
@@ -355,7 +351,7 @@ func newSpacesBucket(r *mqlDigitalocean, client *s3.Client, region string, b s3t
 		return nil, err
 	}
 
-	return CreateResource(r.MqlRuntime, "digitalocean.spacesBucket", map[string]*llx.RawData{
+	return CreateResource(runtime, "digitalocean.spacesBucket", map[string]*llx.RawData{
 		"name":                 llx.StringData(name),
 		"region":               llx.StringData(region),
 		"createdAt":            llx.TimeDataPtr(createdAt),

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -43,6 +44,68 @@ const bucketConcurrency = 8
 
 func (r *mqlDigitaloceanSpacesBucket) id() (string, error) {
 	return "digitalocean.spacesBucket/" + r.Region.Data + "/" + r.Name.Data, nil
+}
+
+// initDigitaloceanSpacesBucket resolves a single bucket — either from
+// explicit name/region args (digitalocean.spacesBucket(name: "...",
+// region: "...")) or from a connected digitalocean-spaces-bucket asset,
+// whose name and region the discovery step stamped on the connection
+// options. A bucket is addressed by (region, name) on the S3-compatible
+// API, so both are required.
+func initDigitaloceanSpacesBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+
+	name := ""
+	if a, ok := args["name"]; ok {
+		name, _ = a.Value.(string)
+	}
+	region := ""
+	if a, ok := args["region"]; ok {
+		region, _ = a.Value.(string)
+	}
+	if name == "" {
+		name = conn.Conf.Options[connection.OptionSpacesBucket]
+	}
+	if region == "" {
+		region = conn.Conf.Options[connection.OptionSpacesRegion]
+	}
+	if name == "" || region == "" {
+		return nil, nil, errors.New("digitalocean.spacesBucket requires name and region (or a connected digitalocean-spaces-bucket asset)")
+	}
+	if _, _, ok := conn.SpacesCredentials(); !ok {
+		return nil, nil, errors.New("DIGITALOCEAN_SPACES_KEY and DIGITALOCEAN_SPACES_SECRET must be set to audit Spaces buckets")
+	}
+
+	client, err := conn.SpacesClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Look up the bucket summary in its region so createdAt is
+	// preserved; fall back to a name-only summary if the listing is
+	// unavailable.
+	summary := s3types.Bucket{Name: aws.String(name)}
+	if out, err := client.ListBuckets(context.Background(), &s3.ListBucketsInput{}); err == nil {
+		for _, b := range out.Buckets {
+			if aws.ToString(b.Name) == name {
+				summary = b
+				break
+			}
+		}
+	}
+
+	parent, err := parentDigitalocean(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newSpacesBucket(parent, client, region, summary)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res.(plugin.Resource), nil
 }
 
 // bucketRef carries the (region, client, summary) tuple from the

--- a/providers/digitalocean/resources/discovery.go
+++ b/providers/digitalocean/resources/discovery.go
@@ -1,0 +1,204 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"maps"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+	"go.mondoo.com/mql/v13/utils/stringx"
+)
+
+// Discover expands a DigitalOcean account connection into the specific
+// child assets the discovery targets ask for. The account itself stays
+// the connected (root) asset; the returned inventory holds the children.
+func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	conf := conn.Asset().Connections[0]
+	if conf.Discover == nil || len(conf.Discover.Targets) == 0 {
+		return nil, nil
+	}
+
+	targets := resolveDiscoveryTargets(conf.Discover.Targets)
+	client := conn.Client()
+	ctx := context.Background()
+
+	// The owning account UUID anchors every child platform id so they
+	// stay stable and unique across scans. An empty UUID (token without
+	// account read access) still yields valid, account-relative ids.
+	accountUUID := ""
+	if acct, _, err := client.Account.Get(ctx); err == nil {
+		accountUUID = acct.UUID
+	}
+
+	assets := []*inventory.Asset{}
+
+	childAsset := func(platform *inventory.Platform, platformID, name string, opts map[string]string) *inventory.Asset {
+		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+		cfg.Options[connection.OptionAccount] = accountUUID
+		maps.Copy(cfg.Options, opts)
+		return &inventory.Asset{
+			PlatformIds: []string{platformID},
+			Name:        name,
+			Platform:    platform,
+			Connections: []*inventory.Config{cfg},
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryDatabases) {
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			dbs, resp, err := client.Databases.List(ctx, opt)
+			if err != nil {
+				return nil, err
+			}
+			for _, db := range dbs {
+				assets = append(assets, childAsset(
+					connection.DatabasePlatform(),
+					connection.NewDatabaseIdentifier(accountUUID, db.ID),
+					"DigitalOcean Database "+db.Name,
+					map[string]string{connection.OptionDatabase: db.ID},
+				))
+			}
+			if resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				break
+			}
+			opt.Page = page + 1
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryKubernetes) {
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			clusters, resp, err := client.Kubernetes.List(ctx, opt)
+			if err != nil {
+				return nil, err
+			}
+			for _, c := range clusters {
+				assets = append(assets, childAsset(
+					connection.KubernetesPlatform(),
+					connection.NewKubernetesIdentifier(accountUUID, c.ID),
+					"DigitalOcean Kubernetes Cluster "+c.Name,
+					map[string]string{connection.OptionKubernetes: c.ID},
+				))
+			}
+			if resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				break
+			}
+			opt.Page = page + 1
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryLoadBalancers) {
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			lbs, resp, err := client.LoadBalancers.List(ctx, opt)
+			if err != nil {
+				return nil, err
+			}
+			for _, lb := range lbs {
+				assets = append(assets, childAsset(
+					connection.LoadBalancerPlatform(),
+					connection.NewLoadBalancerIdentifier(accountUUID, lb.ID),
+					"DigitalOcean Load Balancer "+lb.Name,
+					map[string]string{connection.OptionLoadBalancer: lb.ID},
+				))
+			}
+			if resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				break
+			}
+			opt.Page = page + 1
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryFirewalls) {
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			firewalls, resp, err := client.Firewalls.List(ctx, opt)
+			if err != nil {
+				return nil, err
+			}
+			for _, fw := range firewalls {
+				assets = append(assets, childAsset(
+					connection.FirewallPlatform(),
+					connection.NewFirewallIdentifier(accountUUID, fw.ID),
+					"DigitalOcean Cloud Firewall "+fw.Name,
+					map[string]string{connection.OptionFirewall: fw.ID},
+				))
+			}
+			if resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				break
+			}
+			opt.Page = page + 1
+		}
+	}
+
+	// Spaces buckets can only be enumerated with the optional Spaces
+	// (S3-compatible) credentials. Without them there is nothing to
+	// discover — mirror the resource layer and skip silently.
+	if stringx.Contains(targets, connection.DiscoverySpacesBuckets) {
+		if _, _, ok := conn.SpacesCredentials(); ok {
+			regions := []string{conn.SpacesRegion()}
+			if regions[0] == "" {
+				regions = knownSpacesRegions
+			}
+			refs, err := listSpacesBucketRefs(conn, regions)
+			if err != nil {
+				return nil, err
+			}
+			for _, ref := range refs {
+				name := ""
+				if ref.b.Name != nil {
+					name = *ref.b.Name
+				}
+				assets = append(assets, childAsset(
+					connection.SpacesBucketPlatform(),
+					connection.NewSpacesBucketIdentifier(accountUUID, ref.region, name),
+					"DigitalOcean Spaces Bucket "+name,
+					map[string]string{
+						connection.OptionSpacesBucket: name,
+						connection.OptionSpacesRegion: ref.region,
+					},
+				))
+			}
+		}
+	}
+
+	return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
+}
+
+// resolveDiscoveryTargets expands the "auto"/"all" aliases into the full
+// set of child-asset types the provider can split an account into.
+func resolveDiscoveryTargets(targets []string) []string {
+	if stringx.Contains(targets, connection.DiscoveryAll) || stringx.Contains(targets, connection.DiscoveryAuto) {
+		return []string{
+			connection.DiscoveryDatabases,
+			connection.DiscoveryKubernetes,
+			connection.DiscoveryLoadBalancers,
+			connection.DiscoveryFirewalls,
+			connection.DiscoverySpacesBuckets,
+		}
+	}
+	return targets
+}

--- a/providers/digitalocean/resources/discovery.go
+++ b/providers/digitalocean/resources/discovery.go
@@ -29,12 +29,11 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	ctx := context.Background()
 
 	// The owning account UUID anchors every child platform id so they
-	// stay stable and unique across scans. An empty UUID (token without
-	// account read access) still yields valid, account-relative ids.
-	accountUUID := ""
-	if acct, _, err := client.Account.Get(ctx); err == nil {
-		accountUUID = acct.UUID
-	}
+	// stay stable and unique across scans. It is cached on the
+	// connection and shared with detect(), so this does not add an
+	// Account.Get round-trip. An empty UUID (token without account read
+	// access) still yields valid, account-relative ids.
+	accountUUID := conn.AccountUUID()
 
 	assets := []*inventory.Asset{}
 


### PR DESCRIPTION
## What

Splits a DigitalOcean account into specific child assets during discovery and makes the **singular** MQL resources resolve to a connected child asset.

Discovery default is `auto`, so a plain `digitalocean` scan now surfaces the account **plus** these platforms:

| Platform | Source |
|---|---|
| `digitalocean-database` | managed database clusters |
| `digitalocean-kubernetes-cluster` | DOKS clusters |
| `digitalocean-loadbalancer` | load balancers |
| `digitalocean-firewall` | cloud firewalls |
| `digitalocean-spaces-bucket` | Spaces buckets (only when `DIGITALOCEAN_SPACES_KEY`/`_SECRET` are set) |

`--discover` accepts `auto`, `all`, `databases`, `kubernetes`, `loadbalancers`, `firewalls`, `spaces-buckets`.

## How

Mirrors the existing `github` org/repo/user split:

- **Discovery** (`resources/discovery.go`) lists the five resource types and emits child inventory assets, stamping the resource id (and owning account UUID) into the child connection `Options`.
- **`detect()`** reads those options to set the specific platform and a stable platform id: `…/runtime/digitalocean/account/<uuid>/<type>/<id>`.
- **`init` functions** read the same options so `digitalocean.database` (no args) binds to the connected cluster. They also enable explicit lookups: `digitalocean.database(id: "…")`, `digitalocean.firewall(id: "…")`, `digitalocean.spacesBucket(name: "…", region: "…")`.
- Per-resource **arg-builders** are shared between the account-level list accessors and the singular `init`, so a resource fetched on its own is populated identically to one listed from the account.

No `.lr` schema change → `.lr.versions` untouched; the only generated diff is the five `Init:` wirings in `digitalocean.lr.go`.

## Test

- `go vet`, provider unit tests, `gofmt`, idempotent codegen, provider build + install all pass.
- ⚠️ **No live scan** — this environment has no `DIGITALOCEAN_TOKEN`, so discovery + singular binding were not exercised against a real account. Needs a token to verify end-to-end.

## Follow-up (separate, in `cnspec/content`)

The `mondoo-digitalocean-security` policy groups filter on `asset.platform == "digitalocean"`. To run the firewall/database/DOKS/LB/Spaces checks against the new child assets (using the now-working singular resources), the policy needs per-platform variants/filters. Not included here.
