### PR TITLE
⭐ gcp: add internet-exposure analysis across resources

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -3866,6 +3866,14 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   // or legacy). When false, the control plane is reachable from any source
   // permitted by the endpoint configuration.
   masterAuthorizedNetworksAllowed bool
+  // Whether the control plane (Kubernetes API server) is reachable from the public internet
+  //
+  // True when the control plane has a public IP endpoint enabled AND either
+  // master authorized networks is not enforced (any source may reach it) or
+  // the authorized-networks allowlist contains an open CIDR (0.0.0.0/0 or
+  // ::/0). False means the API server is private or restricted to specific
+  // source ranges. Derived from cached cluster fields; no extra API calls.
+  controlPlaneInternetReachable() bool
   // Logging components enabled on the control plane
   //
   // The members of `loggingConfig.componentConfig.enableComponents` —

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -6278,6 +6278,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.masterAuthorizedNetworksAllowed": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuthorizedNetworksAllowed()).ToDataRes(types.Bool)
 	},
+	"gcp.project.gkeService.cluster.controlPlaneInternetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetControlPlaneInternetReachable()).ToDataRes(types.Bool)
+	},
 	"gcp.project.gkeService.cluster.controlPlaneLoggingComponents": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetControlPlaneLoggingComponents()).ToDataRes(types.Array(types.String))
 	},
@@ -22516,6 +22519,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.masterAuthorizedNetworksAllowed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).MasterAuthorizedNetworksAllowed, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.controlPlaneInternetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).ControlPlaneInternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.controlPlaneLoggingComponents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51074,6 +51081,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	ControlPlanePublicEndpointEnabled        plugin.TValue[bool]
 	MasterAuthorizedNetworksCidrs            plugin.TValue[[]any]
 	MasterAuthorizedNetworksAllowed          plugin.TValue[bool]
+	ControlPlaneInternetReachable            plugin.TValue[bool]
 	ControlPlaneLoggingComponents            plugin.TValue[[]any]
 	ControlPlaneMonitoringComponents         plugin.TValue[[]any]
 	LoggingConfig                            plugin.TValue[any]
@@ -51358,6 +51366,12 @@ func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksCidrs() *plu
 
 func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksAllowed() *plugin.TValue[bool] {
 	return &c.MasterAuthorizedNetworksAllowed
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetControlPlaneInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ControlPlaneInternetReachable, func() (bool, error) {
+		return c.controlPlaneInternetReachable()
+	})
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetControlPlaneLoggingComponents() *plugin.TValue[[]any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3096,6 +3096,7 @@ gcp.project.gkeService.cluster.conditions 13.16.3
 gcp.project.gkeService.cluster.confidentialNodesConfig 9.0.0
 gcp.project.gkeService.cluster.confidentialNodesEnabled 13.18.1
 gcp.project.gkeService.cluster.controlPlaneEndpointsConfig 13.16.3
+gcp.project.gkeService.cluster.controlPlaneInternetReachable 13.24.1
 gcp.project.gkeService.cluster.controlPlaneLoggingComponents 13.18.1
 gcp.project.gkeService.cluster.controlPlaneMonitoringComponents 13.18.1
 gcp.project.gkeService.cluster.controlPlanePublicEndpointEnabled 13.18.1

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "strings"
+
+// openCIDRs are the source ranges that mean "the entire internet".
+var openCIDRs = map[string]struct{}{
+	"0.0.0.0/0": {},
+	"::/0":      {},
+}
+
+// isOpenCIDR reports whether a CIDR string represents the whole internet
+// (IPv4 0.0.0.0/0 or IPv6 ::/0). Surrounding whitespace is tolerated.
+func isOpenCIDR(cidr string) bool {
+	_, ok := openCIDRs[strings.TrimSpace(cidr)]
+	return ok
+}
+
+// gkeControlPlaneInternetReachable derives whether a GKE cluster's control
+// plane (Kubernetes API server) is reachable from the public internet.
+//
+// It is reachable when the public IP endpoint is enabled AND either:
+//   - master authorized networks is NOT enforced (any source IP may connect), or
+//   - the authorized-networks allowlist itself contains an open CIDR
+//     (0.0.0.0/0 or ::/0), which whitelists the entire internet.
+//
+// When the public endpoint is disabled the control plane is private and never
+// internet-reachable, regardless of the authorized-networks configuration.
+func gkeControlPlaneInternetReachable(publicEndpointEnabled, authorizedNetworksEnforced bool, authorizedCIDRs []string) bool {
+	if !publicEndpointEnabled {
+		return false
+	}
+	if !authorizedNetworksEnforced {
+		return true
+	}
+	for _, c := range authorizedCIDRs {
+		if isOpenCIDR(c) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *mqlGcpProjectGkeServiceCluster) controlPlaneInternetReachable() (bool, error) {
+	if g.ControlPlanePublicEndpointEnabled.Error != nil {
+		return false, g.ControlPlanePublicEndpointEnabled.Error
+	}
+	if g.MasterAuthorizedNetworksAllowed.Error != nil {
+		return false, g.MasterAuthorizedNetworksAllowed.Error
+	}
+	if g.MasterAuthorizedNetworksCidrs.Error != nil {
+		return false, g.MasterAuthorizedNetworksCidrs.Error
+	}
+
+	cidrs := make([]string, 0, len(g.MasterAuthorizedNetworksCidrs.Data))
+	for _, raw := range g.MasterAuthorizedNetworksCidrs.Data {
+		if s, ok := raw.(string); ok {
+			cidrs = append(cidrs, s)
+		}
+	}
+
+	return gkeControlPlaneInternetReachable(
+		g.ControlPlanePublicEndpointEnabled.Data,
+		g.MasterAuthorizedNetworksAllowed.Data,
+		cidrs,
+	), nil
+}

--- a/providers/gcp/resources/gcp_exposure_test.go
+++ b/providers/gcp/resources/gcp_exposure_test.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestIsOpenCIDR(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want bool
+	}{
+		{"0.0.0.0/0", true},
+		{"::/0", true},
+		{" 0.0.0.0/0 ", true},
+		{"10.0.0.0/8", false},
+		{"192.168.1.0/24", false},
+		{"0.0.0.0/32", false},
+		{"", false},
+		{"2001:db8::/32", false},
+	}
+	for _, tt := range tests {
+		if got := isOpenCIDR(tt.cidr); got != tt.want {
+			t.Errorf("isOpenCIDR(%q) = %v, want %v", tt.cidr, got, tt.want)
+		}
+	}
+}
+
+func TestGkeControlPlaneInternetReachable(t *testing.T) {
+	tests := []struct {
+		name           string
+		publicEndpoint bool
+		manEnforced    bool
+		cidrs          []string
+		want           bool
+	}{
+		{
+			name:           "private endpoint is never reachable",
+			publicEndpoint: false,
+			manEnforced:    false,
+			cidrs:          nil,
+			want:           false,
+		},
+		{
+			name:           "private endpoint with open authorized cidr still not reachable",
+			publicEndpoint: false,
+			manEnforced:    true,
+			cidrs:          []string{"0.0.0.0/0"},
+			want:           false,
+		},
+		{
+			name:           "public endpoint without authorized networks is reachable",
+			publicEndpoint: true,
+			manEnforced:    false,
+			cidrs:          nil,
+			want:           true,
+		},
+		{
+			name:           "public endpoint restricted to specific cidrs is not reachable",
+			publicEndpoint: true,
+			manEnforced:    true,
+			cidrs:          []string{"203.0.113.0/24", "10.0.0.0/8"},
+			want:           false,
+		},
+		{
+			name:           "public endpoint with open ipv4 cidr in allowlist is reachable",
+			publicEndpoint: true,
+			manEnforced:    true,
+			cidrs:          []string{"203.0.113.0/24", "0.0.0.0/0"},
+			want:           true,
+		},
+		{
+			name:           "public endpoint with open ipv6 cidr in allowlist is reachable",
+			publicEndpoint: true,
+			manEnforced:    true,
+			cidrs:          []string{"::/0"},
+			want:           true,
+		},
+		{
+			name:           "public endpoint with empty enforced allowlist is not reachable",
+			publicEndpoint: true,
+			manEnforced:    true,
+			cidrs:          nil,
+			want:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gkeControlPlaneInternetReachable(tt.publicEndpoint, tt.manEnforced, tt.cidrs)
+			if got != tt.want {
+				t.Errorf("gkeControlPlaneInternetReachable(%v, %v, %v) = %v, want %v",
+					tt.publicEndpoint, tt.manEnforced, tt.cidrs, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds internet-exposure analysis to the GCP provider, following the established cross-provider exposure pattern.

### Resource covered (network-reachability mechanism)

- **`gcp.project.gkeService.cluster.controlPlaneInternetReachable() bool`** — derived predicate reporting whether a GKE cluster's Kubernetes API server (control plane) is reachable from the public internet. True when the public IP endpoint is enabled AND either master authorized networks is **not** enforced (any source may connect) or the authorized-networks allowlist contains an open CIDR (`0.0.0.0/0` or `::/0`). A private endpoint is never internet-reachable regardless of the allowlist.

This reuses the existing cached cluster signals — `controlPlanePublicEndpointEnabled`, `masterAuthorizedNetworksAllowed`, and `masterAuthorizedNetworksCidrs` — and makes **no additional API calls or IAM permission requests**.

### Resources already covered (policy/public-access mechanism) — left unchanged

- `gcp.project.cloudRunService.service` already has `publicInvocable()` (ingress + IAM invoke to allUsers/allAuthenticatedUsers).
- `gcp.project.cloudFunction` and `gcp.project.cloudFunctionV2` already have `allowsUnauthenticated()` (allUsers/allAuthenticatedUsers invoker in the IAM policy).
- `gcp.project.storage.bucket` already has `public()`.

## How

Pure helpers `isOpenCIDR` and `gkeControlPlaneInternetReachable` live in `providers/gcp/resources/gcp_exposure.go`, with the `controlPlaneInternetReachable()` resolver reading the cached `plugin.TValue` fields. CIDR/reachability logic is table-driven unit-tested in `gcp_exposure_test.go`.

## Tests

`go build ./...` passes; `go test ./resources/ -run 'TestIsOpenCIDR|TestGkeControlPlaneInternetReachable'` passes (8 sub-cases covering private endpoints, unenforced/enforced authorized-networks, and open IPv4/IPv6 allowlist entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)