### PR TITLE
⭐ digitalocean: add internet-exposure analysis across resources

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -269,19 +269,20 @@ private digitalocean.firewall.ingressRule @defaults("protocol ports openToIntern
   sourceKubernetesClusters() []digitalocean.kubernetes.cluster
 }
 
-// Droplet internet-exposure breakdown
+// Network internet-exposure breakdown
 //
-// Explains whether a droplet is reachable from the internet: whether it has a
-// public IP and whether its firewalls admit inbound traffic from any address —
-// including the case where no firewall is attached, which leaves it fully open.
+// Explains whether a resource is reachable from the internet: whether it has a
+// public IP and whether its firewall admits inbound traffic from any address —
+// including the case where no firewall restricts ingress at all, which leaves
+// it fully open. Shared by droplets and internet-facing load balancers.
 private digitalocean.network.exposure @defaults("internetReachable hasPublicIp") {
-  // Whether the droplet is reachable from the internet (a public IP and firewall ingress that admits any address)
+  // Whether the resource is reachable from the internet (a public IP and firewall ingress that admits any address)
   internetReachable bool
-  // Whether the droplet has a public IPv4 or IPv6 address
+  // Whether the resource has a public IPv4 or IPv6 address
   hasPublicIp bool
-  // Whether inbound traffic from any address is admitted — a firewall ingress rule open to the internet, or no firewall attached at all
+  // Whether inbound traffic from any address is admitted — a firewall ingress rule open to the internet, or no firewall restricting ingress at all
   firewallAllowsIngress bool
-  // Firewall ingress rules that admit traffic from any address
+  // Droplet firewall ingress rules that admit traffic from any address; empty for resources that do not use cloud-firewall ingress rules
   openIngressRules []digitalocean.firewall.ingressRule
 }
 
@@ -365,6 +366,10 @@ digitalocean.database @defaults("id name engine") {
   tags []string
   // Firewall rules (trusted sources)
   firewallRules() []dict
+  // Whether the cluster is reachable from the internet
+  //
+  // True when the cluster has a public connection endpoint and its trusted-source firewall rules admit any address (an ip_addr rule of 0.0.0.0/0 or ::/0), or when no trusted-source rules are configured at all, which leaves the public endpoint open to every address.
+  internetReachable() bool
   // Public connection host
   connectionHost string
   // Public connection port
@@ -699,6 +704,8 @@ digitalocean.loadBalancer @defaults("id name status") {
   glbSettings dict
   // Regional load balancers this global load balancer distributes traffic to
   targetLoadBalancers() []digitalocean.loadBalancer
+  // Internet-exposure breakdown (public IP combined with the load balancer firewall)
+  exposure() digitalocean.network.exposure
 }
 
 // DigitalOcean VPC

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -780,6 +780,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.database.firewallRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetFirewallRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"digitalocean.database.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDatabase).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"digitalocean.database.connectionHost": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetConnectionHost()).ToDataRes(types.String)
 	},
@@ -1151,6 +1154,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.loadBalancer.targetLoadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetTargetLoadBalancers()).ToDataRes(types.Array(types.Resource("digitalocean.loadBalancer")))
+	},
+	"digitalocean.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancer).GetExposure()).ToDataRes(types.Resource("digitalocean.network.exposure"))
 	},
 	"digitalocean.vpc.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetId()).ToDataRes(types.String)
@@ -3247,6 +3253,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDatabase).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.database.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDatabase).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"digitalocean.database.connectionHost": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabase).ConnectionHost, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -3781,6 +3791,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.loadBalancer.targetLoadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).TargetLoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlDigitaloceanNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7506,6 +7520,7 @@ type mqlDigitaloceanDatabase struct {
 	Vpc                              plugin.TValue[*mqlDigitaloceanVpc]
 	Tags                             plugin.TValue[[]any]
 	FirewallRules                    plugin.TValue[[]any]
+	InternetReachable                plugin.TValue[bool]
 	ConnectionHost                   plugin.TValue[string]
 	ConnectionPort                   plugin.TValue[int64]
 	PrivateConnectionHost            plugin.TValue[string]
@@ -7642,6 +7657,12 @@ func (c *mqlDigitaloceanDatabase) GetTags() *plugin.TValue[[]any] {
 func (c *mqlDigitaloceanDatabase) GetFirewallRules() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.FirewallRules, func() ([]any, error) {
 		return c.firewallRules()
+	})
+}
+
+func (c *mqlDigitaloceanDatabase) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 
@@ -8655,6 +8676,7 @@ type mqlDigitaloceanLoadBalancer struct {
 	Domains                      plugin.TValue[[]any]
 	GlbSettings                  plugin.TValue[any]
 	TargetLoadBalancers          plugin.TValue[[]any]
+	Exposure                     plugin.TValue[*mqlDigitaloceanNetworkExposure]
 }
 
 // createDigitaloceanLoadBalancer creates a new instance of this resource
@@ -8875,6 +8897,22 @@ func (c *mqlDigitaloceanLoadBalancer) GetTargetLoadBalancers() *plugin.TValue[[]
 		}
 
 		return c.targetLoadBalancers()
+	})
+}
+
+func (c *mqlDigitaloceanLoadBalancer) GetExposure() *plugin.TValue[*mqlDigitaloceanNetworkExposure] {
+	return plugin.GetOrCompute[*mqlDigitaloceanNetworkExposure](&c.Exposure, func() (*mqlDigitaloceanNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.loadBalancer", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -80,6 +80,7 @@ digitalocean.database.engine 13.0.1
 digitalocean.database.evictionPolicy 13.1.7
 digitalocean.database.firewallRules 13.0.1
 digitalocean.database.id 13.0.1
+digitalocean.database.internetReachable 13.7.1
 digitalocean.database.latestBackupAt 13.2.1
 digitalocean.database.maintenanceWindow 13.0.1
 digitalocean.database.metricsEndpoints 13.6.2
@@ -577,6 +578,7 @@ digitalocean.loadBalancer.dropletIds 13.0.1
 digitalocean.loadBalancer.droplets 13.0.2
 digitalocean.loadBalancer.enableBackendKeepalive 13.0.1
 digitalocean.loadBalancer.enableProxyProtocol 13.0.1
+digitalocean.loadBalancer.exposure 13.7.1
 digitalocean.loadBalancer.firewallAllow 13.6.2
 digitalocean.loadBalancer.firewallDeny 13.6.2
 digitalocean.loadBalancer.forwardingRules 13.0.1

--- a/providers/digitalocean/resources/digitalocean_exposure.go
+++ b/providers/digitalocean/resources/digitalocean_exposure.go
@@ -5,10 +5,85 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// anyAddressCIDRs are the CIDR notations that mean "every address" — an
+// open-to-the-internet source for either IP stack.
+var anyAddressCIDRs = map[string]struct{}{
+	"0.0.0.0/0": {},
+	"::/0":      {},
+}
+
+// isAnyAddress reports whether a CIDR/IP string admits every address. Bare
+// "0.0.0.0" / "::" (without a prefix) are also treated as any-address since
+// DigitalOcean accepts them as wildcard sources.
+func isAnyAddress(cidr string) bool {
+	c := strings.TrimSpace(cidr)
+	if _, ok := anyAddressCIDRs[c]; ok {
+		return true
+	}
+	return c == "0.0.0.0" || c == "::"
+}
+
+// databaseRuleOpensToInternet reports whether a single managed-database
+// trusted-source rule admits traffic from any address. Only ip_addr rules can
+// reference a CIDR; droplet/k8s/tag/app rules scope to specific resources and
+// never open the cluster to the whole internet.
+func databaseRuleOpensToInternet(ruleType, value string) bool {
+	if ruleType != "ip_addr" {
+		return false
+	}
+	return isAnyAddress(value)
+}
+
+// databaseTrustedSourcesAllowAny inspects a managed database's trusted-source
+// (firewall) rules and reports whether the public endpoint is open to any
+// address. When no rules are configured at all DigitalOcean leaves the public
+// connection endpoint reachable from every address, so an empty rule set also
+// counts as open.
+func databaseTrustedSourcesAllowAny(rules []any) bool {
+	if len(rules) == 0 {
+		return true
+	}
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		ruleType, _ := rule["type"].(string)
+		value, _ := rule["value"].(string)
+		if databaseRuleOpensToInternet(ruleType, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadBalancerFirewallAllowsAny reports whether a load balancer's source
+// firewall admits traffic from any address. The load balancer firewall is an
+// allow/deny list of source CIDRs: when the allow list is empty every source
+// is permitted (subject to the deny list); when it is non-empty only those
+// sources are permitted, so it is open to the internet only if one of the
+// allow entries is itself an any-address CIDR.
+func loadBalancerFirewallAllowsAny(allow []any) bool {
+	if len(allow) == 0 {
+		return true
+	}
+	for _, a := range allow {
+		cidr, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if isAnyAddress(cidr) {
+			return true
+		}
+	}
+	return false
+}
 
 // exposure breaks down whether the droplet is reachable from the internet: a
 // public IP combined with firewall ingress that admits any address. A droplet
@@ -73,6 +148,82 @@ func (d *mqlDigitaloceanDroplet) exposure() (*mqlDigitaloceanNetworkExposure, er
 		"hasPublicIp":           llx.BoolData(hasPublicIp),
 		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
 		"openIngressRules":      llx.ArrayData(openRules, types.Resource("digitalocean.firewall.ingressRule")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDigitaloceanNetworkExposure), nil
+}
+
+// internetReachable reports whether a managed database cluster is reachable
+// from the internet: it has a public connection endpoint and its trusted-source
+// firewall rules admit any address (or no rules are configured, which leaves
+// the public endpoint open to every address). Managed databases use an
+// authorized-networks model rather than droplet-style cloud firewalls, so this
+// is a single predicate rather than the full network.exposure breakdown.
+func (d *mqlDigitaloceanDatabase) internetReachable() (bool, error) {
+	host := d.GetConnectionHost()
+	if host.Error != nil {
+		return false, host.Error
+	}
+	// No public connection endpoint means the cluster is private-only.
+	if host.Data == "" {
+		return false, nil
+	}
+
+	rules := d.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+
+	return databaseTrustedSourcesAllowAny(rules.Data), nil
+}
+
+// exposure breaks down whether a load balancer is reachable from the internet:
+// an EXTERNAL (internet-facing) load balancer has a public IP, and its source
+// firewall admits traffic from any address (an empty allow list, or an allow
+// entry that is itself an any-address CIDR). INTERNAL load balancers serve
+// VPC-only traffic and are not internet-reachable.
+func (l *mqlDigitaloceanLoadBalancer) exposure() (*mqlDigitaloceanNetworkExposure, error) {
+	id := l.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	network := l.GetNetwork()
+	if network.Error != nil {
+		return nil, network.Error
+	}
+
+	ipv4 := l.GetIp()
+	if ipv4.Error != nil {
+		return nil, ipv4.Error
+	}
+	ipv6 := l.GetIpv6()
+	if ipv6.Error != nil {
+		return nil, ipv6.Error
+	}
+	// An INTERNAL load balancer is VPC-only; treat its address as non-public
+	// even though the API may still report an IP.
+	internalOnly := strings.EqualFold(network.Data, "INTERNAL")
+	hasPublicIp := !internalOnly && (ipv4.Data != "" || ipv6.Data != "")
+
+	allow := l.GetFirewallAllow()
+	if allow.Error != nil {
+		return nil, allow.Error
+	}
+	firewallAllowsIngress := loadBalancerFirewallAllowsAny(allow.Data)
+
+	internetReachable := hasPublicIp && firewallAllowsIngress
+
+	res, err := CreateResource(l.MqlRuntime, "digitalocean.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData(fmt.Sprintf("digitalocean.loadBalancer/%s/exposure", id.Data)),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp),
+		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		// openIngressRules are droplet cloud-firewall rules; load balancers use
+		// a source allow/deny list instead, so this is always empty for them.
+		"openIngressRules": llx.ArrayData([]any{}, types.Resource("digitalocean.firewall.ingressRule")),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/digitalocean/resources/digitalocean_exposure_test.go
+++ b/providers/digitalocean/resources/digitalocean_exposure_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAnyAddress(t *testing.T) {
+	cases := []struct {
+		cidr string
+		want bool
+	}{
+		{"0.0.0.0/0", true},
+		{"::/0", true},
+		{"0.0.0.0", true},
+		{"::", true},
+		{" 0.0.0.0/0 ", true}, // surrounding whitespace tolerated
+		{"10.0.0.0/8", false},
+		{"203.0.113.5/32", false},
+		{"2001:db8::/32", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isAnyAddress(c.cidr), "isAnyAddress(%q)", c.cidr)
+	}
+}
+
+func TestDatabaseRuleOpensToInternet(t *testing.T) {
+	cases := []struct {
+		name     string
+		ruleType string
+		value    string
+		want     bool
+	}{
+		{"ip_addr any v4", "ip_addr", "0.0.0.0/0", true},
+		{"ip_addr any v6", "ip_addr", "::/0", true},
+		{"ip_addr specific", "ip_addr", "203.0.113.0/24", false},
+		{"droplet any-looking value", "droplet", "0.0.0.0/0", false}, // type scopes to a droplet, not a CIDR
+		{"tag", "tag", "web", false},
+		{"k8s", "k8s", "cluster-uuid", false},
+		{"app", "app", "app-uuid", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, databaseRuleOpensToInternet(c.ruleType, c.value))
+		})
+	}
+}
+
+func TestDatabaseTrustedSourcesAllowAny(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules []any
+		want  bool
+	}{
+		{"no rules means open", nil, true},
+		{"empty rules means open", []any{}, true},
+		{
+			"only specific ip rules",
+			[]any{
+				map[string]any{"type": "ip_addr", "value": "203.0.113.10/32"},
+				map[string]any{"type": "droplet", "value": "12345"},
+			},
+			false,
+		},
+		{
+			"contains any-address ip rule",
+			[]any{
+				map[string]any{"type": "ip_addr", "value": "203.0.113.10/32"},
+				map[string]any{"type": "ip_addr", "value": "0.0.0.0/0"},
+			},
+			true,
+		},
+		{
+			"contains any-address ipv6 rule",
+			[]any{
+				map[string]any{"type": "ip_addr", "value": "::/0"},
+			},
+			true,
+		},
+		{
+			"only resource-scoped rules",
+			[]any{
+				map[string]any{"type": "tag", "value": "web"},
+				map[string]any{"type": "k8s", "value": "cluster-uuid"},
+			},
+			false,
+		},
+		{
+			"malformed entry ignored",
+			[]any{
+				"not-a-map",
+				map[string]any{"type": "ip_addr", "value": "10.0.0.0/8"},
+			},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, databaseTrustedSourcesAllowAny(c.rules))
+		})
+	}
+}
+
+func TestLoadBalancerFirewallAllowsAny(t *testing.T) {
+	cases := []struct {
+		name  string
+		allow []any
+		want  bool
+	}{
+		{"empty allow list permits all sources", nil, true},
+		{"empty slice permits all sources", []any{}, true},
+		{"specific allow CIDRs only", []any{"203.0.113.0/24", "198.51.100.7/32"}, false},
+		{"allow includes any-address v4", []any{"203.0.113.0/24", "0.0.0.0/0"}, true},
+		{"allow includes any-address v6", []any{"::/0"}, true},
+		{"non-string entry ignored", []any{42, "10.0.0.0/8"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, loadBalancerFirewallAllowsAny(c.allow))
+		})
+	}
+}


### PR DESCRIPTION
Extends the DigitalOcean internet-exposure modeling beyond droplets (droplet exposure was added on a separate branch and is untouched here).

## Resources covered

- **`digitalocean.database.internetReachable() bool`** — authorized-networks mechanism. Managed database clusters use a trusted-sources model rather than droplet-style cloud firewalls, so this is a single predicate. True when the cluster has a public connection endpoint *and* its trusted-source rules admit any address (an `ip_addr` rule of `0.0.0.0/0` or `::/0`), or when no trusted-source rules are configured at all — DigitalOcean leaves the public endpoint reachable from every address in that case.

- **`digitalocean.loadBalancer.exposure() digitalocean.network.exposure`** — network-reachability mechanism. Reuses the shared `digitalocean.network.exposure` sub-resource (its doc-comments were generalized from droplet-specific to cover load balancers too). An `EXTERNAL` (internet-facing) load balancer has a public IP, and its source allow/deny firewall admits any address when the allow list is empty or contains an any-address CIDR. `INTERNAL` load balancers serve VPC-only traffic and are never internet-reachable.

## Mechanism summary

| Resource | Field | Mechanism |
|---|---|---|
| `digitalocean.database` | `internetReachable()` | authorized networks (trusted sources) |
| `digitalocean.loadBalancer` | `exposure()` | network reachability (public IP + LB firewall) |

## Skipped

- **`digitalocean.spacesBucket`** — already exposes public-access signals (`publicAccessBlocked`, `aclPublicRead`, `aclPublicWrite`, `aclAuthenticatedRead`, `policy`); no new predicate needed.
- **`digitalocean.droplet`** — exposure already added on another branch; not redone here.

## Notes

- Rule/CIDR parsing is in pure helpers (`isAnyAddress`, `databaseRuleOpensToInternet`, `databaseTrustedSourcesAllowAny`, `loadBalancerFirewallAllowsAny`) with table-driven unit tests in `digitalocean_exposure_test.go`.
- Reads only cached data (`firewallRules`, `connectionHost`, `ip`/`ipv6`/`network`/`firewallAllow`) — no new API calls or IAM permissions.
- New `.lr.versions` entries land at `13.7.1` (next patch after the provider's `13.7.0`).
- `go build ./...` exits 0; `go test ./resources/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)