### PR TITLE
✨ k8s: seccomp profile rollup predicates for workloads

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -405,6 +405,17 @@ private k8s.pod @defaults("namespace name created"){
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -586,6 +597,17 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -699,6 +721,17 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -811,6 +844,17 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -931,6 +975,17 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1031,6 +1086,17 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1156,6 +1222,17 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Whether any container effectively runs with the Unconfined seccomp profile
+  //
+  // Resolves the container-level seccomp profile, falling back to the pod-level
+  // default. True when any container ends up Unconfined (no syscall filtering).
+  usesUnconfinedSeccomp() bool
+  // Whether every container has a confining seccomp profile set
+  //
+  // True only when each container effectively uses RuntimeDefault or Localhost
+  // (container-level setting wins over the pod default). An unset or Unconfined
+  // profile on any container makes this false.
+  hasSeccompProfile() bool
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -833,6 +833,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetUsesHostPath()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
 	"k8s.pod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetId()).ToDataRes(types.String)
 	},
@@ -1067,6 +1073,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetUsesHostPath()).ToDataRes(types.Bool)
 	},
+	"k8s.deployment.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
 	"k8s.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -1199,6 +1211,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetUsesHostPath()).ToDataRes(types.Bool)
 	},
+	"k8s.daemonset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
 	"k8s.daemonset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetId()).ToDataRes(types.String)
 	},
@@ -1327,6 +1345,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
 	"k8s.statefulset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetId()).ToDataRes(types.String)
@@ -1472,6 +1496,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetUsesHostPath()).ToDataRes(types.Bool)
 	},
+	"k8s.replicaset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
 	"k8s.replicaset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetId()).ToDataRes(types.String)
 	},
@@ -1585,6 +1615,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.job.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
 	"k8s.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetId()).ToDataRes(types.String)
@@ -1735,6 +1771,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
 	"k8s.cronjob.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetId()).ToDataRes(types.String)
@@ -4686,6 +4728,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5002,6 +5052,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5182,6 +5240,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5356,6 +5422,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5554,6 +5628,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5708,6 +5790,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.job.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5912,6 +6002,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesUnconfinedSeccomp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11147,6 +11245,8 @@ type mqlK8sPod struct {
 	AddedCapabilities             plugin.TValue[[]any]
 	UsesHostNamespaces            plugin.TValue[bool]
 	UsesHostPath                  plugin.TValue[bool]
+	UsesUnconfinedSeccomp         plugin.TValue[bool]
+	HasSeccompProfile             plugin.TValue[bool]
 	Id                            plugin.TValue[string]
 	Uid                           plugin.TValue[string]
 	ResourceVersion               plugin.TValue[string]
@@ -11296,6 +11396,18 @@ func (c *mqlK8sPod) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sPod) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -11831,6 +11943,8 @@ type mqlK8sDeployment struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	UsesUnconfinedSeccomp        plugin.TValue[bool]
+	HasSeccompProfile            plugin.TValue[bool]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -11976,6 +12090,18 @@ func (c *mqlK8sDeployment) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -12219,6 +12345,8 @@ type mqlK8sDaemonset struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	UsesUnconfinedSeccomp        plugin.TValue[bool]
+	HasSeccompProfile            plugin.TValue[bool]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -12363,6 +12491,18 @@ func (c *mqlK8sDaemonset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -12600,6 +12740,8 @@ type mqlK8sStatefulset struct {
 	AddedCapabilities                    plugin.TValue[[]any]
 	UsesHostNamespaces                   plugin.TValue[bool]
 	UsesHostPath                         plugin.TValue[bool]
+	UsesUnconfinedSeccomp                plugin.TValue[bool]
+	HasSeccompProfile                    plugin.TValue[bool]
 	Id                                   plugin.TValue[string]
 	Uid                                  plugin.TValue[string]
 	ResourceVersion                      plugin.TValue[string]
@@ -12749,6 +12891,18 @@ func (c *mqlK8sStatefulset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -13016,6 +13170,8 @@ type mqlK8sReplicaset struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	UsesUnconfinedSeccomp        plugin.TValue[bool]
+	HasSeccompProfile            plugin.TValue[bool]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13155,6 +13311,18 @@ func (c *mqlK8sReplicaset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -13362,6 +13530,8 @@ type mqlK8sJob struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	UsesUnconfinedSeccomp        plugin.TValue[bool]
+	HasSeccompProfile            plugin.TValue[bool]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13513,6 +13683,18 @@ func (c *mqlK8sJob) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sJob) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 
@@ -13792,6 +13974,8 @@ type mqlK8sCronjob struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	UsesUnconfinedSeccomp        plugin.TValue[bool]
+	HasSeccompProfile            plugin.TValue[bool]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13933,6 +14117,18 @@ func (c *mqlK8sCronjob) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedSeccomp, func() (bool, error) {
+		return c.usesUnconfinedSeccomp()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasSeccompProfile() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
+		return c.hasSeccompProfile()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -215,6 +215,7 @@ k8s.cronjob.containers 9.0.0
 k8s.cronjob.created 9.0.0
 k8s.cronjob.dropsAllCapabilities 13.2.2
 k8s.cronjob.failedJobsHistoryLimit 13.0.16
+k8s.cronjob.hasSeccompProfile 13.3.1
 k8s.cronjob.hasWritableRootFilesystem 13.2.2
 k8s.cronjob.hostIPC 13.2.2
 k8s.cronjob.hostNetwork 13.2.2
@@ -244,6 +245,7 @@ k8s.cronjob.timeZone 13.0.16
 k8s.cronjob.uid 9.0.0
 k8s.cronjob.usesHostNamespaces 13.2.2
 k8s.cronjob.usesHostPath 13.2.2
+k8s.cronjob.usesUnconfinedSeccomp 13.3.1
 k8s.cronjobs 9.0.0
 k8s.customresource 9.0.0
 k8s.customresource.annotations 9.0.0
@@ -271,6 +273,7 @@ k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
 k8s.daemonset.desiredNumberScheduled 13.0.16
 k8s.daemonset.dropsAllCapabilities 13.2.2
+k8s.daemonset.hasSeccompProfile 13.3.1
 k8s.daemonset.hasWritableRootFilesystem 13.2.2
 k8s.daemonset.hostIPC 13.2.2
 k8s.daemonset.hostNetwork 13.2.2
@@ -303,6 +306,7 @@ k8s.daemonset.updateStrategy 13.0.16
 k8s.daemonset.updatedNumberScheduled 13.0.16
 k8s.daemonset.usesHostNamespaces 13.2.2
 k8s.daemonset.usesHostPath 13.2.2
+k8s.daemonset.usesUnconfinedSeccomp 13.3.1
 k8s.daemonsets 9.0.0
 k8s.deployment 9.0.0
 k8s.deployment.addedCapabilities 13.2.2
@@ -316,6 +320,7 @@ k8s.deployment.containers 9.0.0
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
 k8s.deployment.dropsAllCapabilities 13.2.2
+k8s.deployment.hasSeccompProfile 13.3.1
 k8s.deployment.hasWritableRootFilesystem 13.2.2
 k8s.deployment.hostIPC 13.2.2
 k8s.deployment.hostNetwork 13.2.2
@@ -349,6 +354,7 @@ k8s.deployment.unavailableReplicas 13.0.16
 k8s.deployment.updatedReplicas 13.0.16
 k8s.deployment.usesHostNamespaces 13.2.2
 k8s.deployment.usesHostPath 13.2.2
+k8s.deployment.usesUnconfinedSeccomp 13.3.1
 k8s.deployments 9.0.0
 k8s.endpointSlices 11.1.139
 k8s.endpointslice 11.1.139
@@ -620,6 +626,7 @@ k8s.job.created 9.0.0
 k8s.job.dropsAllCapabilities 13.2.2
 k8s.job.failed 13.0.16
 k8s.job.failedIndexes 13.0.16
+k8s.job.hasSeccompProfile 13.3.1
 k8s.job.hasWritableRootFilesystem 13.2.2
 k8s.job.hostIPC 13.2.2
 k8s.job.hostNetwork 13.2.2
@@ -652,6 +659,7 @@ k8s.job.ttlSecondsAfterFinished 13.0.16
 k8s.job.uid 9.0.0
 k8s.job.usesHostNamespaces 13.2.2
 k8s.job.usesHostPath 13.2.2
+k8s.job.usesUnconfinedSeccomp 13.3.1
 k8s.jobs 9.0.0
 k8s.lease 13.0.16
 k8s.lease.acquireTime 13.0.16
@@ -889,6 +897,7 @@ k8s.pod.dnsPolicy 13.0.16
 k8s.pod.dropsAllCapabilities 13.2.2
 k8s.pod.enableServiceLinks 13.0.16
 k8s.pod.ephemeralContainers 9.0.0
+k8s.pod.hasSeccompProfile 13.3.1
 k8s.pod.hasWritableRootFilesystem 13.2.2
 k8s.pod.hostAliases 13.0.16
 k8s.pod.hostIP 13.0.16
@@ -944,6 +953,7 @@ k8s.pod.topologySpreadConstraints 13.0.16
 k8s.pod.uid 9.0.0
 k8s.pod.usesHostNamespaces 13.2.2
 k8s.pod.usesHostPath 13.2.2
+k8s.pod.usesUnconfinedSeccomp 13.3.1
 k8s.podDisruptionBudgets 13.0.16
 k8s.poddisruptionbudget 13.0.16
 k8s.poddisruptionbudget.annotations 13.0.16
@@ -1092,6 +1102,7 @@ k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
 k8s.replicaset.dropsAllCapabilities 13.2.2
 k8s.replicaset.fullyLabeledReplicas 13.0.16
+k8s.replicaset.hasSeccompProfile 13.3.1
 k8s.replicaset.hasWritableRootFilesystem 13.2.2
 k8s.replicaset.hostIPC 13.2.2
 k8s.replicaset.hostNetwork 13.2.2
@@ -1119,6 +1130,7 @@ k8s.replicaset.selector 13.0.16
 k8s.replicaset.uid 9.0.0
 k8s.replicaset.usesHostNamespaces 13.2.2
 k8s.replicaset.usesHostPath 13.2.2
+k8s.replicaset.usesUnconfinedSeccomp 13.3.1
 k8s.replicasets 9.0.0
 k8s.resourceQuotas 11.1.139
 k8s.resourcequota 11.1.139
@@ -1227,6 +1239,7 @@ k8s.statefulset.currentReplicas 13.0.16
 k8s.statefulset.currentRevision 13.0.16
 k8s.statefulset.desiredReplicas 13.0.16
 k8s.statefulset.dropsAllCapabilities 13.2.2
+k8s.statefulset.hasSeccompProfile 13.3.1
 k8s.statefulset.hasWritableRootFilesystem 13.2.2
 k8s.statefulset.hostIPC 13.2.2
 k8s.statefulset.hostNetwork 13.2.2
@@ -1262,6 +1275,7 @@ k8s.statefulset.updateStrategy 13.0.16
 k8s.statefulset.updatedReplicas 13.0.16
 k8s.statefulset.usesHostNamespaces 13.2.2
 k8s.statefulset.usesHostPath 13.2.2
+k8s.statefulset.usesUnconfinedSeccomp 13.3.1
 k8s.statefulsets 9.0.0
 k8s.storageClasses 11.1.139
 k8s.storageclass 11.1.139

--- a/providers/k8s/resources/testdata/workload-security.yaml
+++ b/providers/k8s/resources/testdata/workload-security.yaml
@@ -19,6 +19,9 @@ spec:
         app: hardened
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: nginx:1.25
@@ -64,6 +67,8 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+          seccompProfile:
+            type: Unconfined
           capabilities:
             add: ["NET_RAW"]
       volumes:

--- a/providers/k8s/resources/workload_security.go
+++ b/providers/k8s/resources/workload_security.go
@@ -175,6 +175,51 @@ func specAutomountServiceAccountToken(spec *corev1.PodSpec) bool {
 	return spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken
 }
 
+// effectiveSeccompType resolves the seccomp profile type that applies to a
+// container: a container-level profile wins over the pod-level default, and an
+// empty string means no profile is set at either level.
+func effectiveSeccompType(spec *corev1.PodSpec, c corev1.Container) corev1.SeccompProfileType {
+	if c.SecurityContext != nil && c.SecurityContext.SeccompProfile != nil {
+		return c.SecurityContext.SeccompProfile.Type
+	}
+	if spec != nil && spec.SecurityContext != nil && spec.SecurityContext.SeccompProfile != nil {
+		return spec.SecurityContext.SeccompProfile.Type
+	}
+	return ""
+}
+
+// specUsesUnconfinedSeccomp reports whether any container effectively runs with
+// the Unconfined seccomp profile (no syscall filtering). This is the Pod
+// Security Standards "baseline" seccomp check.
+func specUsesUnconfinedSeccomp(spec *corev1.PodSpec) bool {
+	for _, c := range allWorkloadContainers(spec) {
+		if effectiveSeccompType(spec, c) == corev1.SeccompProfileTypeUnconfined {
+			return true
+		}
+	}
+	return false
+}
+
+// specHasSeccompProfile reports whether every container has an effective seccomp
+// profile explicitly set to a confining value (RuntimeDefault or Localhost).
+// An unset or Unconfined profile on any container makes this false. This is the
+// stricter Pod Security Standards "restricted" seccomp check.
+func specHasSeccompProfile(spec *corev1.PodSpec) bool {
+	containers := allWorkloadContainers(spec)
+	if len(containers) == 0 {
+		return false
+	}
+	for _, c := range containers {
+		switch effectiveSeccompType(spec, c) {
+		case corev1.SeccompProfileTypeRuntimeDefault, corev1.SeccompProfileTypeLocalhost:
+			// confined
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // boolFromSpec and friends adapt the spec-level helpers to the (value, error)
 // shape the generated resource accessors expect.
 func boolFromSpec(spec *corev1.PodSpec, err error, fn func(*corev1.PodSpec) bool) (bool, error) {
@@ -241,6 +286,16 @@ func (k *mqlK8sPod) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sPod) usesHostPath() (bool, error) {
 	spec, err := k.podSpecTyped()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sPod) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sPod) hasSeccompProfile() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
 }
 
 // ---- k8s.deployment ----
@@ -317,6 +372,16 @@ func (k *mqlK8sDeployment) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sDeployment) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sDeployment) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
+}
+
 // ---- k8s.daemonset ----
 
 func (k *mqlK8sDaemonset) securitySpec() (*corev1.PodSpec, error) {
@@ -389,6 +454,16 @@ func (k *mqlK8sDaemonset) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sDaemonset) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sDaemonset) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sDaemonset) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
 }
 
 // ---- k8s.statefulset ----
@@ -465,6 +540,16 @@ func (k *mqlK8sStatefulset) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sStatefulset) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sStatefulset) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
+}
+
 // ---- k8s.replicaset ----
 
 func (k *mqlK8sReplicaset) securitySpec() (*corev1.PodSpec, error) {
@@ -537,6 +622,16 @@ func (k *mqlK8sReplicaset) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sReplicaset) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sReplicaset) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sReplicaset) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
 }
 
 // ---- k8s.job ----
@@ -613,6 +708,16 @@ func (k *mqlK8sJob) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sJob) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sJob) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
+}
+
 // ---- k8s.cronjob ----
 
 func (k *mqlK8sCronjob) securitySpec() (*corev1.PodSpec, error) {
@@ -685,4 +790,14 @@ func (k *mqlK8sCronjob) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sCronjob) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sCronjob) usesUnconfinedSeccomp() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
+}
+
+func (k *mqlK8sCronjob) hasSeccompProfile() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasSeccompProfile)
 }

--- a/providers/k8s/resources/workload_security_test.go
+++ b/providers/k8s/resources/workload_security_test.go
@@ -61,6 +61,8 @@ func TestWorkloadSecurityRollups_NilSpec(t *testing.T) {
 		assert.False(t, specUsesHostNamespaces(nil), "usesHostNamespaces")
 		assert.False(t, specUsesHostPath(nil), "usesHostPath")
 		assert.False(t, specAutomountServiceAccountToken(nil), "automountServiceAccountToken")
+		assert.False(t, specUsesUnconfinedSeccomp(nil), "usesUnconfinedSeccomp")
+		assert.False(t, specHasSeccompProfile(nil), "hasSeccompProfile")
 	})
 
 	// dictFromSpec must not dereference a nil spec.
@@ -84,6 +86,9 @@ func TestWorkloadSecurityRollups(t *testing.T) {
 		assert.False(t, d.GetUsesHostPath().Data, "usesHostPath")
 		assert.False(t, d.GetAutomountServiceAccountToken().Data, "automountServiceAccountToken")
 		assert.False(t, d.GetHostNetwork().Data, "hostNetwork")
+		// Pod-level RuntimeDefault profile applies to the container.
+		assert.False(t, d.GetUsesUnconfinedSeccomp().Data, "usesUnconfinedSeccomp")
+		assert.True(t, d.GetHasSeccompProfile().Data, "hasSeccompProfile")
 	})
 
 	t.Run("risky workload", func(t *testing.T) {
@@ -102,6 +107,9 @@ func TestWorkloadSecurityRollups(t *testing.T) {
 		assert.False(t, d.GetHostIPC().Data, "hostIPC")
 		// automountServiceAccountToken defaults to true when unset
 		assert.True(t, d.GetAutomountServiceAccountToken().Data, "automountServiceAccountToken")
+		// The main container explicitly sets the Unconfined seccomp profile.
+		assert.True(t, d.GetUsesUnconfinedSeccomp().Data, "usesUnconfinedSeccomp")
+		assert.False(t, d.GetHasSeccompProfile().Data, "hasSeccompProfile")
 	})
 
 	t.Run("pod-level runAsNonRoot is folded into runsAsRoot", func(t *testing.T) {
@@ -164,6 +172,8 @@ type rollupReader interface {
 	GetHostNetwork() *plugin.TValue[bool]
 	GetHostPID() *plugin.TValue[bool]
 	GetHostIPC() *plugin.TValue[bool]
+	GetUsesUnconfinedSeccomp() *plugin.TValue[bool]
+	GetHasSeccompProfile() *plugin.TValue[bool]
 	GetSecurityContext() *plugin.TValue[any]
 }
 
@@ -215,6 +225,9 @@ func TestWorkloadSecurityRollups_AllKinds(t *testing.T) {
 			assert.False(t, r.GetHostNetwork().Data, "hostNetwork")
 			assert.False(t, r.GetHostPID().Data, "hostPID")
 			assert.False(t, r.GetHostIPC().Data, "hostIPC")
+			// No seccomp profile is set, so it is neither Unconfined nor confined.
+			assert.False(t, r.GetUsesUnconfinedSeccomp().Data, "usesUnconfinedSeccomp")
+			assert.False(t, r.GetHasSeccompProfile().Data, "hasSeccompProfile")
 			// securityContext resolves without error even when unset.
 			assert.NoError(t, r.GetSecurityContext().Error, "securityContext")
 		})


### PR DESCRIPTION
## Summary

Completes the workload-level securityContext rollups (added in #8577) with seccomp coverage. Adds two predicates to every workload kind — `k8s.pod`, `k8s.deployment`, `k8s.daemonset`, `k8s.statefulset`, `k8s.replicaset`, `k8s.job`, `k8s.cronjob`:

- **`usesUnconfinedSeccomp()`** — any container effectively runs with the `Unconfined` seccomp profile (no syscall filtering). This is the Pod Security Standards *baseline* seccomp check.
- **`hasSeccompProfile()`** — every container is confined to `RuntimeDefault` or `Localhost`. This is the stricter *restricted* seccomp check.

Both resolve the **effective** profile per container: a container-level `seccompProfile` wins over the pod-level default, matching how the kubelet applies it.

## Why

Seccomp posture was previously only reachable by digging into the raw `securityContext` dict. Now:

```mql
k8s.deployments.where( usesUnconfinedSeccomp )       # find workloads with no syscall filtering
k8s.pods.all( hasSeccompProfile )                    # confirm every pod is confined
```

This is also the last seccomp primitive needed for the Pod Security Standards evaluator (follow-up PR).

## Tests

Extended `testdata/workload-security.yaml` (pod-level `RuntimeDefault` on the hardened workload, container-level `Unconfined` on the risky one) and `workload_security_test.go`: the hardened/risky deployment subtests, the all-kinds per-resource wiring table, and the nil-spec guard all assert both predicates. Full `providers/k8s` test suite passes; `go vet` and `gofmt` clean.

Generated files (`k8s.lr.go`, `k8s.lr.versions`, `dist/k8s.json`) regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)