### PR TITLE
⭐ openstack: internet-exposure modeling (servers + Octavia load balancers)

### DIFF
--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -377,6 +377,33 @@ private openstack.compute.server @defaults("id name status") {
   project() openstack.project
   // User that created this server
   user() openstack.user
+  // Neutron ports attached to this server
+  ports() []openstack.port
+  // Floating (public) IPs mapped to this server through its ports; empty when the server has none
+  floatingIps() []openstack.floatingIp
+  // Internet-exposure summary for this server (public reachability plus the security-group rules that open it up)
+  exposure() openstack.compute.server.exposure
+}
+
+// OpenStack Nova compute server internet exposure
+//
+// Summarizes whether a server is reachable from the public internet and, when
+// it is, the security-group rules that open it up. A server is publicly
+// accessible when it has a floating IP or a port on an external network;
+// internetReachable additionally requires a security-group rule permitting
+// ingress from a public source. Inspect openIngressRules for the rules and
+// their port ranges.
+private openstack.compute.server.exposure @defaults("internetReachable publiclyAccessible securityGroupAllowsIngress") {
+  // Whether the server is reachable from the internet (publicly accessible and a security group permits ingress from a public source)
+  internetReachable bool
+  // Whether the server has a public edge: a floating IP, or a port on an external network
+  publiclyAccessible bool
+  // Whether a security group attached to the server permits ingress from a public source
+  securityGroupAllowsIngress bool
+  // Security-group ingress rules that open the server to the internet, including their port ranges
+  openIngressRules []openstack.securityGroup.rule
+  // Floating (public) IPs mapped to the server
+  floatingIps []openstack.floatingIp
 }
 
 // OpenStack Nova flavor (VM size)
@@ -603,6 +630,8 @@ private openstack.port @defaults("id name status macAddress") {
   server() openstack.compute.server
   // Router this port is attached to; null when the port is not a router interface or gateway
   router() openstack.router
+  // Floating (public) IPs bound to this port; empty when none are bound
+  floatingIps() []openstack.floatingIp
 }
 
 // OpenStack Neutron floating IP
@@ -655,6 +684,8 @@ private openstack.securityGroup @defaults("id name") {
   project() openstack.project
   // Embedded rules
   rules []openstack.securityGroup.rule
+  // Whether any ingress rule permits traffic from a public source (a public CIDR or an unscoped any-source rule)
+  allowsPublicIngress() bool
 }
 
 // OpenStack Neutron security group rule
@@ -683,6 +714,10 @@ private openstack.securityGroup.rule @defaults("id direction protocol portRangeM
   securityGroup() openstack.securityGroup
   // Remote security group the rule matches; null when matched by IP prefix instead
   remoteGroup() openstack.securityGroup
+  // Whether the rule's source reaches the public internet
+  //
+  // True when remoteIpPrefix is a public CIDR (a broad block such as 0.0.0.0/0 or ::/0, excluding private and reserved ranges) or when the rule is unscoped (no remote IP prefix and no remote group), which Neutron treats as any source. Direction-agnostic, so it also classifies egress destinations.
+  includesPublicSource() bool
   // Project that owns this security group rule
   project() openstack.project
 }
@@ -976,6 +1011,28 @@ private openstack.octavia.loadBalancer @defaults("id name provisioningStatus ope
   listeners() []openstack.octavia.listener
   // Pools attached to this load balancer
   pools() []openstack.octavia.pool
+  // Whether every listener uses an encrypted protocol (no plaintext HTTP, TCP, UDP, or SCTP listener)
+  enforcesTls() bool
+  // Internet-exposure summary for this load balancer (public reachability plus the listeners open to the world)
+  exposure() openstack.octavia.loadBalancer.exposure
+}
+
+// OpenStack Octavia load balancer internet exposure
+//
+// Summarizes whether a load balancer is reachable from the public internet and,
+// when it is, the listeners that accept traffic from any source. A load balancer
+// is publicly accessible when its VIP sits on an external network or has a
+// floating IP; internetReachable additionally requires at least one listener
+// open to the world (an empty or public allowedCidrs list).
+private openstack.octavia.loadBalancer.exposure @defaults("internetReachable publiclyAccessible") {
+  // Whether the load balancer is reachable from the internet (publicly accessible and at least one listener is open to the world)
+  internetReachable bool
+  // Whether the VIP has a public edge: it sits on an external network, or a floating IP is mapped to it
+  publiclyAccessible bool
+  // Listeners that accept connections from any source (allowedCidrs is empty or contains a public CIDR)
+  listenersOpenToWorld []openstack.octavia.listener
+  // Floating (public) IPs mapped to the VIP port
+  floatingIps []openstack.floatingIp
 }
 
 // OpenStack Octavia listener
@@ -1037,6 +1094,8 @@ private openstack.octavia.listener @defaults("id name protocol protocolPort prov
   clientCRLContainer() openstack.keymanager.container
   // L7 policies attached to this listener
   l7Policies() []openstack.octavia.l7Policy
+  // Whether the listener accepts connections from any source (allowedCidrs is empty or contains a public CIDR)
+  openToWorld() bool
 }
 
 // OpenStack Octavia backend pool

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -1011,7 +1011,9 @@ private openstack.octavia.loadBalancer @defaults("id name provisioningStatus ope
   listeners() []openstack.octavia.listener
   // Pools attached to this load balancer
   pools() []openstack.octavia.pool
-  // Whether every listener uses an encrypted protocol (no plaintext HTTP, TCP, UDP, or SCTP listener)
+  // Whether every listener uses an encrypted protocol
+  //
+  // True when no listener uses a plaintext protocol (HTTP, TCP, UDP, SCTP, or PROMETHEUS). A load balancer with no listeners has no plaintext exposure and is reported as enforcing; pair with `exposure.internetReachable` to scope an audit to internet-facing load balancers.
   enforcesTls() bool
   // Internet-exposure summary for this load balancer (public reachability plus the listeners open to the world)
   exposure() openstack.octavia.loadBalancer.exposure

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -25,6 +25,7 @@ const (
 	ResourceOpenstackIdentityRoleAssignment          string = "openstack.identity.roleAssignment"
 	ResourceOpenstackIdentityRoleInference           string = "openstack.identity.roleInference"
 	ResourceOpenstackComputeServer                   string = "openstack.compute.server"
+	ResourceOpenstackComputeServerExposure           string = "openstack.compute.server.exposure"
 	ResourceOpenstackComputeFlavor                   string = "openstack.compute.flavor"
 	ResourceOpenstackComputeKeypair                  string = "openstack.compute.keypair"
 	ResourceOpenstackComputeServerGroup              string = "openstack.compute.serverGroup"
@@ -42,6 +43,7 @@ const (
 	ResourceOpenstackKeymanagerContainer             string = "openstack.keymanager.container"
 	ResourceOpenstackKeymanagerOrder                 string = "openstack.keymanager.order"
 	ResourceOpenstackOctaviaLoadBalancer             string = "openstack.octavia.loadBalancer"
+	ResourceOpenstackOctaviaLoadBalancerExposure     string = "openstack.octavia.loadBalancer.exposure"
 	ResourceOpenstackOctaviaListener                 string = "openstack.octavia.listener"
 	ResourceOpenstackOctaviaPool                     string = "openstack.octavia.pool"
 	ResourceOpenstackOctaviaMember                   string = "openstack.octavia.member"
@@ -129,6 +131,10 @@ func init() {
 			Init:   initOpenstackComputeServer,
 			Create: createOpenstackComputeServer,
 		},
+		"openstack.compute.server.exposure": {
+			// to override args, implement: initOpenstackComputeServerExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createOpenstackComputeServerExposure,
+		},
 		"openstack.compute.flavor": {
 			Init:   initOpenstackComputeFlavor,
 			Create: createOpenstackComputeFlavor,
@@ -196,6 +202,10 @@ func init() {
 		"openstack.octavia.loadBalancer": {
 			Init:   initOpenstackOctaviaLoadBalancer,
 			Create: createOpenstackOctaviaLoadBalancer,
+		},
+		"openstack.octavia.loadBalancer.exposure": {
+			// to override args, implement: initOpenstackOctaviaLoadBalancerExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createOpenstackOctaviaLoadBalancerExposure,
 		},
 		"openstack.octavia.listener": {
 			Init:   initOpenstackOctaviaListener,
@@ -874,6 +884,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.compute.server.user": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeServer).GetUser()).ToDataRes(types.Resource("openstack.user"))
 	},
+	"openstack.compute.server.ports": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServer).GetPorts()).ToDataRes(types.Array(types.Resource("openstack.port")))
+	},
+	"openstack.compute.server.floatingIps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServer).GetFloatingIps()).ToDataRes(types.Array(types.Resource("openstack.floatingIp")))
+	},
+	"openstack.compute.server.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServer).GetExposure()).ToDataRes(types.Resource("openstack.compute.server.exposure"))
+	},
+	"openstack.compute.server.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServerExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"openstack.compute.server.exposure.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServerExposure).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"openstack.compute.server.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServerExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"openstack.compute.server.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServerExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("openstack.securityGroup.rule")))
+	},
+	"openstack.compute.server.exposure.floatingIps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackComputeServerExposure).GetFloatingIps()).ToDataRes(types.Array(types.Resource("openstack.floatingIp")))
+	},
 	"openstack.compute.flavor.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeFlavor).GetId()).ToDataRes(types.String)
 	},
@@ -1159,6 +1193,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.port.router": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackPort).GetRouter()).ToDataRes(types.Resource("openstack.router"))
 	},
+	"openstack.port.floatingIps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPort).GetFloatingIps()).ToDataRes(types.Array(types.Resource("openstack.floatingIp")))
+	},
 	"openstack.floatingIp.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackFloatingIp).GetId()).ToDataRes(types.String)
 	},
@@ -1222,6 +1259,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.securityGroup.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroup).GetRules()).ToDataRes(types.Array(types.Resource("openstack.securityGroup.rule")))
 	},
+	"openstack.securityGroup.allowsPublicIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackSecurityGroup).GetAllowsPublicIngress()).ToDataRes(types.Bool)
+	},
 	"openstack.securityGroup.rule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroupRule).GetId()).ToDataRes(types.String)
 	},
@@ -1257,6 +1297,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.securityGroup.rule.remoteGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroupRule).GetRemoteGroup()).ToDataRes(types.Resource("openstack.securityGroup"))
+	},
+	"openstack.securityGroup.rule.includesPublicSource": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackSecurityGroupRule).GetIncludesPublicSource()).ToDataRes(types.Bool)
 	},
 	"openstack.securityGroup.rule.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroupRule).GetProject()).ToDataRes(types.Resource("openstack.project"))
@@ -1639,6 +1682,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.octavia.loadBalancer.pools": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaLoadBalancer).GetPools()).ToDataRes(types.Array(types.Resource("openstack.octavia.pool")))
 	},
+	"openstack.octavia.loadBalancer.enforcesTls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancer).GetEnforcesTls()).ToDataRes(types.Bool)
+	},
+	"openstack.octavia.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancer).GetExposure()).ToDataRes(types.Resource("openstack.octavia.loadBalancer.exposure"))
+	},
+	"openstack.octavia.loadBalancer.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancerExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"openstack.octavia.loadBalancer.exposure.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancerExposure).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"openstack.octavia.loadBalancer.exposure.listenersOpenToWorld": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancerExposure).GetListenersOpenToWorld()).ToDataRes(types.Array(types.Resource("openstack.octavia.listener")))
+	},
+	"openstack.octavia.loadBalancer.exposure.floatingIps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaLoadBalancerExposure).GetFloatingIps()).ToDataRes(types.Array(types.Resource("openstack.floatingIp")))
+	},
 	"openstack.octavia.listener.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetId()).ToDataRes(types.String)
 	},
@@ -1722,6 +1783,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.octavia.listener.l7Policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetL7Policies()).ToDataRes(types.Array(types.Resource("openstack.octavia.l7Policy")))
+	},
+	"openstack.octavia.listener.openToWorld": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetOpenToWorld()).ToDataRes(types.Bool)
 	},
 	"openstack.octavia.pool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaPool).GetId()).ToDataRes(types.String)
@@ -4019,6 +4083,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackComputeServer).User, ok = plugin.RawToTValue[*mqlOpenstackUser](v.Value, v.Error)
 		return
 	},
+	"openstack.compute.server.ports": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServer).Ports, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.floatingIps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServer).FloatingIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServer).Exposure, ok = plugin.RawToTValue[*mqlOpenstackComputeServerExposure](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.compute.server.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.compute.server.exposure.floatingIps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackComputeServerExposure).FloatingIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.compute.flavor.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackComputeFlavor).__id, ok = v.Value.(string)
 		return
@@ -4427,6 +4527,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackPort).Router, ok = plugin.RawToTValue[*mqlOpenstackRouter](v.Value, v.Error)
 		return
 	},
+	"openstack.port.floatingIps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPort).FloatingIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.floatingIp.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackFloatingIp).__id, ok = v.Value.(string)
 		return
@@ -4519,6 +4623,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackSecurityGroup).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"openstack.securityGroup.allowsPublicIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackSecurityGroup).AllowsPublicIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"openstack.securityGroup.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSecurityGroupRule).__id, ok = v.Value.(string)
 		return
@@ -4569,6 +4677,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.securityGroup.rule.remoteGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSecurityGroupRule).RemoteGroup, ok = plugin.RawToTValue[*mqlOpenstackSecurityGroup](v.Value, v.Error)
+		return
+	},
+	"openstack.securityGroup.rule.includesPublicSource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackSecurityGroupRule).IncludesPublicSource, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"openstack.securityGroup.rule.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5107,6 +5219,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackOctaviaLoadBalancer).Pools, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.loadBalancer.enforcesTls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancer).EnforcesTls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlOpenstackOctaviaLoadBalancerExposure](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancerExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancerExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancerExposure).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure.listenersOpenToWorld": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancerExposure).ListenersOpenToWorld, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.loadBalancer.exposure.floatingIps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaLoadBalancerExposure).FloatingIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).__id, ok = v.Value.(string)
 		return
@@ -5221,6 +5361,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.octavia.listener.l7Policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).L7Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.listener.openToWorld": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).OpenToWorld, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"openstack.octavia.pool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9556,6 +9700,9 @@ type mqlOpenstackComputeServer struct {
 	Volumes            plugin.TValue[[]any]
 	Project            plugin.TValue[*mqlOpenstackProject]
 	User               plugin.TValue[*mqlOpenstackUser]
+	Ports              plugin.TValue[[]any]
+	FloatingIps        plugin.TValue[[]any]
+	Exposure           plugin.TValue[*mqlOpenstackComputeServerExposure]
 }
 
 // createOpenstackComputeServer creates a new instance of this resource
@@ -9801,6 +9948,118 @@ func (c *mqlOpenstackComputeServer) GetUser() *plugin.TValue[*mqlOpenstackUser] 
 
 		return c.user()
 	})
+}
+
+func (c *mqlOpenstackComputeServer) GetPorts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Ports, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.compute.server", c.__id, "ports")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ports()
+	})
+}
+
+func (c *mqlOpenstackComputeServer) GetFloatingIps() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.FloatingIps, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.compute.server", c.__id, "floatingIps")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.floatingIps()
+	})
+}
+
+func (c *mqlOpenstackComputeServer) GetExposure() *plugin.TValue[*mqlOpenstackComputeServerExposure] {
+	return plugin.GetOrCompute[*mqlOpenstackComputeServerExposure](&c.Exposure, func() (*mqlOpenstackComputeServerExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.compute.server", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackComputeServerExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
+}
+
+// mqlOpenstackComputeServerExposure for the openstack.compute.server.exposure resource
+type mqlOpenstackComputeServerExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlOpenstackComputeServerExposureInternal it will be used here
+	InternetReachable          plugin.TValue[bool]
+	PubliclyAccessible         plugin.TValue[bool]
+	SecurityGroupAllowsIngress plugin.TValue[bool]
+	OpenIngressRules           plugin.TValue[[]any]
+	FloatingIps                plugin.TValue[[]any]
+}
+
+// createOpenstackComputeServerExposure creates a new instance of this resource
+func createOpenstackComputeServerExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackComputeServerExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.compute.server.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackComputeServerExposure) MqlName() string {
+	return "openstack.compute.server.exposure"
+}
+
+func (c *mqlOpenstackComputeServerExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackComputeServerExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlOpenstackComputeServerExposure) GetPubliclyAccessible() *plugin.TValue[bool] {
+	return &c.PubliclyAccessible
+}
+
+func (c *mqlOpenstackComputeServerExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
+	return &c.SecurityGroupAllowsIngress
+}
+
+func (c *mqlOpenstackComputeServerExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
+}
+
+func (c *mqlOpenstackComputeServerExposure) GetFloatingIps() *plugin.TValue[[]any] {
+	return &c.FloatingIps
 }
 
 // mqlOpenstackComputeFlavor for the openstack.compute.flavor resource
@@ -10613,6 +10872,7 @@ type mqlOpenstackPort struct {
 	Project               plugin.TValue[*mqlOpenstackProject]
 	Server                plugin.TValue[*mqlOpenstackComputeServer]
 	Router                plugin.TValue[*mqlOpenstackRouter]
+	FloatingIps           plugin.TValue[[]any]
 }
 
 // createOpenstackPort creates a new instance of this resource
@@ -10804,6 +11064,22 @@ func (c *mqlOpenstackPort) GetRouter() *plugin.TValue[*mqlOpenstackRouter] {
 	})
 }
 
+func (c *mqlOpenstackPort) GetFloatingIps() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.FloatingIps, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.port", c.__id, "floatingIps")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.floatingIps()
+	})
+}
+
 // mqlOpenstackFloatingIp for the openstack.floatingIp resource
 type mqlOpenstackFloatingIp struct {
 	MqlRuntime *plugin.Runtime
@@ -10961,15 +11237,16 @@ type mqlOpenstackSecurityGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOpenstackSecurityGroupInternal
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Description plugin.TValue[string]
-	Stateful    plugin.TValue[bool]
-	Tags        plugin.TValue[[]any]
-	CreatedAt   plugin.TValue[*time.Time]
-	UpdatedAt   plugin.TValue[*time.Time]
-	Project     plugin.TValue[*mqlOpenstackProject]
-	Rules       plugin.TValue[[]any]
+	Id                  plugin.TValue[string]
+	Name                plugin.TValue[string]
+	Description         plugin.TValue[string]
+	Stateful            plugin.TValue[bool]
+	Tags                plugin.TValue[[]any]
+	CreatedAt           plugin.TValue[*time.Time]
+	UpdatedAt           plugin.TValue[*time.Time]
+	Project             plugin.TValue[*mqlOpenstackProject]
+	Rules               plugin.TValue[[]any]
+	AllowsPublicIngress plugin.TValue[bool]
 }
 
 // createOpenstackSecurityGroup creates a new instance of this resource
@@ -11057,24 +11334,31 @@ func (c *mqlOpenstackSecurityGroup) GetRules() *plugin.TValue[[]any] {
 	return &c.Rules
 }
 
+func (c *mqlOpenstackSecurityGroup) GetAllowsPublicIngress() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsPublicIngress, func() (bool, error) {
+		return c.allowsPublicIngress()
+	})
+}
+
 // mqlOpenstackSecurityGroupRule for the openstack.securityGroup.rule resource
 type mqlOpenstackSecurityGroupRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOpenstackSecurityGroupRuleInternal
-	Id             plugin.TValue[string]
-	Direction      plugin.TValue[string]
-	Ethertype      plugin.TValue[string]
-	Protocol       plugin.TValue[string]
-	PortRangeMin   plugin.TValue[int64]
-	PortRangeMax   plugin.TValue[int64]
-	RemoteIpPrefix plugin.TValue[string]
-	Description    plugin.TValue[string]
-	CreatedAt      plugin.TValue[*time.Time]
-	UpdatedAt      plugin.TValue[*time.Time]
-	SecurityGroup  plugin.TValue[*mqlOpenstackSecurityGroup]
-	RemoteGroup    plugin.TValue[*mqlOpenstackSecurityGroup]
-	Project        plugin.TValue[*mqlOpenstackProject]
+	Id                   plugin.TValue[string]
+	Direction            plugin.TValue[string]
+	Ethertype            plugin.TValue[string]
+	Protocol             plugin.TValue[string]
+	PortRangeMin         plugin.TValue[int64]
+	PortRangeMax         plugin.TValue[int64]
+	RemoteIpPrefix       plugin.TValue[string]
+	Description          plugin.TValue[string]
+	CreatedAt            plugin.TValue[*time.Time]
+	UpdatedAt            plugin.TValue[*time.Time]
+	SecurityGroup        plugin.TValue[*mqlOpenstackSecurityGroup]
+	RemoteGroup          plugin.TValue[*mqlOpenstackSecurityGroup]
+	IncludesPublicSource plugin.TValue[bool]
+	Project              plugin.TValue[*mqlOpenstackProject]
 }
 
 // createOpenstackSecurityGroupRule creates a new instance of this resource
@@ -11183,6 +11467,12 @@ func (c *mqlOpenstackSecurityGroupRule) GetRemoteGroup() *plugin.TValue[*mqlOpen
 		}
 
 		return c.remoteGroup()
+	})
+}
+
+func (c *mqlOpenstackSecurityGroupRule) GetIncludesPublicSource() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IncludesPublicSource, func() (bool, error) {
+		return c.includesPublicSource()
 	})
 }
 
@@ -12335,6 +12625,8 @@ type mqlOpenstackOctaviaLoadBalancer struct {
 	VipSubnet          plugin.TValue[*mqlOpenstackSubnet]
 	Listeners          plugin.TValue[[]any]
 	Pools              plugin.TValue[[]any]
+	EnforcesTls        plugin.TValue[bool]
+	Exposure           plugin.TValue[*mqlOpenstackOctaviaLoadBalancerExposure]
 }
 
 // createOpenstackOctaviaLoadBalancer creates a new instance of this resource
@@ -12526,6 +12818,87 @@ func (c *mqlOpenstackOctaviaLoadBalancer) GetPools() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlOpenstackOctaviaLoadBalancer) GetEnforcesTls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EnforcesTls, func() (bool, error) {
+		return c.enforcesTls()
+	})
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancer) GetExposure() *plugin.TValue[*mqlOpenstackOctaviaLoadBalancerExposure] {
+	return plugin.GetOrCompute[*mqlOpenstackOctaviaLoadBalancerExposure](&c.Exposure, func() (*mqlOpenstackOctaviaLoadBalancerExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.loadBalancer", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackOctaviaLoadBalancerExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
+}
+
+// mqlOpenstackOctaviaLoadBalancerExposure for the openstack.octavia.loadBalancer.exposure resource
+type mqlOpenstackOctaviaLoadBalancerExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlOpenstackOctaviaLoadBalancerExposureInternal it will be used here
+	InternetReachable    plugin.TValue[bool]
+	PubliclyAccessible   plugin.TValue[bool]
+	ListenersOpenToWorld plugin.TValue[[]any]
+	FloatingIps          plugin.TValue[[]any]
+}
+
+// createOpenstackOctaviaLoadBalancerExposure creates a new instance of this resource
+func createOpenstackOctaviaLoadBalancerExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackOctaviaLoadBalancerExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.octavia.loadBalancer.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) MqlName() string {
+	return "openstack.octavia.loadBalancer.exposure"
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) GetPubliclyAccessible() *plugin.TValue[bool] {
+	return &c.PubliclyAccessible
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) GetListenersOpenToWorld() *plugin.TValue[[]any] {
+	return &c.ListenersOpenToWorld
+}
+
+func (c *mqlOpenstackOctaviaLoadBalancerExposure) GetFloatingIps() *plugin.TValue[[]any] {
+	return &c.FloatingIps
+}
+
 // mqlOpenstackOctaviaListener for the openstack.octavia.listener resource
 type mqlOpenstackOctaviaListener struct {
 	MqlRuntime *plugin.Runtime
@@ -12559,6 +12932,7 @@ type mqlOpenstackOctaviaListener struct {
 	ClientCATlsContainer  plugin.TValue[*mqlOpenstackKeymanagerContainer]
 	ClientCRLContainer    plugin.TValue[*mqlOpenstackKeymanagerContainer]
 	L7Policies            plugin.TValue[[]any]
+	OpenToWorld           plugin.TValue[bool]
 }
 
 // createOpenstackOctaviaListener creates a new instance of this resource
@@ -12803,6 +13177,12 @@ func (c *mqlOpenstackOctaviaListener) GetL7Policies() *plugin.TValue[[]any] {
 		}
 
 		return c.l7Policies()
+	})
+}
+
+func (c *mqlOpenstackOctaviaListener) GetOpenToWorld() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.OpenToWorld, func() (bool, error) {
+		return c.openToWorld()
 	})
 }
 

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -221,7 +221,14 @@ openstack.compute.server.availabilityZone 13.0.1
 openstack.compute.server.configDrive 13.4.2
 openstack.compute.server.created 13.0.1
 openstack.compute.server.diskConfig 13.0.1
+openstack.compute.server.exposure 13.4.2
+openstack.compute.server.exposure.floatingIps 13.4.2
+openstack.compute.server.exposure.internetReachable 13.4.2
+openstack.compute.server.exposure.openIngressRules 13.4.2
+openstack.compute.server.exposure.publiclyAccessible 13.4.2
+openstack.compute.server.exposure.securityGroupAllowsIngress 13.4.2
 openstack.compute.server.flavor 13.0.1
+openstack.compute.server.floatingIps 13.4.2
 openstack.compute.server.host 13.4.2
 openstack.compute.server.hostId 13.0.1
 openstack.compute.server.hypervisorHostname 13.4.2
@@ -233,6 +240,7 @@ openstack.compute.server.launchedAt 13.0.1
 openstack.compute.server.locked 13.0.1
 openstack.compute.server.metadata 13.0.1
 openstack.compute.server.name 13.0.1
+openstack.compute.server.ports 13.4.2
 openstack.compute.server.powerState 13.0.1
 openstack.compute.server.project 13.2.1
 openstack.compute.server.securityGroups 13.0.1
@@ -705,6 +713,7 @@ openstack.octavia.listener.insertHeaders 13.0.1
 openstack.octavia.listener.l7Policies 13.0.1
 openstack.octavia.listener.loadBalancer 13.0.1
 openstack.octavia.listener.name 13.0.1
+openstack.octavia.listener.openToWorld 13.4.2
 openstack.octavia.listener.project 13.0.1
 openstack.octavia.listener.protocol 13.0.1
 openstack.octavia.listener.protocolPort 13.0.1
@@ -723,6 +732,12 @@ openstack.octavia.loadBalancer.adminStateUp 13.0.1
 openstack.octavia.loadBalancer.availabilityZone 13.0.1
 openstack.octavia.loadBalancer.createdAt 13.0.1
 openstack.octavia.loadBalancer.description 13.0.1
+openstack.octavia.loadBalancer.enforcesTls 13.4.2
+openstack.octavia.loadBalancer.exposure 13.4.2
+openstack.octavia.loadBalancer.exposure.floatingIps 13.4.2
+openstack.octavia.loadBalancer.exposure.internetReachable 13.4.2
+openstack.octavia.loadBalancer.exposure.listenersOpenToWorld 13.4.2
+openstack.octavia.loadBalancer.exposure.publiclyAccessible 13.4.2
 openstack.octavia.loadBalancer.flavorId 13.0.1
 openstack.octavia.loadBalancer.id 13.0.1
 openstack.octavia.loadBalancer.listeners 13.0.1
@@ -810,6 +825,7 @@ openstack.port.createdAt 13.0.1
 openstack.port.description 13.0.1
 openstack.port.deviceOwner 13.0.1
 openstack.port.fixedIps 13.0.1
+openstack.port.floatingIps 13.4.2
 openstack.port.id 13.0.1
 openstack.port.macAddress 13.0.1
 openstack.port.name 13.0.1
@@ -879,6 +895,7 @@ openstack.secretContainers 13.0.1
 openstack.secretOrders 13.0.1
 openstack.secrets 13.0.1
 openstack.securityGroup 13.0.1
+openstack.securityGroup.allowsPublicIngress 13.4.2
 openstack.securityGroup.createdAt 13.0.1
 openstack.securityGroup.description 13.0.1
 openstack.securityGroup.id 13.0.1
@@ -890,6 +907,7 @@ openstack.securityGroup.rule.description 13.0.1
 openstack.securityGroup.rule.direction 13.0.1
 openstack.securityGroup.rule.ethertype 13.0.1
 openstack.securityGroup.rule.id 13.0.1
+openstack.securityGroup.rule.includesPublicSource 13.4.2
 openstack.securityGroup.rule.portRangeMax 13.0.1
 openstack.securityGroup.rule.portRangeMin 13.0.1
 openstack.securityGroup.rule.project 13.2.1

--- a/providers/openstack/resources/openstack_cidr.go
+++ b/providers/openstack/resources/openstack_cidr.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net"
+)
+
+// privateOrReservedCIDRs are address ranges that are not routable from the
+// public internet. A security-group rule whose source is wholly inside one of
+// these does not constitute internet exposure.
+var privateOrReservedCIDRs = mustParseCIDRs(
+	"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // RFC1918
+	"127.0.0.0/8",    // loopback
+	"169.254.0.0/16", // link-local
+	"100.64.0.0/10",  // carrier-grade NAT
+	"0.0.0.0/8",      // "this host on this network" (RFC1122)
+	"240.0.0.0/4",    // reserved for future use
+	"2001:db8::/32",  // IPv6 documentation (RFC3849)
+	"::1/128",        // IPv6 loopback
+	"fc00::/7",       // IPv6 unique local
+	"fe80::/10",      // IPv6 link-local
+)
+
+// broadPublicPrefix* is the largest prefix length still treated as "broad"
+// internet exposure rather than a specific allow-listed host or network: a /8
+// IPv4 block (16M+ addresses) or a /32 IPv6 block. The threshold is deliberately
+// conservative — narrower public ranges (a single /32 host, a corporate /24) are
+// treated as scoped to avoid false positives on legitimate large allow-lists.
+const (
+	broadPublicPrefixV4 = 8
+	broadPublicPrefixV6 = 32
+)
+
+// mustParseCIDRs parses a fixed set of CIDR literals at init time, panicking on
+// a malformed entry so a typo in the private/reserved list fails loudly rather
+// than silently shrinking the set.
+func mustParseCIDRs(cidrs ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("mustParseCIDRs: %s: %v", c, err))
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+// cidrIsPublic reports whether a CIDR exposes a broad slice of the public
+// internet — the all-addresses 0.0.0.0/0 or ::/0, or any wide block (prefix
+// length at or below the broad-public threshold) that is not contained within a
+// private or reserved range. A specific public host or a narrow allow-listed
+// range is not considered public.
+func cidrIsPublic(cidr string) bool {
+	if cidr == "" {
+		return false
+	}
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	ones, bits := ipnet.Mask.Size()
+	threshold := broadPublicPrefixV4
+	if bits > 32 {
+		threshold = broadPublicPrefixV6
+	}
+	if ones > threshold {
+		return false
+	}
+	for _, pr := range privateOrReservedCIDRs {
+		if cidrWithin(ipnet, pr) {
+			return false
+		}
+	}
+	return true
+}
+
+// cidrWithin reports whether inner is entirely contained within outer.
+func cidrWithin(inner, outer *net.IPNet) bool {
+	innerOnes, innerBits := inner.Mask.Size()
+	outerOnes, outerBits := outer.Mask.Size()
+	if innerBits != outerBits || outerOnes > innerOnes {
+		return false
+	}
+	return outer.Contains(inner.IP)
+}
+
+// anyCidrPublic reports whether any CIDR string in the list exposes the public
+// internet.
+func anyCidrPublic(cidrs []any) bool {
+	for _, c := range cidrs {
+		if s, ok := c.(string); ok && cidrIsPublic(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/openstack/resources/openstack_cidr_test.go
+++ b/providers/openstack/resources/openstack_cidr_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCidrIsPublic(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want bool
+	}{
+		// all-addresses
+		{"0.0.0.0/0", true},
+		{"::/0", true},
+		// broad public blocks that the literal-/0 check used to miss
+		{"0.0.0.0/1", true},
+		{"128.0.0.0/1", true},
+		{"13.0.0.0/8", true},
+		// private / reserved ranges are not internet exposure
+		{"10.0.0.0/8", false},
+		{"172.16.0.0/12", false},
+		{"192.168.0.0/16", false},
+		{"127.0.0.0/8", false},
+		{"169.254.0.0/16", false},
+		{"100.64.0.0/10", false},
+		{"fc00::/7", false},
+		// specific or narrow ranges are scoped, not "the internet"
+		{"203.0.113.5/32", false},
+		{"52.94.0.0/16", false},
+		{"2600:1f00::/24", true},
+		{"2001:db8::/48", false},
+		// malformed / empty
+		{"", false},
+		{"not-a-cidr", false},
+		{"0.0.0.0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cidr, func(t *testing.T) {
+			assert.Equal(t, tt.want, cidrIsPublic(tt.cidr))
+		})
+	}
+}
+
+func TestAnyCidrPublic(t *testing.T) {
+	assert.True(t, anyCidrPublic([]any{"10.0.0.0/8", "0.0.0.0/1"}))
+	assert.False(t, anyCidrPublic([]any{"10.0.0.0/8", "192.168.1.0/24"}))
+	assert.False(t, anyCidrPublic([]any{}))
+	assert.False(t, anyCidrPublic([]any{42, "10.0.0.0/8"}))
+}

--- a/providers/openstack/resources/openstack_exposure.go
+++ b/providers/openstack/resources/openstack_exposure.go
@@ -1,0 +1,304 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// --- security-group source classification ---
+
+// includesPublicSource reports whether the rule's source reaches the public
+// internet: a public remote CIDR, or an unscoped rule (no remote IP prefix and
+// no remote group) which Neutron treats as any source. Direction-agnostic, so
+// it also classifies egress destinations.
+func (r *mqlOpenstackSecurityGroupRule) includesPublicSource() (bool, error) {
+	prefix := r.RemoteIpPrefix.Data
+	if prefix == "" {
+		return r.cacheRemoteGroupID == "", nil
+	}
+	return cidrIsPublic(prefix), nil
+}
+
+// allowsPublicIngress reports whether any ingress rule in the security group
+// permits traffic from a public source.
+func (r *mqlOpenstackSecurityGroup) allowsPublicIngress() (bool, error) {
+	rules := r.GetRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	for _, raw := range rules.Data {
+		rule, ok := raw.(*mqlOpenstackSecurityGroupRule)
+		if !ok || !strings.EqualFold(rule.Direction.Data, "ingress") {
+			continue
+		}
+		public := rule.GetIncludesPublicSource()
+		if public.Error != nil {
+			return false, public.Error
+		}
+		if public.Data {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// --- reverse links ---
+
+// floatingIps returns the floating IPs bound to this port.
+func (r *mqlOpenstackPort) floatingIps() ([]any, error) {
+	return floatingIpsForPortIDs(r.MqlRuntime, map[string]struct{}{r.Id.Data: {}})
+}
+
+// ports returns the Neutron ports attached to this server (those whose
+// device_id is the server's ID). Filters the project's already-cached port
+// list, so it makes no additional API calls.
+func (r *mqlOpenstackComputeServer) ports() ([]any, error) {
+	root, err := CreateResource(r.MqlRuntime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	list := root.(*mqlOpenstack).GetPorts()
+	if list.Error != nil {
+		return nil, list.Error
+	}
+	out := make([]any, 0)
+	for _, raw := range list.Data {
+		port, ok := raw.(*mqlOpenstackPort)
+		if !ok {
+			continue
+		}
+		if port.cacheDeviceID == r.Id.Data {
+			out = append(out, port)
+		}
+	}
+	return out, nil
+}
+
+// floatingIps returns the floating IPs mapped to this server through any of its
+// ports.
+func (r *mqlOpenstackComputeServer) floatingIps() ([]any, error) {
+	ports := r.GetPorts()
+	if ports.Error != nil {
+		return nil, ports.Error
+	}
+	portIDs := make(map[string]struct{}, len(ports.Data))
+	for _, raw := range ports.Data {
+		if port, ok := raw.(*mqlOpenstackPort); ok {
+			portIDs[port.Id.Data] = struct{}{}
+		}
+	}
+	return floatingIpsForPortIDs(r.MqlRuntime, portIDs)
+}
+
+// floatingIpsForPortIDs returns the floating IPs from the project's floating-IP
+// list whose bound port is in the given set.
+func floatingIpsForPortIDs(runtime *plugin.Runtime, portIDs map[string]struct{}) ([]any, error) {
+	if len(portIDs) == 0 {
+		return []any{}, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	list := root.(*mqlOpenstack).GetFloatingIps()
+	if list.Error != nil {
+		return nil, list.Error
+	}
+	out := make([]any, 0)
+	for _, raw := range list.Data {
+		fip, ok := raw.(*mqlOpenstackFloatingIp)
+		if !ok || fip.cachePortID == "" {
+			continue
+		}
+		if _, ok := portIDs[fip.cachePortID]; ok {
+			out = append(out, fip)
+		}
+	}
+	return out, nil
+}
+
+// --- server exposure ---
+
+func (r *mqlOpenstackComputeServer) exposure() (*mqlOpenstackComputeServerExposure, error) {
+	fipsVal := r.GetFloatingIps()
+	if fipsVal.Error != nil {
+		return nil, fipsVal.Error
+	}
+	floatingIps := fipsVal.Data
+
+	portsVal := r.GetPorts()
+	if portsVal.Error != nil {
+		return nil, portsVal.Error
+	}
+
+	onExternalNetwork := false
+	openIngressRules := []any{}
+	seenRules := map[string]struct{}{}
+	for _, raw := range portsVal.Data {
+		port, ok := raw.(*mqlOpenstackPort)
+		if !ok {
+			continue
+		}
+		if net := port.GetNetwork(); net.Error == nil && net.Data != nil {
+			if ext := net.Data.GetExternal(); ext.Error == nil && ext.Data {
+				onExternalNetwork = true
+			}
+		}
+		sgs := port.GetSecurityGroups()
+		if sgs.Error != nil {
+			return nil, sgs.Error
+		}
+		for _, sgRaw := range sgs.Data {
+			sg, ok := sgRaw.(*mqlOpenstackSecurityGroup)
+			if !ok {
+				continue
+			}
+			rules := sg.GetRules()
+			if rules.Error != nil {
+				return nil, rules.Error
+			}
+			for _, ruleRaw := range rules.Data {
+				rule, ok := ruleRaw.(*mqlOpenstackSecurityGroupRule)
+				if !ok || !strings.EqualFold(rule.Direction.Data, "ingress") {
+					continue
+				}
+				public := rule.GetIncludesPublicSource()
+				if public.Error != nil {
+					return nil, public.Error
+				}
+				if !public.Data {
+					continue
+				}
+				if _, dup := seenRules[rule.Id.Data]; dup {
+					continue
+				}
+				seenRules[rule.Id.Data] = struct{}{}
+				openIngressRules = append(openIngressRules, rule)
+			}
+		}
+	}
+
+	publiclyAccessible := len(floatingIps) > 0 || onExternalNetwork
+	securityGroupAllowsIngress := len(openIngressRules) > 0
+	internetReachable := publiclyAccessible && securityGroupAllowsIngress
+
+	res, err := CreateResource(r.MqlRuntime, "openstack.compute.server.exposure", map[string]*llx.RawData{
+		"__id":                       llx.StringData("openstack.compute.server.exposure/" + r.Id.Data),
+		"internetReachable":          llx.BoolData(internetReachable),
+		"publiclyAccessible":         llx.BoolData(publiclyAccessible),
+		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
+		"openIngressRules":           llx.ArrayData(openIngressRules, types.Resource("openstack.securityGroup.rule")),
+		"floatingIps":                llx.ArrayData(floatingIps, types.Resource("openstack.floatingIp")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackComputeServerExposure), nil
+}
+
+// --- load-balancer exposure ---
+
+// listenerProtocolIsPlaintext reports whether an Octavia listener protocol
+// carries traffic without TLS. HTTPS and TERMINATED_HTTPS terminate or pass
+// through TLS; everything else (HTTP, TCP, UDP, SCTP, PROMETHEUS) is plaintext.
+func listenerProtocolIsPlaintext(protocol string) bool {
+	switch strings.ToUpper(strings.TrimSpace(protocol)) {
+	case "HTTPS", "TERMINATED_HTTPS":
+		return false
+	default:
+		return true
+	}
+}
+
+// enforcesTls reports whether every listener on the load balancer uses an
+// encrypted protocol.
+func (r *mqlOpenstackOctaviaLoadBalancer) enforcesTls() (bool, error) {
+	listeners := r.GetListeners()
+	if listeners.Error != nil {
+		return false, listeners.Error
+	}
+	for _, raw := range listeners.Data {
+		l, ok := raw.(*mqlOpenstackOctaviaListener)
+		if !ok {
+			continue
+		}
+		if listenerProtocolIsPlaintext(l.Protocol.Data) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// openToWorld reports whether the listener accepts connections from any source:
+// an empty allowedCidrs list (Octavia's allow-all default) or one that contains
+// a public CIDR.
+func (r *mqlOpenstackOctaviaListener) openToWorld() (bool, error) {
+	cidrs := r.GetAllowedCidrs()
+	if cidrs.Error != nil {
+		return false, cidrs.Error
+	}
+	if len(cidrs.Data) == 0 {
+		return true, nil
+	}
+	return anyCidrPublic(cidrs.Data), nil
+}
+
+func (r *mqlOpenstackOctaviaLoadBalancer) exposure() (*mqlOpenstackOctaviaLoadBalancerExposure, error) {
+	publiclyAccessible := false
+	if vipNet := r.GetVipNetwork(); vipNet.Error == nil && vipNet.Data != nil {
+		if ext := vipNet.Data.GetExternal(); ext.Error == nil && ext.Data {
+			publiclyAccessible = true
+		}
+	}
+
+	floatingIps := []any{}
+	if vipPort := r.GetVipPort(); vipPort.Error == nil && vipPort.Data != nil {
+		fips := vipPort.Data.GetFloatingIps()
+		if fips.Error != nil {
+			return nil, fips.Error
+		}
+		floatingIps = fips.Data
+	}
+	if len(floatingIps) > 0 {
+		publiclyAccessible = true
+	}
+
+	openListeners := []any{}
+	listeners := r.GetListeners()
+	if listeners.Error != nil {
+		return nil, listeners.Error
+	}
+	for _, raw := range listeners.Data {
+		l, ok := raw.(*mqlOpenstackOctaviaListener)
+		if !ok {
+			continue
+		}
+		open := l.GetOpenToWorld()
+		if open.Error != nil {
+			return nil, open.Error
+		}
+		if open.Data {
+			openListeners = append(openListeners, l)
+		}
+	}
+
+	internetReachable := publiclyAccessible && len(openListeners) > 0
+
+	res, err := CreateResource(r.MqlRuntime, "openstack.octavia.loadBalancer.exposure", map[string]*llx.RawData{
+		"__id":                 llx.StringData("openstack.octavia.loadBalancer.exposure/" + r.Id.Data),
+		"internetReachable":    llx.BoolData(internetReachable),
+		"publiclyAccessible":   llx.BoolData(publiclyAccessible),
+		"listenersOpenToWorld": llx.ArrayData(openListeners, types.Resource("openstack.octavia.listener")),
+		"floatingIps":          llx.ArrayData(floatingIps, types.Resource("openstack.floatingIp")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackOctaviaLoadBalancerExposure), nil
+}


### PR DESCRIPTION
## Summary

Models whether OpenStack assets are reachable from the public internet, mirroring the house pattern the AWS provider just adopted (`aws.ec2.instance.exposure` + `aws_cidr.go`). New `.lr.versions` entries at `13.4.2`; no `config.go` bump.

### Foundation — `openstack_cidr.go`
Ported from `aws_cidr.go`: `cidrIsPublic()` / `anyCidrPublic()` treat `0.0.0.0/0`, `::/0`, and wide public blocks as public, while excluding RFC1918/reserved ranges and narrow allow-listed hosts (the wide-CIDR false-negative fix is baked in). Table tests ported too.

### Reverse links (no extra API calls — filter the project's already-cached lists)
- `openstack.compute.server.ports()`, `openstack.compute.server.floatingIps()`
- `openstack.port.floatingIps()`

### Source classification
- `openstack.securityGroup.rule.includesPublicSource()` — public CIDR, or an unscoped any-source rule (Neutron semantics). Direction-agnostic, so it also enables an egress audit.
- `openstack.securityGroup.allowsPublicIngress()`

### Server exposure — `openstack.compute.server.exposure` (via `server.exposure()`)
- `internetReachable` (publicly accessible **and** a public-source ingress rule)
- `publiclyAccessible` (floating IP **or** a port on an external network)
- `securityGroupAllowsIngress`
- `openIngressRules []openstack.securityGroup.rule` (deduplicated; the rules opening it up, with their port ranges)
- `floatingIps []openstack.floatingIp`

### Load-balancer exposure — `openstack.octavia.loadBalancer.exposure` (via `loadBalancer.exposure()`)
- `internetReachable` (publicly accessible **and** a listener open to the world)
- `publiclyAccessible` (VIP on an external network **or** VIP has a floating IP)
- `listenersOpenToWorld []openstack.octavia.listener`
- `floatingIps []openstack.floatingIp`
- Mitigation predicates: `octavia.listener.openToWorld()` (empty/public `allowedCidrs`) and `octavia.loadBalancer.enforcesTls()` (no plaintext listener — mirrors AWS `enforcesTls`).

### Example queries
```mql
# Internet-reachable instances and the rules that open them
openstack.servers.where(exposure.internetReachable) {
  name
  exposure.floatingIps { floatingIpAddress }
  exposure.openIngressRules { protocol portRangeMin portRangeMax remoteIpPrefix }
}

# Public load balancers terminating plaintext traffic
openstack.loadBalancers.where(exposure.internetReachable && !enforcesTls) { name vipAddress }
```

## Notes
- The `*.exposure` accessors return a built resource per anchor; their field path equals the sub-resource name, exactly as `aws.ec2.instance.exposure` does (the generator's "duplicate field paths" note is expected for this pattern).
- `enforcesTls()` is vacuously true for a load balancer with zero listeners (matches AWS).

## Testing
- `go build ./...`, `go vet ./resources/`, `go test ./resources/` (incl. new `openstack_cidr_test.go`), and `gofmt -l` all pass.
- Code-review pass found no issues.
- Not exercised against a live OpenStack cloud (no endpoint available) — recommend a live smoke test of `server.exposure` / `loadBalancer.exposure` before merge.