### PR TITLE
🧹 windows: model binary registry settings as bool instead of int

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6945,34 +6945,32 @@ private windows.update.config @defaults("catalogSource rebootPending") {
 private windows.update.policy @defaults("automaticUpdatesEnabled noAutoUpdate scheduledInstallDay") {
   // Whether automatic updates are configured and enabled (AU\NoAutoUpdate is present and 0)
   automaticUpdatesEnabled bool
-  // Configure Automatic Updates state (AU\NoAutoUpdate): 0 = automatic updates enabled, 1 = disabled; null when not configured
-  noAutoUpdate int
+  // Whether automatic updates are turned off (AU\NoAutoUpdate); null when not configured
+  noAutoUpdate bool
   // Scheduled install day (AU\ScheduledInstallDay): 0 = every day, 1-7 = Sunday-Saturday; null when not configured
   scheduledInstallDay int
   // Scheduled install time as the hour of day (AU\ScheduledInstallTime), 0-23; null when not configured
   scheduledInstallTime int
-  // No auto-restart with logged on users for scheduled installations (AU\NoAutoRebootWithLoggedOnUsers)
-  //
-  // 1 = do not auto-restart while users are logged on, 0 = allow auto-restart; null when not configured.
-  noAutoRebootWithLoggedOnUsers int
+  // Whether scheduled installations do not auto-restart while users are logged on (AU\NoAutoRebootWithLoggedOnUsers); null when not configured
+  noAutoRebootWithLoggedOnUsers bool
   // Manage preview builds (WindowsUpdate\ManagePreviewBuildsPolicyValue)
   //
   // 0 = disable preview builds, 1 = enable, 2 = enable for next release; null when not configured.
   managePreviewBuilds int
-  // Whether feature update deferral is enabled (WindowsUpdate\DeferFeatureUpdates): 1 = enabled, 0 = disabled; null when not configured
-  deferFeatureUpdates int
+  // Whether feature update deferral is enabled (WindowsUpdate\DeferFeatureUpdates); null when not configured
+  deferFeatureUpdates bool
   // Number of days feature updates are deferred (WindowsUpdate\DeferFeatureUpdatesPeriodInDays); null when not configured
   deferFeatureUpdatesPeriodInDays int
-  // Whether quality update deferral is enabled (WindowsUpdate\DeferQualityUpdates): 1 = enabled, 0 = disabled; null when not configured
-  deferQualityUpdates int
+  // Whether quality update deferral is enabled (WindowsUpdate\DeferQualityUpdates); null when not configured
+  deferQualityUpdates bool
   // Number of days quality updates are deferred (WindowsUpdate\DeferQualityUpdatesPeriodInDays); null when not configured
   deferQualityUpdatesPeriodInDays int
-  // Allow temporary enterprise feature control (WindowsUpdate\AllowTemporaryEnterpriseFeatureControl): 0 = disabled, 1 = enabled; null when not configured
-  allowTemporaryEnterpriseFeatureControl int
+  // Whether temporary enterprise feature control is allowed (WindowsUpdate\AllowTemporaryEnterpriseFeatureControl); null when not configured
+  allowTemporaryEnterpriseFeatureControl bool
   // Enable optional updates / optional content (WindowsUpdate\SetAllowOptionalContent); null when not configured
   allowOptionalContent int
-  // Remove access to pause updates (WindowsUpdate\SetDisablePauseUXAccess): 1 = remove the pause option, 0 = keep it; null when not configured
-  disablePauseUXAccess int
+  // Whether access to pause updates is removed (WindowsUpdate\SetDisablePauseUXAccess); null when not configured
+  disablePauseUXAccess bool
 }
 
 // Windows Server feature resource
@@ -7187,15 +7185,15 @@ private windows.winrm.service @defaults("allowBasic allowUnencryptedTraffic") {
 // \Microsoft\Windows\DeviceGuard. These configure Virtualization-Based
 // Security (VBS), Hypervisor-Enforced Code Integrity (HVCI / Memory
 // Integrity), Credential Guard, System Guard Secure Launch, and kernel-mode
-// hardware-enforced stack protection. Every field is an int that reads null
-// when the underlying value is absent, so "not configured" is distinguishable
-// from an explicit 0. Read from the Windows registry, so it is available even
-// on connections that cannot run commands.
+// hardware-enforced stack protection. On/off settings are exposed as booleans
+// and graded settings (such as the HVCI and Credential Guard lock modes) as
+// integers. Every field reads null when the underlying value is absent, so "not
+// configured" is distinguishable from an explicit false or 0. Read from the
+// Windows registry, so it is available even on connections that cannot run
+// commands.
 private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hypervisorEnforcedCodeIntegrity credentialGuardConfig") {
   // Whether Virtualization-Based Security is enabled (EnableVirtualizationBasedSecurity)
-  //
-  // 1=enabled, 0=disabled. Null when the value is not configured.
-  virtualizationBasedSecurityEnabled int
+  virtualizationBasedSecurityEnabled bool
   // Required platform security features for VBS (RequirePlatformSecurityFeatures)
   //
   // 1=Secure Boot, 3=Secure Boot and DMA Protection. Null when not configured.
@@ -7206,18 +7204,14 @@ private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hyperv
   // not configured.
   hypervisorEnforcedCodeIntegrity int
   // Whether HVCI requires a Memory Access Table (HVCIMATRequired)
-  //
-  // 1=require MAT, 0=do not require. Null when not configured.
-  hvciMatRequired int
+  hvciMatRequired bool
   // Credential Guard configuration (LsaCfgFlags)
   //
   // 0=off, 1=enabled with UEFI lock, 2=enabled without lock. Null when not
   // configured.
   credentialGuardConfig int
-  // System Guard Secure Launch configuration (ConfigureSystemGuardLaunch)
-  //
-  // 1=enabled, 0=disabled. Null when not configured.
-  systemGuardLaunch int
+  // Whether System Guard Secure Launch is enabled (ConfigureSystemGuardLaunch)
+  systemGuardLaunch bool
   // Kernel-mode hardware-enforced stack protection (ConfigureKernelShadowStacksLaunch)
   //
   // 1=enabled in enforcement mode, 2=enabled in audit mode, 0=disabled. Null
@@ -7229,43 +7223,45 @@ private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hyperv
 //
 // Examine the Local Security Authority configuration that backs the
 // "Network access", "Network security", and related security options under
-// HKLM\SYSTEM\CurrentControlSet\Control\Lsa. These DWORD and SDDL values
-// control anonymous access restrictions, blank-password use, LAN Manager
-// authentication level, NTLM hashing, LSA protection (RunAsPPL), and audit
-// behaviour. NTLM (MSV1_0 and WDigest) settings are grouped under `ntlm` and
-// the Netlogon secure-channel settings under `secureChannel`. Values are
-// nullable: an absent value resolves to null so it is distinguishable from an
-// explicit 0, letting checks assert on configured-vs-default precisely.
+// HKLM\SYSTEM\CurrentControlSet\Control\Lsa. These values control anonymous
+// access restrictions, blank-password use, LAN Manager authentication level,
+// NTLM hashing, LSA protection (RunAsPPL), and audit behaviour. On/off settings
+// are exposed as booleans and graded settings (such as the LAN Manager
+// authentication level) as integers. NTLM (MSV1_0 and WDigest) settings are
+// grouped under `ntlm` and the Netlogon secure-channel settings under
+// `secureChannel`. Values are nullable: an absent value resolves to null so it
+// is distinguishable from an explicit false or 0, letting checks assert on
+// configured-vs-default precisely.
 windows.lsa {
-  // Whether storing network authentication credentials is disabled (Lsa\DisableDomainCreds; 1 disables)
-  disableDomainCreds() int
-  // Whether the Everyone permissions apply to anonymous users (Lsa\EveryoneIncludesAnonymous; 0 excludes anonymous)
-  everyoneIncludesAnonymous() int
-  // Sharing and security model for local accounts (Lsa\ForceGuest; 0 classic, 1 guest only)
-  forceGuest() int
-  // Whether local accounts with blank passwords are limited to console logon (Lsa\LimitBlankPasswordUse; 1 limits)
-  limitBlankPasswordUse() int
+  // Whether storing network authentication credentials is disabled (Lsa\DisableDomainCreds)
+  disableDomainCreds() bool
+  // Whether the Everyone permissions apply to anonymous users (Lsa\EveryoneIncludesAnonymous)
+  everyoneIncludesAnonymous() bool
+  // Whether the guest-only sharing and security model is used for local accounts (Lsa\ForceGuest)
+  forceGuest() bool
+  // Whether local accounts with blank passwords are limited to console logon (Lsa\LimitBlankPasswordUse)
+  limitBlankPasswordUse() bool
   // LAN Manager authentication level (Lsa\LmCompatibilityLevel; 0-5, higher is stronger)
   lmCompatibilityLevel() int
-  // Whether the LAN Manager (LM) hash of new passwords is not stored (Lsa\NoLMHash; 1 disables LM hash storage)
-  noLmHash() int
+  // Whether the LAN Manager (LM) hash of new passwords is not stored (Lsa\NoLMHash)
+  noLmHash() bool
   // Restrictions on anonymous (null session) connections (Lsa\RestrictAnonymous; higher is more restrictive)
   restrictAnonymous() int
-  // Whether anonymous enumeration of SAM accounts is disallowed (Lsa\RestrictAnonymousSAM; 1 disallows)
-  restrictAnonymousSam() int
+  // Whether anonymous enumeration of SAM accounts is disallowed (Lsa\RestrictAnonymousSAM)
+  restrictAnonymousSam() bool
   // SDDL string controlling which clients may make remote SAM calls (Lsa\restrictremotesam, REG_SZ)
   restrictRemoteSam() string
   // LSA protection / Run as Protected Process Light level (Lsa\RunAsPPL; 1 or 2 enables LSA protection)
   runAsPpl() int
   // Whether advanced audit policy is forced over legacy audit categories (Lsa\SCENoApplyLegacyAuditPolicy)
   //
-  // 1 forces the advanced audit policy subcategories and ignores the legacy
-  // audit categories.
-  sceNoApplyLegacyAuditPolicy() int
-  // Recovery console / authority delegation submit-control flag (Lsa\SubmitControl; 1 allows)
-  submitControl() int
-  // Whether the computer account identity is used for outbound authentication (Lsa\UseMachineId; 1 uses machine identity)
-  useMachineId() int
+  // When set, the advanced audit policy subcategories are forced and the
+  // legacy audit categories are ignored.
+  sceNoApplyLegacyAuditPolicy() bool
+  // Whether recovery console authority delegation submit-control is allowed (Lsa\SubmitControl)
+  submitControl() bool
+  // Whether the computer account identity is used for outbound authentication (Lsa\UseMachineId)
+  useMachineId() bool
   // NTLM authentication settings (Lsa\MSV1_0 and the WDigest provider)
   ntlm() windows.lsa.ntlm
   // Netlogon secure-channel settings (Services\Netlogon\Parameters)
@@ -7280,11 +7276,13 @@ windows.lsa {
 // HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest. These
 // control NULL session fallback, inbound/outbound NTLM auditing and
 // restriction, the minimum negotiated NTLM session security for clients and
-// servers, and whether WDigest caches plaintext credentials in memory. Values
-// are nullable so an absent value is distinguishable from an explicit 0.
+// servers, and whether WDigest caches plaintext credentials in memory. On/off
+// settings are exposed as booleans and graded settings (audit and restriction
+// levels, the minimum-session-security bitmasks) as integers. Values are
+// nullable so an absent value is distinguishable from an explicit false or 0.
 private windows.lsa.ntlm {
-  // Whether NTLM NULL session fallback is allowed (MSV1_0\AllowNullSessionFallback; 0 disallows)
-  allowNullSessionFallback int
+  // Whether NTLM NULL session fallback is allowed (MSV1_0\AllowNullSessionFallback)
+  allowNullSessionFallback bool
   // Audit level for incoming NTLM traffic (MSV1_0\AuditReceivingNTLMTraffic; 0 off, 1 allow, 2 deny-all)
   auditReceivingNtlmTraffic int
   // Minimum session security negotiated for NTLM SSP clients (MSV1_0\NTLMMinClientSec, bitmask)
@@ -7293,10 +7291,10 @@ private windows.lsa.ntlm {
   ntlmMinServerSec int
   // Restriction level for outgoing NTLM traffic to remote servers (MSV1_0\RestrictSendingNTLMTraffic; 0 allow, 1 audit, 2 deny-all)
   restrictSendingNtlmTraffic int
-  // Whether WDigest caches plaintext credentials in memory (WDigest\UseLogonCredential; 0 disables plaintext caching)
-  useLogonCredential int
-  // Whether online identities (PKU2U) may authenticate to this computer (Lsa\pku2u\AllowOnlineID; 0 disallows)
-  allowOnlineId int
+  // Whether WDigest caches plaintext credentials in memory (WDigest\UseLogonCredential)
+  useLogonCredential bool
+  // Whether online identities (PKU2U) may authenticate to this computer (Lsa\pku2u\AllowOnlineID)
+  allowOnlineId bool
 }
 
 // Windows LSA Netlogon secure-channel settings
@@ -7307,27 +7305,29 @@ private windows.lsa.ntlm {
 // password change behaviour and maximum age, strong session keys, NETBIOS
 // discovery, the vulnerable-channel allow list, and inbound NTLM auditing in
 // the domain. BlockNetbiosDiscovery is read from the GPO location
-// HKLM\SOFTWARE\Policies\Microsoft\Netlogon\Parameters. Values are nullable so
-// an absent value is distinguishable from an explicit 0.
+// HKLM\SOFTWARE\Policies\Microsoft\Netlogon\Parameters. On/off settings are
+// exposed as booleans and graded settings (the inbound NTLM audit bitmask and
+// the maximum password age) as integers. Values are nullable so an absent value
+// is distinguishable from an explicit false or 0.
 private windows.lsa.secureChannel {
   // Audit level for inbound NTLM traffic on domain controllers (Netlogon\Parameters\AuditNTLMInDomain, bitmask)
   auditNtlmInDomain int
-  // Whether NetBIOS-based domain controller discovery is blocked (Policies\Microsoft\Netlogon\Parameters\BlockNetbiosDiscovery; 1 blocks)
-  blockNetbiosDiscovery int
-  // Whether automatic machine account password changes are disabled (Netlogon\Parameters\DisablePasswordChange; 1 disables)
-  disablePasswordChange int
+  // Whether NetBIOS-based domain controller discovery is blocked (Policies\Microsoft\Netlogon\Parameters\BlockNetbiosDiscovery)
+  blockNetbiosDiscovery bool
+  // Whether automatic machine account password changes are disabled (Netlogon\Parameters\DisablePasswordChange)
+  disablePasswordChange bool
   // Maximum machine account password age in days (Netlogon\Parameters\MaximumPasswordAge)
   maximumPasswordAge int
-  // Whether the domain controller refuses machine account password changes (Netlogon\Parameters\RefusePasswordChange; 1 refuses)
-  refusePasswordChange int
-  // Whether secure-channel data is digitally signed or sealed when possible (Netlogon\Parameters\RequireSignOrSeal; 1 requires)
-  requireSignOrSeal int
-  // Whether a strong (128-bit) secure-channel session key is required (Netlogon\Parameters\RequireStrongKey; 1 requires)
-  requireStrongKey int
-  // Whether secure-channel data is digitally encrypted when possible (Netlogon\Parameters\SealSecureChannel; 1 seals)
-  sealSecureChannel int
-  // Whether secure-channel data is digitally signed when possible (Netlogon\Parameters\SignSecureChannel; 1 signs)
-  signSecureChannel int
+  // Whether the domain controller refuses machine account password changes (Netlogon\Parameters\RefusePasswordChange)
+  refusePasswordChange bool
+  // Whether secure-channel data is digitally signed or sealed when possible (Netlogon\Parameters\RequireSignOrSeal)
+  requireSignOrSeal bool
+  // Whether a strong (128-bit) secure-channel session key is required (Netlogon\Parameters\RequireStrongKey)
+  requireStrongKey bool
+  // Whether secure-channel data is digitally encrypted when possible (Netlogon\Parameters\SealSecureChannel)
+  sealSecureChannel bool
+  // Whether secure-channel data is digitally signed when possible (Netlogon\Parameters\SignSecureChannel)
+  signSecureChannel bool
   // Allow list of vulnerable Netlogon secure channels (Netlogon\Parameters\vulnerablechannelallowlist, REG_SZ)
   vulnerableChannelAllowList string
 }
@@ -7357,13 +7357,11 @@ windows.spooler {
   disabled() bool
   // Whether incoming remote RPC connections to the spooler are allowed (Printers\RegisterSpoolerRemoteRpcEndPoint)
   //
-  // 0 disables the remote RPC endpoint (the hardened state), 1 enables it.
-  // Null when not configured.
-  registerRemoteRpcEndpoint() int
-  // Redirection Guard policy state (Printers\RedirectionguardPolicy)
-  //
-  // 1 enables Redirection Guard. Null when not configured.
-  redirectionGuardPolicy() int
+  // The hardened state is false (the remote RPC endpoint is disabled). Null
+  // when not configured.
+  registerRemoteRpcEndpoint() bool
+  // Whether Redirection Guard is enabled (Printers\RedirectionguardPolicy). Null when not configured
+  redirectionGuardPolicy() bool
   // Whether downloading of print drivers over HTTP / Web Point-and-Print is disabled (Printers\DisableWebPnPDownload)
   //
   // Defaults to false (downloads allowed) when not configured.
@@ -7372,46 +7370,45 @@ windows.spooler {
   //
   // Defaults to false (HTTP printing allowed) when not configured.
   httpPrintingDisabled() bool
-  // Copy Files policy controlling which color profile / helper files the spooler may copy (Printers\CopyFilesPolicy)
-  //
-  // 1 restricts copied files to the Windows color system. Null when not configured.
-  copyFilesPolicy() int
+  // Whether the spooler restricts copied files to the Windows color system (Printers\CopyFilesPolicy). Null when not configured
+  copyFilesPolicy() bool
   // Whether incoming RPC connections to the spooler require packet privacy (Control\Print\RpcAuthnLevelPrivacyEnabled)
   //
   // Defaults to true (packet privacy enabled), the modern Windows default,
   // when not configured.
   rpcAuthnLevelPrivacyEnabled() bool
-  // Who may add printer drivers via the LanMan print provider (Control\Print\Providers\LanMan Print Services\Servers\AddPrinterDrivers)
+  // Whether adding printer drivers is restricted to administrators
   //
-  // 1 restricts adding printer drivers to administrators. Null when not configured.
-  addPrinterDriversRestricted() int
+  // Maps the LanMan print provider AddPrinterDrivers value
+  // (Control\Print\Providers\LanMan Print Services\Servers\AddPrinterDrivers).
+  // Null when not configured.
+  addPrinterDriversRestricted() bool
   // Point and Print restriction settings (Printers\PointAndPrint)
   pointAndPrint() windows.spooler.pointAndPrint
   // Spooler RPC settings (Printers\RPC)
   rpc() windows.spooler.rpc
   // Internet Printing Protocol (IPP) certificate validation settings (Printers\IPP)
   ipp() windows.spooler.ipp
-  // Windows Protected Print mode policy state (Printers\WPP\WindowsProtectedPrintGroupPolicyState)
-  //
-  // 1 enables Windows Protected Print. Null when not configured.
-  windowsProtectedPrintGroupPolicyState() int
+  // Whether Windows Protected Print mode is enabled (Printers\WPP\WindowsProtectedPrintGroupPolicyState). Null when not configured
+  windowsProtectedPrintGroupPolicyState() bool
 }
 
 // Windows Print Spooler Point and Print restrictions
 //
 // Settings under HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint
 // that govern how non-administrators may install printer drivers from a print
-// server. Integer values are null when not configured.
+// server. Values are null when not configured.
 private windows.spooler.pointAndPrint @defaults("restrictDriverInstallationToAdministrators") {
   // Whether printer driver installation is restricted to administrators (RestrictDriverInstallationToAdministrators)
   //
   // Defaults to true (the hardened Windows default introduced by the
   // PrintNightmare mitigations) when not configured.
   restrictDriverInstallationToAdministrators bool
-  // Whether to suppress elevation/warning prompts when installing a Point-and-Print driver (NoWarningNoElevationOnInstall)
+  // Whether elevation/warning prompts are suppressed when installing a Point-and-Print driver (NoWarningNoElevationOnInstall)
   //
-  // 0 keeps the warning/elevation prompt (the hardened state). Null when not configured.
-  noWarningNoElevationOnInstall int
+  // The hardened state is false (the warning/elevation prompt is kept). Null
+  // when not configured.
+  noWarningNoElevationOnInstall bool
   // Whether to suppress elevation/warning prompts when updating a Point-and-Print driver (UpdatePromptSettings)
   //
   // 0 keeps the warning/elevation prompt (the hardened state). Null when not configured.
@@ -7424,11 +7421,10 @@ private windows.spooler.pointAndPrint @defaults("restrictDriverInstallationToAdm
 // that control the transport and authentication used for spooler RPC.
 // Integer values are null when not configured.
 private windows.spooler.rpc @defaults("authentication protocols") {
-  // RPC over named pipes selection (RpcUseNamedPipeProtocol)
+  // Whether the spooler allows RPC over named pipes in addition to TCP (RpcUseNamedPipeProtocol)
   //
-  // 0 uses RPC over TCP only (the hardened state), 1 also allows named pipes.
-  // Null when not configured.
-  useNamedPipeProtocol int
+  // The hardened state is false (RPC over TCP only). Null when not configured.
+  useNamedPipeProtocol bool
   // RPC authentication requirement for incoming connections (RpcAuthentication)
   //
   // 1 = default, 2 = negotiate, 3 = none. Null when not configured.
@@ -7473,9 +7469,11 @@ private windows.spooler.ipp @defaults("requireIpps") {
 // Examine the effective Windows privacy and telemetry posture read from the
 // Group Policy keys HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection and
 // HKLM\SOFTWARE\Policies\Microsoft\Windows\CloudContent. These are GPO-only
-// DWORD values; every field is nullable so that an absent value (the policy is
-// not configured) is distinguishable from an explicit 0. Read from the
-// registry, so it is available even on connections that cannot run commands.
+// DWORD values. The diagnostic data level is a graded integer; the remaining
+// settings are on/off booleans. Every field is nullable so that an absent value
+// (the policy is not configured) is distinguishable from an explicit false or
+// 0. Read from the registry, so it is available even on connections that cannot
+// run commands.
 windows.telemetry {
   // Diagnostic data level (DataCollection\AllowTelemetry): 0=Security, 1=Basic/Required, 2=Enhanced, 3=Full. Null when not configured.
   allowTelemetry() int
@@ -7483,32 +7481,32 @@ windows.telemetry {
   //
   // Applies to the Connected User Experiences and Telemetry service. Null when
   // the policy is not configured.
-  disableEnterpriseAuthProxy() int
+  disableEnterpriseAuthProxy() bool
   // Whether downloading configuration from the OneSettings service is disabled (DataCollection\DisableOneSettingsDownloads). Null when not configured.
-  disableOneSettingsDownloads() int
+  disableOneSettingsDownloads() bool
   // Whether feedback notifications are suppressed (DataCollection\DoNotShowFeedbackNotifications)
   //
   // When set, the user does not receive telemetry feedback notifications. Null
   // when the policy is not configured.
-  doNotShowFeedbackNotifications() int
+  doNotShowFeedbackNotifications() bool
   // Whether auditing of OneSettings usage is enabled (DataCollection\EnableOneSettingsAuditing). Null when not configured.
-  enableOneSettingsAuditing() int
+  enableOneSettingsAuditing() bool
   // Whether collection of diagnostic logs is limited (DataCollection\LimitDiagnosticLogCollection). Null when not configured.
-  limitDiagnosticLogCollection() int
+  limitDiagnosticLogCollection() bool
   // Whether collection of crash dumps is limited (DataCollection\LimitDumpCollection). Null when not configured.
-  limitDumpCollection() int
+  limitDumpCollection() bool
   // Whether cloud-optimized content is disabled (CloudContent\DisableCloudOptimizedContent)
   //
   // Cloud-optimized content tailors suggestions using cloud data. Null when the
   // policy is not configured.
-  disableCloudOptimizedContent() int
+  disableCloudOptimizedContent() bool
   // Whether consumer account state content is disabled (CloudContent\DisableConsumerAccountStateContent). Null when not configured.
-  disableConsumerAccountStateContent() int
+  disableConsumerAccountStateContent() bool
   // Whether Windows consumer features are disabled (CloudContent\DisableWindowsConsumerFeatures)
   //
   // Consumer features include app suggestions and consumer experiences. Null
   // when the policy is not configured.
-  disableWindowsConsumerFeatures() int
+  disableWindowsConsumerFeatures() bool
 }
 
 // Windows Trusted Platform Module (TPM)
@@ -7909,16 +7907,16 @@ windows.bitlocker {
 // `fixedDataDrives`, and `removableDataDrives`. A field is null when the
 // corresponding policy value is not configured.
 windows.bitlocker.policy {
-  // Require additional authentication at startup (UseAdvancedStartup)
-  useAdvancedStartup int
-  // Allow enhanced PINs for startup (UseEnhancedPin)
-  useEnhancedPin int
-  // Allow BitLocker without a compatible TPM (EnableBDEWithNoTPM)
-  enableBdeWithNoTpm int
-  // Disable new DMA devices when this computer is locked (DisableExternalDMAUnderLock)
-  disableExternalDmaUnderLock int
-  // Allow Secure Boot for integrity validation on operating system drives (OSAllowSecureBootForIntegrity)
-  osAllowSecureBootForIntegrity int
+  // Whether additional authentication is required at startup (UseAdvancedStartup)
+  useAdvancedStartup bool
+  // Whether enhanced PINs for startup are allowed (UseEnhancedPin)
+  useEnhancedPin bool
+  // Whether BitLocker is allowed without a compatible TPM (EnableBDEWithNoTPM)
+  enableBdeWithNoTpm bool
+  // Whether new DMA devices are disabled when this computer is locked (DisableExternalDMAUnderLock)
+  disableExternalDmaUnderLock bool
+  // Whether Secure Boot is allowed for integrity validation on operating system drives (OSAllowSecureBootForIntegrity)
+  osAllowSecureBootForIntegrity bool
   // BitLocker policy settings for operating system drives (OS* values)
   operatingSystemDrives() windows.bitlocker.policy.driveSettings
   // BitLocker policy settings for fixed data drives (FDV* values)
@@ -7939,34 +7937,41 @@ private windows.bitlocker.policy.driveSettings {
   driveType string
   // Choose how BitLocker-protected drives can be recovered (*Recovery)
   recovery int
-  // Allow data recovery agent (*ManageDRA)
-  manageDRA int
+  // Whether a data recovery agent is allowed (*ManageDRA)
+  manageDRA bool
   // Allow 48-digit recovery password (*RecoveryPassword)
+  //
+  // 0 = disallow, 1 = require, 2 = allow. Null when not configured.
   recoveryPassword int
   // Allow 256-bit recovery key (*RecoveryKey)
+  //
+  // 0 = disallow, 1 = require, 2 = allow. Null when not configured.
   recoveryKey int
-  // Omit recovery options from the BitLocker setup wizard (*HideRecoveryPage)
-  hideRecoveryPage int
-  // Save BitLocker recovery information to Active Directory Domain Services (*ActiveDirectoryBackup)
-  activeDirectoryBackup int
+  // Whether recovery options are omitted from the BitLocker setup wizard (*HideRecoveryPage)
+  hideRecoveryPage bool
+  // Whether BitLocker recovery information is saved to Active Directory Domain Services (*ActiveDirectoryBackup)
+  activeDirectoryBackup bool
   // Configure what BitLocker recovery information is stored in AD DS (*ActiveDirectoryInfoToStore)
+  //
+  // 1 = store recovery passwords and key packages, 2 = store recovery passwords
+  // only. Null when not configured.
   activeDirectoryInfoToStore int
-  // Do not enable BitLocker until recovery information is stored in AD DS (*RequireActiveDirectoryBackup)
-  requireActiveDirectoryBackup int
+  // Whether BitLocker is blocked until recovery information is stored in AD DS (*RequireActiveDirectoryBackup)
+  requireActiveDirectoryBackup bool
   // Configure use of hardware-based encryption (*HardwareEncryption)
   hardwareEncryption int
   // Configure use of passwords (*Passphrase)
   passphrase int
-  // Allow certificate-based data recovery agent / smart card (*AllowUserCert)
-  allowUserCert int
-  // Enforce certificate-based data recovery agent / smart card (*EnforceUserCert)
-  enforceUserCert int
+  // Whether a certificate-based data recovery agent / smart card is allowed (*AllowUserCert)
+  allowUserCert bool
+  // Whether a certificate-based data recovery agent / smart card is enforced (*EnforceUserCert)
+  enforceUserCert bool
   // Configure the format used when a drive is auto-unlocked / discovery volume type (*DiscoveryVolumeType)
   discoveryVolumeType string
-  // Deny write access to removable drives not protected by BitLocker (RDVDenyWriteAccess)
-  denyWriteAccess int
-  // Deny write access to devices configured in another organization (RDVDenyCrossOrg)
-  denyCrossOrg int
+  // Whether write access is denied to removable drives not protected by BitLocker (RDVDenyWriteAccess)
+  denyWriteAccess bool
+  // Whether write access is denied to devices configured in another organization (RDVDenyCrossOrg)
+  denyCrossOrg bool
 }
 
 // Windows BitLocker volume

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -8433,7 +8433,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsUpdatePolicy).GetAutomaticUpdatesEnabled()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.noAutoUpdate": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetNoAutoUpdate()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetNoAutoUpdate()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.scheduledInstallDay": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsUpdatePolicy).GetScheduledInstallDay()).ToDataRes(types.Int)
@@ -8442,31 +8442,31 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsUpdatePolicy).GetScheduledInstallTime()).ToDataRes(types.Int)
 	},
 	"windows.update.policy.noAutoRebootWithLoggedOnUsers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetNoAutoRebootWithLoggedOnUsers()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetNoAutoRebootWithLoggedOnUsers()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.managePreviewBuilds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsUpdatePolicy).GetManagePreviewBuilds()).ToDataRes(types.Int)
 	},
 	"windows.update.policy.deferFeatureUpdates": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetDeferFeatureUpdates()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetDeferFeatureUpdates()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.deferFeatureUpdatesPeriodInDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsUpdatePolicy).GetDeferFeatureUpdatesPeriodInDays()).ToDataRes(types.Int)
 	},
 	"windows.update.policy.deferQualityUpdates": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetDeferQualityUpdates()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetDeferQualityUpdates()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.deferQualityUpdatesPeriodInDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsUpdatePolicy).GetDeferQualityUpdatesPeriodInDays()).ToDataRes(types.Int)
 	},
 	"windows.update.policy.allowTemporaryEnterpriseFeatureControl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetAllowTemporaryEnterpriseFeatureControl()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetAllowTemporaryEnterpriseFeatureControl()).ToDataRes(types.Bool)
 	},
 	"windows.update.policy.allowOptionalContent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsUpdatePolicy).GetAllowOptionalContent()).ToDataRes(types.Int)
 	},
 	"windows.update.policy.disablePauseUXAccess": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsUpdatePolicy).GetDisablePauseUXAccess()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsUpdatePolicy).GetDisablePauseUXAccess()).ToDataRes(types.Bool)
 	},
 	"windows.serverFeature.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsServerFeature).GetPath()).ToDataRes(types.String)
@@ -8619,7 +8619,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsWinrmService).GetAllowRemoteShellAccess()).ToDataRes(types.Bool)
 	},
 	"windows.deviceGuard.virtualizationBasedSecurityEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsDeviceGuard).GetVirtualizationBasedSecurityEnabled()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsDeviceGuard).GetVirtualizationBasedSecurityEnabled()).ToDataRes(types.Bool)
 	},
 	"windows.deviceGuard.requirePlatformSecurityFeatures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDeviceGuard).GetRequirePlatformSecurityFeatures()).ToDataRes(types.Int)
@@ -8628,40 +8628,40 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsDeviceGuard).GetHypervisorEnforcedCodeIntegrity()).ToDataRes(types.Int)
 	},
 	"windows.deviceGuard.hvciMatRequired": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsDeviceGuard).GetHvciMatRequired()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsDeviceGuard).GetHvciMatRequired()).ToDataRes(types.Bool)
 	},
 	"windows.deviceGuard.credentialGuardConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDeviceGuard).GetCredentialGuardConfig()).ToDataRes(types.Int)
 	},
 	"windows.deviceGuard.systemGuardLaunch": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsDeviceGuard).GetSystemGuardLaunch()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsDeviceGuard).GetSystemGuardLaunch()).ToDataRes(types.Bool)
 	},
 	"windows.deviceGuard.kernelShadowStacksLaunch": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDeviceGuard).GetKernelShadowStacksLaunch()).ToDataRes(types.Int)
 	},
 	"windows.lsa.disableDomainCreds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetDisableDomainCreds()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetDisableDomainCreds()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.everyoneIncludesAnonymous": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetEveryoneIncludesAnonymous()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetEveryoneIncludesAnonymous()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.forceGuest": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetForceGuest()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetForceGuest()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.limitBlankPasswordUse": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetLimitBlankPasswordUse()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetLimitBlankPasswordUse()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.lmCompatibilityLevel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetLmCompatibilityLevel()).ToDataRes(types.Int)
 	},
 	"windows.lsa.noLmHash": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetNoLmHash()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetNoLmHash()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.restrictAnonymous": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetRestrictAnonymous()).ToDataRes(types.Int)
 	},
 	"windows.lsa.restrictAnonymousSam": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetRestrictAnonymousSam()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetRestrictAnonymousSam()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.restrictRemoteSam": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetRestrictRemoteSam()).ToDataRes(types.String)
@@ -8670,13 +8670,13 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsLsa).GetRunAsPpl()).ToDataRes(types.Int)
 	},
 	"windows.lsa.sceNoApplyLegacyAuditPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetSceNoApplyLegacyAuditPolicy()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetSceNoApplyLegacyAuditPolicy()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.submitControl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetSubmitControl()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetSubmitControl()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.useMachineId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsa).GetUseMachineId()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsa).GetUseMachineId()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.ntlm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetNtlm()).ToDataRes(types.Resource("windows.lsa.ntlm"))
@@ -8685,7 +8685,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsLsa).GetSecureChannel()).ToDataRes(types.Resource("windows.lsa.secureChannel"))
 	},
 	"windows.lsa.ntlm.allowNullSessionFallback": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaNtlm).GetAllowNullSessionFallback()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaNtlm).GetAllowNullSessionFallback()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.ntlm.auditReceivingNtlmTraffic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsaNtlm).GetAuditReceivingNtlmTraffic()).ToDataRes(types.Int)
@@ -8700,37 +8700,37 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsLsaNtlm).GetRestrictSendingNtlmTraffic()).ToDataRes(types.Int)
 	},
 	"windows.lsa.ntlm.useLogonCredential": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaNtlm).GetUseLogonCredential()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaNtlm).GetUseLogonCredential()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.ntlm.allowOnlineId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaNtlm).GetAllowOnlineId()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaNtlm).GetAllowOnlineId()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.auditNtlmInDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsaSecureChannel).GetAuditNtlmInDomain()).ToDataRes(types.Int)
 	},
 	"windows.lsa.secureChannel.blockNetbiosDiscovery": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetBlockNetbiosDiscovery()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetBlockNetbiosDiscovery()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.disablePasswordChange": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetDisablePasswordChange()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetDisablePasswordChange()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.maximumPasswordAge": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsaSecureChannel).GetMaximumPasswordAge()).ToDataRes(types.Int)
 	},
 	"windows.lsa.secureChannel.refusePasswordChange": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetRefusePasswordChange()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetRefusePasswordChange()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.requireSignOrSeal": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetRequireSignOrSeal()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetRequireSignOrSeal()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.requireStrongKey": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetRequireStrongKey()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetRequireStrongKey()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.sealSecureChannel": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetSealSecureChannel()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetSealSecureChannel()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.signSecureChannel": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsLsaSecureChannel).GetSignSecureChannel()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsLsaSecureChannel).GetSignSecureChannel()).ToDataRes(types.Bool)
 	},
 	"windows.lsa.secureChannel.vulnerableChannelAllowList": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsaSecureChannel).GetVulnerableChannelAllowList()).ToDataRes(types.String)
@@ -8742,10 +8742,10 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsSpooler).GetDisabled()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.registerRemoteRpcEndpoint": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpooler).GetRegisterRemoteRpcEndpoint()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpooler).GetRegisterRemoteRpcEndpoint()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.redirectionGuardPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpooler).GetRedirectionGuardPolicy()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpooler).GetRedirectionGuardPolicy()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.webPnpDownloadDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpooler).GetWebPnpDownloadDisabled()).ToDataRes(types.Bool)
@@ -8754,13 +8754,13 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsSpooler).GetHttpPrintingDisabled()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.copyFilesPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpooler).GetCopyFilesPolicy()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpooler).GetCopyFilesPolicy()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.rpcAuthnLevelPrivacyEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpooler).GetRpcAuthnLevelPrivacyEnabled()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.addPrinterDriversRestricted": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpooler).GetAddPrinterDriversRestricted()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpooler).GetAddPrinterDriversRestricted()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.pointAndPrint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpooler).GetPointAndPrint()).ToDataRes(types.Resource("windows.spooler.pointAndPrint"))
@@ -8772,19 +8772,19 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsSpooler).GetIpp()).ToDataRes(types.Resource("windows.spooler.ipp"))
 	},
 	"windows.spooler.windowsProtectedPrintGroupPolicyState": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpooler).GetWindowsProtectedPrintGroupPolicyState()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpooler).GetWindowsProtectedPrintGroupPolicyState()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.pointAndPrint.restrictDriverInstallationToAdministrators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpoolerPointAndPrint).GetRestrictDriverInstallationToAdministrators()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.pointAndPrint.noWarningNoElevationOnInstall": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpoolerPointAndPrint).GetNoWarningNoElevationOnInstall()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpoolerPointAndPrint).GetNoWarningNoElevationOnInstall()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.pointAndPrint.updatePromptSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpoolerPointAndPrint).GetUpdatePromptSettings()).ToDataRes(types.Int)
 	},
 	"windows.spooler.rpc.useNamedPipeProtocol": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsSpoolerRpc).GetUseNamedPipeProtocol()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsSpoolerRpc).GetUseNamedPipeProtocol()).ToDataRes(types.Bool)
 	},
 	"windows.spooler.rpc.authentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSpoolerRpc).GetAuthentication()).ToDataRes(types.Int)
@@ -8817,31 +8817,31 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsTelemetry).GetAllowTelemetry()).ToDataRes(types.Int)
 	},
 	"windows.telemetry.disableEnterpriseAuthProxy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDisableEnterpriseAuthProxy()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDisableEnterpriseAuthProxy()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.disableOneSettingsDownloads": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDisableOneSettingsDownloads()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDisableOneSettingsDownloads()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.doNotShowFeedbackNotifications": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDoNotShowFeedbackNotifications()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDoNotShowFeedbackNotifications()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.enableOneSettingsAuditing": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetEnableOneSettingsAuditing()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetEnableOneSettingsAuditing()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.limitDiagnosticLogCollection": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetLimitDiagnosticLogCollection()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetLimitDiagnosticLogCollection()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.limitDumpCollection": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetLimitDumpCollection()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetLimitDumpCollection()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.disableCloudOptimizedContent": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDisableCloudOptimizedContent()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDisableCloudOptimizedContent()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.disableConsumerAccountStateContent": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDisableConsumerAccountStateContent()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDisableConsumerAccountStateContent()).ToDataRes(types.Bool)
 	},
 	"windows.telemetry.disableWindowsConsumerFeatures": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsTelemetry).GetDisableWindowsConsumerFeatures()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsTelemetry).GetDisableWindowsConsumerFeatures()).ToDataRes(types.Bool)
 	},
 	"windows.tpm.present": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsTpm).GetPresent()).ToDataRes(types.Bool)
@@ -9135,19 +9135,19 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsBitlocker).GetPolicy()).ToDataRes(types.Resource("windows.bitlocker.policy"))
 	},
 	"windows.bitlocker.policy.useAdvancedStartup": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicy).GetUseAdvancedStartup()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicy).GetUseAdvancedStartup()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.useEnhancedPin": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicy).GetUseEnhancedPin()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicy).GetUseEnhancedPin()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.enableBdeWithNoTpm": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicy).GetEnableBdeWithNoTpm()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicy).GetEnableBdeWithNoTpm()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.disableExternalDmaUnderLock": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicy).GetDisableExternalDmaUnderLock()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicy).GetDisableExternalDmaUnderLock()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.osAllowSecureBootForIntegrity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicy).GetOsAllowSecureBootForIntegrity()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicy).GetOsAllowSecureBootForIntegrity()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.operatingSystemDrives": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerPolicy).GetOperatingSystemDrives()).ToDataRes(types.Resource("windows.bitlocker.policy.driveSettings"))
@@ -9165,7 +9165,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetRecovery()).ToDataRes(types.Int)
 	},
 	"windows.bitlocker.policy.driveSettings.manageDRA": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetManageDRA()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetManageDRA()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.recoveryPassword": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetRecoveryPassword()).ToDataRes(types.Int)
@@ -9174,16 +9174,16 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetRecoveryKey()).ToDataRes(types.Int)
 	},
 	"windows.bitlocker.policy.driveSettings.hideRecoveryPage": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetHideRecoveryPage()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetHideRecoveryPage()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.activeDirectoryBackup": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetActiveDirectoryBackup()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetActiveDirectoryBackup()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.activeDirectoryInfoToStore": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetActiveDirectoryInfoToStore()).ToDataRes(types.Int)
 	},
 	"windows.bitlocker.policy.driveSettings.requireActiveDirectoryBackup": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetRequireActiveDirectoryBackup()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetRequireActiveDirectoryBackup()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.hardwareEncryption": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetHardwareEncryption()).ToDataRes(types.Int)
@@ -9192,19 +9192,19 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetPassphrase()).ToDataRes(types.Int)
 	},
 	"windows.bitlocker.policy.driveSettings.allowUserCert": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetAllowUserCert()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetAllowUserCert()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.enforceUserCert": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetEnforceUserCert()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetEnforceUserCert()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.discoveryVolumeType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetDiscoveryVolumeType()).ToDataRes(types.String)
 	},
 	"windows.bitlocker.policy.driveSettings.denyWriteAccess": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetDenyWriteAccess()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetDenyWriteAccess()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.policy.driveSettings.denyCrossOrg": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetDenyCrossOrg()).ToDataRes(types.Int)
+		return (r.(*mqlWindowsBitlockerPolicyDriveSettings).GetDenyCrossOrg()).ToDataRes(types.Bool)
 	},
 	"windows.bitlocker.volume.deviceID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlockerVolume).GetDeviceID()).ToDataRes(types.String)
@@ -20731,7 +20731,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.noAutoUpdate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).NoAutoUpdate, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).NoAutoUpdate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.update.policy.scheduledInstallDay": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20743,7 +20743,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.noAutoRebootWithLoggedOnUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).NoAutoRebootWithLoggedOnUsers, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).NoAutoRebootWithLoggedOnUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.update.policy.managePreviewBuilds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20751,7 +20751,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.deferFeatureUpdates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).DeferFeatureUpdates, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).DeferFeatureUpdates, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.update.policy.deferFeatureUpdatesPeriodInDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20759,7 +20759,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.deferQualityUpdates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).DeferQualityUpdates, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).DeferQualityUpdates, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.update.policy.deferQualityUpdatesPeriodInDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20767,7 +20767,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.allowTemporaryEnterpriseFeatureControl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).AllowTemporaryEnterpriseFeatureControl, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).AllowTemporaryEnterpriseFeatureControl, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.update.policy.allowOptionalContent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20775,7 +20775,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.update.policy.disablePauseUXAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsUpdatePolicy).DisablePauseUXAccess, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsUpdatePolicy).DisablePauseUXAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.serverFeature.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21011,7 +21011,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.deviceGuard.virtualizationBasedSecurityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsDeviceGuard).VirtualizationBasedSecurityEnabled, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsDeviceGuard).VirtualizationBasedSecurityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.deviceGuard.requirePlatformSecurityFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21023,7 +21023,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.deviceGuard.hvciMatRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsDeviceGuard).HvciMatRequired, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsDeviceGuard).HvciMatRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.deviceGuard.credentialGuardConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21031,7 +21031,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.deviceGuard.systemGuardLaunch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsDeviceGuard).SystemGuardLaunch, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsDeviceGuard).SystemGuardLaunch, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.deviceGuard.kernelShadowStacksLaunch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21043,19 +21043,19 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.disableDomainCreds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).DisableDomainCreds, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).DisableDomainCreds, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.everyoneIncludesAnonymous": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).EveryoneIncludesAnonymous, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).EveryoneIncludesAnonymous, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.forceGuest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).ForceGuest, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).ForceGuest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.limitBlankPasswordUse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).LimitBlankPasswordUse, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).LimitBlankPasswordUse, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.lmCompatibilityLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21063,7 +21063,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.noLmHash": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).NoLmHash, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).NoLmHash, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.restrictAnonymous": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21071,7 +21071,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.restrictAnonymousSam": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).RestrictAnonymousSam, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).RestrictAnonymousSam, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.restrictRemoteSam": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21083,15 +21083,15 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.sceNoApplyLegacyAuditPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).SceNoApplyLegacyAuditPolicy, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).SceNoApplyLegacyAuditPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.submitControl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).SubmitControl, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).SubmitControl, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.useMachineId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsa).UseMachineId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsa).UseMachineId, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.ntlm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21107,7 +21107,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.ntlm.allowNullSessionFallback": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaNtlm).AllowNullSessionFallback, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaNtlm).AllowNullSessionFallback, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.ntlm.auditReceivingNtlmTraffic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21127,11 +21127,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.ntlm.useLogonCredential": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaNtlm).UseLogonCredential, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaNtlm).UseLogonCredential, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.ntlm.allowOnlineId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaNtlm).AllowOnlineId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaNtlm).AllowOnlineId, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21143,11 +21143,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.secureChannel.blockNetbiosDiscovery": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).BlockNetbiosDiscovery, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).BlockNetbiosDiscovery, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.disablePasswordChange": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).DisablePasswordChange, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).DisablePasswordChange, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.maximumPasswordAge": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21155,23 +21155,23 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.lsa.secureChannel.refusePasswordChange": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).RefusePasswordChange, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).RefusePasswordChange, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.requireSignOrSeal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).RequireSignOrSeal, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).RequireSignOrSeal, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.requireStrongKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).RequireStrongKey, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).RequireStrongKey, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.sealSecureChannel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).SealSecureChannel, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).SealSecureChannel, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.signSecureChannel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsLsaSecureChannel).SignSecureChannel, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsLsaSecureChannel).SignSecureChannel, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.secureChannel.vulnerableChannelAllowList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21191,11 +21191,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.registerRemoteRpcEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpooler).RegisterRemoteRpcEndpoint, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpooler).RegisterRemoteRpcEndpoint, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.redirectionGuardPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpooler).RedirectionGuardPolicy, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpooler).RedirectionGuardPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.webPnpDownloadDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21207,7 +21207,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.copyFilesPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpooler).CopyFilesPolicy, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpooler).CopyFilesPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.rpcAuthnLevelPrivacyEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21215,7 +21215,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.addPrinterDriversRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpooler).AddPrinterDriversRestricted, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpooler).AddPrinterDriversRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.pointAndPrint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21231,7 +21231,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.windowsProtectedPrintGroupPolicyState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpooler).WindowsProtectedPrintGroupPolicyState, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpooler).WindowsProtectedPrintGroupPolicyState, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.pointAndPrint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21243,7 +21243,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.pointAndPrint.noWarningNoElevationOnInstall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpoolerPointAndPrint).NoWarningNoElevationOnInstall, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpoolerPointAndPrint).NoWarningNoElevationOnInstall, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.pointAndPrint.updatePromptSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21255,7 +21255,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.spooler.rpc.useNamedPipeProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsSpoolerRpc).UseNamedPipeProtocol, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsSpoolerRpc).UseNamedPipeProtocol, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.spooler.rpc.authentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21307,39 +21307,39 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.telemetry.disableEnterpriseAuthProxy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DisableEnterpriseAuthProxy, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DisableEnterpriseAuthProxy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.disableOneSettingsDownloads": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DisableOneSettingsDownloads, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DisableOneSettingsDownloads, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.doNotShowFeedbackNotifications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DoNotShowFeedbackNotifications, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DoNotShowFeedbackNotifications, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.enableOneSettingsAuditing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).EnableOneSettingsAuditing, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).EnableOneSettingsAuditing, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.limitDiagnosticLogCollection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).LimitDiagnosticLogCollection, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).LimitDiagnosticLogCollection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.limitDumpCollection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).LimitDumpCollection, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).LimitDumpCollection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.disableCloudOptimizedContent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DisableCloudOptimizedContent, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DisableCloudOptimizedContent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.disableConsumerAccountStateContent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DisableConsumerAccountStateContent, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DisableConsumerAccountStateContent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.telemetry.disableWindowsConsumerFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsTelemetry).DisableWindowsConsumerFeatures, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsTelemetry).DisableWindowsConsumerFeatures, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.tpm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21787,23 +21787,23 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.useAdvancedStartup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicy).UseAdvancedStartup, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicy).UseAdvancedStartup, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.useEnhancedPin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicy).UseEnhancedPin, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicy).UseEnhancedPin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.enableBdeWithNoTpm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicy).EnableBdeWithNoTpm, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicy).EnableBdeWithNoTpm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.disableExternalDmaUnderLock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicy).DisableExternalDmaUnderLock, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicy).DisableExternalDmaUnderLock, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.osAllowSecureBootForIntegrity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicy).OsAllowSecureBootForIntegrity, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicy).OsAllowSecureBootForIntegrity, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.operatingSystemDrives": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21831,7 +21831,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.manageDRA": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).ManageDRA, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).ManageDRA, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.recoveryPassword": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21843,11 +21843,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.hideRecoveryPage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).HideRecoveryPage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).HideRecoveryPage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.activeDirectoryBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).ActiveDirectoryBackup, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).ActiveDirectoryBackup, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.activeDirectoryInfoToStore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21855,7 +21855,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.requireActiveDirectoryBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).RequireActiveDirectoryBackup, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).RequireActiveDirectoryBackup, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.hardwareEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21867,11 +21867,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.allowUserCert": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).AllowUserCert, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).AllowUserCert, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.enforceUserCert": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).EnforceUserCert, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).EnforceUserCert, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.discoveryVolumeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21879,11 +21879,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.denyWriteAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).DenyWriteAccess, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).DenyWriteAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.policy.driveSettings.denyCrossOrg": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsBitlockerPolicyDriveSettings).DenyCrossOrg, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		r.(*mqlWindowsBitlockerPolicyDriveSettings).DenyCrossOrg, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -54530,18 +54530,18 @@ type mqlWindowsUpdatePolicy struct {
 	__id       string
 	// optional: if you define mqlWindowsUpdatePolicyInternal it will be used here
 	AutomaticUpdatesEnabled                plugin.TValue[bool]
-	NoAutoUpdate                           plugin.TValue[int64]
+	NoAutoUpdate                           plugin.TValue[bool]
 	ScheduledInstallDay                    plugin.TValue[int64]
 	ScheduledInstallTime                   plugin.TValue[int64]
-	NoAutoRebootWithLoggedOnUsers          plugin.TValue[int64]
+	NoAutoRebootWithLoggedOnUsers          plugin.TValue[bool]
 	ManagePreviewBuilds                    plugin.TValue[int64]
-	DeferFeatureUpdates                    plugin.TValue[int64]
+	DeferFeatureUpdates                    plugin.TValue[bool]
 	DeferFeatureUpdatesPeriodInDays        plugin.TValue[int64]
-	DeferQualityUpdates                    plugin.TValue[int64]
+	DeferQualityUpdates                    plugin.TValue[bool]
 	DeferQualityUpdatesPeriodInDays        plugin.TValue[int64]
-	AllowTemporaryEnterpriseFeatureControl plugin.TValue[int64]
+	AllowTemporaryEnterpriseFeatureControl plugin.TValue[bool]
 	AllowOptionalContent                   plugin.TValue[int64]
-	DisablePauseUXAccess                   plugin.TValue[int64]
+	DisablePauseUXAccess                   plugin.TValue[bool]
 }
 
 // createWindowsUpdatePolicy creates a new instance of this resource
@@ -54585,7 +54585,7 @@ func (c *mqlWindowsUpdatePolicy) GetAutomaticUpdatesEnabled() *plugin.TValue[boo
 	return &c.AutomaticUpdatesEnabled
 }
 
-func (c *mqlWindowsUpdatePolicy) GetNoAutoUpdate() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetNoAutoUpdate() *plugin.TValue[bool] {
 	return &c.NoAutoUpdate
 }
 
@@ -54597,7 +54597,7 @@ func (c *mqlWindowsUpdatePolicy) GetScheduledInstallTime() *plugin.TValue[int64]
 	return &c.ScheduledInstallTime
 }
 
-func (c *mqlWindowsUpdatePolicy) GetNoAutoRebootWithLoggedOnUsers() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetNoAutoRebootWithLoggedOnUsers() *plugin.TValue[bool] {
 	return &c.NoAutoRebootWithLoggedOnUsers
 }
 
@@ -54605,7 +54605,7 @@ func (c *mqlWindowsUpdatePolicy) GetManagePreviewBuilds() *plugin.TValue[int64] 
 	return &c.ManagePreviewBuilds
 }
 
-func (c *mqlWindowsUpdatePolicy) GetDeferFeatureUpdates() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetDeferFeatureUpdates() *plugin.TValue[bool] {
 	return &c.DeferFeatureUpdates
 }
 
@@ -54613,7 +54613,7 @@ func (c *mqlWindowsUpdatePolicy) GetDeferFeatureUpdatesPeriodInDays() *plugin.TV
 	return &c.DeferFeatureUpdatesPeriodInDays
 }
 
-func (c *mqlWindowsUpdatePolicy) GetDeferQualityUpdates() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetDeferQualityUpdates() *plugin.TValue[bool] {
 	return &c.DeferQualityUpdates
 }
 
@@ -54621,7 +54621,7 @@ func (c *mqlWindowsUpdatePolicy) GetDeferQualityUpdatesPeriodInDays() *plugin.TV
 	return &c.DeferQualityUpdatesPeriodInDays
 }
 
-func (c *mqlWindowsUpdatePolicy) GetAllowTemporaryEnterpriseFeatureControl() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetAllowTemporaryEnterpriseFeatureControl() *plugin.TValue[bool] {
 	return &c.AllowTemporaryEnterpriseFeatureControl
 }
 
@@ -54629,7 +54629,7 @@ func (c *mqlWindowsUpdatePolicy) GetAllowOptionalContent() *plugin.TValue[int64]
 	return &c.AllowOptionalContent
 }
 
-func (c *mqlWindowsUpdatePolicy) GetDisablePauseUXAccess() *plugin.TValue[int64] {
+func (c *mqlWindowsUpdatePolicy) GetDisablePauseUXAccess() *plugin.TValue[bool] {
 	return &c.DisablePauseUXAccess
 }
 
@@ -55276,12 +55276,12 @@ type mqlWindowsDeviceGuard struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlWindowsDeviceGuardInternal it will be used here
-	VirtualizationBasedSecurityEnabled plugin.TValue[int64]
+	VirtualizationBasedSecurityEnabled plugin.TValue[bool]
 	RequirePlatformSecurityFeatures    plugin.TValue[int64]
 	HypervisorEnforcedCodeIntegrity    plugin.TValue[int64]
-	HvciMatRequired                    plugin.TValue[int64]
+	HvciMatRequired                    plugin.TValue[bool]
 	CredentialGuardConfig              plugin.TValue[int64]
-	SystemGuardLaunch                  plugin.TValue[int64]
+	SystemGuardLaunch                  plugin.TValue[bool]
 	KernelShadowStacksLaunch           plugin.TValue[int64]
 }
 
@@ -55322,7 +55322,7 @@ func (c *mqlWindowsDeviceGuard) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlWindowsDeviceGuard) GetVirtualizationBasedSecurityEnabled() *plugin.TValue[int64] {
+func (c *mqlWindowsDeviceGuard) GetVirtualizationBasedSecurityEnabled() *plugin.TValue[bool] {
 	return &c.VirtualizationBasedSecurityEnabled
 }
 
@@ -55334,7 +55334,7 @@ func (c *mqlWindowsDeviceGuard) GetHypervisorEnforcedCodeIntegrity() *plugin.TVa
 	return &c.HypervisorEnforcedCodeIntegrity
 }
 
-func (c *mqlWindowsDeviceGuard) GetHvciMatRequired() *plugin.TValue[int64] {
+func (c *mqlWindowsDeviceGuard) GetHvciMatRequired() *plugin.TValue[bool] {
 	return &c.HvciMatRequired
 }
 
@@ -55342,7 +55342,7 @@ func (c *mqlWindowsDeviceGuard) GetCredentialGuardConfig() *plugin.TValue[int64]
 	return &c.CredentialGuardConfig
 }
 
-func (c *mqlWindowsDeviceGuard) GetSystemGuardLaunch() *plugin.TValue[int64] {
+func (c *mqlWindowsDeviceGuard) GetSystemGuardLaunch() *plugin.TValue[bool] {
 	return &c.SystemGuardLaunch
 }
 
@@ -55355,19 +55355,19 @@ type mqlWindowsLsa struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlWindowsLsaInternal it will be used here
-	DisableDomainCreds          plugin.TValue[int64]
-	EveryoneIncludesAnonymous   plugin.TValue[int64]
-	ForceGuest                  plugin.TValue[int64]
-	LimitBlankPasswordUse       plugin.TValue[int64]
+	DisableDomainCreds          plugin.TValue[bool]
+	EveryoneIncludesAnonymous   plugin.TValue[bool]
+	ForceGuest                  plugin.TValue[bool]
+	LimitBlankPasswordUse       plugin.TValue[bool]
 	LmCompatibilityLevel        plugin.TValue[int64]
-	NoLmHash                    plugin.TValue[int64]
+	NoLmHash                    plugin.TValue[bool]
 	RestrictAnonymous           plugin.TValue[int64]
-	RestrictAnonymousSam        plugin.TValue[int64]
+	RestrictAnonymousSam        plugin.TValue[bool]
 	RestrictRemoteSam           plugin.TValue[string]
 	RunAsPpl                    plugin.TValue[int64]
-	SceNoApplyLegacyAuditPolicy plugin.TValue[int64]
-	SubmitControl               plugin.TValue[int64]
-	UseMachineId                plugin.TValue[int64]
+	SceNoApplyLegacyAuditPolicy plugin.TValue[bool]
+	SubmitControl               plugin.TValue[bool]
+	UseMachineId                plugin.TValue[bool]
 	Ntlm                        plugin.TValue[*mqlWindowsLsaNtlm]
 	SecureChannel               plugin.TValue[*mqlWindowsLsaSecureChannel]
 }
@@ -55409,26 +55409,26 @@ func (c *mqlWindowsLsa) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlWindowsLsa) GetDisableDomainCreds() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableDomainCreds, func() (int64, error) {
+func (c *mqlWindowsLsa) GetDisableDomainCreds() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableDomainCreds, func() (bool, error) {
 		return c.disableDomainCreds()
 	})
 }
 
-func (c *mqlWindowsLsa) GetEveryoneIncludesAnonymous() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.EveryoneIncludesAnonymous, func() (int64, error) {
+func (c *mqlWindowsLsa) GetEveryoneIncludesAnonymous() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EveryoneIncludesAnonymous, func() (bool, error) {
 		return c.everyoneIncludesAnonymous()
 	})
 }
 
-func (c *mqlWindowsLsa) GetForceGuest() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.ForceGuest, func() (int64, error) {
+func (c *mqlWindowsLsa) GetForceGuest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ForceGuest, func() (bool, error) {
 		return c.forceGuest()
 	})
 }
 
-func (c *mqlWindowsLsa) GetLimitBlankPasswordUse() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.LimitBlankPasswordUse, func() (int64, error) {
+func (c *mqlWindowsLsa) GetLimitBlankPasswordUse() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LimitBlankPasswordUse, func() (bool, error) {
 		return c.limitBlankPasswordUse()
 	})
 }
@@ -55439,8 +55439,8 @@ func (c *mqlWindowsLsa) GetLmCompatibilityLevel() *plugin.TValue[int64] {
 	})
 }
 
-func (c *mqlWindowsLsa) GetNoLmHash() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.NoLmHash, func() (int64, error) {
+func (c *mqlWindowsLsa) GetNoLmHash() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.NoLmHash, func() (bool, error) {
 		return c.noLmHash()
 	})
 }
@@ -55451,8 +55451,8 @@ func (c *mqlWindowsLsa) GetRestrictAnonymous() *plugin.TValue[int64] {
 	})
 }
 
-func (c *mqlWindowsLsa) GetRestrictAnonymousSam() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.RestrictAnonymousSam, func() (int64, error) {
+func (c *mqlWindowsLsa) GetRestrictAnonymousSam() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RestrictAnonymousSam, func() (bool, error) {
 		return c.restrictAnonymousSam()
 	})
 }
@@ -55469,20 +55469,20 @@ func (c *mqlWindowsLsa) GetRunAsPpl() *plugin.TValue[int64] {
 	})
 }
 
-func (c *mqlWindowsLsa) GetSceNoApplyLegacyAuditPolicy() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.SceNoApplyLegacyAuditPolicy, func() (int64, error) {
+func (c *mqlWindowsLsa) GetSceNoApplyLegacyAuditPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SceNoApplyLegacyAuditPolicy, func() (bool, error) {
 		return c.sceNoApplyLegacyAuditPolicy()
 	})
 }
 
-func (c *mqlWindowsLsa) GetSubmitControl() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.SubmitControl, func() (int64, error) {
+func (c *mqlWindowsLsa) GetSubmitControl() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SubmitControl, func() (bool, error) {
 		return c.submitControl()
 	})
 }
 
-func (c *mqlWindowsLsa) GetUseMachineId() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.UseMachineId, func() (int64, error) {
+func (c *mqlWindowsLsa) GetUseMachineId() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UseMachineId, func() (bool, error) {
 		return c.useMachineId()
 	})
 }
@@ -55524,13 +55524,13 @@ type mqlWindowsLsaNtlm struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlWindowsLsaNtlmInternal it will be used here
-	AllowNullSessionFallback   plugin.TValue[int64]
+	AllowNullSessionFallback   plugin.TValue[bool]
 	AuditReceivingNtlmTraffic  plugin.TValue[int64]
 	NtlmMinClientSec           plugin.TValue[int64]
 	NtlmMinServerSec           plugin.TValue[int64]
 	RestrictSendingNtlmTraffic plugin.TValue[int64]
-	UseLogonCredential         plugin.TValue[int64]
-	AllowOnlineId              plugin.TValue[int64]
+	UseLogonCredential         plugin.TValue[bool]
+	AllowOnlineId              plugin.TValue[bool]
 }
 
 // createWindowsLsaNtlm creates a new instance of this resource
@@ -55570,7 +55570,7 @@ func (c *mqlWindowsLsaNtlm) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlWindowsLsaNtlm) GetAllowNullSessionFallback() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaNtlm) GetAllowNullSessionFallback() *plugin.TValue[bool] {
 	return &c.AllowNullSessionFallback
 }
 
@@ -55590,11 +55590,11 @@ func (c *mqlWindowsLsaNtlm) GetRestrictSendingNtlmTraffic() *plugin.TValue[int64
 	return &c.RestrictSendingNtlmTraffic
 }
 
-func (c *mqlWindowsLsaNtlm) GetUseLogonCredential() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaNtlm) GetUseLogonCredential() *plugin.TValue[bool] {
 	return &c.UseLogonCredential
 }
 
-func (c *mqlWindowsLsaNtlm) GetAllowOnlineId() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaNtlm) GetAllowOnlineId() *plugin.TValue[bool] {
 	return &c.AllowOnlineId
 }
 
@@ -55604,14 +55604,14 @@ type mqlWindowsLsaSecureChannel struct {
 	__id       string
 	// optional: if you define mqlWindowsLsaSecureChannelInternal it will be used here
 	AuditNtlmInDomain          plugin.TValue[int64]
-	BlockNetbiosDiscovery      plugin.TValue[int64]
-	DisablePasswordChange      plugin.TValue[int64]
+	BlockNetbiosDiscovery      plugin.TValue[bool]
+	DisablePasswordChange      plugin.TValue[bool]
 	MaximumPasswordAge         plugin.TValue[int64]
-	RefusePasswordChange       plugin.TValue[int64]
-	RequireSignOrSeal          plugin.TValue[int64]
-	RequireStrongKey           plugin.TValue[int64]
-	SealSecureChannel          plugin.TValue[int64]
-	SignSecureChannel          plugin.TValue[int64]
+	RefusePasswordChange       plugin.TValue[bool]
+	RequireSignOrSeal          plugin.TValue[bool]
+	RequireStrongKey           plugin.TValue[bool]
+	SealSecureChannel          plugin.TValue[bool]
+	SignSecureChannel          plugin.TValue[bool]
 	VulnerableChannelAllowList plugin.TValue[string]
 }
 
@@ -55656,11 +55656,11 @@ func (c *mqlWindowsLsaSecureChannel) GetAuditNtlmInDomain() *plugin.TValue[int64
 	return &c.AuditNtlmInDomain
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetBlockNetbiosDiscovery() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetBlockNetbiosDiscovery() *plugin.TValue[bool] {
 	return &c.BlockNetbiosDiscovery
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetDisablePasswordChange() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetDisablePasswordChange() *plugin.TValue[bool] {
 	return &c.DisablePasswordChange
 }
 
@@ -55668,23 +55668,23 @@ func (c *mqlWindowsLsaSecureChannel) GetMaximumPasswordAge() *plugin.TValue[int6
 	return &c.MaximumPasswordAge
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetRefusePasswordChange() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetRefusePasswordChange() *plugin.TValue[bool] {
 	return &c.RefusePasswordChange
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetRequireSignOrSeal() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetRequireSignOrSeal() *plugin.TValue[bool] {
 	return &c.RequireSignOrSeal
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetRequireStrongKey() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetRequireStrongKey() *plugin.TValue[bool] {
 	return &c.RequireStrongKey
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetSealSecureChannel() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetSealSecureChannel() *plugin.TValue[bool] {
 	return &c.SealSecureChannel
 }
 
-func (c *mqlWindowsLsaSecureChannel) GetSignSecureChannel() *plugin.TValue[int64] {
+func (c *mqlWindowsLsaSecureChannel) GetSignSecureChannel() *plugin.TValue[bool] {
 	return &c.SignSecureChannel
 }
 
@@ -55699,17 +55699,17 @@ type mqlWindowsSpooler struct {
 	mqlWindowsSpoolerInternal
 	StartMode                             plugin.TValue[int64]
 	Disabled                              plugin.TValue[bool]
-	RegisterRemoteRpcEndpoint             plugin.TValue[int64]
-	RedirectionGuardPolicy                plugin.TValue[int64]
+	RegisterRemoteRpcEndpoint             plugin.TValue[bool]
+	RedirectionGuardPolicy                plugin.TValue[bool]
 	WebPnpDownloadDisabled                plugin.TValue[bool]
 	HttpPrintingDisabled                  plugin.TValue[bool]
-	CopyFilesPolicy                       plugin.TValue[int64]
+	CopyFilesPolicy                       plugin.TValue[bool]
 	RpcAuthnLevelPrivacyEnabled           plugin.TValue[bool]
-	AddPrinterDriversRestricted           plugin.TValue[int64]
+	AddPrinterDriversRestricted           plugin.TValue[bool]
 	PointAndPrint                         plugin.TValue[*mqlWindowsSpoolerPointAndPrint]
 	Rpc                                   plugin.TValue[*mqlWindowsSpoolerRpc]
 	Ipp                                   plugin.TValue[*mqlWindowsSpoolerIpp]
-	WindowsProtectedPrintGroupPolicyState plugin.TValue[int64]
+	WindowsProtectedPrintGroupPolicyState plugin.TValue[bool]
 }
 
 // createWindowsSpooler creates a new instance of this resource
@@ -55761,14 +55761,14 @@ func (c *mqlWindowsSpooler) GetDisabled() *plugin.TValue[bool] {
 	})
 }
 
-func (c *mqlWindowsSpooler) GetRegisterRemoteRpcEndpoint() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.RegisterRemoteRpcEndpoint, func() (int64, error) {
+func (c *mqlWindowsSpooler) GetRegisterRemoteRpcEndpoint() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RegisterRemoteRpcEndpoint, func() (bool, error) {
 		return c.registerRemoteRpcEndpoint()
 	})
 }
 
-func (c *mqlWindowsSpooler) GetRedirectionGuardPolicy() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.RedirectionGuardPolicy, func() (int64, error) {
+func (c *mqlWindowsSpooler) GetRedirectionGuardPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RedirectionGuardPolicy, func() (bool, error) {
 		return c.redirectionGuardPolicy()
 	})
 }
@@ -55785,8 +55785,8 @@ func (c *mqlWindowsSpooler) GetHttpPrintingDisabled() *plugin.TValue[bool] {
 	})
 }
 
-func (c *mqlWindowsSpooler) GetCopyFilesPolicy() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.CopyFilesPolicy, func() (int64, error) {
+func (c *mqlWindowsSpooler) GetCopyFilesPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CopyFilesPolicy, func() (bool, error) {
 		return c.copyFilesPolicy()
 	})
 }
@@ -55797,8 +55797,8 @@ func (c *mqlWindowsSpooler) GetRpcAuthnLevelPrivacyEnabled() *plugin.TValue[bool
 	})
 }
 
-func (c *mqlWindowsSpooler) GetAddPrinterDriversRestricted() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.AddPrinterDriversRestricted, func() (int64, error) {
+func (c *mqlWindowsSpooler) GetAddPrinterDriversRestricted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AddPrinterDriversRestricted, func() (bool, error) {
 		return c.addPrinterDriversRestricted()
 	})
 }
@@ -55851,8 +55851,8 @@ func (c *mqlWindowsSpooler) GetIpp() *plugin.TValue[*mqlWindowsSpoolerIpp] {
 	})
 }
 
-func (c *mqlWindowsSpooler) GetWindowsProtectedPrintGroupPolicyState() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.WindowsProtectedPrintGroupPolicyState, func() (int64, error) {
+func (c *mqlWindowsSpooler) GetWindowsProtectedPrintGroupPolicyState() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.WindowsProtectedPrintGroupPolicyState, func() (bool, error) {
 		return c.windowsProtectedPrintGroupPolicyState()
 	})
 }
@@ -55863,7 +55863,7 @@ type mqlWindowsSpoolerPointAndPrint struct {
 	__id       string
 	// optional: if you define mqlWindowsSpoolerPointAndPrintInternal it will be used here
 	RestrictDriverInstallationToAdministrators plugin.TValue[bool]
-	NoWarningNoElevationOnInstall              plugin.TValue[int64]
+	NoWarningNoElevationOnInstall              plugin.TValue[bool]
 	UpdatePromptSettings                       plugin.TValue[int64]
 }
 
@@ -55908,7 +55908,7 @@ func (c *mqlWindowsSpoolerPointAndPrint) GetRestrictDriverInstallationToAdminist
 	return &c.RestrictDriverInstallationToAdministrators
 }
 
-func (c *mqlWindowsSpoolerPointAndPrint) GetNoWarningNoElevationOnInstall() *plugin.TValue[int64] {
+func (c *mqlWindowsSpoolerPointAndPrint) GetNoWarningNoElevationOnInstall() *plugin.TValue[bool] {
 	return &c.NoWarningNoElevationOnInstall
 }
 
@@ -55921,7 +55921,7 @@ type mqlWindowsSpoolerRpc struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlWindowsSpoolerRpcInternal it will be used here
-	UseNamedPipeProtocol plugin.TValue[int64]
+	UseNamedPipeProtocol plugin.TValue[bool]
 	Authentication       plugin.TValue[int64]
 	Protocols            plugin.TValue[int64]
 	TcpPort              plugin.TValue[int64]
@@ -55965,7 +55965,7 @@ func (c *mqlWindowsSpoolerRpc) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlWindowsSpoolerRpc) GetUseNamedPipeProtocol() *plugin.TValue[int64] {
+func (c *mqlWindowsSpoolerRpc) GetUseNamedPipeProtocol() *plugin.TValue[bool] {
 	return &c.UseNamedPipeProtocol
 }
 
@@ -56060,15 +56060,15 @@ type mqlWindowsTelemetry struct {
 	__id       string
 	// optional: if you define mqlWindowsTelemetryInternal it will be used here
 	AllowTelemetry                     plugin.TValue[int64]
-	DisableEnterpriseAuthProxy         plugin.TValue[int64]
-	DisableOneSettingsDownloads        plugin.TValue[int64]
-	DoNotShowFeedbackNotifications     plugin.TValue[int64]
-	EnableOneSettingsAuditing          plugin.TValue[int64]
-	LimitDiagnosticLogCollection       plugin.TValue[int64]
-	LimitDumpCollection                plugin.TValue[int64]
-	DisableCloudOptimizedContent       plugin.TValue[int64]
-	DisableConsumerAccountStateContent plugin.TValue[int64]
-	DisableWindowsConsumerFeatures     plugin.TValue[int64]
+	DisableEnterpriseAuthProxy         plugin.TValue[bool]
+	DisableOneSettingsDownloads        plugin.TValue[bool]
+	DoNotShowFeedbackNotifications     plugin.TValue[bool]
+	EnableOneSettingsAuditing          plugin.TValue[bool]
+	LimitDiagnosticLogCollection       plugin.TValue[bool]
+	LimitDumpCollection                plugin.TValue[bool]
+	DisableCloudOptimizedContent       plugin.TValue[bool]
+	DisableConsumerAccountStateContent plugin.TValue[bool]
+	DisableWindowsConsumerFeatures     plugin.TValue[bool]
 }
 
 // createWindowsTelemetry creates a new instance of this resource
@@ -56114,56 +56114,56 @@ func (c *mqlWindowsTelemetry) GetAllowTelemetry() *plugin.TValue[int64] {
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDisableEnterpriseAuthProxy() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableEnterpriseAuthProxy, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDisableEnterpriseAuthProxy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableEnterpriseAuthProxy, func() (bool, error) {
 		return c.disableEnterpriseAuthProxy()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDisableOneSettingsDownloads() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableOneSettingsDownloads, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDisableOneSettingsDownloads() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableOneSettingsDownloads, func() (bool, error) {
 		return c.disableOneSettingsDownloads()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDoNotShowFeedbackNotifications() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DoNotShowFeedbackNotifications, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDoNotShowFeedbackNotifications() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DoNotShowFeedbackNotifications, func() (bool, error) {
 		return c.doNotShowFeedbackNotifications()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetEnableOneSettingsAuditing() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.EnableOneSettingsAuditing, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetEnableOneSettingsAuditing() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EnableOneSettingsAuditing, func() (bool, error) {
 		return c.enableOneSettingsAuditing()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetLimitDiagnosticLogCollection() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.LimitDiagnosticLogCollection, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetLimitDiagnosticLogCollection() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LimitDiagnosticLogCollection, func() (bool, error) {
 		return c.limitDiagnosticLogCollection()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetLimitDumpCollection() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.LimitDumpCollection, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetLimitDumpCollection() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LimitDumpCollection, func() (bool, error) {
 		return c.limitDumpCollection()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDisableCloudOptimizedContent() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableCloudOptimizedContent, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDisableCloudOptimizedContent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableCloudOptimizedContent, func() (bool, error) {
 		return c.disableCloudOptimizedContent()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDisableConsumerAccountStateContent() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableConsumerAccountStateContent, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDisableConsumerAccountStateContent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableConsumerAccountStateContent, func() (bool, error) {
 		return c.disableConsumerAccountStateContent()
 	})
 }
 
-func (c *mqlWindowsTelemetry) GetDisableWindowsConsumerFeatures() *plugin.TValue[int64] {
-	return plugin.GetOrCompute[int64](&c.DisableWindowsConsumerFeatures, func() (int64, error) {
+func (c *mqlWindowsTelemetry) GetDisableWindowsConsumerFeatures() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableWindowsConsumerFeatures, func() (bool, error) {
 		return c.disableWindowsConsumerFeatures()
 	})
 }
@@ -57336,11 +57336,11 @@ type mqlWindowsBitlockerPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlWindowsBitlockerPolicyInternal
-	UseAdvancedStartup            plugin.TValue[int64]
-	UseEnhancedPin                plugin.TValue[int64]
-	EnableBdeWithNoTpm            plugin.TValue[int64]
-	DisableExternalDmaUnderLock   plugin.TValue[int64]
-	OsAllowSecureBootForIntegrity plugin.TValue[int64]
+	UseAdvancedStartup            plugin.TValue[bool]
+	UseEnhancedPin                plugin.TValue[bool]
+	EnableBdeWithNoTpm            plugin.TValue[bool]
+	DisableExternalDmaUnderLock   plugin.TValue[bool]
+	OsAllowSecureBootForIntegrity plugin.TValue[bool]
 	OperatingSystemDrives         plugin.TValue[*mqlWindowsBitlockerPolicyDriveSettings]
 	FixedDataDrives               plugin.TValue[*mqlWindowsBitlockerPolicyDriveSettings]
 	RemovableDataDrives           plugin.TValue[*mqlWindowsBitlockerPolicyDriveSettings]
@@ -57383,23 +57383,23 @@ func (c *mqlWindowsBitlockerPolicy) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlWindowsBitlockerPolicy) GetUseAdvancedStartup() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicy) GetUseAdvancedStartup() *plugin.TValue[bool] {
 	return &c.UseAdvancedStartup
 }
 
-func (c *mqlWindowsBitlockerPolicy) GetUseEnhancedPin() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicy) GetUseEnhancedPin() *plugin.TValue[bool] {
 	return &c.UseEnhancedPin
 }
 
-func (c *mqlWindowsBitlockerPolicy) GetEnableBdeWithNoTpm() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicy) GetEnableBdeWithNoTpm() *plugin.TValue[bool] {
 	return &c.EnableBdeWithNoTpm
 }
 
-func (c *mqlWindowsBitlockerPolicy) GetDisableExternalDmaUnderLock() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicy) GetDisableExternalDmaUnderLock() *plugin.TValue[bool] {
 	return &c.DisableExternalDmaUnderLock
 }
 
-func (c *mqlWindowsBitlockerPolicy) GetOsAllowSecureBootForIntegrity() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicy) GetOsAllowSecureBootForIntegrity() *plugin.TValue[bool] {
 	return &c.OsAllowSecureBootForIntegrity
 }
 
@@ -57458,20 +57458,20 @@ type mqlWindowsBitlockerPolicyDriveSettings struct {
 	// optional: if you define mqlWindowsBitlockerPolicyDriveSettingsInternal it will be used here
 	DriveType                    plugin.TValue[string]
 	Recovery                     plugin.TValue[int64]
-	ManageDRA                    plugin.TValue[int64]
+	ManageDRA                    plugin.TValue[bool]
 	RecoveryPassword             plugin.TValue[int64]
 	RecoveryKey                  plugin.TValue[int64]
-	HideRecoveryPage             plugin.TValue[int64]
-	ActiveDirectoryBackup        plugin.TValue[int64]
+	HideRecoveryPage             plugin.TValue[bool]
+	ActiveDirectoryBackup        plugin.TValue[bool]
 	ActiveDirectoryInfoToStore   plugin.TValue[int64]
-	RequireActiveDirectoryBackup plugin.TValue[int64]
+	RequireActiveDirectoryBackup plugin.TValue[bool]
 	HardwareEncryption           plugin.TValue[int64]
 	Passphrase                   plugin.TValue[int64]
-	AllowUserCert                plugin.TValue[int64]
-	EnforceUserCert              plugin.TValue[int64]
+	AllowUserCert                plugin.TValue[bool]
+	EnforceUserCert              plugin.TValue[bool]
 	DiscoveryVolumeType          plugin.TValue[string]
-	DenyWriteAccess              plugin.TValue[int64]
-	DenyCrossOrg                 plugin.TValue[int64]
+	DenyWriteAccess              plugin.TValue[bool]
+	DenyCrossOrg                 plugin.TValue[bool]
 }
 
 // createWindowsBitlockerPolicyDriveSettings creates a new instance of this resource
@@ -57519,7 +57519,7 @@ func (c *mqlWindowsBitlockerPolicyDriveSettings) GetRecovery() *plugin.TValue[in
 	return &c.Recovery
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetManageDRA() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetManageDRA() *plugin.TValue[bool] {
 	return &c.ManageDRA
 }
 
@@ -57531,11 +57531,11 @@ func (c *mqlWindowsBitlockerPolicyDriveSettings) GetRecoveryKey() *plugin.TValue
 	return &c.RecoveryKey
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetHideRecoveryPage() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetHideRecoveryPage() *plugin.TValue[bool] {
 	return &c.HideRecoveryPage
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetActiveDirectoryBackup() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetActiveDirectoryBackup() *plugin.TValue[bool] {
 	return &c.ActiveDirectoryBackup
 }
 
@@ -57543,7 +57543,7 @@ func (c *mqlWindowsBitlockerPolicyDriveSettings) GetActiveDirectoryInfoToStore()
 	return &c.ActiveDirectoryInfoToStore
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetRequireActiveDirectoryBackup() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetRequireActiveDirectoryBackup() *plugin.TValue[bool] {
 	return &c.RequireActiveDirectoryBackup
 }
 
@@ -57555,11 +57555,11 @@ func (c *mqlWindowsBitlockerPolicyDriveSettings) GetPassphrase() *plugin.TValue[
 	return &c.Passphrase
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetAllowUserCert() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetAllowUserCert() *plugin.TValue[bool] {
 	return &c.AllowUserCert
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetEnforceUserCert() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetEnforceUserCert() *plugin.TValue[bool] {
 	return &c.EnforceUserCert
 }
 
@@ -57567,11 +57567,11 @@ func (c *mqlWindowsBitlockerPolicyDriveSettings) GetDiscoveryVolumeType() *plugi
 	return &c.DiscoveryVolumeType
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetDenyWriteAccess() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetDenyWriteAccess() *plugin.TValue[bool] {
 	return &c.DenyWriteAccess
 }
 
-func (c *mqlWindowsBitlockerPolicyDriveSettings) GetDenyCrossOrg() *plugin.TValue[int64] {
+func (c *mqlWindowsBitlockerPolicyDriveSettings) GetDenyCrossOrg() *plugin.TValue[bool] {
 	return &c.DenyCrossOrg
 }
 

--- a/providers/os/resources/windows_bitlocker.go
+++ b/providers/os/resources/windows_bitlocker.go
@@ -168,27 +168,27 @@ func computeBitlockerDrive(items map[string]registry.RegistryKeyItem, prefix str
 		"driveType": llx.StringData(driveTypeForPrefix(prefix)),
 
 		"recovery":                     llx.IntDataPtr(fveIntPtr(items, prefix+"Recovery")),
-		"manageDRA":                    llx.IntDataPtr(fveIntPtr(items, prefix+"ManageDRA")),
+		"manageDRA":                    llx.BoolDataPtr(regBoolPtr(items, prefix+"ManageDRA")),
 		"recoveryPassword":             llx.IntDataPtr(fveIntPtr(items, prefix+"RecoveryPassword")),
 		"recoveryKey":                  llx.IntDataPtr(fveIntPtr(items, prefix+"RecoveryKey")),
-		"hideRecoveryPage":             llx.IntDataPtr(fveIntPtr(items, prefix+"HideRecoveryPage")),
-		"activeDirectoryBackup":        llx.IntDataPtr(fveIntPtr(items, prefix+"ActiveDirectoryBackup")),
+		"hideRecoveryPage":             llx.BoolDataPtr(regBoolPtr(items, prefix+"HideRecoveryPage")),
+		"activeDirectoryBackup":        llx.BoolDataPtr(regBoolPtr(items, prefix+"ActiveDirectoryBackup")),
 		"activeDirectoryInfoToStore":   llx.IntDataPtr(fveIntPtr(items, prefix+"ActiveDirectoryInfoToStore")),
-		"requireActiveDirectoryBackup": llx.IntDataPtr(fveIntPtr(items, prefix+"RequireActiveDirectoryBackup")),
+		"requireActiveDirectoryBackup": llx.BoolDataPtr(regBoolPtr(items, prefix+"RequireActiveDirectoryBackup")),
 		"hardwareEncryption":           llx.IntDataPtr(fveIntPtr(items, prefix+"HardwareEncryption")),
 		"passphrase":                   llx.IntDataPtr(fveIntPtr(items, prefix+"Passphrase")),
 
 		// AllowUserCert / EnforceUserCert exist only for FDV and RDV drives;
 		// for OS drives the values are absent and these become null.
-		"allowUserCert":   llx.IntDataPtr(fveIntPtr(items, prefix+"AllowUserCert")),
-		"enforceUserCert": llx.IntDataPtr(fveIntPtr(items, prefix+"EnforceUserCert")),
+		"allowUserCert":   llx.BoolDataPtr(regBoolPtr(items, prefix+"AllowUserCert")),
+		"enforceUserCert": llx.BoolDataPtr(regBoolPtr(items, prefix+"EnforceUserCert")),
 
 		// DiscoveryVolumeType is a REG_SZ and exists only for FDV and RDV drives.
 		"discoveryVolumeType": llx.StringDataPtr(fveStringPtr(items, prefix+"DiscoveryVolumeType")),
 
 		// DenyWriteAccess / DenyCrossOrg exist only for removable (RDV) drives.
-		"denyWriteAccess": llx.IntDataPtr(fveIntPtr(items, prefix+"DenyWriteAccess")),
-		"denyCrossOrg":    llx.IntDataPtr(fveIntPtr(items, prefix+"DenyCrossOrg")),
+		"denyWriteAccess": llx.BoolDataPtr(regBoolPtr(items, prefix+"DenyWriteAccess")),
+		"denyCrossOrg":    llx.BoolDataPtr(regBoolPtr(items, prefix+"DenyCrossOrg")),
 	}
 	return args
 }
@@ -199,11 +199,11 @@ func computeBitlockerDrive(items map[string]registry.RegistryKeyItem, prefix str
 func computeBitlockerGlobal(items map[string]registry.RegistryKeyItem) map[string]*llx.RawData {
 	return map[string]*llx.RawData{
 		"__id":                          llx.StringData("windows.bitlocker.policy"),
-		"useAdvancedStartup":            llx.IntDataPtr(fveIntPtr(items, "UseAdvancedStartup")),
-		"useEnhancedPin":                llx.IntDataPtr(fveIntPtr(items, "UseEnhancedPin")),
-		"enableBdeWithNoTpm":            llx.IntDataPtr(fveIntPtr(items, "EnableBDEWithNoTPM")),
-		"disableExternalDmaUnderLock":   llx.IntDataPtr(fveIntPtr(items, "DisableExternalDMAUnderLock")),
-		"osAllowSecureBootForIntegrity": llx.IntDataPtr(fveIntPtr(items, "OSAllowSecureBootForIntegrity")),
+		"useAdvancedStartup":            llx.BoolDataPtr(regBoolPtr(items, "UseAdvancedStartup")),
+		"useEnhancedPin":                llx.BoolDataPtr(regBoolPtr(items, "UseEnhancedPin")),
+		"enableBdeWithNoTpm":            llx.BoolDataPtr(regBoolPtr(items, "EnableBDEWithNoTPM")),
+		"disableExternalDmaUnderLock":   llx.BoolDataPtr(regBoolPtr(items, "DisableExternalDMAUnderLock")),
+		"osAllowSecureBootForIntegrity": llx.BoolDataPtr(regBoolPtr(items, "OSAllowSecureBootForIntegrity")),
 	}
 }
 

--- a/providers/os/resources/windows_bitlocker_internal_test.go
+++ b/providers/os/resources/windows_bitlocker_internal_test.go
@@ -88,6 +88,20 @@ func rawIntPtr(t *testing.T, args map[string]*llx.RawData, key string) *int64 {
 	return &v
 }
 
+// rawBoolPtr extracts the *bool carried by an args value, or nil when the
+// RawData represents a null value.
+func rawBoolPtr(t *testing.T, args map[string]*llx.RawData, key string) *bool {
+	t.Helper()
+	rd, ok := args[key]
+	require.True(t, ok, "missing arg %q", key)
+	if rd.Value == nil {
+		return nil
+	}
+	v, ok := rd.Value.(bool)
+	require.True(t, ok, "arg %q is not a bool", key)
+	return &v
+}
+
 func rawString(t *testing.T, args map[string]*llx.RawData, key string) any {
 	t.Helper()
 	rd, ok := args[key]
@@ -107,21 +121,21 @@ func TestComputeBitlockerGlobal(t *testing.T) {
 		args := computeBitlockerGlobal(items)
 
 		assert.Equal(t, "windows.bitlocker.policy", args["__id"].Value)
-		require.NotNil(t, rawIntPtr(t, args, "useAdvancedStartup"))
-		assert.Equal(t, int64(1), *rawIntPtr(t, args, "useAdvancedStartup"))
+		require.NotNil(t, rawBoolPtr(t, args, "useAdvancedStartup"))
+		assert.Equal(t, true, *rawBoolPtr(t, args, "useAdvancedStartup"))
 		// explicit 0 stays non-null
-		require.NotNil(t, rawIntPtr(t, args, "enableBdeWithNoTpm"))
-		assert.Equal(t, int64(0), *rawIntPtr(t, args, "enableBdeWithNoTpm"))
-		assert.Equal(t, int64(1), *rawIntPtr(t, args, "osAllowSecureBootForIntegrity"))
+		require.NotNil(t, rawBoolPtr(t, args, "enableBdeWithNoTpm"))
+		assert.Equal(t, false, *rawBoolPtr(t, args, "enableBdeWithNoTpm"))
+		assert.Equal(t, true, *rawBoolPtr(t, args, "osAllowSecureBootForIntegrity"))
 	})
 
 	t.Run("absent values are null", func(t *testing.T) {
 		args := computeBitlockerGlobal(map[string]registry.RegistryKeyItem{})
-		assert.Nil(t, rawIntPtr(t, args, "useAdvancedStartup"))
-		assert.Nil(t, rawIntPtr(t, args, "useEnhancedPin"))
-		assert.Nil(t, rawIntPtr(t, args, "enableBdeWithNoTpm"))
-		assert.Nil(t, rawIntPtr(t, args, "disableExternalDmaUnderLock"))
-		assert.Nil(t, rawIntPtr(t, args, "osAllowSecureBootForIntegrity"))
+		assert.Nil(t, rawBoolPtr(t, args, "useAdvancedStartup"))
+		assert.Nil(t, rawBoolPtr(t, args, "useEnhancedPin"))
+		assert.Nil(t, rawBoolPtr(t, args, "enableBdeWithNoTpm"))
+		assert.Nil(t, rawBoolPtr(t, args, "disableExternalDmaUnderLock"))
+		assert.Nil(t, rawBoolPtr(t, args, "osAllowSecureBootForIntegrity"))
 	})
 }
 
@@ -171,23 +185,23 @@ func TestComputeBitlockerDrive_OSDrive(t *testing.T) {
 	// common values present (including explicit zeros)
 	require.NotNil(t, rawIntPtr(t, args, "recovery"))
 	assert.Equal(t, int64(1), *rawIntPtr(t, args, "recovery"))
-	require.NotNil(t, rawIntPtr(t, args, "manageDRA"))
-	assert.Equal(t, int64(0), *rawIntPtr(t, args, "manageDRA"))
+	require.NotNil(t, rawBoolPtr(t, args, "manageDRA"))
+	assert.Equal(t, false, *rawBoolPtr(t, args, "manageDRA"))
 	assert.Equal(t, int64(2), *rawIntPtr(t, args, "recoveryPassword"))
 	assert.Equal(t, int64(2), *rawIntPtr(t, args, "recoveryKey"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "hideRecoveryPage"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "activeDirectoryBackup"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "hideRecoveryPage"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "activeDirectoryBackup"))
 	assert.Equal(t, int64(1), *rawIntPtr(t, args, "activeDirectoryInfoToStore"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "requireActiveDirectoryBackup"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "requireActiveDirectoryBackup"))
 	assert.Equal(t, int64(0), *rawIntPtr(t, args, "hardwareEncryption"))
 	assert.Equal(t, int64(0), *rawIntPtr(t, args, "passphrase"))
 
 	// fields OS drives don't define are null
-	assert.Nil(t, rawIntPtr(t, args, "allowUserCert"))
-	assert.Nil(t, rawIntPtr(t, args, "enforceUserCert"))
+	assert.Nil(t, rawBoolPtr(t, args, "allowUserCert"))
+	assert.Nil(t, rawBoolPtr(t, args, "enforceUserCert"))
 	assert.Nil(t, rawString(t, args, "discoveryVolumeType"))
-	assert.Nil(t, rawIntPtr(t, args, "denyWriteAccess"))
-	assert.Nil(t, rawIntPtr(t, args, "denyCrossOrg"))
+	assert.Nil(t, rawBoolPtr(t, args, "denyWriteAccess"))
+	assert.Nil(t, rawBoolPtr(t, args, "denyCrossOrg"))
 }
 
 func TestComputeBitlockerDrive_FixedData(t *testing.T) {
@@ -202,16 +216,16 @@ func TestComputeBitlockerDrive_FixedData(t *testing.T) {
 	args := computeBitlockerDrive(items, fveFDVPrefix)
 
 	assert.Equal(t, int64(1), *rawIntPtr(t, args, "recovery"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "allowUserCert"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "enforceUserCert"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "allowUserCert"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "enforceUserCert"))
 	assert.Equal(t, "FAT32", rawString(t, args, "discoveryVolumeType"))
 
 	// removable-only fields are null
-	assert.Nil(t, rawIntPtr(t, args, "denyWriteAccess"))
-	assert.Nil(t, rawIntPtr(t, args, "denyCrossOrg"))
+	assert.Nil(t, rawBoolPtr(t, args, "denyWriteAccess"))
+	assert.Nil(t, rawBoolPtr(t, args, "denyCrossOrg"))
 
 	// unset common field is null
-	assert.Nil(t, rawIntPtr(t, args, "manageDRA"))
+	assert.Nil(t, rawBoolPtr(t, args, "manageDRA"))
 }
 
 func TestComputeBitlockerDrive_RemovableData(t *testing.T) {
@@ -228,23 +242,28 @@ func TestComputeBitlockerDrive_RemovableData(t *testing.T) {
 	args := computeBitlockerDrive(items, fveRDVPrefix)
 
 	assert.Equal(t, int64(1), *rawIntPtr(t, args, "recovery"))
-	require.NotNil(t, rawIntPtr(t, args, "allowUserCert"))
-	assert.Equal(t, int64(0), *rawIntPtr(t, args, "allowUserCert"))
-	assert.Equal(t, int64(1), *rawIntPtr(t, args, "denyWriteAccess"))
-	require.NotNil(t, rawIntPtr(t, args, "denyCrossOrg"))
-	assert.Equal(t, int64(0), *rawIntPtr(t, args, "denyCrossOrg"))
+	require.NotNil(t, rawBoolPtr(t, args, "allowUserCert"))
+	assert.Equal(t, false, *rawBoolPtr(t, args, "allowUserCert"))
+	assert.Equal(t, true, *rawBoolPtr(t, args, "denyWriteAccess"))
+	require.NotNil(t, rawBoolPtr(t, args, "denyCrossOrg"))
+	assert.Equal(t, false, *rawBoolPtr(t, args, "denyCrossOrg"))
 	assert.Equal(t, "Default", rawString(t, args, "discoveryVolumeType"))
 }
 
 func TestComputeBitlockerDrive_AllAbsentAreNull(t *testing.T) {
 	args := computeBitlockerDrive(map[string]registry.RegistryKeyItem{}, fveRDVPrefix)
 	for _, k := range []string{
-		"recovery", "manageDRA", "recoveryPassword", "recoveryKey", "hideRecoveryPage",
-		"activeDirectoryBackup", "activeDirectoryInfoToStore", "requireActiveDirectoryBackup",
-		"hardwareEncryption", "passphrase", "allowUserCert", "enforceUserCert",
-		"denyWriteAccess", "denyCrossOrg",
+		"recovery", "recoveryPassword", "recoveryKey",
+		"activeDirectoryInfoToStore", "hardwareEncryption", "passphrase",
 	} {
 		assert.Nil(t, rawIntPtr(t, args, k), "expected %q to be null", k)
+	}
+	for _, k := range []string{
+		"manageDRA", "hideRecoveryPage", "activeDirectoryBackup",
+		"requireActiveDirectoryBackup", "allowUserCert", "enforceUserCert",
+		"denyWriteAccess", "denyCrossOrg",
+	} {
+		assert.Nil(t, rawBoolPtr(t, args, k), "expected %q to be null", k)
 	}
 	assert.Nil(t, rawString(t, args, "discoveryVolumeType"))
 	// driveType is always set even with no values

--- a/providers/os/resources/windows_deviceguard.go
+++ b/providers/os/resources/windows_deviceguard.go
@@ -60,16 +60,17 @@ func regIntPtr(items map[string]registry.RegistryKeyItem, name string) *int64 {
 	return nil
 }
 
-// deviceGuardValues holds the extracted Device Guard DWORDs as nullable ints.
-// A nil pointer means the value name was absent from the registry ("not
-// configured"), which the resource surfaces as a null field rather than 0.
+// deviceGuardValues holds the extracted Device Guard DWORDs as nullable
+// pointers. A nil pointer means the value name was absent from the registry
+// ("not configured"), which the resource surfaces as a null field rather than
+// 0. On/off settings are bools; graded settings are int64s.
 type deviceGuardValues struct {
-	virtualizationBasedSecurityEnabled *int64
+	virtualizationBasedSecurityEnabled *bool
 	requirePlatformSecurityFeatures    *int64
 	hypervisorEnforcedCodeIntegrity    *int64
-	hvciMatRequired                    *int64
+	hvciMatRequired                    *bool
 	credentialGuardConfig              *int64
-	systemGuardLaunch                  *int64
+	systemGuardLaunch                  *bool
 	kernelShadowStacksLaunch           *int64
 }
 
@@ -78,12 +79,12 @@ type deviceGuardValues struct {
 // can tell "not configured" from an explicit 0. Pure function for unit testing.
 func computeDeviceGuard(items map[string]registry.RegistryKeyItem) deviceGuardValues {
 	return deviceGuardValues{
-		virtualizationBasedSecurityEnabled: regIntPtr(items, "EnableVirtualizationBasedSecurity"),
+		virtualizationBasedSecurityEnabled: regBoolPtr(items, "EnableVirtualizationBasedSecurity"),
 		requirePlatformSecurityFeatures:    regIntPtr(items, "RequirePlatformSecurityFeatures"),
 		hypervisorEnforcedCodeIntegrity:    regIntPtr(items, "HypervisorEnforcedCodeIntegrity"),
-		hvciMatRequired:                    regIntPtr(items, "HVCIMATRequired"),
+		hvciMatRequired:                    regBoolPtr(items, "HVCIMATRequired"),
 		credentialGuardConfig:              regIntPtr(items, "LsaCfgFlags"),
-		systemGuardLaunch:                  regIntPtr(items, "ConfigureSystemGuardLaunch"),
+		systemGuardLaunch:                  regBoolPtr(items, "ConfigureSystemGuardLaunch"),
 		kernelShadowStacksLaunch:           regIntPtr(items, "ConfigureKernelShadowStacksLaunch"),
 	}
 }
@@ -98,12 +99,12 @@ func (w *mqlWindows) deviceGuard() (*mqlWindowsDeviceGuard, error) {
 
 	o, err := CreateResource(w.MqlRuntime, "windows.deviceGuard", map[string]*llx.RawData{
 		"__id":                               llx.StringData("windows.deviceGuard"),
-		"virtualizationBasedSecurityEnabled": llx.IntDataPtr(v.virtualizationBasedSecurityEnabled),
+		"virtualizationBasedSecurityEnabled": llx.BoolDataPtr(v.virtualizationBasedSecurityEnabled),
 		"requirePlatformSecurityFeatures":    llx.IntDataPtr(v.requirePlatformSecurityFeatures),
 		"hypervisorEnforcedCodeIntegrity":    llx.IntDataPtr(v.hypervisorEnforcedCodeIntegrity),
-		"hvciMatRequired":                    llx.IntDataPtr(v.hvciMatRequired),
+		"hvciMatRequired":                    llx.BoolDataPtr(v.hvciMatRequired),
 		"credentialGuardConfig":              llx.IntDataPtr(v.credentialGuardConfig),
-		"systemGuardLaunch":                  llx.IntDataPtr(v.systemGuardLaunch),
+		"systemGuardLaunch":                  llx.BoolDataPtr(v.systemGuardLaunch),
 		"kernelShadowStacksLaunch":           llx.IntDataPtr(v.kernelShadowStacksLaunch),
 	})
 	if err != nil {

--- a/providers/os/resources/windows_deviceguard_internal_test.go
+++ b/providers/os/resources/windows_deviceguard_internal_test.go
@@ -84,17 +84,17 @@ func TestComputeDeviceGuard(t *testing.T) {
 			"configurekernelshadowstackslaunch": 1,
 		}))
 		require.NotNil(t, v.virtualizationBasedSecurityEnabled)
-		assert.Equal(t, int64(1), *v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, true, *v.virtualizationBasedSecurityEnabled)
 		require.NotNil(t, v.requirePlatformSecurityFeatures)
 		assert.Equal(t, int64(3), *v.requirePlatformSecurityFeatures)
 		require.NotNil(t, v.hypervisorEnforcedCodeIntegrity)
 		assert.Equal(t, int64(1), *v.hypervisorEnforcedCodeIntegrity)
 		require.NotNil(t, v.hvciMatRequired)
-		assert.Equal(t, int64(1), *v.hvciMatRequired)
+		assert.Equal(t, true, *v.hvciMatRequired)
 		require.NotNil(t, v.credentialGuardConfig)
 		assert.Equal(t, int64(1), *v.credentialGuardConfig)
 		require.NotNil(t, v.systemGuardLaunch)
-		assert.Equal(t, int64(1), *v.systemGuardLaunch)
+		assert.Equal(t, true, *v.systemGuardLaunch)
 		require.NotNil(t, v.kernelShadowStacksLaunch)
 		assert.Equal(t, int64(1), *v.kernelShadowStacksLaunch)
 	})
@@ -110,12 +110,12 @@ func TestComputeDeviceGuard(t *testing.T) {
 			"configuresystemguardlaunch":        0,
 			"configurekernelshadowstackslaunch": 2,
 		}))
-		assert.Equal(t, int64(1), *v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, true, *v.virtualizationBasedSecurityEnabled)
 		assert.Equal(t, int64(3), *v.requirePlatformSecurityFeatures)
 		assert.Equal(t, int64(2), *v.hypervisorEnforcedCodeIntegrity)
-		assert.Equal(t, int64(0), *v.hvciMatRequired)
+		assert.Equal(t, false, *v.hvciMatRequired)
 		assert.Equal(t, int64(2), *v.credentialGuardConfig)
-		assert.Equal(t, int64(0), *v.systemGuardLaunch)
+		assert.Equal(t, false, *v.systemGuardLaunch)
 		assert.Equal(t, int64(2), *v.kernelShadowStacksLaunch)
 	})
 
@@ -126,7 +126,7 @@ func TestComputeDeviceGuard(t *testing.T) {
 			"enablevirtualizationbasedsecurity": 0,
 		}))
 		require.NotNil(t, v.virtualizationBasedSecurityEnabled)
-		assert.Equal(t, int64(0), *v.virtualizationBasedSecurityEnabled)
+		assert.Equal(t, false, *v.virtualizationBasedSecurityEnabled)
 		assert.Nil(t, v.credentialGuardConfig)
 	})
 

--- a/providers/os/resources/windows_lsa.go
+++ b/providers/os/resources/windows_lsa.go
@@ -80,66 +80,78 @@ func regStringPtr(items map[string]registry.RegistryKeyItem, name string) *strin
 	return nil
 }
 
+// regBoolPtr returns a pointer to the boolean interpretation of a registry
+// DWORD (true for any non-zero value), or nil when the value is absent. Used
+// for the on/off LSA settings whose registry value is a 0/1 DWORD.
+func regBoolPtr(items map[string]registry.RegistryKeyItem, name string) *bool {
+	if it, ok := items[strings.ToLower(name)]; ok {
+		v := it.Value.Number != 0
+		return &v
+	}
+	return nil
+}
+
 // lsaValues holds the extracted top-level Lsa values as nullable pointers.
+// On/off settings are bools; graded settings are int64s.
 type lsaValues struct {
-	DisableDomainCreds          *int64
-	EveryoneIncludesAnonymous   *int64
-	ForceGuest                  *int64
-	LimitBlankPasswordUse       *int64
+	DisableDomainCreds          *bool
+	EveryoneIncludesAnonymous   *bool
+	ForceGuest                  *bool
+	LimitBlankPasswordUse       *bool
 	LmCompatibilityLevel        *int64
-	NoLmHash                    *int64
+	NoLmHash                    *bool
 	RestrictAnonymous           *int64
-	RestrictAnonymousSam        *int64
+	RestrictAnonymousSam        *bool
 	RestrictRemoteSam           *string
 	RunAsPpl                    *int64
-	SceNoApplyLegacyAuditPolicy *int64
-	SubmitControl               *int64
-	UseMachineId                *int64
+	SceNoApplyLegacyAuditPolicy *bool
+	SubmitControl               *bool
+	UseMachineId                *bool
 }
 
 // computeLsa extracts the top-level Lsa values from the raw registry items.
 // Pure function for unit testing.
 func computeLsa(items map[string]registry.RegistryKeyItem) lsaValues {
 	return lsaValues{
-		DisableDomainCreds:          regIntPtr(items, "DisableDomainCreds"),
-		EveryoneIncludesAnonymous:   regIntPtr(items, "EveryoneIncludesAnonymous"),
-		ForceGuest:                  regIntPtr(items, "ForceGuest"),
-		LimitBlankPasswordUse:       regIntPtr(items, "LimitBlankPasswordUse"),
+		DisableDomainCreds:          regBoolPtr(items, "DisableDomainCreds"),
+		EveryoneIncludesAnonymous:   regBoolPtr(items, "EveryoneIncludesAnonymous"),
+		ForceGuest:                  regBoolPtr(items, "ForceGuest"),
+		LimitBlankPasswordUse:       regBoolPtr(items, "LimitBlankPasswordUse"),
 		LmCompatibilityLevel:        regIntPtr(items, "LmCompatibilityLevel"),
-		NoLmHash:                    regIntPtr(items, "NoLMHash"),
+		NoLmHash:                    regBoolPtr(items, "NoLMHash"),
 		RestrictAnonymous:           regIntPtr(items, "RestrictAnonymous"),
-		RestrictAnonymousSam:        regIntPtr(items, "RestrictAnonymousSAM"),
+		RestrictAnonymousSam:        regBoolPtr(items, "RestrictAnonymousSAM"),
 		RestrictRemoteSam:           regStringPtr(items, "restrictremotesam"),
 		RunAsPpl:                    regIntPtr(items, "RunAsPPL"),
-		SceNoApplyLegacyAuditPolicy: regIntPtr(items, "SCENoApplyLegacyAuditPolicy"),
-		SubmitControl:               regIntPtr(items, "SubmitControl"),
-		UseMachineId:                regIntPtr(items, "UseMachineId"),
+		SceNoApplyLegacyAuditPolicy: regBoolPtr(items, "SCENoApplyLegacyAuditPolicy"),
+		SubmitControl:               regBoolPtr(items, "SubmitControl"),
+		UseMachineId:                regBoolPtr(items, "UseMachineId"),
 	}
 }
 
 // lsaNtlmValues holds the extracted NTLM (MSV1_0 + WDigest + pku2u) values as
 // nullable pointers.
 type lsaNtlmValues struct {
-	AllowNullSessionFallback   *int64
+	AllowNullSessionFallback   *bool
 	AuditReceivingNtlmTraffic  *int64
 	NtlmMinClientSec           *int64
 	NtlmMinServerSec           *int64
 	RestrictSendingNtlmTraffic *int64
-	UseLogonCredential         *int64
-	AllowOnlineId              *int64
+	UseLogonCredential         *bool
+	AllowOnlineId              *bool
 }
 
 // computeLsaNtlm extracts the NTLM settings from the MSV1_0, WDigest, and pku2u
 // registry items. Pure function for unit testing.
 func computeLsaNtlm(msv10, wdigest, pku2u map[string]registry.RegistryKeyItem) lsaNtlmValues {
 	return lsaNtlmValues{
-		AllowNullSessionFallback:   regIntPtr(msv10, "AllowNullSessionFallback"),
+		AllowNullSessionFallback:   regBoolPtr(msv10, "AllowNullSessionFallback"),
 		AuditReceivingNtlmTraffic:  regIntPtr(msv10, "AuditReceivingNTLMTraffic"),
 		NtlmMinClientSec:           regIntPtr(msv10, "NTLMMinClientSec"),
 		NtlmMinServerSec:           regIntPtr(msv10, "NTLMMinServerSec"),
 		RestrictSendingNtlmTraffic: regIntPtr(msv10, "RestrictSendingNTLMTraffic"),
-		UseLogonCredential:         regIntPtr(wdigest, "UseLogonCredential"),
-		AllowOnlineId:              regIntPtr(pku2u, "AllowOnlineID"),
+		UseLogonCredential:         regBoolPtr(wdigest, "UseLogonCredential"),
+		AllowOnlineId:              regBoolPtr(pku2u, "AllowOnlineID"),
 	}
 }
 
@@ -147,14 +159,14 @@ func computeLsaNtlm(msv10, wdigest, pku2u map[string]registry.RegistryKeyItem) l
 // nullable pointers.
 type lsaSecureChannelValues struct {
 	AuditNtlmInDomain          *int64
-	BlockNetbiosDiscovery      *int64
-	DisablePasswordChange      *int64
+	BlockNetbiosDiscovery      *bool
+	DisablePasswordChange      *bool
 	MaximumPasswordAge         *int64
-	RefusePasswordChange       *int64
-	RequireSignOrSeal          *int64
-	RequireStrongKey           *int64
-	SealSecureChannel          *int64
-	SignSecureChannel          *int64
+	RefusePasswordChange       *bool
+	RequireSignOrSeal          *bool
+	RequireStrongKey           *bool
+	SealSecureChannel          *bool
+	SignSecureChannel          *bool
 	VulnerableChannelAllowList *string
 }
 
@@ -165,31 +177,31 @@ type lsaSecureChannelValues struct {
 func computeLsaSecureChannel(netlogon, netlogonPolicy map[string]registry.RegistryKeyItem) lsaSecureChannelValues {
 	return lsaSecureChannelValues{
 		AuditNtlmInDomain:          regIntPtr(netlogon, "AuditNTLMInDomain"),
-		BlockNetbiosDiscovery:      regIntPtr(netlogonPolicy, "BlockNetbiosDiscovery"),
-		DisablePasswordChange:      regIntPtr(netlogon, "DisablePasswordChange"),
+		BlockNetbiosDiscovery:      regBoolPtr(netlogonPolicy, "BlockNetbiosDiscovery"),
+		DisablePasswordChange:      regBoolPtr(netlogon, "DisablePasswordChange"),
 		MaximumPasswordAge:         regIntPtr(netlogon, "MaximumPasswordAge"),
-		RefusePasswordChange:       regIntPtr(netlogon, "RefusePasswordChange"),
-		RequireSignOrSeal:          regIntPtr(netlogon, "RequireSignOrSeal"),
-		RequireStrongKey:           regIntPtr(netlogon, "RequireStrongKey"),
-		SealSecureChannel:          regIntPtr(netlogon, "SealSecureChannel"),
-		SignSecureChannel:          regIntPtr(netlogon, "SignSecureChannel"),
+		RefusePasswordChange:       regBoolPtr(netlogon, "RefusePasswordChange"),
+		RequireSignOrSeal:          regBoolPtr(netlogon, "RequireSignOrSeal"),
+		RequireStrongKey:           regBoolPtr(netlogon, "RequireStrongKey"),
+		SealSecureChannel:          regBoolPtr(netlogon, "SealSecureChannel"),
+		SignSecureChannel:          regBoolPtr(netlogon, "SignSecureChannel"),
 		VulnerableChannelAllowList: regStringPtr(netlogon, "vulnerablechannelallowlist"),
 	}
 }
 
-func (r *mqlWindowsLsa) disableDomainCreds() (int64, error)          { return 0, r.populate() }
-func (r *mqlWindowsLsa) everyoneIncludesAnonymous() (int64, error)   { return 0, r.populate() }
-func (r *mqlWindowsLsa) forceGuest() (int64, error)                  { return 0, r.populate() }
-func (r *mqlWindowsLsa) limitBlankPasswordUse() (int64, error)       { return 0, r.populate() }
-func (r *mqlWindowsLsa) lmCompatibilityLevel() (int64, error)        { return 0, r.populate() }
-func (r *mqlWindowsLsa) noLmHash() (int64, error)                    { return 0, r.populate() }
-func (r *mqlWindowsLsa) restrictAnonymous() (int64, error)           { return 0, r.populate() }
-func (r *mqlWindowsLsa) restrictAnonymousSam() (int64, error)        { return 0, r.populate() }
-func (r *mqlWindowsLsa) restrictRemoteSam() (string, error)          { return "", r.populate() }
-func (r *mqlWindowsLsa) runAsPpl() (int64, error)                    { return 0, r.populate() }
-func (r *mqlWindowsLsa) sceNoApplyLegacyAuditPolicy() (int64, error) { return 0, r.populate() }
-func (r *mqlWindowsLsa) submitControl() (int64, error)               { return 0, r.populate() }
-func (r *mqlWindowsLsa) useMachineId() (int64, error)                { return 0, r.populate() }
+func (r *mqlWindowsLsa) disableDomainCreds() (bool, error)          { return false, r.populate() }
+func (r *mqlWindowsLsa) everyoneIncludesAnonymous() (bool, error)   { return false, r.populate() }
+func (r *mqlWindowsLsa) forceGuest() (bool, error)                  { return false, r.populate() }
+func (r *mqlWindowsLsa) limitBlankPasswordUse() (bool, error)       { return false, r.populate() }
+func (r *mqlWindowsLsa) lmCompatibilityLevel() (int64, error)       { return 0, r.populate() }
+func (r *mqlWindowsLsa) noLmHash() (bool, error)                    { return false, r.populate() }
+func (r *mqlWindowsLsa) restrictAnonymous() (int64, error)          { return 0, r.populate() }
+func (r *mqlWindowsLsa) restrictAnonymousSam() (bool, error)        { return false, r.populate() }
+func (r *mqlWindowsLsa) restrictRemoteSam() (string, error)         { return "", r.populate() }
+func (r *mqlWindowsLsa) runAsPpl() (int64, error)                   { return 0, r.populate() }
+func (r *mqlWindowsLsa) sceNoApplyLegacyAuditPolicy() (bool, error) { return false, r.populate() }
+func (r *mqlWindowsLsa) submitControl() (bool, error)               { return false, r.populate() }
+func (r *mqlWindowsLsa) useMachineId() (bool, error)                { return false, r.populate() }
 
 // populate reads the Lsa key once and fills every top-level field. Each field
 // accessor delegates here; the lazy-field machinery caches the results so the
@@ -201,19 +213,19 @@ func (r *mqlWindowsLsa) populate() error {
 	}
 	v := computeLsa(items)
 
-	r.DisableDomainCreds = intFieldPtr(v.DisableDomainCreds)
-	r.EveryoneIncludesAnonymous = intFieldPtr(v.EveryoneIncludesAnonymous)
-	r.ForceGuest = intFieldPtr(v.ForceGuest)
-	r.LimitBlankPasswordUse = intFieldPtr(v.LimitBlankPasswordUse)
+	r.DisableDomainCreds = boolFieldPtr(v.DisableDomainCreds)
+	r.EveryoneIncludesAnonymous = boolFieldPtr(v.EveryoneIncludesAnonymous)
+	r.ForceGuest = boolFieldPtr(v.ForceGuest)
+	r.LimitBlankPasswordUse = boolFieldPtr(v.LimitBlankPasswordUse)
 	r.LmCompatibilityLevel = intFieldPtr(v.LmCompatibilityLevel)
-	r.NoLmHash = intFieldPtr(v.NoLmHash)
+	r.NoLmHash = boolFieldPtr(v.NoLmHash)
 	r.RestrictAnonymous = intFieldPtr(v.RestrictAnonymous)
-	r.RestrictAnonymousSam = intFieldPtr(v.RestrictAnonymousSam)
+	r.RestrictAnonymousSam = boolFieldPtr(v.RestrictAnonymousSam)
 	r.RestrictRemoteSam = stringFieldPtr(v.RestrictRemoteSam)
 	r.RunAsPpl = intFieldPtr(v.RunAsPpl)
-	r.SceNoApplyLegacyAuditPolicy = intFieldPtr(v.SceNoApplyLegacyAuditPolicy)
-	r.SubmitControl = intFieldPtr(v.SubmitControl)
-	r.UseMachineId = intFieldPtr(v.UseMachineId)
+	r.SceNoApplyLegacyAuditPolicy = boolFieldPtr(v.SceNoApplyLegacyAuditPolicy)
+	r.SubmitControl = boolFieldPtr(v.SubmitControl)
+	r.UseMachineId = boolFieldPtr(v.UseMachineId)
 	return nil
 }
 
@@ -235,13 +247,13 @@ func (r *mqlWindowsLsa) ntlm() (*mqlWindowsLsaNtlm, error) {
 
 	o, err := CreateResource(r.MqlRuntime, "windows.lsa.ntlm", map[string]*llx.RawData{
 		"__id":                       llx.StringData("windows.lsa.ntlm"),
-		"allowNullSessionFallback":   llx.IntDataPtr(v.AllowNullSessionFallback),
+		"allowNullSessionFallback":   llx.BoolDataPtr(v.AllowNullSessionFallback),
 		"auditReceivingNtlmTraffic":  llx.IntDataPtr(v.AuditReceivingNtlmTraffic),
 		"ntlmMinClientSec":           llx.IntDataPtr(v.NtlmMinClientSec),
 		"ntlmMinServerSec":           llx.IntDataPtr(v.NtlmMinServerSec),
 		"restrictSendingNtlmTraffic": llx.IntDataPtr(v.RestrictSendingNtlmTraffic),
-		"useLogonCredential":         llx.IntDataPtr(v.UseLogonCredential),
-		"allowOnlineId":              llx.IntDataPtr(v.AllowOnlineId),
+		"useLogonCredential":         llx.BoolDataPtr(v.UseLogonCredential),
+		"allowOnlineId":              llx.BoolDataPtr(v.AllowOnlineId),
 	})
 	if err != nil {
 		return nil, err
@@ -264,14 +276,14 @@ func (r *mqlWindowsLsa) secureChannel() (*mqlWindowsLsaSecureChannel, error) {
 	o, err := CreateResource(r.MqlRuntime, "windows.lsa.secureChannel", map[string]*llx.RawData{
 		"__id":                       llx.StringData("windows.lsa.secureChannel"),
 		"auditNtlmInDomain":          llx.IntDataPtr(v.AuditNtlmInDomain),
-		"blockNetbiosDiscovery":      llx.IntDataPtr(v.BlockNetbiosDiscovery),
-		"disablePasswordChange":      llx.IntDataPtr(v.DisablePasswordChange),
+		"blockNetbiosDiscovery":      llx.BoolDataPtr(v.BlockNetbiosDiscovery),
+		"disablePasswordChange":      llx.BoolDataPtr(v.DisablePasswordChange),
 		"maximumPasswordAge":         llx.IntDataPtr(v.MaximumPasswordAge),
-		"refusePasswordChange":       llx.IntDataPtr(v.RefusePasswordChange),
-		"requireSignOrSeal":          llx.IntDataPtr(v.RequireSignOrSeal),
-		"requireStrongKey":           llx.IntDataPtr(v.RequireStrongKey),
-		"sealSecureChannel":          llx.IntDataPtr(v.SealSecureChannel),
-		"signSecureChannel":          llx.IntDataPtr(v.SignSecureChannel),
+		"refusePasswordChange":       llx.BoolDataPtr(v.RefusePasswordChange),
+		"requireSignOrSeal":          llx.BoolDataPtr(v.RequireSignOrSeal),
+		"requireStrongKey":           llx.BoolDataPtr(v.RequireStrongKey),
+		"sealSecureChannel":          llx.BoolDataPtr(v.SealSecureChannel),
+		"signSecureChannel":          llx.BoolDataPtr(v.SignSecureChannel),
 		"vulnerableChannelAllowList": llx.StringDataPtr(v.VulnerableChannelAllowList),
 	})
 	if err != nil {
@@ -287,6 +299,15 @@ func intFieldPtr(v *int64) plugin.TValue[int64] {
 		return plugin.TValue[int64]{State: plugin.StateIsSet | plugin.StateIsNull}
 	}
 	return plugin.TValue[int64]{Data: *v, State: plugin.StateIsSet}
+}
+
+// boolFieldPtr converts a nullable *bool into the generated plugin.TValue[bool]
+// field representation, marking the field null when the source pointer is nil.
+func boolFieldPtr(v *bool) plugin.TValue[bool] {
+	if v == nil {
+		return plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+	}
+	return plugin.TValue[bool]{Data: *v, State: plugin.StateIsSet}
 }
 
 // stringFieldPtr converts a nullable *string into the generated

--- a/providers/os/resources/windows_lsa_internal_test.go
+++ b/providers/os/resources/windows_lsa_internal_test.go
@@ -141,31 +141,31 @@ func TestComputeLsa(t *testing.T) {
 		)
 		v := computeLsa(m)
 		require.NotNil(t, v.DisableDomainCreds)
-		assert.Equal(t, int64(1), *v.DisableDomainCreds)
+		assert.Equal(t, true, *v.DisableDomainCreds)
 		require.NotNil(t, v.EveryoneIncludesAnonymous)
-		assert.Equal(t, int64(0), *v.EveryoneIncludesAnonymous)
+		assert.Equal(t, false, *v.EveryoneIncludesAnonymous)
 		require.NotNil(t, v.ForceGuest)
-		assert.Equal(t, int64(0), *v.ForceGuest)
+		assert.Equal(t, false, *v.ForceGuest)
 		require.NotNil(t, v.LimitBlankPasswordUse)
-		assert.Equal(t, int64(1), *v.LimitBlankPasswordUse)
+		assert.Equal(t, true, *v.LimitBlankPasswordUse)
 		require.NotNil(t, v.LmCompatibilityLevel)
 		assert.Equal(t, int64(5), *v.LmCompatibilityLevel)
 		require.NotNil(t, v.NoLmHash)
-		assert.Equal(t, int64(1), *v.NoLmHash)
+		assert.Equal(t, true, *v.NoLmHash)
 		require.NotNil(t, v.RestrictAnonymous)
 		assert.Equal(t, int64(1), *v.RestrictAnonymous)
 		require.NotNil(t, v.RestrictAnonymousSam)
-		assert.Equal(t, int64(1), *v.RestrictAnonymousSam)
+		assert.Equal(t, true, *v.RestrictAnonymousSam)
 		require.NotNil(t, v.RestrictRemoteSam)
 		assert.Equal(t, "O:BAG:BAD:(A;;RC;;;BA)", *v.RestrictRemoteSam)
 		require.NotNil(t, v.RunAsPpl)
 		assert.Equal(t, int64(1), *v.RunAsPpl)
 		require.NotNil(t, v.SceNoApplyLegacyAuditPolicy)
-		assert.Equal(t, int64(1), *v.SceNoApplyLegacyAuditPolicy)
+		assert.Equal(t, true, *v.SceNoApplyLegacyAuditPolicy)
 		require.NotNil(t, v.SubmitControl)
-		assert.Equal(t, int64(0), *v.SubmitControl)
+		assert.Equal(t, false, *v.SubmitControl)
 		require.NotNil(t, v.UseMachineId)
-		assert.Equal(t, int64(1), *v.UseMachineId)
+		assert.Equal(t, true, *v.UseMachineId)
 	})
 
 	t.Run("partial config leaves unset fields null", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestComputeLsaNtlm(t *testing.T) {
 
 		v := computeLsaNtlm(msv10, wdigest, pku2u)
 		require.NotNil(t, v.AllowNullSessionFallback)
-		assert.Equal(t, int64(0), *v.AllowNullSessionFallback)
+		assert.Equal(t, false, *v.AllowNullSessionFallback)
 		require.NotNil(t, v.AuditReceivingNtlmTraffic)
 		assert.Equal(t, int64(2), *v.AuditReceivingNtlmTraffic)
 		require.NotNil(t, v.NtlmMinClientSec)
@@ -212,11 +212,11 @@ func TestComputeLsaNtlm(t *testing.T) {
 		assert.Equal(t, int64(537395200), *v.NtlmMinServerSec)
 		require.NotNil(t, v.RestrictSendingNtlmTraffic)
 		assert.Equal(t, int64(2), *v.RestrictSendingNtlmTraffic)
-		// UseLogonCredential==0 is the compliant value; absent must not look like 0
+		// UseLogonCredential==false is the compliant value; absent must not look like false
 		require.NotNil(t, v.UseLogonCredential)
-		assert.Equal(t, int64(0), *v.UseLogonCredential)
+		assert.Equal(t, false, *v.UseLogonCredential)
 		require.NotNil(t, v.AllowOnlineId)
-		assert.Equal(t, int64(0), *v.AllowOnlineId)
+		assert.Equal(t, false, *v.AllowOnlineId)
 	})
 
 	t.Run("WDigest value absent stays null while MSV1_0 set", func(t *testing.T) {
@@ -262,21 +262,21 @@ func TestComputeLsaSecureChannel(t *testing.T) {
 		require.NotNil(t, v.AuditNtlmInDomain)
 		assert.Equal(t, int64(7), *v.AuditNtlmInDomain)
 		require.NotNil(t, v.BlockNetbiosDiscovery)
-		assert.Equal(t, int64(1), *v.BlockNetbiosDiscovery)
+		assert.Equal(t, true, *v.BlockNetbiosDiscovery)
 		require.NotNil(t, v.DisablePasswordChange)
-		assert.Equal(t, int64(0), *v.DisablePasswordChange)
+		assert.Equal(t, false, *v.DisablePasswordChange)
 		require.NotNil(t, v.MaximumPasswordAge)
 		assert.Equal(t, int64(30), *v.MaximumPasswordAge)
 		require.NotNil(t, v.RefusePasswordChange)
-		assert.Equal(t, int64(0), *v.RefusePasswordChange)
+		assert.Equal(t, false, *v.RefusePasswordChange)
 		require.NotNil(t, v.RequireSignOrSeal)
-		assert.Equal(t, int64(1), *v.RequireSignOrSeal)
+		assert.Equal(t, true, *v.RequireSignOrSeal)
 		require.NotNil(t, v.RequireStrongKey)
-		assert.Equal(t, int64(1), *v.RequireStrongKey)
+		assert.Equal(t, true, *v.RequireStrongKey)
 		require.NotNil(t, v.SealSecureChannel)
-		assert.Equal(t, int64(1), *v.SealSecureChannel)
+		assert.Equal(t, true, *v.SealSecureChannel)
 		require.NotNil(t, v.SignSecureChannel)
-		assert.Equal(t, int64(1), *v.SignSecureChannel)
+		assert.Equal(t, true, *v.SignSecureChannel)
 		require.NotNil(t, v.VulnerableChannelAllowList)
 		assert.Equal(t, "", *v.VulnerableChannelAllowList)
 	})
@@ -310,6 +310,42 @@ func TestLsaIntFieldPtr(t *testing.T) {
 		assert.True(t, f.IsSet())
 		assert.False(t, f.IsNull())
 		assert.Equal(t, int64(0), f.Data)
+	})
+}
+
+func TestLsaRegBoolPtr(t *testing.T) {
+	m := items(d("RequireSignOrSeal", 1), d("DisablePasswordChange", 0))
+
+	t.Run("non-zero DWORD returns true", func(t *testing.T) {
+		p := regBoolPtr(m, "RequireSignOrSeal")
+		require.NotNil(t, p)
+		assert.True(t, *p)
+	})
+
+	t.Run("explicit 0 returns false, distinguishable from absent", func(t *testing.T) {
+		p := regBoolPtr(m, "DisablePasswordChange")
+		require.NotNil(t, p)
+		assert.False(t, *p)
+	})
+
+	t.Run("absent value returns nil", func(t *testing.T) {
+		assert.Nil(t, regBoolPtr(m, "DoesNotExist"))
+	})
+}
+
+func TestLsaBoolFieldPtr(t *testing.T) {
+	t.Run("nil pointer yields a null field", func(t *testing.T) {
+		f := boolFieldPtr(nil)
+		assert.True(t, f.IsSet())
+		assert.True(t, f.IsNull())
+	})
+
+	t.Run("explicit false is set and not null", func(t *testing.T) {
+		val := false
+		f := boolFieldPtr(&val)
+		assert.True(t, f.IsSet())
+		assert.False(t, f.IsNull())
+		assert.Equal(t, false, f.Data)
 	})
 }
 

--- a/providers/os/resources/windows_spooler.go
+++ b/providers/os/resources/windows_spooler.go
@@ -154,6 +154,18 @@ func resolveNullableInt(field *plugin.TValue[int64], v *int64) (int64, error) {
 	return *v, nil
 }
 
+// resolveNullableBool backs a lazily-computed bool field that must be able to
+// render as MQL null. When v is nil the field is set null proactively;
+// otherwise the boolean value is returned for GetOrCompute to cache. This keeps
+// "not configured" distinct from an explicit false.
+func resolveNullableBool(field *plugin.TValue[bool], v *bool) (bool, error) {
+	if v == nil {
+		*field = plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return false, nil
+	}
+	return *v, nil
+}
+
 // --- top-level fields -------------------------------------------------------
 
 func (r *mqlWindowsSpooler) startMode() (int64, error) {
@@ -187,22 +199,22 @@ func spoolerDisabled(service map[string]registry.RegistryKeyItem) bool {
 	return false
 }
 
-func (r *mqlWindowsSpooler) registerRemoteRpcEndpoint() (int64, error) {
+func (r *mqlWindowsSpooler) registerRemoteRpcEndpoint() (bool, error) {
 	reg, err := r.load()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return resolveNullableInt(&r.RegisterRemoteRpcEndpoint,
-		regIntPtr(reg.printers, "RegisterSpoolerRemoteRpcEndPoint"))
+	return resolveNullableBool(&r.RegisterRemoteRpcEndpoint,
+		regBoolPtr(reg.printers, "RegisterSpoolerRemoteRpcEndPoint"))
 }
 
-func (r *mqlWindowsSpooler) redirectionGuardPolicy() (int64, error) {
+func (r *mqlWindowsSpooler) redirectionGuardPolicy() (bool, error) {
 	reg, err := r.load()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return resolveNullableInt(&r.RedirectionGuardPolicy,
-		regIntPtr(reg.printers, "RedirectionguardPolicy"))
+	return resolveNullableBool(&r.RedirectionGuardPolicy,
+		regBoolPtr(reg.printers, "RedirectionguardPolicy"))
 }
 
 func (r *mqlWindowsSpooler) webPnpDownloadDisabled() (bool, error) {
@@ -221,12 +233,12 @@ func (r *mqlWindowsSpooler) httpPrintingDisabled() (bool, error) {
 	return regBoolDefault(reg.printers, "DisableHTTPPrinting", false), nil
 }
 
-func (r *mqlWindowsSpooler) copyFilesPolicy() (int64, error) {
+func (r *mqlWindowsSpooler) copyFilesPolicy() (bool, error) {
 	reg, err := r.load()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return resolveNullableInt(&r.CopyFilesPolicy, regIntPtr(reg.printers, "CopyFilesPolicy"))
+	return resolveNullableBool(&r.CopyFilesPolicy, regBoolPtr(reg.printers, "CopyFilesPolicy"))
 }
 
 func (r *mqlWindowsSpooler) rpcAuthnLevelPrivacyEnabled() (bool, error) {
@@ -238,22 +250,22 @@ func (r *mqlWindowsSpooler) rpcAuthnLevelPrivacyEnabled() (bool, error) {
 	return regBoolDefault(reg.controlPrint, "RpcAuthnLevelPrivacyEnabled", true), nil
 }
 
-func (r *mqlWindowsSpooler) addPrinterDriversRestricted() (int64, error) {
+func (r *mqlWindowsSpooler) addPrinterDriversRestricted() (bool, error) {
 	reg, err := r.load()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return resolveNullableInt(&r.AddPrinterDriversRestricted,
-		regIntPtr(reg.lanManServers, "AddPrinterDrivers"))
+	return resolveNullableBool(&r.AddPrinterDriversRestricted,
+		regBoolPtr(reg.lanManServers, "AddPrinterDrivers"))
 }
 
-func (r *mqlWindowsSpooler) windowsProtectedPrintGroupPolicyState() (int64, error) {
+func (r *mqlWindowsSpooler) windowsProtectedPrintGroupPolicyState() (bool, error) {
 	reg, err := r.load()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return resolveNullableInt(&r.WindowsProtectedPrintGroupPolicyState,
-		regIntPtr(reg.wpp, "WindowsProtectedPrintGroupPolicyState"))
+	return resolveNullableBool(&r.WindowsProtectedPrintGroupPolicyState,
+		regBoolPtr(reg.wpp, "WindowsProtectedPrintGroupPolicyState"))
 }
 
 // --- sub-resources ----------------------------------------------------------
@@ -273,14 +285,15 @@ func (r *mqlWindowsSpooler) pointAndPrint() (*mqlWindowsSpoolerPointAndPrint, er
 
 // spoolerPointAndPrintArgs builds the args for the PointAndPrint sub-resource.
 // restrictDriverInstallationToAdministrators defaults to true — the hardened
-// default established by the PrintNightmare mitigations — while the prompt
-// settings are nullable so an explicit 0 (keep the prompt) is preserved.
+// default established by the PrintNightmare mitigations — while
+// noWarningNoElevationOnInstall and updatePromptSettings are nullable so an
+// absent setting stays distinguishable from an explicit value.
 func spoolerPointAndPrintArgs(items map[string]registry.RegistryKeyItem) map[string]*llx.RawData {
 	return map[string]*llx.RawData{
 		"__id": llx.StringData("windows.spooler.pointAndPrint"),
 		"restrictDriverInstallationToAdministrators": llx.BoolData(
 			regBoolDefault(items, "RestrictDriverInstallationToAdministrators", true)),
-		"noWarningNoElevationOnInstall": llx.IntDataPtr(regIntPtr(items, "NoWarningNoElevationOnInstall")),
+		"noWarningNoElevationOnInstall": llx.BoolDataPtr(regBoolPtr(items, "NoWarningNoElevationOnInstall")),
 		"updatePromptSettings":          llx.IntDataPtr(regIntPtr(items, "UpdatePromptSettings")),
 	}
 }
@@ -298,12 +311,12 @@ func (r *mqlWindowsSpooler) rpc() (*mqlWindowsSpoolerRpc, error) {
 }
 
 // spoolerRpcArgs builds the args for the RPC sub-resource. All DWORD settings
-// are nullable so an unconfigured value (and the compliant 0 of
+// are nullable so an unconfigured value (and the compliant disabled state of
 // useNamedPipeProtocol) is distinguishable from a default.
 func spoolerRpcArgs(items map[string]registry.RegistryKeyItem) map[string]*llx.RawData {
 	return map[string]*llx.RawData{
 		"__id":                 llx.StringData("windows.spooler.rpc"),
-		"useNamedPipeProtocol": llx.IntDataPtr(regIntPtr(items, "RpcUseNamedPipeProtocol")),
+		"useNamedPipeProtocol": llx.BoolDataPtr(regBoolPtr(items, "RpcUseNamedPipeProtocol")),
 		"authentication":       llx.IntDataPtr(regIntPtr(items, "RpcAuthentication")),
 		"protocols":            llx.IntDataPtr(regIntPtr(items, "RpcProtocols")),
 		"tcpPort":              llx.IntDataPtr(regIntPtr(items, "RpcTcpPort")),

--- a/providers/os/resources/windows_spooler_internal_test.go
+++ b/providers/os/resources/windows_spooler_internal_test.go
@@ -90,13 +90,20 @@ func TestSpoolerPointAndPrintArgs(t *testing.T) {
 		assert.Nil(t, args["updatePromptSettings"].Value)
 	})
 
-	t.Run("explicit zero on prompt settings is preserved as 0, not null", func(t *testing.T) {
+	t.Run("explicit zero on prompt settings is preserved, not null", func(t *testing.T) {
 		args := spoolerPointAndPrintArgs(spoolerRegItems(map[string]int64{
 			"NoWarningNoElevationOnInstall": 0,
 			"UpdatePromptSettings":          0,
 		}))
-		assert.Equal(t, int64(0), args["noWarningNoElevationOnInstall"].Value)
+		assert.Equal(t, false, args["noWarningNoElevationOnInstall"].Value)
 		assert.Equal(t, int64(0), args["updatePromptSettings"].Value)
+	})
+
+	t.Run("noWarningNoElevationOnInstall non-zero resolves to true", func(t *testing.T) {
+		args := spoolerPointAndPrintArgs(spoolerRegItems(map[string]int64{
+			"NoWarningNoElevationOnInstall": 1,
+		}))
+		assert.Equal(t, true, args["noWarningNoElevationOnInstall"].Value)
 	})
 
 	t.Run("explicit restrict=false overrides the default", func(t *testing.T) {
@@ -117,13 +124,13 @@ func TestSpoolerRpcArgs(t *testing.T) {
 		assert.Equal(t, false, args["forceKerberos"].Value)
 	})
 
-	t.Run("compliant useNamedPipeProtocol=0 is preserved", func(t *testing.T) {
+	t.Run("compliant useNamedPipeProtocol=false is preserved", func(t *testing.T) {
 		args := spoolerRpcArgs(spoolerRegItems(map[string]int64{
 			"RpcUseNamedPipeProtocol": 0,
 			"RpcAuthentication":       1,
 			"ForceKerberosForRpc":     1,
 		}))
-		assert.Equal(t, int64(0), args["useNamedPipeProtocol"].Value)
+		assert.Equal(t, false, args["useNamedPipeProtocol"].Value)
 		assert.Equal(t, int64(1), args["authentication"].Value)
 		assert.Equal(t, true, args["forceKerberos"].Value)
 	})

--- a/providers/os/resources/windows_telemetry.go
+++ b/providers/os/resources/windows_telemetry.go
@@ -59,19 +59,19 @@ func (r *mqlWindowsTelemetry) readTelemetryKey(path string) (map[string]registry
 // telemetryValues holds the nullable DataCollection diagnostic-data settings.
 type telemetryValues struct {
 	allowTelemetry                 *int64
-	disableEnterpriseAuthProxy     *int64
-	disableOneSettingsDownloads    *int64
-	doNotShowFeedbackNotifications *int64
-	enableOneSettingsAuditing      *int64
-	limitDiagnosticLogCollection   *int64
-	limitDumpCollection            *int64
+	disableEnterpriseAuthProxy     *bool
+	disableOneSettingsDownloads    *bool
+	doNotShowFeedbackNotifications *bool
+	enableOneSettingsAuditing      *bool
+	limitDiagnosticLogCollection   *bool
+	limitDumpCollection            *bool
 }
 
 // consumerContentValues holds the nullable CloudContent consumer settings.
 type consumerContentValues struct {
-	disableCloudOptimizedContent       *int64
-	disableConsumerAccountStateContent *int64
-	disableWindowsConsumerFeatures     *int64
+	disableCloudOptimizedContent       *bool
+	disableConsumerAccountStateContent *bool
+	disableWindowsConsumerFeatures     *bool
 }
 
 // computeTelemetry extracts the DataCollection diagnostic-data DWORDs from the
@@ -80,12 +80,12 @@ type consumerContentValues struct {
 func computeTelemetry(items map[string]registry.RegistryKeyItem) telemetryValues {
 	return telemetryValues{
 		allowTelemetry:                 regIntPtr(items, "AllowTelemetry"),
-		disableEnterpriseAuthProxy:     regIntPtr(items, "DisableEnterpriseAuthProxy"),
-		disableOneSettingsDownloads:    regIntPtr(items, "DisableOneSettingsDownloads"),
-		doNotShowFeedbackNotifications: regIntPtr(items, "DoNotShowFeedbackNotifications"),
-		enableOneSettingsAuditing:      regIntPtr(items, "EnableOneSettingsAuditing"),
-		limitDiagnosticLogCollection:   regIntPtr(items, "LimitDiagnosticLogCollection"),
-		limitDumpCollection:            regIntPtr(items, "LimitDumpCollection"),
+		disableEnterpriseAuthProxy:     regBoolPtr(items, "DisableEnterpriseAuthProxy"),
+		disableOneSettingsDownloads:    regBoolPtr(items, "DisableOneSettingsDownloads"),
+		doNotShowFeedbackNotifications: regBoolPtr(items, "DoNotShowFeedbackNotifications"),
+		enableOneSettingsAuditing:      regBoolPtr(items, "EnableOneSettingsAuditing"),
+		limitDiagnosticLogCollection:   regBoolPtr(items, "LimitDiagnosticLogCollection"),
+		limitDumpCollection:            regBoolPtr(items, "LimitDumpCollection"),
 	}
 }
 
@@ -94,9 +94,9 @@ func computeTelemetry(items map[string]registry.RegistryKeyItem) telemetryValues
 // unit testing.
 func computeConsumerContent(items map[string]registry.RegistryKeyItem) consumerContentValues {
 	return consumerContentValues{
-		disableCloudOptimizedContent:       regIntPtr(items, "DisableCloudOptimizedContent"),
-		disableConsumerAccountStateContent: regIntPtr(items, "DisableConsumerAccountStateContent"),
-		disableWindowsConsumerFeatures:     regIntPtr(items, "DisableWindowsConsumerFeatures"),
+		disableCloudOptimizedContent:       regBoolPtr(items, "DisableCloudOptimizedContent"),
+		disableConsumerAccountStateContent: regBoolPtr(items, "DisableConsumerAccountStateContent"),
+		disableWindowsConsumerFeatures:     regBoolPtr(items, "DisableWindowsConsumerFeatures"),
 	}
 }
 
@@ -126,28 +126,36 @@ func (r *mqlWindowsTelemetry) populate() error {
 	c := computeConsumerContent(cloudContent)
 
 	r.AllowTelemetry = telemetryIntField(v.allowTelemetry)
-	r.DisableEnterpriseAuthProxy = telemetryIntField(v.disableEnterpriseAuthProxy)
-	r.DisableOneSettingsDownloads = telemetryIntField(v.disableOneSettingsDownloads)
-	r.DoNotShowFeedbackNotifications = telemetryIntField(v.doNotShowFeedbackNotifications)
-	r.EnableOneSettingsAuditing = telemetryIntField(v.enableOneSettingsAuditing)
-	r.LimitDiagnosticLogCollection = telemetryIntField(v.limitDiagnosticLogCollection)
-	r.LimitDumpCollection = telemetryIntField(v.limitDumpCollection)
-	r.DisableCloudOptimizedContent = telemetryIntField(c.disableCloudOptimizedContent)
-	r.DisableConsumerAccountStateContent = telemetryIntField(c.disableConsumerAccountStateContent)
-	r.DisableWindowsConsumerFeatures = telemetryIntField(c.disableWindowsConsumerFeatures)
+	r.DisableEnterpriseAuthProxy = boolFieldPtr(v.disableEnterpriseAuthProxy)
+	r.DisableOneSettingsDownloads = boolFieldPtr(v.disableOneSettingsDownloads)
+	r.DoNotShowFeedbackNotifications = boolFieldPtr(v.doNotShowFeedbackNotifications)
+	r.EnableOneSettingsAuditing = boolFieldPtr(v.enableOneSettingsAuditing)
+	r.LimitDiagnosticLogCollection = boolFieldPtr(v.limitDiagnosticLogCollection)
+	r.LimitDumpCollection = boolFieldPtr(v.limitDumpCollection)
+	r.DisableCloudOptimizedContent = boolFieldPtr(c.disableCloudOptimizedContent)
+	r.DisableConsumerAccountStateContent = boolFieldPtr(c.disableConsumerAccountStateContent)
+	r.DisableWindowsConsumerFeatures = boolFieldPtr(c.disableWindowsConsumerFeatures)
 	return nil
 }
 
-func (r *mqlWindowsTelemetry) allowTelemetry() (int64, error)                 { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) disableEnterpriseAuthProxy() (int64, error)     { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) disableOneSettingsDownloads() (int64, error)    { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) doNotShowFeedbackNotifications() (int64, error) { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) enableOneSettingsAuditing() (int64, error)      { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) limitDiagnosticLogCollection() (int64, error)   { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) limitDumpCollection() (int64, error)            { return 0, r.populate() }
-
-func (r *mqlWindowsTelemetry) disableCloudOptimizedContent() (int64, error) { return 0, r.populate() }
-func (r *mqlWindowsTelemetry) disableConsumerAccountStateContent() (int64, error) {
-	return 0, r.populate()
+func (r *mqlWindowsTelemetry) allowTelemetry() (int64, error)             { return 0, r.populate() }
+func (r *mqlWindowsTelemetry) disableEnterpriseAuthProxy() (bool, error)  { return false, r.populate() }
+func (r *mqlWindowsTelemetry) disableOneSettingsDownloads() (bool, error) { return false, r.populate() }
+func (r *mqlWindowsTelemetry) doNotShowFeedbackNotifications() (bool, error) {
+	return false, r.populate()
 }
-func (r *mqlWindowsTelemetry) disableWindowsConsumerFeatures() (int64, error) { return 0, r.populate() }
+func (r *mqlWindowsTelemetry) enableOneSettingsAuditing() (bool, error) { return false, r.populate() }
+func (r *mqlWindowsTelemetry) limitDiagnosticLogCollection() (bool, error) {
+	return false, r.populate()
+}
+func (r *mqlWindowsTelemetry) limitDumpCollection() (bool, error) { return false, r.populate() }
+
+func (r *mqlWindowsTelemetry) disableCloudOptimizedContent() (bool, error) {
+	return false, r.populate()
+}
+func (r *mqlWindowsTelemetry) disableConsumerAccountStateContent() (bool, error) {
+	return false, r.populate()
+}
+func (r *mqlWindowsTelemetry) disableWindowsConsumerFeatures() (bool, error) {
+	return false, r.populate()
+}

--- a/providers/os/resources/windows_telemetry_internal_test.go
+++ b/providers/os/resources/windows_telemetry_internal_test.go
@@ -66,17 +66,17 @@ func TestComputeTelemetry(t *testing.T) {
 		require.NotNil(t, v.allowTelemetry)
 		assert.Equal(t, int64(0), *v.allowTelemetry)
 		require.NotNil(t, v.disableEnterpriseAuthProxy)
-		assert.Equal(t, int64(0), *v.disableEnterpriseAuthProxy)
+		assert.Equal(t, false, *v.disableEnterpriseAuthProxy)
 		require.NotNil(t, v.disableOneSettingsDownloads)
-		assert.Equal(t, int64(0), *v.disableOneSettingsDownloads)
+		assert.Equal(t, false, *v.disableOneSettingsDownloads)
 		require.NotNil(t, v.doNotShowFeedbackNotifications)
-		assert.Equal(t, int64(0), *v.doNotShowFeedbackNotifications)
+		assert.Equal(t, false, *v.doNotShowFeedbackNotifications)
 		require.NotNil(t, v.enableOneSettingsAuditing)
-		assert.Equal(t, int64(0), *v.enableOneSettingsAuditing)
+		assert.Equal(t, false, *v.enableOneSettingsAuditing)
 		require.NotNil(t, v.limitDiagnosticLogCollection)
-		assert.Equal(t, int64(0), *v.limitDiagnosticLogCollection)
+		assert.Equal(t, false, *v.limitDiagnosticLogCollection)
 		require.NotNil(t, v.limitDumpCollection)
-		assert.Equal(t, int64(0), *v.limitDumpCollection)
+		assert.Equal(t, false, *v.limitDumpCollection)
 	})
 
 	t.Run("typical hardened values map through", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestComputeTelemetry(t *testing.T) {
 		require.NotNil(t, v.allowTelemetry)
 		assert.Equal(t, int64(1), *v.allowTelemetry)
 		require.NotNil(t, v.enableOneSettingsAuditing)
-		assert.Equal(t, int64(1), *v.enableOneSettingsAuditing)
+		assert.Equal(t, true, *v.enableOneSettingsAuditing)
 	})
 
 	t.Run("partial configuration leaves unset fields nil", func(t *testing.T) {
@@ -132,11 +132,11 @@ func TestComputeConsumerContent(t *testing.T) {
 			"DisableWindowsConsumerFeatures":     0,
 		}))
 		require.NotNil(t, v.disableCloudOptimizedContent)
-		assert.Equal(t, int64(0), *v.disableCloudOptimizedContent)
+		assert.Equal(t, false, *v.disableCloudOptimizedContent)
 		require.NotNil(t, v.disableConsumerAccountStateContent)
-		assert.Equal(t, int64(0), *v.disableConsumerAccountStateContent)
+		assert.Equal(t, false, *v.disableConsumerAccountStateContent)
 		require.NotNil(t, v.disableWindowsConsumerFeatures)
-		assert.Equal(t, int64(0), *v.disableWindowsConsumerFeatures)
+		assert.Equal(t, false, *v.disableWindowsConsumerFeatures)
 	})
 
 	t.Run("hardened values (all 1) map through", func(t *testing.T) {
@@ -146,11 +146,11 @@ func TestComputeConsumerContent(t *testing.T) {
 			"DisableWindowsConsumerFeatures":     1,
 		}))
 		require.NotNil(t, v.disableCloudOptimizedContent)
-		assert.Equal(t, int64(1), *v.disableCloudOptimizedContent)
+		assert.Equal(t, true, *v.disableCloudOptimizedContent)
 		require.NotNil(t, v.disableConsumerAccountStateContent)
-		assert.Equal(t, int64(1), *v.disableConsumerAccountStateContent)
+		assert.Equal(t, true, *v.disableConsumerAccountStateContent)
 		require.NotNil(t, v.disableWindowsConsumerFeatures)
-		assert.Equal(t, int64(1), *v.disableWindowsConsumerFeatures)
+		assert.Equal(t, true, *v.disableWindowsConsumerFeatures)
 	})
 
 	t.Run("partial configuration leaves unset fields nil", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestComputeConsumerContent(t *testing.T) {
 			"DisableWindowsConsumerFeatures": 1,
 		}))
 		require.NotNil(t, v.disableWindowsConsumerFeatures)
-		assert.Equal(t, int64(1), *v.disableWindowsConsumerFeatures)
+		assert.Equal(t, true, *v.disableWindowsConsumerFeatures)
 		assert.Nil(t, v.disableCloudOptimizedContent)
 		assert.Nil(t, v.disableConsumerAccountStateContent)
 	})

--- a/providers/os/resources/windows_update.go
+++ b/providers/os/resources/windows_update.go
@@ -232,18 +232,18 @@ func (c *mqlWindowsUpdateConfig) service() (*mqlService, error) {
 // the corresponding policy value is not configured.
 type windowsUpdatePolicyValues struct {
 	automaticUpdatesEnabled                bool
-	noAutoUpdate                           *int64
+	noAutoUpdate                           *bool
 	scheduledInstallDay                    *int64
 	scheduledInstallTime                   *int64
-	noAutoRebootWithLoggedOnUsers          *int64
+	noAutoRebootWithLoggedOnUsers          *bool
 	managePreviewBuilds                    *int64
-	deferFeatureUpdates                    *int64
+	deferFeatureUpdates                    *bool
 	deferFeatureUpdatesPeriodInDays        *int64
-	deferQualityUpdates                    *int64
+	deferQualityUpdates                    *bool
 	deferQualityUpdatesPeriodInDays        *int64
-	allowTemporaryEnterpriseFeatureControl *int64
+	allowTemporaryEnterpriseFeatureControl *bool
 	allowOptionalContent                   *int64
-	disablePauseUXAccess                   *int64
+	disablePauseUXAccess                   *bool
 }
 
 // computeWindowsUpdatePolicy maps the raw registry values from the
@@ -254,18 +254,18 @@ func computeWindowsUpdatePolicy(policy, au map[string]registry.RegistryKeyItem) 
 		// Automatic Updates is "enabled" only when NoAutoUpdate is explicitly
 		// present and set to 0; an absent value is the unmanaged default.
 		automaticUpdatesEnabled:                regHas(au, "NoAutoUpdate") && regInt(au, "NoAutoUpdate") == 0,
-		noAutoUpdate:                           regIntPtr(au, "NoAutoUpdate"),
+		noAutoUpdate:                           regBoolPtr(au, "NoAutoUpdate"),
 		scheduledInstallDay:                    regIntPtr(au, "ScheduledInstallDay"),
 		scheduledInstallTime:                   regIntPtr(au, "ScheduledInstallTime"),
-		noAutoRebootWithLoggedOnUsers:          regIntPtr(au, "NoAutoRebootWithLoggedOnUsers"),
+		noAutoRebootWithLoggedOnUsers:          regBoolPtr(au, "NoAutoRebootWithLoggedOnUsers"),
 		managePreviewBuilds:                    regIntPtr(policy, "ManagePreviewBuildsPolicyValue"),
-		deferFeatureUpdates:                    regIntPtr(policy, "DeferFeatureUpdates"),
+		deferFeatureUpdates:                    regBoolPtr(policy, "DeferFeatureUpdates"),
 		deferFeatureUpdatesPeriodInDays:        regIntPtr(policy, "DeferFeatureUpdatesPeriodInDays"),
-		deferQualityUpdates:                    regIntPtr(policy, "DeferQualityUpdates"),
+		deferQualityUpdates:                    regBoolPtr(policy, "DeferQualityUpdates"),
 		deferQualityUpdatesPeriodInDays:        regIntPtr(policy, "DeferQualityUpdatesPeriodInDays"),
-		allowTemporaryEnterpriseFeatureControl: regIntPtr(policy, "AllowTemporaryEnterpriseFeatureControl"),
+		allowTemporaryEnterpriseFeatureControl: regBoolPtr(policy, "AllowTemporaryEnterpriseFeatureControl"),
 		allowOptionalContent:                   regIntPtr(policy, "SetAllowOptionalContent"),
-		disablePauseUXAccess:                   regIntPtr(policy, "SetDisablePauseUXAccess"),
+		disablePauseUXAccess:                   regBoolPtr(policy, "SetDisablePauseUXAccess"),
 	}
 }
 
@@ -286,18 +286,18 @@ func (w *mqlWindowsUpdate) policy() (*mqlWindowsUpdatePolicy, error) {
 	o, err := CreateResource(w.MqlRuntime, "windows.update.policy", map[string]*llx.RawData{
 		"__id":                                   llx.StringData("windows.update.policy"),
 		"automaticUpdatesEnabled":                llx.BoolData(v.automaticUpdatesEnabled),
-		"noAutoUpdate":                           intPtrData(v.noAutoUpdate),
+		"noAutoUpdate":                           llx.BoolDataPtr(v.noAutoUpdate),
 		"scheduledInstallDay":                    intPtrData(v.scheduledInstallDay),
 		"scheduledInstallTime":                   intPtrData(v.scheduledInstallTime),
-		"noAutoRebootWithLoggedOnUsers":          intPtrData(v.noAutoRebootWithLoggedOnUsers),
+		"noAutoRebootWithLoggedOnUsers":          llx.BoolDataPtr(v.noAutoRebootWithLoggedOnUsers),
 		"managePreviewBuilds":                    intPtrData(v.managePreviewBuilds),
-		"deferFeatureUpdates":                    intPtrData(v.deferFeatureUpdates),
+		"deferFeatureUpdates":                    llx.BoolDataPtr(v.deferFeatureUpdates),
 		"deferFeatureUpdatesPeriodInDays":        intPtrData(v.deferFeatureUpdatesPeriodInDays),
-		"deferQualityUpdates":                    intPtrData(v.deferQualityUpdates),
+		"deferQualityUpdates":                    llx.BoolDataPtr(v.deferQualityUpdates),
 		"deferQualityUpdatesPeriodInDays":        intPtrData(v.deferQualityUpdatesPeriodInDays),
-		"allowTemporaryEnterpriseFeatureControl": intPtrData(v.allowTemporaryEnterpriseFeatureControl),
+		"allowTemporaryEnterpriseFeatureControl": llx.BoolDataPtr(v.allowTemporaryEnterpriseFeatureControl),
 		"allowOptionalContent":                   intPtrData(v.allowOptionalContent),
-		"disablePauseUXAccess":                   intPtrData(v.disablePauseUXAccess),
+		"disablePauseUXAccess":                   llx.BoolDataPtr(v.disablePauseUXAccess),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/windows_update_test.go
+++ b/providers/os/resources/windows_update_test.go
@@ -40,7 +40,7 @@ func TestComputeWindowsUpdatePolicy(t *testing.T) {
 		v := computeWindowsUpdatePolicy(nil, au)
 		assert.True(t, v.automaticUpdatesEnabled)
 		require.NotNil(t, v.noAutoUpdate)
-		assert.Equal(t, int64(0), *v.noAutoUpdate)
+		assert.False(t, *v.noAutoUpdate)
 		// ScheduledInstallDay=0 ("every day") must be distinguishable from absent.
 		require.NotNil(t, v.scheduledInstallDay)
 		assert.Equal(t, int64(0), *v.scheduledInstallDay)
@@ -51,7 +51,7 @@ func TestComputeWindowsUpdatePolicy(t *testing.T) {
 		v := computeWindowsUpdatePolicy(nil, au)
 		assert.False(t, v.automaticUpdatesEnabled)
 		require.NotNil(t, v.noAutoUpdate)
-		assert.Equal(t, int64(1), *v.noAutoUpdate)
+		assert.True(t, *v.noAutoUpdate)
 	})
 
 	t.Run("case-insensitive value names", func(t *testing.T) {
@@ -85,9 +85,9 @@ func TestComputeWindowsUpdatePolicy(t *testing.T) {
 		require.NotNil(t, v.deferQualityUpdatesPeriodInDays)
 		assert.Equal(t, int64(0), *v.deferQualityUpdatesPeriodInDays)
 		require.NotNil(t, v.disablePauseUXAccess)
-		assert.Equal(t, int64(1), *v.disablePauseUXAccess)
+		assert.True(t, *v.disablePauseUXAccess)
 		require.NotNil(t, v.noAutoRebootWithLoggedOnUsers)
-		assert.Equal(t, int64(0), *v.noAutoRebootWithLoggedOnUsers)
+		assert.False(t, *v.noAutoRebootWithLoggedOnUsers)
 	})
 }
 


### PR DESCRIPTION
## What

The Windows hardening resources merged over the last day exposed many on/off registry DWORDs as raw `int`, so compliance queries read `windows.lsa.restrictAnonymousSam == 1` rather than describing what they check. This converts the genuinely binary (0/1) settings to `bool` so the same query reads:

```mql
windows.lsa.restrictAnonymousSam            // was: == 1
!windows.lsa.everyoneIncludesAnonymous      // was: == 0
windows.telemetry.disableWindowsConsumerFeatures
windows.deviceGuard.systemGuardLaunch
windows.update.policy.deferQualityUpdates
windows.bitlocker.policy.useAdvancedStartup
```

## What stays `int` (on purpose)

Graded/ordinal values where the number carries meaning and benchmarks compare with `>=`/`==`:

- `lmCompatibilityLevel` (0–5), `restrictAnonymous` (0/1/2), `runAsPpl`
- RDP `securityLayer` / `minEncryptionLevel`, timeouts (`maxIdleTimeMs`, …)
- deviceGuard HVCI / Credential Guard lock modes, `kernelShadowStacksLaunch`
- telemetry `allowTelemetry` (0–3)
- BitLocker `recovery*` enums (0/1/2), `activeDirectoryInfoToStore`
- NTLM min-session-security bitmasks, password ages, ports, scalars

Converting these to strings/bools would lose the ordered comparisons. Nullability is preserved everywhere: an absent value stays null, distinct from an explicit `false`.

## Resources touched

`windows.lsa` (+ `ntlm`, `secureChannel`), `windows.deviceGuard`, `windows.spooler` (+ `pointAndPrint`, `rpc`), `windows.telemetry`, `windows.update.policy`, `windows.bitlocker.policy` (+ `driveSettings`).

`rdp`, `winrm`, `smb`, `defender`, `smartScreen`, and `exploitProtection` already modeled their toggles as `bool` — no changes needed.

## Not a breaking change

These fields are versioned `13.29.1`, one patch ahead of the released os provider (`13.29.0`), so they have **not shipped yet**. No `.lr.versions` bumps and no `*.permissions.json` changes.

## Verification

- `mqlr generate` clean and idempotent
- `go build`, `go vet`, and the full `providers/os/resources` test suite pass (compute-function unit tests updated for the new bool types)