### PR TITLE
🐛 aws: detect wide-CIDR and prefix-list public sources (fix false negatives)

### DIFF
--- a/providers/aws/resources/aws_cidr.go
+++ b/providers/aws/resources/aws_cidr.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "net"
+
+// privateOrReservedCIDRs are address ranges that are not routable from the
+// public internet. A security-group or network-ACL rule whose source is wholly
+// inside one of these does not constitute internet exposure.
+var privateOrReservedCIDRs = mustParseCIDRs(
+	"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // RFC1918
+	"127.0.0.0/8",    // loopback
+	"169.254.0.0/16", // link-local
+	"100.64.0.0/10",  // carrier-grade NAT
+	"0.0.0.0/8",      // "this host on this network" (RFC1122)
+	"240.0.0.0/4",    // reserved for future use
+	"2001:db8::/32",  // IPv6 documentation (RFC3849)
+	"::1/128",        // IPv6 loopback
+	"fc00::/7",       // IPv6 unique local
+	"fe80::/10",      // IPv6 link-local
+)
+
+// broadPublicPrefix* is the largest prefix length still treated as "broad"
+// internet exposure rather than a specific allow-listed host or network: a /8
+// IPv4 block (16M+ addresses) or a /32 IPv6 block. The threshold is deliberately
+// conservative — narrower public ranges (a single /32 host, a corporate /24) are
+// treated as scoped to avoid false positives on legitimate large allow-lists.
+const (
+	broadPublicPrefixV4 = 8
+	broadPublicPrefixV6 = 32
+)
+
+func mustParseCIDRs(cidrs ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		if _, n, err := net.ParseCIDR(c); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}
+
+// cidrIsPublic reports whether a CIDR exposes a broad slice of the public
+// internet — the all-addresses 0.0.0.0/0 or ::/0, or any wide block (prefix
+// length at or below the broad-public threshold) that is not contained within a
+// private or reserved range. A specific public host or a narrow allow-listed
+// range is not considered public.
+func cidrIsPublic(cidr string) bool {
+	if cidr == "" {
+		return false
+	}
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	ones, bits := ipnet.Mask.Size()
+	threshold := broadPublicPrefixV4
+	if bits > 32 {
+		threshold = broadPublicPrefixV6
+	}
+	if ones > threshold {
+		return false
+	}
+	for _, pr := range privateOrReservedCIDRs {
+		if cidrWithin(ipnet, pr) {
+			return false
+		}
+	}
+	return true
+}
+
+// cidrWithin reports whether inner is entirely contained within outer.
+func cidrWithin(inner, outer *net.IPNet) bool {
+	innerOnes, innerBits := inner.Mask.Size()
+	outerOnes, outerBits := outer.Mask.Size()
+	if innerBits != outerBits || outerOnes > innerOnes {
+		return false
+	}
+	return outer.Contains(inner.IP)
+}
+
+// anyCidrPublic reports whether any CIDR string in the list exposes the public
+// internet.
+func anyCidrPublic(cidrs []any) bool {
+	for _, c := range cidrs {
+		if s, ok := c.(string); ok && cidrIsPublic(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/aws/resources/aws_cidr.go
+++ b/providers/aws/resources/aws_cidr.go
@@ -3,7 +3,10 @@
 
 package resources
 
-import "net"
+import (
+	"fmt"
+	"net"
+)
 
 // privateOrReservedCIDRs are address ranges that are not routable from the
 // public internet. A security-group or network-ACL rule whose source is wholly
@@ -31,12 +34,17 @@ const (
 	broadPublicPrefixV6 = 32
 )
 
+// mustParseCIDRs parses a fixed set of CIDR literals at init time, panicking on
+// a malformed entry so a typo in the private/reserved list fails loudly rather
+// than silently shrinking the set.
 func mustParseCIDRs(cidrs ...string) []*net.IPNet {
 	nets := make([]*net.IPNet, 0, len(cidrs))
 	for _, c := range cidrs {
-		if _, n, err := net.ParseCIDR(c); err == nil {
-			nets = append(nets, n)
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("mustParseCIDRs: %s: %v", c, err))
 		}
+		nets = append(nets, n)
 	}
 	return nets
 }

--- a/providers/aws/resources/aws_cidr_test.go
+++ b/providers/aws/resources/aws_cidr_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCidrIsPublic(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want bool
+	}{
+		// all-addresses
+		{"0.0.0.0/0", true},
+		{"::/0", true},
+		// broad public blocks that the literal-/0 check used to miss
+		{"0.0.0.0/1", true},
+		{"128.0.0.0/1", true},
+		{"13.0.0.0/8", true},
+		// private / reserved ranges are not internet exposure
+		{"10.0.0.0/8", false},
+		{"172.16.0.0/12", false},
+		{"192.168.0.0/16", false},
+		{"127.0.0.0/8", false},
+		{"169.254.0.0/16", false},
+		{"100.64.0.0/10", false},
+		{"fc00::/7", false},
+		// specific or narrow ranges are scoped, not "the internet"
+		{"203.0.113.5/32", false},
+		{"52.94.0.0/16", false},
+		{"2600:1f00::/24", true},
+		{"2001:db8::/48", false},
+		// malformed / empty
+		{"", false},
+		{"not-a-cidr", false},
+		{"0.0.0.0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cidr, func(t *testing.T) {
+			assert.Equal(t, tt.want, cidrIsPublic(tt.cidr))
+		})
+	}
+}
+
+func TestAnyCidrPublic(t *testing.T) {
+	assert.True(t, anyCidrPublic([]any{"10.0.0.0/8", "0.0.0.0/1"}))
+	assert.False(t, anyCidrPublic([]any{"10.0.0.0/8", "192.168.1.0/24"}))
+	assert.False(t, anyCidrPublic([]any{}))
+	assert.False(t, anyCidrPublic([]any{42, "10.0.0.0/8"}))
+}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -323,7 +323,7 @@ func (a *mqlAwsEc2NetworkaclEntry) id() (string, error) {
 // entire internet, matching every IPv4 address (0.0.0.0/0) or every IPv6
 // address (::/0).
 func cidrEntryIsPublic(cidrBlock, ipv6CidrBlock string) bool {
-	return cidrBlock == "0.0.0.0/0" || ipv6CidrBlock == "::/0"
+	return cidrIsPublic(cidrBlock) || cidrIsPublic(ipv6CidrBlock)
 }
 
 // isPublic reports whether the entry opens traffic to the entire internet.
@@ -2155,14 +2155,40 @@ func (a *mqlAwsEc2SecuritygroupIppermission) includesPublicSource() (bool, error
 	if ipv4.Error != nil {
 		return false, ipv4.Error
 	}
-	if anyStringEquals(ipv4.Data, "0.0.0.0/0") {
+	if anyCidrPublic(ipv4.Data) {
 		return true, nil
 	}
 	ipv6 := a.GetIpv6Ranges()
 	if ipv6.Error != nil {
 		return false, ipv6.Error
 	}
-	return anyStringEquals(ipv6.Data, "::/0"), nil
+	if anyCidrPublic(ipv6.Data) {
+		return true, nil
+	}
+
+	// A referenced managed prefix list can itself contain public ranges, so a
+	// rule that names only a prefix list can still be internet-facing.
+	prefixLists := a.GetPrefixLists()
+	if prefixLists.Error != nil {
+		return false, prefixLists.Error
+	}
+	for _, pl := range prefixLists.Data {
+		mpl, ok := pl.(*mqlAwsEc2ManagedPrefixList)
+		if !ok {
+			continue
+		}
+		entries := mpl.GetEntries()
+		if entries.Error != nil {
+			return false, entries.Error
+		}
+		for _, e := range entries.Data {
+			entry, ok := e.(*mqlAwsEc2ManagedPrefixListEntry)
+			if ok && cidrIsPublic(entry.Cidr.Data) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // anyStringEquals reports whether any element of the slice equals target.


### PR DESCRIPTION
First of the exposure-analysis follow-ups (foundational — every network predicate inherits this).

## Problem
`includesPublicSource` (security-group rules) and `cidrEntryIsPublic` (NACL entries) only matched the **literal** `0.0.0.0/0` / `::/0`. They missed:
- wide-but-not-`/0` public blocks (`0.0.0.0/1`, a public `/8`), and
- security-group rules that reference a **managed prefix list** containing public ranges (the rule named no CIDR at all).

That's a false negative inherited by every network-exposure predicate shipped so far — `instance.internetReachable`, `rds.internetReachable`, and the NACL evaluation.

## Fix
New `cidrIsPublic` helper: a CIDR is public when it is `0.0.0.0/0`/`::/0`, **or** a broad block (prefix length ≤ `/8` IPv4, ≤ `/32` IPv6) that is **not** contained within a private/reserved range (RFC1918, loopback, link-local, CGNAT, documentation, reserved-for-future). Narrow or specific ranges (a `/32` host, a corporate `/24`) stay scoped — a deliberately conservative threshold to avoid false positives on large legitimate allow-lists.

`includesPublicSource` now also expands referenced managed prefix lists and checks their entries.

## Notes
- The `/8` (IPv4) / `/32` (IPv6) broad-public threshold is the one judgment knob; documented in `aws_cidr.go` and easy to tune.
- Pure helpers — **no schema change, no new API calls or permissions.**

## Tests
`aws_cidr_test.go` — table-driven `cidrIsPublic` (all-/0, broad public, every private/reserved range, narrow/specific, malformed), `anyCidrPublic`. The pre-existing `TestCidrEntryIsPublic` still passes (documentation range `2001:db8::/32` correctly excluded).

## Verification
Live: public SGs still flagged (no regression on the literal `0.0.0.0/0` case), now with wide-CIDR + prefix-list coverage added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)