### PR TITLE
✨ k8s: image-provenance rollups for workloads

### DIFF
--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/aws/smithy-go v1.27.2
+	github.com/distribution/reference v0.6.0
 	golang.org/x/oauth2 v0.36.0
 	k8s.io/kube-aggregator v0.36.2
 	sigs.k8s.io/gateway-api v1.5.1
@@ -83,7 +84,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v29.5.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect

--- a/providers/k8s/resources/image_provenance.go
+++ b/providers/k8s/resources/image_provenance.go
@@ -1,0 +1,203 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// This file wires image-provenance rollups onto every workload kind, the
+// supply-chain view of which images a workload runs:
+//
+//   usesImageDigest()  every container image is pinned by digest (immutable)
+//   usesLatestTag()    any container image uses the mutable "latest" tag
+//                      (explicitly or implicitly, when no tag is set)
+//   imageRegistries()  the distinct registry domains the images come from
+//
+// Only regular and init containers are considered; ephemeral (debug) containers
+// are transient and commonly run ad-hoc "latest" tooling, so counting them
+// would create noise. Images that fail to parse are treated as unpinned (they
+// cannot satisfy usesImageDigest) and contribute no registry.
+
+import (
+	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type parsedImageRef struct {
+	registry string
+	digested bool
+	latest   bool
+	ok       bool
+}
+
+func parseImageRef(image string) parsedImageRef {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return parsedImageRef{}
+	}
+	ref := parsedImageRef{registry: reference.Domain(named), ok: true}
+	if _, isDigested := named.(reference.Digested); isDigested {
+		ref.digested = true
+		return ref
+	}
+	// No digest: resolve the tag, defaulting to "latest" when none is set.
+	if tagged, ok := reference.TagNameOnly(named).(reference.Tagged); ok {
+		ref.latest = tagged.Tag() == "latest"
+	}
+	return ref
+}
+
+func imageContainers(spec *corev1.PodSpec) []corev1.Container {
+	if spec == nil {
+		return nil
+	}
+	out := make([]corev1.Container, 0, len(spec.Containers)+len(spec.InitContainers))
+	out = append(out, spec.Containers...)
+	out = append(out, spec.InitContainers...)
+	return out
+}
+
+func specUsesImageDigest(spec *corev1.PodSpec) bool {
+	containers := imageContainers(spec)
+	if len(containers) == 0 {
+		return false
+	}
+	for _, c := range containers {
+		ref := parseImageRef(c.Image)
+		if !ref.ok || !ref.digested {
+			return false
+		}
+	}
+	return true
+}
+
+func specUsesLatestTag(spec *corev1.PodSpec) bool {
+	for _, c := range imageContainers(spec) {
+		if ref := parseImageRef(c.Image); ref.ok && ref.latest {
+			return true
+		}
+	}
+	return false
+}
+
+func specImageRegistries(spec *corev1.PodSpec) []any {
+	seen := map[string]struct{}{}
+	out := []any{}
+	for _, c := range imageContainers(spec) {
+		ref := parseImageRef(c.Image)
+		if !ref.ok || ref.registry == "" {
+			continue
+		}
+		if _, ok := seen[ref.registry]; ok {
+			continue
+		}
+		seen[ref.registry] = struct{}{}
+		out = append(out, ref.registry)
+	}
+	return out
+}
+
+// ---- per-kind wiring ----
+
+func (k *mqlK8sPod) usesImageDigest() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sPod) usesLatestTag() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sPod) imageRegistries() ([]any, error) {
+	spec, err := k.podSpecTyped()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sDeployment) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sDeployment) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sDeployment) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sDaemonset) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sDaemonset) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sDaemonset) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sStatefulset) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sStatefulset) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sStatefulset) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sReplicaset) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sReplicaset) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sReplicaset) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sJob) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sJob) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sJob) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+func (k *mqlK8sCronjob) usesImageDigest() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesImageDigest)
+}
+
+func (k *mqlK8sCronjob) usesLatestTag() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesLatestTag)
+}
+
+func (k *mqlK8sCronjob) imageRegistries() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specImageRegistries)
+}

--- a/providers/k8s/resources/image_provenance_test.go
+++ b/providers/k8s/resources/image_provenance_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestImageProvenanceRollups_Fixtures(t *testing.T) {
+	k8s := workloadSecurityK8s(t)
+
+	t.Run("digest-pinned workload", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "digest-pinned")
+		assert.True(t, d.GetUsesImageDigest().Data, "usesImageDigest")
+		assert.False(t, d.GetUsesLatestTag().Data, "usesLatestTag")
+		assert.ElementsMatch(t, []any{"docker.io"}, d.GetImageRegistries().Data, "imageRegistries")
+	})
+
+	t.Run("latest-tag workload from multiple registries", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "latest-image")
+		assert.False(t, d.GetUsesImageDigest().Data, "usesImageDigest")
+		assert.True(t, d.GetUsesLatestTag().Data, "usesLatestTag")
+		assert.ElementsMatch(t, []any{"docker.io", "gcr.io"}, d.GetImageRegistries().Data, "imageRegistries")
+	})
+
+	t.Run("pinned-tag workload is neither digest nor latest", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "hardened") // nginx:1.25
+		assert.False(t, d.GetUsesImageDigest().Data, "usesImageDigest")
+		assert.False(t, d.GetUsesLatestTag().Data, "usesLatestTag")
+	})
+}
+
+func TestParseImageRef(t *testing.T) {
+	cases := []struct {
+		image    string
+		registry string
+		digested bool
+		latest   bool
+		ok       bool
+	}{
+		{"nginx", "docker.io", false, true, true},                                  // implicit latest
+		{"nginx:latest", "docker.io", false, true, true},                           // explicit latest
+		{"nginx:1.25", "docker.io", false, false, true},                            // pinned tag
+		{"gcr.io/proj/app:v2", "gcr.io", false, false, true},                       // private registry, tag
+		{"registry.local:5000/app:1.0", "registry.local:5000", false, false, true}, // registry with port
+		{"nginx@sha256:" + zeros64, "docker.io", true, false, true},                // digest
+		{"UPPER CASE !! invalid", "", false, false, false},                         // unparseable
+	}
+	for _, tc := range cases {
+		t.Run(tc.image, func(t *testing.T) {
+			ref := parseImageRef(tc.image)
+			assert.Equal(t, tc.ok, ref.ok, "ok")
+			assert.Equal(t, tc.registry, ref.registry, "registry")
+			assert.Equal(t, tc.digested, ref.digested, "digested")
+			assert.Equal(t, tc.latest, ref.latest, "latest")
+		})
+	}
+}
+
+const zeros64 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestImageProvenanceRollups_Helpers(t *testing.T) {
+	t.Run("nil and empty specs", func(t *testing.T) {
+		assert.False(t, specUsesImageDigest(nil), "digest nil")
+		assert.False(t, specUsesLatestTag(nil), "latest nil")
+		assert.Empty(t, specImageRegistries(nil), "registries nil")
+		assert.False(t, specUsesImageDigest(&corev1.PodSpec{}), "digest empty")
+	})
+
+	t.Run("digest requires every container", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "a", Image: "nginx@sha256:" + zeros64},
+			{Name: "b", Image: "redis:7"},
+		}}
+		assert.False(t, specUsesImageDigest(spec), "one tagged container breaks digest pinning")
+	})
+
+	t.Run("init container latest tag is detected", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init", Image: "busybox"}},
+			Containers:     []corev1.Container{{Name: "a", Image: "nginx:1.25"}},
+		}
+		assert.True(t, specUsesLatestTag(spec), "init busybox is implicit latest")
+	})
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -442,6 +442,12 @@ private k8s.pod @defaults("namespace name created"){
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -658,6 +664,12 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -806,6 +818,12 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -953,6 +971,12 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1108,6 +1132,12 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1243,6 +1273,12 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1403,6 +1439,12 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   mountsSecretVolumes() bool
   // Names of every Secret the workload references (env vars, mounted/projected volumes, and image-pull secrets)
   consumedSecrets() []string
+  // Whether every container image is pinned by digest (immutable)
+  usesImageDigest() bool
+  // Whether any container image uses the mutable "latest" tag (explicitly or implicitly)
+  usesLatestTag() bool
+  // Distinct registry domains the container images are pulled from
+  imageRegistries() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -872,6 +872,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.pod.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.pod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetId()).ToDataRes(types.String)
 	},
@@ -1142,6 +1151,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.deployment.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -1310,6 +1328,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.daemonset.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.daemonset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetId()).ToDataRes(types.String)
 	},
@@ -1474,6 +1501,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.statefulset.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.statefulset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetId()).ToDataRes(types.String)
@@ -1655,6 +1691,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.replicaset.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.replicaset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetId()).ToDataRes(types.String)
 	},
@@ -1804,6 +1849,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.job.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.job.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.job.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetId()).ToDataRes(types.String)
@@ -1990,6 +2044,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.consumedSecrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetConsumedSecrets()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.cronjob.usesImageDigest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesImageDigest()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.usesLatestTag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesLatestTag()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.cronjob.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetId()).ToDataRes(types.String)
@@ -5047,6 +5110,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5411,6 +5486,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5639,6 +5726,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5861,6 +5960,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6107,6 +6218,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6309,6 +6432,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.job.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6561,6 +6696,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.consumedSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).ConsumedSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesImageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesImageDigest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesLatestTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesLatestTag, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11887,6 +12034,9 @@ type mqlK8sPod struct {
 	UsesSecretsAsEnv              plugin.TValue[bool]
 	MountsSecretVolumes           plugin.TValue[bool]
 	ConsumedSecrets               plugin.TValue[[]any]
+	UsesImageDigest               plugin.TValue[bool]
+	UsesLatestTag                 plugin.TValue[bool]
+	ImageRegistries               plugin.TValue[[]any]
 	Id                            plugin.TValue[string]
 	Uid                           plugin.TValue[string]
 	ResourceVersion               plugin.TValue[string]
@@ -12108,6 +12258,24 @@ func (c *mqlK8sPod) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sPod) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -12655,6 +12823,9 @@ type mqlK8sDeployment struct {
 	UsesSecretsAsEnv             plugin.TValue[bool]
 	MountsSecretVolumes          plugin.TValue[bool]
 	ConsumedSecrets              plugin.TValue[[]any]
+	UsesImageDigest              plugin.TValue[bool]
+	UsesLatestTag                plugin.TValue[bool]
+	ImageRegistries              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -12872,6 +13043,24 @@ func (c *mqlK8sDeployment) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sDeployment) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -13127,6 +13316,9 @@ type mqlK8sDaemonset struct {
 	UsesSecretsAsEnv             plugin.TValue[bool]
 	MountsSecretVolumes          plugin.TValue[bool]
 	ConsumedSecrets              plugin.TValue[[]any]
+	UsesImageDigest              plugin.TValue[bool]
+	UsesLatestTag                plugin.TValue[bool]
+	ImageRegistries              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13343,6 +13535,24 @@ func (c *mqlK8sDaemonset) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -13592,6 +13802,9 @@ type mqlK8sStatefulset struct {
 	UsesSecretsAsEnv                     plugin.TValue[bool]
 	MountsSecretVolumes                  plugin.TValue[bool]
 	ConsumedSecrets                      plugin.TValue[[]any]
+	UsesImageDigest                      plugin.TValue[bool]
+	UsesLatestTag                        plugin.TValue[bool]
+	ImageRegistries                      plugin.TValue[[]any]
 	Id                                   plugin.TValue[string]
 	Uid                                  plugin.TValue[string]
 	ResourceVersion                      plugin.TValue[string]
@@ -13813,6 +14026,24 @@ func (c *mqlK8sStatefulset) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -14092,6 +14323,9 @@ type mqlK8sReplicaset struct {
 	UsesSecretsAsEnv             plugin.TValue[bool]
 	MountsSecretVolumes          plugin.TValue[bool]
 	ConsumedSecrets              plugin.TValue[[]any]
+	UsesImageDigest              plugin.TValue[bool]
+	UsesLatestTag                plugin.TValue[bool]
+	ImageRegistries              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -14303,6 +14537,24 @@ func (c *mqlK8sReplicaset) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -14522,6 +14774,9 @@ type mqlK8sJob struct {
 	UsesSecretsAsEnv             plugin.TValue[bool]
 	MountsSecretVolumes          plugin.TValue[bool]
 	ConsumedSecrets              plugin.TValue[[]any]
+	UsesImageDigest              plugin.TValue[bool]
+	UsesLatestTag                plugin.TValue[bool]
+	ImageRegistries              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -14745,6 +15000,24 @@ func (c *mqlK8sJob) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sJob) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 
@@ -15036,6 +15309,9 @@ type mqlK8sCronjob struct {
 	UsesSecretsAsEnv             plugin.TValue[bool]
 	MountsSecretVolumes          plugin.TValue[bool]
 	ConsumedSecrets              plugin.TValue[[]any]
+	UsesImageDigest              plugin.TValue[bool]
+	UsesLatestTag                plugin.TValue[bool]
+	ImageRegistries              plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -15249,6 +15525,24 @@ func (c *mqlK8sCronjob) GetMountsSecretVolumes() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetConsumedSecrets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ConsumedSecrets, func() ([]any, error) {
 		return c.consumedSecrets()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesImageDigest() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesImageDigest, func() (bool, error) {
+		return c.usesImageDigest()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesLatestTag() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesLatestTag, func() (bool, error) {
+		return c.usesLatestTag()
+	})
+}
+
+func (c *mqlK8sCronjob) GetImageRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
+		return c.imageRegistries()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -228,6 +228,7 @@ k8s.cronjob.hostIPC 13.2.2
 k8s.cronjob.hostNetwork 13.2.2
 k8s.cronjob.hostPID 13.2.2
 k8s.cronjob.id 9.0.0
+k8s.cronjob.imageRegistries 13.3.1
 k8s.cronjob.initContainers 9.0.0
 k8s.cronjob.jobs 13.0.16
 k8s.cronjob.kind 9.0.0
@@ -256,6 +257,8 @@ k8s.cronjob.timeZone 13.0.16
 k8s.cronjob.uid 9.0.0
 k8s.cronjob.usesHostNamespaces 13.2.2
 k8s.cronjob.usesHostPath 13.2.2
+k8s.cronjob.usesImageDigest 13.3.1
+k8s.cronjob.usesLatestTag 13.3.1
 k8s.cronjob.usesSecretsAsEnv 13.3.1
 k8s.cronjob.usesUnconfinedSeccomp 13.3.1
 k8s.cronjobs 9.0.0
@@ -296,6 +299,7 @@ k8s.daemonset.hostIPC 13.2.2
 k8s.daemonset.hostNetwork 13.2.2
 k8s.daemonset.hostPID 13.2.2
 k8s.daemonset.id 9.0.0
+k8s.daemonset.imageRegistries 13.3.1
 k8s.daemonset.initContainers 9.0.0
 k8s.daemonset.kind 9.0.0
 k8s.daemonset.labels 9.0.0
@@ -327,6 +331,8 @@ k8s.daemonset.updateStrategy 13.0.16
 k8s.daemonset.updatedNumberScheduled 13.0.16
 k8s.daemonset.usesHostNamespaces 13.2.2
 k8s.daemonset.usesHostPath 13.2.2
+k8s.daemonset.usesImageDigest 13.3.1
+k8s.daemonset.usesLatestTag 13.3.1
 k8s.daemonset.usesSecretsAsEnv 13.3.1
 k8s.daemonset.usesUnconfinedSeccomp 13.3.1
 k8s.daemonsets 9.0.0
@@ -353,6 +359,7 @@ k8s.deployment.hostIPC 13.2.2
 k8s.deployment.hostNetwork 13.2.2
 k8s.deployment.hostPID 13.2.2
 k8s.deployment.id 9.0.0
+k8s.deployment.imageRegistries 13.3.1
 k8s.deployment.initContainers 9.0.0
 k8s.deployment.kind 9.0.0
 k8s.deployment.labels 9.0.0
@@ -385,6 +392,8 @@ k8s.deployment.unavailableReplicas 13.0.16
 k8s.deployment.updatedReplicas 13.0.16
 k8s.deployment.usesHostNamespaces 13.2.2
 k8s.deployment.usesHostPath 13.2.2
+k8s.deployment.usesImageDigest 13.3.1
+k8s.deployment.usesLatestTag 13.3.1
 k8s.deployment.usesSecretsAsEnv 13.3.1
 k8s.deployment.usesUnconfinedSeccomp 13.3.1
 k8s.deployments 9.0.0
@@ -669,6 +678,7 @@ k8s.job.hostIPC 13.2.2
 k8s.job.hostNetwork 13.2.2
 k8s.job.hostPID 13.2.2
 k8s.job.id 9.0.0
+k8s.job.imageRegistries 13.3.1
 k8s.job.initContainers 9.0.0
 k8s.job.kind 9.0.0
 k8s.job.labels 9.0.0
@@ -700,6 +710,8 @@ k8s.job.ttlSecondsAfterFinished 13.0.16
 k8s.job.uid 9.0.0
 k8s.job.usesHostNamespaces 13.2.2
 k8s.job.usesHostPath 13.2.2
+k8s.job.usesImageDigest 13.3.1
+k8s.job.usesLatestTag 13.3.1
 k8s.job.usesSecretsAsEnv 13.3.1
 k8s.job.usesUnconfinedSeccomp 13.3.1
 k8s.jobs 9.0.0
@@ -955,6 +967,7 @@ k8s.pod.hostPID 13.0.16
 k8s.pod.hostname 13.0.16
 k8s.pod.id 9.0.0
 k8s.pod.imagePullSecrets 13.0.16
+k8s.pod.imageRegistries 13.3.1
 k8s.pod.initContainers 9.0.0
 k8s.pod.job 13.0.16
 k8s.pod.kind 9.0.0
@@ -1005,6 +1018,8 @@ k8s.pod.topologySpreadConstraints 13.0.16
 k8s.pod.uid 9.0.0
 k8s.pod.usesHostNamespaces 13.2.2
 k8s.pod.usesHostPath 13.2.2
+k8s.pod.usesImageDigest 13.3.1
+k8s.pod.usesLatestTag 13.3.1
 k8s.pod.usesSecretsAsEnv 13.3.1
 k8s.pod.usesUnconfinedSeccomp 13.3.1
 k8s.podDisruptionBudgets 13.0.16
@@ -1176,6 +1191,7 @@ k8s.replicaset.hostIPC 13.2.2
 k8s.replicaset.hostNetwork 13.2.2
 k8s.replicaset.hostPID 13.2.2
 k8s.replicaset.id 9.0.0
+k8s.replicaset.imageRegistries 13.3.1
 k8s.replicaset.initContainers 9.0.0
 k8s.replicaset.kind 9.0.0
 k8s.replicaset.labels 9.0.0
@@ -1202,6 +1218,8 @@ k8s.replicaset.selector 13.0.16
 k8s.replicaset.uid 9.0.0
 k8s.replicaset.usesHostNamespaces 13.2.2
 k8s.replicaset.usesHostPath 13.2.2
+k8s.replicaset.usesImageDigest 13.3.1
+k8s.replicaset.usesLatestTag 13.3.1
 k8s.replicaset.usesSecretsAsEnv 13.3.1
 k8s.replicaset.usesUnconfinedSeccomp 13.3.1
 k8s.replicasets 9.0.0
@@ -1329,6 +1347,7 @@ k8s.statefulset.hostIPC 13.2.2
 k8s.statefulset.hostNetwork 13.2.2
 k8s.statefulset.hostPID 13.2.2
 k8s.statefulset.id 9.0.0
+k8s.statefulset.imageRegistries 13.3.1
 k8s.statefulset.initContainers 9.0.0
 k8s.statefulset.kind 9.0.0
 k8s.statefulset.labels 9.0.0
@@ -1363,6 +1382,8 @@ k8s.statefulset.updateStrategy 13.0.16
 k8s.statefulset.updatedReplicas 13.0.16
 k8s.statefulset.usesHostNamespaces 13.2.2
 k8s.statefulset.usesHostPath 13.2.2
+k8s.statefulset.usesImageDigest 13.3.1
+k8s.statefulset.usesLatestTag 13.3.1
 k8s.statefulset.usesSecretsAsEnv 13.3.1
 k8s.statefulset.usesUnconfinedSeccomp 13.3.1
 k8s.statefulsets 9.0.0

--- a/providers/k8s/resources/testdata/workload-security.yaml
+++ b/providers/k8s/resources/testdata/workload-security.yaml
@@ -267,3 +267,43 @@ spec:
       - name: tls
         secret:
           secretName: tls-secret
+---
+# All images pinned by digest (immutable). Used by image-provenance tests.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digest-pinned
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: digest-pinned
+  template:
+    metadata:
+      labels:
+        app: digest-pinned
+    spec:
+      containers:
+      - name: app
+        image: nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000
+---
+# Uses the latest tag implicitly (nginx) and explicitly from another registry.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: latest-image
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: latest-image
+  template:
+    metadata:
+      labels:
+        app: latest-image
+    spec:
+      containers:
+      - name: app
+        image: nginx
+      - name: side
+        image: gcr.io/foo/bar:latest


### PR DESCRIPTION
## Summary

Adds the supply-chain view of a workload's images to every workload kind (`pod`, `deployment`, `daemonset`, `statefulset`, `replicaset`, `job`, `cronjob`):

- **`usesImageDigest()`** — every container image is pinned by digest (immutable)
- **`usesLatestTag()`** — any container image uses the mutable `latest` tag, explicitly or implicitly (no tag set)
- **`imageRegistries()`** — the distinct registry domains the images come from (enables registry allow-listing)

```mql
k8s.deployments.where( usesLatestTag )
k8s.deployments.where( !imageRegistries.containsOnly(["gcr.io"]) )
```

## Details

- Image references are parsed with `github.com/distribution/reference` (promoted from indirect to a direct dependency) for correct handling of implicit `docker.io`, registries with ports, digests, and `latest` defaulting.
- Only **regular and init** containers are considered; ephemeral debug containers commonly run ad-hoc `latest` tooling and would add noise.
- Unparseable images are treated as unpinned (can't satisfy `usesImageDigest`) and contribute no registry.

## Tests

Fixtures for digest-pinned, latest-tag (multi-registry), and pinned-tag workloads; a `parseImageRef` table covering implicit/explicit latest, pinned tags, private registries with ports, digests, and unparseable input; plus helper tests for nil/empty specs and init-container latest detection. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)