### PR TITLE
⭐ aws: mitigation-context fields (exposed-and-undefended detection)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5307,6 +5307,8 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   instances() []aws.ec2.instance
   // List of listeners for ALB/NLB load balancers (typed)
   listeners() []aws.elb.listener
+  // Whether all listeners use an encrypted protocol (no plaintext HTTP, TCP, or UDP listener)
+  enforcesTls() bool
   // Typed attributes for ALB/NLB load balancers
   attribute() aws.elb.loadbalancer.attribute
   // Health check configuration (classic load balancers only; null for ALB/NLB)
@@ -9287,6 +9289,10 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   webAclId string
   // AWS WAF web ACL associated with the distribution
   webAcl() aws.waf.acl
+  // Whether a WAF web ACL is associated with the distribution
+  protectedByWaf() bool
+  // Whether viewers are required to use HTTPS (viewer protocol policy is not allow-all)
+  enforcesHttps() bool
   // ID of the continuous deployment policy associated with the distribution (empty string when none)
   continuousDeploymentPolicyId() string
   // Type of geographic restriction applied to the distribution (none, whitelist, or blacklist)

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9291,7 +9291,7 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   webAcl() aws.waf.acl
   // Whether a WAF web ACL is associated with the distribution
   protectedByWaf() bool
-  // Whether viewers are required to use HTTPS (viewer protocol policy is not allow-all)
+  // Whether every cache behavior requires viewers to use HTTPS (no behavior uses the allow-all viewer protocol policy)
   enforcesHttps() bool
   // ID of the continuous deployment policy associated with the distribution (empty string when none)
   continuousDeploymentPolicyId() string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10701,6 +10701,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.listeners": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetListeners()).ToDataRes(types.Array(types.Resource("aws.elb.listener")))
 	},
+	"aws.elb.loadbalancer.enforcesTls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetEnforcesTls()).ToDataRes(types.Bool)
+	},
 	"aws.elb.loadbalancer.attribute": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetAttribute()).ToDataRes(types.Resource("aws.elb.loadbalancer.attribute"))
 	},
@@ -14918,6 +14921,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cloudfront.distribution.webAcl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetWebAcl()).ToDataRes(types.Resource("aws.waf.acl"))
+	},
+	"aws.cloudfront.distribution.protectedByWaf": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetProtectedByWaf()).ToDataRes(types.Bool)
+	},
+	"aws.cloudfront.distribution.enforcesHttps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetEnforcesHttps()).ToDataRes(types.Bool)
 	},
 	"aws.cloudfront.distribution.continuousDeploymentPolicyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetContinuousDeploymentPolicyId()).ToDataRes(types.String)
@@ -41593,6 +41602,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElbLoadbalancer).Listeners, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elb.loadbalancer.enforcesTls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).EnforcesTls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.elb.loadbalancer.attribute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).Attribute, ok = plugin.RawToTValue[*mqlAwsElbLoadbalancerAttribute](v.Value, v.Error)
 		return
@@ -47859,6 +47872,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudfront.distribution.webAcl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudfrontDistribution).WebAcl, ok = plugin.RawToTValue[*mqlAwsWafAcl](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.protectedByWaf": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).ProtectedByWaf, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.enforcesHttps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).EnforcesHttps, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.cloudfront.distribution.continuousDeploymentPolicyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -97454,6 +97475,7 @@ type mqlAwsElbLoadbalancer struct {
 	TargetGroups         plugin.TValue[[]any]
 	Instances            plugin.TValue[[]any]
 	Listeners            plugin.TValue[[]any]
+	EnforcesTls          plugin.TValue[bool]
 	Attribute            plugin.TValue[*mqlAwsElbLoadbalancerAttribute]
 	HealthCheck          plugin.TValue[any]
 }
@@ -97606,6 +97628,12 @@ func (c *mqlAwsElbLoadbalancer) GetListeners() *plugin.TValue[[]any] {
 		}
 
 		return c.listeners()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetEnforcesTls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EnforcesTls, func() (bool, error) {
+		return c.enforcesTls()
 	})
 }
 
@@ -114591,6 +114619,8 @@ type mqlAwsCloudfrontDistribution struct {
 	SslSupportMethod             plugin.TValue[string]
 	WebAclId                     plugin.TValue[string]
 	WebAcl                       plugin.TValue[*mqlAwsWafAcl]
+	ProtectedByWaf               plugin.TValue[bool]
+	EnforcesHttps                plugin.TValue[bool]
 	ContinuousDeploymentPolicyId plugin.TValue[string]
 	GeoRestrictionType           plugin.TValue[string]
 	LastModifiedAt               plugin.TValue[*time.Time]
@@ -114710,6 +114740,18 @@ func (c *mqlAwsCloudfrontDistribution) GetWebAcl() *plugin.TValue[*mqlAwsWafAcl]
 		}
 
 		return c.webAcl()
+	})
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetProtectedByWaf() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ProtectedByWaf, func() (bool, error) {
+		return c.protectedByWaf()
+	})
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetEnforcesHttps() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EnforcesHttps, func() (bool, error) {
+		return c.enforcesHttps()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1453,6 +1453,7 @@ aws.cloudfront.distribution.continuousDeploymentPolicyId 13.29.1
 aws.cloudfront.distribution.defaultCacheBehavior 11.15.2
 aws.cloudfront.distribution.domainName 11.15.2
 aws.cloudfront.distribution.enabled 11.15.2
+aws.cloudfront.distribution.enforcesHttps 13.37.1
 aws.cloudfront.distribution.geoRestrictionType 11.15.2
 aws.cloudfront.distribution.httpVersion 11.15.2
 aws.cloudfront.distribution.isIPV6Enabled 11.15.2
@@ -1476,6 +1477,7 @@ aws.cloudfront.distribution.origin.originMtlsClientCertificate 13.20.1
 aws.cloudfront.distribution.origin.originPath 11.15.2
 aws.cloudfront.distribution.origins 11.15.2
 aws.cloudfront.distribution.priceClass 11.15.2
+aws.cloudfront.distribution.protectedByWaf 13.37.1
 aws.cloudfront.distribution.sslSupportMethod 13.3.1
 aws.cloudfront.distribution.status 11.15.2
 aws.cloudfront.distribution.viewerMtlsMode 13.25.1
@@ -4229,6 +4231,7 @@ aws.elb.loadbalancer.availabilityZones 11.15.2
 aws.elb.loadbalancer.createdAt 11.15.2
 aws.elb.loadbalancer.dnsName 11.15.2
 aws.elb.loadbalancer.elbType 11.15.2
+aws.elb.loadbalancer.enforcesTls 13.37.1
 aws.elb.loadbalancer.healthCheck 13.26.2
 aws.elb.loadbalancer.hostedZoneId 11.15.2
 aws.elb.loadbalancer.instances 11.15.2

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -597,3 +597,19 @@ func (a *mqlAwsCloudfront) trustStores() ([]any, error) {
 	}
 	return res, nil
 }
+
+func (a *mqlAwsCloudfrontDistribution) protectedByWaf() (bool, error) {
+	webAclId := a.GetWebAclId()
+	if webAclId.Error != nil {
+		return false, webAclId.Error
+	}
+	return webAclId.Data != "", nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) enforcesHttps() (bool, error) {
+	policy := a.GetViewerProtocolPolicy()
+	if policy.Error != nil {
+		return false, policy.Error
+	}
+	return viewerPolicyEnforcesHttps(policy.Data), nil
+}

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -606,10 +606,32 @@ func (a *mqlAwsCloudfrontDistribution) protectedByWaf() (bool, error) {
 	return webAclId.Data != "", nil
 }
 
+// enforcesHttps reports whether every cache behavior — the default plus any
+// additional behaviors — requires viewers to use HTTPS. A single allow-all
+// behavior leaves a plaintext path open, so all are checked.
 func (a *mqlAwsCloudfrontDistribution) enforcesHttps() (bool, error) {
 	policy := a.GetViewerProtocolPolicy()
 	if policy.Error != nil {
 		return false, policy.Error
 	}
-	return viewerPolicyEnforcesHttps(policy.Data), nil
+	if !viewerPolicyEnforcesHttps(policy.Data) {
+		return false, nil
+	}
+
+	cacheBehaviors := a.GetCacheBehaviors()
+	if cacheBehaviors.Error != nil {
+		return false, cacheBehaviors.Error
+	}
+	for _, cb := range cacheBehaviors.Data {
+		behavior, ok := cb.(map[string]any)
+		if !ok {
+			continue
+		}
+		// aws-sdk-go-v2 types carry no json tags, so JsonToDict preserves the
+		// Go field name "ViewerProtocolPolicy".
+		if vp, ok := behavior["ViewerProtocolPolicy"].(string); ok && !viewerPolicyEnforcesHttps(vp) {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -847,23 +847,22 @@ func (a *mqlAwsElbTargetgroup) lambdaTargets() ([]any, error) {
 }
 
 // enforcesTls reports whether every listener terminates an encrypted protocol —
-// i.e. no plaintext HTTP, TCP, or UDP listener accepts traffic. A load balancer
-// with no listeners vacuously enforces TLS (nothing accepts plaintext).
+// i.e. no plaintext HTTP, TCP, or UDP listener accepts traffic. It reads
+// listenerDescriptions, which covers both classic ELBs (where the protocol is
+// nested under "Listener") and ALB/NLB load balancers (top-level "Protocol"), so
+// a classic HTTP load balancer is not missed. A load balancer with no listeners
+// vacuously enforces TLS (nothing accepts plaintext).
 func (a *mqlAwsElbLoadbalancer) enforcesTls() (bool, error) {
-	listeners := a.GetListeners()
-	if listeners.Error != nil {
-		return false, listeners.Error
+	descriptions := a.GetListenerDescriptions()
+	if descriptions.Error != nil {
+		return false, descriptions.Error
 	}
-	for _, l := range listeners.Data {
-		listener, ok := l.(*mqlAwsElbListener)
+	for _, d := range descriptions.Data {
+		desc, ok := d.(map[string]any)
 		if !ok {
 			continue
 		}
-		protocol := listener.GetProtocol()
-		if protocol.Error != nil {
-			return false, protocol.Error
-		}
-		if listenerProtocolIsPlaintext(protocol.Data) {
+		if listenerProtocolIsPlaintext(listenerDescriptionProtocol(desc)) {
 			return false, nil
 		}
 	}

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -845,3 +845,27 @@ func (a *mqlAwsElbTargetgroup) lambdaTargets() ([]any, error) {
 	// TODO
 	return nil, nil
 }
+
+// enforcesTls reports whether every listener terminates an encrypted protocol —
+// i.e. no plaintext HTTP, TCP, or UDP listener accepts traffic. A load balancer
+// with no listeners vacuously enforces TLS (nothing accepts plaintext).
+func (a *mqlAwsElbLoadbalancer) enforcesTls() (bool, error) {
+	listeners := a.GetListeners()
+	if listeners.Error != nil {
+		return false, listeners.Error
+	}
+	for _, l := range listeners.Data {
+		listener, ok := l.(*mqlAwsElbListener)
+		if !ok {
+			continue
+		}
+		protocol := listener.GetProtocol()
+		if protocol.Error != nil {
+			return false, protocol.Error
+		}
+		if listenerProtocolIsPlaintext(protocol.Data) {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/providers/aws/resources/aws_exposure.go
+++ b/providers/aws/resources/aws_exposure.go
@@ -22,3 +22,19 @@ func listenerProtocolIsPlaintext(protocol string) bool {
 		return false
 	}
 }
+
+// listenerDescriptionProtocol extracts the protocol from a load balancer
+// listener-description dict, handling both shapes: ALB/NLB listeners (from
+// DescribeListeners) carry "Protocol" at the top level, while classic ELB
+// listener descriptions nest it under "Listener".
+func listenerDescriptionProtocol(desc map[string]any) string {
+	if p, ok := desc["Protocol"].(string); ok && p != "" {
+		return p
+	}
+	if listener, ok := desc["Listener"].(map[string]any); ok {
+		if p, ok := listener["Protocol"].(string); ok {
+			return p
+		}
+	}
+	return ""
+}

--- a/providers/aws/resources/aws_exposure.go
+++ b/providers/aws/resources/aws_exposure.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "strings"
+
+// viewerPolicyEnforcesHttps reports whether a CloudFront viewer protocol policy
+// requires HTTPS. "allow-all" permits plaintext HTTP; "https-only" and
+// "redirect-to-https" enforce TLS. An empty policy is treated as not enforcing.
+func viewerPolicyEnforcesHttps(policy string) bool {
+	return policy != "" && !strings.EqualFold(policy, "allow-all")
+}
+
+// listenerProtocolIsPlaintext reports whether a load balancer listener protocol
+// carries traffic without transport encryption.
+func listenerProtocolIsPlaintext(protocol string) bool {
+	switch strings.ToUpper(protocol) {
+	case "HTTP", "TCP", "UDP", "TCP_UDP":
+		return true
+	default:
+		return false
+	}
+}

--- a/providers/aws/resources/aws_exposure_test.go
+++ b/providers/aws/resources/aws_exposure_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestViewerPolicyEnforcesHttps(t *testing.T) {
+	assert.True(t, viewerPolicyEnforcesHttps("https-only"))
+	assert.True(t, viewerPolicyEnforcesHttps("redirect-to-https"))
+	assert.False(t, viewerPolicyEnforcesHttps("allow-all"))
+	assert.False(t, viewerPolicyEnforcesHttps("Allow-All"))
+	assert.False(t, viewerPolicyEnforcesHttps(""))
+}
+
+func TestListenerProtocolIsPlaintext(t *testing.T) {
+	for _, p := range []string{"HTTP", "TCP", "UDP", "TCP_UDP", "http", "tcp"} {
+		assert.True(t, listenerProtocolIsPlaintext(p), p)
+	}
+	for _, p := range []string{"HTTPS", "TLS", "https", "tls", ""} {
+		assert.False(t, listenerProtocolIsPlaintext(p), p)
+	}
+}

--- a/providers/aws/resources/aws_exposure_test.go
+++ b/providers/aws/resources/aws_exposure_test.go
@@ -25,3 +25,13 @@ func TestListenerProtocolIsPlaintext(t *testing.T) {
 		assert.False(t, listenerProtocolIsPlaintext(p), p)
 	}
 }
+
+func TestListenerDescriptionProtocol(t *testing.T) {
+	// ALB/NLB shape: protocol at the top level.
+	assert.Equal(t, "HTTPS", listenerDescriptionProtocol(map[string]any{"Protocol": "HTTPS"}))
+	// Classic ELB shape: protocol nested under "Listener".
+	assert.Equal(t, "HTTP", listenerDescriptionProtocol(map[string]any{"Listener": map[string]any{"Protocol": "HTTP"}}))
+	// Neither shape present.
+	assert.Equal(t, "", listenerDescriptionProtocol(map[string]any{"PolicyNames": []any{}}))
+	assert.Equal(t, "", listenerDescriptionProtocol(map[string]any{}))
+}


### PR DESCRIPTION
Exposure dimension A — "exposed *and undefended*". A public resource with a WAF and enforced TLS is far less of a finding than one without; these fields let policies make that distinction instead of treating every exposure equally.

## Fields
- **`aws.cloudfront.distribution.protectedByWaf`** — a WAF web ACL is associated with the distribution.
- **`aws.cloudfront.distribution.enforcesHttps`** — viewer protocol policy is not `allow-all` (plaintext HTTP rejected/redirected).
- **`aws.elb.loadbalancer.enforcesTls`** — no plaintext HTTP/TCP/UDP listener accepts traffic.

Enables findings like:
```
aws.cloudfront.distributions.where(enabled).all(protectedByWaf && enforcesHttps)
aws.elb.loadBalancers.where(scheme == "internet-facing").all(enforcesTls)
```

## Notes
- Pure helpers (`viewerPolicyEnforcesHttps`, `listenerProtocolIsPlaintext`) with table-driven tests.
- Reads cached `webAclId` / `viewerProtocolPolicy` / `listeners` — **no new API calls or permissions** (912, unchanged). Versions `13.37.1`.

## Verification
Live: an NLB with a plaintext TCP listener reports `enforcesTls=false`; an all-encrypted load balancer reports `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)