### PR TITLE
⭐ aws: trust, egress, and embedded-config exposure predicates

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2207,6 +2207,10 @@ private aws.iam.role @defaults("arn name") {
   assumeRolePolicyDocument dict
   // Parsed statements from the role trust policy
   assumeRolePolicyStatements() []aws.iam.policyStatement
+  // Whether the trust policy allows any principal ("*") to assume the role without a scoping condition
+  assumableByPublic() bool
+  // AWS account IDs outside this account that the trust policy allows to assume the role
+  assumableByExternalAccounts() []string
   // Time when the role was last used to make an AWS request
   lastUsedAt time
   // Region in which the role was last used
@@ -14200,6 +14204,8 @@ private aws.lambda.function @defaults("arn") {
   kmsKey() aws.kms.key
   // Environment variables configured for the function
   environment map[string]string
+  // Environment variable names that look like inline secrets (password, token, secret, access key, and similar) and should likely use Secrets Manager
+  environmentSecretLikeKeys() []string
   // Layers attached to the function
   layers []aws.lambda.function.layer
   // Logging configuration for the function
@@ -15289,6 +15295,8 @@ private aws.ec2.launchtemplate @defaults("name region") {
   tags map[string]string
   // User data from the default version (base64-decoded)
   userData() string
+  // Whether the launch template has user data set (a launch script that may embed secrets)
+  userDataPresent() bool
   // Metadata options from the default version (httpTokens, httpEndpoint, httpPutResponseHopLimit)
   metadataOptions() dict
   // Security group IDs from the default version
@@ -16130,6 +16138,8 @@ private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   ipPermissions() []aws.ec2.securitygroup.ippermission
   // IP permissions (egress) for the security group
   ipPermissionsEgress() []aws.ec2.securitygroup.ippermission
+  // Whether any egress rule permits outbound traffic to the internet (0.0.0.0/0 or ::/0)
+  allowsUnrestrictedEgress() bool
   // Region associated with the security group
   region string
   // Whether the security group is attached to Amazon Elastic Compute Cloud

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6924,6 +6924,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.role.assumeRolePolicyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetAssumeRolePolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
+	"aws.iam.role.assumableByPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetAssumableByPublic()).ToDataRes(types.Bool)
+	},
+	"aws.iam.role.assumableByExternalAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetAssumableByExternalAccounts()).ToDataRes(types.Array(types.String))
+	},
 	"aws.iam.role.lastUsedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetLastUsedAt()).ToDataRes(types.Time)
 	},
@@ -20199,6 +20205,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.environment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetEnvironment()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.lambda.function.environmentSecretLikeKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetEnvironmentSecretLikeKeys()).ToDataRes(types.Array(types.String))
+	},
 	"aws.lambda.function.layers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetLayers()).ToDataRes(types.Array(types.Resource("aws.lambda.function.layer")))
 	},
@@ -21498,6 +21507,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.launchtemplate.userData": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Launchtemplate).GetUserData()).ToDataRes(types.String)
 	},
+	"aws.ec2.launchtemplate.userDataPresent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Launchtemplate).GetUserDataPresent()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.launchtemplate.metadataOptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Launchtemplate).GetMetadataOptions()).ToDataRes(types.Dict)
 	},
@@ -22511,6 +22523,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.ipPermissionsEgress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetIpPermissionsEgress()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup.ippermission")))
+	},
+	"aws.ec2.securitygroup.allowsUnrestrictedEgress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Securitygroup).GetAllowsUnrestrictedEgress()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.securitygroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetRegion()).ToDataRes(types.String)
@@ -36112,6 +36127,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.role.assumeRolePolicyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).AssumeRolePolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.assumableByPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).AssumableByPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.assumableByExternalAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).AssumableByExternalAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.role.lastUsedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55538,6 +55561,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaFunction).Environment, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.function.environmentSecretLikeKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).EnvironmentSecretLikeKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.function.layers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).Layers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -57438,6 +57465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Launchtemplate).UserData, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.launchtemplate.userDataPresent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Launchtemplate).UserDataPresent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.launchtemplate.metadataOptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Launchtemplate).MetadataOptions, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -58908,6 +58939,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.ipPermissionsEgress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Securitygroup).IpPermissionsEgress, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.allowsUnrestrictedEgress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Securitygroup).AllowsUnrestrictedEgress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -82935,24 +82970,26 @@ type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsIamRoleInternal it will be used here
-	Arn                        plugin.TValue[string]
-	Id                         plugin.TValue[string]
-	Name                       plugin.TValue[string]
-	Description                plugin.TValue[string]
-	Tags                       plugin.TValue[map[string]any]
-	CreatedAt                  plugin.TValue[*time.Time]
-	AssumeRolePolicyDocument   plugin.TValue[any]
-	AssumeRolePolicyStatements plugin.TValue[[]any]
-	LastUsedAt                 plugin.TValue[*time.Time]
-	LastUsedRegion             plugin.TValue[string]
-	MaxSessionDuration         plugin.TValue[int64]
-	PermissionsBoundaryArn     plugin.TValue[string]
-	PermissionsBoundary        plugin.TValue[*mqlAwsIamPolicy]
-	UsedByInstances            plugin.TValue[[]any]
-	Path                       plugin.TValue[string]
-	IsServiceLinked            plugin.TValue[bool]
-	AttachedPolicies           plugin.TValue[[]any]
-	InlinePolicies             plugin.TValue[[]any]
+	Arn                         plugin.TValue[string]
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	Description                 plugin.TValue[string]
+	Tags                        plugin.TValue[map[string]any]
+	CreatedAt                   plugin.TValue[*time.Time]
+	AssumeRolePolicyDocument    plugin.TValue[any]
+	AssumeRolePolicyStatements  plugin.TValue[[]any]
+	AssumableByPublic           plugin.TValue[bool]
+	AssumableByExternalAccounts plugin.TValue[[]any]
+	LastUsedAt                  plugin.TValue[*time.Time]
+	LastUsedRegion              plugin.TValue[string]
+	MaxSessionDuration          plugin.TValue[int64]
+	PermissionsBoundaryArn      plugin.TValue[string]
+	PermissionsBoundary         plugin.TValue[*mqlAwsIamPolicy]
+	UsedByInstances             plugin.TValue[[]any]
+	Path                        plugin.TValue[string]
+	IsServiceLinked             plugin.TValue[bool]
+	AttachedPolicies            plugin.TValue[[]any]
+	InlinePolicies              plugin.TValue[[]any]
 }
 
 // createAwsIamRole creates a new instance of this resource
@@ -83033,6 +83070,18 @@ func (c *mqlAwsIamRole) GetAssumeRolePolicyStatements() *plugin.TValue[[]any] {
 		}
 
 		return c.assumeRolePolicyStatements()
+	})
+}
+
+func (c *mqlAwsIamRole) GetAssumableByPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AssumableByPublic, func() (bool, error) {
+		return c.assumableByPublic()
+	})
+}
+
+func (c *mqlAwsIamRole) GetAssumableByExternalAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AssumableByExternalAccounts, func() ([]any, error) {
+		return c.assumableByExternalAccounts()
 	})
 }
 
@@ -133344,6 +133393,7 @@ type mqlAwsLambdaFunction struct {
 	KmsKeyArn                     plugin.TValue[string]
 	KmsKey                        plugin.TValue[*mqlAwsKmsKey]
 	Environment                   plugin.TValue[map[string]any]
+	EnvironmentSecretLikeKeys     plugin.TValue[[]any]
 	Layers                        plugin.TValue[[]any]
 	LoggingConfig                 plugin.TValue[*mqlAwsLambdaFunctionLoggingConfig]
 	SnapStartApplyOn              plugin.TValue[string]
@@ -133637,6 +133687,12 @@ func (c *mqlAwsLambdaFunction) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
 
 func (c *mqlAwsLambdaFunction) GetEnvironment() *plugin.TValue[map[string]any] {
 	return &c.Environment
+}
+
+func (c *mqlAwsLambdaFunction) GetEnvironmentSecretLikeKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EnvironmentSecretLikeKeys, func() ([]any, error) {
+		return c.environmentSecretLikeKeys()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetLayers() *plugin.TValue[[]any] {
@@ -138380,6 +138436,7 @@ type mqlAwsEc2Launchtemplate struct {
 	LatestVersion      plugin.TValue[int64]
 	Tags               plugin.TValue[map[string]any]
 	UserData           plugin.TValue[string]
+	UserDataPresent    plugin.TValue[bool]
 	MetadataOptions    plugin.TValue[any]
 	SecurityGroupIds   plugin.TValue[[]any]
 	IamInstanceProfile plugin.TValue[string]
@@ -138463,6 +138520,12 @@ func (c *mqlAwsEc2Launchtemplate) GetTags() *plugin.TValue[map[string]any] {
 func (c *mqlAwsEc2Launchtemplate) GetUserData() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.UserData, func() (string, error) {
 		return c.userData()
+	})
+}
+
+func (c *mqlAwsEc2Launchtemplate) GetUserDataPresent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UserDataPresent, func() (bool, error) {
+		return c.userDataPresent()
 	})
 }
 
@@ -141801,6 +141864,7 @@ type mqlAwsEc2Securitygroup struct {
 	Vpc                          plugin.TValue[*mqlAwsVpc]
 	IpPermissions                plugin.TValue[[]any]
 	IpPermissionsEgress          plugin.TValue[[]any]
+	AllowsUnrestrictedEgress     plugin.TValue[bool]
 	Region                       plugin.TValue[string]
 	IsAttachedToNetworkInterface plugin.TValue[bool]
 	NetworkInterfaces            plugin.TValue[[]any]
@@ -141911,6 +141975,12 @@ func (c *mqlAwsEc2Securitygroup) GetIpPermissionsEgress() *plugin.TValue[[]any] 
 		}
 
 		return c.ipPermissionsEgress()
+	})
+}
+
+func (c *mqlAwsEc2Securitygroup) GetAllowsUnrestrictedEgress() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsUnrestrictedEgress, func() (bool, error) {
+		return c.allowsUnrestrictedEgress()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3182,6 +3182,7 @@ aws.ec2.launchtemplate.region 13.5.0
 aws.ec2.launchtemplate.securityGroupIds 13.6.3
 aws.ec2.launchtemplate.tags 13.5.0
 aws.ec2.launchtemplate.userData 13.5.0
+aws.ec2.launchtemplate.userDataPresent 13.37.1
 aws.ec2.managedPrefixList 13.6.3
 aws.ec2.managedPrefixList.addressFamily 13.6.3
 aws.ec2.managedPrefixList.arn 13.6.3
@@ -3265,6 +3266,7 @@ aws.ec2.placementGroup.tags 13.6.3
 aws.ec2.placementGroups 13.6.3
 aws.ec2.securityGroups 11.15.2
 aws.ec2.securitygroup 11.15.2
+aws.ec2.securitygroup.allowsUnrestrictedEgress 13.37.1
 aws.ec2.securitygroup.arn 11.15.2
 aws.ec2.securitygroup.cloudformationStack 13.37.1
 aws.ec2.securitygroup.description 11.15.2
@@ -5296,6 +5298,8 @@ aws.iam.policyversion.statements 13.32.2
 aws.iam.policyversion.versionId 11.15.2
 aws.iam.role 11.15.2
 aws.iam.role.arn 11.15.2
+aws.iam.role.assumableByExternalAccounts 13.37.1
+aws.iam.role.assumableByPublic 13.37.1
 aws.iam.role.assumeRolePolicyDocument 11.15.2
 aws.iam.role.assumeRolePolicyStatements 13.32.2
 aws.iam.role.attachedPolicies 13.6.3
@@ -5866,6 +5870,7 @@ aws.lambda.function.concurrency 11.15.2
 aws.lambda.function.description 11.15.2
 aws.lambda.function.dlqTargetArn 11.15.2
 aws.lambda.function.environment 11.15.2
+aws.lambda.function.environmentSecretLikeKeys 13.37.1
 aws.lambda.function.ephemeralStorageSize 11.15.2
 aws.lambda.function.eventInvokeConfig 13.6.3
 aws.lambda.function.eventSourceMappings 11.15.2

--- a/providers/aws/resources/aws_exposure_predicates.go
+++ b/providers/aws/resources/aws_exposure_predicates.go
@@ -1,0 +1,180 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sort"
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// --- IAM role trust exposure ---
+
+// assumableByPublic reports whether the role's trust policy lets any principal
+// ("*") assume it without a source-scoping condition. Reuses statementsAllowPublic
+// so trust-policy "public" matches the resource-policy definition.
+func (a *mqlAwsIamRole) assumableByPublic() (bool, error) {
+	stmts := a.GetAssumeRolePolicyStatements()
+	if stmts.Error != nil {
+		return false, stmts.Error
+	}
+	return statementsAllowPublic(stmts.Data)
+}
+
+// assumableByExternalAccounts returns the AWS account IDs outside this account
+// that the trust policy allows to assume the role.
+func (a *mqlAwsIamRole) assumableByExternalAccounts() ([]any, error) {
+	stmts := a.GetAssumeRolePolicyStatements()
+	if stmts.Error != nil {
+		return nil, stmts.Error
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	ownAccount := conn.AccountId()
+
+	accounts := map[string]struct{}{}
+	for _, s := range stmts.Data {
+		stmt, ok := s.(*mqlAwsIamPolicyStatement)
+		if !ok {
+			continue
+		}
+		effect := stmt.GetEffect()
+		if effect.Error != nil {
+			return nil, effect.Error
+		}
+		if !strings.EqualFold(effect.Data, "Allow") {
+			continue
+		}
+		principals := stmt.GetPrincipals()
+		if principals.Error != nil {
+			return nil, principals.Error
+		}
+		for _, v := range principals.Data {
+			vals, ok := v.([]any)
+			if !ok {
+				continue
+			}
+			for _, item := range vals {
+				p, ok := item.(string)
+				if !ok {
+					continue
+				}
+				if acct := accountIdFromPrincipal(p); acct != "" && acct != ownAccount {
+					accounts[acct] = struct{}{}
+				}
+			}
+		}
+	}
+
+	res := make([]any, 0, len(accounts))
+	for acct := range accounts {
+		res = append(res, acct)
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].(string) < res[j].(string) })
+	return res, nil
+}
+
+// accountIdFromPrincipal extracts the 12-digit AWS account ID from a trust
+// policy principal value, which may be a bare account ID or an IAM ARN such as
+// arn:aws:iam::123456789012:root. Returns "" for the "*" wildcard and for
+// service principals (e.g. ec2.amazonaws.com).
+func accountIdFromPrincipal(principal string) string {
+	if principal == "" || principal == "*" {
+		return ""
+	}
+	if isAwsAccountId(principal) {
+		return principal
+	}
+	if strings.HasPrefix(principal, "arn:") {
+		parts := strings.Split(principal, ":")
+		if len(parts) >= 5 && isAwsAccountId(parts[4]) {
+			return parts[4]
+		}
+	}
+	return ""
+}
+
+func isAwsAccountId(s string) bool {
+	if len(s) != 12 {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Egress exposure ---
+
+// allowsUnrestrictedEgress reports whether any egress rule permits outbound
+// traffic to the public internet (0.0.0.0/0 or ::/0, including via a managed
+// prefix list). Reuses includesPublicSource, where the rule's CIDRs are the
+// destination.
+func (a *mqlAwsEc2Securitygroup) allowsUnrestrictedEgress() (bool, error) {
+	perms := a.GetIpPermissionsEgress()
+	if perms.Error != nil {
+		return false, perms.Error
+	}
+	for _, p := range perms.Data {
+		perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+		if !ok {
+			continue
+		}
+		public := perm.GetIncludesPublicSource()
+		if public.Error != nil {
+			return false, public.Error
+		}
+		if public.Data {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// --- Embedded-config exposure ---
+
+func (a *mqlAwsEc2Launchtemplate) userDataPresent() (bool, error) {
+	userData := a.GetUserData()
+	if userData.Error != nil {
+		return false, userData.Error
+	}
+	return strings.TrimSpace(userData.Data) != "", nil
+}
+
+// environmentSecretLikeKeys returns the function's environment variable names
+// whose names suggest an inline credential rather than benign configuration.
+func (a *mqlAwsLambdaFunction) environmentSecretLikeKeys() ([]any, error) {
+	env := a.GetEnvironment()
+	if env.Error != nil {
+		return nil, env.Error
+	}
+	res := []any{}
+	for key := range env.Data {
+		if looksLikeSecretKey(key) {
+			res = append(res, key)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].(string) < res[j].(string) })
+	return res, nil
+}
+
+// looksLikeSecretKey reports whether an environment variable name suggests it
+// holds a credential. It matches on substrings specific enough to avoid benign
+// names like KMS_KEY_ID (it does not match a bare "key").
+func looksLikeSecretKey(key string) bool {
+	k := strings.ToLower(key)
+	for _, marker := range []string{
+		"password", "passwd", "pwd",
+		"secret", "token", "credential",
+		"apikey", "api_key", "accesskey", "access_key",
+		"private_key", "privatekey",
+	} {
+		if strings.Contains(k, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/aws/resources/aws_exposure_predicates_test.go
+++ b/providers/aws/resources/aws_exposure_predicates_test.go
@@ -1,0 +1,37 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountIdFromPrincipal(t *testing.T) {
+	assert.Equal(t, "123456789012", accountIdFromPrincipal("123456789012"))
+	assert.Equal(t, "123456789012", accountIdFromPrincipal("arn:aws:iam::123456789012:root"))
+	assert.Equal(t, "123456789012", accountIdFromPrincipal("arn:aws:iam::123456789012:role/Example"))
+	assert.Equal(t, "", accountIdFromPrincipal("*"))
+	assert.Equal(t, "", accountIdFromPrincipal("ec2.amazonaws.com"))
+	assert.Equal(t, "", accountIdFromPrincipal(""))
+	assert.Equal(t, "", accountIdFromPrincipal("arn:aws:iam::aws:policy/Foo")) // "aws" is not an account id
+}
+
+func TestIsAwsAccountId(t *testing.T) {
+	assert.True(t, isAwsAccountId("123456789012"))
+	assert.False(t, isAwsAccountId("12345678901"))   // 11 digits
+	assert.False(t, isAwsAccountId("1234567890123")) // 13 digits
+	assert.False(t, isAwsAccountId("12345678901a"))
+	assert.False(t, isAwsAccountId(""))
+}
+
+func TestLooksLikeSecretKey(t *testing.T) {
+	for _, k := range []string{"DB_PASSWORD", "API_TOKEN", "MY_SECRET", "aws_access_key_id", "ApiKey", "PRIVATE_KEY", "passwd"} {
+		assert.True(t, looksLikeSecretKey(k), k)
+	}
+	for _, k := range []string{"KMS_KEY_ID", "REGION", "LOG_LEVEL", "BUCKET_NAME", "KEY_NAME"} {
+		assert.False(t, looksLikeSecretKey(k), k)
+	}
+}


### PR DESCRIPTION
Three more exposure dimensions in one PR, each a pure synthesis of data already in the schema.

## Trust-relationship exposure — roles assumable from outside
- **`aws.iam.role.assumableByPublic`** — the trust policy allows `"*"` without a scoping condition (reuses `statementsAllowPublic`).
- **`aws.iam.role.assumableByExternalAccounts`** — account IDs outside this account that the trust policy lets assume the role.

Covers a top exposure vector (cross-account assumption / confused-deputy) we hadn't modeled.

## Egress exposure — the exfiltration direction
- **`aws.ec2.securitygroup.allowsUnrestrictedEgress`** — an egress rule permits outbound to `0.0.0.0/0`/`::/0` (reuses the CIDR/prefix-list-aware `includesPublicSource`). We'd only modeled ingress before.

## Embedded-config exposure
- **`aws.ec2.launchtemplate.userDataPresent`** — a launch script is set (may embed secrets).
- **`aws.lambda.function.environmentSecretLikeKeys`** — env var names that look like inline credentials (`password`, `token`, `secret`, `access_key`, …; specific enough to skip benign names like `KMS_KEY_ID`).

## Notes
- Pure helpers (`accountIdFromPrincipal`, `isAwsAccountId`, `looksLikeSecretKey`) with table-driven tests.
- Reads cached data — **no new API calls or permissions** (912, unchanged). Versions `13.37.1`.

## Verification
Live: the `CnspecCrossAccountScan` role is reported `assumableByPublic=false` with external account `921877552404` listed; a security group with open egress is flagged by `allowsUnrestrictedEgress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)