### PR TITLE
⭐ digitalocean: droplet network-exposure breakdown

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -177,6 +177,8 @@ digitalocean.droplet @defaults("id name status") {
   firewalls() []digitalocean.firewall
   // True when no firewall is attached to the droplet (by id or tag); does not check inbound rule restrictiveness — for that, query `firewalls`
   missingFirewall() bool
+  // Internet-exposure breakdown (public IP combined with firewall ingress)
+  exposure() digitalocean.network.exposure
   // Block storage volumes attached to the droplet
   volumes() []digitalocean.volume
   // Linux kernel the droplet boots (id, name, version); null on droplets using the current external boot loader
@@ -265,6 +267,22 @@ private digitalocean.firewall.ingressRule @defaults("protocol ports openToIntern
   sourceLoadBalancers() []digitalocean.loadBalancer
   // Kubernetes clusters trusted as a traffic source by this rule
   sourceKubernetesClusters() []digitalocean.kubernetes.cluster
+}
+
+// Droplet internet-exposure breakdown
+//
+// Explains whether a droplet is reachable from the internet: whether it has a
+// public IP and whether its firewalls admit inbound traffic from any address —
+// including the case where no firewall is attached, which leaves it fully open.
+private digitalocean.network.exposure @defaults("internetReachable hasPublicIp") {
+  // Whether the droplet is reachable from the internet (a public IP and firewall ingress that admits any address)
+  internetReachable bool
+  // Whether the droplet has a public IPv4 or IPv6 address
+  hasPublicIp bool
+  // Whether inbound traffic from any address is admitted — a firewall ingress rule open to the internet, or no firewall attached at all
+  firewallAllowsIngress bool
+  // Firewall ingress rules that admit traffic from any address
+  openIngressRules []digitalocean.firewall.ingressRule
 }
 
 // Egress rule of a DigitalOcean cloud firewall

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -21,6 +21,7 @@ const (
 	ResourceDigitaloceanDroplet                                         string = "digitalocean.droplet"
 	ResourceDigitaloceanFirewall                                        string = "digitalocean.firewall"
 	ResourceDigitaloceanFirewallIngressRule                             string = "digitalocean.firewall.ingressRule"
+	ResourceDigitaloceanNetworkExposure                                 string = "digitalocean.network.exposure"
 	ResourceDigitaloceanFirewallEgressRule                              string = "digitalocean.firewall.egressRule"
 	ResourceDigitaloceanDatabase                                        string = "digitalocean.database"
 	ResourceDigitaloceanDatabaseBackup                                  string = "digitalocean.database.backup"
@@ -106,6 +107,10 @@ func init() {
 		"digitalocean.firewall.ingressRule": {
 			// to override args, implement: initDigitaloceanFirewallIngressRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDigitaloceanFirewallIngressRule,
+		},
+		"digitalocean.network.exposure": {
+			// to override args, implement: initDigitaloceanNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanNetworkExposure,
 		},
 		"digitalocean.firewall.egressRule": {
 			// to override args, implement: initDigitaloceanFirewallEgressRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -613,6 +618,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.droplet.missingFirewall": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetMissingFirewall()).ToDataRes(types.Bool)
 	},
+	"digitalocean.droplet.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetExposure()).ToDataRes(types.Resource("digitalocean.network.exposure"))
+	},
 	"digitalocean.droplet.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetVolumes()).ToDataRes(types.Array(types.Resource("digitalocean.volume")))
 	},
@@ -687,6 +695,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.firewall.ingressRule.sourceKubernetesClusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewallIngressRule).GetSourceKubernetesClusters()).ToDataRes(types.Array(types.Resource("digitalocean.kubernetes.cluster")))
+	},
+	"digitalocean.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"digitalocean.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
+	"digitalocean.network.exposure.firewallAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanNetworkExposure).GetFirewallAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"digitalocean.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("digitalocean.firewall.ingressRule")))
 	},
 	"digitalocean.firewall.egressRule.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewallEgressRule).GetProtocol()).ToDataRes(types.String)
@@ -2991,6 +3011,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDroplet).MissingFirewall, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"digitalocean.droplet.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).Exposure, ok = plugin.RawToTValue[*mqlDigitaloceanNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"digitalocean.droplet.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDroplet).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -3097,6 +3121,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.firewall.ingressRule.sourceKubernetesClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanFirewallIngressRule).SourceKubernetesClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.network.exposure.firewallAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanNetworkExposure).FirewallAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.firewall.egressRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6765,6 +6809,7 @@ type mqlDigitaloceanDroplet struct {
 	BaseImage             plugin.TValue[*mqlDigitaloceanImage]
 	Firewalls             plugin.TValue[[]any]
 	MissingFirewall       plugin.TValue[bool]
+	Exposure              plugin.TValue[*mqlDigitaloceanNetworkExposure]
 	Volumes               plugin.TValue[[]any]
 	Kernel                plugin.TValue[any]
 	NextBackupWindowStart plugin.TValue[*time.Time]
@@ -6937,6 +6982,22 @@ func (c *mqlDigitaloceanDroplet) GetFirewalls() *plugin.TValue[[]any] {
 func (c *mqlDigitaloceanDroplet) GetMissingFirewall() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MissingFirewall, func() (bool, error) {
 		return c.missingFirewall()
+	})
+}
+
+func (c *mqlDigitaloceanDroplet) GetExposure() *plugin.TValue[*mqlDigitaloceanNetworkExposure] {
+	return plugin.GetOrCompute[*mqlDigitaloceanNetworkExposure](&c.Exposure, func() (*mqlDigitaloceanNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.droplet", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -7248,6 +7309,65 @@ func (c *mqlDigitaloceanFirewallIngressRule) GetSourceKubernetesClusters() *plug
 
 		return c.sourceKubernetesClusters()
 	})
+}
+
+// mqlDigitaloceanNetworkExposure for the digitalocean.network.exposure resource
+type mqlDigitaloceanNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDigitaloceanNetworkExposureInternal it will be used here
+	InternetReachable     plugin.TValue[bool]
+	HasPublicIp           plugin.TValue[bool]
+	FirewallAllowsIngress plugin.TValue[bool]
+	OpenIngressRules      plugin.TValue[[]any]
+}
+
+// createDigitaloceanNetworkExposure creates a new instance of this resource
+func createDigitaloceanNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanNetworkExposure) MqlName() string {
+	return "digitalocean.network.exposure"
+}
+
+func (c *mqlDigitaloceanNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlDigitaloceanNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+	return &c.HasPublicIp
+}
+
+func (c *mqlDigitaloceanNetworkExposure) GetFirewallAllowsIngress() *plugin.TValue[bool] {
+	return &c.FirewallAllowsIngress
+}
+
+func (c *mqlDigitaloceanNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
 }
 
 // mqlDigitaloceanFirewallEgressRule for the digitalocean.firewall.egressRule resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -152,6 +152,7 @@ digitalocean.droplet.backupsEnabled 13.0.1
 digitalocean.droplet.baseImage 13.1.7
 digitalocean.droplet.createdAt 13.0.1
 digitalocean.droplet.disk 13.0.1
+digitalocean.droplet.exposure 13.7.1
 digitalocean.droplet.features 13.0.1
 digitalocean.droplet.firewalls 13.0.2
 digitalocean.droplet.id 13.0.1
@@ -603,6 +604,11 @@ digitalocean.loadBalancer.type 13.6.2
 digitalocean.loadBalancer.vpc 13.0.2
 digitalocean.loadBalancer.vpcUuid 13.0.1
 digitalocean.loadBalancers 13.0.1
+digitalocean.network.exposure 13.7.1
+digitalocean.network.exposure.firewallAllowsIngress 13.7.1
+digitalocean.network.exposure.hasPublicIp 13.7.1
+digitalocean.network.exposure.internetReachable 13.7.1
+digitalocean.network.exposure.openIngressRules 13.7.1
 digitalocean.nfs 13.4.2
 digitalocean.nfs.createdAt 13.4.2
 digitalocean.nfs.host 13.4.2

--- a/providers/digitalocean/resources/digitalocean_exposure.go
+++ b/providers/digitalocean/resources/digitalocean_exposure.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// exposure breaks down whether the droplet is reachable from the internet: a
+// public IP combined with firewall ingress that admits any address. A droplet
+// with no firewall attached is fully open, so missingFirewall counts as
+// admitting ingress.
+func (d *mqlDigitaloceanDroplet) exposure() (*mqlDigitaloceanNetworkExposure, error) {
+	id := d.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	ipv4 := d.GetPublicIpv4()
+	if ipv4.Error != nil {
+		return nil, ipv4.Error
+	}
+	ipv6 := d.GetPublicIpv6()
+	if ipv6.Error != nil {
+		return nil, ipv6.Error
+	}
+	hasPublicIp := ipv4.Data != "" || ipv6.Data != ""
+
+	missingFirewall := d.GetMissingFirewall()
+	if missingFirewall.Error != nil {
+		return nil, missingFirewall.Error
+	}
+
+	openRules := []any{}
+	firewalls := d.GetFirewalls()
+	if firewalls.Error != nil {
+		return nil, firewalls.Error
+	}
+	for _, f := range firewalls.Data {
+		fw, ok := f.(*mqlDigitaloceanFirewall)
+		if !ok {
+			continue
+		}
+		rules := fw.GetIngressRules()
+		if rules.Error != nil {
+			return nil, rules.Error
+		}
+		for _, r := range rules.Data {
+			rule, ok := r.(*mqlDigitaloceanFirewallIngressRule)
+			if !ok {
+				continue
+			}
+			open := rule.GetOpenToInternet()
+			if open.Error != nil {
+				return nil, open.Error
+			}
+			if open.Data {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+
+	firewallAllowsIngress := missingFirewall.Data || len(openRules) > 0
+	internetReachable := hasPublicIp && firewallAllowsIngress
+
+	res, err := CreateResource(d.MqlRuntime, "digitalocean.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData(fmt.Sprintf("digitalocean.droplet/%d/exposure", id.Data)),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp),
+		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		"openIngressRules":      llx.ArrayData(openRules, types.Resource("digitalocean.firewall.ingressRule")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDigitaloceanNetworkExposure), nil
+}


### PR DESCRIPTION
First of the cross-provider exposure resources (one PR per provider). Mirrors `aws.network.exposure`.

## `digitalocean.network.exposure`
Added `digitalocean.droplet.exposure` returning:
| field | meaning |
|---|---|
| `internetReachable` | a public IP **and** firewall ingress that admits any address |
| `hasPublicIp` | the droplet has a public IPv4 or IPv6 |
| `firewallAllowsIngress` | a firewall ingress rule is open to the internet, **or no firewall is attached at all** (fully open) |
| `openIngressRules` | the ingress rules that admit traffic from any address |

The DO firewall default (no firewall = fully open) is captured via the existing `missingFirewall` signal, and rule-level internet exposure reuses the existing `firewall.ingressRule.openToInternet`.

## Notes
- Reads cached droplet/firewall data — **no new API calls**. Versions `13.7.1`.
- Verified via build + codegen; mirrors the proven AWS exposure model (no DigitalOcean account available to run live).

## Cross-provider plan
This is the template. Remaining per the request, one PR each: Azure, GCP, Hetzner, StackIT (clean server/firewall/public-IP models). Proxmox and Nutanix are on-prem virtualization where "internet-facing" maps weakly — I'll treat those last and may scope them to firewall-rule exposure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)