### PR TITLE
✨ k8s: Secret-consumption rollups for workloads

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -426,6 +426,12 @@ private k8s.pod @defaults("namespace name created"){
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -628,6 +634,12 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -762,6 +774,12 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -895,6 +913,12 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1036,6 +1060,12 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1157,6 +1187,12 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1303,6 +1339,12 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   meetsPodSecurityBaseline() bool
   // Whether the workload satisfies the Pod Security Standards restricted profile
   meetsPodSecurityRestricted() bool
+  // Whether any container injects a Secret as an environment variable (secretKeyRef or envFrom)
+  usesSecretsAsEnv() bool
+  // Whether the workload mounts a Secret as a volume (including projected secret sources)
+  mountsSecretVolumes() bool
+  // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
+  consumedSecrets() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -848,6 +848,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.pod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetId()).ToDataRes(types.String)
 	},
@@ -1097,6 +1106,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
 	},
+	"k8s.deployment.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -1244,6 +1262,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
 	},
+	"k8s.daemonset.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.daemonset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetId()).ToDataRes(types.String)
 	},
@@ -1387,6 +1414,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.statefulset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetId()).ToDataRes(types.String)
@@ -1547,6 +1583,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
 	},
+	"k8s.replicaset.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.replicaset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetId()).ToDataRes(types.String)
 	},
@@ -1675,6 +1720,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
+	},
+	"k8s.job.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.job.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.job.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetId()).ToDataRes(types.String)
@@ -1840,6 +1894,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.meetsPodSecurityRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetMeetsPodSecurityRestricted()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.usesSecretsAsEnv": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesSecretsAsEnv()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.mountsSecretVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetMountsSecretVolumes()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.cronjob.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetId()).ToDataRes(types.String)
@@ -4859,6 +4922,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5195,6 +5270,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5395,6 +5482,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5589,6 +5688,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.meetsPodSecurityRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5807,6 +5918,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5981,6 +6104,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.meetsPodSecurityRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.job.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6205,6 +6340,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.meetsPodSecurityRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).MeetsPodSecurityRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesSecretsAsEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesSecretsAsEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.mountsSecretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).MountsSecretVolumes, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11509,6 +11656,9 @@ type mqlK8sPod struct {
 	PodSecurityStandard           plugin.TValue[string]
 	MeetsPodSecurityBaseline      plugin.TValue[bool]
 	MeetsPodSecurityRestricted    plugin.TValue[bool]
+	UsesSecretsAsEnv              plugin.TValue[bool]
+	MountsSecretVolumes           plugin.TValue[bool]
+	ConsumedSecrets               plugin.TValue[[]any]
 	Id                            plugin.TValue[string]
 	Uid                           plugin.TValue[string]
 	ResourceVersion               plugin.TValue[string]
@@ -11688,6 +11838,24 @@ func (c *mqlK8sPod) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sPod) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sPod) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -12228,6 +12396,9 @@ type mqlK8sDeployment struct {
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
+	UsesSecretsAsEnv             plugin.TValue[bool]
+	MountsSecretVolumes          plugin.TValue[bool]
+	ConsumedSecrets              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -12403,6 +12574,24 @@ func (c *mqlK8sDeployment) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sDeployment) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sDeployment) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -12651,6 +12840,9 @@ type mqlK8sDaemonset struct {
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
+	UsesSecretsAsEnv             plugin.TValue[bool]
+	MountsSecretVolumes          plugin.TValue[bool]
+	ConsumedSecrets              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -12825,6 +13017,24 @@ func (c *mqlK8sDaemonset) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -13067,6 +13277,9 @@ type mqlK8sStatefulset struct {
 	PodSecurityStandard                  plugin.TValue[string]
 	MeetsPodSecurityBaseline             plugin.TValue[bool]
 	MeetsPodSecurityRestricted           plugin.TValue[bool]
+	UsesSecretsAsEnv                     plugin.TValue[bool]
+	MountsSecretVolumes                  plugin.TValue[bool]
+	ConsumedSecrets                      plugin.TValue[[]any]
 	Id                                   plugin.TValue[string]
 	Uid                                  plugin.TValue[string]
 	ResourceVersion                      plugin.TValue[string]
@@ -13246,6 +13459,24 @@ func (c *mqlK8sStatefulset) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -13518,6 +13749,9 @@ type mqlK8sReplicaset struct {
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
+	UsesSecretsAsEnv             plugin.TValue[bool]
+	MountsSecretVolumes          plugin.TValue[bool]
+	ConsumedSecrets              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13687,6 +13921,24 @@ func (c *mqlK8sReplicaset) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -13899,6 +14151,9 @@ type mqlK8sJob struct {
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
+	UsesSecretsAsEnv             plugin.TValue[bool]
+	MountsSecretVolumes          plugin.TValue[bool]
+	ConsumedSecrets              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -14080,6 +14335,24 @@ func (c *mqlK8sJob) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sJob) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sJob) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 
@@ -14364,6 +14637,9 @@ type mqlK8sCronjob struct {
 	PodSecurityStandard          plugin.TValue[string]
 	MeetsPodSecurityBaseline     plugin.TValue[bool]
 	MeetsPodSecurityRestricted   plugin.TValue[bool]
+	UsesSecretsAsEnv             plugin.TValue[bool]
+	MountsSecretVolumes          plugin.TValue[bool]
+	ConsumedSecrets              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -14535,6 +14811,24 @@ func (c *mqlK8sCronjob) GetMeetsPodSecurityBaseline() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetMeetsPodSecurityRestricted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.MeetsPodSecurityRestricted, func() (bool, error) {
 		return c.meetsPodSecurityRestricted()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesSecretsAsEnv() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesSecretsAsEnv, func() (bool, error) {
+		return c.usesSecretsAsEnv()
+	})
+}
+
+func (c *mqlK8sCronjob) GetMountsSecretVolumes() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MountsSecretVolumes, func() (bool, error) {
+		return c.mountsSecretVolumes()
+	})
+}
+
+func (c *mqlK8sCronjob) GetConsumedSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
+		return c.consumedSecrets()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -211,6 +211,7 @@ k8s.cronjob.allowsPrivilegeEscalation 13.2.2
 k8s.cronjob.annotations 9.0.0
 k8s.cronjob.automountServiceAccountToken 13.2.2
 k8s.cronjob.concurrencyPolicy 13.0.16
+k8s.cronjob.consumedSecrets 13.3.1
 k8s.cronjob.containers 9.0.0
 k8s.cronjob.created 9.0.0
 k8s.cronjob.dropsAllCapabilities 13.2.2
@@ -231,6 +232,7 @@ k8s.cronjob.managedFields 13.2.2
 k8s.cronjob.manifest 9.0.0
 k8s.cronjob.meetsPodSecurityBaseline 13.3.1
 k8s.cronjob.meetsPodSecurityRestricted 13.3.1
+k8s.cronjob.mountsSecretVolumes 13.3.1
 k8s.cronjob.name 9.0.0
 k8s.cronjob.namespace 9.0.0
 k8s.cronjob.ownerReferences 13.2.2
@@ -248,6 +250,7 @@ k8s.cronjob.timeZone 13.0.16
 k8s.cronjob.uid 9.0.0
 k8s.cronjob.usesHostNamespaces 13.2.2
 k8s.cronjob.usesHostPath 13.2.2
+k8s.cronjob.usesSecretsAsEnv 13.3.1
 k8s.cronjob.usesUnconfinedSeccomp 13.3.1
 k8s.cronjobs 9.0.0
 k8s.customresource 9.0.0
@@ -271,6 +274,7 @@ k8s.daemonset.annotations 9.0.0
 k8s.daemonset.automountServiceAccountToken 13.2.2
 k8s.daemonset.collisionCount 13.0.16
 k8s.daemonset.conditions 13.0.16
+k8s.daemonset.consumedSecrets 13.3.1
 k8s.daemonset.containers 9.0.0
 k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
@@ -290,6 +294,7 @@ k8s.daemonset.manifest 9.0.0
 k8s.daemonset.meetsPodSecurityBaseline 13.3.1
 k8s.daemonset.meetsPodSecurityRestricted 13.3.1
 k8s.daemonset.minReadySeconds 13.0.16
+k8s.daemonset.mountsSecretVolumes 13.3.1
 k8s.daemonset.name 9.0.0
 k8s.daemonset.namespace 9.0.0
 k8s.daemonset.numberAvailable 13.0.16
@@ -312,6 +317,7 @@ k8s.daemonset.updateStrategy 13.0.16
 k8s.daemonset.updatedNumberScheduled 13.0.16
 k8s.daemonset.usesHostNamespaces 13.2.2
 k8s.daemonset.usesHostPath 13.2.2
+k8s.daemonset.usesSecretsAsEnv 13.3.1
 k8s.daemonset.usesUnconfinedSeccomp 13.3.1
 k8s.daemonsets 9.0.0
 k8s.deployment 9.0.0
@@ -322,6 +328,7 @@ k8s.deployment.automountServiceAccountToken 13.2.2
 k8s.deployment.availableReplicas 13.0.16
 k8s.deployment.collisionCount 13.0.16
 k8s.deployment.conditions 13.0.16
+k8s.deployment.consumedSecrets 13.3.1
 k8s.deployment.containers 9.0.0
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
@@ -340,6 +347,7 @@ k8s.deployment.manifest 9.0.0
 k8s.deployment.meetsPodSecurityBaseline 13.3.1
 k8s.deployment.meetsPodSecurityRestricted 13.3.1
 k8s.deployment.minReadySeconds 13.0.16
+k8s.deployment.mountsSecretVolumes 13.3.1
 k8s.deployment.name 9.0.0
 k8s.deployment.namespace 9.0.0
 k8s.deployment.observedGeneration 13.0.16
@@ -363,6 +371,7 @@ k8s.deployment.unavailableReplicas 13.0.16
 k8s.deployment.updatedReplicas 13.0.16
 k8s.deployment.usesHostNamespaces 13.2.2
 k8s.deployment.usesHostPath 13.2.2
+k8s.deployment.usesSecretsAsEnv 13.3.1
 k8s.deployment.usesUnconfinedSeccomp 13.3.1
 k8s.deployments 9.0.0
 k8s.endpointSlices 11.1.139
@@ -630,6 +639,7 @@ k8s.job.completionMode 13.0.16
 k8s.job.completionTime 13.0.16
 k8s.job.completions 13.0.16
 k8s.job.conditions 13.0.16
+k8s.job.consumedSecrets 13.3.1
 k8s.job.containers 9.0.0
 k8s.job.created 9.0.0
 k8s.job.dropsAllCapabilities 13.2.2
@@ -649,6 +659,7 @@ k8s.job.manifest 9.0.0
 k8s.job.maxFailedIndexes 13.0.16
 k8s.job.meetsPodSecurityBaseline 13.3.1
 k8s.job.meetsPodSecurityRestricted 13.3.1
+k8s.job.mountsSecretVolumes 13.3.1
 k8s.job.name 9.0.0
 k8s.job.namespace 9.0.0
 k8s.job.ownerReferences 13.2.2
@@ -671,6 +682,7 @@ k8s.job.ttlSecondsAfterFinished 13.0.16
 k8s.job.uid 9.0.0
 k8s.job.usesHostNamespaces 13.2.2
 k8s.job.usesHostPath 13.2.2
+k8s.job.usesSecretsAsEnv 13.3.1
 k8s.job.usesUnconfinedSeccomp 13.3.1
 k8s.jobs 9.0.0
 k8s.lease 13.0.16
@@ -899,6 +911,7 @@ k8s.pod.annotations 9.0.0
 k8s.pod.apiVersion 9.0.0
 k8s.pod.automountServiceAccountToken 13.0.16
 k8s.pod.conditions 13.0.16
+k8s.pod.consumedSecrets 13.3.1
 k8s.pod.containerStatuses 11.1.110
 k8s.pod.containers 9.0.0
 k8s.pod.created 9.0.0
@@ -928,6 +941,7 @@ k8s.pod.manifest 9.0.0
 k8s.pod.meetsPodSecurityBaseline 13.3.1
 k8s.pod.meetsPodSecurityRestricted 13.3.1
 k8s.pod.message 13.0.16
+k8s.pod.mountsSecretVolumes 13.3.1
 k8s.pod.name 9.0.0
 k8s.pod.namespace 9.0.0
 k8s.pod.node 9.0.0
@@ -968,6 +982,7 @@ k8s.pod.topologySpreadConstraints 13.0.16
 k8s.pod.uid 9.0.0
 k8s.pod.usesHostNamespaces 13.2.2
 k8s.pod.usesHostPath 13.2.2
+k8s.pod.usesSecretsAsEnv 13.3.1
 k8s.pod.usesUnconfinedSeccomp 13.3.1
 k8s.podDisruptionBudgets 13.0.16
 k8s.poddisruptionbudget 13.0.16
@@ -1122,6 +1137,7 @@ k8s.replicaset.annotations 9.0.0
 k8s.replicaset.automountServiceAccountToken 13.2.2
 k8s.replicaset.availableReplicas 13.0.16
 k8s.replicaset.conditions 13.0.16
+k8s.replicaset.consumedSecrets 13.3.1
 k8s.replicaset.containers 9.0.0
 k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
@@ -1141,6 +1157,7 @@ k8s.replicaset.manifest 9.0.0
 k8s.replicaset.meetsPodSecurityBaseline 13.3.1
 k8s.replicaset.meetsPodSecurityRestricted 13.3.1
 k8s.replicaset.minReadySeconds 13.0.16
+k8s.replicaset.mountsSecretVolumes 13.3.1
 k8s.replicaset.name 9.0.0
 k8s.replicaset.namespace 9.0.0
 k8s.replicaset.observedGeneration 13.0.16
@@ -1158,6 +1175,7 @@ k8s.replicaset.selector 13.0.16
 k8s.replicaset.uid 9.0.0
 k8s.replicaset.usesHostNamespaces 13.2.2
 k8s.replicaset.usesHostPath 13.2.2
+k8s.replicaset.usesSecretsAsEnv 13.3.1
 k8s.replicaset.usesUnconfinedSeccomp 13.3.1
 k8s.replicasets 9.0.0
 k8s.resourceQuotas 11.1.139
@@ -1267,6 +1285,7 @@ k8s.statefulset.automountServiceAccountToken 13.2.2
 k8s.statefulset.availableReplicas 13.0.16
 k8s.statefulset.collisionCount 13.0.16
 k8s.statefulset.conditions 13.0.16
+k8s.statefulset.consumedSecrets 13.3.1
 k8s.statefulset.containers 9.0.0
 k8s.statefulset.created 9.0.0
 k8s.statefulset.currentReplicas 13.0.16
@@ -1287,6 +1306,7 @@ k8s.statefulset.manifest 9.0.0
 k8s.statefulset.meetsPodSecurityBaseline 13.3.1
 k8s.statefulset.meetsPodSecurityRestricted 13.3.1
 k8s.statefulset.minReadySeconds 13.0.16
+k8s.statefulset.mountsSecretVolumes 13.3.1
 k8s.statefulset.name 9.0.0
 k8s.statefulset.namespace 9.0.0
 k8s.statefulset.observedGeneration 13.0.16
@@ -1312,6 +1332,7 @@ k8s.statefulset.updateStrategy 13.0.16
 k8s.statefulset.updatedReplicas 13.0.16
 k8s.statefulset.usesHostNamespaces 13.2.2
 k8s.statefulset.usesHostPath 13.2.2
+k8s.statefulset.usesSecretsAsEnv 13.3.1
 k8s.statefulset.usesUnconfinedSeccomp 13.3.1
 k8s.statefulsets 9.0.0
 k8s.storageClasses 11.1.139

--- a/providers/k8s/resources/secret_consumption.go
+++ b/providers/k8s/resources/secret_consumption.go
@@ -1,0 +1,216 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// This file wires Secret-consumption rollups onto every workload kind, the
+// "what secrets can a compromised pod reach?" view that complements the
+// security rollups. k8s.secret.usedBy() already answers the reverse (which pods
+// reference a Secret); these answer it from the workload side:
+//
+//   usesSecretsAsEnv()    a Secret is injected as an environment variable
+//   mountsSecretVolumes() a Secret is mounted as a volume
+//   consumedSecrets()     names of every Secret the workload references
+//
+// Environment-variable injection is called out separately because it is the
+// higher-risk path: env values leak into process listings, crash dumps, and
+// child processes, where a mounted file does not.
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func specUsesSecretsAsEnv(spec *corev1.PodSpec) bool {
+	for _, c := range allWorkloadContainers(spec) {
+		for _, e := range c.Env {
+			if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+				return true
+			}
+		}
+		for _, ef := range c.EnvFrom {
+			if ef.SecretRef != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func specMountsSecretVolumes(spec *corev1.PodSpec) bool {
+	if spec == nil {
+		return false
+	}
+	for i := range spec.Volumes {
+		v := spec.Volumes[i]
+		if v.Secret != nil {
+			return true
+		}
+		if v.Projected != nil {
+			for _, src := range v.Projected.Sources {
+				if src.Secret != nil {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// specConsumedSecrets returns the deduplicated names of every Secret the
+// workload references: via environment variables, mounted (or projected)
+// volumes, and image-pull secrets.
+func specConsumedSecrets(spec *corev1.PodSpec) []any {
+	seen := map[string]struct{}{}
+	out := []any{}
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+
+	for _, c := range allWorkloadContainers(spec) {
+		for _, e := range c.Env {
+			if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+				add(e.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+		for _, ef := range c.EnvFrom {
+			if ef.SecretRef != nil {
+				add(ef.SecretRef.Name)
+			}
+		}
+	}
+
+	if spec != nil {
+		for i := range spec.Volumes {
+			v := spec.Volumes[i]
+			if v.Secret != nil {
+				add(v.Secret.SecretName)
+			}
+			if v.Projected != nil {
+				for _, src := range v.Projected.Sources {
+					if src.Secret != nil {
+						add(src.Secret.Name)
+					}
+				}
+			}
+		}
+		for _, ips := range spec.ImagePullSecrets {
+			add(ips.Name)
+		}
+	}
+
+	return out
+}
+
+// ---- per-kind wiring ----
+
+func (k *mqlK8sPod) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sPod) mountsSecretVolumes() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sPod) consumedSecrets() ([]any, error) {
+	spec, err := k.podSpecTyped()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sDeployment) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sDeployment) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sDeployment) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sDaemonset) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sDaemonset) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sDaemonset) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sStatefulset) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sStatefulset) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sStatefulset) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sReplicaset) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sReplicaset) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sReplicaset) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sJob) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sJob) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sJob) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}
+
+func (k *mqlK8sCronjob) usesSecretsAsEnv() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesSecretsAsEnv)
+}
+
+func (k *mqlK8sCronjob) mountsSecretVolumes() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specMountsSecretVolumes)
+}
+
+func (k *mqlK8sCronjob) consumedSecrets() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specConsumedSecrets)
+}

--- a/providers/k8s/resources/secret_consumption_test.go
+++ b/providers/k8s/resources/secret_consumption_test.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestSecretConsumptionRollups_Fixtures checks the workload-side Secret rollups:
+// secret-consumer references Secrets via env, a mounted volume, and an image
+// pull secret, while hardened references none.
+func TestSecretConsumptionRollups_Fixtures(t *testing.T) {
+	k8s := workloadSecurityK8s(t)
+
+	t.Run("workload that consumes secrets", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "secret-consumer")
+		assert.True(t, d.GetUsesSecretsAsEnv().Data, "usesSecretsAsEnv")
+		assert.True(t, d.GetMountsSecretVolumes().Data, "mountsSecretVolumes")
+		assert.ElementsMatch(t,
+			[]any{"api-secret", "env-secret", "tls-secret", "registry-creds"},
+			d.GetConsumedSecrets().Data, "consumedSecrets")
+	})
+
+	t.Run("workload that consumes no secrets", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "hardened")
+		assert.False(t, d.GetUsesSecretsAsEnv().Data, "usesSecretsAsEnv")
+		assert.False(t, d.GetMountsSecretVolumes().Data, "mountsSecretVolumes")
+		assert.Empty(t, d.GetConsumedSecrets().Data, "consumedSecrets")
+	})
+}
+
+func TestSecretConsumptionRollups_Helpers(t *testing.T) {
+	t.Run("nil spec", func(t *testing.T) {
+		assert.False(t, specUsesSecretsAsEnv(nil))
+		assert.False(t, specMountsSecretVolumes(nil))
+		assert.Empty(t, specConsumedSecrets(nil))
+	})
+
+	t.Run("env secretKeyRef only", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "a",
+			Env: []corev1.EnvVar{{Name: "K", ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "s1"}, Key: "k",
+				},
+			}}},
+		}}}
+		assert.True(t, specUsesSecretsAsEnv(spec))
+		assert.False(t, specMountsSecretVolumes(spec))
+		assert.ElementsMatch(t, []any{"s1"}, specConsumedSecrets(spec))
+	})
+
+	t.Run("projected secret volume and dedup", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{Name: "v1", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "shared"}}},
+				{Name: "v2", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shared"},
+					}}},
+				}}},
+			},
+			Containers: []corev1.Container{{
+				Name:    "a",
+				EnvFrom: []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "shared"}}}},
+			}},
+		}
+		assert.True(t, specMountsSecretVolumes(spec))
+		assert.True(t, specUsesSecretsAsEnv(spec))
+		// "shared" is referenced three ways but appears once.
+		assert.ElementsMatch(t, []any{"shared"}, specConsumedSecrets(spec))
+	})
+
+	t.Run("configmap refs are not secrets", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    "a",
+			EnvFrom: []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "cm"}}}},
+		}}}
+		assert.False(t, specUsesSecretsAsEnv(spec))
+		assert.Empty(t, specConsumedSecrets(spec))
+	})
+}

--- a/providers/k8s/resources/testdata/workload-security.yaml
+++ b/providers/k8s/resources/testdata/workload-security.yaml
@@ -225,3 +225,38 @@ spec:
             image: docker:24
             securityContext:
               privileged: true
+---
+# Consumes Secrets every which way: env (secretKeyRef + envFrom), a mounted
+# secret volume, and an image-pull secret. Used by the secret-consumption tests.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secret-consumer
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: secret-consumer
+  template:
+    metadata:
+      labels:
+        app: secret-consumer
+    spec:
+      imagePullSecrets:
+      - name: registry-creds
+      containers:
+      - name: app
+        image: nginx:1.25
+        env:
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-secret
+              key: key
+        envFrom:
+        - secretRef:
+            name: env-secret
+      volumes:
+      - name: tls
+        secret:
+          secretName: tls-secret


### PR DESCRIPTION
## Summary

`k8s.secret.usedBy()` already answers "which pods reference this Secret." This adds the **workload side** — "what Secrets can a (compromised) pod reach?" — to every workload kind (`pod`, `deployment`, `daemonset`, `statefulset`, `replicaset`, `job`, `cronjob`):

- **`usesSecretsAsEnv()`** — a Secret is injected as an environment variable (`secretKeyRef` or `envFrom` `secretRef`)
- **`mountsSecretVolumes()`** — a Secret is mounted as a volume (including projected secret sources)
- **`consumedSecrets()`** — names of every Secret the workload references (env, mounted/projected volumes, image-pull secrets)

Env-var injection is surfaced on its own because it's the higher-risk path: env values leak into process listings, crash dumps, and child processes where a mounted file does not.

```mql
k8s.deployments.where( usesSecretsAsEnv )    # secrets exposed via env
```

## Why

This is the "loot" leg of attack-path analysis — combined with the workload→`serviceAccount` linkage and the RBAC effective-access rollups, you can reason about which exposed/over-privileged workloads can reach which secrets.

## Tests

Fixture coverage (a `secret-consumer` workload referencing Secrets via env, a mounted volume, and an image-pull secret vs the `hardened` workload that references none) plus helper unit tests for env-only, projected volumes, cross-source dedup, configmap-refs-aren't-secrets, and nil specs. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)