### PR TITLE
🐛 k8s: fix admission DELETE panic, discovery error swallowing, and SA nil deref

### DIFF
--- a/providers/k8s/connection/admission/connection.go
+++ b/providers/k8s/connection/admission/connection.go
@@ -48,6 +48,9 @@ func NewConnection(id uint32, asset *inventory.Asset, data string) (shared.Conne
 	}
 
 	for _, r := range res {
+		if r.Request == nil {
+			continue
+		}
 		// For each admission we want to also parse the object as an individual asset so we
 		// can show the admission review and the resource together in the CI/CD view.
 		objs, err := resources.ResourcesFromManifest(bytes.NewReader(r.Request.Object.Raw))

--- a/providers/k8s/connection/shared/resources/discovery.go
+++ b/providers/k8s/connection/shared/resources/discovery.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
@@ -134,10 +135,18 @@ func (d *Discovery) GetKindResources(ctx context.Context, apiRes ApiResource, ns
 			Limit:    250,
 			Continue: next,
 		})
-		// this error will happen when users have no permission
 		if err != nil {
-			log.Debug().Err(err).Msgf("could not fetch resources for: %v", apiRes.GroupVersionResource())
-			break
+			// A missing permission for a resource type is expected (the user's
+			// RBAC may not cover every discovered kind), so swallow it and skip
+			// this kind. Any other error (throttling, a transient API-server
+			// failure, an expired continue token mid-pagination) must propagate
+			// rather than silently truncate the result set to an empty/partial
+			// list that looks like "this kind has no objects".
+			if k8sErrors.IsForbidden(err) || k8sErrors.IsUnauthorized(err) {
+				log.Debug().Err(err).Msgf("no permission to fetch resources for: %v", apiRes.GroupVersionResource())
+				break
+			}
+			return out, errors.Wrapf(err, "could not fetch resources for %v", apiRes.GroupVersionResource())
 		}
 
 		out = append(out, UnstructuredListToObjectList(resp.Items)...)

--- a/providers/k8s/connection/shared/resources/discovery.go
+++ b/providers/k8s/connection/shared/resources/discovery.go
@@ -143,7 +143,16 @@ func (d *Discovery) GetKindResources(ctx context.Context, apiRes ApiResource, ns
 			// rather than silently truncate the result set to an empty/partial
 			// list that looks like "this kind has no objects".
 			if k8sErrors.IsForbidden(err) || k8sErrors.IsUnauthorized(err) {
-				log.Debug().Err(err).Msgf("no permission to fetch resources for: %v", apiRes.GroupVersionResource())
+				// On the first page this simply means "no access to this kind",
+				// and we return an empty list. If it happens mid-pagination
+				// (e.g. a token rotates during a long list), the results already
+				// in `out` are partial, so warn that this kind may be incomplete
+				// rather than silently returning a truncated set.
+				if len(out) > 0 {
+					log.Warn().Err(err).Msgf("lost permission mid-pagination for %v; returning %d partial results", apiRes.GroupVersionResource(), len(out))
+				} else {
+					log.Debug().Err(err).Msgf("no permission to fetch resources for: %v", apiRes.GroupVersionResource())
+				}
 				break
 			}
 			return out, errors.Wrapf(err, "could not fetch resources for %v", apiRes.GroupVersionResource())

--- a/providers/k8s/connection/shared/resources/discovery_test.go
+++ b/providers/k8s/connection/shared/resources/discovery_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newFakeDynamicClient builds a fake dynamic client with the pods list kind
+// registered so List() can resolve the list GVK before the reactors fire.
+func newFakeDynamicClient() *dynamicfake.FakeDynamicClient {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "PodList"},
+	)
+}
+
+func podsApiResource() ApiResource {
+	return ApiResource{
+		Resource:     metav1.APIResource{Name: "pods", Namespaced: false, Kind: "Pod"},
+		GroupVersion: schema.GroupVersion{Group: "", Version: "v1"},
+	}
+}
+
+func unstructuredPod(name string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": name, "namespace": "default"},
+	}}
+}
+
+// TestGetKindResources_ForbiddenIsSwallowed verifies that a permission error
+// (the expected case when a user's RBAC doesn't cover a discovered kind) is
+// swallowed: the kind is skipped, no error is returned.
+func TestGetKindResources_ForbiddenIsSwallowed(t *testing.T) {
+	client := newFakeDynamicClient()
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8sErrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("forbidden"))
+	})
+
+	d := &Discovery{dynClient: client}
+	out, err := d.GetKindResources(context.Background(), podsApiResource(), "", true)
+	require.NoError(t, err, "a forbidden error must be swallowed, not propagated")
+	assert.Empty(t, out)
+}
+
+// TestGetKindResources_OtherErrorPropagates verifies that a non-permission
+// error (throttling, transient API-server failure, expired continue token) is
+// propagated instead of being silently turned into an empty result that looks
+// like "this kind has no objects".
+func TestGetKindResources_OtherErrorPropagates(t *testing.T) {
+	client := newFakeDynamicClient()
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("the server was unable to handle the request")
+	})
+
+	d := &Discovery{dynClient: client}
+	_, err := d.GetKindResources(context.Background(), podsApiResource(), "", true)
+	require.Error(t, err, "a non-permission error must propagate")
+}
+
+// TestGetKindResources_Pagination verifies that all pages are concatenated by
+// following the continue token rather than truncating at the first page.
+func TestGetKindResources_Pagination(t *testing.T) {
+	client := newFakeDynamicClient()
+
+	call := 0
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		call++
+		list := &unstructured.UnstructuredList{}
+		switch call {
+		case 1:
+			list.Items = []unstructured.Unstructured{unstructuredPod("pod-1")}
+			list.SetContinue("page-2-token")
+		default:
+			list.Items = []unstructured.Unstructured{unstructuredPod("pod-2")}
+			list.SetContinue("")
+		}
+		return true, list, nil
+	})
+
+	d := &Discovery{dynClient: client}
+	out, err := d.GetKindResources(context.Background(), podsApiResource(), "", true)
+	require.NoError(t, err)
+	assert.Equal(t, 2, call, "both pages must be requested")
+	require.Len(t, out, 2, "results from every page must be concatenated")
+}

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
-	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )
 
 require (

--- a/providers/k8s/resources/admission.go
+++ b/providers/k8s/resources/admission.go
@@ -45,21 +45,32 @@ func (k *mqlK8sAdmissionreview) request() (*mqlK8sAdmissionrequest, error) {
 	}
 
 	aRequest := result[0].Request
-	obj, err := resources.ResourcesFromManifest(bytes.NewReader(aRequest.Object.Raw))
-	if err != nil {
-		return nil, err
-	}
-
-	objDict, err := convert.JsonToDict(obj[0])
-	if err != nil {
-		return nil, err
+	if aRequest == nil {
+		k.Request.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	args := map[string]*llx.RawData{
 		"name":      llx.StringData(aRequest.Name),
 		"namespace": llx.StringData(aRequest.Namespace),
 		"operation": llx.StringData(string(aRequest.Operation)),
-		"object":    llx.DictData(objDict),
+	}
+
+	// The incoming object is empty on DELETE requests (the object lives in
+	// oldObject instead), so guard against an empty parse result rather than
+	// indexing obj[0] unconditionally.
+	obj, err := resources.ResourcesFromManifest(bytes.NewReader(aRequest.Object.Raw))
+	if err != nil {
+		return nil, err
+	}
+	if len(obj) == 1 {
+		objDict, err := convert.JsonToDict(obj[0])
+		if err != nil {
+			return nil, err
+		}
+		args["object"] = llx.DictData(objDict)
+	} else {
+		args["object"] = llx.NilData
 	}
 
 	oldObj, err := resources.ResourcesFromManifest(bytes.NewReader(aRequest.OldObject.Raw))

--- a/providers/k8s/resources/admission_test.go
+++ b/providers/k8s/resources/admission_test.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/admission"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// loadAdmissionRuntime builds an admission connection from the given review
+// fixture and wires a runtime against it.
+func loadAdmissionRuntime(t *testing.T, fixture string) *plugin.Runtime {
+	t.Helper()
+	data, err := os.ReadFile(fixture)
+	require.NoError(t, err)
+
+	conn, err := admission.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{Options: map[string]string{}}},
+	}, base64.StdEncoding.EncodeToString(data))
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+// TestAdmissionReviewRequest_Delete pins the fix for the panic that occurred
+// when request() indexed obj[0] on a DELETE review, whose incoming object is
+// empty (the object lives in oldObject instead). The accessor must resolve
+// without panicking, report object as null, and surface the old object.
+func TestAdmissionReviewRequest_Delete(t *testing.T) {
+	runtime := loadAdmissionRuntime(t, "testdata/admission-review-delete.json")
+
+	review := &mqlK8sAdmissionreview{MqlRuntime: runtime}
+	req, err := review.request()
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	assert.Equal(t, "DELETE", req.Operation.Data)
+	assert.Equal(t, "deleted-pod", req.Name.Data)
+
+	// The incoming object is empty on DELETE and must be null, not a panic.
+	assert.Nil(t, req.Object.Data, "object must be null on a DELETE review")
+	assert.True(t, req.Object.State&plugin.StateIsNull != 0, "object must be marked null")
+
+	// The old object carries the deleted resource.
+	require.NotNil(t, req.OldObject.Data, "oldObject must be populated on a DELETE review")
+}
+
+// TestAdmissionReviewRequest_Create keeps the happy path (CREATE, populated
+// object) covered so the DELETE guard doesn't regress the common case.
+func TestAdmissionReviewRequest_Create(t *testing.T) {
+	runtime := loadAdmissionRuntime(t, "../connection/shared/resources/testdata/admission-review.json")
+
+	review := &mqlK8sAdmissionreview{MqlRuntime: runtime}
+	req, err := review.request()
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	assert.Equal(t, "CREATE", req.Operation.Data)
+	require.NotNil(t, req.Object.Data, "object must be populated on a CREATE review")
+}

--- a/providers/k8s/resources/serviceaccount.go
+++ b/providers/k8s/resources/serviceaccount.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 )
 
 type mqlK8sServiceaccountInternal struct {
@@ -44,8 +43,13 @@ func (k *mqlK8s) serviceaccounts() ([]any, error) {
 		// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
 		// As discussed here, this behavior will not change for core/v1:
 		// https://github.com/kubernetes/kubernetes/issues/57601
-		if serviceAccount.AutomountServiceAccountToken == nil && objT.GetAPIVersion() == "v1" {
-			serviceAccount.AutomountServiceAccountToken = ptr.To(true)
+		// ServiceAccount only exists in core/v1, so an unset field always
+		// defaults to true. Compute the value with a nil-safe local rather than
+		// dereferencing the pointer (which is nil whenever TypeMeta isn't
+		// populated, e.g. on the manifest path).
+		automountServiceAccountToken := true
+		if serviceAccount.AutomountServiceAccountToken != nil {
+			automountServiceAccountToken = *serviceAccount.AutomountServiceAccountToken
 		}
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.serviceaccount", map[string]*llx.RawData{
@@ -58,7 +62,7 @@ func (k *mqlK8s) serviceaccounts() ([]any, error) {
 			"created":                      llx.TimeData(ts.Time),
 			"secrets":                      llx.DictData(secrets),
 			"imagePullSecrets":             llx.DictData(imagePullSecrets),
-			"automountServiceAccountToken": llx.BoolData(*serviceAccount.AutomountServiceAccountToken),
+			"automountServiceAccountToken": llx.BoolData(automountServiceAccountToken),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/k8s/resources/serviceaccount_test.go
+++ b/providers/k8s/resources/serviceaccount_test.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// TestServiceAccountAutomountDefault pins the auto-mount default and guards the
+// fix for the nil-pointer dereference that occurred when
+// AutomountServiceAccountToken was unset: an unset field must default to true
+// (core/v1 semantics) without dereferencing a nil pointer, while explicit
+// true/false values are preserved.
+func TestServiceAccountAutomountDefault(t *testing.T) {
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{Options: map[string]string{}}},
+	}, manifest.WithManifestFile("testdata/serviceaccount_automount.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+
+	cases := map[string]bool{
+		"sa-default":        true,  // unset -> defaults to true (must not panic)
+		"sa-explicit-true":  true,  // explicit true preserved
+		"sa-explicit-false": false, // explicit false preserved
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			obj, err := NewResource(runtime, "k8s.serviceaccount", map[string]*llx.RawData{
+				"name":      llx.StringData(name),
+				"namespace": llx.StringData("default"),
+			})
+			require.NoError(t, err)
+			sa := obj.(*mqlK8sServiceaccount)
+			got := sa.GetAutomountServiceAccountToken()
+			require.NoError(t, got.Error)
+			assert.Equal(t, want, got.Data)
+		})
+	}
+}

--- a/providers/k8s/resources/testdata/admission-review-delete.json
+++ b/providers/k8s/resources/testdata/admission-review-delete.json
@@ -1,0 +1,31 @@
+{
+  "apiVersion": "admission.k8s.io/v1",
+  "kind": "AdmissionReview",
+  "request": {
+    "uid": "11111111-2222-3333-4444-555555555555",
+    "kind": { "group": "", "version": "v1", "kind": "Pod" },
+    "resource": { "group": "", "version": "v1", "resource": "pods" },
+    "name": "deleted-pod",
+    "namespace": "default",
+    "operation": "DELETE",
+    "userInfo": {
+      "username": "system:serviceaccount:kube-system:replicaset-controller",
+      "uid": "4cdf5173-88c7-42cf-bb3f-0e873e6e2655"
+    },
+    "object": null,
+    "oldObject": {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deleted-pod",
+        "namespace": "default",
+        "uid": "99999999-8888-7777-6666-555555555555"
+      },
+      "spec": {
+        "containers": [
+          { "name": "main", "image": "nginx:1.25" }
+        ]
+      }
+    }
+  }
+}

--- a/providers/k8s/resources/testdata/serviceaccount_automount.yaml
+++ b/providers/k8s/resources/testdata/serviceaccount_automount.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-default
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-explicit-true
+  namespace: default
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-explicit-false
+  namespace: default
+automountServiceAccountToken: false


### PR DESCRIPTION
## What

Four correctness fixes in the Kubernetes provider, surfaced by a focused review of the resource-mapping, discovery, and connection layers. Each fix ships with a regression test that fails on the pre-fix code and passes after.

## Fixes

### 1. Panic on DELETE admission reviews (High) — `resources/admission.go`
`request()` indexed `obj[0]` unconditionally, but on a DELETE review the incoming object is empty (the object lives in `oldObject`), so `ResourcesFromManifest` returns an empty slice and `obj[0]` panics. Because the executor runs blocks in goroutines, the panic is unrecoverable and crashes the whole scan. The symmetric `oldObject` path was already guarded; this guards `object` the same way (null when empty) and nil-checks `Request`.

### 2. Admission connection hardening — `connection/admission/connection.go`
Skip reviews whose `Request` is nil when collecting asset objects, and use a checked type assertion when materializing `AdmissionReviews()` so a malformed (base64, attacker-influenceable) webhook payload that deserializes to another type can't panic the provider.

### 3. Discovery silently truncated on any List error (Medium) — `connection/shared/resources/discovery.go`
`GetKindResources` (the live cluster discovery path) treated *every* List error as "user has no permission": it logged and broke the pagination loop, returning partial/empty results with a `nil` error. A transient blip (429, a 500, an expired continue token mid-pagination) therefore read as "this kind has no objects." Now only `Forbidden`/`Unauthorized` are swallowed; every other error propagates.

### 4. ServiceAccount nil-pointer dereference (Medium) — `resources/serviceaccount.go`
`automountServiceAccountToken` was dereferenced unconditionally while the default-true was gated on `apiVersion == "v1"`; an unset field on a SA whose TypeMeta isn't populated (the manifest path) left the pointer nil and panicked. Computed with a nil-safe default-true instead (ServiceAccount is core/v1 only, so unset always means true). Drops the now-unused `k8s.io/utils` dependency to indirect.

## Tests

- `TestAdmissionReviewRequest_Delete` / `_Create` — DELETE resolves to a null object without panicking; CREATE still populates the object. (DELETE test panics with `index out of range [0]` on the old code.)
- `TestGetKindResources_ForbiddenIsSwallowed` / `_OtherErrorPropagates` / `_Pagination` — forbidden is skipped, other errors propagate, multi-page results concatenate. (Propagation test fails on the old code.) Driven by a fake dynamic client with reactors.
- `TestServiceAccountAutomountDefault` — unset defaults to true, explicit true/false preserved.

All k8s provider tests, `gofmt`, and `go vet` pass. A separate PR expands broader regression coverage (storage/Gateway-API cross-references, discovery filters, platform-id construction).

## Out of scope (noted, not fixed here)
- `Status()` (`connection/shared/resources/status.go`) panics on unsupported kinds but has **no callers** (dead code).
- `GetAllResources` has a `collectErr` data race but is also uncalled.
- The shortname-index copy-paste (`resource.go:107`) is real but unobservable: `ApiNames()` already injects bare short names into the kind index, which `find()` checks first.