### PR TITLE
⭐ hetzner: add internet-exposure analysis across resources

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -151,19 +151,28 @@ private hetzner.server.firewallBinding @defaults("status") {
   status string
 }
 
-// Server internet-exposure breakdown
+// Internet-exposure breakdown
 //
-// Explains whether a server is reachable from the internet: whether it has a
-// public IP and whether its firewalls admit inbound traffic from any address —
-// including the case where no firewall is attached, which leaves it open.
+// Explains whether a resource is reachable from the internet: whether it has a
+// public IP and whether inbound traffic from any address is admitted. For a
+// server that means a firewall inbound rule open to the internet (or no firewall
+// attached at all); for a load balancer it means an enabled public network with
+// at least one forwarding service.
 private hetzner.network.exposure @defaults("internetReachable hasPublicIp") {
-  // Whether the server is reachable from the internet (a public IP and firewall ingress that admits any address)
+  // Whether the resource is reachable from the internet (a public IP and ingress that admits any address)
   internetReachable bool
-  // Whether the server has a public IPv4 or IPv6 address
+  // Whether the resource has a public IPv4 or IPv6 address
   hasPublicIp bool
-  // Whether inbound traffic from any address is admitted — a firewall inbound rule open to the internet, or no firewall attached at all
+  // Whether inbound traffic from any address is admitted
+  //
+  // For a server, a firewall inbound rule open to the internet or no firewall
+  // attached at all; for a load balancer, an enabled public network with at
+  // least one forwarding service.
   firewallAllowsIngress bool
-  // Firewall inbound rules that admit traffic from any address (0.0.0.0/0 or ::/0)
+  // Ingress rules or services that admit traffic from any address
+  //
+  // For a server, firewall inbound rules whose source is 0.0.0.0/0 or ::/0; for
+  // a load balancer, the forwarding services reachable on the public network.
   openIngressRules []dict
 }
 
@@ -415,6 +424,8 @@ hetzner.loadBalancer @defaults("id name") {
   services() []hetzner.loadBalancer.service
   // Targets behind the load balancer
   targets() []hetzner.loadBalancer.target
+  // Internet-exposure breakdown (public network combined with forwarding services)
+  exposure() hetzner.network.exposure
   // Resource protection (delete)
   protection dict
   // User-defined labels for organizing the resource

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -699,6 +699,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.loadBalancer.targets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancer).GetTargets()).ToDataRes(types.Array(types.Resource("hetzner.loadBalancer.target")))
 	},
+	"hetzner.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancer).GetExposure()).ToDataRes(types.Resource("hetzner.network.exposure"))
+	},
 	"hetzner.loadBalancer.protection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancer).GetProtection()).ToDataRes(types.Dict)
 	},
@@ -1653,6 +1656,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.loadBalancer.targets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancer).Targets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"hetzner.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlHetznerNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"hetzner.loadBalancer.protection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3937,6 +3944,7 @@ type mqlHetznerLoadBalancer struct {
 	Algorithm        plugin.TValue[string]
 	Services         plugin.TValue[[]any]
 	Targets          plugin.TValue[[]any]
+	Exposure         plugin.TValue[*mqlHetznerNetworkExposure]
 	Protection       plugin.TValue[any]
 	Labels           plugin.TValue[map[string]any]
 	Created          plugin.TValue[*time.Time]
@@ -4075,6 +4083,22 @@ func (c *mqlHetznerLoadBalancer) GetTargets() *plugin.TValue[[]any] {
 		}
 
 		return c.targets()
+	})
+}
+
+func (c *mqlHetznerLoadBalancer) GetExposure() *plugin.TValue[*mqlHetznerNetworkExposure] {
+	return plugin.GetOrCompute[*mqlHetznerNetworkExposure](&c.Exposure, func() (*mqlHetznerNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -80,6 +80,7 @@ hetzner.isos 13.0.1
 hetzner.loadBalancer 13.0.1
 hetzner.loadBalancer.algorithm 13.0.1
 hetzner.loadBalancer.created 13.0.1
+hetzner.loadBalancer.exposure 13.3.1
 hetzner.loadBalancer.id 13.0.1
 hetzner.loadBalancer.includedTraffic 13.0.1
 hetzner.loadBalancer.ingoingTraffic 13.0.1

--- a/providers/hetzner/resources/hetzner_exposure.go
+++ b/providers/hetzner/resources/hetzner_exposure.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -78,6 +79,56 @@ func (s *mqlHetznerServer) exposure() (*mqlHetznerNetworkExposure, error) {
 		"internetReachable":     llx.BoolData(internetReachable),
 		"hasPublicIp":           llx.BoolData(hasPublicIp),
 		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		"openIngressRules":      llx.ArrayData(openRules, types.Dict),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHetznerNetworkExposure), nil
+}
+
+// loadBalancerHasPublicIp reports whether a Hetzner load balancer's public
+// network is enabled and carries a public IPv4 or IPv6 address.
+func loadBalancerHasPublicIp(pn hcloud.LoadBalancerPublicNet) bool {
+	if !pn.Enabled {
+		return false
+	}
+	return pn.IPv4.IP != nil || pn.IPv6.IP != nil
+}
+
+// loadBalancerServiceDicts renders a load balancer's forwarding services as
+// dicts describing the public listeners that admit traffic from any address.
+func loadBalancerServiceDicts(services []hcloud.LoadBalancerService) []any {
+	out := make([]any, 0, len(services))
+	for _, s := range services {
+		out = append(out, map[string]any{
+			"protocol":        string(s.Protocol),
+			"listenPort":      int64(s.ListenPort),
+			"destinationPort": int64(s.DestinationPort),
+		})
+	}
+	return out
+}
+
+// exposure breaks down whether the load balancer is reachable from the internet.
+// A Hetzner load balancer has no firewall; its public network being enabled with
+// a public IP plus at least one forwarding service makes it internet-reachable.
+func (m *mqlHetznerLoadBalancer) exposure() (*mqlHetznerNetworkExposure, error) {
+	id := m.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	hasPublicIp := loadBalancerHasPublicIp(m.cachePublicNet)
+	openRules := loadBalancerServiceDicts(m.cacheServices)
+	servicesAllowIngress := len(openRules) > 0
+	internetReachable := hasPublicIp && servicesAllowIngress
+
+	res, err := CreateResource(m.MqlRuntime, "hetzner.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData(fmt.Sprintf("hetzner.loadBalancer/%d/exposure", id.Data)),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp),
+		"firewallAllowsIngress": llx.BoolData(servicesAllowIngress),
 		"openIngressRules":      llx.ArrayData(openRules, types.Dict),
 	})
 	if err != nil {

--- a/providers/hetzner/resources/hetzner_exposure_test.go
+++ b/providers/hetzner/resources/hetzner_exposure_test.go
@@ -4,8 +4,10 @@
 package resources
 
 import (
+	"net"
 	"testing"
 
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,4 +30,37 @@ func TestFirewallRuleOpenToInternet(t *testing.T) {
 			assert.Equal(t, tt.want, firewallRuleOpenToInternet(tt.rule))
 		})
 	}
+}
+
+func TestLoadBalancerHasPublicIp(t *testing.T) {
+	ipv4 := net.ParseIP("203.0.113.10")
+	ipv6 := net.ParseIP("2001:db8::1")
+	tests := []struct {
+		name string
+		pn   hcloud.LoadBalancerPublicNet
+		want bool
+	}{
+		{"disabled with ipv4", hcloud.LoadBalancerPublicNet{Enabled: false, IPv4: hcloud.LoadBalancerPublicNetIPv4{IP: ipv4}}, false},
+		{"enabled with ipv4", hcloud.LoadBalancerPublicNet{Enabled: true, IPv4: hcloud.LoadBalancerPublicNetIPv4{IP: ipv4}}, true},
+		{"enabled with ipv6 only", hcloud.LoadBalancerPublicNet{Enabled: true, IPv6: hcloud.LoadBalancerPublicNetIPv6{IP: ipv6}}, true},
+		{"enabled no ip", hcloud.LoadBalancerPublicNet{Enabled: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, loadBalancerHasPublicIp(tt.pn))
+		})
+	}
+}
+
+func TestLoadBalancerServiceDicts(t *testing.T) {
+	got := loadBalancerServiceDicts([]hcloud.LoadBalancerService{
+		{Protocol: hcloud.LoadBalancerServiceProtocolHTTPS, ListenPort: 443, DestinationPort: 8443},
+	})
+	assert.Len(t, got, 1)
+	d := got[0].(map[string]any)
+	assert.Equal(t, "https", d["protocol"])
+	assert.Equal(t, int64(443), d["listenPort"])
+	assert.Equal(t, int64(8443), d["destinationPort"])
+
+	assert.Empty(t, loadBalancerServiceDicts(nil))
 }

--- a/providers/hetzner/resources/hetzner_loadbalancer.go
+++ b/providers/hetzner/resources/hetzner_loadbalancer.go
@@ -18,6 +18,7 @@ type mqlHetznerLoadBalancerInternal struct {
 	cacheServices         []hcloud.LoadBalancerService
 	cacheTargets          []hcloud.LoadBalancerTarget
 	cachePrivateNet       []hcloud.LoadBalancerPrivateNet
+	cachePublicNet        hcloud.LoadBalancerPublicNet
 }
 
 func (r *mqlHetznerLoadBalancer) id() (string, error) {
@@ -72,6 +73,7 @@ func newMqlHetznerLoadBalancer(runtime *plugin.Runtime, lb *hcloud.LoadBalancer)
 	m.cacheServices = lb.Services
 	m.cacheTargets = lb.Targets
 	m.cachePrivateNet = lb.PrivateNet
+	m.cachePublicNet = lb.PublicNet
 	return m, nil
 }
 


### PR DESCRIPTION
## Summary

Extends internet-exposure analysis to Hetzner **load balancers**, reusing the
shared `hetzner.network.exposure` sub-resource already used by `hetzner.server`
(added on a prior branch — not touched here).

## Resource covered

- **`hetzner.loadBalancer`** — new `exposure() hetzner.network.exposure`
  (NETWORK REACHABILITY mechanism). A Hetzner load balancer has no firewall, so
  reachability is derived from its public network: `internetReachable` is true
  when the public network is enabled with a public IPv4/IPv6 address
  (`hasPublicIp`) **and** at least one forwarding service is defined
  (`firewallAllowsIngress`). `openIngressRules` lists those public-facing
  services (protocol, listen port, destination port).

The shared `hetzner.network.exposure` doc-comment was generalized from
server-only to cover both servers and load balancers.

Hetzner exposes no object storage / serverless / KMS resources, so no
policy/public-access (`isPublic`) work applies — load balancer is the only
additional reachable resource.

## Tests

Pure helpers `loadBalancerHasPublicIp` and `loadBalancerServiceDicts` with
table-driven unit tests (plain `testing` + the provider's existing testify
usage). `go build ./...` and `go test ./resources/` pass.

Reads cached data only — no new API calls or IAM permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)