### PR TITLE
⭐ gcp: compute instance network-exposure breakdown

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1383,8 +1383,11 @@ gcp.project.computeService.instance @defaults("name id") {
   networkStackTypes []string
   // Whether the instance has at least one external IP attached via a network interface accessConfig
   hasPublicIp() bool
-  // Internet-exposure breakdown (public IP combined with applicable firewall ingress)
-  exposure() gcp.project.computeService.network.exposure
+  // Internet-exposure breakdown
+  //
+  // Explains whether the instance is reachable from the internet by combining
+  // external-IP presence with the VPC firewall ingress rules that apply to it.
+  exposure() gcp.project.computeService.instance.exposure
   // Whether the instance runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com)
   usesDefaultServiceAccount() bool
   // Whether any attached service account has the broad cloud-platform OAuth scope
@@ -1487,7 +1490,7 @@ gcp.project.computeService.instance @defaults("name id") {
 // whether it has an external IP and whether a VPC firewall rule that applies to
 // it (same network, matching target tags or service accounts) admits ingress
 // from any address.
-private gcp.project.computeService.network.exposure @defaults("internetReachable hasPublicIp") {
+private gcp.project.computeService.instance.exposure @defaults("internetReachable hasPublicIp") {
   // Whether the instance is reachable from the internet (an external IP and an applicable firewall rule that admits any address)
   internetReachable bool
   // Whether the instance has an external IP

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2690,6 +2690,8 @@ private gcp.project.sqlService.instance @defaults("name") {
   settings gcp.project.sqlService.instance.settings
   // Whether the instance is reachable on a public IP — flat hoist of settings.ipConfiguration.ipv4Enabled
   publicIpEnabled() bool
+  // Whether the instance is reachable from the internet (a public IP and an authorized network open to 0.0.0.0/0)
+  internetReachable() bool
   // Whether IAM database authentication is enabled — true when the cloudsql.iam_authentication database flag is on
   iamAuthenticationEnabled() bool
   // Whether automated backups are enabled — flat hoist of settings.backupConfiguration.enabled

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1383,6 +1383,8 @@ gcp.project.computeService.instance @defaults("name id") {
   networkStackTypes []string
   // Whether the instance has at least one external IP attached via a network interface accessConfig
   hasPublicIp() bool
+  // Internet-exposure breakdown (public IP combined with applicable firewall ingress)
+  exposure() gcp.project.computeService.network.exposure
   // Whether the instance runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com)
   usesDefaultServiceAccount() bool
   // Whether any attached service account has the broad cloud-platform OAuth scope
@@ -1477,6 +1479,23 @@ gcp.project.computeService.instance @defaults("name id") {
   inventory() gcp.project.computeService.instance.osInventory
   // VM Manager vulnerability report for the instance
   vulnerabilityReport() gcp.project.computeService.instance.vulnerabilityReport
+}
+
+// Compute instance internet-exposure breakdown
+//
+// Explains whether a Compute Engine instance is reachable from the internet:
+// whether it has an external IP and whether a VPC firewall rule that applies to
+// it (same network, matching target tags or service accounts) admits ingress
+// from any address.
+private gcp.project.computeService.network.exposure @defaults("internetReachable hasPublicIp") {
+  // Whether the instance is reachable from the internet (an external IP and an applicable firewall rule that admits any address)
+  internetReachable bool
+  // Whether the instance has an external IP
+  hasPublicIp bool
+  // Whether a firewall rule that applies to the instance admits inbound traffic from any address (0.0.0.0/0 or ::/0)
+  firewallAllowsIngress bool
+  // Firewall rules that apply to the instance and admit ingress from any address
+  openIngressFirewalls []gcp.project.computeService.firewall
 }
 
 // VM Manager OS inventory for a Compute Engine instance

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -50,7 +50,7 @@ const (
 	ResourceGcpProjectComputeServiceZone                                               string = "gcp.project.computeService.zone"
 	ResourceGcpProjectComputeServiceMachineType                                        string = "gcp.project.computeService.machineType"
 	ResourceGcpProjectComputeServiceInstance                                           string = "gcp.project.computeService.instance"
-	ResourceGcpProjectComputeServiceNetworkExposure                                    string = "gcp.project.computeService.network.exposure"
+	ResourceGcpProjectComputeServiceInstanceExposure                                   string = "gcp.project.computeService.instance.exposure"
 	ResourceGcpProjectComputeServiceInstanceOsInventory                                string = "gcp.project.computeService.instance.osInventory"
 	ResourceGcpProjectComputeServiceInstanceOsInventoryItem                            string = "gcp.project.computeService.instance.osInventory.item"
 	ResourceGcpProjectComputeServiceInstanceVulnerabilityReport                        string = "gcp.project.computeService.instance.vulnerabilityReport"
@@ -607,9 +607,9 @@ func init() {
 			Init:   initGcpProjectComputeServiceInstance,
 			Create: createGcpProjectComputeServiceInstance,
 		},
-		"gcp.project.computeService.network.exposure": {
-			// to override args, implement: initGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createGcpProjectComputeServiceNetworkExposure,
+		"gcp.project.computeService.instance.exposure": {
+			// to override args, implement: initGcpProjectComputeServiceInstanceExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectComputeServiceInstanceExposure,
 		},
 		"gcp.project.computeService.instance.osInventory": {
 			// to override args, implement: initGcpProjectComputeServiceInstanceOsInventory(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3818,7 +3818,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.instance.exposure": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetExposure()).ToDataRes(types.Resource("gcp.project.computeService.network.exposure"))
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetExposure()).ToDataRes(types.Resource("gcp.project.computeService.instance.exposure"))
 	},
 	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetUsesDefaultServiceAccount()).ToDataRes(types.Bool)
@@ -3922,17 +3922,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.vulnerabilityReport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetVulnerabilityReport()).ToDataRes(types.Resource("gcp.project.computeService.instance.vulnerabilityReport"))
 	},
-	"gcp.project.computeService.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	"gcp.project.computeService.instance.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetInternetReachable()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	"gcp.project.computeService.instance.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.network.exposure.firewallAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetFirewallAllowsIngress()).ToDataRes(types.Bool)
+	"gcp.project.computeService.instance.exposure.firewallAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetFirewallAllowsIngress()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.network.exposure.openIngressFirewalls": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetOpenIngressFirewalls()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewall")))
+	"gcp.project.computeService.instance.exposure.openIngressFirewalls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetOpenIngressFirewalls()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewall")))
 	},
 	"gcp.project.computeService.instance.osInventory.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetName()).ToDataRes(types.String)
@@ -19033,7 +19033,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"gcp.project.computeService.instance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).Exposure, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetworkExposure](v.Value, v.Error)
+		r.(*mqlGcpProjectComputeServiceInstance).Exposure, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceExposure](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19172,24 +19172,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).VulnerabilityReport, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceVulnerabilityReport](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkExposure).__id, ok = v.Value.(string)
+	"gcp.project.computeService.instance.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).__id, ok = v.Value.(string)
 		return
 	},
-	"gcp.project.computeService.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"gcp.project.computeService.instance.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"gcp.project.computeService.instance.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.network.exposure.firewallAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkExposure).FirewallAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"gcp.project.computeService.instance.exposure.firewallAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).FirewallAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.network.exposure.openIngressFirewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkExposure).OpenIngressFirewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"gcp.project.computeService.instance.exposure.openIngressFirewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).OpenIngressFirewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.osInventory.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -43922,7 +43922,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	NetworkInterfaces               plugin.TValue[[]any]
 	NetworkStackTypes               plugin.TValue[[]any]
 	HasPublicIp                     plugin.TValue[bool]
-	Exposure                        plugin.TValue[*mqlGcpProjectComputeServiceNetworkExposure]
+	Exposure                        plugin.TValue[*mqlGcpProjectComputeServiceInstanceExposure]
 	UsesDefaultServiceAccount       plugin.TValue[bool]
 	HasFullCloudPlatformScope       plugin.TValue[bool]
 	BlockProjectSshKeysEnabled      plugin.TValue[bool]
@@ -44094,15 +44094,15 @@ func (c *mqlGcpProjectComputeServiceInstance) GetHasPublicIp() *plugin.TValue[bo
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceInstance) GetExposure() *plugin.TValue[*mqlGcpProjectComputeServiceNetworkExposure] {
-	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetworkExposure](&c.Exposure, func() (*mqlGcpProjectComputeServiceNetworkExposure, error) {
+func (c *mqlGcpProjectComputeServiceInstance) GetExposure() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceExposure] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceInstanceExposure](&c.Exposure, func() (*mqlGcpProjectComputeServiceInstanceExposure, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "exposure")
 			if err != nil {
 				return nil, err
 			}
 			if d != nil {
-				return d.Value.(*mqlGcpProjectComputeServiceNetworkExposure), nil
+				return d.Value.(*mqlGcpProjectComputeServiceInstanceExposure), nil
 			}
 		}
 
@@ -44294,20 +44294,20 @@ func (c *mqlGcpProjectComputeServiceInstance) GetVulnerabilityReport() *plugin.T
 	})
 }
 
-// mqlGcpProjectComputeServiceNetworkExposure for the gcp.project.computeService.network.exposure resource
-type mqlGcpProjectComputeServiceNetworkExposure struct {
+// mqlGcpProjectComputeServiceInstanceExposure for the gcp.project.computeService.instance.exposure resource
+type mqlGcpProjectComputeServiceInstanceExposure struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceNetworkExposureInternal it will be used here
+	// optional: if you define mqlGcpProjectComputeServiceInstanceExposureInternal it will be used here
 	InternetReachable     plugin.TValue[bool]
 	HasPublicIp           plugin.TValue[bool]
 	FirewallAllowsIngress plugin.TValue[bool]
 	OpenIngressFirewalls  plugin.TValue[[]any]
 }
 
-// createGcpProjectComputeServiceNetworkExposure creates a new instance of this resource
-func createGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlGcpProjectComputeServiceNetworkExposure{
+// createGcpProjectComputeServiceInstanceExposure creates a new instance of this resource
+func createGcpProjectComputeServiceInstanceExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectComputeServiceInstanceExposure{
 		MqlRuntime: runtime,
 	}
 
@@ -44319,7 +44319,7 @@ func createGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args
 	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("gcp.project.computeService.network.exposure", res.__id)
+		args, err = runtime.ResourceFromRecording("gcp.project.computeService.instance.exposure", res.__id)
 		if err != nil || args == nil {
 			return res, err
 		}
@@ -44329,27 +44329,27 @@ func createGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args
 	return res, nil
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) MqlName() string {
-	return "gcp.project.computeService.network.exposure"
+func (c *mqlGcpProjectComputeServiceInstanceExposure) MqlName() string {
+	return "gcp.project.computeService.instance.exposure"
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) MqlID() string {
+func (c *mqlGcpProjectComputeServiceInstanceExposure) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+func (c *mqlGcpProjectComputeServiceInstanceExposure) GetInternetReachable() *plugin.TValue[bool] {
 	return &c.InternetReachable
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+func (c *mqlGcpProjectComputeServiceInstanceExposure) GetHasPublicIp() *plugin.TValue[bool] {
 	return &c.HasPublicIp
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) GetFirewallAllowsIngress() *plugin.TValue[bool] {
+func (c *mqlGcpProjectComputeServiceInstanceExposure) GetFirewallAllowsIngress() *plugin.TValue[bool] {
 	return &c.FirewallAllowsIngress
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkExposure) GetOpenIngressFirewalls() *plugin.TValue[[]any] {
+func (c *mqlGcpProjectComputeServiceInstanceExposure) GetOpenIngressFirewalls() *plugin.TValue[[]any] {
 	return &c.OpenIngressFirewalls
 }
 

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -50,6 +50,7 @@ const (
 	ResourceGcpProjectComputeServiceZone                                               string = "gcp.project.computeService.zone"
 	ResourceGcpProjectComputeServiceMachineType                                        string = "gcp.project.computeService.machineType"
 	ResourceGcpProjectComputeServiceInstance                                           string = "gcp.project.computeService.instance"
+	ResourceGcpProjectComputeServiceNetworkExposure                                    string = "gcp.project.computeService.network.exposure"
 	ResourceGcpProjectComputeServiceInstanceOsInventory                                string = "gcp.project.computeService.instance.osInventory"
 	ResourceGcpProjectComputeServiceInstanceOsInventoryItem                            string = "gcp.project.computeService.instance.osInventory.item"
 	ResourceGcpProjectComputeServiceInstanceVulnerabilityReport                        string = "gcp.project.computeService.instance.vulnerabilityReport"
@@ -605,6 +606,10 @@ func init() {
 		"gcp.project.computeService.instance": {
 			Init:   initGcpProjectComputeServiceInstance,
 			Create: createGcpProjectComputeServiceInstance,
+		},
+		"gcp.project.computeService.network.exposure": {
+			// to override args, implement: initGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectComputeServiceNetworkExposure,
 		},
 		"gcp.project.computeService.instance.osInventory": {
 			// to override args, implement: initGcpProjectComputeServiceInstanceOsInventory(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3812,6 +3817,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.instance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetExposure()).ToDataRes(types.Resource("gcp.project.computeService.network.exposure"))
+	},
 	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetUsesDefaultServiceAccount()).ToDataRes(types.Bool)
 	},
@@ -3913,6 +3921,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetVulnerabilityReport()).ToDataRes(types.Resource("gcp.project.computeService.instance.vulnerabilityReport"))
+	},
+	"gcp.project.computeService.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.network.exposure.firewallAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetFirewallAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.network.exposure.openIngressFirewalls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkExposure).GetOpenIngressFirewalls()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewall")))
 	},
 	"gcp.project.computeService.instance.osInventory.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetName()).ToDataRes(types.String)
@@ -19009,6 +19029,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).Exposure, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).UsesDefaultServiceAccount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -19143,6 +19167,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).VulnerabilityReport, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceVulnerabilityReport](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.computeService.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.exposure.firewallAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkExposure).FirewallAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.exposure.openIngressFirewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkExposure).OpenIngressFirewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.osInventory.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -43871,6 +43915,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	NetworkInterfaces               plugin.TValue[[]any]
 	NetworkStackTypes               plugin.TValue[[]any]
 	HasPublicIp                     plugin.TValue[bool]
+	Exposure                        plugin.TValue[*mqlGcpProjectComputeServiceNetworkExposure]
 	UsesDefaultServiceAccount       plugin.TValue[bool]
 	HasFullCloudPlatformScope       plugin.TValue[bool]
 	BlockProjectSshKeysEnabled      plugin.TValue[bool]
@@ -44039,6 +44084,22 @@ func (c *mqlGcpProjectComputeServiceInstance) GetNetworkStackTypes() *plugin.TVa
 func (c *mqlGcpProjectComputeServiceInstance) GetHasPublicIp() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasPublicIp, func() (bool, error) {
 		return c.hasPublicIp()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetExposure() *plugin.TValue[*mqlGcpProjectComputeServiceNetworkExposure] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetworkExposure](&c.Exposure, func() (*mqlGcpProjectComputeServiceNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -44224,6 +44285,65 @@ func (c *mqlGcpProjectComputeServiceInstance) GetVulnerabilityReport() *plugin.T
 
 		return c.vulnerabilityReport()
 	})
+}
+
+// mqlGcpProjectComputeServiceNetworkExposure for the gcp.project.computeService.network.exposure resource
+type mqlGcpProjectComputeServiceNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectComputeServiceNetworkExposureInternal it will be used here
+	InternetReachable     plugin.TValue[bool]
+	HasPublicIp           plugin.TValue[bool]
+	FirewallAllowsIngress plugin.TValue[bool]
+	OpenIngressFirewalls  plugin.TValue[[]any]
+}
+
+// createGcpProjectComputeServiceNetworkExposure creates a new instance of this resource
+func createGcpProjectComputeServiceNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectComputeServiceNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.computeService.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) MqlName() string {
+	return "gcp.project.computeService.network.exposure"
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+	return &c.HasPublicIp
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) GetFirewallAllowsIngress() *plugin.TValue[bool] {
+	return &c.FirewallAllowsIngress
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkExposure) GetOpenIngressFirewalls() *plugin.TValue[[]any] {
+	return &c.OpenIngressFirewalls
 }
 
 // mqlGcpProjectComputeServiceInstanceOsInventory for the gcp.project.computeService.instance.osInventory resource

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5122,6 +5122,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.publicIpEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetPublicIpEnabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.sqlService.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"gcp.project.sqlService.instance.iamAuthenticationEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetIamAuthenticationEnabled()).ToDataRes(types.Bool)
 	},
@@ -20875,6 +20878,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.publicIpEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).PublicIpEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.iamAuthenticationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47663,6 +47670,7 @@ type mqlGcpProjectSqlServiceInstance struct {
 	ReplicaNames                               plugin.TValue[[]any]
 	Settings                                   plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettings]
 	PublicIpEnabled                            plugin.TValue[bool]
+	InternetReachable                          plugin.TValue[bool]
 	IamAuthenticationEnabled                   plugin.TValue[bool]
 	BackupConfigurationEnabled                 plugin.TValue[bool]
 	PointInTimeRecoveryEnabled                 plugin.TValue[bool]
@@ -47847,6 +47855,12 @@ func (c *mqlGcpProjectSqlServiceInstance) GetSettings() *plugin.TValue[*mqlGcpPr
 func (c *mqlGcpProjectSqlServiceInstance) GetPublicIpEnabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.PublicIpEnabled, func() (bool, error) {
 		return c.publicIpEnabled()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1732,6 +1732,7 @@ gcp.project.computeService.instance.enableDisplay 9.0.0
 gcp.project.computeService.instance.enableIntegrityMonitoring 9.0.0
 gcp.project.computeService.instance.enableSecureBoot 9.0.0
 gcp.project.computeService.instance.enableVtpm 9.0.0
+gcp.project.computeService.instance.exposure 13.24.1
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
 gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2
@@ -1937,6 +1938,11 @@ gcp.project.computeService.network.autoCreateSubnetworks 9.0.0
 gcp.project.computeService.network.created 9.0.0
 gcp.project.computeService.network.description 9.0.0
 gcp.project.computeService.network.enableUlaInternalIpv6 9.0.0
+gcp.project.computeService.network.exposure 13.24.1
+gcp.project.computeService.network.exposure.firewallAllowsIngress 13.24.1
+gcp.project.computeService.network.exposure.hasPublicIp 13.24.1
+gcp.project.computeService.network.exposure.internetReachable 13.24.1
+gcp.project.computeService.network.exposure.openIngressFirewalls 13.24.1
 gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4451,6 +4451,7 @@ gcp.project.sqlService.instance.gceZone 9.0.0
 gcp.project.sqlService.instance.hasBuiltInUsers 13.12.2
 gcp.project.sqlService.instance.iamAuthenticationEnabled 13.21.2
 gcp.project.sqlService.instance.instanceType 9.0.0
+gcp.project.sqlService.instance.internetReachable 13.24.1
 gcp.project.sqlService.instance.ipAddresses 9.0.0
 gcp.project.sqlService.instance.ipMapping 9.0.0
 gcp.project.sqlService.instance.ipMapping.id 9.0.0

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1733,6 +1733,10 @@ gcp.project.computeService.instance.enableIntegrityMonitoring 9.0.0
 gcp.project.computeService.instance.enableSecureBoot 9.0.0
 gcp.project.computeService.instance.enableVtpm 9.0.0
 gcp.project.computeService.instance.exposure 13.24.1
+gcp.project.computeService.instance.exposure.firewallAllowsIngress 13.24.1
+gcp.project.computeService.instance.exposure.hasPublicIp 13.24.1
+gcp.project.computeService.instance.exposure.internetReachable 13.24.1
+gcp.project.computeService.instance.exposure.openIngressFirewalls 13.24.1
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
 gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2
@@ -1938,11 +1942,6 @@ gcp.project.computeService.network.autoCreateSubnetworks 9.0.0
 gcp.project.computeService.network.created 9.0.0
 gcp.project.computeService.network.description 9.0.0
 gcp.project.computeService.network.enableUlaInternalIpv6 9.0.0
-gcp.project.computeService.network.exposure 13.24.1
-gcp.project.computeService.network.exposure.firewallAllowsIngress 13.24.1
-gcp.project.computeService.network.exposure.hasPublicIp 13.24.1
-gcp.project.computeService.network.exposure.internetReachable 13.24.1
-gcp.project.computeService.network.exposure.openIngressFirewalls 13.24.1
 gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -131,7 +131,7 @@ func anyStringSet(items []any) map[string]bool {
 	return set
 }
 
-func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeServiceNetworkExposure, error) {
+func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeServiceInstanceExposure, error) {
 	id := g.GetId()
 	if id.Error != nil {
 		return nil, id.Error
@@ -237,7 +237,7 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 	firewallAllowsIngress := len(openFirewalls) > 0
 	internetReachable := hasPublicIp.Data && firewallAllowsIngress
 
-	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.network.exposure", map[string]*llx.RawData{
+	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.instance.exposure", map[string]*llx.RawData{
 		"__id":                  llx.StringData("gcp.project.computeService.instance/" + id.Data + "/exposure"),
 		"internetReachable":     llx.BoolData(internetReachable),
 		"hasPublicIp":           llx.BoolData(hasPublicIp.Data),
@@ -247,7 +247,7 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceNetworkExposure), nil
+	return res.(*mqlGcpProjectComputeServiceInstanceExposure), nil
 }
 
 // internetReachable reports whether the Cloud SQL instance is reachable from the

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -249,3 +249,36 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 	}
 	return res.(*mqlGcpProjectComputeServiceNetworkExposure), nil
 }
+
+// internetReachable reports whether the Cloud SQL instance is reachable from the
+// internet: it has a public IP and an authorized network that admits any address
+// (0.0.0.0/0). Reuses the existing publicIpEnabled and hasOpenAuthorizedNetworks
+// signals.
+func (g *mqlGcpProjectSqlServiceInstance) internetReachable() (bool, error) {
+	public := g.GetPublicIpEnabled()
+	if public.Error != nil {
+		return false, public.Error
+	}
+	if !public.Data {
+		return false, nil
+	}
+	settings := g.GetSettings()
+	if settings.Error != nil {
+		return false, settings.Error
+	}
+	if settings.Data == nil {
+		return false, nil
+	}
+	ipConfig := settings.Data.GetIpConfiguration()
+	if ipConfig.Error != nil {
+		return false, ipConfig.Error
+	}
+	if ipConfig.Data == nil {
+		return false, nil
+	}
+	open := ipConfig.Data.GetHasOpenAuthorizedNetworks()
+	if open.Error != nil {
+		return false, open.Error
+	}
+	return open.Data, nil
+}

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -3,7 +3,12 @@
 
 package resources
 
-import "strings"
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
 
 // openCIDRs are the source ranges that mean "the entire internet".
 var openCIDRs = map[string]struct{}{
@@ -66,4 +71,181 @@ func (g *mqlGcpProjectGkeServiceCluster) controlPlaneInternetReachable() (bool, 
 		g.MasterAuthorizedNetworksAllowed.Data,
 		cidrs,
 	), nil
+}
+
+// firewallRuleOpenIngress reports whether a firewall rule admits inbound traffic
+// from any address — an enabled INGRESS rule whose source ranges include
+// 0.0.0.0/0 or ::/0.
+func firewallRuleOpenIngress(direction string, disabled bool, sourceRanges []any) bool {
+	if disabled || !strings.EqualFold(direction, "INGRESS") {
+		return false
+	}
+	for _, s := range sourceRanges {
+		if cidr, ok := s.(string); ok && (cidr == "0.0.0.0/0" || cidr == "::/0") {
+			return true
+		}
+	}
+	return false
+}
+
+// networkNameFromUrl returns the trailing network name from a GCP network URL or
+// partial reference, so full URLs and short names compare equal.
+func networkNameFromUrl(url string) string {
+	if i := strings.LastIndex(url, "/networks/"); i >= 0 {
+		return url[i+len("/networks/"):]
+	}
+	if i := strings.LastIndex(url, "/"); i >= 0 {
+		return url[i+1:]
+	}
+	return url
+}
+
+// firewallTargetsInstance reports whether a firewall rule's targeting applies to
+// an instance. A rule with no target tags and no target service accounts applies
+// to every instance in its network; otherwise it applies only when a target tag
+// or target service account matches the instance.
+func firewallTargetsInstance(targetTags, targetServiceAccounts []any, instanceTags, instanceServiceAccounts map[string]bool) bool {
+	if len(targetTags) == 0 && len(targetServiceAccounts) == 0 {
+		return true
+	}
+	for _, t := range targetTags {
+		if tag, ok := t.(string); ok && instanceTags[tag] {
+			return true
+		}
+	}
+	for _, sa := range targetServiceAccounts {
+		if email, ok := sa.(string); ok && instanceServiceAccounts[email] {
+			return true
+		}
+	}
+	return false
+}
+
+func anyStringSet(items []any) map[string]bool {
+	set := map[string]bool{}
+	for _, i := range items {
+		if s, ok := i.(string); ok && s != "" {
+			set[s] = true
+		}
+	}
+	return set
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeServiceNetworkExposure, error) {
+	id := g.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+	hasPublicIp := g.GetHasPublicIp()
+	if hasPublicIp.Error != nil {
+		return nil, hasPublicIp.Error
+	}
+	projectId := g.GetProjectId()
+	if projectId.Error != nil {
+		return nil, projectId.Error
+	}
+
+	// Networks the instance is attached to.
+	nics := g.GetNetworkInterfaces()
+	if nics.Error != nil {
+		return nil, nics.Error
+	}
+	instanceNetworks := map[string]bool{}
+	for _, n := range nics.Data {
+		nic, ok := n.(map[string]any)
+		if !ok {
+			continue
+		}
+		if network, ok := nic["network"].(string); ok && network != "" {
+			instanceNetworks[networkNameFromUrl(network)] = true
+		}
+	}
+
+	tags := g.GetTags()
+	if tags.Error != nil {
+		return nil, tags.Error
+	}
+	instanceTags := anyStringSet(tags.Data)
+
+	serviceAccounts := g.GetServiceAccounts()
+	if serviceAccounts.Error != nil {
+		return nil, serviceAccounts.Error
+	}
+	instanceServiceAccounts := map[string]bool{}
+	for _, s := range serviceAccounts.Data {
+		sa, ok := s.(*mqlGcpProjectComputeServiceServiceaccount)
+		if !ok {
+			continue
+		}
+		email := sa.GetEmail()
+		if email.Error != nil {
+			return nil, email.Error
+		}
+		if email.Data != "" {
+			instanceServiceAccounts[email.Data] = true
+		}
+	}
+
+	svc, err := NewResource(g.MqlRuntime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	firewalls := svc.(*mqlGcpProjectComputeService).GetFirewalls()
+	if firewalls.Error != nil {
+		return nil, firewalls.Error
+	}
+
+	openFirewalls := []any{}
+	for _, f := range firewalls.Data {
+		fw, ok := f.(*mqlGcpProjectComputeServiceFirewall)
+		if !ok {
+			continue
+		}
+		direction := fw.GetDirection()
+		if direction.Error != nil {
+			return nil, direction.Error
+		}
+		disabled := fw.GetDisabled()
+		if disabled.Error != nil {
+			return nil, disabled.Error
+		}
+		sourceRanges := fw.GetSourceRanges()
+		if sourceRanges.Error != nil {
+			return nil, sourceRanges.Error
+		}
+		if !firewallRuleOpenIngress(direction.Data, disabled.Data, sourceRanges.Data) {
+			continue
+		}
+		if !instanceNetworks[networkNameFromUrl(fw.cacheNetworkUrl)] {
+			continue
+		}
+		targetTags := fw.GetTargetTags()
+		if targetTags.Error != nil {
+			return nil, targetTags.Error
+		}
+		targetServiceAccounts := fw.GetTargetServiceAccounts()
+		if targetServiceAccounts.Error != nil {
+			return nil, targetServiceAccounts.Error
+		}
+		if firewallTargetsInstance(targetTags.Data, targetServiceAccounts.Data, instanceTags, instanceServiceAccounts) {
+			openFirewalls = append(openFirewalls, fw)
+		}
+	}
+
+	firewallAllowsIngress := len(openFirewalls) > 0
+	internetReachable := hasPublicIp.Data && firewallAllowsIngress
+
+	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData("gcp.project.computeService.instance/" + id.Data + "/exposure"),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp.Data),
+		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		"openIngressFirewalls":  llx.ArrayData(openFirewalls, types.Resource("gcp.project.computeService.firewall")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectComputeServiceNetworkExposure), nil
 }

--- a/providers/gcp/resources/gcp_exposure_test.go
+++ b/providers/gcp/resources/gcp_exposure_test.go
@@ -94,3 +94,67 @@ func TestGkeControlPlaneInternetReachable(t *testing.T) {
 		})
 	}
 }
+
+func TestFirewallRuleOpenIngress(t *testing.T) {
+	cases := []struct {
+		name      string
+		direction string
+		disabled  bool
+		sources   []any
+		want      bool
+	}{
+		{"ingress any v4", "INGRESS", false, []any{"0.0.0.0/0"}, true},
+		{"ingress any v6", "INGRESS", false, []any{"::/0"}, true},
+		{"ingress lowercase", "ingress", false, []any{"0.0.0.0/0"}, true},
+		{"disabled", "INGRESS", true, []any{"0.0.0.0/0"}, false},
+		{"egress", "EGRESS", false, []any{"0.0.0.0/0"}, false},
+		{"scoped source", "INGRESS", false, []any{"10.0.0.0/8"}, false},
+		{"no sources", "INGRESS", false, []any{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := firewallRuleOpenIngress(c.direction, c.disabled, c.sources); got != c.want {
+				t.Errorf("firewallRuleOpenIngress(%q,%v,%v) = %v, want %v", c.direction, c.disabled, c.sources, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNetworkNameFromUrl(t *testing.T) {
+	cases := map[string]string{
+		"https://www.googleapis.com/compute/v1/projects/p/global/networks/default": "default",
+		"projects/p/global/networks/my-vpc":                                        "my-vpc",
+		"default":                                                                  "default",
+		"":                                                                         "",
+	}
+	for in, want := range cases {
+		if got := networkNameFromUrl(in); got != want {
+			t.Errorf("networkNameFromUrl(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFirewallTargetsInstance(t *testing.T) {
+	tags := map[string]bool{"web": true}
+	sas := map[string]bool{"sa@project.iam.gserviceaccount.com": true}
+
+	cases := []struct {
+		name       string
+		targetTags []any
+		targetSAs  []any
+		want       bool
+	}{
+		{"no targets applies to all", []any{}, []any{}, true},
+		{"matching tag", []any{"web"}, []any{}, true},
+		{"non-matching tag", []any{"db"}, []any{}, false},
+		{"matching service account", []any{}, []any{"sa@project.iam.gserviceaccount.com"}, true},
+		{"non-matching service account", []any{}, []any{"other@project.iam.gserviceaccount.com"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := firewallTargetsInstance(c.targetTags, c.targetSAs, tags, sas); got != c.want {
+				t.Errorf("firewallTargetsInstance(%v,%v) = %v, want %v", c.targetTags, c.targetSAs, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cross-provider exposure (one PR per provider) — GCP. Mirrors `aws.network.exposure`.

## `gcp.project.computeService.network.exposure`
Added `gcp.project.computeService.instance.exposure`:
| field | meaning |
|---|---|
| `internetReachable` | an external IP **and** an applicable firewall rule admitting any address |
| `hasPublicIp` | the instance has an external IP (reuses existing `hasPublicIp`) |
| `firewallAllowsIngress` | a firewall rule that applies to this instance admits `0.0.0.0/0`/`::/0` |
| `openIngressFirewalls` | the applicable internet-open INGRESS firewall rules |

GCP firewalls are VPC-level and apply by **network + target tags / target service accounts**, so the resolver correlates each firewall's network and targeting against the instance (a rule with no targets applies to all instances in its network).

## Tests
The non-trivial matching logic is in pure, unit-tested helpers:
- `firewallRuleOpenIngress` (enabled INGRESS + any-address source)
- `networkNameFromUrl` (so full URLs and short names compare equal)
- `firewallTargetsInstance` (no-targets = all; else tag / service-account match)

## Notes
- Reads cached instance/firewall data — **no new API calls**. Versions `13.24.1`.
- The firewall-matching helpers are unit-tested; no GCP account available for live verification, so the resolver wiring (network correlation across the project's firewalls) is verified by build + the helper tests rather than a live scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)