### PR TITLE
⭐ proxmox: add internet-exposure analysis across resources

### DIFF
--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -810,6 +810,17 @@ proxmox.firewall.rule @defaults("pos action") {
   // than a verb like ACCEPT/DROP, and apply that named rule set in
   // place. This resolves the reference; null for non-group rules.
   group() proxmox.firewall.group
+  // Whether this rule permits inbound traffic from any source
+  //
+  // True when the rule is enabled, an inbound (`type == "in"`) ACCEPT
+  // rule, and its `source` is unrestricted: empty (Proxmox treats an
+  // empty source as "any"), `0.0.0.0/0`, `::/0`, or an equivalent
+  // all-addresses match. Such a rule opens the guarded VM, container,
+  // node, or cluster to every network the host can reach, including the
+  // internet when the bridge is routed publicly. False for outbound
+  // rules, DROP/REJECT rules, disabled rules, and rules restricted to a
+  // specific CIDR, IP, alias, or IPset reference.
+  allowsPublicIngress() bool
 }
 
 // Proxmox VE user

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -1030,6 +1030,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.firewall.rule.group": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxFirewallRule).GetGroup()).ToDataRes(types.Resource("proxmox.firewall.group"))
 	},
+	"proxmox.firewall.rule.allowsPublicIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxFirewallRule).GetAllowsPublicIngress()).ToDataRes(types.Bool)
+	},
 	"proxmox.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetId()).ToDataRes(types.String)
 	},
@@ -2860,6 +2863,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.firewall.rule.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxFirewallRule).Group, ok = plugin.RawToTValue[*mqlProxmoxFirewallGroup](v.Value, v.Error)
+		return
+	},
+	"proxmox.firewall.rule.allowsPublicIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxFirewallRule).AllowsPublicIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"proxmox.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6663,20 +6670,21 @@ type mqlProxmoxFirewallRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlProxmoxFirewallRuleInternal
-	Pos     plugin.TValue[int64]
-	Type    plugin.TValue[string]
-	Action  plugin.TValue[string]
-	Comment plugin.TValue[string]
-	Dest    plugin.TValue[string]
-	Dport   plugin.TValue[string]
-	Enable  plugin.TValue[bool]
-	Iface   plugin.TValue[string]
-	Log     plugin.TValue[string]
-	Macro   plugin.TValue[string]
-	Proto   plugin.TValue[string]
-	Source  plugin.TValue[string]
-	Sport   plugin.TValue[string]
-	Group   plugin.TValue[*mqlProxmoxFirewallGroup]
+	Pos                 plugin.TValue[int64]
+	Type                plugin.TValue[string]
+	Action              plugin.TValue[string]
+	Comment             plugin.TValue[string]
+	Dest                plugin.TValue[string]
+	Dport               plugin.TValue[string]
+	Enable              plugin.TValue[bool]
+	Iface               plugin.TValue[string]
+	Log                 plugin.TValue[string]
+	Macro               plugin.TValue[string]
+	Proto               plugin.TValue[string]
+	Source              plugin.TValue[string]
+	Sport               plugin.TValue[string]
+	Group               plugin.TValue[*mqlProxmoxFirewallGroup]
+	AllowsPublicIngress plugin.TValue[bool]
 }
 
 // createProxmoxFirewallRule creates a new instance of this resource
@@ -6781,6 +6789,12 @@ func (c *mqlProxmoxFirewallRule) GetGroup() *plugin.TValue[*mqlProxmoxFirewallGr
 		}
 
 		return c.group()
+	})
+}
+
+func (c *mqlProxmoxFirewallRule) GetAllowsPublicIngress() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsPublicIngress, func() (bool, error) {
+		return c.allowsPublicIngress()
 	})
 }
 

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -193,6 +193,7 @@ proxmox.firewall.options.radv 0.1.9
 proxmox.firewall.options.scope 0.1.9
 proxmox.firewall.rule 0.1.1
 proxmox.firewall.rule.action 0.1.1
+proxmox.firewall.rule.allowsPublicIngress 0.1.13
 proxmox.firewall.rule.comment 0.1.1
 proxmox.firewall.rule.dest 0.1.1
 proxmox.firewall.rule.dport 0.1.1

--- a/providers/proxmox/resources/proxmox_exposure.go
+++ b/providers/proxmox/resources/proxmox_exposure.go
@@ -1,0 +1,121 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "strings"
+
+// firewallRuleAllowsPublicIngress reports whether a Proxmox firewall rule
+// permits inbound traffic from any source.
+//
+// Proxmox VE is on-prem virtualization, so "internet exposure" only maps
+// meaningfully at the firewall-rule level: a rule that accepts inbound
+// traffic from an unrestricted source opens whatever it guards (a VM,
+// container, node, or the whole cluster) to every network the host bridge
+// can reach. The predicate is true only when ALL of the following hold:
+//
+//   - the rule is enabled,
+//   - it is an inbound rule (type == "in"); empty type also defaults to
+//     inbound in PVE, but only ACCEPT verbs below qualify,
+//   - the action accepts traffic (ACCEPT, case-insensitive),
+//   - the source is unrestricted (see sourceIsAnywhere).
+//
+// Outbound rules, DROP/REJECT rules, disabled rules, group references, and
+// rules scoped to a specific CIDR/IP/alias/IPset all return false. This is a
+// pure function over already-cached rule fields — it makes no API calls.
+func firewallRuleAllowsPublicIngress(ruleType, action, source string, enable bool) bool {
+	if !enable {
+		return false
+	}
+
+	t := strings.ToLower(strings.TrimSpace(ruleType))
+	// Only inbound rules expose a target. PVE treats an empty type as an
+	// inbound match, so accept "" as well; "out" and "group" do not.
+	if t != "in" && t != "" {
+		return false
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(action), "ACCEPT") {
+		return false
+	}
+
+	return sourceIsAnywhere(source)
+}
+
+// sourceIsAnywhere reports whether a Proxmox firewall rule source matches
+// every address. Proxmox accepts the source in several forms:
+//
+//   - empty string — PVE treats an absent source as "any",
+//   - the all-IPv4 route 0.0.0.0/0 (any prefix length that is effectively a
+//     /0, e.g. "0.0.0.0/0"),
+//   - the all-IPv6 route ::/0,
+//   - a bare "0.0.0.0" or "::" with no prefix.
+//
+// A reference to a named alias or IPset (e.g. "+myset" or "dc/myalias") or
+// any concrete CIDR/host is NOT considered "anywhere" — its breadth depends
+// on data this function deliberately does not resolve, so it returns false
+// to avoid over-reporting. Multiple comma-separated sources count as
+// "anywhere" if ANY entry is an all-addresses match.
+func sourceIsAnywhere(source string) bool {
+	s := strings.TrimSpace(source)
+	if s == "" {
+		return true
+	}
+
+	for _, part := range strings.Split(s, ",") {
+		if entryIsAnywhere(part) {
+			return true
+		}
+	}
+	return false
+}
+
+func entryIsAnywhere(entry string) bool {
+	e := strings.TrimSpace(entry)
+	if e == "" {
+		// An empty entry within a list behaves like an absent source.
+		return true
+	}
+
+	// A leading '+' denotes an IPset reference and '!' a negation; neither is
+	// an unconditional all-addresses match.
+	if strings.HasPrefix(e, "+") || strings.HasPrefix(e, "!") {
+		return false
+	}
+
+	addr := e
+	prefix := ""
+	if idx := strings.IndexByte(e, '/'); idx >= 0 {
+		addr = strings.TrimSpace(e[:idx])
+		prefix = strings.TrimSpace(e[idx+1:])
+	}
+
+	isAllZeroV4 := addr == "0.0.0.0"
+	isAllZeroV6 := addr == "::"
+	if !isAllZeroV4 && !isAllZeroV6 {
+		return false
+	}
+
+	// No prefix on the all-zero address means the host itself, which in
+	// practice only matches when used as a wildcard; treat 0.0.0.0 / :: as
+	// "anywhere".
+	if prefix == "" {
+		return true
+	}
+
+	// With a prefix, only a /0 covers every address.
+	return prefix == "0"
+}
+
+// allowsPublicIngress is the generated resolver for
+// proxmox.firewall.rule.allowsPublicIngress. It reads only fields already
+// populated on the rule resource (type, action, source, enable) — no API
+// call, no new permissions.
+func (r *mqlProxmoxFirewallRule) allowsPublicIngress() (bool, error) {
+	return firewallRuleAllowsPublicIngress(
+		r.Type.Data,
+		r.Action.Data,
+		r.Source.Data,
+		r.Enable.Data,
+	), nil
+}

--- a/providers/proxmox/resources/proxmox_exposure.go
+++ b/providers/proxmox/resources/proxmox_exposure.go
@@ -30,7 +30,11 @@ func firewallRuleAllowsPublicIngress(ruleType, action, source string, enable boo
 
 	t := strings.ToLower(strings.TrimSpace(ruleType))
 	// Only inbound rules expose a target. PVE treats an empty type as an
-	// inbound match, so accept "" as well; "out" and "group" do not.
+	// inbound match, so accept "" as well; "out" and "group" do not. This
+	// intentionally over-reports: a misconfigured rule with type="" and
+	// action=ACCEPT is flagged as internet-exposed. For an exposure check that
+	// is the safer direction — over-reporting beats silently missing a real
+	// exposure. (See the "empty type defaults inbound" case in the test.)
 	if t != "in" && t != "" {
 		return false
 	}

--- a/providers/proxmox/resources/proxmox_exposure_test.go
+++ b/providers/proxmox/resources/proxmox_exposure_test.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestSourceIsAnywhere(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{"empty is any", "", true},
+		{"whitespace is any", "   ", true},
+		{"ipv4 default route", "0.0.0.0/0", true},
+		{"ipv6 default route", "::/0", true},
+		{"bare all-zero ipv4", "0.0.0.0", true},
+		{"bare all-zero ipv6", "::", true},
+		{"padded default route", " 0.0.0.0/0 ", true},
+		{"list with any", "10.0.0.0/8,0.0.0.0/0", true},
+		{"specific host", "203.0.113.5", false},
+		{"specific cidr", "10.0.0.0/8", false},
+		{"ipset reference", "+myset", false},
+		{"alias reference", "dc/myalias", false},
+		{"negated source", "!0.0.0.0/0", false},
+		{"non-zero /0 host", "192.168.0.0/0", false},
+		{"list without any", "10.0.0.0/8,192.168.0.0/16", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sourceIsAnywhere(tt.source); got != tt.want {
+				t.Errorf("sourceIsAnywhere(%q) = %v, want %v", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirewallRuleAllowsPublicIngress(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleType string
+		action   string
+		source   string
+		enable   bool
+		want     bool
+	}{
+		{"inbound accept any", "in", "ACCEPT", "0.0.0.0/0", true, true},
+		{"inbound accept empty source", "in", "ACCEPT", "", true, true},
+		{"empty type defaults inbound", "", "ACCEPT", "0.0.0.0/0", true, true},
+		{"lowercase action", "in", "accept", "::/0", true, true},
+		{"disabled rule", "in", "ACCEPT", "0.0.0.0/0", false, false},
+		{"outbound rule", "out", "ACCEPT", "0.0.0.0/0", true, false},
+		{"group rule", "group", "ACCEPT", "0.0.0.0/0", true, false},
+		{"drop action", "in", "DROP", "0.0.0.0/0", true, false},
+		{"reject action", "in", "REJECT", "0.0.0.0/0", true, false},
+		{"scoped source", "in", "ACCEPT", "10.0.0.0/8", true, false},
+		{"ipset source", "in", "ACCEPT", "+trusted", true, false},
+		{"padded inbound accept", " in ", " ACCEPT ", "0.0.0.0/0", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firewallRuleAllowsPublicIngress(tt.ruleType, tt.action, tt.source, tt.enable)
+			if got != tt.want {
+				t.Errorf("firewallRuleAllowsPublicIngress(%q,%q,%q,%v) = %v, want %v",
+					tt.ruleType, tt.action, tt.source, tt.enable, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds internet-exposure analysis to the Proxmox provider via a new `allowsPublicIngress()` predicate on `proxmox.firewall.rule`.

## Why this mechanism

Proxmox VE is on-prem virtualization. There is no cloud-style public-IP / security-group / authorized-networks model to map onto network-reachability exposure — VMs and containers have no `publiclyAccessible`/`publicIp` signal, and reachability is governed entirely by the PVE firewall. The only place where "internet exposure" maps cleanly and meaningfully is the firewall rule itself.

## Resource covered

- **`proxmox.firewall.rule.allowsPublicIngress` (bool)** — firewall-rule-level public-ingress predicate. The same `proxmox.firewall.rule` resource is shared across cluster, node, VM, and container scopes (`firewallRules` on each), so this single predicate covers every firewall scope.

`allowsPublicIngress` is true only when the rule is:
- enabled, and
- inbound (`type == "in"`, or empty which PVE defaults to inbound), and
- `ACCEPT` (case-insensitive), and
- sourced from anywhere — empty source (PVE treats absent as "any"), `0.0.0.0/0`, `::/0`, or a bare all-zero address.

Outbound/`DROP`/`REJECT`/disabled rules, group references, and rules restricted to a specific CIDR/IP/alias/IPset all return false. Alias/IPset references are deliberately treated as not-anywhere to avoid over-reporting (their breadth is not resolved here).

## Implementation notes

- Pure helpers `firewallRuleAllowsPublicIngress` and `sourceIsAnywhere` in `providers/proxmox/resources/proxmox_exposure.go`, with table-driven unit tests (`proxmox_exposure_test.go`, plain `testing`, no new deps).
- The resolver reads only fields already cached on the rule resource (`type`, `action`, `source`, `enable`) — **no new API calls and no new IAM/token permissions**.
- New `.lr.versions` entry `proxmox.firewall.rule.allowsPublicIngress` at `0.1.13` (next patch after the provider's current `0.1.12`).

## Tests

`go test ./resources/ -run 'TestSourceIsAnywhere|TestFirewallRuleAllowsPublicIngress'` passes; `go build ./...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)