### PR TITLE
⭐ aws: shared network.exposure sub-resource for RDS, DocumentDB, and ELB

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5293,6 +5293,8 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   availabilityZones []string
   // VPC security groups for the load balancer
   securityGroups []aws.ec2.securitygroup
+  // Internet-exposure breakdown (internet-facing scheme combined with security group ingress)
+  exposure() aws.network.exposure
   // ID of the Amazon Route 53 hosted zone associated with the load balancer
   hostedZoneId string
   // Region where the load balancer exists
@@ -5317,6 +5319,24 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   attribute() aws.elb.loadbalancer.attribute
   // Health check configuration (classic load balancers only; null for ALB/NLB)
   healthCheck dict
+}
+
+// Network internet-exposure breakdown
+//
+// Explains whether a network-attached resource (database, load balancer, and
+// similar) is reachable from the internet: whether it is configured for public
+// access and whether an attached security group opens it to the internet, with
+// the specific ingress rules. Shared by resources whose exposure follows the
+// public-toggle-plus-security-group model.
+private aws.network.exposure @defaults("internetReachable publiclyAccessible") {
+  // Whether the resource is reachable from the internet (configured for public access and an attached security group permits public ingress)
+  internetReachable bool
+  // Whether the resource is configured for public access (a publicly-accessible flag or an internet-facing scheme)
+  publiclyAccessible bool
+  // Whether an attached security group permits inbound traffic from the internet
+  securityGroupAllowsIngress bool
+  // Security group ingress rules that open the resource to the internet, including their port ranges
+  openIngressRules []aws.ec2.securitygroup.ippermission
 }
 
 // AWS ELB listener
@@ -11610,8 +11630,8 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   availabilityZone string
   // Whether the instance is publicly accessible
   publiclyAccessible bool
-  // Whether the database is reachable from the internet (publicly accessible with a security group open to 0.0.0.0/0 or ::/0)
-  internetReachable() bool
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // List of log types the instance is configured to export to CloudWatch logs
   enabledCloudwatchLogsExports []string
   // Whether deletion protection is enabled
@@ -17429,6 +17449,8 @@ private aws.documentdb.instance @defaults("arn name status") {
   caCertificateValidTill time
   // Whether the instance is publicly accessible
   publiclyAccessible bool
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // Whether tags are copied from the instance to snapshots
   copyTagsToSnapshot bool
   // Latest time to which a database can be restored using point-in-time restore

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -219,6 +219,7 @@ const (
 	ResourceAwsElbTargetgroup                                                   string = "aws.elb.targetgroup"
 	ResourceAwsElbTargetgroupAttributes                                         string = "aws.elb.targetgroup.attributes"
 	ResourceAwsElbLoadbalancer                                                  string = "aws.elb.loadbalancer"
+	ResourceAwsNetworkExposure                                                  string = "aws.network.exposure"
 	ResourceAwsElbListener                                                      string = "aws.elb.listener"
 	ResourceAwsElbLoadbalancerAttribute                                         string = "aws.elb.loadbalancer.attribute"
 	ResourceAwsCodebuild                                                        string = "aws.codebuild"
@@ -1733,6 +1734,10 @@ func init() {
 		"aws.elb.loadbalancer": {
 			Init:   initAwsElbLoadbalancer,
 			Create: createAwsElbLoadbalancer,
+		},
+		"aws.network.exposure": {
+			// to override args, implement: initAwsNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsNetworkExposure,
 		},
 		"aws.elb.listener": {
 			// to override args, implement: initAwsElbListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -10680,6 +10685,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.elb.loadbalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetHostedZoneId()).ToDataRes(types.String)
 	},
@@ -10715,6 +10723,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.loadbalancer.healthCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetHealthCheck()).ToDataRes(types.Dict)
+	},
+	"aws.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"aws.network.exposure.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkExposure).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"aws.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup.ippermission")))
 	},
 	"aws.elb.listener.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListener).GetArn()).ToDataRes(types.String)
@@ -17370,8 +17390,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbinstance.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetPubliclyAccessible()).ToDataRes(types.Bool)
 	},
-	"aws.rds.dbinstance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsRdsDbinstance).GetInternetReachable()).ToDataRes(types.Bool)
+	"aws.rds.dbinstance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.rds.dbinstance.enabledCloudwatchLogsExports": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetEnabledCloudwatchLogsExports()).ToDataRes(types.Array(types.String))
@@ -24017,6 +24037,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.documentdb.instance.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbInstance).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.documentdb.instance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbInstance).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.documentdb.instance.copyTagsToSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbInstance).GetCopyTagsToSnapshot()).ToDataRes(types.Bool)
@@ -41601,6 +41624,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElbLoadbalancer).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elb.loadbalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).HostedZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -41647,6 +41674,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.loadbalancer.healthCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).HealthCheck, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.network.exposure.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkExposure).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.elb.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51481,8 +51528,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbinstance).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"aws.rds.dbinstance.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsRdsDbinstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"aws.rds.dbinstance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.enabledCloudwatchLogsExports": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -61075,6 +61122,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.documentdb.instance.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDocumentdbInstance).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.instance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbInstance).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.documentdb.instance.copyTagsToSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -97543,6 +97594,7 @@ type mqlAwsElbLoadbalancer struct {
 	CreatedAt            plugin.TValue[*time.Time]
 	AvailabilityZones    plugin.TValue[[]any]
 	SecurityGroups       plugin.TValue[[]any]
+	Exposure             plugin.TValue[*mqlAwsNetworkExposure]
 	HostedZoneId         plugin.TValue[string]
 	Region               plugin.TValue[string]
 	ElbType              plugin.TValue[string]
@@ -97632,6 +97684,22 @@ func (c *mqlAwsElbLoadbalancer) GetAvailabilityZones() *plugin.TValue[[]any] {
 
 func (c *mqlAwsElbLoadbalancer) GetSecurityGroups() *plugin.TValue[[]any] {
 	return &c.SecurityGroups
+}
+
+func (c *mqlAwsElbLoadbalancer) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elb.loadbalancer", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
 }
 
 func (c *mqlAwsElbLoadbalancer) GetHostedZoneId() *plugin.TValue[string] {
@@ -97732,6 +97800,65 @@ func (c *mqlAwsElbLoadbalancer) GetAttribute() *plugin.TValue[*mqlAwsElbLoadbala
 
 func (c *mqlAwsElbLoadbalancer) GetHealthCheck() *plugin.TValue[any] {
 	return &c.HealthCheck
+}
+
+// mqlAwsNetworkExposure for the aws.network.exposure resource
+type mqlAwsNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsNetworkExposureInternal it will be used here
+	InternetReachable          plugin.TValue[bool]
+	PubliclyAccessible         plugin.TValue[bool]
+	SecurityGroupAllowsIngress plugin.TValue[bool]
+	OpenIngressRules           plugin.TValue[[]any]
+}
+
+// createAwsNetworkExposure creates a new instance of this resource
+func createAwsNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsNetworkExposure) MqlName() string {
+	return "aws.network.exposure"
+}
+
+func (c *mqlAwsNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlAwsNetworkExposure) GetPubliclyAccessible() *plugin.TValue[bool] {
+	return &c.PubliclyAccessible
+}
+
+func (c *mqlAwsNetworkExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
+	return &c.SecurityGroupAllowsIngress
+}
+
+func (c *mqlAwsNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
 }
 
 // mqlAwsElbListener for the aws.elb.listener resource
@@ -123802,7 +123929,7 @@ type mqlAwsRdsDbinstance struct {
 	Region                             plugin.TValue[string]
 	AvailabilityZone                   plugin.TValue[string]
 	PubliclyAccessible                 plugin.TValue[bool]
-	InternetReachable                  plugin.TValue[bool]
+	Exposure                           plugin.TValue[*mqlAwsNetworkExposure]
 	EnabledCloudwatchLogsExports       plugin.TValue[[]any]
 	DeletionProtection                 plugin.TValue[bool]
 	MultiAZ                            plugin.TValue[bool]
@@ -123961,9 +124088,19 @@ func (c *mqlAwsRdsDbinstance) GetPubliclyAccessible() *plugin.TValue[bool] {
 	return &c.PubliclyAccessible
 }
 
-func (c *mqlAwsRdsDbinstance) GetInternetReachable() *plugin.TValue[bool] {
-	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
-		return c.internetReachable()
+func (c *mqlAwsRdsDbinstance) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -147022,6 +147159,7 @@ type mqlAwsDocumentdbInstance struct {
 	CaCertificateDetailsCAIdentifier plugin.TValue[string]
 	CaCertificateValidTill           plugin.TValue[*time.Time]
 	PubliclyAccessible               plugin.TValue[bool]
+	Exposure                         plugin.TValue[*mqlAwsNetworkExposure]
 	CopyTagsToSnapshot               plugin.TValue[bool]
 	LatestRestorableTime             plugin.TValue[*time.Time]
 	PerformanceInsightsEnabled       plugin.TValue[bool]
@@ -147204,6 +147342,22 @@ func (c *mqlAwsDocumentdbInstance) GetCaCertificateValidTill() *plugin.TValue[*t
 
 func (c *mqlAwsDocumentdbInstance) GetPubliclyAccessible() *plugin.TValue[bool] {
 	return &c.PubliclyAccessible
+}
+
+func (c *mqlAwsDocumentdbInstance) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.documentdb.instance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
 }
 
 func (c *mqlAwsDocumentdbInstance) GetCopyTagsToSnapshot() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2533,6 +2533,7 @@ aws.documentdb.instance.endpointHostedZoneId 13.19.1
 aws.documentdb.instance.endpointPort 13.19.1
 aws.documentdb.instance.engine 11.16.1
 aws.documentdb.instance.engineVersion 11.16.1
+aws.documentdb.instance.exposure 13.37.1
 aws.documentdb.instance.instanceClass 11.16.1
 aws.documentdb.instance.isClusterWriter 13.19.1
 aws.documentdb.instance.kmsKey 11.16.1
@@ -4238,6 +4239,7 @@ aws.elb.loadbalancer.createdAt 11.15.2
 aws.elb.loadbalancer.dnsName 11.15.2
 aws.elb.loadbalancer.elbType 11.15.2
 aws.elb.loadbalancer.enforcesTls 13.37.1
+aws.elb.loadbalancer.exposure 13.37.1
 aws.elb.loadbalancer.healthCheck 13.26.2
 aws.elb.loadbalancer.hostedZoneId 11.15.2
 aws.elb.loadbalancer.instances 11.15.2
@@ -6735,6 +6737,11 @@ aws.neptuneAnalytics.graph.statusReason 13.18.1
 aws.neptuneAnalytics.graph.tags 13.18.1
 aws.neptuneAnalytics.graph.vectorSearchDimension 13.18.1
 aws.neptuneAnalytics.graphs 13.18.1
+aws.network.exposure 13.37.1
+aws.network.exposure.internetReachable 13.37.1
+aws.network.exposure.openIngressRules 13.37.1
+aws.network.exposure.publiclyAccessible 13.37.1
+aws.network.exposure.securityGroupAllowsIngress 13.37.1
 aws.networkfirewall 11.16.1
 aws.networkfirewall.firewall 11.16.1
 aws.networkfirewall.firewall.arn 11.16.1
@@ -7149,9 +7156,9 @@ aws.rds.dbinstance.engine 11.15.2
 aws.rds.dbinstance.engineLifecycleSupport 11.15.2
 aws.rds.dbinstance.engineVersion 11.15.2
 aws.rds.dbinstance.enhancedMonitoringResourceArn 11.15.2
+aws.rds.dbinstance.exposure 13.37.1
 aws.rds.dbinstance.iamDatabaseAuthentication 11.15.2
 aws.rds.dbinstance.id 11.15.2
-aws.rds.dbinstance.internetReachable 13.37.1
 aws.rds.dbinstance.kmsKey 11.15.2
 aws.rds.dbinstance.latestRestorableTime 11.15.2
 aws.rds.dbinstance.licenseModel 11.15.2

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3858,36 +3858,14 @@ func (a *mqlAwsEc2Securitygroup) instances() ([]any, error) {
 }
 
 // securityGroupsAllowPublicIngress reports whether any of the given security
-// groups permits inbound traffic from 0.0.0.0/0 or ::/0. It is shared by the
-// resource-level internetReachable fields that gate on network reachability.
+// groups permits inbound traffic from 0.0.0.0/0 or ::/0. It shares the traversal
+// with openIngressRulesFromSecurityGroups so the two cannot diverge.
 func securityGroupsAllowPublicIngress(sgs *plugin.TValue[[]any]) (bool, error) {
-	if sgs.Error != nil {
-		return false, sgs.Error
+	rules, err := openIngressRulesFromSecurityGroups(sgs)
+	if err != nil {
+		return false, err
 	}
-	for _, s := range sgs.Data {
-		sg, ok := s.(*mqlAwsEc2Securitygroup)
-		if !ok {
-			continue
-		}
-		perms := sg.GetIpPermissions()
-		if perms.Error != nil {
-			return false, perms.Error
-		}
-		for _, p := range perms.Data {
-			perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
-			if !ok {
-				continue
-			}
-			public := perm.GetIncludesPublicSource()
-			if public.Error != nil {
-				return false, public.Error
-			}
-			if public.Data {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
+	return len(rules) > 0, nil
 }
 
 // subnet returns the subnet of the instance's primary network interface, which

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -67,25 +67,37 @@ func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible
 }
 
 func (a *mqlAwsRdsDbinstance) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
 	publiclyAccessible := a.GetPubliclyAccessible()
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsDocumentdbInstance) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
 	publiclyAccessible := a.GetPubliclyAccessible()
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsElbLoadbalancer) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
 	scheme := a.GetScheme()
 	if scheme.Error != nil {
 		return nil, scheme.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", scheme.Data == "internet-facing", a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", scheme.Data == "internet-facing", a.GetSecurityGroups())
 }

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// openIngressRulesFromSecurityGroups returns the ingress rules across the given
+// security groups that permit inbound traffic from the internet.
+func openIngressRulesFromSecurityGroups(sgs *plugin.TValue[[]any]) ([]any, error) {
+	if sgs.Error != nil {
+		return nil, sgs.Error
+	}
+	rules := []any{}
+	for _, s := range sgs.Data {
+		sg, ok := s.(*mqlAwsEc2Securitygroup)
+		if !ok {
+			continue
+		}
+		perms := sg.GetIpPermissions()
+		if perms.Error != nil {
+			return nil, perms.Error
+		}
+		for _, p := range perms.Data {
+			perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+			if !ok {
+				continue
+			}
+			public := perm.GetIncludesPublicSource()
+			if public.Error != nil {
+				return nil, public.Error
+			}
+			if public.Data {
+				rules = append(rules, perm)
+			}
+		}
+	}
+	return rules, nil
+}
+
+// buildNetworkExposure creates a shared aws.network.exposure from a resource's
+// public-access toggle and its attached security groups. internetReachable is
+// true only when the resource is publicly accessible and a security group opens
+// it.
+func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible bool, sgs *plugin.TValue[[]any]) (*mqlAwsNetworkExposure, error) {
+	openRules, err := openIngressRulesFromSecurityGroups(sgs)
+	if err != nil {
+		return nil, err
+	}
+	sgAllows := len(openRules) > 0
+
+	res, err := CreateResource(runtime, "aws.network.exposure", map[string]*llx.RawData{
+		"__id":                       llx.StringData(id),
+		"internetReachable":          llx.BoolData(publiclyAccessible && sgAllows),
+		"publiclyAccessible":         llx.BoolData(publiclyAccessible),
+		"securityGroupAllowsIngress": llx.BoolData(sgAllows),
+		"openIngressRules":           llx.ArrayData(openRules, types.Resource("aws.ec2.securitygroup.ippermission")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsNetworkExposure), nil
+}
+
+func (a *mqlAwsRdsDbinstance) exposure() (*mqlAwsNetworkExposure, error) {
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsDocumentdbInstance) exposure() (*mqlAwsNetworkExposure, error) {
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsElbLoadbalancer) exposure() (*mqlAwsNetworkExposure, error) {
+	scheme := a.GetScheme()
+	if scheme.Error != nil {
+		return nil, scheme.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, a.Arn.Data+"/exposure", scheme.Data == "internet-facing", a.GetSecurityGroups())
+}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -1940,17 +1940,3 @@ func (a *mqlAwsRdsDbcluster) globalCluster() (*mqlAwsRdsGlobalCluster, error) {
 	}
 	return newMqlAwsRdsGlobalCluster(a.MqlRuntime, resp.GlobalClusters[0])
 }
-
-// internetReachable reports whether the database is reachable from the internet:
-// it is publicly accessible (AWS assigns it a public endpoint) and an attached
-// security group permits inbound traffic from 0.0.0.0/0 or ::/0.
-func (a *mqlAwsRdsDbinstance) internetReachable() (bool, error) {
-	public := a.GetPubliclyAccessible()
-	if public.Error != nil {
-		return false, public.Error
-	}
-	if !public.Data {
-		return false, nil
-	}
-	return securityGroupsAllowPublicIngress(a.GetSecurityGroups())
-}


### PR DESCRIPTION
Extends the `exposure` breakdown to the other security-group-fronted network resources via a **shared** `aws.network.exposure` sub-resource (companion to #8536's `aws.ec2.instance.exposure`).

## `aws.network.exposure`
| field | meaning |
|---|---|
| `internetReachable` | public toggle **and** a security group permits public ingress |
| `publiclyAccessible` | the resource's public-access flag / internet-facing scheme |
| `securityGroupAllowsIngress` | an attached SG opens it to the internet |
| `openIngressRules` | the SG ingress rules that open it, with port ranges |

Added `exposure()` to:
- `aws.rds.dbinstance`
- `aws.documentdb.instance`
- `aws.elb.loadbalancer` (publiclyAccessible derived from `scheme == "internet-facing"`)

## Removed
- `aws.rds.dbinstance.internetReachable` — the standalone field was never released and is now redundant with `rds.exposure.internetReachable`. Single source of truth.

## Notes
- Reuses the CIDR/prefix-list-aware `includesPublicSource`. Reads cached data — **no new API calls or permissions** (912, unchanged). Versions `13.37.1`.
- Redshift/Neptune were skipped — they expose `publiclyAccessible` but no typed `securityGroups()`, so the SG breakdown can't be built yet.

## Verification
Live: a publicly-accessible RDS instance (`luna-sensitive`) whose security group is closed reports `exposure.internetReachable=false` with `publiclyAccessible=true` — exactly the false-positive distinction the breakdown is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)