### PR TITLE
✨ k8s: container resource-limit rollups for workloads

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -416,6 +416,14 @@ private k8s.pod @defaults("namespace name created"){
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -618,6 +626,14 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -752,6 +768,14 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -885,6 +909,14 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -1026,6 +1058,14 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -1147,6 +1187,14 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity
@@ -1293,6 +1341,14 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether every container sets a CPU limit (regular and init containers)
+  hasCpuLimit() bool
+  // Whether every container sets a memory limit (regular and init containers)
+  hasMemoryLimit() bool
+  // Whether every container sets both CPU and memory limits
+  hasResourceLimits() bool
+  // Whether every container sets both CPU and memory requests
+  hasResourceRequests() bool
   // Highest Pod Security Standards level the workload satisfies
   //
   // One of "restricted", "baseline", or "privileged" (the level a PodSecurity

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -839,6 +839,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasResourceRequests()).ToDataRes(types.Bool)
+	},
 	"k8s.pod.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetPodSecurityStandard()).ToDataRes(types.String)
 	},
@@ -1088,6 +1100,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.deployment.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasResourceRequests()).ToDataRes(types.Bool)
+	},
 	"k8s.deployment.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetPodSecurityStandard()).ToDataRes(types.String)
 	},
@@ -1235,6 +1259,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.daemonset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasResourceRequests()).ToDataRes(types.Bool)
+	},
 	"k8s.daemonset.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetPodSecurityStandard()).ToDataRes(types.String)
 	},
@@ -1378,6 +1414,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasResourceRequests()).ToDataRes(types.Bool)
 	},
 	"k8s.statefulset.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetPodSecurityStandard()).ToDataRes(types.String)
@@ -1538,6 +1586,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.replicaset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasResourceRequests()).ToDataRes(types.Bool)
+	},
 	"k8s.replicaset.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetPodSecurityStandard()).ToDataRes(types.String)
 	},
@@ -1666,6 +1726,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasResourceRequests()).ToDataRes(types.Bool)
 	},
 	"k8s.job.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetPodSecurityStandard()).ToDataRes(types.String)
@@ -1831,6 +1903,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasCpuLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasMemoryLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasMemoryLimit()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasResourceLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasResourceLimits()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasResourceRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasResourceRequests()).ToDataRes(types.Bool)
 	},
 	"k8s.cronjob.podSecurityStandard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetPodSecurityStandard()).ToDataRes(types.String)
@@ -4847,6 +4931,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).PodSecurityStandard, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5183,6 +5283,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).PodSecurityStandard, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5383,6 +5499,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).PodSecurityStandard, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5577,6 +5709,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5795,6 +5943,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).PodSecurityStandard, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5969,6 +6133,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.job.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6193,6 +6373,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasMemoryLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasMemoryLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasResourceLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasResourceLimits, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasResourceRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasResourceRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.podSecurityStandard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11506,6 +11702,10 @@ type mqlK8sPod struct {
 	UsesHostPath                  plugin.TValue[bool]
 	UsesUnconfinedSeccomp         plugin.TValue[bool]
 	HasSeccompProfile             plugin.TValue[bool]
+	HasCpuLimit                   plugin.TValue[bool]
+	HasMemoryLimit                plugin.TValue[bool]
+	HasResourceLimits             plugin.TValue[bool]
+	HasResourceRequests           plugin.TValue[bool]
 	PodSecurityStandard           plugin.TValue[string]
 	MeetsPodSecurityBaseline      plugin.TValue[bool]
 	MeetsPodSecurityRestricted    plugin.TValue[bool]
@@ -11670,6 +11870,30 @@ func (c *mqlK8sPod) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sPod) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sPod) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sPod) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sPod) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -12225,6 +12449,10 @@ type mqlK8sDeployment struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	HasCpuLimit                  plugin.TValue[bool]
+	HasMemoryLimit               plugin.TValue[bool]
+	HasResourceLimits            plugin.TValue[bool]
+	HasResourceRequests          plugin.TValue[bool]
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
@@ -12385,6 +12613,30 @@ func (c *mqlK8sDeployment) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -12648,6 +12900,10 @@ type mqlK8sDaemonset struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	HasCpuLimit                  plugin.TValue[bool]
+	HasMemoryLimit               plugin.TValue[bool]
+	HasResourceLimits            plugin.TValue[bool]
+	HasResourceRequests          plugin.TValue[bool]
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
@@ -12807,6 +13063,30 @@ func (c *mqlK8sDaemonset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -13064,6 +13344,10 @@ type mqlK8sStatefulset struct {
 	UsesHostPath                         plugin.TValue[bool]
 	UsesUnconfinedSeccomp                plugin.TValue[bool]
 	HasSeccompProfile                    plugin.TValue[bool]
+	HasCpuLimit                          plugin.TValue[bool]
+	HasMemoryLimit                       plugin.TValue[bool]
+	HasResourceLimits                    plugin.TValue[bool]
+	HasResourceRequests                  plugin.TValue[bool]
 	PodSecurityStandard                  plugin.TValue[string]
 	MeetsPodSecurityBaseline             plugin.TValue[bool]
 	MeetsPodSecurityRestricted           plugin.TValue[bool]
@@ -13228,6 +13512,30 @@ func (c *mqlK8sStatefulset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -13515,6 +13823,10 @@ type mqlK8sReplicaset struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	HasCpuLimit                  plugin.TValue[bool]
+	HasMemoryLimit               plugin.TValue[bool]
+	HasResourceLimits            plugin.TValue[bool]
+	HasResourceRequests          plugin.TValue[bool]
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
@@ -13669,6 +13981,30 @@ func (c *mqlK8sReplicaset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -13896,6 +14232,10 @@ type mqlK8sJob struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	HasCpuLimit                  plugin.TValue[bool]
+	HasMemoryLimit               plugin.TValue[bool]
+	HasResourceLimits            plugin.TValue[bool]
+	HasResourceRequests          plugin.TValue[bool]
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
@@ -14062,6 +14402,30 @@ func (c *mqlK8sJob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sJob) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sJob) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sJob) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sJob) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 
@@ -14361,6 +14725,10 @@ type mqlK8sCronjob struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	HasCpuLimit                  plugin.TValue[bool]
+	HasMemoryLimit               plugin.TValue[bool]
+	HasResourceLimits            plugin.TValue[bool]
+	HasResourceRequests          plugin.TValue[bool]
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
@@ -14517,6 +14885,30 @@ func (c *mqlK8sCronjob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasCpuLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasCpuLimit, func() (bool, error) {
+		return c.hasCpuLimit()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasMemoryLimit() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasMemoryLimit, func() (bool, error) {
+		return c.hasMemoryLimit()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasResourceLimits() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceLimits, func() (bool, error) {
+		return c.hasResourceLimits()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasResourceRequests() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasResourceRequests, func() (bool, error) {
+		return c.hasResourceRequests()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -215,6 +215,10 @@ k8s.cronjob.containers 9.0.0
 k8s.cronjob.created 9.0.0
 k8s.cronjob.dropsAllCapabilities 13.2.2
 k8s.cronjob.failedJobsHistoryLimit 13.0.16
+k8s.cronjob.hasCpuLimit 13.3.1
+k8s.cronjob.hasMemoryLimit 13.3.1
+k8s.cronjob.hasResourceLimits 13.3.1
+k8s.cronjob.hasResourceRequests 13.3.1
 k8s.cronjob.hasSeccompProfile 13.3.1
 k8s.cronjob.hasWritableRootFilesystem 13.2.2
 k8s.cronjob.hostIPC 13.2.2
@@ -276,6 +280,10 @@ k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
 k8s.daemonset.desiredNumberScheduled 13.0.16
 k8s.daemonset.dropsAllCapabilities 13.2.2
+k8s.daemonset.hasCpuLimit 13.3.1
+k8s.daemonset.hasMemoryLimit 13.3.1
+k8s.daemonset.hasResourceLimits 13.3.1
+k8s.daemonset.hasResourceRequests 13.3.1
 k8s.daemonset.hasSeccompProfile 13.3.1
 k8s.daemonset.hasWritableRootFilesystem 13.2.2
 k8s.daemonset.hostIPC 13.2.2
@@ -326,6 +334,10 @@ k8s.deployment.containers 9.0.0
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
 k8s.deployment.dropsAllCapabilities 13.2.2
+k8s.deployment.hasCpuLimit 13.3.1
+k8s.deployment.hasMemoryLimit 13.3.1
+k8s.deployment.hasResourceLimits 13.3.1
+k8s.deployment.hasResourceRequests 13.3.1
 k8s.deployment.hasSeccompProfile 13.3.1
 k8s.deployment.hasWritableRootFilesystem 13.2.2
 k8s.deployment.hostIPC 13.2.2
@@ -635,6 +647,10 @@ k8s.job.created 9.0.0
 k8s.job.dropsAllCapabilities 13.2.2
 k8s.job.failed 13.0.16
 k8s.job.failedIndexes 13.0.16
+k8s.job.hasCpuLimit 13.3.1
+k8s.job.hasMemoryLimit 13.3.1
+k8s.job.hasResourceLimits 13.3.1
+k8s.job.hasResourceRequests 13.3.1
 k8s.job.hasSeccompProfile 13.3.1
 k8s.job.hasWritableRootFilesystem 13.2.2
 k8s.job.hostIPC 13.2.2
@@ -909,6 +925,10 @@ k8s.pod.dnsPolicy 13.0.16
 k8s.pod.dropsAllCapabilities 13.2.2
 k8s.pod.enableServiceLinks 13.0.16
 k8s.pod.ephemeralContainers 9.0.0
+k8s.pod.hasCpuLimit 13.3.1
+k8s.pod.hasMemoryLimit 13.3.1
+k8s.pod.hasResourceLimits 13.3.1
+k8s.pod.hasResourceRequests 13.3.1
 k8s.pod.hasSeccompProfile 13.3.1
 k8s.pod.hasWritableRootFilesystem 13.2.2
 k8s.pod.hostAliases 13.0.16
@@ -1127,6 +1147,10 @@ k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
 k8s.replicaset.dropsAllCapabilities 13.2.2
 k8s.replicaset.fullyLabeledReplicas 13.0.16
+k8s.replicaset.hasCpuLimit 13.3.1
+k8s.replicaset.hasMemoryLimit 13.3.1
+k8s.replicaset.hasResourceLimits 13.3.1
+k8s.replicaset.hasResourceRequests 13.3.1
 k8s.replicaset.hasSeccompProfile 13.3.1
 k8s.replicaset.hasWritableRootFilesystem 13.2.2
 k8s.replicaset.hostIPC 13.2.2
@@ -1273,6 +1297,10 @@ k8s.statefulset.currentReplicas 13.0.16
 k8s.statefulset.currentRevision 13.0.16
 k8s.statefulset.desiredReplicas 13.0.16
 k8s.statefulset.dropsAllCapabilities 13.2.2
+k8s.statefulset.hasCpuLimit 13.3.1
+k8s.statefulset.hasMemoryLimit 13.3.1
+k8s.statefulset.hasResourceLimits 13.3.1
+k8s.statefulset.hasResourceRequests 13.3.1
 k8s.statefulset.hasSeccompProfile 13.3.1
 k8s.statefulset.hasWritableRootFilesystem 13.2.2
 k8s.statefulset.hostIPC 13.2.2

--- a/providers/k8s/resources/resource_limits.go
+++ b/providers/k8s/resources/resource_limits.go
@@ -1,0 +1,218 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// This file wires container resource-constraint rollup predicates onto every
+// workload kind. Unbounded containers are a denial-of-service / noisy-neighbor
+// risk, so these complement the security rollups in workload_security.go with
+// an availability view:
+//
+//   hasCpuLimit / hasMemoryLimit  every container sets that limit
+//   hasResourceLimits             every container sets both CPU and memory limits
+//   hasResourceRequests           every container sets both CPU and memory requests
+//
+// Only regular and init containers are considered. Ephemeral containers are
+// excluded because they are transient debug aids, not part of the steady-state
+// workload (and the Kubernetes API disallows setting resources on them anyway),
+// so counting them would make every workload with a debug container report false.
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func resourceContainers(spec *corev1.PodSpec) []corev1.Container {
+	if spec == nil {
+		return nil
+	}
+	out := make([]corev1.Container, 0, len(spec.Containers)+len(spec.InitContainers))
+	out = append(out, spec.Containers...)
+	out = append(out, spec.InitContainers...)
+	return out
+}
+
+// resourceQuantitySet reports whether the resource list sets a non-zero quantity
+// for the named resource.
+func resourceQuantitySet(list corev1.ResourceList, name corev1.ResourceName) bool {
+	q, ok := list[name]
+	return ok && !q.IsZero()
+}
+
+// specAllContainersHave reports whether every resource-bearing container sets
+// the named quantity in its limits (when limits is true) or requests list.
+func specAllContainersHave(spec *corev1.PodSpec, limits bool, name corev1.ResourceName) bool {
+	containers := resourceContainers(spec)
+	// A pod with no regular or init containers is treated as unconstrained.
+	if len(containers) == 0 {
+		return false
+	}
+	for _, c := range containers {
+		list := c.Resources.Requests
+		if limits {
+			list = c.Resources.Limits
+		}
+		if !resourceQuantitySet(list, name) {
+			return false
+		}
+	}
+	return true
+}
+
+func specHasCPULimit(spec *corev1.PodSpec) bool {
+	return specAllContainersHave(spec, true, corev1.ResourceCPU)
+}
+
+func specHasMemoryLimit(spec *corev1.PodSpec) bool {
+	return specAllContainersHave(spec, true, corev1.ResourceMemory)
+}
+
+func specHasResourceLimits(spec *corev1.PodSpec) bool {
+	return specHasCPULimit(spec) && specHasMemoryLimit(spec)
+}
+
+func specHasResourceRequests(spec *corev1.PodSpec) bool {
+	return specAllContainersHave(spec, false, corev1.ResourceCPU) &&
+		specAllContainersHave(spec, false, corev1.ResourceMemory)
+}
+
+// ---- per-kind wiring ----
+
+func (k *mqlK8sPod) hasCpuLimit() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sPod) hasMemoryLimit() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sPod) hasResourceLimits() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sPod) hasResourceRequests() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sDeployment) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sDeployment) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sDeployment) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sDeployment) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sDaemonset) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sDaemonset) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sDaemonset) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sDaemonset) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sStatefulset) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sStatefulset) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sStatefulset) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sStatefulset) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sReplicaset) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sReplicaset) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sReplicaset) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sReplicaset) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sJob) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sJob) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sJob) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sJob) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}
+
+func (k *mqlK8sCronjob) hasCpuLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasCPULimit)
+}
+
+func (k *mqlK8sCronjob) hasMemoryLimit() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasMemoryLimit)
+}
+
+func (k *mqlK8sCronjob) hasResourceLimits() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceLimits)
+}
+
+func (k *mqlK8sCronjob) hasResourceRequests() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasResourceRequests)
+}

--- a/providers/k8s/resources/resource_limits_test.go
+++ b/providers/k8s/resources/resource_limits_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestResourceLimitRollups_Fixtures checks the rollups against the shared
+// workload fixtures: the hardened deployment sets full CPU/memory
+// limits+requests, while the risky one sets none.
+func TestResourceLimitRollups_Fixtures(t *testing.T) {
+	k8s := workloadSecurityK8s(t)
+
+	t.Run("fully constrained workload", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "hardened")
+		assert.True(t, d.GetHasCpuLimit().Data, "hasCpuLimit")
+		assert.True(t, d.GetHasMemoryLimit().Data, "hasMemoryLimit")
+		assert.True(t, d.GetHasResourceLimits().Data, "hasResourceLimits")
+		assert.True(t, d.GetHasResourceRequests().Data, "hasResourceRequests")
+	})
+
+	t.Run("unconstrained workload", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "risky")
+		assert.False(t, d.GetHasCpuLimit().Data, "hasCpuLimit")
+		assert.False(t, d.GetHasMemoryLimit().Data, "hasMemoryLimit")
+		assert.False(t, d.GetHasResourceLimits().Data, "hasResourceLimits")
+		assert.False(t, d.GetHasResourceRequests().Data, "hasResourceRequests")
+	})
+}
+
+func qty(s string) resource.Quantity { return resource.MustParse(s) }
+
+// TestResourceLimitRollups_Helpers exercises the spec helpers directly, covering
+// partial coverage, init containers, and the nil/empty cases.
+func TestResourceLimitRollups_Helpers(t *testing.T) {
+	bothLimits := corev1.ResourceList{corev1.ResourceCPU: qty("500m"), corev1.ResourceMemory: qty("256Mi")}
+	bothRequests := corev1.ResourceList{corev1.ResourceCPU: qty("100m"), corev1.ResourceMemory: qty("128Mi")}
+
+	t.Run("nil spec is false", func(t *testing.T) {
+		assert.False(t, specHasCPULimit(nil))
+		assert.False(t, specHasMemoryLimit(nil))
+		assert.False(t, specHasResourceLimits(nil))
+		assert.False(t, specHasResourceRequests(nil))
+	})
+
+	t.Run("all set", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "a", Resources: corev1.ResourceRequirements{Limits: bothLimits, Requests: bothRequests}},
+		}}
+		assert.True(t, specHasResourceLimits(spec))
+		assert.True(t, specHasResourceRequests(spec))
+	})
+
+	t.Run("memory limit missing on one container", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "a", Resources: corev1.ResourceRequirements{Limits: bothLimits}},
+			{Name: "b", Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{corev1.ResourceCPU: qty("250m")}}},
+		}}
+		assert.True(t, specHasCPULimit(spec), "both set cpu")
+		assert.False(t, specHasMemoryLimit(spec), "container b lacks memory limit")
+		assert.False(t, specHasResourceLimits(spec))
+	})
+
+	t.Run("init container without limits fails", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init"}},
+			Containers:     []corev1.Container{{Name: "a", Resources: corev1.ResourceRequirements{Limits: bothLimits}}},
+		}
+		assert.False(t, specHasResourceLimits(spec), "init container is unbounded")
+	})
+
+	t.Run("ephemeral containers are ignored", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "a", Resources: corev1.ResourceRequirements{Limits: bothLimits, Requests: bothRequests}}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debug"}},
+			},
+		}
+		assert.True(t, specHasResourceLimits(spec), "ephemeral debug container must not flip the result")
+	})
+
+	t.Run("zero quantity does not count as set", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "a", Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				corev1.ResourceCPU: qty("0"), corev1.ResourceMemory: qty("0"),
+			}}},
+		}}
+		assert.False(t, specHasCPULimit(spec))
+		assert.False(t, specHasMemoryLimit(spec))
+	})
+}

--- a/providers/k8s/resources/testdata/workload-security.yaml
+++ b/providers/k8s/resources/testdata/workload-security.yaml
@@ -25,6 +25,13 @@ spec:
       containers:
       - name: app
         image: nginx:1.25
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Adds availability-oriented rollups to every workload kind — `k8s.pod`, `k8s.deployment`, `k8s.daemonset`, `k8s.statefulset`, `k8s.replicaset`, `k8s.job`, `k8s.cronjob`:

- **`hasCpuLimit()`** / **`hasMemoryLimit()`** — every container sets that limit
- **`hasResourceLimits()`** — every container sets both CPU and memory limits
- **`hasResourceRequests()`** — every container sets both CPU and memory requests

Container `resources` was previously only reachable as a raw dict. Unbounded containers are a denial-of-service / noisy-neighbor risk, so these complement the security rollups (privileged/seccomp/PSS) with an **availability** view, and pair with the existing `LimitRange`/`ResourceQuota` resources for enforcement checks.

```mql
k8s.deployments.where( !hasMemoryLimit )    # unbounded workloads
```

## Details

- Considers **regular and init** containers. **Ephemeral** (debug) containers are excluded because Kubernetes forbids setting `resources` on them — counting them would make every workload with a debug container report false.
- A **zero** quantity does not count as set.
- Follows the established `specXxx` + per-kind wiring pattern; nil specs report false.

## Tests

`resource_limits_test.go`: fixture coverage (fully constrained `hardened` vs unconstrained `risky`) plus spec-helper unit tests for partial coverage (one container missing a limit), init-container inclusion, ephemeral-container exclusion, zero quantities, and nil specs. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)