### PR TITLE
🌟 Add windows.smartScreen resource for Microsoft Defender SmartScreen

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6359,6 +6359,9 @@ windows {
   deviceGuard() windows.deviceGuard
   // System-wide Windows Exploit Protection configuration
   exploitProtection() windows.exploitProtection
+
+  // Microsoft Defender SmartScreen policy
+  smartScreen() windows.smartScreen
 }
 
 // Windows Exploit Protection

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6453,6 +6453,34 @@ private windows.exploitProtection.heap @defaults("terminateOnError") {
   terminateOnError string
 }
 
+// Microsoft Defender SmartScreen
+//
+// Examine the Microsoft Defender SmartScreen policy configuration across its
+// three surfaces: Windows / File Explorer (which checks apps and files), the
+// Microsoft Edge browser, and Microsoft Store apps. SmartScreen is configured
+// through Group Policy registry values rather than a dedicated cmdlet; a value
+// that has not been configured resolves to its disabled default (false, or an
+// empty string for `explorerLevel`).
+windows.smartScreen @defaults("explorerEnabled explorerLevel edgeEnabled") {
+  // Whether SmartScreen is enabled for Windows / File Explorer
+  explorerEnabled() bool
+  // Enforcement level for Windows / File Explorer SmartScreen
+  //
+  // "Block" prevents the user from bypassing warnings; "Warn" lets the user
+  // continue; an empty string means no level is configured.
+  explorerLevel() string
+  // Whether SmartScreen is enabled for Microsoft Edge
+  edgeEnabled() bool
+  // Whether Edge SmartScreen blocks potentially unwanted applications (PUA)
+  edgePuaEnabled() bool
+  // Whether users are prevented from bypassing Edge SmartScreen warnings about sites
+  edgePreventOverride() bool
+  // Whether users are prevented from bypassing Edge SmartScreen warnings about downloads
+  edgePreventOverrideForFiles() bool
+  // Whether SmartScreen web-content evaluation is enabled for Microsoft Store apps
+  storeAppsEnabled() bool
+}
+
 // Windows Task Scheduler task
 //
 // Examine a registered task from the Windows Task Scheduler: its identity

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -323,6 +323,7 @@ const (
 	ResourceWindowsExploitProtectionCfg                   string = "windows.exploitProtection.cfg"
 	ResourceWindowsExploitProtectionSehop                 string = "windows.exploitProtection.sehop"
 	ResourceWindowsExploitProtectionHeap                  string = "windows.exploitProtection.heap"
+	ResourceWindowsSmartScreen                            string = "windows.smartScreen"
 	ResourceWindowsScheduledTask                          string = "windows.scheduledTask"
 	ResourceWindowsScheduledTaskPrincipal                 string = "windows.scheduledTask.principal"
 	ResourceWindowsScheduledTaskAction                    string = "windows.scheduledTask.action"
@@ -1716,6 +1717,10 @@ func init() {
 		"windows.exploitProtection.heap": {
 			// to override args, implement: initWindowsExploitProtectionHeap(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsExploitProtectionHeap,
+		},
+		"windows.smartScreen": {
+			// to override args, implement: initWindowsSmartScreen(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsSmartScreen,
 		},
 		"windows.scheduledTask": {
 			// to override args, implement: initWindowsScheduledTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -7935,6 +7940,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.exploitProtection.heap.terminateOnError": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsExploitProtectionHeap).GetTerminateOnError()).ToDataRes(types.String)
+	},
+	"windows.smartScreen.explorerEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetExplorerEnabled()).ToDataRes(types.Bool)
+	},
+	"windows.smartScreen.explorerLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetExplorerLevel()).ToDataRes(types.String)
+	},
+	"windows.smartScreen.edgeEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetEdgeEnabled()).ToDataRes(types.Bool)
+	},
+	"windows.smartScreen.edgePuaEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetEdgePuaEnabled()).ToDataRes(types.Bool)
+	},
+	"windows.smartScreen.edgePreventOverride": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetEdgePreventOverride()).ToDataRes(types.Bool)
+	},
+	"windows.smartScreen.edgePreventOverrideForFiles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetEdgePreventOverrideForFiles()).ToDataRes(types.Bool)
+	},
+	"windows.smartScreen.storeAppsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSmartScreen).GetStoreAppsEnabled()).ToDataRes(types.Bool)
 	},
 	"windows.scheduledTask.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsScheduledTask).GetName()).ToDataRes(types.String)
@@ -19776,6 +19802,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.exploitProtection.heap.terminateOnError": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsExploitProtectionHeap).TerminateOnError, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.smartScreen.explorerEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).ExplorerEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.explorerLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).ExplorerLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.edgeEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).EdgeEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.edgePuaEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).EdgePuaEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.edgePreventOverride": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).EdgePreventOverride, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.edgePreventOverrideForFiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).EdgePreventOverrideForFiles, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen.storeAppsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSmartScreen).StoreAppsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.scheduledTask.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52345,6 +52403,94 @@ func (c *mqlWindowsExploitProtectionHeap) MqlID() string {
 
 func (c *mqlWindowsExploitProtectionHeap) GetTerminateOnError() *plugin.TValue[string] {
 	return &c.TerminateOnError
+}
+
+// mqlWindowsSmartScreen for the windows.smartScreen resource
+type mqlWindowsSmartScreen struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlWindowsSmartScreenInternal
+	ExplorerEnabled             plugin.TValue[bool]
+	ExplorerLevel               plugin.TValue[string]
+	EdgeEnabled                 plugin.TValue[bool]
+	EdgePuaEnabled              plugin.TValue[bool]
+	EdgePreventOverride         plugin.TValue[bool]
+	EdgePreventOverrideForFiles plugin.TValue[bool]
+	StoreAppsEnabled            plugin.TValue[bool]
+}
+
+// createWindowsSmartScreen creates a new instance of this resource
+func createWindowsSmartScreen(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsSmartScreen{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.smartScreen", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsSmartScreen) MqlName() string {
+	return "windows.smartScreen"
+}
+
+func (c *mqlWindowsSmartScreen) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsSmartScreen) GetExplorerEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ExplorerEnabled, func() (bool, error) {
+		return c.explorerEnabled()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetExplorerLevel() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ExplorerLevel, func() (string, error) {
+		return c.explorerLevel()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetEdgeEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EdgeEnabled, func() (bool, error) {
+		return c.edgeEnabled()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetEdgePuaEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EdgePuaEnabled, func() (bool, error) {
+		return c.edgePuaEnabled()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetEdgePreventOverride() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EdgePreventOverride, func() (bool, error) {
+		return c.edgePreventOverride()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetEdgePreventOverrideForFiles() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EdgePreventOverrideForFiles, func() (bool, error) {
+		return c.edgePreventOverrideForFiles()
+	})
+}
+
+func (c *mqlWindowsSmartScreen) GetStoreAppsEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.StoreAppsEnabled, func() (bool, error) {
+		return c.storeAppsEnabled()
+	})
 }
 
 // mqlWindowsScheduledTask for the windows.scheduledTask resource

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -7884,6 +7884,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.exploitProtection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindows).GetExploitProtection()).ToDataRes(types.Resource("windows.exploitProtection"))
 	},
+	"windows.smartScreen": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindows).GetSmartScreen()).ToDataRes(types.Resource("windows.smartScreen"))
+	},
 	"windows.exploitProtection.available": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsExploitProtection).GetAvailable()).ToDataRes(types.Bool)
 	},
@@ -19702,6 +19705,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.exploitProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindows).ExploitProtection, ok = plugin.RawToTValue[*mqlWindowsExploitProtection](v.Value, v.Error)
+		return
+	},
+	"windows.smartScreen": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindows).SmartScreen, ok = plugin.RawToTValue[*mqlWindowsSmartScreen](v.Value, v.Error)
 		return
 	},
 	"windows.exploitProtection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51876,6 +51883,7 @@ type mqlWindows struct {
 	ScheduledTasks    plugin.TValue[[]any]
 	DeviceGuard       plugin.TValue[*mqlWindowsDeviceGuard]
 	ExploitProtection plugin.TValue[*mqlWindowsExploitProtection]
+	SmartScreen       plugin.TValue[*mqlWindowsSmartScreen]
 }
 
 // createWindows creates a new instance of this resource
@@ -52009,6 +52017,22 @@ func (c *mqlWindows) GetExploitProtection() *plugin.TValue[*mqlWindowsExploitPro
 		}
 
 		return c.exploitProtection()
+	})
+}
+
+func (c *mqlWindows) GetSmartScreen() *plugin.TValue[*mqlWindowsSmartScreen] {
+	return plugin.GetOrCompute[*mqlWindowsSmartScreen](&c.SmartScreen, func() (*mqlWindowsSmartScreen, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows", c.__id, "smartScreen")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlWindowsSmartScreen), nil
+			}
+		}
+
+		return c.smartScreen()
 	})
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -52454,7 +52454,12 @@ func createWindowsSmartScreen(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("windows.smartScreen", res.__id)

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -3144,6 +3144,14 @@ windows.serverFeature.installed 11.2.6
 windows.serverFeature.name 11.2.6
 windows.serverFeature.path 11.2.6
 windows.serverFeatures 11.2.6
+windows.smartScreen 13.29.1
+windows.smartScreen.edgeEnabled 13.29.1
+windows.smartScreen.edgePreventOverride 13.29.1
+windows.smartScreen.edgePreventOverrideForFiles 13.29.1
+windows.smartScreen.edgePuaEnabled 13.29.1
+windows.smartScreen.explorerEnabled 13.29.1
+windows.smartScreen.explorerLevel 13.29.1
+windows.smartScreen.storeAppsEnabled 13.29.1
 windows.smb 13.28.2
 windows.smb.clientConfiguration 13.29.1
 windows.smb.clientConfiguration.allowInsecureGuestAuth 13.29.1

--- a/providers/os/resources/windows/smartscreen.go
+++ b/providers/os/resources/windows/smartscreen.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"io"
+
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+)
+
+// Microsoft Defender SmartScreen is configured entirely through policy registry
+// values; there is no dedicated cmdlet. We read the well-known policy values for
+// the three SmartScreen surfaces (Windows/File Explorer, Microsoft Edge, and
+// Microsoft Store apps) in a single PowerShell call and emit a normalized JSON
+// object. Missing values serialize as null, which we treat as "not configured".
+//
+// References:
+// https://learn.microsoft.com/en-us/windows/security/operating-system-security/virus-and-threat-protection/microsoft-defender-smartscreen/
+
+const smartScreenScript = `
+function Get-RegVal($path, $name) {
+  try { return (Get-ItemProperty -Path $path -Name $name -ErrorAction Stop).$name } catch { return $null }
+}
+$o = [pscustomobject]@{
+  EnableSmartScreen                   = Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System' 'EnableSmartScreen'
+  ShellSmartScreenLevel               = [string](Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System' 'ShellSmartScreenLevel')
+  EdgeSmartScreenEnabled              = Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' 'SmartScreenEnabled'
+  EdgeSmartScreenPuaEnabled           = Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' 'SmartScreenPuaEnabled'
+  EdgePreventOverride                 = Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' 'PreventSmartScreenPromptOverride'
+  EdgePreventOverrideForFiles         = Get-RegVal 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' 'PreventSmartScreenPromptOverrideForFiles'
+  StoreAppsEnableWebContentEvaluation = Get-RegVal 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppHost' 'EnableWebContentEvaluation'
+}
+$o | ConvertTo-Json -Compress
+`
+
+// SmartScreenSettings holds the raw policy values that drive SmartScreen. The
+// numeric toggles use pointers so a missing (null) value is distinguishable
+// from an explicit 0.
+type SmartScreenSettings struct {
+	EnableSmartScreen                   *int64
+	ShellSmartScreenLevel               string
+	EdgeSmartScreenEnabled              *int64
+	EdgeSmartScreenPuaEnabled           *int64
+	EdgePreventOverride                 *int64
+	EdgePreventOverrideForFiles         *int64
+	StoreAppsEnableWebContentEvaluation *int64
+}
+
+// Enabled reports whether a pointer-backed DWORD toggle is present and set to 1.
+func enabledFlag(v *int64) bool { return v != nil && *v == 1 }
+
+// ExplorerEnabled reports whether SmartScreen is enabled for Windows/File Explorer.
+func (s *SmartScreenSettings) ExplorerEnabled() bool { return enabledFlag(s.EnableSmartScreen) }
+
+// EdgeEnabled reports whether SmartScreen is enabled for Microsoft Edge.
+func (s *SmartScreenSettings) EdgeEnabled() bool { return enabledFlag(s.EdgeSmartScreenEnabled) }
+
+// EdgePuaEnabled reports whether Edge SmartScreen blocks potentially unwanted apps.
+func (s *SmartScreenSettings) EdgePuaEnabled() bool { return enabledFlag(s.EdgeSmartScreenPuaEnabled) }
+
+// EdgePreventOverrideEnabled reports whether users are prevented from bypassing
+// Edge SmartScreen warnings about sites.
+func (s *SmartScreenSettings) EdgePreventOverrideEnabled() bool {
+	return enabledFlag(s.EdgePreventOverride)
+}
+
+// EdgePreventOverrideForFilesEnabled reports whether users are prevented from
+// bypassing Edge SmartScreen warnings about downloads.
+func (s *SmartScreenSettings) EdgePreventOverrideForFilesEnabled() bool {
+	return enabledFlag(s.EdgePreventOverrideForFiles)
+}
+
+// StoreAppsEnabled reports whether SmartScreen web-content evaluation is enabled
+// for Microsoft Store apps.
+func (s *SmartScreenSettings) StoreAppsEnabled() bool {
+	return enabledFlag(s.StoreAppsEnableWebContentEvaluation)
+}
+
+// GetSmartScreenSettings reads the SmartScreen policy values from the target.
+func GetSmartScreenSettings(p shared.Connection) (*SmartScreenSettings, error) {
+	c, err := p.RunCommand(powershell.Encode(smartScreenScript))
+	if err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(c.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSmartScreenSettings(data)
+}
+
+func ParseSmartScreenSettings(data []byte) (*SmartScreenSettings, error) {
+	var s SmartScreenSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/providers/os/resources/windows/smartscreen.go
+++ b/providers/os/resources/windows/smartscreen.go
@@ -49,7 +49,7 @@ type SmartScreenSettings struct {
 	StoreAppsEnableWebContentEvaluation *int64
 }
 
-// Enabled reports whether a pointer-backed DWORD toggle is present and set to 1.
+// enabledFlag reports whether a pointer-backed DWORD toggle is present and set to 1.
 func enabledFlag(v *int64) bool { return v != nil && *v == 1 }
 
 // ExplorerEnabled reports whether SmartScreen is enabled for Windows/File Explorer.

--- a/providers/os/resources/windows/smartscreen_test.go
+++ b/providers/os/resources/windows/smartscreen_test.go
@@ -54,3 +54,32 @@ func TestParseSmartScreenSettings_ExplicitZero(t *testing.T) {
 	assert.Equal(t, int64(0), *s.EnableSmartScreen)
 	assert.Equal(t, "Warn", s.ShellSmartScreenLevel)
 }
+
+// A surface may be configured while others are not (e.g. Explorer on, Edge off).
+func TestParseSmartScreenSettings_Mixed(t *testing.T) {
+	s, err := ParseSmartScreenSettings([]byte(`{"EnableSmartScreen":1,"ShellSmartScreenLevel":"Block","EdgeSmartScreenEnabled":0}`))
+	require.NoError(t, err)
+	assert.True(t, s.ExplorerEnabled())
+	assert.Equal(t, "Block", s.ShellSmartScreenLevel)
+	assert.False(t, s.EdgeEnabled())
+	// untouched surfaces are unconfigured, not enabled
+	assert.Nil(t, s.StoreAppsEnableWebContentEvaluation)
+	assert.False(t, s.StoreAppsEnabled())
+}
+
+func TestParseSmartScreenSettings_Malformed(t *testing.T) {
+	_, err := ParseSmartScreenSettings([]byte("not json"))
+	require.Error(t, err)
+}
+
+// enabledFlag only treats an explicit 1 as enabled; any other value (including
+// an unexpected non-1 DWORD) is "not enabled".
+func TestSmartScreenEnabledFlag(t *testing.T) {
+	one := int64(1)
+	two := int64(2)
+	zero := int64(0)
+	assert.True(t, enabledFlag(&one))
+	assert.False(t, enabledFlag(&two))
+	assert.False(t, enabledFlag(&zero))
+	assert.False(t, enabledFlag(nil))
+}

--- a/providers/os/resources/windows/smartscreen_test.go
+++ b/providers/os/resources/windows/smartscreen_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSmartScreenSettings_Configured(t *testing.T) {
+	data, err := os.ReadFile("testdata/smartscreen_configured.json")
+	require.NoError(t, err)
+
+	s, err := ParseSmartScreenSettings(data)
+	require.NoError(t, err)
+
+	assert.True(t, s.ExplorerEnabled())
+	assert.Equal(t, "Block", s.ShellSmartScreenLevel)
+	assert.True(t, s.EdgeEnabled())
+	assert.True(t, s.EdgePuaEnabled())
+	assert.True(t, s.EdgePreventOverrideEnabled())
+	assert.True(t, s.EdgePreventOverrideForFilesEnabled())
+	assert.True(t, s.StoreAppsEnabled())
+}
+
+func TestParseSmartScreenSettings_NotConfigured(t *testing.T) {
+	data, err := os.ReadFile("testdata/smartscreen_notconfigured.json")
+	require.NoError(t, err)
+
+	s, err := ParseSmartScreenSettings(data)
+	require.NoError(t, err)
+
+	// A missing (null) value resolves to its disabled default, never an error.
+	assert.False(t, s.ExplorerEnabled())
+	assert.Equal(t, "", s.ShellSmartScreenLevel)
+	assert.False(t, s.EdgeEnabled())
+	assert.False(t, s.EdgePuaEnabled())
+	assert.False(t, s.EdgePreventOverrideEnabled())
+	assert.False(t, s.EdgePreventOverrideForFilesEnabled())
+	assert.False(t, s.StoreAppsEnabled())
+}
+
+// A DWORD explicitly set to 0 is distinct from an unconfigured value but both
+// resolve to "not enabled".
+func TestParseSmartScreenSettings_ExplicitZero(t *testing.T) {
+	s, err := ParseSmartScreenSettings([]byte(`{"EnableSmartScreen":0,"ShellSmartScreenLevel":"Warn"}`))
+	require.NoError(t, err)
+	assert.False(t, s.ExplorerEnabled())
+	require.NotNil(t, s.EnableSmartScreen)
+	assert.Equal(t, int64(0), *s.EnableSmartScreen)
+	assert.Equal(t, "Warn", s.ShellSmartScreenLevel)
+}

--- a/providers/os/resources/windows/testdata/smartscreen_configured.json
+++ b/providers/os/resources/windows/testdata/smartscreen_configured.json
@@ -1,0 +1,1 @@
+{"EnableSmartScreen":1,"ShellSmartScreenLevel":"Block","EdgeSmartScreenEnabled":1,"EdgeSmartScreenPuaEnabled":1,"EdgePreventOverride":1,"EdgePreventOverrideForFiles":1,"StoreAppsEnableWebContentEvaluation":1}

--- a/providers/os/resources/windows/testdata/smartscreen_notconfigured.json
+++ b/providers/os/resources/windows/testdata/smartscreen_notconfigured.json
@@ -1,0 +1,1 @@
+{"EnableSmartScreen":null,"ShellSmartScreenLevel":"","EdgeSmartScreenEnabled":null,"EdgeSmartScreenPuaEnabled":null,"EdgePreventOverride":null,"EdgePreventOverrideForFiles":null,"StoreAppsEnableWebContentEvaluation":null}

--- a/providers/os/resources/windows_smartscreen.go
+++ b/providers/os/resources/windows_smartscreen.go
@@ -11,11 +11,17 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/windows"
 )
 
+func (r *mqlWindowsSmartScreen) id() (string, error) {
+	return "windows.smartScreen", nil
+}
+
 // smartScreen exposes the Microsoft Defender SmartScreen policy from the parent
 // windows resource. Every field is a computed method backed by a single lazy
 // policy read, so the resource is created without up-front arguments.
 func (w *mqlWindows) smartScreen() (*mqlWindowsSmartScreen, error) {
-	o, err := CreateResource(w.MqlRuntime, "windows.smartScreen", map[string]*llx.RawData{})
+	o, err := CreateResource(w.MqlRuntime, "windows.smartScreen", map[string]*llx.RawData{
+		"__id": llx.StringData("windows.smartScreen"),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/windows_smartscreen.go
+++ b/providers/os/resources/windows_smartscreen.go
@@ -6,9 +6,21 @@ package resources
 import (
 	"sync"
 
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/resources/windows"
 )
+
+// smartScreen exposes the Microsoft Defender SmartScreen policy from the parent
+// windows resource. Every field is a computed method backed by a single lazy
+// policy read, so the resource is created without up-front arguments.
+func (w *mqlWindows) smartScreen() (*mqlWindowsSmartScreen, error) {
+	o, err := CreateResource(w.MqlRuntime, "windows.smartScreen", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return o.(*mqlWindowsSmartScreen), nil
+}
 
 // mqlWindowsSmartScreenInternal caches the policy read so every accessor shares
 // a single PowerShell invocation.

--- a/providers/os/resources/windows_smartscreen.go
+++ b/providers/os/resources/windows_smartscreen.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/windows"
+)
+
+// mqlWindowsSmartScreenInternal caches the policy read so every accessor shares
+// a single PowerShell invocation.
+type mqlWindowsSmartScreenInternal struct {
+	lock     sync.Mutex
+	fetched  bool
+	settings *windows.SmartScreenSettings
+	err      error
+}
+
+func (s *mqlWindowsSmartScreen) get() (*windows.SmartScreenSettings, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.fetched {
+		return s.settings, s.err
+	}
+	conn := s.MqlRuntime.Connection.(shared.Connection)
+	s.settings, s.err = windows.GetSmartScreenSettings(conn)
+	s.fetched = true
+	return s.settings, s.err
+}
+
+func (s *mqlWindowsSmartScreen) explorerEnabled() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.ExplorerEnabled(), nil
+}
+
+func (s *mqlWindowsSmartScreen) explorerLevel() (string, error) {
+	v, err := s.get()
+	if err != nil {
+		return "", err
+	}
+	return v.ShellSmartScreenLevel, nil
+}
+
+func (s *mqlWindowsSmartScreen) edgeEnabled() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.EdgeEnabled(), nil
+}
+
+func (s *mqlWindowsSmartScreen) edgePuaEnabled() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.EdgePuaEnabled(), nil
+}
+
+func (s *mqlWindowsSmartScreen) edgePreventOverride() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.EdgePreventOverrideEnabled(), nil
+}
+
+func (s *mqlWindowsSmartScreen) edgePreventOverrideForFiles() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.EdgePreventOverrideForFilesEnabled(), nil
+}
+
+func (s *mqlWindowsSmartScreen) storeAppsEnabled() (bool, error) {
+	v, err := s.get()
+	if err != nil {
+		return false, err
+	}
+	return v.StoreAppsEnabled(), nil
+}


### PR DESCRIPTION
## Summary

Adds a **`windows.smartScreen`** resource exposing the Microsoft Defender SmartScreen policy configuration across its three surfaces. SmartScreen is a separate feature from Defender Antivirus (it has no `Get-Mp*` cmdlet), so it gets its own resource backed by the well-known Group Policy registry values.

### Fields
| Field | Surface | Backing policy value |
|---|---|---|
| `explorerEnabled` | Windows / File Explorer | `…\Windows\System:EnableSmartScreen` |
| `explorerLevel` | Windows / File Explorer | `…\Windows\System:ShellSmartScreenLevel` (`Block`/`Warn`) |
| `edgeEnabled` | Microsoft Edge | `…\Edge:SmartScreenEnabled` |
| `edgePuaEnabled` | Microsoft Edge | `…\Edge:SmartScreenPuaEnabled` |
| `edgePreventOverride` | Microsoft Edge | `…\Edge:PreventSmartScreenPromptOverride` |
| `edgePreventOverrideForFiles` | Microsoft Edge | `…\Edge:PreventSmartScreenPromptOverrideForFiles` |
| `storeAppsEnabled` | Microsoft Store apps | `…\AppHost:EnableWebContentEvaluation` |

### Notes
- All values are read in a **single PowerShell call** and emitted as normalized JSON. Values are numeric DWORDs / strings — **locale-invariant**, so the resource works on non-English Windows.
- An **unconfigured** value resolves to its disabled default (`false`, or `""` for `explorerLevel`) rather than erroring. DWORD toggles are pointer-backed so an unconfigured value is distinguishable from an explicit `0`.

### Why
Enables the enterprise Windows policies (windows-10/11, windows-server-2016/2019/2022) to express the SmartScreen CIS controls through a typed resource instead of raw `registrykey.property(...)` reads.

### Tests
`ParseSmartScreenSettings` is covered for configured, not-configured (null), and explicit-zero inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)