### PR TITLE
⭐ openstack: discover security groups as openstack-security-group assets

### DIFF
--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -32,9 +32,13 @@ Authentication options (in priority order):
 Application credentials are also supported via --application-credential-id
 and --application-credential-secret.
 `,
-			MinArgs:   0,
-			MaxArgs:   0,
-			Discovery: []string{},
+			MinArgs: 0,
+			MaxArgs: 0,
+			Discovery: []string{
+				connection.DiscoveryAuto,
+				connection.DiscoveryAll,
+				connection.DiscoverySecurityGroups,
+			},
 			Flags: []plugin.Flag{
 				{Long: connection.OPTION_CLOUD, Type: plugin.FlagType_String, Desc: "clouds.yaml entry to use"},
 				{Long: connection.OPTION_AUTH_URL, Type: plugin.FlagType_String, Desc: "Keystone auth URL (env: OS_AUTH_URL)"},

--- a/providers/openstack/connection/platform.go
+++ b/providers/openstack/connection/platform.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// Discovery targets understood by the openstack connector.
+const (
+	// DiscoveryAuto is the default; it keeps the connection as a single root
+	// (project/domain/system) asset and does not expand into child assets.
+	DiscoveryAuto = "auto"
+	// DiscoveryAll expands every supported child-asset type.
+	DiscoveryAll = "all"
+	// DiscoverySecurityGroups expands the scope into one asset per security group.
+	DiscoverySecurityGroups = "security-groups"
+)
+
+// OptionSecurityGroup carries the id of the security group a child connection is
+// scoped to. Present only on discovered openstack-security-group assets.
+const OptionSecurityGroup = "security-group"
+
+// scopeIdentifier returns the platform id of the connection's root scope
+// (project, domain, or system) — the same id detect() assigns to the root
+// asset. Child platform ids are anchored under it so they stay stable and
+// unique across scans.
+func (c *OpenstackConnection) scopeIdentifier() string {
+	switch {
+	case c.ProjectID() != "":
+		return PlatformIdOpenstackProject + c.ProjectID()
+	case c.DomainID() != "":
+		return PlatformIdOpenstackDomain + c.DomainID()
+	default:
+		sum := sha256.Sum256([]byte(c.AuthURL()))
+		return PlatformIdOpenstackSystem + hex.EncodeToString(sum[:])
+	}
+}
+
+// SecurityGroupPlatform describes a single discovered OpenStack security group,
+// mirroring the naming of other providers' object platforms (aws-security-group,
+// digitalocean-firewall).
+func SecurityGroupPlatform() *inventory.Platform {
+	return &inventory.Platform{
+		Name:    "openstack-security-group",
+		Title:   "OpenStack Security Group",
+		Family:  []string{"openstack"},
+		Kind:    "api",
+		Runtime: "openstack",
+	}
+}
+
+// NewSecurityGroupIdentifier builds the platform id for a single security group,
+// anchored under the connection's root scope.
+func (c *OpenstackConnection) NewSecurityGroupIdentifier(sgID string) string {
+	return c.scopeIdentifier() + "/security-group/" + sgID
+}
+
+// SecurityGroupID returns the id of the security group this connection is scoped
+// to, or an empty string when the connection is a root scope.
+func (c *OpenstackConnection) SecurityGroupID() string {
+	return c.Conf.Options[OptionSecurityGroup]
+}
+
+// SubAssetPlatform reports the platform, platform id, and name when the
+// connection is scoped to a single discovered child asset (currently a security
+// group). It returns nils for a root (project/domain/system) scope.
+func (c *OpenstackConnection) SubAssetPlatform() (*inventory.Platform, string, string) {
+	if sgID := c.SecurityGroupID(); sgID != "" {
+		return SecurityGroupPlatform(), c.NewSecurityGroupIdentifier(sgID), "OpenStack Security Group " + sgID
+	}
+	return nil, "", ""
+}

--- a/providers/openstack/provider/provider.go
+++ b/providers/openstack/provider/provider.go
@@ -70,6 +70,16 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options[connection.OPTION_INSECURE] = "true"
 	}
 
+	// Discovery expands the connected scope into specific child assets.
+	discoverTargets := []string{connection.DiscoveryAuto}
+	if x, ok := flags["discover"]; ok && len(x.Array) != 0 {
+		discoverTargets = discoverTargets[:0]
+		for i := range x.Array {
+			discoverTargets = append(discoverTargets, string(x.Array[i].Value))
+		}
+	}
+	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
+
 	asset := &inventory.Asset{
 		Connections: []*inventory.Config{conf},
 	}
@@ -94,12 +104,29 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
+	inv, err := s.discover(conn)
+	if err != nil {
+		return nil, err
+	}
+
 	return &plugin.ConnectRes{
 		Id:        conn.ID(),
 		Name:      conn.Name(),
 		Asset:     req.Asset,
-		Inventory: nil,
+		Inventory: inv,
 	}, nil
+}
+
+func (s *Service) discover(conn *connection.OpenstackConnection) (*inventory.Inventory, error) {
+	conf := conn.Asset().Connections[0]
+	if conf.Discover == nil {
+		return nil, nil
+	}
+	runtime, err := s.GetRuntime(conn.ID())
+	if err != nil {
+		return nil, err
+	}
+	return resources.Discover(runtime)
 }
 
 func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*connection.OpenstackConnection, error) {
@@ -142,6 +169,18 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.OpenstackConnection) error {
+	// A discovered child asset (e.g. a single security group) carries its scope
+	// in the connection options; report its platform instead of the root scope.
+	if platform, platformID, name := conn.SubAssetPlatform(); platform != nil {
+		asset.Platform = platform
+		asset.Id = platformID
+		asset.PlatformIds = []string{platformID}
+		if asset.Name == "" {
+			asset.Name = name
+		}
+		return nil
+	}
+
 	asset.Platform = &inventory.Platform{
 		Family:  []string{"openstack"},
 		Kind:    "api",

--- a/providers/openstack/resources/discovery.go
+++ b/providers/openstack/resources/discovery.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"maps"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/openstack/connection"
+	"go.mondoo.com/mql/v13/utils/stringx"
+)
+
+// Discover expands the connected OpenStack scope into the child assets the
+// discovery targets ask for. The scope (project/domain/system) stays the
+// connected root asset; the returned inventory holds the children.
+func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
+	c := conn(runtime)
+	conf := c.Asset().Connections[0]
+	if conf.Discover == nil || len(conf.Discover.Targets) == 0 {
+		return nil, nil
+	}
+	targets := resolveDiscoveryTargets(conf.Discover.Targets)
+
+	assets := []*inventory.Asset{}
+
+	// childAsset clones the parent connection (discovery off, parented to this
+	// connection) and stamps the per-child scoping options onto it.
+	childAsset := func(platform *inventory.Platform, platformID, name string, opts map[string]string) *inventory.Asset {
+		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(c.ID()))
+		maps.Copy(cfg.Options, opts)
+		return &inventory.Asset{
+			PlatformIds: []string{platformID},
+			Name:        name,
+			Platform:    platform,
+			Connections: []*inventory.Config{cfg},
+		}
+	}
+
+	if stringx.Contains(targets, connection.DiscoverySecurityGroups) {
+		client, err := c.NetworkClient()
+		if err != nil {
+			return nil, err
+		}
+		pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
+		if err != nil {
+			// A scope without the network service (or without access) simply
+			// yields no security-group children rather than failing the scan.
+			if translateOpenstackError(err) == nil {
+				return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
+			}
+			return nil, err
+		}
+		items, err := groups.ExtractGroups(pages)
+		if err != nil {
+			return nil, err
+		}
+		for i := range items {
+			sg := &items[i]
+			name := sg.Name
+			if name == "" {
+				name = sg.ID
+			}
+			assets = append(assets, childAsset(
+				connection.SecurityGroupPlatform(),
+				c.NewSecurityGroupIdentifier(sg.ID),
+				"OpenStack Security Group "+name,
+				map[string]string{connection.OptionSecurityGroup: sg.ID},
+			))
+		}
+	}
+
+	return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
+}
+
+// resolveDiscoveryTargets normalizes the requested targets. "all" expands to
+// every supported child type; "auto" (the default) matches nothing here, so a
+// plain connection stays a single root asset.
+func resolveDiscoveryTargets(targets []string) []string {
+	if stringx.Contains(targets, connection.DiscoveryAll) {
+		return []string{connection.DiscoverySecurityGroups}
+	}
+	return targets
+}

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -814,7 +814,17 @@ func (r *mqlOpenstackSecurityGroup) id() (string, error) {
 func initOpenstackSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := stringArg(args, "id")
 	if !ok || id == "" {
-		return args, nil, nil
+		// On a discovered openstack-security-group asset the connection is
+		// scoped to a single group; resolve it when the caller passes no id, so
+		// a bare `openstack.securityGroup` query works on that platform. A root
+		// (project/domain/system) scope has no scoped group, so fall back to the
+		// bare empty resource as before.
+		sgID := conn(runtime).SecurityGroupID()
+		if sgID == "" {
+			return args, nil, nil
+		}
+		id = sgID
+		args["id"] = llx.StringData(id)
 	}
 	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -874,12 +874,58 @@ func initOpenstackSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.Ra
 	return args, mqlSG, nil
 }
 
+// newMqlOpenstackSecurityGroup maps a Neutron security group to its MQL
+// resource, including embedded rules and the cached project id used by the
+// project() accessor.
+func newMqlOpenstackSecurityGroup(runtime *plugin.Runtime, sg *groups.SecGroup) (*mqlOpenstackSecurityGroup, error) {
+	ruleResources, err := buildSecurityGroupRules(runtime, sg)
+	if err != nil {
+		return nil, err
+	}
+	res, err := CreateResource(runtime, "openstack.securityGroup", map[string]*llx.RawData{
+		"__id":        llx.StringData("openstack.securityGroup/" + sg.ID),
+		"id":          llx.StringData(sg.ID),
+		"name":        llx.StringData(sg.Name),
+		"description": llx.StringData(sg.Description),
+		"stateful":    llx.BoolData(sg.Stateful),
+		"tags":        stringSliceData(sg.Tags),
+		"createdAt":   llx.TimeDataPtr(timePtr(sg.CreatedAt)),
+		"updatedAt":   llx.TimeDataPtr(timePtr(sg.UpdatedAt)),
+		"rules":       llx.ArrayData(ruleResources, types.Resource("openstack.securityGroup.rule")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlSG := res.(*mqlOpenstackSecurityGroup)
+	mqlSG.cacheProjectID = sg.ProjectID
+	return mqlSG, nil
+}
+
 func (o *mqlOpenstack) securityGroups() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.NetworkClient()
 	if err != nil {
 		return nil, err
 	}
+
+	// On a discovered openstack-security-group asset the connection is scoped to
+	// a single group; return just that one (fetched directly) so per-asset checks
+	// operate on it without listing the whole project.
+	if sgID := c.SecurityGroupID(); sgID != "" {
+		sg, err := groups.Get(ctx(), client, sgID).Extract()
+		if err != nil {
+			if translateGetError(err) == nil {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		mqlSG, err := newMqlOpenstackSecurityGroup(o.MqlRuntime, sg)
+		if err != nil {
+			return nil, err
+		}
+		return []any{mqlSG}, nil
+	}
+
 	pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
 	if err != nil {
 		if translateOpenstackError(err) == nil {
@@ -909,27 +955,10 @@ func (o *mqlOpenstack) securityGroups() ([]any, error) {
 
 	out := make([]any, 0, len(items))
 	for i := range items {
-		sg := &items[i]
-		ruleResources, err := buildSecurityGroupRules(o.MqlRuntime, sg)
+		mqlSG, err := newMqlOpenstackSecurityGroup(o.MqlRuntime, &items[i])
 		if err != nil {
 			return nil, err
 		}
-		res, err := CreateResource(o.MqlRuntime, "openstack.securityGroup", map[string]*llx.RawData{
-			"__id":        llx.StringData("openstack.securityGroup/" + sg.ID),
-			"id":          llx.StringData(sg.ID),
-			"name":        llx.StringData(sg.Name),
-			"description": llx.StringData(sg.Description),
-			"stateful":    llx.BoolData(sg.Stateful),
-			"tags":        stringSliceData(sg.Tags),
-			"createdAt":   llx.TimeDataPtr(timePtr(sg.CreatedAt)),
-			"updatedAt":   llx.TimeDataPtr(timePtr(sg.UpdatedAt)),
-			"rules":       llx.ArrayData(ruleResources, types.Resource("openstack.securityGroup.rule")),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mqlSG := res.(*mqlOpenstackSecurityGroup)
-		mqlSG.cacheProjectID = sg.ProjectID
 		out = append(out, mqlSG)
 	}
 	return out, nil


### PR DESCRIPTION
## Summary

Adds a discoverable **`openstack-security-group`** platform so each security group can be scanned as its own asset, mirroring the DigitalOcean discovery pattern and the `aws-security-group` naming. This is the highest-check resource in `mondoo-openstack-security` (4 of 20 checks), so per-asset scoring is worthwhile.

### What's new
- **Discovery targets**: `security-groups` (plus `auto`/`all`), advertised in `config.go` and exposed via `--discover`.
- **Platform**: `openstack-security-group` / "OpenStack Security Group" (family `openstack`, kind `api`), matching `aws-security-group` and `digitalocean-firewall`.
- **Platform IDs**: anchored under the connected scope — `…/openstack/project/<projId>/security-group/<sgId>` (and `/domain/…`, `/system/…`).
- **Per-asset scoping**: when a connection carries a `security-group` id, `openstack.securityGroups()` returns just that one group (direct Neutron `Get`), so per-asset checks run against it without re-listing the whole project.

### Behavior
- A plain scan (`auto`) stays a **single root asset** — discovery is opt-in via `--discover all` or `--discover security-groups`. (Intentional divergence from DigitalOcean, whose `auto` expands children.)
- `--discover security-groups` emits one child asset per security group; each re-scopes to its group and produces a stable, scope-anchored platform id.

### Files
- `connection/platform.go` (new) — platform, discovery/option consts, scope-anchored id helpers, `SubAssetPlatform`.
- `resources/discovery.go` (new) — `Discover()` lists groups via Neutron and emits child assets.
- `provider/provider.go` — `--discover` parsing, `Connect`→`discover`, `detect()` reports the security-group platform for a scoped connection.
- `resources/network.go` — scoped `securityGroups()` + extracted `newMqlOpenstackSecurityGroup` helper.
- `config/config.go` — discovery targets.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and the provider CLI gen all pass; the generated CLI advertises the `security-groups` discovery target.
- Code-review pass found no issues (platform-id stability, scoping error handling, and nil-safety all verified against the DigitalOcean reference).
- Not exercised against a live OpenStack cloud (no endpoint available) — recommend a `--discover security-groups` smoke test before merge.

## Follow-ups (not in this PR)
- The `mondoo-openstack-security` policy's 4 security-group checks would need `asset.platform == "openstack-security-group"` variants to score per-asset (cnspec content change).
- Same discovery framework extends naturally to `compute.server`, `containerinfra.cluster`, etc.