### PR TITLE
✨ k8s: effective-access rollups for service accounts

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -1965,6 +1965,18 @@ private k8s.serviceaccount @defaults("namespace name created") {
   imagePullSecrets []dict
   // Whether pods running as this service account should have an API token automatically mounted
   automountServiceAccountToken bool
+  // RoleBindings in this namespace that grant this service account a role
+  roleBindings() []k8s.rbac.rolebinding
+  // ClusterRoleBindings that grant this service account a cluster role
+  clusterRoleBindings() []k8s.rbac.clusterrolebinding
+  // Whether any bound role confers cluster-admin (wildcard verbs, API groups, and resources)
+  isClusterAdmin() bool
+  // Whether any bound role allows RBAC privilege escalation (escalate/bind/impersonate)
+  canEscalatePrivileges() bool
+  // Whether any bound role can read Secrets (get, list, or watch)
+  canReadSecrets() bool
+  // Whether any bound role has a wildcard rule (wildcard verbs, API groups, or resources)
+  hasWildcardPermissions() bool
 }
 
 // Kubernetes ClusterRole

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -2594,6 +2594,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.serviceaccount.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sServiceaccount).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
 	},
+	"k8s.serviceaccount.roleBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetRoleBindings()).ToDataRes(types.Array(types.Resource("k8s.rbac.rolebinding")))
+	},
+	"k8s.serviceaccount.clusterRoleBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetClusterRoleBindings()).ToDataRes(types.Array(types.Resource("k8s.rbac.clusterrolebinding")))
+	},
+	"k8s.serviceaccount.isClusterAdmin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetIsClusterAdmin()).ToDataRes(types.Bool)
+	},
+	"k8s.serviceaccount.canEscalatePrivileges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetCanEscalatePrivileges()).ToDataRes(types.Bool)
+	},
+	"k8s.serviceaccount.canReadSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetCanReadSecrets()).ToDataRes(types.Bool)
+	},
+	"k8s.serviceaccount.hasWildcardPermissions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetHasWildcardPermissions()).ToDataRes(types.Bool)
+	},
 	"k8s.rbac.clusterrole.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetId()).ToDataRes(types.String)
 	},
@@ -7251,6 +7269,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.serviceaccount.automountServiceAccountToken": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sServiceaccount).AutomountServiceAccountToken, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.roleBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).RoleBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.clusterRoleBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).ClusterRoleBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.isClusterAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).IsClusterAdmin, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.canEscalatePrivileges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).CanEscalatePrivileges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.canReadSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).CanReadSecrets, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.hasWildcardPermissions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).HasWildcardPermissions, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.clusterrole.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16654,6 +16696,12 @@ type mqlK8sServiceaccount struct {
 	Secrets                      plugin.TValue[[]any]
 	ImagePullSecrets             plugin.TValue[[]any]
 	AutomountServiceAccountToken plugin.TValue[bool]
+	RoleBindings                 plugin.TValue[[]any]
+	ClusterRoleBindings          plugin.TValue[[]any]
+	IsClusterAdmin               plugin.TValue[bool]
+	CanEscalatePrivileges        plugin.TValue[bool]
+	CanReadSecrets               plugin.TValue[bool]
+	HasWildcardPermissions       plugin.TValue[bool]
 }
 
 // createK8sServiceaccount creates a new instance of this resource
@@ -16781,6 +16829,62 @@ func (c *mqlK8sServiceaccount) GetImagePullSecrets() *plugin.TValue[[]any] {
 
 func (c *mqlK8sServiceaccount) GetAutomountServiceAccountToken() *plugin.TValue[bool] {
 	return &c.AutomountServiceAccountToken
+}
+
+func (c *mqlK8sServiceaccount) GetRoleBindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoleBindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.serviceaccount", c.__id, "roleBindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roleBindings()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetClusterRoleBindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ClusterRoleBindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.serviceaccount", c.__id, "clusterRoleBindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.clusterRoleBindings()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetIsClusterAdmin() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsClusterAdmin, func() (bool, error) {
+		return c.isClusterAdmin()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetCanEscalatePrivileges() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CanEscalatePrivileges, func() (bool, error) {
+		return c.canEscalatePrivileges()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetCanReadSecrets() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CanReadSecrets, func() (bool, error) {
+		return c.canReadSecrets()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetHasWildcardPermissions() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardPermissions, func() (bool, error) {
+		return c.hasWildcardPermissions()
+	})
 }
 
 // mqlK8sRbacClusterrole for the k8s.rbac.clusterrole resource

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -1238,9 +1238,14 @@ k8s.service.uid 9.0.0
 k8s.serviceaccount 9.0.0
 k8s.serviceaccount.annotations 9.0.0
 k8s.serviceaccount.automountServiceAccountToken 9.0.0
+k8s.serviceaccount.canEscalatePrivileges 13.3.1
+k8s.serviceaccount.canReadSecrets 13.3.1
+k8s.serviceaccount.clusterRoleBindings 13.3.1
 k8s.serviceaccount.created 9.0.0
+k8s.serviceaccount.hasWildcardPermissions 13.3.1
 k8s.serviceaccount.id 9.0.0
 k8s.serviceaccount.imagePullSecrets 9.0.0
+k8s.serviceaccount.isClusterAdmin 13.3.1
 k8s.serviceaccount.kind 9.0.0
 k8s.serviceaccount.labels 9.0.0
 k8s.serviceaccount.managedFields 13.2.2
@@ -1249,6 +1254,7 @@ k8s.serviceaccount.name 9.0.0
 k8s.serviceaccount.namespace 9.0.0
 k8s.serviceaccount.ownerReferences 13.2.2
 k8s.serviceaccount.resourceVersion 9.0.0
+k8s.serviceaccount.roleBindings 13.3.1
 k8s.serviceaccount.secrets 9.0.0
 k8s.serviceaccount.uid 9.0.0
 k8s.serviceaccounts 9.0.0

--- a/providers/k8s/resources/serviceaccount.go
+++ b/providers/k8s/resources/serviceaccount.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -18,6 +19,13 @@ import (
 type mqlK8sServiceaccountInternal struct {
 	lock sync.Mutex
 	obj  *corev1.ServiceAccount
+
+	// effectiveRules is aggregated once and shared by the access rollups
+	// (isClusterAdmin, canEscalatePrivileges, canReadSecrets,
+	// hasWildcardPermissions) so they make a single pass over the bindings.
+	effectiveRulesOnce sync.Once
+	effectiveRulesData []rbacv1.PolicyRule
+	effectiveRulesErr  error
 }
 
 func (k *mqlK8s) serviceaccounts() ([]any, error) {
@@ -94,6 +102,154 @@ func (k *mqlK8sServiceaccount) annotations() (map[string]any, error) {
 
 func (k *mqlK8sServiceaccount) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
+}
+
+// subjectsIncludeServiceAccount reports whether subjects lists the given
+// ServiceAccount. A subject's namespace falls back to fallbackNamespace when
+// omitted (kube-apiserver behavior for RoleBindings; pass "" for the
+// cluster-scoped ClusterRoleBinding, which requires an explicit namespace).
+func subjectsIncludeServiceAccount(subjects []rbacv1.Subject, saName, saNamespace, fallbackNamespace string) bool {
+	for _, s := range subjects {
+		if s.Kind != "ServiceAccount" || s.Name != saName {
+			continue
+		}
+		ns := s.Namespace
+		if ns == "" {
+			ns = fallbackNamespace
+		}
+		if ns == saNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+func (k *mqlK8sServiceaccount) k8sResource() (*mqlK8s, error) {
+	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return o.(*mqlK8s), nil
+}
+
+// roleBindings returns the RoleBindings (in this ServiceAccount's namespace)
+// that list it as a subject.
+func (k *mqlK8sServiceaccount) roleBindings() ([]any, error) {
+	o, err := k.k8sResource()
+	if err != nil {
+		return nil, err
+	}
+	rbs := o.GetRolebindings()
+	if rbs.Error != nil {
+		return nil, rbs.Error
+	}
+	out := []any{}
+	for i := range rbs.Data {
+		rb, ok := rbs.Data[i].(*mqlK8sRbacRolebinding)
+		if !ok {
+			continue
+		}
+		if subjectsIncludeServiceAccount(rb.obj.Subjects, k.Name.Data, k.Namespace.Data, rb.obj.Namespace) {
+			out = append(out, rb)
+		}
+	}
+	return out, nil
+}
+
+// clusterRoleBindings returns the ClusterRoleBindings that list this
+// ServiceAccount as a subject.
+func (k *mqlK8sServiceaccount) clusterRoleBindings() ([]any, error) {
+	o, err := k.k8sResource()
+	if err != nil {
+		return nil, err
+	}
+	crbs := o.GetClusterrolebindings()
+	if crbs.Error != nil {
+		return nil, crbs.Error
+	}
+	out := []any{}
+	for i := range crbs.Data {
+		crb, ok := crbs.Data[i].(*mqlK8sRbacClusterrolebinding)
+		if !ok {
+			continue
+		}
+		if subjectsIncludeServiceAccount(crb.obj.Subjects, k.Name.Data, k.Namespace.Data, "") {
+			out = append(out, crb)
+		}
+	}
+	return out, nil
+}
+
+// effectiveRules aggregates the policy rules of every Role and ClusterRole bound
+// to this ServiceAccount, the union of what the account is permitted to do. The
+// result is computed once and reused by the four access rollups.
+func (k *mqlK8sServiceaccount) effectiveRules() ([]rbacv1.PolicyRule, error) {
+	k.effectiveRulesOnce.Do(func() {
+		k.effectiveRulesData, k.effectiveRulesErr = k.computeEffectiveRules()
+	})
+	return k.effectiveRulesData, k.effectiveRulesErr
+}
+
+func (k *mqlK8sServiceaccount) computeEffectiveRules() ([]rbacv1.PolicyRule, error) {
+	var rules []rbacv1.PolicyRule
+
+	rbs := k.GetRoleBindings()
+	if rbs.Error != nil {
+		return nil, rbs.Error
+	}
+	for i := range rbs.Data {
+		rr, err := rbs.Data[i].(*mqlK8sRbacRolebinding).referencedRules()
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rr...)
+	}
+
+	crbs := k.GetClusterRoleBindings()
+	if crbs.Error != nil {
+		return nil, crbs.Error
+	}
+	for i := range crbs.Data {
+		rr, err := crbs.Data[i].(*mqlK8sRbacClusterrolebinding).referencedRules()
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rr...)
+	}
+
+	return rules, nil
+}
+
+func (k *mqlK8sServiceaccount) isClusterAdmin() (bool, error) {
+	rules, err := k.effectiveRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacGrantsClusterAdmin(rules), nil
+}
+
+func (k *mqlK8sServiceaccount) canEscalatePrivileges() (bool, error) {
+	rules, err := k.effectiveRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacAllowsPrivilegeEscalation(rules), nil
+}
+
+func (k *mqlK8sServiceaccount) canReadSecrets() (bool, error) {
+	rules, err := k.effectiveRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacCanReadSecrets(rules), nil
+}
+
+func (k *mqlK8sServiceaccount) hasWildcardPermissions() (bool, error) {
+	rules, err := k.effectiveRules()
+	if err != nil {
+		return false, err
+	}
+	return rbacHasWildcardRule(rules), nil
 }
 
 func (k *mqlK8sServiceaccount) ownerReferences() ([]any, error) {

--- a/providers/k8s/resources/serviceaccount_rbac_test.go
+++ b/providers/k8s/resources/serviceaccount_rbac_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serviceAccountByName(t *testing.T, k8s *mqlK8s, namespace, name string) *mqlK8sServiceaccount {
+	t.Helper()
+	sas := k8s.GetServiceaccounts()
+	require.NoError(t, sas.Error)
+	for i := range sas.Data {
+		sa := sas.Data[i].(*mqlK8sServiceaccount)
+		if sa.GetName().Data == name && sa.GetNamespace().Data == namespace {
+			return sa
+		}
+	}
+	require.FailNowf(t, "serviceaccount not found", "serviceaccount %s/%s not found", namespace, name)
+	return nil
+}
+
+func TestServiceAccountRbacRollups(t *testing.T) {
+	k8sObj, err := NewResource(rbacRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	t.Run("cluster-admin service account", func(t *testing.T) {
+		sa := serviceAccountByName(t, k8s, "default", "admin-sa")
+		assert.True(t, sa.GetIsClusterAdmin().Data, "isClusterAdmin")
+		assert.True(t, sa.GetCanEscalatePrivileges().Data, "canEscalatePrivileges")
+		assert.True(t, sa.GetCanReadSecrets().Data, "canReadSecrets")
+		assert.True(t, sa.GetHasWildcardPermissions().Data, "hasWildcardPermissions")
+
+		// bound via a ClusterRoleBinding, not a RoleBinding
+		crbs := sa.GetClusterRoleBindings()
+		require.NoError(t, crbs.Error)
+		assert.Len(t, crbs.Data, 1, "clusterRoleBindings")
+		rbs := sa.GetRoleBindings()
+		require.NoError(t, rbs.Error)
+		assert.Empty(t, rbs.Data, "roleBindings")
+	})
+
+	t.Run("benign service account", func(t *testing.T) {
+		sa := serviceAccountByName(t, k8s, "default", "reader-sa")
+		assert.False(t, sa.GetIsClusterAdmin().Data, "isClusterAdmin")
+		assert.False(t, sa.GetCanEscalatePrivileges().Data, "canEscalatePrivileges")
+		assert.False(t, sa.GetCanReadSecrets().Data, "canReadSecrets")
+		assert.False(t, sa.GetHasWildcardPermissions().Data, "hasWildcardPermissions")
+
+		rbs := sa.GetRoleBindings()
+		require.NoError(t, rbs.Error)
+		assert.Len(t, rbs.Data, 1, "roleBindings")
+	})
+
+	t.Run("secret-reading service account via cluster role", func(t *testing.T) {
+		// secret-sa is bound (via a RoleBinding) to the ClusterRole secret-reader.
+		sa := serviceAccountByName(t, k8s, "default", "secret-sa")
+		assert.True(t, sa.GetCanReadSecrets().Data, "canReadSecrets")
+		assert.False(t, sa.GetIsClusterAdmin().Data, "isClusterAdmin")
+		assert.False(t, sa.GetCanEscalatePrivileges().Data, "canEscalatePrivileges")
+	})
+
+	t.Run("privilege-escalating service account", func(t *testing.T) {
+		sa := serviceAccountByName(t, k8s, "default", "binder-sa")
+		assert.True(t, sa.GetCanEscalatePrivileges().Data, "canEscalatePrivileges")
+		assert.False(t, sa.GetIsClusterAdmin().Data, "isClusterAdmin")
+		assert.False(t, sa.GetCanReadSecrets().Data, "canReadSecrets")
+	})
+
+	t.Run("namespaced-only binding has no cluster bindings", func(t *testing.T) {
+		// binder-sa is bound only via a RoleBinding, so its clusterRoleBindings
+		// list is empty.
+		sa := serviceAccountByName(t, k8s, "default", "binder-sa")
+		crbs := sa.GetClusterRoleBindings()
+		require.NoError(t, crbs.Error)
+		assert.Empty(t, crbs.Data, "clusterRoleBindings")
+	})
+}


### PR DESCRIPTION
## Summary

Completes the RBAC subject-side analysis: answers *"what can this identity actually do?"* by walking the bindings that reference a `ServiceAccount` and aggregating the rules of the roles they grant. Adds to `k8s.serviceaccount`:

- **`roleBindings()`** / **`clusterRoleBindings()`** — the bindings that grant this SA a role
- **`isClusterAdmin()`** — any bound role confers cluster-admin
- **`canEscalatePrivileges()`** — any bound role allows `escalate`/`bind`/`impersonate`
- **`canReadSecrets()`** — any bound role can read Secrets
- **`hasWildcardPermissions()`** — any bound role has a wildcard rule

```mql
k8s.serviceaccounts.where( isClusterAdmin )          # over-privileged identities
k8s.serviceaccounts.where( canReadSecrets )          # who can read Secrets
```

Subject matching mirrors kube-apiserver: a RoleBinding subject's namespace falls back to the binding's namespace, while ClusterRoleBinding subjects require an explicit namespace. Effective rules reuse the binding `referencedRules()` resolution from PR A, so dangling references contribute nothing rather than erroring.

## Why

This is the payoff of the RBAC work: over-permissioned service accounts and cluster-admin sprawl are a top real-world k8s finding, and they're now a one-line query against the *identity* rather than something you reconstruct from roles + bindings by hand. Together with the workload runtime-security rollups (#8577/#8581/#8582), the two main k8s security axes — workload hardening and identity/access — are now directly queryable.

## Stacked on #8584

Built on **#8584** (RBAC binding rollups), which adds the `referencedRules()` helpers this PR consumes. Base is set to that branch; review/merge #8584 first (this diff then shows only the service-account changes).

## Tests

Reuses the bindings/service-account fixtures: a cluster-admin SA (all true), a benign SA (all false), a secret-reader bound via a ClusterRole (through a RoleBinding), and a privilege-escalating SA, plus the binding-list accessors. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)