### PR TITLE
Add windows.deviceGuard resource for VBS, HVCI, and Credential Guard policy

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6354,6 +6354,9 @@ windows {
 
   // Registered Windows Task Scheduler tasks
   scheduledTasks() []windows.scheduledTask
+
+  // Device Guard policy (Virtualization-Based Security, HVCI, and Credential Guard)
+  deviceGuard() windows.deviceGuard
 }
 
 // Windows Task Scheduler task
@@ -6976,6 +6979,50 @@ private windows.winrm.service @defaults("allowBasic allowUnencryptedTraffic") {
   // Defaults to true (remote shell access is allowed when the policy is not
   // configured).
   allowRemoteShellAccess bool
+}
+
+// Windows Device Guard policy (Virtualization-Based Security, HVCI, and Credential Guard)
+//
+// Examine the Device Guard Group Policy values under HKLM\SOFTWARE\Policies
+// \Microsoft\Windows\DeviceGuard. These configure Virtualization-Based
+// Security (VBS), Hypervisor-Enforced Code Integrity (HVCI / Memory
+// Integrity), Credential Guard, System Guard Secure Launch, and kernel-mode
+// hardware-enforced stack protection. Every field is an int that reads null
+// when the underlying value is absent, so "not configured" is distinguishable
+// from an explicit 0. Read from the Windows registry, so it is available even
+// on connections that cannot run commands.
+private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hypervisorEnforcedCodeIntegrity credentialGuardConfig") {
+  // Whether Virtualization-Based Security is enabled (EnableVirtualizationBasedSecurity)
+  //
+  // 1=enabled, 0=disabled. Null when the value is not configured.
+  virtualizationBasedSecurityEnabled int
+  // Required platform security features for VBS (RequirePlatformSecurityFeatures)
+  //
+  // 1=Secure Boot, 3=Secure Boot and DMA Protection. Null when not configured.
+  requirePlatformSecurityFeatures int
+  // Hypervisor-Enforced Code Integrity / Memory Integrity (HypervisorEnforcedCodeIntegrity)
+  //
+  // 0=disabled, 1=enabled with UEFI lock, 2=enabled without lock. Null when
+  // not configured.
+  hypervisorEnforcedCodeIntegrity int
+  // Whether HVCI requires a Memory Access Table (HVCIMATRequired)
+  //
+  // 1=require MAT, 0=do not require. Null when not configured.
+  hvciMatRequired int
+  // Credential Guard configuration (LsaCfgFlags)
+  //
+  // 0=off, 1=enabled with UEFI lock, 2=enabled without lock. Null when not
+  // configured.
+  credentialGuardConfig int
+  // System Guard Secure Launch configuration (ConfigureSystemGuardLaunch)
+  //
+  // 1=enabled, 0=disabled. Null when not configured.
+  systemGuardLaunch int
+  // Kernel-mode hardware-enforced stack protection (ConfigureKernelShadowStacksLaunch)
+  //
+  // 1=enabled in enforcement mode, 2=enabled in audit mode, 0=disabled. Null
+  // when not configured.
+  kernelShadowStacksLaunch int
 }
 
 // Windows Trusted Platform Module (TPM)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -338,6 +338,7 @@ const (
 	ResourceWindowsWinrm                                  string = "windows.winrm"
 	ResourceWindowsWinrmClient                            string = "windows.winrm.client"
 	ResourceWindowsWinrmService                           string = "windows.winrm.service"
+	ResourceWindowsDeviceGuard                            string = "windows.deviceGuard"
 	ResourceWindowsTpm                                    string = "windows.tpm"
 	ResourceWindowsAuditPolicy                            string = "windows.auditPolicy"
 	ResourceWindowsAuditPolicySubcategory                 string = "windows.auditPolicy.subcategory"
@@ -1763,6 +1764,10 @@ func init() {
 		"windows.winrm.service": {
 			// to override args, implement: initWindowsWinrmService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsWinrmService,
+		},
+		"windows.deviceGuard": {
+			// to override args, implement: initWindowsDeviceGuard(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsDeviceGuard,
 		},
 		"windows.tpm": {
 			// to override args, implement: initWindowsTpm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -7808,6 +7813,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.scheduledTasks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindows).GetScheduledTasks()).ToDataRes(types.Array(types.Resource("windows.scheduledTask")))
 	},
+	"windows.deviceGuard": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindows).GetDeviceGuard()).ToDataRes(types.Resource("windows.deviceGuard"))
+	},
 	"windows.scheduledTask.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsScheduledTask).GetName()).ToDataRes(types.String)
 	},
@@ -8350,6 +8358,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.winrm.service.allowRemoteShellAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsWinrmService).GetAllowRemoteShellAccess()).ToDataRes(types.Bool)
+	},
+	"windows.deviceGuard.virtualizationBasedSecurityEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetVirtualizationBasedSecurityEnabled()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.requirePlatformSecurityFeatures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetRequirePlatformSecurityFeatures()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.hypervisorEnforcedCodeIntegrity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetHypervisorEnforcedCodeIntegrity()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.hvciMatRequired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetHvciMatRequired()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.credentialGuardConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetCredentialGuardConfig()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.systemGuardLaunch": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetSystemGuardLaunch()).ToDataRes(types.Int)
+	},
+	"windows.deviceGuard.kernelShadowStacksLaunch": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDeviceGuard).GetKernelShadowStacksLaunch()).ToDataRes(types.Int)
 	},
 	"windows.tpm.present": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsTpm).GetPresent()).ToDataRes(types.Bool)
@@ -19302,6 +19331,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWindows).ScheduledTasks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"windows.deviceGuard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindows).DeviceGuard, ok = plugin.RawToTValue[*mqlWindowsDeviceGuard](v.Value, v.Error)
+		return
+	},
 	"windows.scheduledTask.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsScheduledTask).__id, ok = v.Value.(string)
 		return
@@ -20108,6 +20141,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.winrm.service.allowRemoteShellAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsWinrmService).AllowRemoteShellAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.deviceGuard.virtualizationBasedSecurityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).VirtualizationBasedSecurityEnabled, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.requirePlatformSecurityFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).RequirePlatformSecurityFeatures, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.hypervisorEnforcedCodeIntegrity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).HypervisorEnforcedCodeIntegrity, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.hvciMatRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).HvciMatRequired, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.credentialGuardConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).CredentialGuardConfig, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.systemGuardLaunch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).SystemGuardLaunch, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.deviceGuard.kernelShadowStacksLaunch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDeviceGuard).KernelShadowStacksLaunch, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"windows.tpm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50992,6 +51057,7 @@ type mqlWindows struct {
 	ServerFeatures   plugin.TValue[[]any]
 	OptionalFeatures plugin.TValue[[]any]
 	ScheduledTasks   plugin.TValue[[]any]
+	DeviceGuard      plugin.TValue[*mqlWindowsDeviceGuard]
 }
 
 // createWindows creates a new instance of this resource
@@ -51093,6 +51159,22 @@ func (c *mqlWindows) GetScheduledTasks() *plugin.TValue[[]any] {
 		}
 
 		return c.scheduledTasks()
+	})
+}
+
+func (c *mqlWindows) GetDeviceGuard() *plugin.TValue[*mqlWindowsDeviceGuard] {
+	return plugin.GetOrCompute[*mqlWindowsDeviceGuard](&c.DeviceGuard, func() (*mqlWindowsDeviceGuard, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows", c.__id, "deviceGuard")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlWindowsDeviceGuard), nil
+			}
+		}
+
+		return c.deviceGuard()
 	})
 }
 
@@ -53073,6 +53155,85 @@ func (c *mqlWindowsWinrmService) GetAllowAutoConfig() *plugin.TValue[bool] {
 
 func (c *mqlWindowsWinrmService) GetAllowRemoteShellAccess() *plugin.TValue[bool] {
 	return &c.AllowRemoteShellAccess
+}
+
+// mqlWindowsDeviceGuard for the windows.deviceGuard resource
+type mqlWindowsDeviceGuard struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlWindowsDeviceGuardInternal it will be used here
+	VirtualizationBasedSecurityEnabled plugin.TValue[int64]
+	RequirePlatformSecurityFeatures    plugin.TValue[int64]
+	HypervisorEnforcedCodeIntegrity    plugin.TValue[int64]
+	HvciMatRequired                    plugin.TValue[int64]
+	CredentialGuardConfig              plugin.TValue[int64]
+	SystemGuardLaunch                  plugin.TValue[int64]
+	KernelShadowStacksLaunch           plugin.TValue[int64]
+}
+
+// createWindowsDeviceGuard creates a new instance of this resource
+func createWindowsDeviceGuard(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsDeviceGuard{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.deviceGuard", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsDeviceGuard) MqlName() string {
+	return "windows.deviceGuard"
+}
+
+func (c *mqlWindowsDeviceGuard) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsDeviceGuard) GetVirtualizationBasedSecurityEnabled() *plugin.TValue[int64] {
+	return &c.VirtualizationBasedSecurityEnabled
+}
+
+func (c *mqlWindowsDeviceGuard) GetRequirePlatformSecurityFeatures() *plugin.TValue[int64] {
+	return &c.RequirePlatformSecurityFeatures
+}
+
+func (c *mqlWindowsDeviceGuard) GetHypervisorEnforcedCodeIntegrity() *plugin.TValue[int64] {
+	return &c.HypervisorEnforcedCodeIntegrity
+}
+
+func (c *mqlWindowsDeviceGuard) GetHvciMatRequired() *plugin.TValue[int64] {
+	return &c.HvciMatRequired
+}
+
+func (c *mqlWindowsDeviceGuard) GetCredentialGuardConfig() *plugin.TValue[int64] {
+	return &c.CredentialGuardConfig
+}
+
+func (c *mqlWindowsDeviceGuard) GetSystemGuardLaunch() *plugin.TValue[int64] {
+	return &c.SystemGuardLaunch
+}
+
+func (c *mqlWindowsDeviceGuard) GetKernelShadowStacksLaunch() *plugin.TValue[int64] {
+	return &c.KernelShadowStacksLaunch
 }
 
 // mqlWindowsTpm for the windows.tpm resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2914,6 +2914,14 @@ windows.defender.threatIdAction 13.29.1
 windows.defender.threatIdAction.action 13.29.1
 windows.defender.threatIdAction.threatId 13.29.1
 windows.defender.threats 13.29.1
+windows.deviceGuard 13.29.1
+windows.deviceGuard.credentialGuardConfig 13.29.1
+windows.deviceGuard.hvciMatRequired 13.29.1
+windows.deviceGuard.hypervisorEnforcedCodeIntegrity 13.29.1
+windows.deviceGuard.kernelShadowStacksLaunch 13.29.1
+windows.deviceGuard.requirePlatformSecurityFeatures 13.29.1
+windows.deviceGuard.systemGuardLaunch 13.29.1
+windows.deviceGuard.virtualizationBasedSecurityEnabled 13.29.1
 windows.eventlog 13.22.2
 windows.eventlog.maxSizeKB 13.22.2
 windows.eventlog.name 13.22.2

--- a/providers/os/resources/windows_deviceguard.go
+++ b/providers/os/resources/windows_deviceguard.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/os/registry"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+// Registry location that backs windows.deviceGuard. These are GPO-only DWORD
+// values; every one is optional, so an absent value means "not configured"
+// rather than 0.
+const deviceGuardPolicyKey = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard`
+
+func (r *mqlWindowsDeviceGuard) id() (string, error) {
+	return "windows.deviceGuard", nil
+}
+
+// readDeviceGuardKey reads the Device Guard policy key and returns its values as
+// a name->item map (lower-cased keys). A missing key yields an empty map rather
+// than an error, so every field falls through to null ("not configured").
+func (w *mqlWindows) readDeviceGuardKey(path string) (map[string]registry.RegistryKeyItem, error) {
+	o, err := CreateResource(w.MqlRuntime, "registrykey", map[string]*llx.RawData{
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := o.(*mqlRegistrykey).getEntries()
+	if err != nil {
+		// a missing key is expected (e.g. no Group Policy configured); treat it
+		// as empty so every value resolves to null
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			return map[string]registry.RegistryKeyItem{}, nil
+		}
+		return nil, err
+	}
+
+	res := make(map[string]registry.RegistryKeyItem, len(entries))
+	for i := range entries {
+		res[strings.ToLower(entries[i].Key)] = entries[i]
+	}
+	return res, nil
+}
+
+// regIntPtr returns a pointer to the numeric value of a registry item, or nil
+// when the value name is absent. The pointer makes "not configured" (nil)
+// distinguishable from an explicit 0.
+func regIntPtr(items map[string]registry.RegistryKeyItem, name string) *int64 {
+	if it, ok := items[strings.ToLower(name)]; ok {
+		v := it.Value.Number
+		return &v
+	}
+	return nil
+}
+
+// deviceGuardValues holds the extracted Device Guard DWORDs as nullable ints.
+// A nil pointer means the value name was absent from the registry ("not
+// configured"), which the resource surfaces as a null field rather than 0.
+type deviceGuardValues struct {
+	virtualizationBasedSecurityEnabled *int64
+	requirePlatformSecurityFeatures    *int64
+	hypervisorEnforcedCodeIntegrity    *int64
+	hvciMatRequired                    *int64
+	credentialGuardConfig              *int64
+	systemGuardLaunch                  *int64
+	kernelShadowStacksLaunch           *int64
+}
+
+// computeDeviceGuard extracts the Device Guard policy values from the raw
+// registry items. Each field is nil when its value name is absent, so callers
+// can tell "not configured" from an explicit 0. Pure function for unit testing.
+func computeDeviceGuard(items map[string]registry.RegistryKeyItem) deviceGuardValues {
+	return deviceGuardValues{
+		virtualizationBasedSecurityEnabled: regIntPtr(items, "EnableVirtualizationBasedSecurity"),
+		requirePlatformSecurityFeatures:    regIntPtr(items, "RequirePlatformSecurityFeatures"),
+		hypervisorEnforcedCodeIntegrity:    regIntPtr(items, "HypervisorEnforcedCodeIntegrity"),
+		hvciMatRequired:                    regIntPtr(items, "HVCIMATRequired"),
+		credentialGuardConfig:              regIntPtr(items, "LsaCfgFlags"),
+		systemGuardLaunch:                  regIntPtr(items, "ConfigureSystemGuardLaunch"),
+		kernelShadowStacksLaunch:           regIntPtr(items, "ConfigureKernelShadowStacksLaunch"),
+	}
+}
+
+func (w *mqlWindows) deviceGuard() (*mqlWindowsDeviceGuard, error) {
+	items, err := w.readDeviceGuardKey(deviceGuardPolicyKey)
+	if err != nil {
+		return nil, err
+	}
+
+	v := computeDeviceGuard(items)
+
+	o, err := CreateResource(w.MqlRuntime, "windows.deviceGuard", map[string]*llx.RawData{
+		"__id":                               llx.StringData("windows.deviceGuard"),
+		"virtualizationBasedSecurityEnabled": llx.IntDataPtr(v.virtualizationBasedSecurityEnabled),
+		"requirePlatformSecurityFeatures":    llx.IntDataPtr(v.requirePlatformSecurityFeatures),
+		"hypervisorEnforcedCodeIntegrity":    llx.IntDataPtr(v.hypervisorEnforcedCodeIntegrity),
+		"hvciMatRequired":                    llx.IntDataPtr(v.hvciMatRequired),
+		"credentialGuardConfig":              llx.IntDataPtr(v.credentialGuardConfig),
+		"systemGuardLaunch":                  llx.IntDataPtr(v.systemGuardLaunch),
+		"kernelShadowStacksLaunch":           llx.IntDataPtr(v.kernelShadowStacksLaunch),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return o.(*mqlWindowsDeviceGuard), nil
+}

--- a/providers/os/resources/windows_deviceguard_internal_test.go
+++ b/providers/os/resources/windows_deviceguard_internal_test.go
@@ -1,0 +1,147 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/registry"
+)
+
+// dwordItems builds a name->item map mirroring what readDeviceGuardKey produces:
+// lower-cased value names mapping to registry items carrying a numeric value.
+func dwordItems(values map[string]int64) map[string]registry.RegistryKeyItem {
+	items := make(map[string]registry.RegistryKeyItem, len(values))
+	for name, v := range values {
+		items[name] = registry.RegistryKeyItem{
+			Key:   name,
+			Value: registry.RegistryKeyValue{Kind: registry.DWORD, Number: v},
+		}
+	}
+	return items
+}
+
+func TestRegIntPtr(t *testing.T) {
+	t.Run("present returns a pointer to the value", func(t *testing.T) {
+		items := dwordItems(map[string]int64{"enablevirtualizationbasedsecurity": 1})
+		got := regIntPtr(items, "EnableVirtualizationBasedSecurity")
+		require.NotNil(t, got)
+		assert.Equal(t, int64(1), *got)
+	})
+
+	t.Run("explicit 0 is distinguishable from absent", func(t *testing.T) {
+		items := dwordItems(map[string]int64{"enablevirtualizationbasedsecurity": 0})
+		got := regIntPtr(items, "EnableVirtualizationBasedSecurity")
+		require.NotNil(t, got)
+		assert.Equal(t, int64(0), *got)
+	})
+
+	t.Run("absent returns nil", func(t *testing.T) {
+		assert.Nil(t, regIntPtr(dwordItems(map[string]int64{}), "EnableVirtualizationBasedSecurity"))
+		assert.Nil(t, regIntPtr(nil, "EnableVirtualizationBasedSecurity"))
+	})
+
+	t.Run("value name matching is case insensitive", func(t *testing.T) {
+		items := dwordItems(map[string]int64{"lsacfgflags": 2})
+		got := regIntPtr(items, "LsaCfgFlags")
+		require.NotNil(t, got)
+		assert.Equal(t, int64(2), *got)
+	})
+}
+
+func TestComputeDeviceGuard(t *testing.T) {
+	t.Run("empty registry yields all-null fields", func(t *testing.T) {
+		v := computeDeviceGuard(dwordItems(map[string]int64{}))
+		assert.Nil(t, v.virtualizationBasedSecurityEnabled)
+		assert.Nil(t, v.requirePlatformSecurityFeatures)
+		assert.Nil(t, v.hypervisorEnforcedCodeIntegrity)
+		assert.Nil(t, v.hvciMatRequired)
+		assert.Nil(t, v.credentialGuardConfig)
+		assert.Nil(t, v.systemGuardLaunch)
+		assert.Nil(t, v.kernelShadowStacksLaunch)
+	})
+
+	t.Run("nil map yields all-null fields", func(t *testing.T) {
+		v := computeDeviceGuard(nil)
+		assert.Nil(t, v.virtualizationBasedSecurityEnabled)
+		assert.Nil(t, v.kernelShadowStacksLaunch)
+	})
+
+	t.Run("fully hardened CIS values map to the right fields", func(t *testing.T) {
+		// A CIS-compliant Device Guard configuration: VBS on with Secure Boot +
+		// DMA, HVCI enabled with lock, MAT required, Credential Guard with UEFI
+		// lock, System Guard and kernel shadow stacks enabled.
+		v := computeDeviceGuard(dwordItems(map[string]int64{
+			"enablevirtualizationbasedsecurity": 1,
+			"requireplatformsecurityfeatures":   3,
+			"hypervisorenforcedcodeintegrity":   1,
+			"hvcimatrequired":                   1,
+			"lsacfgflags":                       1,
+			"configuresystemguardlaunch":        1,
+			"configurekernelshadowstackslaunch": 1,
+		}))
+		require.NotNil(t, v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, int64(1), *v.virtualizationBasedSecurityEnabled)
+		require.NotNil(t, v.requirePlatformSecurityFeatures)
+		assert.Equal(t, int64(3), *v.requirePlatformSecurityFeatures)
+		require.NotNil(t, v.hypervisorEnforcedCodeIntegrity)
+		assert.Equal(t, int64(1), *v.hypervisorEnforcedCodeIntegrity)
+		require.NotNil(t, v.hvciMatRequired)
+		assert.Equal(t, int64(1), *v.hvciMatRequired)
+		require.NotNil(t, v.credentialGuardConfig)
+		assert.Equal(t, int64(1), *v.credentialGuardConfig)
+		require.NotNil(t, v.systemGuardLaunch)
+		assert.Equal(t, int64(1), *v.systemGuardLaunch)
+		require.NotNil(t, v.kernelShadowStacksLaunch)
+		assert.Equal(t, int64(1), *v.kernelShadowStacksLaunch)
+	})
+
+	t.Run("each value maps to its own field (no cross-wiring)", func(t *testing.T) {
+		// Distinct values per name guard against accidental copy/paste mapping.
+		v := computeDeviceGuard(dwordItems(map[string]int64{
+			"enablevirtualizationbasedsecurity": 1,
+			"requireplatformsecurityfeatures":   3,
+			"hypervisorenforcedcodeintegrity":   2,
+			"hvcimatrequired":                   0,
+			"lsacfgflags":                       2,
+			"configuresystemguardlaunch":        0,
+			"configurekernelshadowstackslaunch": 2,
+		}))
+		assert.Equal(t, int64(1), *v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, int64(3), *v.requirePlatformSecurityFeatures)
+		assert.Equal(t, int64(2), *v.hypervisorEnforcedCodeIntegrity)
+		assert.Equal(t, int64(0), *v.hvciMatRequired)
+		assert.Equal(t, int64(2), *v.credentialGuardConfig)
+		assert.Equal(t, int64(0), *v.systemGuardLaunch)
+		assert.Equal(t, int64(2), *v.kernelShadowStacksLaunch)
+	})
+
+	t.Run("explicit 0 stays distinguishable from null in the struct", func(t *testing.T) {
+		// VBS explicitly disabled (0) must be non-nil; Credential Guard absent
+		// must be nil.
+		v := computeDeviceGuard(dwordItems(map[string]int64{
+			"enablevirtualizationbasedsecurity": 0,
+		}))
+		require.NotNil(t, v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, int64(0), *v.virtualizationBasedSecurityEnabled)
+		assert.Nil(t, v.credentialGuardConfig)
+	})
+
+	t.Run("partial configuration leaves unset values null", func(t *testing.T) {
+		// Only Credential Guard configured; everything else stays null.
+		v := computeDeviceGuard(dwordItems(map[string]int64{
+			"lsacfgflags": 1,
+		}))
+		require.NotNil(t, v.credentialGuardConfig)
+		assert.Equal(t, int64(1), *v.credentialGuardConfig)
+		assert.Nil(t, v.virtualizationBasedSecurityEnabled)
+		assert.Nil(t, v.requirePlatformSecurityFeatures)
+		assert.Nil(t, v.hypervisorEnforcedCodeIntegrity)
+		assert.Nil(t, v.hvciMatRequired)
+		assert.Nil(t, v.systemGuardLaunch)
+		assert.Nil(t, v.kernelShadowStacksLaunch)
+	})
+}


### PR DESCRIPTION
## Summary

Adds a flat `windows.deviceGuard` MQL resource that surfaces the Device Guard Group Policy values under `HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard` as readable, nullable camelCase int fields. This lets the CIS Windows Device Guard checks move off raw `registrykey.property(...)` lookups.

Covers Virtualization-Based Security (VBS), Hypervisor-Enforced Code Integrity (HVCI / Memory Integrity), Credential Guard, System Guard Secure Launch, and kernel-mode hardware-enforced stack protection.

## Before → After

| Before (raw registry) | After (typed resource) |
|---|---|
| `registrykey.property(path: '...\DeviceGuard', name: 'EnableVirtualizationBasedSecurity')` | `windows.deviceGuard.virtualizationBasedSecurityEnabled` |
| `registrykey.property(path: '...\DeviceGuard', name: 'RequirePlatformSecurityFeatures')` | `windows.deviceGuard.requirePlatformSecurityFeatures` |
| `registrykey.property(path: '...\DeviceGuard', name: 'HypervisorEnforcedCodeIntegrity')` | `windows.deviceGuard.hypervisorEnforcedCodeIntegrity` |
| `registrykey.property(path: '...\DeviceGuard', name: 'HVCIMATRequired')` | `windows.deviceGuard.hvciMatRequired` |
| `registrykey.property(path: '...\DeviceGuard', name: 'LsaCfgFlags')` | `windows.deviceGuard.credentialGuardConfig` |
| `registrykey.property(path: '...\DeviceGuard', name: 'ConfigureSystemGuardLaunch')` | `windows.deviceGuard.systemGuardLaunch` |
| `registrykey.property(path: '...\DeviceGuard', name: 'ConfigureKernelShadowStacksLaunch')` | `windows.deviceGuard.kernelShadowStacksLaunch` |

All seven Device Guard registry values referenced across `windows-10`, `windows-11`, `windows-server-2016/2019/2022` policies are covered (verified by grep).

## Fields

All fields are nullable `int`. A null value means "not configured" and is distinguishable from an explicit `0`, which matters because compliant values are specific numbers.

| Field | Registry value | Meaning |
|---|---|---|
| `virtualizationBasedSecurityEnabled` | `EnableVirtualizationBasedSecurity` | 1=enabled, 0=disabled |
| `requirePlatformSecurityFeatures` | `RequirePlatformSecurityFeatures` | 1=Secure Boot, 3=Secure Boot + DMA |
| `hypervisorEnforcedCodeIntegrity` | `HypervisorEnforcedCodeIntegrity` | 0=disabled, 1=enabled w/ lock, 2=enabled w/o lock |
| `hvciMatRequired` | `HVCIMATRequired` | 1=require MAT, 0=do not require |
| `credentialGuardConfig` | `LsaCfgFlags` | 0=off, 1=on w/ UEFI lock, 2=on w/o lock |
| `systemGuardLaunch` | `ConfigureSystemGuardLaunch` | 1=enabled, 0=disabled |
| `kernelShadowStacksLaunch` | `ConfigureKernelShadowStacksLaunch` | 1=enforcement, 2=audit, 0=disabled |

## Design notes

- **Nullable correctness.** Args are built with `llx.IntDataPtr(*int64)`, which sets the field null when the pointer is nil. Absent registry values therefore surface as null rather than `0`, so a check can tell "policy never set" from "explicitly disabled".
- **Registry access mirrors `windows.update` / `windows.winrm`.** The key is read through the `registrykey` resource via `CreateResource` + `getEntries()`; a `codes.NotFound` (absent key) is treated as an empty map so every field falls through to null. Reading the registry needs no command execution, so the resource works on snapshot/filesystem connections too.
- **Pure, testable extraction.** Value extraction is factored into `computeDeviceGuard(items map[string]registry.RegistryKeyItem) deviceGuardValues`, a pure function with no runtime dependency, plus a `regIntPtr` helper. Value-name matching is case-insensitive (names are lower-cased on read).

## Testing

- `./lr go providers/os/resources/os.lr --dist providers/os/dist` — no fatal/error
- `./lr versions providers/os/resources/os.lr` — adds `windows.deviceGuard*` at 13.29.1
- `cd providers/os && go run ./gen/main.go .` — clean
- `cd providers/os && go build ./...` — passes
- `cd providers/os && go vet ./resources/` — clean
- `cd providers/os && go test ./resources/ -run 'DeviceGuard|RegIntPtr' -v` — all pass (presence, absence, explicit-0 vs null, per-field no-cross-wiring, partial config)
- `gofmt -l` on both new Go files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)