### PR TITLE
🎉 digitalocean-13.8.0, hetzner-13.4.0, openstack-13.5.0, proxmox-0.2.0, stackit-13.1.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.7.0",
+	Version:         "13.8.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.3.0",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.4.1",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.1.12",
+	Version:         "0.2.0",
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.0.5",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Minor version release for five providers, bundling all changes since each provider's last release.

## digitalocean `13.7.0 → 13.8.0`
- ⭐ Add internet-exposure analysis for databases and load balancers (#8547)
- ⭐ Add droplet network-exposure breakdown (#8540)

## hetzner `13.3.0 → 13.4.0`
- ⭐ Add internet-exposure analysis for load balancers (#8548)
- ⭐ Add server network-exposure breakdown (#8541)

## openstack `13.4.1 → 13.5.0`
- ⭐ Discover security groups as `openstack-security-group` assets (#8552)
- ⭐ Internet-exposure modeling (servers + Octavia load balancers) (#8542)
- ⭐ Security-insights expansion (identity, field gaps, typed refs) (#8537)
- 🧹 Update deps for mql and providers 20260615 (#8443)

## proxmox `0.1.12 → 0.2.0`
- 🧹 Regression test for cluster storage enabled normalization (#8504)
- 🐛 Fix cluster storage `enabled=false` and `vm.updates` agent failure (#8497)
- 🧹 Update deps for mql and providers 20260615 (#8443)

## stackit `13.0.5 → 13.1.0`
- ⭐ Add internet-exposure analysis across resources (#8550)
- ⭐ Add server network-exposure breakdown (#8543)