### PR TITLE
Add windows.rdp endSessionWhenTimeLimitReached and cloudClipboardIntegrationDisabled fields

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -7097,6 +7097,10 @@ windows.rdp {
   // to the client; higher values permit progressively more content. Resolves
   // to 3 (unrestricted) when the policy is not configured.
   clipboardServerToClientLevel() int
+  // Whether a session is ended rather than disconnected when a time limit is reached (fResetBroken)
+  endSessionWhenTimeLimitReached() bool
+  // Whether RDP Cloud Clipboard integration for server-to-client data transfer is disabled (DisableCloudClipboardIntegration)
+  cloudClipboardIntegrationDisabled() bool
 }
 
 // Windows Remote Management (WinRM)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -8579,6 +8579,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.rdp.clipboardServerToClientLevel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsRdp).GetClipboardServerToClientLevel()).ToDataRes(types.Int)
 	},
+	"windows.rdp.endSessionWhenTimeLimitReached": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsRdp).GetEndSessionWhenTimeLimitReached()).ToDataRes(types.Bool)
+	},
+	"windows.rdp.cloudClipboardIntegrationDisabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsRdp).GetCloudClipboardIntegrationDisabled()).ToDataRes(types.Bool)
+	},
 	"windows.winrm.client": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsWinrm).GetClient()).ToDataRes(types.Resource("windows.winrm.client"))
 	},
@@ -20934,6 +20940,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.rdp.clipboardServerToClientLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsRdp).ClipboardServerToClientLevel, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.rdp.endSessionWhenTimeLimitReached": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsRdp).EndSessionWhenTimeLimitReached, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.rdp.cloudClipboardIntegrationDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsRdp).CloudClipboardIntegrationDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.winrm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -54837,28 +54851,30 @@ type mqlWindowsRdp struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlWindowsRdpInternal
-	NetworkLevelAuthentication       plugin.TValue[bool]
-	AlwaysPromptForPassword          plugin.TValue[bool]
-	DriveRedirectionDisabled         plugin.TValue[bool]
-	ComPortRedirectionDisabled       plugin.TValue[bool]
-	LptPortRedirectionDisabled       plugin.TValue[bool]
-	PnpDeviceRedirectionDisabled     plugin.TValue[bool]
-	PasswordSavingDisabled           plugin.TValue[bool]
-	DeleteTempDirsOnExit             plugin.TValue[bool]
-	SecureRpcRequired                plugin.TValue[bool]
-	SecurityLayer                    plugin.TValue[int64]
-	MinEncryptionLevel               plugin.TValue[int64]
-	MaxIdleTimeMs                    plugin.TValue[int64]
-	MaxDisconnectionTimeMs           plugin.TValue[int64]
-	ConnectionsDenied                plugin.TValue[bool]
-	SingleSessionPerUser             plugin.TValue[bool]
-	PerSessionTempDirsUsed           plugin.TValue[bool]
-	SolicitedRemoteAssistanceAllowed plugin.TValue[bool]
-	OfferRemoteAssistanceAllowed     plugin.TValue[bool]
-	WebAuthnRedirectionDisabled      plugin.TValue[bool]
-	LocationRedirectionDisabled      plugin.TValue[bool]
-	UiAutomationRedirectionEnabled   plugin.TValue[bool]
-	ClipboardServerToClientLevel     plugin.TValue[int64]
+	NetworkLevelAuthentication        plugin.TValue[bool]
+	AlwaysPromptForPassword           plugin.TValue[bool]
+	DriveRedirectionDisabled          plugin.TValue[bool]
+	ComPortRedirectionDisabled        plugin.TValue[bool]
+	LptPortRedirectionDisabled        plugin.TValue[bool]
+	PnpDeviceRedirectionDisabled      plugin.TValue[bool]
+	PasswordSavingDisabled            plugin.TValue[bool]
+	DeleteTempDirsOnExit              plugin.TValue[bool]
+	SecureRpcRequired                 plugin.TValue[bool]
+	SecurityLayer                     plugin.TValue[int64]
+	MinEncryptionLevel                plugin.TValue[int64]
+	MaxIdleTimeMs                     plugin.TValue[int64]
+	MaxDisconnectionTimeMs            plugin.TValue[int64]
+	ConnectionsDenied                 plugin.TValue[bool]
+	SingleSessionPerUser              plugin.TValue[bool]
+	PerSessionTempDirsUsed            plugin.TValue[bool]
+	SolicitedRemoteAssistanceAllowed  plugin.TValue[bool]
+	OfferRemoteAssistanceAllowed      plugin.TValue[bool]
+	WebAuthnRedirectionDisabled       plugin.TValue[bool]
+	LocationRedirectionDisabled       plugin.TValue[bool]
+	UiAutomationRedirectionEnabled    plugin.TValue[bool]
+	ClipboardServerToClientLevel      plugin.TValue[int64]
+	EndSessionWhenTimeLimitReached    plugin.TValue[bool]
+	CloudClipboardIntegrationDisabled plugin.TValue[bool]
 }
 
 // createWindowsRdp creates a new instance of this resource
@@ -55027,6 +55043,18 @@ func (c *mqlWindowsRdp) GetUiAutomationRedirectionEnabled() *plugin.TValue[bool]
 func (c *mqlWindowsRdp) GetClipboardServerToClientLevel() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.ClipboardServerToClientLevel, func() (int64, error) {
 		return c.clipboardServerToClientLevel()
+	})
+}
+
+func (c *mqlWindowsRdp) GetEndSessionWhenTimeLimitReached() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EndSessionWhenTimeLimitReached, func() (bool, error) {
+		return c.endSessionWhenTimeLimitReached()
+	})
+}
+
+func (c *mqlWindowsRdp) GetCloudClipboardIntegrationDisabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CloudClipboardIntegrationDisabled, func() (bool, error) {
+		return c.cloudClipboardIntegrationDisabled()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -3064,10 +3064,12 @@ windows.optionalFeatures 11.2.6
 windows.rdp 13.22.2
 windows.rdp.alwaysPromptForPassword 13.22.2
 windows.rdp.clipboardServerToClientLevel 13.29.1
+windows.rdp.cloudClipboardIntegrationDisabled 13.29.1
 windows.rdp.comPortRedirectionDisabled 13.22.2
 windows.rdp.connectionsDenied 13.29.1
 windows.rdp.deleteTempDirsOnExit 13.22.2
 windows.rdp.driveRedirectionDisabled 13.22.2
+windows.rdp.endSessionWhenTimeLimitReached 13.29.1
 windows.rdp.locationRedirectionDisabled 13.29.1
 windows.rdp.lptPortRedirectionDisabled 13.22.2
 windows.rdp.maxDisconnectionTimeMs 13.22.2

--- a/providers/os/resources/windows_rdp.go
+++ b/providers/os/resources/windows_rdp.go
@@ -22,6 +22,7 @@ func (r *mqlWindowsRdp) id() (string, error) {
 // documented Windows default applies.
 const (
 	rdpPolicyPath         = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services`
+	rdpPolicyClientPath   = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\Client`
 	rdpWinStationsPath    = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp`
 	rdpTerminalServerPath = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server`
 )
@@ -41,10 +42,11 @@ type mqlWindowsRdpInternal struct {
 	lock   sync.Mutex
 	loaded bool
 	// each map is name (lower-cased) -> DWORD value for one registry key
-	policy  map[string]int64
-	winSta  map[string]int64
-	tsRoot  map[string]int64
-	loadErr error
+	policy       map[string]int64
+	policyClient map[string]int64
+	winSta       map[string]int64
+	tsRoot       map[string]int64
+	loadErr      error
 }
 
 // readRdpKey reads a single registry key and returns its numeric values keyed
@@ -92,6 +94,11 @@ func (r *mqlWindowsRdp) load() error {
 		r.loadErr = err
 		return err
 	}
+	policyClient, err := r.readRdpKey(rdpPolicyClientPath)
+	if err != nil {
+		r.loadErr = err
+		return err
+	}
 	winSta, err := r.readRdpKey(rdpWinStationsPath)
 	if err != nil {
 		r.loadErr = err
@@ -104,6 +111,7 @@ func (r *mqlWindowsRdp) load() error {
 	}
 
 	r.policy = policy
+	r.policyClient = policyClient
 	r.winSta = winSta
 	r.tsRoot = tsRoot
 	r.loaded = true
@@ -251,4 +259,19 @@ func (r *mqlWindowsRdp) clipboardServerToClientLevel() (int64, error) {
 	// 3 == unrestricted server-to-client clipboard, the behavior when the
 	// "Restrict clipboard transfer from server to client" policy is not set
 	return r.resolve("SCClipLevel", rdpWinStations, 3)
+}
+
+func (r *mqlWindowsRdp) endSessionWhenTimeLimitReached() (bool, error) {
+	// when not configured, a session that hits a time limit is disconnected
+	// rather than ended, so the setting defaults to off
+	return r.resolveBool("fResetBroken", rdpWinStations, 0)
+}
+
+func (r *mqlWindowsRdp) cloudClipboardIntegrationDisabled() (bool, error) {
+	if err := r.load(); err != nil {
+		return false, err
+	}
+	// Group Policy-only setting under the Terminal Services\Client subkey; cloud
+	// clipboard integration is enabled (not disabled) when it is not configured
+	return resolveRdpValue(r.policyClient, nil, "DisableCloudClipboardIntegration", 0) == 1, nil
 }

--- a/providers/os/resources/windows_rdp_internal_test.go
+++ b/providers/os/resources/windows_rdp_internal_test.go
@@ -53,6 +53,8 @@ func TestRdpSettingDefaults(t *testing.T) {
 		{"fDisableLocationRedir", 0},
 		{"EnableUiaRedirection", 0},
 		{"SCClipLevel", 3},
+		{"fResetBroken", 0},
+		{"DisableCloudClipboardIntegration", 0},
 	}
 	for _, c := range cases {
 		t.Run(c.name+" default", func(t *testing.T) {


### PR DESCRIPTION
## What

Extends the `windows.rdp` resource with the final two Remote Desktop / Terminal Services CIS settings that did not yet have a typed field, so the Windows policies can drop their last raw `registrykey` RDP checks (follow-up to mondoohq/cnspec-enterprise-policies#2837).

| New field | Registry value | Source | Default |
|---|---|---|---|
| `endSessionWhenTimeLimitReached() bool` | `fResetBroken` | GPO → `WinStations\RDP-Tcp` → default | `false` (timed-out sessions are disconnected, not ended, when unconfigured) |
| `cloudClipboardIntegrationDisabled() bool` | `DisableCloudClipboardIntegration` | GPO-only, under `…\Terminal Services\Client` subkey | `false` (cloud clipboard integration enabled when unconfigured) |

## Notes

- `endSessionWhenTimeLimitReached` uses the existing `resolveBool` precedence (policy-wins → effective per-listener key → documented default), like the other per-listener Terminal Services settings.
- `cloudClipboardIntegrationDisabled` lives under the `Terminal Services\Client` **policy subkey**, which the resource did not previously read — added a dedicated `policyClient` key read in `load()`. It is a Group-Policy-only setting (no per-listener effective equivalent), resolved via the unit-tested `resolveRdpValue` helper.

## Tests

`TestRdpSettingDefaults` extended with the `fResetBroken` and `DisableCloudClipboardIntegration` defaults (both `0`) and their policy-override cases.

- `gofmt -l`: clean
- `go build ./...`: OK
- `go vet ./providers/os/resources/`: OK
- `go test ./providers/os/resources/ -run 'TestResolveRdpValue|TestRdpSettingDefaults'`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)