### PR TITLE
⭐ azure: add internet-exposure analysis across resources

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2532,11 +2532,12 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
 
 // Internet-exposure summary for a network-reachable Azure resource
 //
-// Combines whether the resource has a public IP with whether an attached
-// network security group permits inbound traffic from the internet. A resource
-// is considered internet-reachable only when it has a public IP AND a security
-// rule allows ingress from any source (0.0.0.0/0, ::/0, *, or the "Internet"
-// service tag). Computed from cached NIC, public-IP, and NSG data.
+// Combines whether the resource has a public IP with whether its effective
+// network security rules permit inbound traffic from the internet. A resource
+// is considered internet-reachable only when it has a public IP AND an
+// effective rule allows ingress from any source (0.0.0.0/0, ::/0, *, or the
+// "Internet" service tag). The effective rules merge the NSG on the NIC, the
+// NSG on its subnet, and application security groups.
 private azure.subscription.networkService.exposure {
   // Stable identifier of the exposure summary (derived from the owning resource ID)
   id string
@@ -2547,10 +2548,14 @@ private azure.subscription.networkService.exposure {
   internetReachable bool
   // Whether the resource has at least one public IP address assigned
   hasPublicIp bool
-  // Whether an attached network security group has an inbound Allow rule open to any source
+  // Whether an effective NSG rule (NIC, subnet, or ASG) has an inbound Allow rule open to any source
   securityGroupAllowsIngress bool
-  // Inbound security rules that allow traffic from any internet source
-  openIngressRules []azure.subscription.networkService.securityrule
+  // Effective inbound security rules that allow traffic from any internet source
+  //
+  // Sourced from the NIC's effective security rules, which merge the NSG
+  // attached to the NIC, the NSG attached to its subnet, and any application
+  // security group rules. Each entry is the raw Azure effective-rule object.
+  openIngressRules []dict
 }
 
 // Azure Network Watcher

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -443,6 +443,12 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   patchMode string
   // Virtual Machine Scale Set that manages this VM, if any (resolved from managedBy)
   vmScaleSet() azure.subscription.computeService.vmScaleSet
+  // Internet-exposure summary combining public IPs and NSG ingress rules
+  //
+  // Reports whether the VM is reachable from the public internet by checking for
+  // an assigned public IP and an attached network security group rule that
+  // allows inbound traffic from any source.
+  exposure() azure.network.exposure
 }
 
 // Azure VM image reference
@@ -2524,6 +2530,29 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
   provisioningState string
 }
 
+// Internet-exposure summary for a network-reachable Azure resource
+//
+// Combines whether the resource has a public IP with whether an attached
+// network security group permits inbound traffic from the internet. A resource
+// is considered internet-reachable only when it has a public IP AND a security
+// rule allows ingress from any source (0.0.0.0/0, ::/0, *, or the "Internet"
+// service tag). Computed from cached NIC, public-IP, and NSG data.
+private azure.network.exposure {
+  // Stable identifier of the exposure summary (derived from the owning resource ID)
+  id string
+  // Whether the resource is reachable from the public internet
+  //
+  // True when the resource has a public IP AND an attached security group
+  // allows inbound traffic from any source. False when either signal is absent.
+  internetReachable bool
+  // Whether the resource has at least one public IP address assigned
+  hasPublicIp bool
+  // Whether an attached network security group has an inbound Allow rule open to any source
+  securityGroupAllowsIngress bool
+  // Inbound security rules that allow traffic from any internet source
+  openIngressRules []azure.subscription.networkService.securityrule
+}
+
 // Azure Network Watcher
 private azure.subscription.networkService.watcher @defaults("name location") {
   // Network watcher ID
@@ -3659,6 +3688,13 @@ private azure.subscription.storageService.account @defaults("id name location") 
   defenderForStorage() azure.subscription.storageService.account.defenderForStorageSetting
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
+  // Whether the storage account is exposed to anonymous public access
+  //
+  // True when public network access is not disabled, the network rule set
+  // defaults to Allow (no deny-by-default firewall), AND blob containers may be
+  // configured for anonymous public access (`allowBlobPublicAccess`). All three
+  // gates must be open for anonymous internet reads to be possible.
+  isPublic() bool
 }
 
 // Azure Storage account queue
@@ -4806,6 +4842,12 @@ private azure.subscription.sqlService.server @defaults("name location properties
   failoverGroups() []azure.subscription.sqlService.server.failoverGroup
   // Geo-replication links from databases on this server to partners
   replicationLinks() []azure.subscription.sqlService.server.replicationLink
+  // Whether the SQL server is reachable from the public internet
+  //
+  // True when `publicNetworkAccess` is enabled AND at least one firewall rule
+  // opens the server to any internet address — either the "allow all Azure
+  // services" rule (0.0.0.0) or a rule whose range spans 0.0.0.0-255.255.255.255.
+  internetReachable() bool
 }
 
 // Azure SQL Database server vulnerability assessment settings
@@ -5392,6 +5434,12 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   threatProtectionState() string
   // Private endpoint connections for the PostgreSQL flexible server
   privateEndpointConnections() []azure.subscription.privateEndpointConnection
+  // Whether the PostgreSQL flexible server is reachable from the public internet
+  //
+  // True when `publicNetworkAccess` is enabled AND at least one firewall rule
+  // opens the server to any internet address (the all-Azure-services 0.0.0.0
+  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  internetReachable() bool
 }
 
 // Azure Database for PostgreSQL server
@@ -5428,6 +5476,12 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   databases() []azure.subscription.postgreSqlService.database
   // PostgreSQL server firewall rules
   firewallRules() []azure.subscription.sqlService.firewallrule
+  // Whether the PostgreSQL server is reachable from the public internet
+  //
+  // True when `publicNetworkAccess` is enabled AND at least one firewall rule
+  // opens the server to any internet address (the all-Azure-services 0.0.0.0
+  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  internetReachable() bool
 }
 
 // Azure Database for PostgreSQL database
@@ -5642,6 +5696,12 @@ private azure.subscription.mySqlService.server @defaults("id name location") {
   databases() []azure.subscription.mySqlService.database
   // MySQL server firewall rules
   firewallRules() []azure.subscription.sqlService.firewallrule
+  // Whether the MySQL server is reachable from the public internet
+  //
+  // True when `publicNetworkAccess` is enabled AND at least one firewall rule
+  // opens the server to any internet address (the all-Azure-services 0.0.0.0
+  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  internetReachable() bool
 }
 
 // Azure Database for MySQL database
@@ -5698,6 +5758,12 @@ private azure.subscription.mySqlService.flexibleServer @defaults("name location 
   highAvailabilityMode string
   // High availability state ("NotEnabled", "CreatingStandby", "ReplicatingData", "FailingOver", "Healthy", or "RemovingStandby")
   highAvailabilityState string
+  // Whether the MySQL flexible server is reachable from the public internet
+  //
+  // True when `publicNetworkAccess` is enabled AND at least one firewall rule
+  // opens the server to any internet address (the all-Azure-services 0.0.0.0
+  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  internetReachable() bool
 }
 
 // Azure Cosmos DB
@@ -7507,6 +7573,13 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   identityBindings() []azure.subscription.aksService.cluster.identityBinding
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
+  // Whether the AKS API server is reachable from the public internet
+  //
+  // True when the cluster is not a private cluster, `publicNetworkAccess` is not
+  // disabled, and no authorized-IP-range allowlist restricts API access. False
+  // when any of those gates (private cluster, disabled public access, or a
+  // non-empty authorized-IP-range list) is present.
+  internetReachable() bool
 }
 
 // Azure Kubernetes Service cluster AAD profile

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2539,8 +2539,6 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
 // "Internet" service tag). The effective rules merge the NSG on the NIC, the
 // NSG on its subnet, and application security groups.
 private azure.subscription.networkService.exposure {
-  // Stable identifier of the exposure summary (derived from the owning resource ID)
-  id string
   // Whether the resource is reachable from the public internet
   //
   // True when the resource has a public IP AND an attached security group

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -448,7 +448,7 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   // Reports whether the VM is reachable from the public internet by checking for
   // an assigned public IP and an attached network security group rule that
   // allows inbound traffic from any source.
-  exposure() azure.network.exposure
+  exposure() azure.subscription.networkService.exposure
 }
 
 // Azure VM image reference
@@ -2537,7 +2537,7 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
 // is considered internet-reachable only when it has a public IP AND a security
 // rule allows ingress from any source (0.0.0.0/0, ::/0, *, or the "Internet"
 // service tag). Computed from cached NIC, public-IP, and NSG data.
-private azure.network.exposure {
+private azure.subscription.networkService.exposure {
   // Stable identifier of the exposure summary (derived from the owning resource ID)
   id string
   // Whether the resource is reachable from the public internet

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -4845,8 +4845,9 @@ private azure.subscription.sqlService.server @defaults("name location properties
   // Whether the SQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to any internet address — either the "allow all Azure
-  // services" rule (0.0.0.0) or a rule whose range spans 0.0.0.0-255.255.255.255.
+  // opens the server to the entire public internet — a rule whose range spans
+  // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
+  // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 
@@ -5437,8 +5438,9 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   // Whether the PostgreSQL flexible server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to any internet address (the all-Azure-services 0.0.0.0
-  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  // opens the server to the entire public internet — a rule whose range spans
+  // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
+  // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 
@@ -5479,8 +5481,9 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   // Whether the PostgreSQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to any internet address (the all-Azure-services 0.0.0.0
-  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  // opens the server to the entire public internet — a rule whose range spans
+  // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
+  // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 
@@ -5699,8 +5702,9 @@ private azure.subscription.mySqlService.server @defaults("id name location") {
   // Whether the MySQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to any internet address (the all-Azure-services 0.0.0.0
-  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  // opens the server to the entire public internet — a rule whose range spans
+  // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
+  // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 
@@ -5761,8 +5765,9 @@ private azure.subscription.mySqlService.flexibleServer @defaults("name location 
   // Whether the MySQL flexible server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to any internet address (the all-Azure-services 0.0.0.0
-  // rule or a rule spanning 0.0.0.0-255.255.255.255).
+  // opens the server to the entire public internet — a rule whose range spans
+  // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
+  // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -85,6 +85,7 @@ const (
 	ResourceAzureSubscriptionNetworkServiceBastionHost                                           string = "azure.subscription.networkService.bastionHost"
 	ResourceAzureSubscriptionNetworkServiceSecurityGroup                                         string = "azure.subscription.networkService.securityGroup"
 	ResourceAzureSubscriptionNetworkServiceSecurityrule                                          string = "azure.subscription.networkService.securityrule"
+	ResourceAzureNetworkExposure                                                                 string = "azure.network.exposure"
 	ResourceAzureSubscriptionNetworkServiceWatcher                                               string = "azure.subscription.networkService.watcher"
 	ResourceAzureSubscriptionNetworkServiceWatcherFlowlog                                        string = "azure.subscription.networkService.watcher.flowlog"
 	ResourceAzureSubscriptionNetworkServiceWatcherPacketCapture                                  string = "azure.subscription.networkService.watcher.packetCapture"
@@ -700,6 +701,10 @@ func init() {
 		"azure.subscription.networkService.securityrule": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceSecurityrule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionNetworkServiceSecurityrule,
+		},
+		"azure.network.exposure": {
+			// to override args, implement: initAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureNetworkExposure,
 		},
 		"azure.subscription.networkService.watcher": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceWatcher(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2608,6 +2613,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.vm.vmScaleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetVmScaleSet()).ToDataRes(types.Resource("azure.subscription.computeService.vmScaleSet"))
+	},
+	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetExposure()).ToDataRes(types.Resource("azure.network.exposure"))
 	},
 	"azure.subscription.computeService.vm.imageReference.publisher": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetPublisher()).ToDataRes(types.String)
@@ -4910,6 +4918,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityrule.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.network.exposure.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureNetworkExposure).GetId()).ToDataRes(types.String)
+	},
+	"azure.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"azure.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
+	"azure.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureNetworkExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"azure.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
+	},
 	"azure.subscription.networkService.watcher.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcher).GetId()).ToDataRes(types.String)
 	},
@@ -6136,6 +6159,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
+	"azure.subscription.storageService.account.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetIsPublic()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.storageService.account.queue.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetId()).ToDataRes(types.String)
@@ -7451,6 +7477,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.server.replicationLinks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetReplicationLinks()).ToDataRes(types.Array(types.Resource("azure.subscription.sqlService.server.replicationLink")))
 	},
+	"azure.subscription.sqlService.server.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.sqlService.server.vulnerabilityassessmentsettings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings).GetId()).ToDataRes(types.String)
 	},
@@ -8162,6 +8191,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.postgreSqlService.flexibleServer.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
+	"azure.subscription.postgreSqlService.flexibleServer.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.postgreSqlService.server.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceServer).GetId()).ToDataRes(types.String)
 	},
@@ -8209,6 +8241,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.postgreSqlService.server.firewallRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceServer).GetFirewallRules()).ToDataRes(types.Array(types.Resource("azure.subscription.sqlService.firewallrule")))
+	},
+	"azure.subscription.postgreSqlService.server.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPostgreSqlServiceServer).GetInternetReachable()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.postgreSqlService.database.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceDatabase).GetId()).ToDataRes(types.String)
@@ -8468,6 +8503,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.mySqlService.server.firewallRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMySqlServiceServer).GetFirewallRules()).ToDataRes(types.Array(types.Resource("azure.subscription.sqlService.firewallrule")))
 	},
+	"azure.subscription.mySqlService.server.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMySqlServiceServer).GetInternetReachable()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.mySqlService.database.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMySqlServiceDatabase).GetId()).ToDataRes(types.String)
 	},
@@ -8539,6 +8577,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.mySqlService.flexibleServer.highAvailabilityState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).GetHighAvailabilityState()).ToDataRes(types.String)
+	},
+	"azure.subscription.mySqlService.flexibleServer.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).GetInternetReachable()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.cosmosDbService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbService).GetSubscriptionId()).ToDataRes(types.String)
@@ -10654,6 +10695,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
+	"azure.subscription.aksService.cluster.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetInternetReachable()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.aksService.cluster.aadProfile.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceClusterAadProfile).GetId()).ToDataRes(types.String)
@@ -16132,6 +16176,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).VmScaleSet, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceVmScaleSet](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).Exposure, ok = plugin.RawToTValue[*mqlAzureNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vm.imageReference.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).__id, ok = v.Value.(string)
 		return
@@ -19440,6 +19488,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.network.exposure.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.watcher.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceWatcher).__id, ok = v.Value.(string)
 		return
@@ -21186,6 +21258,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccount).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.queue.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23116,6 +23192,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceServer).ReplicationLinks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sqlService.server.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sqlService.server.vulnerabilityassessmentsettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings).__id, ok = v.Value.(string)
 		return
@@ -24168,6 +24248,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.postgreSqlService.flexibleServer.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.postgreSqlService.server.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPostgreSqlServiceServer).__id, ok = v.Value.(string)
 		return
@@ -24234,6 +24318,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.postgreSqlService.server.firewallRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPostgreSqlServiceServer).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.postgreSqlService.server.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPostgreSqlServiceServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.postgreSqlService.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24612,6 +24700,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMySqlServiceServer).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.mySqlService.server.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMySqlServiceServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.mySqlService.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMySqlServiceDatabase).__id, ok = v.Value.(string)
 		return
@@ -24714,6 +24806,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.mySqlService.flexibleServer.highAvailabilityState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).HighAvailabilityState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.mySqlService.flexibleServer.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cosmosDbService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27782,6 +27878,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.aksService.cluster.aadProfile.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36490,6 +36590,7 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	EnableAutomaticUpdates        plugin.TValue[bool]
 	PatchMode                     plugin.TValue[string]
 	VmScaleSet                    plugin.TValue[*mqlAzureSubscriptionComputeServiceVmScaleSet]
+	Exposure                      plugin.TValue[*mqlAzureNetworkExposure]
 }
 
 // createAzureSubscriptionComputeServiceVm creates a new instance of this resource
@@ -36810,6 +36911,22 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetVmScaleSet() *plugin.TValue[*m
 		}
 
 		return c.vmScaleSet()
+	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetExposure() *plugin.TValue[*mqlAzureNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAzureNetworkExposure](&c.Exposure, func() (*mqlAzureNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vm", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -44365,6 +44482,75 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetProvisioningState() 
 	return &c.ProvisioningState
 }
 
+// mqlAzureNetworkExposure for the azure.network.exposure resource
+type mqlAzureNetworkExposure struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureNetworkExposureInternal it will be used here
+	Id                         plugin.TValue[string]
+	InternetReachable          plugin.TValue[bool]
+	HasPublicIp                plugin.TValue[bool]
+	SecurityGroupAllowsIngress plugin.TValue[bool]
+	OpenIngressRules           plugin.TValue[[]any]
+}
+
+// createAzureNetworkExposure creates a new instance of this resource
+func createAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureNetworkExposure{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.network.exposure", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureNetworkExposure) MqlName() string {
+	return "azure.network.exposure"
+}
+
+func (c *mqlAzureNetworkExposure) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureNetworkExposure) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+	return &c.InternetReachable
+}
+
+func (c *mqlAzureNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+	return &c.HasPublicIp
+}
+
+func (c *mqlAzureNetworkExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
+	return &c.SecurityGroupAllowsIngress
+}
+
+func (c *mqlAzureNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressRules
+}
+
 // mqlAzureSubscriptionNetworkServiceWatcher for the azure.subscription.networkService.watcher resource
 type mqlAzureSubscriptionNetworkServiceWatcher struct {
 	MqlRuntime *plugin.Runtime
@@ -47585,6 +47771,7 @@ type mqlAzureSubscriptionStorageServiceAccount struct {
 	BlobInventoryPolicy                              plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy]
 	DefenderForStorage                               plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountDefenderForStorageSetting]
 	SystemMetadata                                   plugin.TValue[*mqlAzureSubscriptionSystemData]
+	IsPublic                                         plugin.TValue[bool]
 }
 
 // createAzureSubscriptionStorageServiceAccount creates a new instance of this resource
@@ -48115,6 +48302,12 @@ func (c *mqlAzureSubscriptionStorageServiceAccount) GetSystemMetadata() *plugin.
 		}
 
 		return c.systemMetadata()
+	})
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 
@@ -52382,6 +52575,7 @@ type mqlAzureSubscriptionSqlServiceServer struct {
 	PrivateEndpointConnections       plugin.TValue[[]any]
 	FailoverGroups                   plugin.TValue[[]any]
 	ReplicationLinks                 plugin.TValue[[]any]
+	InternetReachable                plugin.TValue[bool]
 }
 
 // createAzureSubscriptionSqlServiceServer creates a new instance of this resource
@@ -52774,6 +52968,12 @@ func (c *mqlAzureSubscriptionSqlServiceServer) GetReplicationLinks() *plugin.TVa
 		}
 
 		return c.replicationLinks()
+	})
+}
+
+func (c *mqlAzureSubscriptionSqlServiceServer) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 
@@ -55168,6 +55368,7 @@ type mqlAzureSubscriptionPostgreSqlServiceFlexibleServer struct {
 	GeoRedundantBackup           plugin.TValue[string]
 	ThreatProtectionState        plugin.TValue[string]
 	PrivateEndpointConnections   plugin.TValue[[]any]
+	InternetReachable            plugin.TValue[bool]
 }
 
 // createAzureSubscriptionPostgreSqlServiceFlexibleServer creates a new instance of this resource
@@ -55369,6 +55570,12 @@ func (c *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) GetPrivateEndpoint
 	})
 }
 
+func (c *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
+	})
+}
+
 // mqlAzureSubscriptionPostgreSqlServiceServer for the azure.subscription.postgreSqlService.server resource
 type mqlAzureSubscriptionPostgreSqlServiceServer struct {
 	MqlRuntime *plugin.Runtime
@@ -55390,6 +55597,7 @@ type mqlAzureSubscriptionPostgreSqlServiceServer struct {
 	Configuration            plugin.TValue[[]any]
 	Databases                plugin.TValue[[]any]
 	FirewallRules            plugin.TValue[[]any]
+	InternetReachable        plugin.TValue[bool]
 }
 
 // createAzureSubscriptionPostgreSqlServiceServer creates a new instance of this resource
@@ -55526,6 +55734,12 @@ func (c *mqlAzureSubscriptionPostgreSqlServiceServer) GetFirewallRules() *plugin
 		}
 
 		return c.firewallRules()
+	})
+}
+
+func (c *mqlAzureSubscriptionPostgreSqlServiceServer) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 
@@ -56275,6 +56489,7 @@ type mqlAzureSubscriptionMySqlServiceServer struct {
 	Configuration            plugin.TValue[[]any]
 	Databases                plugin.TValue[[]any]
 	FirewallRules            plugin.TValue[[]any]
+	InternetReachable        plugin.TValue[bool]
 }
 
 // createAzureSubscriptionMySqlServiceServer creates a new instance of this resource
@@ -56414,6 +56629,12 @@ func (c *mqlAzureSubscriptionMySqlServiceServer) GetFirewallRules() *plugin.TVal
 	})
 }
 
+func (c *mqlAzureSubscriptionMySqlServiceServer) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
+	})
+}
+
 // mqlAzureSubscriptionMySqlServiceDatabase for the azure.subscription.mySqlService.database resource
 type mqlAzureSubscriptionMySqlServiceDatabase struct {
 	MqlRuntime *plugin.Runtime
@@ -56507,6 +56728,7 @@ type mqlAzureSubscriptionMySqlServiceFlexibleServer struct {
 	GeoBackupEncryptionKey plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	HighAvailabilityMode   plugin.TValue[string]
 	HighAvailabilityState  plugin.TValue[string]
+	InternetReachable      plugin.TValue[bool]
 }
 
 // createAzureSubscriptionMySqlServiceFlexibleServer creates a new instance of this resource
@@ -56682,6 +56904,12 @@ func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetHighAvailabilityMode
 
 func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetHighAvailabilityState() *plugin.TValue[string] {
 	return &c.HighAvailabilityState
+}
+
+func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
+	})
 }
 
 // mqlAzureSubscriptionCosmosDbService for the azure.subscription.cosmosDbService resource
@@ -63636,6 +63864,7 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	ControlPlaneMetricsEnabled        plugin.TValue[bool]
 	IdentityBindings                  plugin.TValue[[]any]
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
+	InternetReachable                 plugin.TValue[bool]
 }
 
 // createAzureSubscriptionAksServiceCluster creates a new instance of this resource
@@ -63952,6 +64181,12 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetSystemMetadata() *plugin.TVal
 		}
 
 		return c.systemMetadata()
+	})
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -85,7 +85,7 @@ const (
 	ResourceAzureSubscriptionNetworkServiceBastionHost                                           string = "azure.subscription.networkService.bastionHost"
 	ResourceAzureSubscriptionNetworkServiceSecurityGroup                                         string = "azure.subscription.networkService.securityGroup"
 	ResourceAzureSubscriptionNetworkServiceSecurityrule                                          string = "azure.subscription.networkService.securityrule"
-	ResourceAzureNetworkExposure                                                                 string = "azure.network.exposure"
+	ResourceAzureSubscriptionNetworkServiceExposure                                              string = "azure.subscription.networkService.exposure"
 	ResourceAzureSubscriptionNetworkServiceWatcher                                               string = "azure.subscription.networkService.watcher"
 	ResourceAzureSubscriptionNetworkServiceWatcherFlowlog                                        string = "azure.subscription.networkService.watcher.flowlog"
 	ResourceAzureSubscriptionNetworkServiceWatcherPacketCapture                                  string = "azure.subscription.networkService.watcher.packetCapture"
@@ -702,9 +702,9 @@ func init() {
 			// to override args, implement: initAzureSubscriptionNetworkServiceSecurityrule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionNetworkServiceSecurityrule,
 		},
-		"azure.network.exposure": {
-			// to override args, implement: initAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createAzureNetworkExposure,
+		"azure.subscription.networkService.exposure": {
+			// to override args, implement: initAzureSubscriptionNetworkServiceExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionNetworkServiceExposure,
 		},
 		"azure.subscription.networkService.watcher": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceWatcher(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2615,7 +2615,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetVmScaleSet()).ToDataRes(types.Resource("azure.subscription.computeService.vmScaleSet"))
 	},
 	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetExposure()).ToDataRes(types.Resource("azure.network.exposure"))
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetExposure()).ToDataRes(types.Resource("azure.subscription.networkService.exposure"))
 	},
 	"azure.subscription.computeService.vm.imageReference.publisher": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetPublisher()).ToDataRes(types.String)
@@ -4918,20 +4918,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityrule.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetProvisioningState()).ToDataRes(types.String)
 	},
-	"azure.network.exposure.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureNetworkExposure).GetId()).ToDataRes(types.String)
+	"azure.subscription.networkService.exposure.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetId()).ToDataRes(types.String)
 	},
-	"azure.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
+	"azure.subscription.networkService.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetInternetReachable()).ToDataRes(types.Bool)
 	},
-	"azure.network.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureNetworkExposure).GetHasPublicIp()).ToDataRes(types.Bool)
+	"azure.subscription.networkService.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
-	"azure.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureNetworkExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
+	"azure.subscription.networkService.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
 	},
-	"azure.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
+	"azure.subscription.networkService.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
 	},
 	"azure.subscription.networkService.watcher.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcher).GetId()).ToDataRes(types.String)
@@ -16177,7 +16177,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceVm).Exposure, ok = plugin.RawToTValue[*mqlAzureNetworkExposure](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionComputeServiceVm).Exposure, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceExposure](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.vm.imageReference.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19488,28 +19488,28 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).__id, ok = v.Value.(string)
+	"azure.subscription.networkService.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).__id, ok = v.Value.(string)
 		return
 	},
-	"azure.network.exposure.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"azure.subscription.networkService.exposure.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.network.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"azure.subscription.networkService.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.network.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"azure.subscription.networkService.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"azure.subscription.networkService.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"azure.subscription.networkService.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.watcher.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36590,7 +36590,7 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	EnableAutomaticUpdates        plugin.TValue[bool]
 	PatchMode                     plugin.TValue[string]
 	VmScaleSet                    plugin.TValue[*mqlAzureSubscriptionComputeServiceVmScaleSet]
-	Exposure                      plugin.TValue[*mqlAzureNetworkExposure]
+	Exposure                      plugin.TValue[*mqlAzureSubscriptionNetworkServiceExposure]
 }
 
 // createAzureSubscriptionComputeServiceVm creates a new instance of this resource
@@ -36914,15 +36914,15 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetVmScaleSet() *plugin.TValue[*m
 	})
 }
 
-func (c *mqlAzureSubscriptionComputeServiceVm) GetExposure() *plugin.TValue[*mqlAzureNetworkExposure] {
-	return plugin.GetOrCompute[*mqlAzureNetworkExposure](&c.Exposure, func() (*mqlAzureNetworkExposure, error) {
+func (c *mqlAzureSubscriptionComputeServiceVm) GetExposure() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceExposure] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceExposure](&c.Exposure, func() (*mqlAzureSubscriptionNetworkServiceExposure, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vm", c.__id, "exposure")
 			if err != nil {
 				return nil, err
 			}
 			if d != nil {
-				return d.Value.(*mqlAzureNetworkExposure), nil
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceExposure), nil
 			}
 		}
 
@@ -44482,11 +44482,11 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetProvisioningState() 
 	return &c.ProvisioningState
 }
 
-// mqlAzureNetworkExposure for the azure.network.exposure resource
-type mqlAzureNetworkExposure struct {
+// mqlAzureSubscriptionNetworkServiceExposure for the azure.subscription.networkService.exposure resource
+type mqlAzureSubscriptionNetworkServiceExposure struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureNetworkExposureInternal it will be used here
+	// optional: if you define mqlAzureSubscriptionNetworkServiceExposureInternal it will be used here
 	Id                         plugin.TValue[string]
 	InternetReachable          plugin.TValue[bool]
 	HasPublicIp                plugin.TValue[bool]
@@ -44494,9 +44494,9 @@ type mqlAzureNetworkExposure struct {
 	OpenIngressRules           plugin.TValue[[]any]
 }
 
-// createAzureNetworkExposure creates a new instance of this resource
-func createAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlAzureNetworkExposure{
+// createAzureSubscriptionNetworkServiceExposure creates a new instance of this resource
+func createAzureSubscriptionNetworkServiceExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionNetworkServiceExposure{
 		MqlRuntime: runtime,
 	}
 
@@ -44513,7 +44513,7 @@ func createAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 
 	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("azure.network.exposure", res.__id)
+		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.exposure", res.__id)
 		if err != nil || args == nil {
 			return res, err
 		}
@@ -44523,31 +44523,31 @@ func createAzureNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.Ra
 	return res, nil
 }
 
-func (c *mqlAzureNetworkExposure) MqlName() string {
-	return "azure.network.exposure"
+func (c *mqlAzureSubscriptionNetworkServiceExposure) MqlName() string {
+	return "azure.subscription.networkService.exposure"
 }
 
-func (c *mqlAzureNetworkExposure) MqlID() string {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlAzureNetworkExposure) GetId() *plugin.TValue[string] {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
-func (c *mqlAzureNetworkExposure) GetInternetReachable() *plugin.TValue[bool] {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetInternetReachable() *plugin.TValue[bool] {
 	return &c.InternetReachable
 }
 
-func (c *mqlAzureNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetHasPublicIp() *plugin.TValue[bool] {
 	return &c.HasPublicIp
 }
 
-func (c *mqlAzureNetworkExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
 	return &c.SecurityGroupAllowsIngress
 }
 
-func (c *mqlAzureNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
 	return &c.OpenIngressRules
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4931,7 +4931,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.networkService.watcher.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcher).GetId()).ToDataRes(types.String)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4918,9 +4918,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityrule.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetProvisioningState()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.exposure.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetInternetReachable()).ToDataRes(types.Bool)
 	},
@@ -19490,10 +19487,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceExposure).__id, ok = v.Value.(string)
-		return
-	},
-	"azure.subscription.networkService.exposure.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceExposure).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.exposure.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44487,7 +44480,6 @@ type mqlAzureSubscriptionNetworkServiceExposure struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceExposureInternal it will be used here
-	Id                         plugin.TValue[string]
 	InternetReachable          plugin.TValue[bool]
 	HasPublicIp                plugin.TValue[bool]
 	SecurityGroupAllowsIngress plugin.TValue[bool]
@@ -44505,12 +44497,7 @@ func createAzureSubscriptionNetworkServiceExposure(runtime *plugin.Runtime, args
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.exposure", res.__id)
@@ -44529,10 +44516,6 @@ func (c *mqlAzureSubscriptionNetworkServiceExposure) MqlName() string {
 
 func (c *mqlAzureSubscriptionNetworkServiceExposure) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceExposure) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceExposure) GetInternetReachable() *plugin.TValue[bool] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 azure 9.0.0
-azure.network.exposure 13.20.1
-azure.network.exposure.hasPublicIp 13.20.1
-azure.network.exposure.id 13.20.1
-azure.network.exposure.internetReachable 13.20.1
-azure.network.exposure.openIngressRules 13.20.1
-azure.network.exposure.securityGroupAllowsIngress 13.20.1
 azure.subscription 11.4.28
 azure.subscription.advisor 11.4.28
 azure.subscription.advisorService 9.0.13
@@ -2842,6 +2836,12 @@ azure.subscription.networkService.ddosProtectionPlan.tags 13.3.3
 azure.subscription.networkService.ddosProtectionPlan.type 13.3.3
 azure.subscription.networkService.ddosProtectionPlan.virtualNetworks 13.3.3
 azure.subscription.networkService.ddosProtectionPlans 13.3.3
+azure.subscription.networkService.exposure 13.20.1
+azure.subscription.networkService.exposure.hasPublicIp 13.20.1
+azure.subscription.networkService.exposure.id 13.20.1
+azure.subscription.networkService.exposure.internetReachable 13.20.1
+azure.subscription.networkService.exposure.openIngressRules 13.20.1
+azure.subscription.networkService.exposure.securityGroupAllowsIngress 13.20.1
 azure.subscription.networkService.expressRouteCircuit 13.12.2
 azure.subscription.networkService.expressRouteCircuit.allowClassicOperations 13.12.2
 azure.subscription.networkService.expressRouteCircuit.authorization 13.12.2

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 azure 9.0.0
+azure.network.exposure 13.20.1
+azure.network.exposure.hasPublicIp 13.20.1
+azure.network.exposure.id 13.20.1
+azure.network.exposure.internetReachable 13.20.1
+azure.network.exposure.openIngressRules 13.20.1
+azure.network.exposure.securityGroupAllowsIngress 13.20.1
 azure.subscription 11.4.28
 azure.subscription.advisor 11.4.28
 azure.subscription.advisorService 9.0.13
@@ -89,6 +95,7 @@ azure.subscription.aksService.cluster.identityBinding.provisioningState 13.15.2
 azure.subscription.aksService.cluster.identityBindings 13.15.2
 azure.subscription.aksService.cluster.imageCleanerEnabled 11.4.28
 azure.subscription.aksService.cluster.imageCleanerIntervalHours 11.4.28
+azure.subscription.aksService.cluster.internetReachable 13.20.1
 azure.subscription.aksService.cluster.kubernetesVersion 9.0.1
 azure.subscription.aksService.cluster.location 9.0.1
 azure.subscription.aksService.cluster.name 9.0.1
@@ -1087,6 +1094,7 @@ azure.subscription.computeService.vm.dependencyAgentInstalled 13.12.2
 azure.subscription.computeService.vm.disablePasswordAuthentication 13.5.1
 azure.subscription.computeService.vm.enableAutomaticUpdates 13.5.1
 azure.subscription.computeService.vm.encryptionAtHost 11.4.28
+azure.subscription.computeService.vm.exposure 13.20.1
 azure.subscription.computeService.vm.extensions 9.0.1
 azure.subscription.computeService.vm.fipsEncryptionEnabled 13.8.2
 azure.subscription.computeService.vm.id 9.0.1
@@ -2683,6 +2691,7 @@ azure.subscription.mySqlService.flexibleServer.geoRedundantBackup 13.8.2
 azure.subscription.mySqlService.flexibleServer.highAvailabilityMode 13.8.2
 azure.subscription.mySqlService.flexibleServer.highAvailabilityState 13.8.2
 azure.subscription.mySqlService.flexibleServer.id 9.0.1
+azure.subscription.mySqlService.flexibleServer.internetReachable 13.20.1
 azure.subscription.mySqlService.flexibleServer.location 9.0.1
 azure.subscription.mySqlService.flexibleServer.name 9.0.1
 azure.subscription.mySqlService.flexibleServer.properties 9.0.1
@@ -2700,6 +2709,7 @@ azure.subscription.mySqlService.server.firewallRules 9.0.1
 azure.subscription.mySqlService.server.geoRedundantBackup 13.1.8
 azure.subscription.mySqlService.server.id 9.0.1
 azure.subscription.mySqlService.server.infrastructureEncryption 11.4.28
+azure.subscription.mySqlService.server.internetReachable 13.20.1
 azure.subscription.mySqlService.server.location 9.0.1
 azure.subscription.mySqlService.server.minimalTlsVersion 11.4.28
 azure.subscription.mySqlService.server.name 9.0.1
@@ -3612,6 +3622,7 @@ azure.subscription.postgreSqlService.flexibleServer.geoBackupEncryptionKey 13.1.
 azure.subscription.postgreSqlService.flexibleServer.geoBackupEncryptionKeyStatus 11.4.28
 azure.subscription.postgreSqlService.flexibleServer.geoRedundantBackup 13.1.8
 azure.subscription.postgreSqlService.flexibleServer.id 11.0.9
+azure.subscription.postgreSqlService.flexibleServer.internetReachable 13.20.1
 azure.subscription.postgreSqlService.flexibleServer.location 11.0.9
 azure.subscription.postgreSqlService.flexibleServer.name 11.0.9
 azure.subscription.postgreSqlService.flexibleServer.passwordAuth 11.4.28
@@ -3632,6 +3643,7 @@ azure.subscription.postgreSqlService.server.firewallRules 9.0.1
 azure.subscription.postgreSqlService.server.geoRedundantBackup 13.1.8
 azure.subscription.postgreSqlService.server.id 9.0.1
 azure.subscription.postgreSqlService.server.infrastructureEncryption 11.4.28
+azure.subscription.postgreSqlService.server.internetReachable 13.20.1
 azure.subscription.postgreSqlService.server.location 9.0.1
 azure.subscription.postgreSqlService.server.minimalTlsVersion 11.4.28
 azure.subscription.postgreSqlService.server.name 9.0.1
@@ -4146,6 +4158,7 @@ azure.subscription.sqlService.server.failoverGroups 13.8.2
 azure.subscription.sqlService.server.firewallRules 9.0.1
 azure.subscription.sqlService.server.fullyQualifiedDomainName 11.4.28
 azure.subscription.sqlService.server.id 9.0.1
+azure.subscription.sqlService.server.internetReachable 13.20.1
 azure.subscription.sqlService.server.key 13.8.2
 azure.subscription.sqlService.server.key.autoRotationEnabled 13.8.2
 azure.subscription.sqlService.server.key.creationDate 13.8.2
@@ -4354,6 +4367,7 @@ azure.subscription.storageService.account.immutableStoragePolicyPeriodDays 13.10
 azure.subscription.storageService.account.immutableStoragePolicyState 13.10.2
 azure.subscription.storageService.account.isHnsEnabled 11.4.28
 azure.subscription.storageService.account.isLocalUserEnabled 11.4.28
+azure.subscription.storageService.account.isPublic 13.20.1
 azure.subscription.storageService.account.isSftpEnabled 11.4.28
 azure.subscription.storageService.account.keyExpirationPeriodInDays 13.5.1
 azure.subscription.storageService.account.kind 9.0.1

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2838,7 +2838,6 @@ azure.subscription.networkService.ddosProtectionPlan.virtualNetworks 13.3.3
 azure.subscription.networkService.ddosProtectionPlans 13.3.3
 azure.subscription.networkService.exposure 13.20.1
 azure.subscription.networkService.exposure.hasPublicIp 13.20.1
-azure.subscription.networkService.exposure.id 13.20.1
 azure.subscription.networkService.exposure.internetReachable 13.20.1
 azure.subscription.networkService.exposure.openIngressRules 13.20.1
 azure.subscription.networkService.exposure.securityGroupAllowsIngress 13.20.1

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -107,7 +107,7 @@ func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAcces
 
 // --- Resolvers ---
 
-func (a *mqlAzureNetworkExposure) id() (string, error) {
+func (a *mqlAzureSubscriptionNetworkServiceExposure) id() (string, error) {
 	return a.Id.Data, nil
 }
 
@@ -121,7 +121,7 @@ func (a *mqlAzureNetworkExposure) id() (string, error) {
 // shadow a lower-priority Allow-from-internet rule. This breakdown flags any
 // matching Allow rule as opening ingress, so securityGroupAllowsIngress may
 // report true even when a higher-priority Deny actually blocks the traffic.
-func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExposure, error) {
+func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscriptionNetworkServiceExposure, error) {
 	publicIps := a.GetPublicIpAddresses()
 	if publicIps.Error != nil {
 		return nil, publicIps.Error
@@ -139,12 +139,19 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExpos
 			continue
 		}
 		nsgVal := nic.GetNetworkSecurityGroup()
-		if nsgVal.Error != nil || nsgVal.Data == nil {
+		if nsgVal.Error != nil {
+			// Propagate rather than swallow: a failed NSG load (e.g. a
+			// permissions error) would otherwise make the VM look like it has no
+			// open ingress rules — a false negative for internet exposure.
+			return nil, nsgVal.Error
+		}
+		if nsgVal.Data == nil {
+			// A NIC legitimately may have no NSG attached.
 			continue
 		}
 		rules := nsgVal.Data.GetSecurityRules()
 		if rules.Error != nil {
-			continue
+			return nil, rules.Error
 		}
 		for _, r := range rules.Data {
 			rule, ok := r.(*mqlAzureSubscriptionNetworkServiceSecurityrule)
@@ -170,7 +177,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExpos
 	securityGroupAllowsIngress := len(openRules) > 0
 	internetReachable := hasPublicIp && securityGroupAllowsIngress
 
-	res, err := CreateResource(a.MqlRuntime, "azure.network.exposure", map[string]*llx.RawData{
+	res, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("azure.subscription.computeService.vm/" + a.Id.Data + "/exposure"),
 		"id":                         llx.StringData(a.Id.Data + "/exposure"),
 		"internetReachable":          llx.BoolData(internetReachable),
@@ -181,7 +188,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExpos
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureNetworkExposure), nil
+	return res.(*mqlAzureSubscriptionNetworkServiceExposure), nil
 }
 
 // sqlFirewallRanges collects (startIp, endIp) pairs from a list of MQL SQL

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -1,0 +1,305 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// --- Pure helpers (table-tested in azure_exposure_test.go) ---
+
+// internetOpenSourcePrefixes is the set of NSG source address prefixes that
+// represent "any internet source". An inbound Allow rule whose source matches
+// one of these exposes the destination to the public internet.
+//   - "*"            wildcard, any source
+//   - "0.0.0.0/0"    all IPv4
+//   - "::/0"         all IPv6
+//   - "internet"     the Azure "Internet" service tag (everything outside the VNet)
+func isInternetOpenSourcePrefix(prefix string) bool {
+	p := strings.ToLower(strings.TrimSpace(prefix))
+	switch p {
+	case "*", "0.0.0.0/0", "::/0", "internet":
+		return true
+	default:
+		return false
+	}
+}
+
+// securityRuleAllowsInternetIngress reports whether a single NSG security rule
+// opens inbound traffic to the public internet. A rule qualifies when it is an
+// inbound Allow rule whose source (single prefix or any entry in the prefix
+// list) is an internet-open source. Direction/access matching is
+// case-insensitive to tolerate API casing variations.
+func securityRuleAllowsInternetIngress(direction, access, sourcePrefix string, sourcePrefixes []string) bool {
+	if !strings.EqualFold(strings.TrimSpace(direction), "Inbound") {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(access), "Allow") {
+		return false
+	}
+	if isInternetOpenSourcePrefix(sourcePrefix) {
+		return true
+	}
+	for _, p := range sourcePrefixes {
+		if isInternetOpenSourcePrefix(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// publicNetworkAccessEnabled interprets the Azure `publicNetworkAccess` string,
+// which is "Enabled"/"Disabled" on most resources (and may be empty when the
+// API omits it). Empty is treated as enabled because Azure defaults public
+// access on when the property is not explicitly set to "Disabled".
+func publicNetworkAccessEnabled(value string) bool {
+	return !strings.EqualFold(strings.TrimSpace(value), "Disabled")
+}
+
+// firewallRuleAllowsAnyInternet reports whether a database firewall rule (start
+// IP / end IP range) opens the server to any internet address. Two forms count:
+//   - the special "allow all Azure services" rule 0.0.0.0 -> 0.0.0.0
+//   - a rule whose range spans the entire IPv4 space (0.0.0.0 -> 255.255.255.255)
+func firewallRuleAllowsAnyInternet(startIp, endIp string) bool {
+	start := strings.TrimSpace(startIp)
+	end := strings.TrimSpace(endIp)
+	if start == "0.0.0.0" && (end == "0.0.0.0" || end == "255.255.255.255") {
+		return true
+	}
+	return false
+}
+
+// databaseInternetReachable combines the publicNetworkAccess gate with the
+// presence of at least one internet-opening firewall rule. A database is
+// internet-reachable only when public access is enabled AND some firewall rule
+// permits an internet-wide source range.
+func databaseInternetReachable(publicNetworkAccess string, firewallRanges [][2]string) bool {
+	if !publicNetworkAccessEnabled(publicNetworkAccess) {
+		return false
+	}
+	for _, r := range firewallRanges {
+		if firewallRuleAllowsAnyInternet(r[0], r[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// aksApiServerInternetReachable reports whether an AKS API server is reachable
+// from the public internet. It is reachable only when the cluster is not a
+// private cluster, public network access is not disabled, and no authorized-IP
+// allowlist restricts API access. Any of those gates closes the exposure.
+func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAccess string, authorizedIPRanges []string) bool {
+	if enablePrivateCluster {
+		return false
+	}
+	if !publicNetworkAccessEnabled(publicNetworkAccess) {
+		return false
+	}
+	if len(authorizedIPRanges) > 0 {
+		return false
+	}
+	return true
+}
+
+// --- Resolvers ---
+
+func (a *mqlAzureNetworkExposure) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+// exposure builds the network-exposure summary for a VM from its already-cached
+// public IPs and the security rules of NSGs attached to its NICs. No new API
+// calls are made beyond the existing publicIpAddresses()/networkInterfaces()
+// accessors, both of which are cached on the VM resource.
+func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExposure, error) {
+	publicIps := a.GetPublicIpAddresses()
+	if publicIps.Error != nil {
+		return nil, publicIps.Error
+	}
+	hasPublicIp := len(publicIps.Data) > 0
+
+	openRules := []any{}
+	nics := a.GetNetworkInterfaces()
+	if nics.Error != nil {
+		return nil, nics.Error
+	}
+	for _, n := range nics.Data {
+		nic, ok := n.(*mqlAzureSubscriptionNetworkServiceInterface)
+		if !ok {
+			continue
+		}
+		nsgVal := nic.GetNetworkSecurityGroup()
+		if nsgVal.Error != nil || nsgVal.Data == nil {
+			continue
+		}
+		rules := nsgVal.Data.GetSecurityRules()
+		if rules.Error != nil {
+			continue
+		}
+		for _, r := range rules.Data {
+			rule, ok := r.(*mqlAzureSubscriptionNetworkServiceSecurityrule)
+			if !ok {
+				continue
+			}
+			direction := rule.GetDirection()
+			access := rule.GetAccess()
+			sourcePrefix := rule.GetSourceAddressPrefix()
+			sourcePrefixesVal := rule.GetSourceAddressPrefixes()
+			sourcePrefixes := []string{}
+			for _, p := range sourcePrefixesVal.Data {
+				if s, ok := p.(string); ok {
+					sourcePrefixes = append(sourcePrefixes, s)
+				}
+			}
+			if securityRuleAllowsInternetIngress(direction.Data, access.Data, sourcePrefix.Data, sourcePrefixes) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+
+	securityGroupAllowsIngress := len(openRules) > 0
+	internetReachable := hasPublicIp && securityGroupAllowsIngress
+
+	res, err := CreateResource(a.MqlRuntime, "azure.network.exposure", map[string]*llx.RawData{
+		"__id":                       llx.StringData("azure.subscription.computeService.vm/" + a.Id.Data + "/exposure"),
+		"id":                         llx.StringData(a.Id.Data + "/exposure"),
+		"internetReachable":          llx.BoolData(internetReachable),
+		"hasPublicIp":                llx.BoolData(hasPublicIp),
+		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
+		"openIngressRules":           llx.ArrayData(openRules, "azure.subscription.networkService.securityrule"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureNetworkExposure), nil
+}
+
+// sqlFirewallRanges collects (startIp, endIp) pairs from a list of MQL SQL
+// firewall-rule resources, ignoring rules whose accessor lookups error.
+func sqlFirewallRanges(rules []any) [][2]string {
+	out := make([][2]string, 0, len(rules))
+	for _, r := range rules {
+		fr, ok := r.(*mqlAzureSubscriptionSqlServiceFirewallrule)
+		if !ok {
+			continue
+		}
+		out = append(out, [2]string{fr.GetStartIpAddress().Data, fr.GetEndIpAddress().Data})
+	}
+	return out
+}
+
+func (a *mqlAzureSubscriptionSqlServiceServer) internetReachable() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rules := a.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return databaseInternetReachable(pna.Data, sqlFirewallRanges(rules.Data)), nil
+}
+
+func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) internetReachable() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rules := a.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return databaseInternetReachable(pna.Data, sqlFirewallRanges(rules.Data)), nil
+}
+
+func (a *mqlAzureSubscriptionPostgreSqlServiceServer) internetReachable() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rules := a.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return databaseInternetReachable(pna.Data, sqlFirewallRanges(rules.Data)), nil
+}
+
+func (a *mqlAzureSubscriptionMySqlServiceServer) internetReachable() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rules := a.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return databaseInternetReachable(pna.Data, sqlFirewallRanges(rules.Data)), nil
+}
+
+func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) internetReachable() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rules := a.GetFirewallRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return databaseInternetReachable(pna.Data, sqlFirewallRanges(rules.Data)), nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceCluster) internetReachable() (bool, error) {
+	priv := a.GetEnablePrivateCluster()
+	if priv.Error != nil {
+		return false, priv.Error
+	}
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	rangesVal := a.GetApiServerAuthorizedIPRanges()
+	if rangesVal.Error != nil {
+		return false, rangesVal.Error
+	}
+	ranges := []string{}
+	for _, r := range rangesVal.Data {
+		if s, ok := r.(string); ok {
+			ranges = append(ranges, s)
+		}
+	}
+	return aksApiServerInternetReachable(priv.Data, pna.Data, ranges), nil
+}
+
+// storageAccountIsPublic combines the three gates that must all be open for a
+// storage account to allow anonymous public reads: public network access not
+// disabled, the network rule set defaulting to Allow, and blob containers
+// permitted to be made anonymously public.
+func storageAccountIsPublic(publicNetworkAccess, networkRuleDefaultAction string, allowBlobPublicAccess bool) bool {
+	if !publicNetworkAccessEnabled(publicNetworkAccess) {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(networkRuleDefaultAction), "Allow") {
+		return false
+	}
+	return allowBlobPublicAccess
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccount) isPublic() (bool, error) {
+	pna := a.GetPublicNetworkAccess()
+	if pna.Error != nil {
+		return false, pna.Error
+	}
+	defaultAction := a.GetNetworkRuleDefaultAction()
+	if defaultAction.Error != nil {
+		return false, defaultAction.Error
+	}
+	allowBlobPublic := a.GetAllowBlobPublicAccess()
+	if allowBlobPublic.Error != nil {
+		return false, allowBlobPublic.Error
+	}
+	return storageAccountIsPublic(pna.Data, defaultAction.Data, allowBlobPublic.Data), nil
+}

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // --- Pure helpers (table-tested in azure_exposure_test.go) ---
@@ -60,8 +61,10 @@ func publicNetworkAccessEnabled(value string) bool {
 }
 
 // firewallRuleAllowsAnyInternet reports whether a database firewall rule (start
-// IP / end IP range) opens the server to the entire public internet — a rule
-// whose range spans the whole IPv4 space (0.0.0.0 -> 255.255.255.255).
+// IP / end IP range) opens the server to the public internet. A rule qualifies
+// when it starts at 0.0.0.0 and extends to any address beyond it — this catches
+// the full IPv4 span (0.0.0.0 -> 255.255.255.255) as well as wide partial
+// ranges such as 0.0.0.0 -> 128.255.255.255.
 //
 // The special "allow all Azure services" rule (0.0.0.0 -> 0.0.0.0) is
 // deliberately NOT treated as internet-open. That rule permits traffic only
@@ -69,7 +72,9 @@ func publicNetworkAccessEnabled(value string) bool {
 // counting it as internet-reachable would be a false positive for servers that
 // have nothing but that rule enabled.
 func firewallRuleAllowsAnyInternet(startIp, endIp string) bool {
-	return strings.TrimSpace(startIp) == "0.0.0.0" && strings.TrimSpace(endIp) == "255.255.255.255"
+	start := strings.TrimSpace(startIp)
+	end := strings.TrimSpace(endIp)
+	return start == "0.0.0.0" && end != "" && end != "0.0.0.0"
 }
 
 // databaseInternetReachable combines the publicNetworkAccess gate with the
@@ -111,10 +116,36 @@ func (a *mqlAzureSubscriptionNetworkServiceExposure) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+// effectiveRuleAllowsInternetIngress reports whether a single Azure
+// effective-security-rule object (the raw dict returned by a NIC's
+// effectiveSecurityRules) is an inbound Allow rule open to any internet source.
+// It reads the camelCase keys of the Azure effective-NSG payload and reuses
+// securityRuleAllowsInternetIngress for the direction/access/source matching.
+func effectiveRuleAllowsInternetIngress(rule map[string]any) bool {
+	direction, _ := rule["direction"].(string)
+	access, _ := rule["access"].(string)
+	sourcePrefix, _ := rule["sourceAddressPrefix"].(string)
+	sourcePrefixes := []string{}
+	// The effective rule lists sources both as the configured prefixes and the
+	// expanded set (service tags resolved to CIDRs); check both.
+	for _, key := range []string{"sourceAddressPrefixes", "expandedSourceAddressPrefix"} {
+		if arr, ok := rule[key].([]any); ok {
+			for _, p := range arr {
+				if s, ok := p.(string); ok {
+					sourcePrefixes = append(sourcePrefixes, s)
+				}
+			}
+		}
+	}
+	return securityRuleAllowsInternetIngress(direction, access, sourcePrefix, sourcePrefixes)
+}
+
 // exposure builds the network-exposure summary for a VM from its already-cached
-// public IPs and the security rules of NSGs attached to its NICs. No new API
-// calls are made beyond the existing publicIpAddresses()/networkInterfaces()
-// accessors, both of which are cached on the VM resource.
+// public IPs and the effective security rules of its NICs. The effective rules
+// (via the NIC's effectiveSecurityRules accessor) merge the NSG attached to the
+// NIC, the NSG attached to its subnet, and application security group rules, so
+// a subnet-level NSG that opens the VM is accounted for. Resolving effective
+// rules is a live Azure call per NIC; it is only paid when exposure is queried.
 //
 // Limitation: NSG rule priorities are not evaluated. Azure applies rules in
 // priority order (lowest number wins), so a higher-priority Deny rule can
@@ -138,37 +169,20 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 		if !ok {
 			continue
 		}
-		nsgVal := nic.GetNetworkSecurityGroup()
-		if nsgVal.Error != nil {
-			// Propagate rather than swallow: a failed NSG load (e.g. a
-			// permissions error) would otherwise make the VM look like it has no
-			// open ingress rules — a false negative for internet exposure.
-			return nil, nsgVal.Error
+		// effectiveSecurityRules merges NIC-level NSG, subnet-level NSG, and ASG
+		// rules. It propagates real errors but returns an empty set for
+		// stopped/detached NICs (the Azure API can't compute effective rules
+		// there), so those simply contribute no open rules.
+		eff := nic.GetEffectiveSecurityRules()
+		if eff.Error != nil {
+			return nil, eff.Error
 		}
-		if nsgVal.Data == nil {
-			// A NIC legitimately may have no NSG attached.
-			continue
-		}
-		rules := nsgVal.Data.GetSecurityRules()
-		if rules.Error != nil {
-			return nil, rules.Error
-		}
-		for _, r := range rules.Data {
-			rule, ok := r.(*mqlAzureSubscriptionNetworkServiceSecurityrule)
+		for _, r := range eff.Data {
+			rule, ok := r.(map[string]any)
 			if !ok {
 				continue
 			}
-			direction := rule.GetDirection()
-			access := rule.GetAccess()
-			sourcePrefix := rule.GetSourceAddressPrefix()
-			sourcePrefixesVal := rule.GetSourceAddressPrefixes()
-			sourcePrefixes := []string{}
-			for _, p := range sourcePrefixesVal.Data {
-				if s, ok := p.(string); ok {
-					sourcePrefixes = append(sourcePrefixes, s)
-				}
-			}
-			if securityRuleAllowsInternetIngress(direction.Data, access.Data, sourcePrefix.Data, sourcePrefixes) {
+			if effectiveRuleAllowsInternetIngress(rule) {
 				openRules = append(openRules, rule)
 			}
 		}
@@ -183,7 +197,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 		"internetReachable":          llx.BoolData(internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
 		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
-		"openIngressRules":           llx.ArrayData(openRules, "azure.subscription.networkService.securityrule"),
+		"openIngressRules":           llx.ArrayData(openRules, types.Dict),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -112,10 +112,6 @@ func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAcces
 
 // --- Resolvers ---
 
-func (a *mqlAzureSubscriptionNetworkServiceExposure) id() (string, error) {
-	return a.Id.Data, nil
-}
-
 // effectiveRuleAllowsInternetIngress reports whether a single Azure
 // effective-security-rule object (the raw dict returned by a NIC's
 // effectiveSecurityRules) is an inbound Allow rule open to any internet source.
@@ -193,7 +189,6 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("azure.subscription.computeService.vm/" + a.Id.Data + "/exposure"),
-		"id":                         llx.StringData(a.Id.Data + "/exposure"),
 		"internetReachable":          llx.BoolData(internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
 		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -60,16 +60,16 @@ func publicNetworkAccessEnabled(value string) bool {
 }
 
 // firewallRuleAllowsAnyInternet reports whether a database firewall rule (start
-// IP / end IP range) opens the server to any internet address. Two forms count:
-//   - the special "allow all Azure services" rule 0.0.0.0 -> 0.0.0.0
-//   - a rule whose range spans the entire IPv4 space (0.0.0.0 -> 255.255.255.255)
+// IP / end IP range) opens the server to the entire public internet — a rule
+// whose range spans the whole IPv4 space (0.0.0.0 -> 255.255.255.255).
+//
+// The special "allow all Azure services" rule (0.0.0.0 -> 0.0.0.0) is
+// deliberately NOT treated as internet-open. That rule permits traffic only
+// from Azure-internal service IPs, not from arbitrary public addresses, so
+// counting it as internet-reachable would be a false positive for servers that
+// have nothing but that rule enabled.
 func firewallRuleAllowsAnyInternet(startIp, endIp string) bool {
-	start := strings.TrimSpace(startIp)
-	end := strings.TrimSpace(endIp)
-	if start == "0.0.0.0" && (end == "0.0.0.0" || end == "255.255.255.255") {
-		return true
-	}
-	return false
+	return strings.TrimSpace(startIp) == "0.0.0.0" && strings.TrimSpace(endIp) == "255.255.255.255"
 }
 
 // databaseInternetReachable combines the publicNetworkAccess gate with the
@@ -115,6 +115,12 @@ func (a *mqlAzureNetworkExposure) id() (string, error) {
 // public IPs and the security rules of NSGs attached to its NICs. No new API
 // calls are made beyond the existing publicIpAddresses()/networkInterfaces()
 // accessors, both of which are cached on the VM resource.
+//
+// Limitation: NSG rule priorities are not evaluated. Azure applies rules in
+// priority order (lowest number wins), so a higher-priority Deny rule can
+// shadow a lower-priority Allow-from-internet rule. This breakdown flags any
+// matching Allow rule as opening ingress, so securityGroupAllowsIngress may
+// report true even when a higher-priority Deny actually blocks the traffic.
 func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureNetworkExposure, error) {
 	publicIps := a.GetPublicIpAddresses()
 	if publicIps.Error != nil {

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInternetOpenSourcePrefix(t *testing.T) {
+	cases := []struct {
+		prefix string
+		want   bool
+	}{
+		{"*", true},
+		{"0.0.0.0/0", true},
+		{"::/0", true},
+		{"Internet", true},
+		{"internet", true},
+		{" * ", true},
+		{"10.0.0.0/8", false},
+		{"VirtualNetwork", false},
+		{"203.0.113.4", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, isInternetOpenSourcePrefix(c.prefix), "prefix %q", c.prefix)
+	}
+}
+
+func TestSecurityRuleAllowsInternetIngress(t *testing.T) {
+	t.Run("inbound allow from any is open", func(t *testing.T) {
+		assert.True(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "0.0.0.0/0", nil))
+	})
+	t.Run("inbound allow via service tag is open", func(t *testing.T) {
+		assert.True(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "Internet", nil))
+	})
+	t.Run("inbound allow via prefix list is open", func(t *testing.T) {
+		assert.True(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "10.0.0.0/8", []string{"VirtualNetwork", "*"}))
+	})
+	t.Run("outbound is not ingress", func(t *testing.T) {
+		assert.False(t, securityRuleAllowsInternetIngress("Outbound", "Allow", "*", nil))
+	})
+	t.Run("deny is not open", func(t *testing.T) {
+		assert.False(t, securityRuleAllowsInternetIngress("Inbound", "Deny", "*", nil))
+	})
+	t.Run("scoped source is not open", func(t *testing.T) {
+		assert.False(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "10.0.0.0/8", []string{"172.16.0.0/12"}))
+	})
+	t.Run("case insensitive direction/access", func(t *testing.T) {
+		assert.True(t, securityRuleAllowsInternetIngress("inbound", "allow", "*", nil))
+	})
+}
+
+func TestPublicNetworkAccessEnabled(t *testing.T) {
+	assert.True(t, publicNetworkAccessEnabled("Enabled"))
+	assert.True(t, publicNetworkAccessEnabled(""), "empty defaults to enabled")
+	assert.True(t, publicNetworkAccessEnabled("enabled"))
+	assert.False(t, publicNetworkAccessEnabled("Disabled"))
+	assert.False(t, publicNetworkAccessEnabled("disabled"))
+}
+
+func TestFirewallRuleAllowsAnyInternet(t *testing.T) {
+	cases := []struct {
+		start, end string
+		want       bool
+	}{
+		{"0.0.0.0", "0.0.0.0", true},             // allow-all-Azure-services rule
+		{"0.0.0.0", "255.255.255.255", true},     // full IPv4 span
+		{"203.0.113.1", "203.0.113.10", false},   // scoped range
+		{"10.0.0.0", "10.255.255.255", false},    // private span
+		{"", "", false},                          // empty
+		{" 0.0.0.0 ", " 255.255.255.255 ", true}, // trimmed
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, firewallRuleAllowsAnyInternet(c.start, c.end), "%s-%s", c.start, c.end)
+	}
+}
+
+func TestDatabaseInternetReachable(t *testing.T) {
+	t.Run("public access disabled is never reachable", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Disabled", [][2]string{{"0.0.0.0", "255.255.255.255"}}))
+	})
+	t.Run("public access enabled with open rule is reachable", func(t *testing.T) {
+		assert.True(t, databaseInternetReachable("Enabled", [][2]string{{"0.0.0.0", "0.0.0.0"}}))
+	})
+	t.Run("public access enabled but only scoped rules is not reachable", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{{"203.0.113.1", "203.0.113.10"}}))
+	})
+	t.Run("no firewall rules is not reachable", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", nil))
+	})
+}
+
+func TestAksApiServerInternetReachable(t *testing.T) {
+	t.Run("public cluster with no allowlist is reachable", func(t *testing.T) {
+		assert.True(t, aksApiServerInternetReachable(false, "Enabled", nil))
+	})
+	t.Run("private cluster is not reachable", func(t *testing.T) {
+		assert.False(t, aksApiServerInternetReachable(true, "Enabled", nil))
+	})
+	t.Run("disabled public access is not reachable", func(t *testing.T) {
+		assert.False(t, aksApiServerInternetReachable(false, "Disabled", nil))
+	})
+	t.Run("authorized IP ranges close exposure", func(t *testing.T) {
+		assert.False(t, aksApiServerInternetReachable(false, "Enabled", []string{"203.0.113.0/24"}))
+	})
+	t.Run("empty publicNetworkAccess defaults to reachable", func(t *testing.T) {
+		assert.True(t, aksApiServerInternetReachable(false, "", nil))
+	})
+}
+
+func TestStorageAccountIsPublic(t *testing.T) {
+	t.Run("all gates open is public", func(t *testing.T) {
+		assert.True(t, storageAccountIsPublic("Enabled", "Allow", true))
+	})
+	t.Run("blob public access off is not public", func(t *testing.T) {
+		assert.False(t, storageAccountIsPublic("Enabled", "Allow", false))
+	})
+	t.Run("deny default action is not public", func(t *testing.T) {
+		assert.False(t, storageAccountIsPublic("Enabled", "Deny", true))
+	})
+	t.Run("disabled public network access is not public", func(t *testing.T) {
+		assert.False(t, storageAccountIsPublic("Disabled", "Allow", true))
+	})
+	t.Run("empty default action is treated as not Allow", func(t *testing.T) {
+		assert.False(t, storageAccountIsPublic("Enabled", "", true))
+	})
+}

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -54,6 +54,43 @@ func TestSecurityRuleAllowsInternetIngress(t *testing.T) {
 	})
 }
 
+func TestEffectiveRuleAllowsInternetIngress(t *testing.T) {
+	t.Run("inbound allow from any prefix is open", func(t *testing.T) {
+		assert.True(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "0.0.0.0/0",
+		}))
+	})
+	t.Run("inbound allow via Internet service tag is open", func(t *testing.T) {
+		assert.True(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "Internet",
+		}))
+	})
+	t.Run("inbound allow via expanded prefixes is open", func(t *testing.T) {
+		assert.True(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "VirtualNetwork",
+			"expandedSourceAddressPrefix": []any{"10.0.0.0/8", "*"},
+		}))
+	})
+	t.Run("outbound is not ingress", func(t *testing.T) {
+		assert.False(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Outbound", "access": "Allow", "sourceAddressPrefix": "*",
+		}))
+	})
+	t.Run("deny is not open", func(t *testing.T) {
+		assert.False(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Inbound", "access": "Deny", "sourceAddressPrefix": "*",
+		}))
+	})
+	t.Run("scoped source is not open", func(t *testing.T) {
+		assert.False(t, effectiveRuleAllowsInternetIngress(map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "10.0.0.0/8",
+		}))
+	})
+	t.Run("missing keys are not open", func(t *testing.T) {
+		assert.False(t, effectiveRuleAllowsInternetIngress(map[string]any{}))
+	})
+}
+
 func TestPublicNetworkAccessEnabled(t *testing.T) {
 	assert.True(t, publicNetworkAccessEnabled("Enabled"))
 	assert.True(t, publicNetworkAccessEnabled(""), "empty defaults to enabled")
@@ -69,9 +106,11 @@ func TestFirewallRuleAllowsAnyInternet(t *testing.T) {
 	}{
 		{"0.0.0.0", "0.0.0.0", false},            // allow-all-Azure-services rule, not the public internet
 		{"0.0.0.0", "255.255.255.255", true},     // full IPv4 span
+		{"0.0.0.0", "128.255.255.255", true},     // wide partial span starting at 0.0.0.0
 		{"203.0.113.1", "203.0.113.10", false},   // scoped range
 		{"10.0.0.0", "10.255.255.255", false},    // private span
 		{"", "", false},                          // empty
+		{"0.0.0.0", "", false},                   // open start but no end
 		{" 0.0.0.0 ", " 255.255.255.255 ", true}, // trimmed
 	}
 	for _, c := range cases {

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -67,7 +67,7 @@ func TestFirewallRuleAllowsAnyInternet(t *testing.T) {
 		start, end string
 		want       bool
 	}{
-		{"0.0.0.0", "0.0.0.0", true},             // allow-all-Azure-services rule
+		{"0.0.0.0", "0.0.0.0", false},            // allow-all-Azure-services rule, not the public internet
 		{"0.0.0.0", "255.255.255.255", true},     // full IPv4 span
 		{"203.0.113.1", "203.0.113.10", false},   // scoped range
 		{"10.0.0.0", "10.255.255.255", false},    // private span
@@ -84,7 +84,10 @@ func TestDatabaseInternetReachable(t *testing.T) {
 		assert.False(t, databaseInternetReachable("Disabled", [][2]string{{"0.0.0.0", "255.255.255.255"}}))
 	})
 	t.Run("public access enabled with open rule is reachable", func(t *testing.T) {
-		assert.True(t, databaseInternetReachable("Enabled", [][2]string{{"0.0.0.0", "0.0.0.0"}}))
+		assert.True(t, databaseInternetReachable("Enabled", [][2]string{{"0.0.0.0", "255.255.255.255"}}))
+	})
+	t.Run("allow-all-Azure-services rule alone is not reachable", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{{"0.0.0.0", "0.0.0.0"}}))
 	})
 	t.Run("public access enabled but only scoped rules is not reachable", func(t *testing.T) {
 		assert.False(t, databaseInternetReachable("Enabled", [][2]string{{"203.0.113.1", "203.0.113.10"}}))


### PR DESCRIPTION
Adds internet-exposure predicates to Azure resources, following the established cross-provider pattern.

## Network reachability (public IP + effective NSG ingress)
New private sub-resource **`azure.subscription.networkService.exposure`** with `internetReachable`, `hasPublicIp`, `securityGroupAllowsIngress`, and `openIngressRules`. An ingress rule is "open" when it is `Inbound` + `Allow` with a source of `*`, `0.0.0.0/0`, `::/0`, or the `Internet` service tag.

- `azure.subscription.computeService.vm` → `exposure()`. Rules are sourced from each NIC's **`effectiveSecurityRules()`**, which merges the NSG attached to the NIC, the NSG attached to its **subnet**, and application security group rules — so a subnet-level NSG that opens the VM is accounted for. `openIngressRules` is `[]dict` (the raw Azure effective-rule objects).

## Database reachability (firewall-rule model)
Simpler `internetReachable() bool` combining `publicNetworkAccess` with firewall rules that open the server to the public internet — any rule that starts at `0.0.0.0` and extends beyond it (e.g. `0.0.0.0 → 255.255.255.255` or a wide partial range like `0.0.0.0 → 128.255.255.255`). The special `0.0.0.0 → 0.0.0.0` "allow all Azure services" rule is **excluded**, since it admits only Azure-internal IPs:

- `azure.subscription.sqlService.server`
- `azure.subscription.postgreSqlService.flexibleServer`
- `azure.subscription.postgreSqlService.server`
- `azure.subscription.mySqlService.server`
- `azure.subscription.mySqlService.flexibleServer`

## API-server reachability
- `azure.subscription.aksService.cluster` → `internetReachable()` (not a private cluster AND public access not disabled AND no authorized-IP allowlist)

## Public access
- `azure.subscription.storageService.account` → `isPublic()` (public network access not disabled AND network rule default action `Allow` AND `allowBlobPublicAccess`)

## Notes
- Rule/CIDR/firewall/source-prefix matching lives in pure helpers with table-driven unit tests (`azure_exposure_test.go`, plain testify matching the provider's existing test style), including `effectiveRuleAllowsInternetIngress` over the raw effective-rule dict.
- `exposure()` resolves effective rules via a live Azure call per NIC (the effective-NSG API). Because `exposure()` is an opt-in computed field, that cost is only paid when the field is queried; stopped/detached NICs degrade gracefully to no rules. Errors from NSG/effective-rule resolution are propagated rather than swallowed, so a permissions failure surfaces instead of becoming a false negative.
- Database / AKS / storage predicates read existing cached signals only (`publicNetworkAccess`, `firewallRules`, `enablePrivateCluster`, `apiServerAuthorizedIPRanges`, `allowBlobPublicAccess`, `networkRuleDefaultAction`).
- `.lr.versions` entries land at `13.20.1` (next patch after the provider's `13.20.0`).
- `go build ./...` and the exposure unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)