### PR TITLE
⭐ aws: add internet-exposure analysis across resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1385,6 +1385,11 @@ private aws.efs.filesystem @defaults("name id region") {
   fileSystemPolicy() string
   // Parsed statements from the file system policy
   policyStatements() []aws.iam.policyStatement
+  // Whether the file system policy grants access to a public (wildcard) principal
+  //
+  // True when an Allow statement grants a wildcard principal access that is not
+  // scoped by a source-restricting condition.
+  isPublic() bool
   // Performance mode: generalPurpose or maxIO
   performanceMode string
   // Throughput mode: bursting, provisioned, or elastic
@@ -4764,6 +4769,14 @@ private aws.es.domain @defaults("arn name") {
   tlsSecurityPolicy string
   // IAM access policy as a JSON-formatted string
   accessPolicies string
+  // Parsed statements from the domain access policy
+  policyStatements() []aws.iam.policyStatement
+  // Whether the domain is reachable from the internet
+  //
+  // True when the domain is not deployed inside a VPC (its endpoint is publicly
+  // resolvable) and its access policy grants a wildcard principal access that is
+  // not scoped by a source-restricting condition.
+  isPublic() bool
   // Whether the domain creation is complete
   created bool
   // Whether the domain is being deleted
@@ -6846,6 +6859,11 @@ aws.secretsmanager.secret @defaults("arn name") {
   resourcePolicy() string
   // Parsed statements from the resource-based policy
   policyStatements() []aws.iam.policyStatement
+  // Whether the resource policy grants access to a public (wildcard) principal
+  //
+  // True when an Allow statement grants a wildcard principal access that is not
+  // scoped by a source-restricting condition.
+  isPublic() bool
   // Regions where the secret is replicated
   replicaRegions() []aws.secretsmanager.secret.replicaRegion
   // Secret type: USER (user-created) or MANAGED_EXTERNAL (managed by another service)
@@ -10811,6 +10829,11 @@ private aws.backup.vault @defaults("name region") {
   accessPolicy() string
   // Parsed statements from the vault access policy
   policyStatements() []aws.iam.policyStatement
+  // Whether the vault access policy grants access to a public (wildcard) principal
+  //
+  // True when an Allow statement grants a wildcard principal access that is not
+  // scoped by a source-restricting condition.
+  isPublic() bool
 }
 
 // AWS Backup vault recovery point
@@ -12195,6 +12218,11 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   preferredMaintenanceWindow string
   // Whether the cluster is publicly accessible
   publiclyAccessible bool
+  // Whether the cluster is reachable from the internet
+  //
+  // True when the cluster is configured for public access, which assigns it a
+  // publicly resolvable endpoint reachable from outside its VPC.
+  internetReachable() bool
   // Connection endpoint address for the cluster (empty when the cluster has no endpoint)
   endpointAddress string
   // Connection endpoint port for the cluster (0 when the cluster has no endpoint)
@@ -16985,6 +17013,8 @@ private aws.neptune.instance @defaults("arn name status"){
   tdeCredentialArn string
   // Whether the DB instance is publicly accessible
   publiclyAccessible bool
+  // Internet-exposure breakdown (publicly-accessible flag combined with the parent cluster's security group ingress)
+  exposure() aws.network.exposure
   // ID of the Certificate Authority
   certificateAuthority string
   // Network protocol the instance is accessible over (IPV4 or DUAL for IPv4/IPv6 dual-stack)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6052,6 +6052,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.filesystem.policyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
+	"aws.efs.filesystem.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystem).GetIsPublic()).ToDataRes(types.Bool)
+	},
 	"aws.efs.filesystem.performanceMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetPerformanceMode()).ToDataRes(types.String)
 	},
@@ -10012,6 +10015,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.es.domain.accessPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetAccessPolicies()).ToDataRes(types.String)
 	},
+	"aws.es.domain.policyStatements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.es.domain.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetIsPublic()).ToDataRes(types.Bool)
+	},
 	"aws.es.domain.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetCreated()).ToDataRes(types.Bool)
 	},
@@ -12336,6 +12345,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.secretsmanager.secret.policyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.secretsmanager.secret.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetIsPublic()).ToDataRes(types.Bool)
 	},
 	"aws.secretsmanager.secret.replicaRegions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetReplicaRegions()).ToDataRes(types.Array(types.Resource("aws.secretsmanager.secret.replicaRegion")))
@@ -16471,6 +16483,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.backup.vault.policyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVault).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
+	"aws.backup.vault.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupVault).GetIsPublic()).ToDataRes(types.Bool)
+	},
 	"aws.backup.vaultRecoveryPoint.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVaultRecoveryPoint).GetArn()).ToDataRes(types.String)
 	},
@@ -18075,6 +18090,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.redshift.cluster.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.redshift.cluster.internetReachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftCluster).GetInternetReachable()).ToDataRes(types.Bool)
 	},
 	"aws.redshift.cluster.endpointAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetEndpointAddress()).ToDataRes(types.String)
@@ -23520,6 +23538,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.neptune.instance.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneInstance).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.neptune.instance.certificateAuthority": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneInstance).GetCertificateAuthority()).ToDataRes(types.String)
@@ -34907,6 +34928,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEfsFilesystem).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.efs.filesystem.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystem).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.efs.filesystem.performanceMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystem).PerformanceMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -40711,6 +40736,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEsDomain).AccessPolicies, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.es.domain.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.es.domain.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEsDomain).Created, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -44081,6 +44114,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.secretsmanager.secret.policyStatements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecret).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.secretsmanager.secret.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.secretsmanager.secret.replicaRegions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50239,6 +50276,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsBackupVault).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.backup.vault.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupVault).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.backup.vaultRecoveryPoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupVaultRecoveryPoint).__id, ok = v.Value.(string)
 		return
@@ -52529,6 +52570,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.redshift.cluster.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftCluster).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.cluster.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftCluster).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.cluster.endpointAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60425,6 +60470,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.neptune.instance.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsNeptuneInstance).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.neptune.instance.certificateAuthority": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -79737,6 +79786,7 @@ type mqlAwsEfsFilesystem struct {
 	AccessPoints             plugin.TValue[[]any]
 	FileSystemPolicy         plugin.TValue[string]
 	PolicyStatements         plugin.TValue[[]any]
+	IsPublic                 plugin.TValue[bool]
 	PerformanceMode          plugin.TValue[string]
 	ThroughputMode           plugin.TValue[string]
 	SizeInBytes              plugin.TValue[int64]
@@ -79888,6 +79938,12 @@ func (c *mqlAwsEfsFilesystem) GetPolicyStatements() *plugin.TValue[[]any] {
 		}
 
 		return c.policyStatements()
+	})
+}
+
+func (c *mqlAwsEfsFilesystem) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 
@@ -95726,6 +95782,8 @@ type mqlAwsEsDomain struct {
 	EnforceHTTPS                       plugin.TValue[bool]
 	TlsSecurityPolicy                  plugin.TValue[string]
 	AccessPolicies                     plugin.TValue[string]
+	PolicyStatements                   plugin.TValue[[]any]
+	IsPublic                           plugin.TValue[bool]
 	Created                            plugin.TValue[bool]
 	Deleted                            plugin.TValue[bool]
 	Processing                         plugin.TValue[bool]
@@ -95890,6 +95948,28 @@ func (c *mqlAwsEsDomain) GetTlsSecurityPolicy() *plugin.TValue[string] {
 
 func (c *mqlAwsEsDomain) GetAccessPolicies() *plugin.TValue[string] {
 	return &c.AccessPolicies
+}
+
+func (c *mqlAwsEsDomain) GetPolicyStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyStatements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.es.domain", c.__id, "policyStatements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyStatements()
+	})
+}
+
+func (c *mqlAwsEsDomain) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
+	})
 }
 
 func (c *mqlAwsEsDomain) GetCreated() *plugin.TValue[bool] {
@@ -103871,6 +103951,7 @@ type mqlAwsSecretsmanagerSecret struct {
 	Tags             plugin.TValue[map[string]any]
 	ResourcePolicy   plugin.TValue[string]
 	PolicyStatements plugin.TValue[[]any]
+	IsPublic         plugin.TValue[bool]
 	ReplicaRegions   plugin.TValue[[]any]
 	Type             plugin.TValue[string]
 	Versions         plugin.TValue[[]any]
@@ -104005,6 +104086,12 @@ func (c *mqlAwsSecretsmanagerSecret) GetPolicyStatements() *plugin.TValue[[]any]
 		}
 
 		return c.policyStatements()
+	})
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 
@@ -120837,6 +120924,7 @@ type mqlAwsBackupVault struct {
 	MinRetentionDays plugin.TValue[int64]
 	AccessPolicy     plugin.TValue[string]
 	PolicyStatements plugin.TValue[[]any]
+	IsPublic         plugin.TValue[bool]
 }
 
 // createAwsBackupVault creates a new instance of this resource
@@ -120963,6 +121051,12 @@ func (c *mqlAwsBackupVault) GetPolicyStatements() *plugin.TValue[[]any] {
 		}
 
 		return c.policyStatements()
+	})
+}
+
+func (c *mqlAwsBackupVault) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 
@@ -126210,6 +126304,7 @@ type mqlAwsRedshiftCluster struct {
 	Parameters                       plugin.TValue[[]any]
 	PreferredMaintenanceWindow       plugin.TValue[string]
 	PubliclyAccessible               plugin.TValue[bool]
+	InternetReachable                plugin.TValue[bool]
 	EndpointAddress                  plugin.TValue[string]
 	EndpointPort                     plugin.TValue[int64]
 	EndpointVpcEndpoints             plugin.TValue[[]any]
@@ -126372,6 +126467,12 @@ func (c *mqlAwsRedshiftCluster) GetPreferredMaintenanceWindow() *plugin.TValue[s
 
 func (c *mqlAwsRedshiftCluster) GetPubliclyAccessible() *plugin.TValue[bool] {
 	return &c.PubliclyAccessible
+}
+
+func (c *mqlAwsRedshiftCluster) GetInternetReachable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
+		return c.internetReachable()
+	})
 }
 
 func (c *mqlAwsRedshiftCluster) GetEndpointAddress() *plugin.TValue[string] {
@@ -145591,6 +145692,7 @@ type mqlAwsNeptuneInstance struct {
 	StorageType                      plugin.TValue[string]
 	TdeCredentialArn                 plugin.TValue[string]
 	PubliclyAccessible               plugin.TValue[bool]
+	Exposure                         plugin.TValue[*mqlAwsNetworkExposure]
 	CertificateAuthority             plugin.TValue[string]
 	NetworkType                      plugin.TValue[string]
 }
@@ -145781,6 +145883,22 @@ func (c *mqlAwsNeptuneInstance) GetTdeCredentialArn() *plugin.TValue[string] {
 
 func (c *mqlAwsNeptuneInstance) GetPubliclyAccessible() *plugin.TValue[bool] {
 	return &c.PubliclyAccessible
+}
+
+func (c *mqlAwsNeptuneInstance) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune.instance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
 }
 
 func (c *mqlAwsNeptuneInstance) GetCertificateAuthority() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -821,6 +821,7 @@ aws.backup.vault.arn 11.15.2
 aws.backup.vault.createdAt 11.15.2
 aws.backup.vault.encryptionKey 13.12.1
 aws.backup.vault.encryptionKeyArn 11.15.2
+aws.backup.vault.isPublic 13.37.1
 aws.backup.vault.locked 11.15.2
 aws.backup.vault.lockedAt 11.15.2
 aws.backup.vault.maxRetentionDays 11.15.2
@@ -3827,6 +3828,7 @@ aws.efs.filesystem.encrypted 11.15.2
 aws.efs.filesystem.fileSystemPolicy 11.15.2
 aws.efs.filesystem.fileSystemProtection 13.12.1
 aws.efs.filesystem.id 11.15.2
+aws.efs.filesystem.isPublic 13.37.1
 aws.efs.filesystem.kmsKey 11.15.2
 aws.efs.filesystem.lifecycleConfiguration 13.12.1
 aws.efs.filesystem.lifecycleConfiguration.transitionToArchive 13.12.1
@@ -4448,9 +4450,11 @@ aws.es.domain.indexSlowLogGroup 13.21.4
 aws.es.domain.instanceCount 13.21.4
 aws.es.domain.instanceType 13.21.4
 aws.es.domain.internalUserDatabaseEnabled 13.21.4
+aws.es.domain.isPublic 13.37.1
 aws.es.domain.kmsKey 13.21.4
 aws.es.domain.name 11.15.2
 aws.es.domain.nodeToNodeEncryptionEnabled 11.15.2
+aws.es.domain.policyStatements 13.37.1
 aws.es.domain.processing 13.21.4
 aws.es.domain.region 11.15.2
 aws.es.domain.searchSlowLogEnabled 13.21.4
@@ -6684,6 +6688,7 @@ aws.neptune.instance.endpoint 11.15.2
 aws.neptune.instance.engine 11.15.2
 aws.neptune.instance.engineVersion 11.15.2
 aws.neptune.instance.enhancedMonitoringResourceArn 11.15.2
+aws.neptune.instance.exposure 13.37.1
 aws.neptune.instance.iamDatabaseAuthenticationEnabled 11.15.2
 aws.neptune.instance.instanceClass 11.15.2
 aws.neptune.instance.kmsKey 11.16.1
@@ -7341,6 +7346,7 @@ aws.redshift.cluster.endpointPort 13.15.2
 aws.redshift.cluster.endpointVpcEndpoints 13.15.2
 aws.redshift.cluster.enhancedVpcRouting 11.15.2
 aws.redshift.cluster.hsmStatus 11.16.1
+aws.redshift.cluster.internetReachable 13.37.1
 aws.redshift.cluster.ipAddressType 11.15.2
 aws.redshift.cluster.kmsKey 11.16.1
 aws.redshift.cluster.logging 11.15.2
@@ -8832,6 +8838,7 @@ aws.secretsmanager.secret.arn 11.15.2
 aws.secretsmanager.secret.createdAt 11.15.2
 aws.secretsmanager.secret.deletedAt 13.12.1
 aws.secretsmanager.secret.description 11.15.2
+aws.secretsmanager.secret.isPublic 13.37.1
 aws.secretsmanager.secret.kmsKey 11.15.2
 aws.secretsmanager.secret.lastAccessedDate 11.15.2
 aws.secretsmanager.secret.lastChangedDate 11.15.2

--- a/providers/aws/resources/aws_internet_exposure.go
+++ b/providers/aws/resources/aws_internet_exposure.go
@@ -91,7 +91,11 @@ func (a *mqlAwsBackupVault) isPublic() (bool, error) {
 }
 
 func (a *mqlAwsEsDomain) policyStatements() ([]any, error) {
-	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetAccessPolicies())
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	return policyStatementsFromString(a.MqlRuntime, arn.Data, a.GetAccessPolicies())
 }
 
 // esDomainIsPublic reports whether an Elasticsearch/OpenSearch domain is
@@ -112,9 +116,8 @@ func (a *mqlAwsEsDomain) isPublic() (bool, error) {
 	if inVPC {
 		return false, nil
 	}
-	policyAllowsPublic, err := resourceIsPublic(a.GetPolicyStatements())
-	if err != nil {
-		return false, err
-	}
-	return esDomainIsPublic(inVPC, policyAllowsPublic), nil
+	// Not in a VPC (checked above), so public reachability reduces to whether the
+	// access policy grants a wildcard principal. esDomainIsPublic encodes the full
+	// rule and is covered directly by unit tests.
+	return resourceIsPublic(a.GetPolicyStatements())
 }

--- a/providers/aws/resources/aws_internet_exposure.go
+++ b/providers/aws/resources/aws_internet_exposure.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// internetReachable reports whether a Redshift cluster is reachable from the
+// internet. Redshift does not expose its VPC security groups as a queryable
+// field, so reachability follows the public-access toggle alone: a publicly
+// accessible cluster is assigned a publicly resolvable endpoint reachable from
+// outside its VPC.
+func (a *mqlAwsRedshiftCluster) internetReachable() (bool, error) {
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return false, publiclyAccessible.Error
+	}
+	return publiclyAccessible.Data, nil
+}
+
+// exposure builds the shared network-exposure breakdown for a Neptune instance.
+// The public-access flag lives on the instance, while the VPC security groups
+// live on its parent cluster, so the open ingress rules are sourced from the
+// cluster identified by clusterIdentifier.
+func (a *mqlAwsNeptuneInstance) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	sgs, err := a.clusterSecurityGroups()
+	if err != nil {
+		return nil, err
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, sgs)
+}
+
+// clusterSecurityGroups returns the security groups of the Neptune cluster that
+// owns this instance, located among the already-cached clusters by matching the
+// instance's clusterIdentifier. It returns nil security groups (rather than an
+// error) when the cluster cannot be found, so exposure still resolves.
+func (a *mqlAwsNeptuneInstance) clusterSecurityGroups() (*plugin.TValue[[]any], error) {
+	clusterIdentifier := a.GetClusterIdentifier()
+	if clusterIdentifier.Error != nil {
+		return nil, clusterIdentifier.Error
+	}
+	if clusterIdentifier.Data == "" {
+		return nil, nil
+	}
+
+	obj, err := CreateResource(a.MqlRuntime, "aws.neptune", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	clusters := obj.(*mqlAwsNeptune).GetClusters()
+	if clusters.Error != nil {
+		return nil, clusters.Error
+	}
+	for _, raw := range clusters.Data {
+		cluster, ok := raw.(*mqlAwsNeptuneCluster)
+		if !ok {
+			continue
+		}
+		id := cluster.GetClusterIdentifier()
+		if id.Error != nil {
+			return nil, id.Error
+		}
+		if id.Data == clusterIdentifier.Data {
+			return cluster.GetSecurityGroups(), nil
+		}
+	}
+	return nil, nil
+}
+
+func (a *mqlAwsSecretsmanagerSecret) isPublic() (bool, error) {
+	return resourceIsPublic(a.GetPolicyStatements())
+}
+
+func (a *mqlAwsEfsFilesystem) isPublic() (bool, error) {
+	return resourceIsPublic(a.GetPolicyStatements())
+}
+
+func (a *mqlAwsBackupVault) isPublic() (bool, error) {
+	return resourceIsPublic(a.GetPolicyStatements())
+}
+
+func (a *mqlAwsEsDomain) policyStatements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetAccessPolicies())
+}
+
+// esDomainIsPublic reports whether an Elasticsearch/OpenSearch domain is
+// reachable from the internet. A domain is public only when it has a public
+// endpoint (it is not deployed inside a VPC) and its access policy grants a
+// wildcard principal. VPC domains are unreachable from the internet regardless
+// of their access policy.
+func esDomainIsPublic(inVPC bool, policyAllowsPublic bool) bool {
+	return !inVPC && policyAllowsPublic
+}
+
+// isPublic reports whether an Elasticsearch/OpenSearch (es) domain is reachable
+// from the internet: it has a public endpoint (it is not deployed inside a VPC)
+// and its access policy grants a wildcard principal access that is not scoped by
+// a source-restricting condition.
+func (a *mqlAwsEsDomain) isPublic() (bool, error) {
+	inVPC := a.cacheVpcId != nil && *a.cacheVpcId != ""
+	if inVPC {
+		return false, nil
+	}
+	policyAllowsPublic, err := resourceIsPublic(a.GetPolicyStatements())
+	if err != nil {
+		return false, err
+	}
+	return esDomainIsPublic(inVPC, policyAllowsPublic), nil
+}

--- a/providers/aws/resources/aws_internet_exposure_test.go
+++ b/providers/aws/resources/aws_internet_exposure_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestNaclAllowsPublicIngress(t *testing.T) {
@@ -78,4 +80,56 @@ func TestRouteAuthIsPublic(t *testing.T) {
 	assert.False(t, routeAuthIsPublic("AWS_IAM"))
 	assert.False(t, routeAuthIsPublic("JWT"))
 	assert.False(t, routeAuthIsPublic("CUSTOM"))
+}
+
+func setBoolValue(v bool) plugin.TValue[bool] {
+	return plugin.TValue[bool]{Data: v, State: plugin.StateIsSet}
+}
+
+func TestEsDomainIsPublic(t *testing.T) {
+	tests := []struct {
+		name               string
+		inVPC              bool
+		policyAllowsPublic bool
+		want               bool
+	}{
+		{"public endpoint, public policy", false, true, true},
+		{"public endpoint, scoped policy", false, false, false},
+		{"vpc domain, public policy", true, true, false},
+		{"vpc domain, scoped policy", true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, esDomainIsPublic(tt.inVPC, tt.policyAllowsPublic))
+		})
+	}
+}
+
+func TestRedshiftClusterInternetReachable(t *testing.T) {
+	tests := []struct {
+		name               string
+		publiclyAccessible bool
+		want               bool
+	}{
+		{"publicly accessible", true, true},
+		{"private", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &mqlAwsRedshiftCluster{
+				PubliclyAccessible: setBoolValue(tt.publiclyAccessible),
+			}
+			got, err := cluster.internetReachable()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOpenIngressRulesFromSecurityGroupsNil(t *testing.T) {
+	// A nil security-group TValue (e.g. a Neptune instance whose parent cluster
+	// could not be located) must yield no open rules rather than panicking.
+	rules, err := openIngressRulesFromSecurityGroups(nil)
+	require.NoError(t, err)
+	assert.Empty(t, rules)
 }

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -12,6 +12,9 @@ import (
 // openIngressRulesFromSecurityGroups returns the ingress rules across the given
 // security groups that permit inbound traffic from the internet.
 func openIngressRulesFromSecurityGroups(sgs *plugin.TValue[[]any]) ([]any, error) {
+	if sgs == nil {
+		return []any{}, nil
+	}
 	if sgs.Error != nil {
 		return nil, sgs.Error
 	}


### PR DESCRIPTION
## Summary

Extends internet-exposure coverage to AWS resources that previously lacked it, filling the gaps around the already-shipped `aws.network.exposure` work. Reuses the established shared resource (`aws.network.exposure`) and the existing resource-policy public-access helpers (`resourceIsPublic` / `statementsAllowPublic`) — no new derivation logic where a signal already existed.

## Resources covered

**Network reachability**
- `aws.neptune.instance` → `exposure() aws.network.exposure`. Combines the instance `publiclyAccessible` flag with the parent cluster's security group ingress. Because Neptune security groups live on the cluster, the open ingress rules are sourced from the cluster matched by `clusterIdentifier` among the already-cached clusters.
- `aws.redshift.cluster` → `internetReachable() bool`. Redshift does not expose its VPC security groups as a queryable field, so reachability follows the public-access toggle alone (the simpler authorized-networks-style predicate).

**Policy / public access** (reuses `resourceIsPublic` + `statementsAllowPublic`)
- `aws.secretsmanager.secret` → `isPublic()`
- `aws.efs.filesystem` → `isPublic()`
- `aws.backup.vault` → `isPublic()`
- `aws.es.domain` → `policyStatements()` + `isPublic()`. An Elasticsearch/OpenSearch domain is public only when it is **not** deployed in a VPC (public endpoint) **and** its access policy grants a wildcard principal not scoped by a source-restricting condition.

## Skipped (already covered or no public-access signal)
- `aws.rds.dbinstance`, `aws.documentdb.instance`, `aws.elb.loadbalancer` — already have `exposure()`.
- `aws.elasticache.cluster`, `aws.memorydb.cluster`, `aws.neptune.cluster` — VPC-only, no `publiclyAccessible`/public-endpoint signal.
- `aws.opensearch.domain` — has no resource access-policy field to derive public access from.
- Glacier vault — no such resource exists in the AWS schema.

## Notes
- All predicates read **cached data only** — no new API calls or IAM permissions.
- Pure helpers (`esDomainIsPublic`, Redshift `internetReachable`, and the nil security-group guard added to `openIngressRulesFromSecurityGroups`) have table-driven unit tests in `aws_internet_exposure_test.go`.
- New `.lr.versions` entries land at `13.37.1` (next patch after the provider's `13.37.0`).
- `go build ./...` passes; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)