### PR TITLE
⭐ hetzner: server network-exposure breakdown

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -97,6 +97,8 @@ private hetzner.server @defaults("id name status") {
   firewalls() []hetzner.firewall
   // Firewalls applied to the server, with per-binding application status (applied, pending)
   firewallBindings() []hetzner.server.firewallBinding
+  // Internet-exposure breakdown (public IP combined with firewall ingress)
+  exposure() hetzner.network.exposure
   // Load balancers attached to the server
   loadBalancers() []hetzner.loadBalancer
   // Backup window (e.g., "22-02"); empty if backups disabled
@@ -147,6 +149,22 @@ private hetzner.server.firewallBinding @defaults("status") {
   firewall() hetzner.firewall
   // Application status (applied, pending)
   status string
+}
+
+// Server internet-exposure breakdown
+//
+// Explains whether a server is reachable from the internet: whether it has a
+// public IP and whether its firewalls admit inbound traffic from any address —
+// including the case where no firewall is attached, which leaves it open.
+private hetzner.network.exposure @defaults("internetReachable hasPublicIp") {
+  // Whether the server is reachable from the internet (a public IP and firewall ingress that admits any address)
+  internetReachable bool
+  // Whether the server has a public IPv4 or IPv6 address
+  hasPublicIp bool
+  // Whether inbound traffic from any address is admitted — a firewall inbound rule open to the internet, or no firewall attached at all
+  firewallAllowsIngress bool
+  // Firewall inbound rules that admit traffic from any address (0.0.0.0/0 or ::/0)
+  openIngressRules []dict
 }
 
 // Hetzner Cloud server type (VM size)

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -20,6 +20,7 @@ const (
 	ResourceHetznerServer                 string = "hetzner.server"
 	ResourceHetznerServerPrivateNet       string = "hetzner.server.privateNet"
 	ResourceHetznerServerFirewallBinding  string = "hetzner.server.firewallBinding"
+	ResourceHetznerNetworkExposure        string = "hetzner.network.exposure"
 	ResourceHetznerServerType             string = "hetzner.serverType"
 	ResourceHetznerServerTypeLocation     string = "hetzner.serverType.location"
 	ResourceHetznerImage                  string = "hetzner.image"
@@ -60,6 +61,10 @@ func init() {
 		"hetzner.server.firewallBinding": {
 			// to override args, implement: initHetznerServerFirewallBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createHetznerServerFirewallBinding,
+		},
+		"hetzner.network.exposure": {
+			// to override args, implement: initHetznerNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createHetznerNetworkExposure,
 		},
 		"hetzner.serverType": {
 			Init:   initHetznerServerType,
@@ -319,6 +324,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.firewallBindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetFirewallBindings()).ToDataRes(types.Array(types.Resource("hetzner.server.firewallBinding")))
 	},
+	"hetzner.server.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetExposure()).ToDataRes(types.Resource("hetzner.network.exposure"))
+	},
 	"hetzner.server.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("hetzner.loadBalancer")))
 	},
@@ -381,6 +389,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.server.firewallBinding.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerFirewallBinding).GetStatus()).ToDataRes(types.String)
+	},
+	"hetzner.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"hetzner.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
+	"hetzner.network.exposure.firewallAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerNetworkExposure).GetFirewallAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"hetzner.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Dict))
 	},
 	"hetzner.serverType.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerType).GetId()).ToDataRes(types.Int)
@@ -1087,6 +1107,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerServer).FirewallBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"hetzner.server.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).Exposure, ok = plugin.RawToTValue[*mqlHetznerNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"hetzner.server.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServer).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1177,6 +1201,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.server.firewallBinding.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServerFirewallBinding).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"hetzner.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"hetzner.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"hetzner.network.exposure.firewallAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetworkExposure).FirewallAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"hetzner.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"hetzner.serverType.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2337,6 +2381,7 @@ type mqlHetznerServer struct {
 	PublicIpv6DnsPtr  plugin.TValue[[]any]
 	Firewalls         plugin.TValue[[]any]
 	FirewallBindings  plugin.TValue[[]any]
+	Exposure          plugin.TValue[*mqlHetznerNetworkExposure]
 	LoadBalancers     plugin.TValue[[]any]
 	BackupWindow      plugin.TValue[string]
 	RescueEnabled     plugin.TValue[bool]
@@ -2603,6 +2648,22 @@ func (c *mqlHetznerServer) GetFirewallBindings() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlHetznerServer) GetExposure() *plugin.TValue[*mqlHetznerNetworkExposure] {
+	return plugin.GetOrCompute[*mqlHetznerNetworkExposure](&c.Exposure, func() (*mqlHetznerNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
+}
+
 func (c *mqlHetznerServer) GetLoadBalancers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -2843,6 +2904,65 @@ func (c *mqlHetznerServerFirewallBinding) GetFirewall() *plugin.TValue[*mqlHetzn
 
 func (c *mqlHetznerServerFirewallBinding) GetStatus() *plugin.TValue[string] {
 	return &c.Status
+}
+
+// mqlHetznerNetworkExposure for the hetzner.network.exposure resource
+type mqlHetznerNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlHetznerNetworkExposureInternal it will be used here
+	InternetReachable     plugin.TValue[bool]
+	HasPublicIp           plugin.TValue[bool]
+	FirewallAllowsIngress plugin.TValue[bool]
+	OpenIngressRules      plugin.TValue[[]any]
+}
+
+// createHetznerNetworkExposure creates a new instance of this resource
+func createHetznerNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlHetznerNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("hetzner.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlHetznerNetworkExposure) MqlName() string {
+	return "hetzner.network.exposure"
+}
+
+func (c *mqlHetznerNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlHetznerNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlHetznerNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+	return &c.HasPublicIp
+}
+
+func (c *mqlHetznerNetworkExposure) GetFirewallAllowsIngress() *plugin.TValue[bool] {
+	return &c.FirewallAllowsIngress
+}
+
+func (c *mqlHetznerNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
 }
 
 // mqlHetznerServerType for the hetzner.serverType resource

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -138,6 +138,11 @@ hetzner.locations 13.0.1
 hetzner.network 13.0.1
 hetzner.network.created 13.0.1
 hetzner.network.exposeRoutesToVswitch 13.0.1
+hetzner.network.exposure 13.3.1
+hetzner.network.exposure.firewallAllowsIngress 13.3.1
+hetzner.network.exposure.hasPublicIp 13.3.1
+hetzner.network.exposure.internetReachable 13.3.1
+hetzner.network.exposure.openIngressRules 13.3.1
 hetzner.network.id 13.0.1
 hetzner.network.ipRange 13.0.1
 hetzner.network.labels 13.0.1
@@ -177,6 +182,7 @@ hetzner.server 13.0.1
 hetzner.server.backupWindow 13.0.1
 hetzner.server.created 13.0.1
 hetzner.server.datacenter 13.0.1
+hetzner.server.exposure 13.3.1
 hetzner.server.firewallBinding 13.1.2
 hetzner.server.firewallBinding.firewall 13.1.2
 hetzner.server.firewallBinding.firewallId 13.1.2

--- a/providers/hetzner/resources/hetzner_exposure.go
+++ b/providers/hetzner/resources/hetzner_exposure.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// firewallRuleOpenToInternet reports whether a Hetzner firewall rule dict is an
+// inbound rule whose source admits any address (0.0.0.0/0 or ::/0).
+func firewallRuleOpenToInternet(rule map[string]any) bool {
+	if direction, _ := rule["direction"].(string); direction != "in" {
+		return false
+	}
+	sources, ok := rule["sourceIps"].([]any)
+	if !ok {
+		return false
+	}
+	for _, s := range sources {
+		if cidr, ok := s.(string); ok && (cidr == "0.0.0.0/0" || cidr == "::/0") {
+			return true
+		}
+	}
+	return false
+}
+
+// exposure breaks down whether the server is reachable from the internet: a
+// public IP combined with firewall ingress that admits any address. A server
+// with no firewall attached is open, so an empty firewall set counts as
+// admitting ingress.
+func (s *mqlHetznerServer) exposure() (*mqlHetznerNetworkExposure, error) {
+	id := s.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	ipv4 := s.GetPublicIpv4()
+	if ipv4.Error != nil {
+		return nil, ipv4.Error
+	}
+	ipv6 := s.GetPublicIpv6()
+	if ipv6.Error != nil {
+		return nil, ipv6.Error
+	}
+	hasPublicIp := ipv4.Data != "" || ipv6.Data != ""
+
+	firewalls := s.GetFirewalls()
+	if firewalls.Error != nil {
+		return nil, firewalls.Error
+	}
+	openRules := []any{}
+	for _, f := range firewalls.Data {
+		fw, ok := f.(*mqlHetznerFirewall)
+		if !ok {
+			continue
+		}
+		rules := fw.GetRules()
+		if rules.Error != nil {
+			return nil, rules.Error
+		}
+		for _, r := range rules.Data {
+			rule, ok := r.(map[string]any)
+			if ok && firewallRuleOpenToInternet(rule) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+
+	firewallAllowsIngress := len(firewalls.Data) == 0 || len(openRules) > 0
+	internetReachable := hasPublicIp && firewallAllowsIngress
+
+	res, err := CreateResource(s.MqlRuntime, "hetzner.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData(fmt.Sprintf("hetzner.server/%d/exposure", id.Data)),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp),
+		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		"openIngressRules":      llx.ArrayData(openRules, types.Dict),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHetznerNetworkExposure), nil
+}

--- a/providers/hetzner/resources/hetzner_exposure_test.go
+++ b/providers/hetzner/resources/hetzner_exposure_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirewallRuleOpenToInternet(t *testing.T) {
+	tests := []struct {
+		name string
+		rule map[string]any
+		want bool
+	}{
+		{"inbound any ipv4", map[string]any{"direction": "in", "sourceIps": []any{"0.0.0.0/0"}}, true},
+		{"inbound any ipv6", map[string]any{"direction": "in", "sourceIps": []any{"::/0"}}, true},
+		{"inbound mixed with any", map[string]any{"direction": "in", "sourceIps": []any{"10.0.0.0/8", "0.0.0.0/0"}}, true},
+		{"inbound scoped source", map[string]any{"direction": "in", "sourceIps": []any{"203.0.113.0/24"}}, false},
+		{"outbound any", map[string]any{"direction": "out", "sourceIps": []any{"0.0.0.0/0"}}, false},
+		{"no sources", map[string]any{"direction": "in"}, false},
+		{"empty", map[string]any{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firewallRuleOpenToInternet(tt.rule))
+		})
+	}
+}


### PR DESCRIPTION
Cross-provider exposure (one PR per provider) — Hetzner. Mirrors `aws.network.exposure` / `digitalocean.network.exposure`.

## `hetzner.network.exposure`
Added `hetzner.server.exposure`:
| field | meaning |
|---|---|
| `internetReachable` | a public IP **and** firewall ingress admitting any address |
| `hasPublicIp` | the server has a public IPv4 or IPv6 |
| `firewallAllowsIngress` | an inbound rule open to `0.0.0.0/0`/`::/0`, **or no firewall attached** (open) |
| `openIngressRules` | the inbound rules that admit any address |

## Tests
Hetzner firewall rules are raw dicts (no typed `openToInternet` like DO), so a pure `firewallRuleOpenToInternet` helper parses `direction` + `sourceIps` — covered by a table-driven unit test (inbound-any v4/v6, mixed, scoped source, outbound, empty).

## Notes
- Reads cached server/firewall data — **no new API calls**. Versions `13.3.1`.
- Verified via build + unit test; no Hetzner account available for live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)