### PR TITLE
🧹 k8s: expand regression test coverage (cross-refs, filters, platform ids)

### DIFF
--- a/providers/k8s/connection/shared/platform_id_test.go
+++ b/providers/k8s/connection/shared/platform_id_test.go
@@ -1,0 +1,48 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewWorkloadPlatformId pins the workload platform-id construction, which
+// is load-bearing for asset identity and caching: a regression silently merges
+// or splits assets. It covers pluralization, the namespace-injection branch
+// (which keys off whether the cluster identifier already contains "namespace"),
+// and the namespace delegation.
+func TestNewWorkloadPlatformId(t *testing.T) {
+	const base = "//platformid.api.mondoo.app/runtime/k8s/uid/abc"
+
+	t.Run("injects namespace when cluster id lacks one", func(t *testing.T) {
+		got := NewWorkloadPlatformId(base, "/cluster/123", "deployment", "prod", "api", "uid-1")
+		assert.Equal(t, "/cluster/123/namespace/prod/deployments/name/api", got)
+	})
+
+	t.Run("does not double-inject namespace when cluster id already has one", func(t *testing.T) {
+		// When scanning with --namespace, the cluster identifier already
+		// carries the namespace and must not get a second segment.
+		clusterID := "/cluster/123/namespace/prod"
+		got := NewWorkloadPlatformId(base, clusterID, "deployment", "prod", "api", "uid-1")
+		assert.Equal(t, "/cluster/123/namespace/prod/deployments/name/api", got)
+	})
+
+	t.Run("omits namespace segment for empty namespace", func(t *testing.T) {
+		got := NewWorkloadPlatformId(base, "/cluster/123", "node", "", "worker-1", "uid-2")
+		assert.Equal(t, "/cluster/123/nodes/name/worker-1", got)
+	})
+
+	t.Run("namespace workload type delegates to namespace id", func(t *testing.T) {
+		got := NewWorkloadPlatformId(base, "/cluster/123", "namespace", "", "prod", "uid-3")
+		assert.Equal(t, NewNamespacePlatformId(base, "prod", "uid-3"), got)
+	})
+}
+
+func TestNewNamespacePlatformId(t *testing.T) {
+	const base = "//platformid.api.mondoo.app/runtime/k8s/uid/abc"
+	got := NewNamespacePlatformId(base, "prod", "uid-3")
+	assert.Equal(t, base+"uid-3/namespace/prod", got)
+}

--- a/providers/k8s/resources/cross_references_storage_test.go
+++ b/providers/k8s/resources/cross_references_storage_test.go
@@ -1,0 +1,125 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// These tests cover the storage and networking/Gateway-API cross-references,
+// which had no fixture coverage. They lean on the shared cross_references.yaml
+// fixture and the loadCrossRefRuntime harness.
+
+func TestPVClaimAndStorageClassRefs(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.persistentvolume", map[string]*llx.RawData{
+		"name": llx.StringData("pv-data"),
+	})
+	require.NoError(t, err)
+	pv := obj.(*mqlK8sPersistentvolume)
+
+	claim := pv.GetClaim()
+	require.NoError(t, claim.Error)
+	require.NotNil(t, claim.Data, "pv-data is bound to data-claim")
+	assert.Equal(t, "data-claim", claim.Data.Name.Data)
+	assert.Equal(t, "prod", claim.Data.Namespace.Data,
+		"claim() must carry the namespace from claimRef, not drop it")
+
+	sc := pv.GetStorageClass()
+	require.NoError(t, sc.Error)
+	require.NotNil(t, sc.Data)
+	assert.Equal(t, "fast", sc.Data.Name.Data)
+}
+
+func TestPVUnboundRefsAreNull(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.persistentvolume", map[string]*llx.RawData{
+		"name": llx.StringData("pv-unbound"),
+	})
+	require.NoError(t, err)
+	pv := obj.(*mqlK8sPersistentvolume)
+
+	claim := pv.GetClaim()
+	require.NoError(t, claim.Error)
+	assert.Nil(t, claim.Data, "an unbound PV has no claim")
+	assert.NotZero(t, claim.State&plugin.StateIsNull, "claim must be marked null, not left unresolved")
+
+	sc := pv.GetStorageClass()
+	require.NoError(t, sc.Error)
+	assert.Nil(t, sc.Data, "a PV without a storageClassName has no storage class")
+	assert.NotZero(t, sc.State&plugin.StateIsNull)
+}
+
+func TestPVCVolumeAndStorageClassRefs(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.persistentvolumeclaim", map[string]*llx.RawData{
+		"name":      llx.StringData("data-claim"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pvc := obj.(*mqlK8sPersistentvolumeclaim)
+
+	vol := pvc.GetVolume()
+	require.NoError(t, vol.Error)
+	require.NotNil(t, vol.Data, "data-claim is bound to pv-data")
+	assert.Equal(t, "pv-data", vol.Data.Name.Data)
+
+	sc := pvc.GetStorageClass()
+	require.NoError(t, sc.Error)
+	require.NotNil(t, sc.Data)
+	assert.Equal(t, "fast", sc.Data.Name.Data)
+}
+
+// TestPVCStorageClassNotFoundIsNull exercises the ErrResourceNotFound swallow:
+// a PVC that references a StorageClass with no matching object must resolve to
+// null (not error), so a deleted/cluster-scoped class doesn't fail the query.
+func TestPVCStorageClassNotFoundIsNull(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.persistentvolumeclaim", map[string]*llx.RawData{
+		"name":      llx.StringData("missing-sc-claim"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pvc := obj.(*mqlK8sPersistentvolumeclaim)
+
+	sc := pvc.GetStorageClass()
+	require.NoError(t, sc.Error, "a missing StorageClass must resolve to null, not error")
+	assert.Nil(t, sc.Data)
+	assert.NotZero(t, sc.State&plugin.StateIsNull)
+}
+
+func TestIngressClassRef(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.ingress", map[string]*llx.RawData{
+		"name":      llx.StringData("web"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	ing := obj.(*mqlK8sIngress)
+
+	ic := ing.GetIngressClass()
+	require.NoError(t, ic.Error)
+	require.NotNil(t, ic.Data, "ingress 'web' references ingressClassName 'nginx'")
+	assert.Equal(t, "nginx", ic.Data.Name.Data)
+}
+
+func TestGatewayClassRef(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.gateway", map[string]*llx.RawData{
+		"name":      llx.StringData("public-gw"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	gw := obj.(*mqlK8sGateway)
+
+	gc := gw.GetGatewayClass()
+	require.NoError(t, gc.Error)
+	require.NotNil(t, gc.Data, "gateway 'public-gw' references gatewayClassName 'istio'")
+	assert.Equal(t, "istio", gc.Data.Name.Data)
+}

--- a/providers/k8s/resources/namespace_filter_test.go
+++ b/providers/k8s/resources/namespace_filter_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSkipNamespace pins the include/exclude precedence and glob behavior of
+// the namespace filter, which governs exactly which namespaces become assets.
+// It is a small, inverted-condition-prone function with no prior coverage.
+func TestSkipNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		include   []string
+		exclude   []string
+		namespace string
+		wantSkip  bool
+	}{
+		{name: "no filters accepts everything", namespace: "prod", wantSkip: false},
+		{name: "include exact match is kept", include: []string{"prod"}, namespace: "prod", wantSkip: false},
+		{name: "include non-match is skipped", include: []string{"prod"}, namespace: "dev", wantSkip: true},
+		{name: "include glob match is kept", include: []string{"kube-*"}, namespace: "kube-system", wantSkip: false},
+		{name: "include glob non-match is skipped", include: []string{"kube-*"}, namespace: "prod", wantSkip: true},
+		{name: "exclude exact match is skipped", exclude: []string{"kube-system"}, namespace: "kube-system", wantSkip: true},
+		{name: "exclude non-match is kept", exclude: []string{"kube-system"}, namespace: "prod", wantSkip: false},
+		{name: "exclude glob match is skipped", exclude: []string{"kube-*"}, namespace: "kube-public", wantSkip: true},
+		// include takes precedence: a namespace matched by include is kept even
+		// if it would also match exclude.
+		{name: "include wins over exclude (kept)", include: []string{"prod"}, exclude: []string{"prod"}, namespace: "prod", wantSkip: false},
+		// with include set, a namespace not in include is skipped regardless of exclude.
+		{name: "include set skips non-included even when not excluded", include: []string{"prod"}, exclude: []string{"dev"}, namespace: "staging", wantSkip: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &NamespaceFilterOpts{include: tt.include, exclude: tt.exclude}
+			assert.Equal(t, tt.wantSkip, f.skipNamespace(tt.namespace))
+		})
+	}
+}

--- a/providers/k8s/resources/testdata/cross_references.yaml
+++ b/providers/k8s/resources/testdata/cross_references.yaml
@@ -597,3 +597,108 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Ignore
+---
+# --- Storage cross-references -------------------------------------------------
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast
+provisioner: kubernetes.io/no-provisioner
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-data
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: fast
+  claimRef:
+    name: data-claim
+    namespace: prod
+  hostPath:
+    path: /tmp/pv-data
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-unbound
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes: ["ReadWriteOnce"]
+  hostPath:
+    path: /tmp/pv-unbound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-claim
+  namespace: prod
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: fast
+  volumeName: pv-data
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: missing-sc-claim
+  namespace: prod
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: nonexistent
+  resources:
+    requests:
+      storage: 1Gi
+---
+# --- Ingress cross-references -------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: prod
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 80
+---
+# --- Gateway API cross-references ---------------------------------------------
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public-gw
+  namespace: prod
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80


### PR DESCRIPTION
## What

Adds regression coverage for parts of the Kubernetes provider that had none. Every test passes against current `main` (this PR adds no production code), so it's a safety net for future refactors. It complements the bugfix PR #8578, which carries its own bug-pinning tests.

## Coverage added

### Storage & Gateway-API cross-references
The shared fixture `testdata/cross_references.yaml` had zero storage or Gateway-API objects, leaving those cross-references untested. Added a `StorageClass`, two `PersistentVolume`s (bound + unbound), two `PersistentVolumeClaim`s (bound + one with a dangling `storageClassName`), an `IngressClass`/`Ingress`, and a `GatewayClass`/`Gateway`. New tests (`cross_references_storage_test.go`):

- `pv.claim` (carrying the namespace from `claimRef`) and `pv.storageClass`
- `pvc.volume` and `pvc.storageClass`
- `ingress.ingressClass`, `gateway.gatewayClass`
- the unbound/empty **null** paths (state marked `StateIsNull`, not left unresolved)
- the `ErrResourceNotFound → null` swallow for a referenced-but-missing `StorageClass`

### Namespace filter
`NamespaceFilterOpts.skipNamespace` decides which namespaces become assets and is a small, inverted-condition-prone function with no prior coverage. A table test (`namespace_filter_test.go`) pins include/exclude precedence (include wins), glob matching (`kube-*`), and the empty-filter accept-all case.

### Platform-id construction
`NewWorkloadPlatformId` / `NewNamespacePlatformId` underpin asset identity and caching — a regression silently merges or splits assets. `platform_id_test.go` pins pluralization, the namespace-injection branch (keyed on whether the cluster identifier already contains `namespace`), the empty-namespace case, and the `namespace` workload-type delegation.

All k8s provider tests and `gofmt` pass.