### PR TITLE
⭐ aws: external-sharing fields for AMIs and snapshots

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15411,6 +15411,10 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   outpostArn string
   // Whether the snapshot is public (shared with all AWS accounts)
   isPublic() bool
+  // AWS account IDs this snapshot is explicitly shared with (excludes public sharing)
+  sharedWithAccounts() []string
+  // Whether the snapshot is shared outside this account, either publicly or with specific accounts
+  sharedExternally() bool
 }
 
 // Amazon EC2 (EBS) volume
@@ -15961,6 +15965,10 @@ private aws.ec2.image @defaults("ownerAlias id name") {
   region string
   // Launch permissions for the image (user IDs and groups that can launch instances from this AMI)
   launchPermissions() []aws.ec2.image.launchPermission
+  // AWS account IDs this image is explicitly shared with (excludes public sharing)
+  sharedWithAccounts() []string
+  // Whether the image is shared outside this account, either publicly or with specific accounts
+  sharedExternally() bool
   // Description of the AMI
   description string
   // Type of image: machine, kernel, or ramdisk

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -21651,6 +21651,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetIsPublic()).ToDataRes(types.Bool)
 	},
+	"aws.ec2.snapshot.sharedWithAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetSharedWithAccounts()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.snapshot.sharedExternally": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetSharedExternally()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.volume.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetArn()).ToDataRes(types.String)
 	},
@@ -22313,6 +22319,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.image.launchPermissions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetLaunchPermissions()).ToDataRes(types.Array(types.Resource("aws.ec2.image.launchPermission")))
+	},
+	"aws.ec2.image.sharedWithAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetSharedWithAccounts()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.image.sharedExternally": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetSharedExternally()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.image.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetDescription()).ToDataRes(types.String)
@@ -57641,6 +57653,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Snapshot).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.sharedWithAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).SharedWithAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.sharedExternally": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).SharedExternally, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).__id, ok = v.Value.(string)
 		return
@@ -58595,6 +58615,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.image.launchPermissions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Image).LaunchPermissions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.sharedWithAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).SharedWithAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.sharedExternally": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).SharedExternally, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.image.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -138788,6 +138816,8 @@ type mqlAwsEc2Snapshot struct {
 	OwnerAlias             plugin.TValue[string]
 	OutpostArn             plugin.TValue[string]
 	IsPublic               plugin.TValue[bool]
+	SharedWithAccounts     plugin.TValue[[]any]
+	SharedExternally       plugin.TValue[bool]
 }
 
 // createAwsEc2Snapshot creates a new instance of this resource
@@ -138928,6 +138958,18 @@ func (c *mqlAwsEc2Snapshot) GetOutpostArn() *plugin.TValue[string] {
 func (c *mqlAwsEc2Snapshot) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
+	})
+}
+
+func (c *mqlAwsEc2Snapshot) GetSharedWithAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SharedWithAccounts, func() ([]any, error) {
+		return c.sharedWithAccounts()
+	})
+}
+
+func (c *mqlAwsEc2Snapshot) GetSharedExternally() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SharedExternally, func() (bool, error) {
+		return c.sharedExternally()
 	})
 }
 
@@ -141033,6 +141075,8 @@ type mqlAwsEc2Image struct {
 	Tags                     plugin.TValue[map[string]any]
 	Region                   plugin.TValue[string]
 	LaunchPermissions        plugin.TValue[[]any]
+	SharedWithAccounts       plugin.TValue[[]any]
+	SharedExternally         plugin.TValue[bool]
 	Description              plugin.TValue[string]
 	ImageType                plugin.TValue[string]
 	FreeTierEligible         plugin.TValue[bool]
@@ -141173,6 +141217,18 @@ func (c *mqlAwsEc2Image) GetLaunchPermissions() *plugin.TValue[[]any] {
 		}
 
 		return c.launchPermissions()
+	})
+}
+
+func (c *mqlAwsEc2Image) GetSharedWithAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SharedWithAccounts, func() ([]any, error) {
+		return c.sharedWithAccounts()
+	})
+}
+
+func (c *mqlAwsEc2Image) GetSharedExternally() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SharedExternally, func() (bool, error) {
+		return c.sharedExternally()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2934,6 +2934,8 @@ aws.ec2.image.public 11.15.2
 aws.ec2.image.region 11.15.2
 aws.ec2.image.rootDeviceName 11.15.3
 aws.ec2.image.rootDeviceType 11.15.2
+aws.ec2.image.sharedExternally 13.37.1
+aws.ec2.image.sharedWithAccounts 13.37.1
 aws.ec2.image.sourceImage 13.35.2
 aws.ec2.image.sourceImageId 11.15.3
 aws.ec2.image.sourceImageRegion 11.15.3
@@ -3302,6 +3304,8 @@ aws.ec2.snapshot.kmsKey 11.15.2
 aws.ec2.snapshot.outpostArn 13.35.2
 aws.ec2.snapshot.ownerAlias 13.35.2
 aws.ec2.snapshot.region 11.15.2
+aws.ec2.snapshot.sharedExternally 13.37.1
+aws.ec2.snapshot.sharedWithAccounts 13.37.1
 aws.ec2.snapshot.sourceVolume 13.35.2
 aws.ec2.snapshot.startTime 11.15.2
 aws.ec2.snapshot.state 11.15.2

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -4145,3 +4145,80 @@ func (i *mqlAwsEc2Instance) managedBy() (string, error) {
 func (a *mqlAwsEc2Securitygroup) managedBy() (string, error) {
 	return managedByFromTags(a.Tags.Data), nil
 }
+
+func (i *mqlAwsEc2Image) sharedWithAccounts() ([]any, error) {
+	perms := i.GetLaunchPermissions()
+	if perms.Error != nil {
+		return nil, perms.Error
+	}
+	res := []any{}
+	for _, p := range perms.Data {
+		perm, ok := p.(*mqlAwsEc2ImageLaunchPermission)
+		if !ok {
+			continue
+		}
+		userId := perm.GetUserId()
+		if userId.Error != nil {
+			return nil, userId.Error
+		}
+		if userId.Data != "" {
+			res = append(res, userId.Data)
+		}
+	}
+	return res, nil
+}
+
+func (i *mqlAwsEc2Image) sharedExternally() (bool, error) {
+	public := i.GetPublic()
+	if public.Error != nil {
+		return false, public.Error
+	}
+	if public.Data {
+		return true, nil
+	}
+	accounts := i.GetSharedWithAccounts()
+	if accounts.Error != nil {
+		return false, accounts.Error
+	}
+	return len(accounts.Data) > 0, nil
+}
+
+// accountIdsFromVolumePermissions extracts the account IDs from a snapshot's
+// createVolumePermission entries, ignoring the public ("all" group) entry which
+// carries no UserId.
+func accountIdsFromVolumePermissions(perms []any) []any {
+	res := []any{}
+	for _, p := range perms {
+		m, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if uid, ok := m["UserId"].(string); ok && uid != "" {
+			res = append(res, uid)
+		}
+	}
+	return res
+}
+
+func (a *mqlAwsEc2Snapshot) sharedWithAccounts() ([]any, error) {
+	perms := a.GetCreateVolumePermission()
+	if perms.Error != nil {
+		return nil, perms.Error
+	}
+	return accountIdsFromVolumePermissions(perms.Data), nil
+}
+
+func (a *mqlAwsEc2Snapshot) sharedExternally() (bool, error) {
+	public := a.GetIsPublic()
+	if public.Error != nil {
+		return false, public.Error
+	}
+	if public.Data {
+		return true, nil
+	}
+	accounts := a.GetSharedWithAccounts()
+	if accounts.Error != nil {
+		return false, accounts.Error
+	}
+	return len(accounts.Data) > 0, nil
+}

--- a/providers/aws/resources/aws_external_sharing_test.go
+++ b/providers/aws/resources/aws_external_sharing_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountIdsFromVolumePermissions(t *testing.T) {
+	tests := []struct {
+		name  string
+		perms []any
+		want  []any
+	}{
+		{
+			name:  "shared with two accounts",
+			perms: []any{map[string]any{"UserId": "111111111111"}, map[string]any{"UserId": "222222222222"}},
+			want:  []any{"111111111111", "222222222222"},
+		},
+		{
+			name:  "public group entry has no UserId",
+			perms: []any{map[string]any{"Group": "all"}},
+			want:  []any{},
+		},
+		{
+			name:  "mixed public and account",
+			perms: []any{map[string]any{"Group": "all"}, map[string]any{"UserId": "333333333333"}},
+			want:  []any{"333333333333"},
+		},
+		{
+			name:  "empty UserId skipped",
+			perms: []any{map[string]any{"UserId": ""}},
+			want:  []any{},
+		},
+		{
+			name:  "no permissions",
+			perms: []any{},
+			want:  []any{},
+		},
+		{
+			name:  "non-map entries ignored",
+			perms: []any{"unexpected", map[string]any{"UserId": "444444444444"}},
+			want:  []any{"444444444444"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, accountIdsFromVolumePermissions(tt.perms))
+		})
+	}
+}


### PR DESCRIPTION
Exposure dimension B — **shared with specific external accounts**, the middle ground between private and public. `public`/`isPublic` already exist on AMIs and snapshots, but they only capture the "shared with everyone" case; sharing a snapshot or AMI with a handful of outside account IDs is exposure too, and wasn't queryable.

## Fields
- **`aws.ec2.image.sharedWithAccounts`** / **`.sharedExternally`**
- **`aws.ec2.snapshot.sharedWithAccounts`** / **`.sharedExternally`**

`sharedWithAccounts` lists the account IDs in the launch / create-volume permissions (excluding the public `all` group). `sharedExternally` is true when the resource is public **or** shared with any specific account — one predicate for "leaves this account."

```
aws.ec2.snapshots.where(sharedExternally)
aws.ec2.images.where(sharedWithAccounts != [])
```

## Notes
- Builds on the existing `public` / `isPublic` fields.
- Pure account-extraction helper (`accountIdsFromVolumePermissions`) with table-driven tests (public-group entry, mixed, empty, non-map).
- Reads cached launch/create-volume permission data — **no new API calls or permissions** (912, unchanged). Versions `13.37.1`.

## Follow-up
RDS/cluster snapshot sharing and KMS external-grant detection are natural extensions of this dimension; left for a follow-up (KMS needs own-account comparison to classify "external").

🤖 Generated with [Claude Code](https://claude.com/claude-code)