### PR TITLE
⭐ stackit: server network-exposure breakdown

### DIFF
--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -158,6 +158,8 @@ private stackit.server @defaults("id name status machineType") {
   securityGroupIds []string
   // Security groups attached to the server
   securityGroups() []stackit.securityGroup
+  // Internet-exposure breakdown (public IP combined with security group ingress)
+  exposure() stackit.network.exposure
   // Service account mail addresses attached to the server
   serviceAccountMails []string
   // Network interfaces: [{nicId, ipv4, ipv6, mac, networkId, securityGroups, allowedAddresses}]
@@ -391,6 +393,22 @@ private stackit.securityGroup.rule @defaults("id direction protocol") {
   ipRange string
   // Remote security group UUID (empty if remote is a CIDR)
   remoteSecurityGroupId string
+}
+
+// Server internet-exposure breakdown
+//
+// Explains whether a server is reachable from the internet: whether one of its
+// network interfaces has a public IP and whether an attached security group
+// admits inbound traffic from any address.
+private stackit.network.exposure @defaults("internetReachable hasPublicIp") {
+  // Whether the server is reachable from the internet (a public IP and a security group ingress rule that admits any address)
+  internetReachable bool
+  // Whether any network interface has a public IP
+  hasPublicIp bool
+  // Whether an attached security group permits inbound traffic from any address (0.0.0.0/0 or ::/0)
+  securityGroupAllowsIngress bool
+  // Security group ingress rules that admit traffic from any address
+  openIngressRules []stackit.securityGroup.rule
 }
 
 // STACKIT SSH key pair

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -26,6 +26,7 @@ const (
 	ResourceStackitPublicIp                   string = "stackit.publicIp"
 	ResourceStackitSecurityGroup              string = "stackit.securityGroup"
 	ResourceStackitSecurityGroupRule          string = "stackit.securityGroup.rule"
+	ResourceStackitNetworkExposure            string = "stackit.network.exposure"
 	ResourceStackitKeyPair                    string = "stackit.keyPair"
 	ResourceStackitLoadBalancer               string = "stackit.loadBalancer"
 	ResourceStackitLoadBalancerListener       string = "stackit.loadBalancer.listener"
@@ -126,6 +127,10 @@ func init() {
 		"stackit.securityGroup.rule": {
 			// to override args, implement: initStackitSecurityGroupRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createStackitSecurityGroupRule,
+		},
+		"stackit.network.exposure": {
+			// to override args, implement: initStackitNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createStackitNetworkExposure,
 		},
 		"stackit.keyPair": {
 			Init:   initStackitKeyPair,
@@ -589,6 +594,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.server.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("stackit.securityGroup")))
 	},
+	"stackit.server.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServer).GetExposure()).ToDataRes(types.Resource("stackit.network.exposure"))
+	},
 	"stackit.server.serviceAccountMails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetServiceAccountMails()).ToDataRes(types.Array(types.String))
 	},
@@ -840,6 +848,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.securityGroup.rule.remoteSecurityGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecurityGroupRule).GetRemoteSecurityGroupId()).ToDataRes(types.String)
+	},
+	"stackit.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"stackit.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
+	"stackit.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitNetworkExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"stackit.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("stackit.securityGroup.rule")))
 	},
 	"stackit.keyPair.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitKeyPair).GetName()).ToDataRes(types.String)
@@ -2191,6 +2211,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitServer).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"stackit.server.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServer).Exposure, ok = plugin.RawToTValue[*mqlStackitNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"stackit.server.serviceAccountMails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServer).ServiceAccountMails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -2553,6 +2577,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.securityGroup.rule.remoteSecurityGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSecurityGroupRule).RemoteSecurityGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetworkExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"stackit.keyPair.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4939,6 +4983,7 @@ type mqlStackitServer struct {
 	Volumes             plugin.TValue[[]any]
 	SecurityGroupIds    plugin.TValue[[]any]
 	SecurityGroups      plugin.TValue[[]any]
+	Exposure            plugin.TValue[*mqlStackitNetworkExposure]
 	ServiceAccountMails plugin.TValue[[]any]
 	Nics                plugin.TValue[[]any]
 	UserData            plugin.TValue[string]
@@ -5104,6 +5149,22 @@ func (c *mqlStackitServer) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlStackitServer) GetExposure() *plugin.TValue[*mqlStackitNetworkExposure] {
+	return plugin.GetOrCompute[*mqlStackitNetworkExposure](&c.Exposure, func() (*mqlStackitNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -5876,6 +5937,65 @@ func (c *mqlStackitSecurityGroupRule) GetIpRange() *plugin.TValue[string] {
 
 func (c *mqlStackitSecurityGroupRule) GetRemoteSecurityGroupId() *plugin.TValue[string] {
 	return &c.RemoteSecurityGroupId
+}
+
+// mqlStackitNetworkExposure for the stackit.network.exposure resource
+type mqlStackitNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlStackitNetworkExposureInternal it will be used here
+	InternetReachable          plugin.TValue[bool]
+	HasPublicIp                plugin.TValue[bool]
+	SecurityGroupAllowsIngress plugin.TValue[bool]
+	OpenIngressRules           plugin.TValue[[]any]
+}
+
+// createStackitNetworkExposure creates a new instance of this resource
+func createStackitNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitNetworkExposure) MqlName() string {
+	return "stackit.network.exposure"
+}
+
+func (c *mqlStackitNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlStackitNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+	return &c.HasPublicIp
+}
+
+func (c *mqlStackitNetworkExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
+	return &c.SecurityGroupAllowsIngress
+}
+
+func (c *mqlStackitNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
 }
 
 // mqlStackitKeyPair for the stackit.keyPair resource

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -212,6 +212,11 @@ stackit.mongoDbFlex.instance.storage 13.0.0
 stackit.mongoDbFlex.instance.version 13.0.0
 stackit.mongoDbFlex.instances 13.0.0
 stackit.network 13.0.0
+stackit.network.exposure 13.0.6
+stackit.network.exposure.hasPublicIp 13.0.6
+stackit.network.exposure.internetReachable 13.0.6
+stackit.network.exposure.openIngressRules 13.0.6
+stackit.network.exposure.securityGroupAllowsIngress 13.0.6
 stackit.network.id 13.0.0
 stackit.network.ipv4Gateway 13.0.0
 stackit.network.ipv4Nameservers 13.0.0
@@ -356,6 +361,7 @@ stackit.server.availabilityZone 13.0.0
 stackit.server.configDrive 13.0.0
 stackit.server.createdAt 13.0.0
 stackit.server.errorMessage 13.0.0
+stackit.server.exposure 13.0.6
 stackit.server.id 13.0.0
 stackit.server.image 13.0.0
 stackit.server.imageId 13.0.0

--- a/providers/stackit/resources/stackit_exposure.go
+++ b/providers/stackit/resources/stackit_exposure.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// nicsHavePublicIp reports whether any network interface dict carries a
+// non-empty public IP.
+func nicsHavePublicIp(nics []any) bool {
+	for _, n := range nics {
+		nic, ok := n.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ip, ok := nic["publicIp"].(string); ok && ip != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// securityRuleOpenToInternet reports whether a security group rule is an ingress
+// rule whose remote CIDR admits any address (0.0.0.0/0 or ::/0).
+func securityRuleOpenToInternet(direction, ipRange string) bool {
+	if !strings.EqualFold(direction, "ingress") {
+		return false
+	}
+	return ipRange == "0.0.0.0/0" || ipRange == "::/0"
+}
+
+// exposure breaks down whether the server is reachable from the internet: a
+// network interface with a public IP combined with a security group ingress
+// rule that admits any address.
+func (s *mqlStackitServer) exposure() (*mqlStackitNetworkExposure, error) {
+	id := s.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	nics := s.GetNics()
+	if nics.Error != nil {
+		return nil, nics.Error
+	}
+	hasPublicIp := nicsHavePublicIp(nics.Data)
+
+	openRules := []any{}
+	sgs := s.GetSecurityGroups()
+	if sgs.Error != nil {
+		return nil, sgs.Error
+	}
+	for _, g := range sgs.Data {
+		sg, ok := g.(*mqlStackitSecurityGroup)
+		if !ok {
+			continue
+		}
+		rules := sg.GetRules()
+		if rules.Error != nil {
+			return nil, rules.Error
+		}
+		for _, r := range rules.Data {
+			rule, ok := r.(*mqlStackitSecurityGroupRule)
+			if !ok {
+				continue
+			}
+			direction := rule.GetDirection()
+			if direction.Error != nil {
+				return nil, direction.Error
+			}
+			ipRange := rule.GetIpRange()
+			if ipRange.Error != nil {
+				return nil, ipRange.Error
+			}
+			if securityRuleOpenToInternet(direction.Data, ipRange.Data) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+	sgAllows := len(openRules) > 0
+	internetReachable := hasPublicIp && sgAllows
+
+	res, err := CreateResource(s.MqlRuntime, "stackit.network.exposure", map[string]*llx.RawData{
+		"__id":                       llx.StringData("stackit.server/" + id.Data + "/exposure"),
+		"internetReachable":          llx.BoolData(internetReachable),
+		"hasPublicIp":                llx.BoolData(hasPublicIp),
+		"securityGroupAllowsIngress": llx.BoolData(sgAllows),
+		"openIngressRules":           llx.ArrayData(openRules, types.Resource("stackit.securityGroup.rule")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitNetworkExposure), nil
+}

--- a/providers/stackit/resources/stackit_exposure_test.go
+++ b/providers/stackit/resources/stackit_exposure_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestNicsHavePublicIp(t *testing.T) {
+	cases := []struct {
+		name string
+		nics []any
+		want bool
+	}{
+		{"has public ip", []any{map[string]any{"publicIp": "203.0.113.5"}}, true},
+		{"second nic has ip", []any{map[string]any{"publicIp": ""}, map[string]any{"publicIp": "203.0.113.5"}}, true},
+		{"empty public ip", []any{map[string]any{"publicIp": ""}}, false},
+		{"no public ip key", []any{map[string]any{"nicId": "x"}}, false},
+		{"no nics", []any{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nicsHavePublicIp(c.nics); got != c.want {
+				t.Errorf("nicsHavePublicIp(%v) = %v, want %v", c.nics, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSecurityRuleOpenToInternet(t *testing.T) {
+	cases := []struct {
+		direction string
+		ipRange   string
+		want      bool
+	}{
+		{"ingress", "0.0.0.0/0", true},
+		{"ingress", "::/0", true},
+		{"INGRESS", "0.0.0.0/0", true},
+		{"ingress", "203.0.113.0/24", false},
+		{"ingress", "", false},
+		{"egress", "0.0.0.0/0", false},
+	}
+	for _, c := range cases {
+		if got := securityRuleOpenToInternet(c.direction, c.ipRange); got != c.want {
+			t.Errorf("securityRuleOpenToInternet(%q, %q) = %v, want %v", c.direction, c.ipRange, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Cross-provider exposure (one PR per provider) — STACKIT. Mirrors `aws.network.exposure`.

## `stackit.network.exposure`
Added `stackit.server.exposure`:
| field | meaning |
|---|---|
| `internetReachable` | a NIC with a public IP **and** a security group ingress rule admitting any address |
| `hasPublicIp` | any network interface has a public IP |
| `securityGroupAllowsIngress` | an attached SG ingress rule admits `0.0.0.0/0`/`::/0` |
| `openIngressRules` | the ingress rules that admit any address |

STACKIT servers require a security group for ingress (no default-open), so the model mirrors AWS rather than the no-firewall-is-open model of DigitalOcean/Hetzner.

## Tests
Pure helpers `nicsHavePublicIp` (scans nic dicts for a `publicIp`) and `securityRuleOpenToInternet` (ingress + any-address CIDR) with table-driven tests, written in plain `testing` to match the provider's existing test style (no new dependency).

## Notes
- Reads cached server/SG data — **no new API calls**. Versions `13.0.6`.
- Verified via build + unit tests; no STACKIT account available for live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)