### PR TITLE
🎉 k8s-13.3.0

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.2.1",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### k8s (13.3.0)
- 🧹 k8s: expand regression test coverage for cross-refs, filters, platform ids (#8579)
- ✨ k8s: workload-level securityContext rollup predicates (#8577)
- 📄 k8s: add multi-line descriptions to top-level resources (#8576)
- ✨ k8s: typed RBAC policy rules + privilege-escalation predicates (#8575)
- ✨ k8s: surface Pod Security Standards + ValidatingAdmissionPolicy (#8574)
- 🧹 Update deps for mql and providers 20260615 (#8443)
- ✨ k8s: expose object provenance via typed ownerReferences and managedFields (#8357)
