### PR TITLE
✨ k8s: admission-enforcement posture predicates

### DIFF
--- a/providers/k8s/resources/admission.go
+++ b/providers/k8s/resources/admission.go
@@ -173,6 +173,19 @@ func (k *mqlK8sAdmissionValidatingwebhookconfiguration) webhooks() ([]any, error
 	return dict, nil
 }
 
+// failsOpen reports whether any webhook has failurePolicy: Ignore, meaning
+// admission proceeds when the webhook is unreachable or errors — the guardrail
+// can be bypassed by making it fail. An unset failurePolicy defaults to Fail.
+func (k *mqlK8sAdmissionValidatingwebhookconfiguration) failsOpen() (bool, error) {
+	for i := range k.obj.Webhooks {
+		fp := k.obj.Webhooks[i].FailurePolicy
+		if fp != nil && *fp == admissionregistrationv1.Ignore {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (k *mqlK8sAdmissionValidatingwebhookconfiguration) id() (string, error) {
 	return k.Id.Data, nil
 }

--- a/providers/k8s/resources/admission_enforcement_test.go
+++ b/providers/k8s/resources/admission_enforcement_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func admissionEnforcementK8s(t *testing.T) *mqlK8s {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{}},
+	}, manifest.WithManifestFile("./testdata/admission-enforcement.yaml"))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+
+	obj, err := NewResource(runtime, "k8s", nil)
+	require.NoError(t, err)
+	return obj.(*mqlK8s)
+}
+
+func TestNamespaceEnforcesPodSecurity(t *testing.T) {
+	k8s := admissionEnforcementK8s(t)
+
+	want := map[string]bool{
+		"enforced-ns":   true,
+		"audit-only-ns": false, // audit-only is not enforcement
+		"unenforced-ns": false,
+	}
+
+	nss := k8s.GetNamespaces()
+	require.NoError(t, nss.Error)
+	seen := map[string]bool{}
+	for i := range nss.Data {
+		ns := nss.Data[i].(*mqlK8sNamespace)
+		name := ns.GetName().Data
+		if exp, ok := want[name]; ok {
+			seen[name] = true
+			assert.Equal(t, exp, ns.GetEnforcesPodSecurity().Data, "enforcesPodSecurity for %s", name)
+		}
+	}
+	for name := range want {
+		assert.True(t, seen[name], "namespace %s not found", name)
+	}
+}
+
+func TestWebhookFailsOpen(t *testing.T) {
+	k8s := admissionEnforcementK8s(t)
+
+	t.Run("validating webhooks", func(t *testing.T) {
+		want := map[string]bool{"vwc-failopen": true, "vwc-failclosed": false}
+		list := k8s.GetValidatingWebhookConfigurations()
+		require.NoError(t, list.Error)
+		seen := map[string]bool{}
+		for i := range list.Data {
+			w := list.Data[i].(*mqlK8sAdmissionValidatingwebhookconfiguration)
+			name := w.GetName().Data
+			if exp, ok := want[name]; ok {
+				seen[name] = true
+				assert.Equal(t, exp, w.GetFailsOpen().Data, "failsOpen for %s", name)
+			}
+		}
+		for name := range want {
+			assert.True(t, seen[name], "validatingwebhookconfiguration %s not found", name)
+		}
+	})
+
+	t.Run("mutating webhooks", func(t *testing.T) {
+		list := k8s.GetMutatingWebhookConfigurations()
+		require.NoError(t, list.Error)
+		var found bool
+		for i := range list.Data {
+			w := list.Data[i].(*mqlK8sAdmissionMutatingwebhookconfiguration)
+			if w.GetName().Data == "mwc-failopen" {
+				found = true
+				assert.True(t, w.GetFailsOpen().Data, "failsOpen for mwc-failopen")
+			}
+		}
+		assert.True(t, found, "mwc-failopen not found")
+	})
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -252,6 +252,8 @@ private k8s.namespace @defaults("name created") {
   // Value of the `pod-security.kubernetes.io/warn-version` label. Empty when
   // unset.
   podSecurityWarnVersion() string
+  // Whether the namespace enforces a non-privileged Pod Security Standards level (baseline or restricted)
+  enforcesPodSecurity() bool
 }
 
 // Kubernetes node
@@ -2761,6 +2763,8 @@ private k8s.admission.validatingwebhookconfiguration @defaults("name") {
   manifest() dict
   // Webhooks configuration
   webhooks() []dict
+  // Whether any webhook is fail-open (failurePolicy: Ignore), so admission proceeds when the webhook errors or is unreachable
+  failsOpen() bool
 }
 
 // Kubernetes Application
@@ -3034,6 +3038,8 @@ private k8s.admission.mutatingwebhookconfiguration @defaults("name") {
   manifest() dict
   // Webhooks configuration
   webhooks() []dict
+  // Whether any webhook is fail-open (failurePolicy: Ignore), so admission proceeds when the webhook errors or is unreachable
+  failsOpen() bool
 }
 
 // Kubernetes ValidatingAdmissionPolicy

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -683,6 +683,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.namespace.podSecurityWarnVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNamespace).GetPodSecurityWarnVersion()).ToDataRes(types.String)
 	},
+	"k8s.namespace.enforcesPodSecurity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNamespace).GetEnforcesPodSecurity()).ToDataRes(types.Bool)
+	},
 	"k8s.node.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNode).GetId()).ToDataRes(types.String)
 	},
@@ -3506,6 +3509,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.admission.validatingwebhookconfiguration.webhooks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingwebhookconfiguration).GetWebhooks()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.admission.validatingwebhookconfiguration.failsOpen": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionValidatingwebhookconfiguration).GetFailsOpen()).ToDataRes(types.Bool)
+	},
 	"k8s.app.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sApp).GetName()).ToDataRes(types.String)
 	},
@@ -3802,6 +3808,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.admission.mutatingwebhookconfiguration.webhooks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionMutatingwebhookconfiguration).GetWebhooks()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.admission.mutatingwebhookconfiguration.failsOpen": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionMutatingwebhookconfiguration).GetFailsOpen()).ToDataRes(types.Bool)
 	},
 	"k8s.admission.validatingadmissionpolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingadmissionpolicy).GetId()).ToDataRes(types.String)
@@ -4617,6 +4626,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.namespace.podSecurityWarnVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNamespace).PodSecurityWarnVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.namespace.enforcesPodSecurity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNamespace).EnforcesPodSecurity, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.node.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8563,6 +8576,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sAdmissionValidatingwebhookconfiguration).Webhooks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.admission.validatingwebhookconfiguration.failsOpen": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionValidatingwebhookconfiguration).FailsOpen, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.app.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sApp).__id, ok = v.Value.(string)
 		return
@@ -8985,6 +9002,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.admission.mutatingwebhookconfiguration.webhooks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAdmissionMutatingwebhookconfiguration).Webhooks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.admission.mutatingwebhookconfiguration.failsOpen": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionMutatingwebhookconfiguration).FailsOpen, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.admission.validatingadmissionpolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10543,6 +10564,7 @@ type mqlK8sNamespace struct {
 	PodSecurityAuditVersion   plugin.TValue[string]
 	PodSecurityWarn           plugin.TValue[string]
 	PodSecurityWarnVersion    plugin.TValue[string]
+	EnforcesPodSecurity       plugin.TValue[bool]
 }
 
 // createK8sNamespace creates a new instance of this resource
@@ -11021,6 +11043,12 @@ func (c *mqlK8sNamespace) GetPodSecurityWarn() *plugin.TValue[string] {
 func (c *mqlK8sNamespace) GetPodSecurityWarnVersion() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.PodSecurityWarnVersion, func() (string, error) {
 		return c.podSecurityWarnVersion()
+	})
+}
+
+func (c *mqlK8sNamespace) GetEnforcesPodSecurity() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EnforcesPodSecurity, func() (bool, error) {
+		return c.enforcesPodSecurity()
 	})
 }
 
@@ -19916,6 +19944,7 @@ type mqlK8sAdmissionValidatingwebhookconfiguration struct {
 	Created         plugin.TValue[*time.Time]
 	Manifest        plugin.TValue[any]
 	Webhooks        plugin.TValue[[]any]
+	FailsOpen       plugin.TValue[bool]
 }
 
 // createK8sAdmissionValidatingwebhookconfiguration creates a new instance of this resource
@@ -20032,6 +20061,12 @@ func (c *mqlK8sAdmissionValidatingwebhookconfiguration) GetManifest() *plugin.TV
 func (c *mqlK8sAdmissionValidatingwebhookconfiguration) GetWebhooks() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Webhooks, func() ([]any, error) {
 		return c.webhooks()
+	})
+}
+
+func (c *mqlK8sAdmissionValidatingwebhookconfiguration) GetFailsOpen() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FailsOpen, func() (bool, error) {
+		return c.failsOpen()
 	})
 }
 
@@ -20908,6 +20943,7 @@ type mqlK8sAdmissionMutatingwebhookconfiguration struct {
 	Created         plugin.TValue[*time.Time]
 	Manifest        plugin.TValue[any]
 	Webhooks        plugin.TValue[[]any]
+	FailsOpen       plugin.TValue[bool]
 }
 
 // createK8sAdmissionMutatingwebhookconfiguration creates a new instance of this resource
@@ -21024,6 +21060,12 @@ func (c *mqlK8sAdmissionMutatingwebhookconfiguration) GetManifest() *plugin.TVal
 func (c *mqlK8sAdmissionMutatingwebhookconfiguration) GetWebhooks() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Webhooks, func() ([]any, error) {
 		return c.webhooks()
+	})
+}
+
+func (c *mqlK8sAdmissionMutatingwebhookconfiguration) GetFailsOpen() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FailsOpen, func() (bool, error) {
+		return c.failsOpen()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -5,6 +5,7 @@ k8s 9.0.0
 k8s.admission.mutatingwebhookconfiguration 13.0.16
 k8s.admission.mutatingwebhookconfiguration.annotations 13.0.16
 k8s.admission.mutatingwebhookconfiguration.created 13.0.16
+k8s.admission.mutatingwebhookconfiguration.failsOpen 13.3.1
 k8s.admission.mutatingwebhookconfiguration.id 13.0.16
 k8s.admission.mutatingwebhookconfiguration.kind 13.0.16
 k8s.admission.mutatingwebhookconfiguration.labels 13.0.16
@@ -55,6 +56,7 @@ k8s.admission.validatingadmissionpolicybinding.validationActions 13.2.2
 k8s.admission.validatingwebhookconfiguration 11.1.63
 k8s.admission.validatingwebhookconfiguration.annotations 11.1.63
 k8s.admission.validatingwebhookconfiguration.created 11.1.63
+k8s.admission.validatingwebhookconfiguration.failsOpen 13.3.1
 k8s.admission.validatingwebhookconfiguration.id 11.1.63
 k8s.admission.validatingwebhookconfiguration.kind 11.1.63
 k8s.admission.validatingwebhookconfiguration.labels 11.1.63
@@ -727,6 +729,7 @@ k8s.namespace.cronjobs 13.0.16
 k8s.namespace.daemonsets 13.0.16
 k8s.namespace.deployments 13.0.16
 k8s.namespace.endpointSlices 13.0.16
+k8s.namespace.enforcesPodSecurity 13.3.1
 k8s.namespace.horizontalPodAutoscalers 13.0.16
 k8s.namespace.id 9.0.0
 k8s.namespace.ingresses 13.0.16

--- a/providers/k8s/resources/mutatingwebhookconfiguration.go
+++ b/providers/k8s/resources/mutatingwebhookconfiguration.go
@@ -65,6 +65,19 @@ func (k *mqlK8sAdmissionMutatingwebhookconfiguration) webhooks() ([]any, error) 
 	return convert.JsonToDictSlice(k.obj.Webhooks)
 }
 
+// failsOpen reports whether any webhook has failurePolicy: Ignore, meaning
+// admission proceeds when the webhook is unreachable or errors — the guardrail
+// can be bypassed by making it fail. An unset failurePolicy defaults to Fail.
+func (k *mqlK8sAdmissionMutatingwebhookconfiguration) failsOpen() (bool, error) {
+	for i := range k.obj.Webhooks {
+		fp := k.obj.Webhooks[i].FailurePolicy
+		if fp != nil && *fp == admissionregistrationv1.Ignore {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func initK8sAdmissionMutatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	return initResource[*mqlK8sAdmissionMutatingwebhookconfiguration](runtime, args, func(k *mqlK8s) *plugin.TValue[[]any] {
 		return k.GetMutatingWebhookConfigurations()

--- a/providers/k8s/resources/namespace.go
+++ b/providers/k8s/resources/namespace.go
@@ -200,6 +200,15 @@ func (k *mqlK8sNamespace) podSecurityWarnVersion() (string, error) {
 	return k.obj.GetLabels()[psaWarnVersionLabel], nil
 }
 
+// enforcesPodSecurity reports whether the namespace actively enforces a
+// non-privileged Pod Security Standards level. An unset or "privileged" enforce
+// label means workloads are not constrained at admission, so PSS findings on
+// those workloads are advisory rather than enforced.
+func (k *mqlK8sNamespace) enforcesPodSecurity() (bool, error) {
+	level := k.obj.GetLabels()[psaEnforceLabel]
+	return level == "baseline" || level == "restricted", nil
+}
+
 func (k *mqlK8sNamespace) ownerReferences() ([]any, error) {
 	return k8sOwnerReferences(k.MqlRuntime, k.obj)
 }

--- a/providers/k8s/resources/testdata/admission-enforcement.yaml
+++ b/providers/k8s/resources/testdata/admission-enforcement.yaml
@@ -1,0 +1,68 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Exercises namespace PSA enforcement and webhook fail-open detection.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: enforced-ns
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: audit-only-ns
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unenforced-ns
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vwc-failopen
+webhooks:
+  - name: v.example.com
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: svc
+        namespace: default
+        path: /validate
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vwc-failclosed
+webhooks:
+  - name: v.example.com
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: svc
+        namespace: default
+        path: /validate
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mwc-failopen
+webhooks:
+  - name: m.example.com
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: svc
+        namespace: default
+        path: /mutate
+    admissionReviewVersions: ["v1"]
+    sideEffects: None


### PR DESCRIPTION
## Summary

Static workload findings only matter if the cluster actually *enforces* its guardrails. This adds the meta-security view:

- **`k8s.namespace.enforcesPodSecurity()`** — the `pod-security.kubernetes.io/enforce` label is `baseline` or `restricted` (an unset or `privileged` level means pods aren't constrained at admission, so PSS findings there are advisory).
- **`k8s.admission.validatingwebhookconfiguration.failsOpen()`** / **`k8s.admission.mutatingwebhookconfiguration.failsOpen()`** — any webhook uses `failurePolicy: Ignore`, so admission proceeds when the webhook errors or is unreachable. An unset policy defaults to `Fail`; a fail-open guardrail can be bypassed by making it fail.

```mql
k8s.namespaces.where( !enforcesPodSecurity )
k8s.admission.validatingwebhookconfigurations.where( failsOpen )
```

## Why

This pairs directly with the Pod Security Standards rollups (#8582): a workload that fails `restricted` is a much sharper finding in a namespace that actually enforces `restricted` — and a fail-open admission webhook quietly turns policy enforcement into theater.

## Tests

Fixture with enforced / audit-only / unenforced namespaces and fail-open vs fail-closed validating and mutating webhook configurations. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)