### PR TITLE
✨ k8s: RBAC binding-level access rollups

### DIFF
--- a/providers/k8s/resources/clusterrole.go
+++ b/providers/k8s/resources/clusterrole.go
@@ -97,6 +97,10 @@ func (k *mqlK8sRbacClusterrole) canReadSecrets() (bool, error) {
 	return rbacCanReadSecrets(k.obj.Rules), nil
 }
 
+func (k *mqlK8sRbacClusterrole) grantsClusterAdmin() (bool, error) {
+	return rbacGrantsClusterAdmin(k.obj.Rules), nil
+}
+
 func (k *mqlK8sRbacClusterrole) boundBy() ([]any, error) {
 	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -109,6 +109,53 @@ func (k *mqlK8sRbacClusterrolebinding) clusterRole() (*mqlK8sRbacClusterrole, er
 	return r.(*mqlK8sRbacClusterrole), nil
 }
 
+// referencedRules returns the policy rules of the ClusterRole this binding
+// grants. It resolves to nil (no rules) when the roleRef is missing or the
+// referenced ClusterRole cannot be found, so the rollups below report false
+// rather than erroring on a dangling reference.
+func (k *mqlK8sRbacClusterrolebinding) referencedRules() ([]rbacv1.PolicyRule, error) {
+	cr := k.GetClusterRole()
+	if cr.Error != nil {
+		return nil, cr.Error
+	}
+	if cr.Data == nil {
+		return nil, nil
+	}
+	return cr.Data.obj.Rules, nil
+}
+
+func (k *mqlK8sRbacClusterrolebinding) grantsClusterAdmin() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacGrantsClusterAdmin(rules), nil
+}
+
+func (k *mqlK8sRbacClusterrolebinding) hasWildcardRule() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacHasWildcardRule(rules), nil
+}
+
+func (k *mqlK8sRbacClusterrolebinding) allowsPrivilegeEscalation() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacAllowsPrivilegeEscalation(rules), nil
+}
+
+func (k *mqlK8sRbacClusterrolebinding) canReadSecrets() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacCanReadSecrets(rules), nil
+}
+
 func (k *mqlK8sRbacClusterrolebinding) ownerReferences() ([]any, error) {
 	return k8sOwnerReferences(k.MqlRuntime, k.obj)
 }

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -2012,6 +2012,8 @@ private k8s.rbac.clusterrole @defaults("name created") {
   allowsPrivilegeEscalation() bool
   // Whether any rule grants read access (get, list, or watch) to Secrets
   canReadSecrets() bool
+  // Whether any rule grants unrestricted access (wildcard verbs, API groups, and resources), i.e. cluster-admin
+  grantsClusterAdmin() bool
   // ClusterRole aggregation rule
   aggregationRule dict
   // ClusterRoleBindings that reference this ClusterRole via roleRef
@@ -2071,6 +2073,14 @@ private k8s.rbac.clusterrolebinding @defaults("name created") {
   roleRef dict
   // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
   serviceAccounts() []k8s.serviceaccount
+  // Whether the granted ClusterRole confers cluster-admin (wildcard verbs, API groups, and resources)
+  grantsClusterAdmin() bool
+  // Whether the granted ClusterRole has any wildcard rule
+  hasWildcardRule() bool
+  // Whether the granted ClusterRole allows RBAC privilege escalation (escalate/bind/impersonate)
+  allowsPrivilegeEscalation() bool
+  // Whether the granted ClusterRole can read Secrets (get, list, or watch)
+  canReadSecrets() bool
   // The ClusterRole granted by this binding (roleRef.name)
   clusterRole() k8s.rbac.clusterrole
 }
@@ -2122,6 +2132,8 @@ private k8s.rbac.role @defaults("name namespace") {
   allowsPrivilegeEscalation() bool
   // Whether any rule grants read access (get, list, or watch) to Secrets
   canReadSecrets() bool
+  // Whether any rule grants unrestricted access (wildcard verbs, API groups, and resources), i.e. cluster-admin
+  grantsClusterAdmin() bool
   // RoleBindings in this namespace that reference this Role via roleRef
   boundBy() []k8s.rbac.rolebinding
 }
@@ -2164,6 +2176,14 @@ private k8s.rbac.rolebinding @defaults("name namespace created") {
   roleRef dict
   // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
   serviceAccounts() []k8s.serviceaccount
+  // Whether the granted role confers cluster-admin (wildcard verbs, API groups, and resources)
+  grantsClusterAdmin() bool
+  // Whether the granted role has any wildcard rule
+  hasWildcardRule() bool
+  // Whether the granted role allows RBAC privilege escalation (escalate/bind/impersonate)
+  allowsPrivilegeEscalation() bool
+  // Whether the granted role can read Secrets (get, list, or watch)
+  canReadSecrets() bool
   // The Role granted by this binding (null when roleRef points to a ClusterRole)
   role() k8s.rbac.role
   // The ClusterRole granted by this binding (null when roleRef points to a Role)

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -2642,6 +2642,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.clusterrole.canReadSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetCanReadSecrets()).ToDataRes(types.Bool)
 	},
+	"k8s.rbac.clusterrole.grantsClusterAdmin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrole).GetGrantsClusterAdmin()).ToDataRes(types.Bool)
+	},
 	"k8s.rbac.clusterrole.aggregationRule": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetAggregationRule()).ToDataRes(types.Dict)
 	},
@@ -2705,6 +2708,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.clusterrolebinding.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrolebinding).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("k8s.serviceaccount")))
 	},
+	"k8s.rbac.clusterrolebinding.grantsClusterAdmin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetGrantsClusterAdmin()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.clusterrolebinding.hasWildcardRule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetHasWildcardRule()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.clusterrolebinding.allowsPrivilegeEscalation": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetAllowsPrivilegeEscalation()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.clusterrolebinding.canReadSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetCanReadSecrets()).ToDataRes(types.Bool)
+	},
 	"k8s.rbac.clusterrolebinding.clusterRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrolebinding).GetClusterRole()).ToDataRes(types.Resource("k8s.rbac.clusterrole"))
 	},
@@ -2759,6 +2774,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.role.canReadSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetCanReadSecrets()).ToDataRes(types.Bool)
 	},
+	"k8s.rbac.role.grantsClusterAdmin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRole).GetGrantsClusterAdmin()).ToDataRes(types.Bool)
+	},
 	"k8s.rbac.role.boundBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetBoundBy()).ToDataRes(types.Array(types.Resource("k8s.rbac.rolebinding")))
 	},
@@ -2806,6 +2824,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.rolebinding.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("k8s.serviceaccount")))
+	},
+	"k8s.rbac.rolebinding.grantsClusterAdmin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetGrantsClusterAdmin()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.rolebinding.hasWildcardRule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetHasWildcardRule()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.rolebinding.allowsPrivilegeEscalation": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetAllowsPrivilegeEscalation()).ToDataRes(types.Bool)
+	},
+	"k8s.rbac.rolebinding.canReadSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetCanReadSecrets()).ToDataRes(types.Bool)
 	},
 	"k8s.rbac.rolebinding.role": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetRole()).ToDataRes(types.Resource("k8s.rbac.role"))
@@ -7291,6 +7321,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacClusterrole).CanReadSecrets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.clusterrole.grantsClusterAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrole).GrantsClusterAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.clusterrole.aggregationRule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacClusterrole).AggregationRule, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -7383,6 +7417,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacClusterrolebinding).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.clusterrolebinding.grantsClusterAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).GrantsClusterAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.clusterrolebinding.hasWildcardRule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).HasWildcardRule, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.clusterrolebinding.allowsPrivilegeEscalation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).AllowsPrivilegeEscalation, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.clusterrolebinding.canReadSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).CanReadSecrets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.clusterrolebinding.clusterRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacClusterrolebinding).ClusterRole, ok = plugin.RawToTValue[*mqlK8sRbacClusterrole](v.Value, v.Error)
 		return
@@ -7459,6 +7509,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacRole).CanReadSecrets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.role.grantsClusterAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRole).GrantsClusterAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.role.boundBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRole).BoundBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -7525,6 +7579,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.rolebinding.serviceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRolebinding).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.grantsClusterAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).GrantsClusterAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.hasWildcardRule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).HasWildcardRule, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.allowsPrivilegeEscalation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).AllowsPrivilegeEscalation, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.canReadSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).CanReadSecrets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.rolebinding.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16734,6 +16804,7 @@ type mqlK8sRbacClusterrole struct {
 	HasWildcardRule           plugin.TValue[bool]
 	AllowsPrivilegeEscalation plugin.TValue[bool]
 	CanReadSecrets            plugin.TValue[bool]
+	GrantsClusterAdmin        plugin.TValue[bool]
 	AggregationRule           plugin.TValue[any]
 	BoundBy                   plugin.TValue[[]any]
 }
@@ -16887,6 +16958,12 @@ func (c *mqlK8sRbacClusterrole) GetCanReadSecrets() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sRbacClusterrole) GetGrantsClusterAdmin() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.GrantsClusterAdmin, func() (bool, error) {
+		return c.grantsClusterAdmin()
+	})
+}
+
 func (c *mqlK8sRbacClusterrole) GetAggregationRule() *plugin.TValue[any] {
 	return &c.AggregationRule
 }
@@ -16976,21 +17053,25 @@ type mqlK8sRbacClusterrolebinding struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlK8sRbacClusterrolebindingInternal
-	Id              plugin.TValue[string]
-	Uid             plugin.TValue[string]
-	ResourceVersion plugin.TValue[string]
-	Labels          plugin.TValue[map[string]any]
-	Annotations     plugin.TValue[map[string]any]
-	OwnerReferences plugin.TValue[[]any]
-	ManagedFields   plugin.TValue[[]any]
-	Name            plugin.TValue[string]
-	Kind            plugin.TValue[string]
-	Created         plugin.TValue[*time.Time]
-	Manifest        plugin.TValue[any]
-	Subjects        plugin.TValue[[]any]
-	RoleRef         plugin.TValue[any]
-	ServiceAccounts plugin.TValue[[]any]
-	ClusterRole     plugin.TValue[*mqlK8sRbacClusterrole]
+	Id                        plugin.TValue[string]
+	Uid                       plugin.TValue[string]
+	ResourceVersion           plugin.TValue[string]
+	Labels                    plugin.TValue[map[string]any]
+	Annotations               plugin.TValue[map[string]any]
+	OwnerReferences           plugin.TValue[[]any]
+	ManagedFields             plugin.TValue[[]any]
+	Name                      plugin.TValue[string]
+	Kind                      plugin.TValue[string]
+	Created                   plugin.TValue[*time.Time]
+	Manifest                  plugin.TValue[any]
+	Subjects                  plugin.TValue[[]any]
+	RoleRef                   plugin.TValue[any]
+	ServiceAccounts           plugin.TValue[[]any]
+	GrantsClusterAdmin        plugin.TValue[bool]
+	HasWildcardRule           plugin.TValue[bool]
+	AllowsPrivilegeEscalation plugin.TValue[bool]
+	CanReadSecrets            plugin.TValue[bool]
+	ClusterRole               plugin.TValue[*mqlK8sRbacClusterrole]
 }
 
 // createK8sRbacClusterrolebinding creates a new instance of this resource
@@ -17128,6 +17209,30 @@ func (c *mqlK8sRbacClusterrolebinding) GetServiceAccounts() *plugin.TValue[[]any
 	})
 }
 
+func (c *mqlK8sRbacClusterrolebinding) GetGrantsClusterAdmin() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.GrantsClusterAdmin, func() (bool, error) {
+		return c.grantsClusterAdmin()
+	})
+}
+
+func (c *mqlK8sRbacClusterrolebinding) GetHasWildcardRule() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardRule, func() (bool, error) {
+		return c.hasWildcardRule()
+	})
+}
+
+func (c *mqlK8sRbacClusterrolebinding) GetAllowsPrivilegeEscalation() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsPrivilegeEscalation, func() (bool, error) {
+		return c.allowsPrivilegeEscalation()
+	})
+}
+
+func (c *mqlK8sRbacClusterrolebinding) GetCanReadSecrets() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CanReadSecrets, func() (bool, error) {
+		return c.canReadSecrets()
+	})
+}
+
 func (c *mqlK8sRbacClusterrolebinding) GetClusterRole() *plugin.TValue[*mqlK8sRbacClusterrole] {
 	return plugin.GetOrCompute[*mqlK8sRbacClusterrole](&c.ClusterRole, func() (*mqlK8sRbacClusterrole, error) {
 		if c.MqlRuntime.HasRecording {
@@ -17166,6 +17271,7 @@ type mqlK8sRbacRole struct {
 	HasWildcardRule           plugin.TValue[bool]
 	AllowsPrivilegeEscalation plugin.TValue[bool]
 	CanReadSecrets            plugin.TValue[bool]
+	GrantsClusterAdmin        plugin.TValue[bool]
 	BoundBy                   plugin.TValue[[]any]
 }
 
@@ -17322,6 +17428,12 @@ func (c *mqlK8sRbacRole) GetCanReadSecrets() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sRbacRole) GetGrantsClusterAdmin() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.GrantsClusterAdmin, func() (bool, error) {
+		return c.grantsClusterAdmin()
+	})
+}
+
 func (c *mqlK8sRbacRole) GetBoundBy() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.BoundBy, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -17343,23 +17455,27 @@ type mqlK8sRbacRolebinding struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlK8sRbacRolebindingInternal
-	Id              plugin.TValue[string]
-	Uid             plugin.TValue[string]
-	ResourceVersion plugin.TValue[string]
-	Labels          plugin.TValue[map[string]any]
-	Annotations     plugin.TValue[map[string]any]
-	OwnerReferences plugin.TValue[[]any]
-	ManagedFields   plugin.TValue[[]any]
-	Name            plugin.TValue[string]
-	Namespace       plugin.TValue[string]
-	Kind            plugin.TValue[string]
-	Created         plugin.TValue[*time.Time]
-	Manifest        plugin.TValue[any]
-	Subjects        plugin.TValue[[]any]
-	RoleRef         plugin.TValue[any]
-	ServiceAccounts plugin.TValue[[]any]
-	Role            plugin.TValue[*mqlK8sRbacRole]
-	ClusterRole     plugin.TValue[*mqlK8sRbacClusterrole]
+	Id                        plugin.TValue[string]
+	Uid                       plugin.TValue[string]
+	ResourceVersion           plugin.TValue[string]
+	Labels                    plugin.TValue[map[string]any]
+	Annotations               plugin.TValue[map[string]any]
+	OwnerReferences           plugin.TValue[[]any]
+	ManagedFields             plugin.TValue[[]any]
+	Name                      plugin.TValue[string]
+	Namespace                 plugin.TValue[string]
+	Kind                      plugin.TValue[string]
+	Created                   plugin.TValue[*time.Time]
+	Manifest                  plugin.TValue[any]
+	Subjects                  plugin.TValue[[]any]
+	RoleRef                   plugin.TValue[any]
+	ServiceAccounts           plugin.TValue[[]any]
+	GrantsClusterAdmin        plugin.TValue[bool]
+	HasWildcardRule           plugin.TValue[bool]
+	AllowsPrivilegeEscalation plugin.TValue[bool]
+	CanReadSecrets            plugin.TValue[bool]
+	Role                      plugin.TValue[*mqlK8sRbacRole]
+	ClusterRole               plugin.TValue[*mqlK8sRbacClusterrole]
 }
 
 // createK8sRbacRolebinding creates a new instance of this resource
@@ -17498,6 +17614,30 @@ func (c *mqlK8sRbacRolebinding) GetServiceAccounts() *plugin.TValue[[]any] {
 		}
 
 		return c.serviceAccounts()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetGrantsClusterAdmin() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.GrantsClusterAdmin, func() (bool, error) {
+		return c.grantsClusterAdmin()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetHasWildcardRule() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardRule, func() (bool, error) {
+		return c.hasWildcardRule()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetAllowsPrivilegeEscalation() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsPrivilegeEscalation, func() (bool, error) {
+		return c.allowsPrivilegeEscalation()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetCanReadSecrets() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CanReadSecrets, func() (bool, error) {
+		return c.canReadSecrets()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -1018,6 +1018,7 @@ k8s.rbac.clusterrole.annotations 9.0.0
 k8s.rbac.clusterrole.boundBy 13.0.16
 k8s.rbac.clusterrole.canReadSecrets 13.2.2
 k8s.rbac.clusterrole.created 9.0.0
+k8s.rbac.clusterrole.grantsClusterAdmin 13.3.1
 k8s.rbac.clusterrole.hasWildcardRule 13.2.2
 k8s.rbac.clusterrole.id 9.0.0
 k8s.rbac.clusterrole.kind 9.0.0
@@ -1031,9 +1032,13 @@ k8s.rbac.clusterrole.resourceVersion 9.0.0
 k8s.rbac.clusterrole.rules 9.0.0
 k8s.rbac.clusterrole.uid 9.0.0
 k8s.rbac.clusterrolebinding 9.0.0
+k8s.rbac.clusterrolebinding.allowsPrivilegeEscalation 13.3.1
 k8s.rbac.clusterrolebinding.annotations 9.0.0
+k8s.rbac.clusterrolebinding.canReadSecrets 13.3.1
 k8s.rbac.clusterrolebinding.clusterRole 13.0.16
 k8s.rbac.clusterrolebinding.created 9.0.0
+k8s.rbac.clusterrolebinding.grantsClusterAdmin 13.3.1
+k8s.rbac.clusterrolebinding.hasWildcardRule 13.3.1
 k8s.rbac.clusterrolebinding.id 9.0.0
 k8s.rbac.clusterrolebinding.kind 9.0.0
 k8s.rbac.clusterrolebinding.labels 9.0.0
@@ -1058,6 +1063,7 @@ k8s.rbac.role.annotations 9.0.0
 k8s.rbac.role.boundBy 13.0.16
 k8s.rbac.role.canReadSecrets 13.2.2
 k8s.rbac.role.created 9.0.0
+k8s.rbac.role.grantsClusterAdmin 13.3.1
 k8s.rbac.role.hasWildcardRule 13.2.2
 k8s.rbac.role.id 9.0.0
 k8s.rbac.role.kind 9.0.0
@@ -1072,9 +1078,13 @@ k8s.rbac.role.resourceVersion 9.0.0
 k8s.rbac.role.rules 9.0.0
 k8s.rbac.role.uid 9.0.0
 k8s.rbac.rolebinding 9.0.0
+k8s.rbac.rolebinding.allowsPrivilegeEscalation 13.3.1
 k8s.rbac.rolebinding.annotations 9.0.0
+k8s.rbac.rolebinding.canReadSecrets 13.3.1
 k8s.rbac.rolebinding.clusterRole 13.0.16
 k8s.rbac.rolebinding.created 9.0.0
+k8s.rbac.rolebinding.grantsClusterAdmin 13.3.1
+k8s.rbac.rolebinding.hasWildcardRule 13.3.1
 k8s.rbac.rolebinding.id 9.0.0
 k8s.rbac.rolebinding.kind 9.0.0
 k8s.rbac.rolebinding.labels 9.0.0

--- a/providers/k8s/resources/rbac.go
+++ b/providers/k8s/resources/rbac.go
@@ -64,6 +64,22 @@ func rbacHasWildcardRule(rules []rbacv1.PolicyRule) bool {
 	return false
 }
 
+// rbacGrantsClusterAdmin reports whether any rule grants unrestricted access:
+// the verb, API group, and resource dimensions all include the wildcard "*".
+// This is the rule shape of the built-in cluster-admin ClusterRole and of any
+// equivalent custom role.
+func rbacGrantsClusterAdmin(rules []rbacv1.PolicyRule) bool {
+	for i := range rules {
+		rule := rules[i]
+		if stringx.Contains(rule.Verbs, "*") &&
+			stringx.Contains(rule.APIGroups, "*") &&
+			stringx.Contains(rule.Resources, "*") {
+			return true
+		}
+	}
+	return false
+}
+
 // rbacAllowsPrivilegeEscalation reports whether any rule grants one of the
 // canonical RBAC privilege-escalation permissions.
 func rbacAllowsPrivilegeEscalation(rules []rbacv1.PolicyRule) bool {

--- a/providers/k8s/resources/rbac_binding_test.go
+++ b/providers/k8s/resources/rbac_binding_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clusterRoleBindingByName(t *testing.T, k8s *mqlK8s, name string) *mqlK8sRbacClusterrolebinding {
+	t.Helper()
+	bindings := k8s.GetClusterrolebindings()
+	require.NoError(t, bindings.Error)
+	for i := range bindings.Data {
+		b := bindings.Data[i].(*mqlK8sRbacClusterrolebinding)
+		if b.GetName().Data == name {
+			return b
+		}
+	}
+	require.FailNowf(t, "clusterrolebinding not found", "clusterrolebinding %q not found", name)
+	return nil
+}
+
+func roleBindingByName(t *testing.T, k8s *mqlK8s, name string) *mqlK8sRbacRolebinding {
+	t.Helper()
+	bindings := k8s.GetRolebindings()
+	require.NoError(t, bindings.Error)
+	for i := range bindings.Data {
+		b := bindings.Data[i].(*mqlK8sRbacRolebinding)
+		if b.GetName().Data == name {
+			return b
+		}
+	}
+	require.FailNowf(t, "rolebinding not found", "rolebinding %q not found", name)
+	return nil
+}
+
+func TestRbacRoleGrantsClusterAdmin(t *testing.T) {
+	k8sObj, err := NewResource(rbacRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	assert.True(t, clusterRoleByName(t, k8s, "wildcard-admin").GetGrantsClusterAdmin().Data, "wildcard-admin")
+	assert.False(t, clusterRoleByName(t, k8s, "secret-reader").GetGrantsClusterAdmin().Data, "secret-reader")
+	// A role that escalates but isn't a full wildcard is not cluster-admin.
+	assert.False(t, clusterRoleByName(t, k8s, "escalator").GetGrantsClusterAdmin().Data, "escalator")
+	assert.False(t, roleByName(t, k8s, "binder").GetGrantsClusterAdmin().Data, "binder")
+}
+
+// TestRbacClusterRoleBindingRollups checks that a ClusterRoleBinding surfaces
+// the danger of the ClusterRole it grants.
+func TestRbacClusterRoleBindingRollups(t *testing.T) {
+	k8sObj, err := NewResource(rbacRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	b := clusterRoleBindingByName(t, k8s, "admin-binding")
+	assert.True(t, b.GetGrantsClusterAdmin().Data, "grantsClusterAdmin")
+	assert.True(t, b.GetHasWildcardRule().Data, "hasWildcardRule")
+	assert.True(t, b.GetAllowsPrivilegeEscalation().Data, "allowsPrivilegeEscalation")
+	assert.True(t, b.GetCanReadSecrets().Data, "canReadSecrets")
+}
+
+// TestRbacRoleBindingRollups checks the rollups for RoleBindings that reference
+// a namespaced Role and ones that reference a ClusterRole.
+func TestRbacRoleBindingRollups(t *testing.T) {
+	k8sObj, err := NewResource(rbacRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	t.Run("benign role binding", func(t *testing.T) {
+		b := roleBindingByName(t, k8s, "reader-binding")
+		assert.False(t, b.GetGrantsClusterAdmin().Data, "grantsClusterAdmin")
+		assert.False(t, b.GetHasWildcardRule().Data, "hasWildcardRule")
+		assert.False(t, b.GetAllowsPrivilegeEscalation().Data, "allowsPrivilegeEscalation")
+		assert.False(t, b.GetCanReadSecrets().Data, "canReadSecrets")
+	})
+
+	t.Run("role binding to escalating role", func(t *testing.T) {
+		b := roleBindingByName(t, k8s, "binder-binding")
+		assert.True(t, b.GetAllowsPrivilegeEscalation().Data, "allowsPrivilegeEscalation")
+		assert.False(t, b.GetGrantsClusterAdmin().Data, "grantsClusterAdmin")
+		assert.False(t, b.GetCanReadSecrets().Data, "canReadSecrets")
+	})
+
+	t.Run("role binding referencing a cluster role", func(t *testing.T) {
+		// secret-binding -> ClusterRole secret-reader, resolved via the
+		// clusterRole() path.
+		b := roleBindingByName(t, k8s, "secret-binding")
+		assert.True(t, b.GetCanReadSecrets().Data, "canReadSecrets")
+		assert.False(t, b.GetGrantsClusterAdmin().Data, "grantsClusterAdmin")
+		assert.False(t, b.GetAllowsPrivilegeEscalation().Data, "allowsPrivilegeEscalation")
+	})
+}

--- a/providers/k8s/resources/role.go
+++ b/providers/k8s/resources/role.go
@@ -93,6 +93,10 @@ func (k *mqlK8sRbacRole) canReadSecrets() (bool, error) {
 	return rbacCanReadSecrets(k.obj.Rules), nil
 }
 
+func (k *mqlK8sRbacRole) grantsClusterAdmin() (bool, error) {
+	return rbacGrantsClusterAdmin(k.obj.Rules), nil
+}
+
 func (k *mqlK8sRbacRole) boundBy() ([]any, error) {
 	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -165,6 +165,61 @@ func resolveServiceAccountSubjects(runtime *plugin.Runtime, subjects []rbacv1.Su
 	return out, nil
 }
 
+// referencedRules returns the policy rules this binding grants, resolving the
+// roleRef to either a namespaced Role or a ClusterRole. It resolves to nil (no
+// rules) when the reference is missing or cannot be found (including a
+// ClusterRole that isn't loaded for a namespace-scoped asset), so the rollups
+// report false rather than erroring on an unresolvable reference.
+func (k *mqlK8sRbacRolebinding) referencedRules() ([]rbacv1.PolicyRule, error) {
+	role := k.GetRole()
+	if role.Error != nil {
+		return nil, role.Error
+	}
+	if role.Data != nil {
+		return role.Data.obj.Rules, nil
+	}
+	cr := k.GetClusterRole()
+	if cr.Error != nil {
+		return nil, cr.Error
+	}
+	if cr.Data == nil {
+		return nil, nil
+	}
+	return cr.Data.obj.Rules, nil
+}
+
+func (k *mqlK8sRbacRolebinding) grantsClusterAdmin() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacGrantsClusterAdmin(rules), nil
+}
+
+func (k *mqlK8sRbacRolebinding) hasWildcardRule() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacHasWildcardRule(rules), nil
+}
+
+func (k *mqlK8sRbacRolebinding) allowsPrivilegeEscalation() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacAllowsPrivilegeEscalation(rules), nil
+}
+
+func (k *mqlK8sRbacRolebinding) canReadSecrets() (bool, error) {
+	rules, err := k.referencedRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacCanReadSecrets(rules), nil
+}
+
 func (k *mqlK8sRbacRolebinding) ownerReferences() ([]any, error) {
 	return k8sOwnerReferences(k.MqlRuntime, k.obj)
 }

--- a/providers/k8s/resources/testdata/rbac-rules.yaml
+++ b/providers/k8s/resources/testdata/rbac-rules.yaml
@@ -58,3 +58,87 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles"]
     verbs: ["bind", "create"]
+---
+# Service accounts used as binding subjects.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-sa
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reader-sa
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-sa
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: binder-sa
+  namespace: default
+---
+# Cluster-admin binding: grants wildcard-admin cluster-wide to admin-sa.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wildcard-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-sa
+    namespace: default
+---
+# Benign: binds the read-only configmap-reader Role to reader-sa.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reader-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: configmap-reader
+subjects:
+  - kind: ServiceAccount
+    name: reader-sa
+    namespace: default
+---
+# RoleBinding that references a ClusterRole (secret-reader) in one namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: secret-sa
+    namespace: default
+---
+# Binds the privilege-escalating binder Role to binder-sa.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: binder-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: binder
+subjects:
+  - kind: ServiceAccount
+    name: binder-sa
+    namespace: default


### PR DESCRIPTION
## Summary

Today RBAC analysis stops at the **role** level (`hasWildcardRule`, `allowsPrivilegeEscalation`, `canReadSecrets` on `k8s.rbac.role`/`clusterrole`). This PR pushes that analysis to the **bindings**, which is where access is actually granted. Adds to both `k8s.rbac.clusterrolebinding` and `k8s.rbac.rolebinding`:

- **`grantsClusterAdmin()`** — the granted role confers cluster-admin
- **`hasWildcardRule()`** — the granted role has any wildcard rule
- **`allowsPrivilegeEscalation()`** — the granted role allows `escalate`/`bind`/`impersonate`
- **`canReadSecrets()`** — the granted role can read Secrets

Each binding resolves the role it references (RoleBindings handle both a namespaced `Role` and a `ClusterRole`, via the existing `role()`/`clusterRole()` accessors) and reuses the existing rule helpers. A dangling reference (deleted role, or a ClusterRole not loaded for a namespace-scoped asset) resolves to no rules, so the rollups report `false` rather than erroring.

Also adds **`grantsClusterAdmin()`** to `k8s.rbac.role` and `k8s.rbac.clusterrole` — a new `rbacGrantsClusterAdmin` helper detecting a rule whose verbs, API groups, and resources all include `*` (the built-in cluster-admin shape) — which the binding rollups build on.

```mql
k8s.rbac.clusterrolebindings.where( grantsClusterAdmin )   # who is granted cluster-admin
k8s.rbac.rolebindings.where( canReadSecrets )              # bindings that expose Secrets
```

## Why

Over-permissioned bindings and cluster-admin sprawl are consistently a top category of real-world k8s findings. This is the access-side complement to the workload runtime-security rollups (#8577/#8581/#8582). Next up (PR B) is the subject side: `k8s.serviceaccount` effective-permission rollups built on these helpers.

## Tests

Extends `testdata/rbac-rules.yaml` with bindings and service-account subjects. Covers: cluster-admin binding (all true), benign role binding (all false), escalating role binding, a RoleBinding that references a ClusterRole (resolved via the `clusterRole()` path), and role-level `grantsClusterAdmin` (wildcard vs escalate-only vs benign). Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)