### PR TITLE
⭐ aws: link IAM Access Analyzer findings to resources (observed exposure)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1718,6 +1718,8 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   policyStatements() []aws.iam.policyStatement
   // Whether the resource policy grants public access (a wildcard principal with no scoping conditions)
   isPublic() bool
+  // IAM Access Analyzer findings reporting external or public access to this resource
+  externalAccessFindings() []aws.iam.accessAnalyzer.finding
   // Describes the type of key material in the key
   //
   // One of: SYMMETRIC_DEFAULT, RSA_2048, RSA_3072, RSA_4096, ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, ECC_SECG_P256K1, HMAC_224, HMAC_256, HMAC_384, HMAC_512, SM2.
@@ -2233,6 +2235,8 @@ private aws.iam.role @defaults("arn name") {
   attachedPolicies() []aws.iam.policy
   // List of inline policy names embedded in the role
   inlinePolicies() []string
+  // IAM Access Analyzer findings reporting external or public access to this resource
+  externalAccessFindings() []aws.iam.accessAnalyzer.finding
 }
 
 // AWS IAM group
@@ -4667,6 +4671,8 @@ private aws.sns.topic @defaults("arn") {
   policyStatements() []aws.iam.policyStatement
   // Whether the resource policy grants public access (a wildcard principal with no scoping conditions)
   isPublic() bool
+  // IAM Access Analyzer findings reporting external or public access to this resource
+  externalAccessFindings() []aws.iam.accessAnalyzer.finding
   // Whether the topic is a FIFO topic
   fifoTopic() bool
   // Whether content-based deduplication is enabled (FIFO topics only)
@@ -10145,6 +10151,8 @@ private aws.s3.bucket @defaults("name location public") {
   //
   // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the bucket is unmanaged or managed by a tool that leaves no recognizable tag.
   managedBy() string
+  // IAM Access Analyzer findings reporting external or public access to this resource
+  externalAccessFindings() []aws.iam.accessAnalyzer.finding
 }
 
 // Amazon S3 bucket event notification

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6425,6 +6425,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetIsPublic()).ToDataRes(types.Bool)
 	},
+	"aws.kms.key.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
+	},
 	"aws.kms.key.keySpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetKeySpec()).ToDataRes(types.String)
 	},
@@ -6964,6 +6967,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.role.inlinePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetInlinePolicies()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.role.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
 	},
 	"aws.iam.group.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetArn()).ToDataRes(types.String)
@@ -9889,6 +9895,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.sns.topic.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetIsPublic()).ToDataRes(types.Bool)
+	},
+	"aws.sns.topic.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSnsTopic).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
 	},
 	"aws.sns.topic.fifoTopic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetFifoTopic()).ToDataRes(types.Bool)
@@ -15739,6 +15748,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.s3.bucket.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetManagedBy()).ToDataRes(types.String)
+	},
+	"aws.s3.bucket.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
 	},
 	"aws.s3.bucket.eventNotification.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketEventNotification).GetId()).ToDataRes(types.String)
@@ -35424,6 +35436,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKmsKey).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.kms.key.externalAccessFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.kms.key.keySpec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).KeySpec, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -36198,6 +36214,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.role.inlinePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).InlinePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.externalAccessFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.group.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40506,6 +40526,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.sns.topic.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSnsTopic).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.sns.topic.externalAccessFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSnsTopic).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.sns.topic.fifoTopic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49126,6 +49150,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.s3.bucket.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.externalAccessFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.s3.bucket.eventNotification.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -81054,6 +81082,7 @@ type mqlAwsKmsKey struct {
 	Policy                    plugin.TValue[string]
 	PolicyStatements          plugin.TValue[[]any]
 	IsPublic                  plugin.TValue[bool]
+	ExternalAccessFindings    plugin.TValue[[]any]
 	KeySpec                   plugin.TValue[string]
 	KeyUsage                  plugin.TValue[string]
 	MultiRegion               plugin.TValue[bool]
@@ -81224,6 +81253,22 @@ func (c *mqlAwsKmsKey) GetPolicyStatements() *plugin.TValue[[]any] {
 func (c *mqlAwsKmsKey) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetExternalAccessFindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalAccessFindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kms.key", c.__id, "externalAccessFindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.externalAccessFindings()
 	})
 }
 
@@ -83041,6 +83086,7 @@ type mqlAwsIamRole struct {
 	IsServiceLinked             plugin.TValue[bool]
 	AttachedPolicies            plugin.TValue[[]any]
 	InlinePolicies              plugin.TValue[[]any]
+	ExternalAccessFindings      plugin.TValue[[]any]
 }
 
 // createAwsIamRole creates a new instance of this resource
@@ -83211,6 +83257,22 @@ func (c *mqlAwsIamRole) GetAttachedPolicies() *plugin.TValue[[]any] {
 func (c *mqlAwsIamRole) GetInlinePolicies() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.InlinePolicies, func() ([]any, error) {
 		return c.inlinePolicies()
+	})
+}
+
+func (c *mqlAwsIamRole) GetExternalAccessFindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalAccessFindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.role", c.__id, "externalAccessFindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.externalAccessFindings()
 	})
 }
 
@@ -95206,6 +95268,7 @@ type mqlAwsSnsTopic struct {
 	Policy                    plugin.TValue[any]
 	PolicyStatements          plugin.TValue[[]any]
 	IsPublic                  plugin.TValue[bool]
+	ExternalAccessFindings    plugin.TValue[[]any]
 	FifoTopic                 plugin.TValue[bool]
 	ContentBasedDeduplication plugin.TValue[bool]
 	DataProtectionPolicy      plugin.TValue[any]
@@ -95334,6 +95397,22 @@ func (c *mqlAwsSnsTopic) GetPolicyStatements() *plugin.TValue[[]any] {
 func (c *mqlAwsSnsTopic) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
+	})
+}
+
+func (c *mqlAwsSnsTopic) GetExternalAccessFindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalAccessFindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sns.topic", c.__id, "externalAccessFindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.externalAccessFindings()
 	})
 }
 
@@ -117688,6 +117767,7 @@ type mqlAwsS3Bucket struct {
 	AccessPoints                     plugin.TValue[[]any]
 	CloudformationStack              plugin.TValue[*mqlAwsCloudformationStack]
 	ManagedBy                        plugin.TValue[string]
+	ExternalAccessFindings           plugin.TValue[[]any]
 }
 
 // createAwsS3Bucket creates a new instance of this resource
@@ -118098,6 +118178,22 @@ func (c *mqlAwsS3Bucket) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudfor
 func (c *mqlAwsS3Bucket) GetManagedBy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetExternalAccessFindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalAccessFindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket", c.__id, "externalAccessFindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.externalAccessFindings()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5307,6 +5307,7 @@ aws.iam.role.assumeRolePolicyStatements 13.32.2
 aws.iam.role.attachedPolicies 13.6.3
 aws.iam.role.createdAt 11.15.2
 aws.iam.role.description 11.15.2
+aws.iam.role.externalAccessFindings 13.37.1
 aws.iam.role.id 11.15.2
 aws.iam.role.inlinePolicies 13.6.3
 aws.iam.role.isServiceLinked 13.6.3
@@ -5758,6 +5759,7 @@ aws.kms.key.enabled 11.15.2
 aws.kms.key.encryptedVolumes 13.37.1
 aws.kms.key.encryptionAlgorithms 13.12.1
 aws.kms.key.expirationModel 13.12.1
+aws.kms.key.externalAccessFindings 13.37.1
 aws.kms.key.grants 11.15.2
 aws.kms.key.id 11.15.2
 aws.kms.key.isPublic 13.37.1
@@ -7764,6 +7766,7 @@ aws.s3.bucket.eventNotification.topic 13.29.1
 aws.s3.bucket.eventNotification.type 13.29.1
 aws.s3.bucket.eventNotifications 13.29.1
 aws.s3.bucket.exists 11.15.2
+aws.s3.bucket.externalAccessFindings 13.37.1
 aws.s3.bucket.grant 11.15.2
 aws.s3.bucket.grant.grantee 11.15.2
 aws.s3.bucket.grant.id 11.15.2
@@ -9119,6 +9122,7 @@ aws.sns.topic.contentBasedDeduplication 13.12.1
 aws.sns.topic.dataProtectionPolicy 13.12.1
 aws.sns.topic.deliveryPolicy 13.12.1
 aws.sns.topic.displayName 13.12.1
+aws.sns.topic.externalAccessFindings 13.37.1
 aws.sns.topic.fifoTopic 13.12.1
 aws.sns.topic.isPublic 13.37.1
 aws.sns.topic.kmsMasterKey 11.15.2

--- a/providers/aws/resources/aws_observed_exposure.go
+++ b/providers/aws/resources/aws_observed_exposure.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// accessAnalyzerFindingsForArn returns the IAM Access Analyzer findings whose
+// resource is the given ARN — AWS's own determination that a resource is
+// externally or publicly accessible. The account-wide findings list is cached
+// after first use, so this is an in-memory scan per resource. Returns an empty
+// list when Access Analyzer is not enabled (no findings).
+func accessAnalyzerFindingsForArn(runtime *plugin.Runtime, arn string) ([]any, error) {
+	if arn == "" {
+		return []any{}, nil
+	}
+	obj, err := CreateResource(runtime, ResourceAwsIamAccessAnalyzer, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	findings := obj.(*mqlAwsIamAccessAnalyzer).GetFindings()
+	if findings.Error != nil {
+		return nil, findings.Error
+	}
+	res := []any{}
+	for _, f := range findings.Data {
+		finding, ok := f.(*mqlAwsIamAccessAnalyzerFinding)
+		if !ok {
+			continue
+		}
+		resourceArn := finding.GetResourceArn()
+		if resourceArn.Error != nil {
+			return nil, resourceArn.Error
+		}
+		if resourceArn.Data == arn {
+			res = append(res, finding)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAwsS3Bucket) externalAccessFindings() ([]any, error) {
+	return accessAnalyzerFindingsForArn(a.MqlRuntime, a.Arn.Data)
+}
+
+func (a *mqlAwsIamRole) externalAccessFindings() ([]any, error) {
+	return accessAnalyzerFindingsForArn(a.MqlRuntime, a.Arn.Data)
+}
+
+func (a *mqlAwsKmsKey) externalAccessFindings() ([]any, error) {
+	return accessAnalyzerFindingsForArn(a.MqlRuntime, a.Arn.Data)
+}
+
+func (a *mqlAwsSnsTopic) externalAccessFindings() ([]any, error) {
+	return accessAnalyzerFindingsForArn(a.MqlRuntime, a.Arn.Data)
+}


### PR DESCRIPTION
The **observed-exposure** dimension: surface AWS's own external/public-access determination per resource, moving from *"configured to be exposed"* to *"AWS confirms externally accessible."*

## Fields
`externalAccessFindings()` on `aws.s3.bucket`, `aws.iam.role`, `aws.kms.key`, `aws.sns.topic` — each returns the IAM Access Analyzer findings whose `resourceArn` matches the resource.

```
aws.s3.buckets.where(externalAccessFindings != [])
aws.iam.roles.where(externalAccessFindings.any(status == "ACTIVE"))
```

## Notes
- Reuses the existing account-wide `aws.iam.accessAnalyzer.findings()` list (cached), so the per-resource lookup is an in-memory ARN scan. Returns empty when Access Analyzer isn't enabled. **No new API calls or permissions** (912, unchanged). Versions `13.37.1`.

## Follow-up
GuardDuty findings linkage is the natural next step but harder — GuardDuty findings carry `resourceDetails` (a dict) rather than a direct resource ARN, so matching needs per-`resourceType` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)