### PR TITLE
⭐ hetzner: discover specific assets (firewall, loadbalancer)

### DIFF
--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -31,9 +31,14 @@ Authenticate with a Hetzner Cloud API token:
 
 You can also pass the token via the %s environment variable.
 `, connection.HCLOUD_TOKEN_VAR),
-			MinArgs:   0,
-			MaxArgs:   0,
-			Discovery: []string{},
+			MinArgs: 0,
+			MaxArgs: 0,
+			Discovery: []string{
+				connection.DiscoveryAuto,
+				connection.DiscoveryAll,
+				connection.DiscoveryFirewalls,
+				connection.DiscoveryLoadBalancers,
+			},
 			Flags: []plugin.Flag{
 				{
 					Long:    connection.OPTION_TOKEN,

--- a/providers/hetzner/connection/platform.go
+++ b/providers/hetzner/connection/platform.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"strconv"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// Discovery targets. "auto" and "all" both expand to every specific
+// child-asset type the provider can split a project into.
+const (
+	DiscoveryAuto          = "auto"
+	DiscoveryAll           = "all"
+	DiscoveryFirewalls     = "firewalls"
+	DiscoveryLoadBalancers = "loadbalancers"
+)
+
+// Connection options that scope a connection to a single discovered
+// sub-asset. When set, the connection represents that specific resource
+// (not the whole project), and the matching singular MQL resource
+// (e.g. hetzner.firewall) binds to it. The value is the resource's
+// numeric id as a string.
+const (
+	OptionFirewall     = "firewall"
+	OptionLoadBalancer = "loadbalancer"
+)
+
+func childPlatform(name, title, segment string) *inventory.Platform {
+	return &inventory.Platform{
+		Name:                  name,
+		Title:                 title,
+		Family:                []string{"hetzner"},
+		Kind:                  "api",
+		Runtime:               "hetzner",
+		TechnologyUrlSegments: []string{"cloud", "hetzner", segment},
+	}
+}
+
+// FirewallPlatform is a single Hetzner Cloud firewall.
+func FirewallPlatform() *inventory.Platform {
+	return childPlatform("hetzner-firewall", "Hetzner Cloud Firewall", "firewall")
+}
+
+// LoadBalancerPlatform is a single Hetzner Cloud load balancer.
+func LoadBalancerPlatform() *inventory.Platform {
+	return childPlatform("hetzner-loadbalancer", "Hetzner Cloud Load Balancer", "loadbalancer")
+}
+
+// NewFirewallIdentifier builds the platform id for a firewall, anchored
+// on the project identifier so it stays stable and unique per project.
+func (c *HetznerConnection) NewFirewallIdentifier(id string) string {
+	return c.Identifier() + "/firewall/" + id
+}
+
+// NewLoadBalancerIdentifier builds the platform id for a load balancer,
+// anchored on the project identifier.
+func (c *HetznerConnection) NewLoadBalancerIdentifier(id string) string {
+	return c.Identifier() + "/loadbalancer/" + id
+}
+
+// SubAssetPlatform reports the specific platform, platform id, and asset
+// name when this connection is scoped to a single discovered sub-asset.
+// It returns (nil, "", "") for a plain project connection.
+func (c *HetznerConnection) SubAssetPlatform() (*inventory.Platform, string, string) {
+	opts := c.Conf.Options
+	if id := opts[OptionFirewall]; id != "" {
+		return FirewallPlatform(), c.NewFirewallIdentifier(id), "Hetzner Firewall " + id
+	}
+	if id := opts[OptionLoadBalancer]; id != "" {
+		return LoadBalancerPlatform(), c.NewLoadBalancerIdentifier(id), "Hetzner Load Balancer " + id
+	}
+	return nil, "", ""
+}
+
+// AssetID parses the numeric resource id stored under the given option
+// key. Returns (0, false) when the option is unset or not an integer.
+func AssetID(conf *inventory.Config, key string) (int64, bool) {
+	if conf == nil {
+		return 0, false
+	}
+	s := conf.Options[key]
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/providers/hetzner/provider/provider.go
+++ b/providers/hetzner/provider/provider.go
@@ -46,6 +46,18 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options[connection.OPTION_ENDPOINT] = string(v.Value)
 	}
 
+	// Discovery expands the project into specific child assets (firewalls
+	// and load balancers). Default to "auto" so a plain `hetzner` scan
+	// surfaces per-resource assets alongside the project.
+	discoverTargets := []string{connection.DiscoveryAuto}
+	if v, ok := flags["discover"]; ok && len(v.Array) != 0 {
+		discoverTargets = discoverTargets[:0]
+		for i := range v.Array {
+			discoverTargets = append(discoverTargets, string(v.Array[i].Value))
+		}
+	}
+	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
+
 	asset := &inventory.Asset{
 		Name:        "Hetzner Cloud",
 		Connections: []*inventory.Config{conf},
@@ -70,12 +82,30 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
+	inv, err := s.discover(conn)
+	if err != nil {
+		return nil, err
+	}
+
 	return &plugin.ConnectRes{
 		Id:        conn.ID(),
 		Name:      conn.Name(),
 		Asset:     req.Asset,
-		Inventory: nil,
+		Inventory: inv,
 	}, nil
+}
+
+func (s *Service) discover(conn *connection.HetznerConnection) (*inventory.Inventory, error) {
+	conf := conn.Asset().Connections[0]
+	if conf.Discover == nil {
+		return nil, nil
+	}
+
+	runtime, err := s.GetRuntime(conn.ID())
+	if err != nil {
+		return nil, err
+	}
+	return resources.Discover(runtime)
 }
 
 func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*connection.HetznerConnection, error) {
@@ -122,6 +152,17 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.HetznerConnection) error {
+	// A connection scoped to a single discovered sub-asset carries its
+	// type and id in the connection options; surface the specific
+	// platform for it instead of the project root.
+	if platform, platformID, name := conn.SubAssetPlatform(); platform != nil {
+		asset.Id = platformID
+		asset.Name = name
+		asset.Platform = platform
+		asset.PlatformIds = []string{platformID}
+		return nil
+	}
+
 	asset.Id = conn.Conf.Type
 	asset.Platform = conn.PlatformInfo()
 	asset.PlatformIds = []string{conn.Identifier()}

--- a/providers/hetzner/resources/discovery.go
+++ b/providers/hetzner/resources/discovery.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/hetzner/connection"
+	"go.mondoo.com/mql/v13/utils/stringx"
+)
+
+// Discover expands a Hetzner Cloud project connection into the specific
+// child assets the discovery targets ask for. The project itself stays
+// the connected (root) asset; the returned inventory holds the children.
+func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
+	c := conn(runtime)
+	conf := c.Asset().Connections[0]
+	if conf.Discover == nil || len(conf.Discover.Targets) == 0 {
+		return nil, nil
+	}
+
+	targets := resolveDiscoveryTargets(conf.Discover.Targets)
+	assets := []*inventory.Asset{}
+
+	childAsset := func(platform *inventory.Platform, platformID, name, optKey, optVal string) *inventory.Asset {
+		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(c.ID()))
+		cfg.Options[optKey] = optVal
+		return &inventory.Asset{
+			PlatformIds: []string{platformID},
+			Name:        name,
+			Platform:    platform,
+			Connections: []*inventory.Config{cfg},
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryFirewalls) {
+		items, err := paginate(func(opts hcloud.ListOpts) ([]*hcloud.Firewall, *hcloud.Response, error) {
+			return c.Client().Firewall.List(ctx(), hcloud.FirewallListOpts{ListOpts: opts})
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, fw := range items {
+			idStr := strconv.FormatInt(fw.ID, 10)
+			assets = append(assets, childAsset(
+				connection.FirewallPlatform(),
+				c.NewFirewallIdentifier(idStr),
+				"Hetzner Firewall "+fw.Name,
+				connection.OptionFirewall, idStr,
+			))
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoveryLoadBalancers) {
+		items, err := paginate(func(opts hcloud.ListOpts) ([]*hcloud.LoadBalancer, *hcloud.Response, error) {
+			return c.Client().LoadBalancer.List(ctx(), hcloud.LoadBalancerListOpts{ListOpts: opts})
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, lb := range items {
+			idStr := strconv.FormatInt(lb.ID, 10)
+			assets = append(assets, childAsset(
+				connection.LoadBalancerPlatform(),
+				c.NewLoadBalancerIdentifier(idStr),
+				"Hetzner Load Balancer "+lb.Name,
+				connection.OptionLoadBalancer, idStr,
+			))
+		}
+	}
+
+	return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
+}
+
+// resolveDiscoveryTargets expands the "auto"/"all" aliases into the full
+// set of child-asset types the provider can split a project into.
+func resolveDiscoveryTargets(targets []string) []string {
+	if stringx.Contains(targets, connection.DiscoveryAll) || stringx.Contains(targets, connection.DiscoveryAuto) {
+		return []string{
+			connection.DiscoveryFirewalls,
+			connection.DiscoveryLoadBalancers,
+		}
+	}
+	return targets
+}

--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -369,7 +369,15 @@ private hetzner.primaryIp @defaults("id ip type") {
 }
 
 // Hetzner Cloud load balancer
-private hetzner.loadBalancer @defaults("id name") {
+//
+// A managed L4/L7 load balancer. Surfaces the routing `algorithm`, the
+// public network configuration, the `services()` it exposes (listen and
+// destination ports, health checks, the HTTP redirect flag, and attached
+// `certificates`), the backend `targets()`, the `privateNet`
+// attachments, the traffic counters, resource protection, applied
+// `labels`, and the creation timestamp. Select a load balancer by id
+// with `hetzner.loadBalancer(id: 123)`.
+hetzner.loadBalancer @defaults("id name") {
   init(id? int)
   // Load balancer ID
   id int
@@ -475,7 +483,14 @@ private hetzner.loadBalancerType @defaults("id name") {
 }
 
 // Hetzner Cloud firewall
-private hetzner.firewall @defaults("id name") {
+//
+// A stateful, project-level firewall rule set applied to servers
+// directly or by label selector. Surfaces the firewall `rules` (each
+// with direction, protocol, port, and the `sourceIps`/`destinationIps`
+// CIDRs), the `servers()` the firewall is directly applied to, the
+// `labelSelectors` it targets, applied `labels`, and the creation
+// timestamp. Select a firewall by id with `hetzner.firewall(id: 123)`.
+hetzner.firewall @defaults("id name") {
   init(id? int)
   // Firewall ID
   id int

--- a/providers/hetzner/resources/hetzner_firewall.go
+++ b/providers/hetzner/resources/hetzner_firewall.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/hetzner/connection"
 )
 
 type mqlHetznerFirewallInternal struct {
@@ -95,7 +96,12 @@ func newMqlHetznerFirewall(runtime *plugin.Runtime, fw *hcloud.Firewall) (*mqlHe
 func initHetznerFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
-		return args, nil, nil
+		// Fall back to a connected hetzner-firewall asset, whose id the
+		// discovery step stamped on the connection options.
+		id, ok = connection.AssetID(conn(runtime).Conf, connection.OptionFirewall)
+		if !ok {
+			return args, nil, nil
+		}
 	}
 	fw, _, err := conn(runtime).Client().Firewall.GetByID(ctx(), id)
 	if err != nil {

--- a/providers/hetzner/resources/hetzner_loadbalancer.go
+++ b/providers/hetzner/resources/hetzner_loadbalancer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/hetzner/connection"
 )
 
 type mqlHetznerLoadBalancerInternal struct {
@@ -77,7 +78,12 @@ func newMqlHetznerLoadBalancer(runtime *plugin.Runtime, lb *hcloud.LoadBalancer)
 func initHetznerLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
-		return args, nil, nil
+		// Fall back to a connected hetzner-loadbalancer asset, whose id
+		// the discovery step stamped on the connection options.
+		id, ok = connection.AssetID(conn(runtime).Conf, connection.OptionLoadBalancer)
+		if !ok {
+			return args, nil, nil
+		}
 	}
 	lb, _, err := conn(runtime).Client().LoadBalancer.GetByID(ctx(), id)
 	if err != nil {


### PR DESCRIPTION
## What

Splits a Hetzner Cloud project into specific child assets during discovery and makes the **singular** MQL resources resolve to a connected child asset. Same approach as the DigitalOcean asset-split.

Discovery default is `auto`, so a plain `hetzner` scan now surfaces the project **plus**:

| Platform | Checks it serves (in `mondoo-hetzner-security`) |
|---|---|
| `hetzner-firewall` | firewall no-unrestricted-ssh / -rdp / -db-ports / no-all-ports-open (4) |
| `hetzner-loadbalancer` | lb-http-redirected-to-https, lb-https-service-has-certificate (2) |

`--discover` accepts `auto`, `all`, `firewalls`, `loadbalancers`.

## How

- **Discovery** (`resources/discovery.go`) lists firewalls and load balancers and emits child inventory assets, stamping the resource id into the child connection `Options`.
- **`detect()`** reads those options (via `SubAssetPlatform`) to set the specific platform and a stable platform id anchored on the project identifier: `…/runtime/hetzner/project/<hash>/firewall/<id>`.
- **`init` binding** — `hetzner.firewall` / `hetzner.loadBalancer` already had by-id `init`s; they now fall back to the connection option, so on a discovered `hetzner-firewall` asset, `hetzner.firewall.rules` (no args) resolves to that firewall. Explicit `hetzner.firewall(id: 123)` still works.
- **Un-privated** `hetzner.firewall` and `hetzner.loadBalancer` so they're first-class top-level singulars (added the required two-part doc-comments). Resource-level `private` lives only in the generated schema (`resources.json`), so there's no `.lr.go` diff and `.lr.versions` is untouched.

## Test

- `go vet`, provider unit tests, `gofmt`, idempotent codegen, provider build + install all pass.
- ⚠️ **No live scan** — no `HCLOUD_TOKEN` in this environment, so discovery + singular binding weren't exercised against a real project. Needs a token to verify end-to-end.

## Follow-up (separate, in `cnspec/content`)

The `mondoo-hetzner-security` policy groups don't filter on platform yet. To run the firewall/LB checks against the new child assets (using the singular resources), the policy needs per-platform variants/filters. Not included here.

## Notes

Scoped to firewall + loadbalancer per request. `hetzner-server` (3 checks) is the other strong candidate if we want compute assets later; certificate / floating-ip / primary-ip are 1 check each and read as account-level config.
