### PR TITLE
✨ k8s: image pull-policy & unpinned-image provenance rollups

### DIFF
--- a/providers/k8s/resources/image_provenance.go
+++ b/providers/k8s/resources/image_provenance.go
@@ -95,6 +95,80 @@ func specImageRegistries(spec *corev1.PodSpec) []any {
 	return out
 }
 
+// effectivePullPolicy returns the image pull policy that applies to a container,
+// resolving the Kubernetes default when the field is unset: Always for a
+// "latest" (or untagged) image, IfNotPresent otherwise. An unparseable image
+// reference defaults to IfNotPresent so it is never mistaken for an Always pull.
+func effectivePullPolicy(c corev1.Container) corev1.PullPolicy {
+	if c.ImagePullPolicy != "" {
+		return c.ImagePullPolicy
+	}
+	if ref := parseImageRef(c.Image); ref.ok && ref.latest {
+		return corev1.PullAlways
+	}
+	return corev1.PullIfNotPresent
+}
+
+// specUsesAlwaysImagePullPolicy reports whether every container pulls its image
+// on each start. Always forces the kubelet to contact the registry (re-pulling
+// and re-authorizing) rather than trusting a node-cached layer.
+func specUsesAlwaysImagePullPolicy(spec *corev1.PodSpec) bool {
+	containers := imageContainers(spec)
+	if len(containers) == 0 {
+		return false
+	}
+	for _, c := range containers {
+		if effectivePullPolicy(c) != corev1.PullAlways {
+			return false
+		}
+	}
+	return true
+}
+
+// specRisksStaleImage reports whether any container can run a node-cached image
+// that no longer matches its reference: a mutable (non-digest) tag combined with
+// a pull policy other than Always. The node may serve a stale or attacker-seeded
+// image for that tag. Digest-pinned images are always exact and never at risk.
+func specRisksStaleImage(spec *corev1.PodSpec) bool {
+	for _, c := range imageContainers(spec) {
+		ref := parseImageRef(c.Image)
+		if ref.ok && ref.digested {
+			continue
+		}
+		if effectivePullPolicy(c) != corev1.PullAlways {
+			return true
+		}
+	}
+	return false
+}
+
+// specContainerImages returns the deduplicated image references of all regular
+// and init containers.
+func specContainerImages(spec *corev1.PodSpec) []any {
+	return dedupImages(spec, func(parsedImageRef) bool { return true })
+}
+
+// specUnpinnedImages returns the image references that are not pinned by digest.
+func specUnpinnedImages(spec *corev1.PodSpec) []any {
+	return dedupImages(spec, func(ref parsedImageRef) bool { return !(ref.ok && ref.digested) })
+}
+
+func dedupImages(spec *corev1.PodSpec, include func(parsedImageRef) bool) []any {
+	seen := map[string]struct{}{}
+	out := []any{}
+	for _, c := range imageContainers(spec) {
+		if c.Image == "" || !include(parseImageRef(c.Image)) {
+			continue
+		}
+		if _, ok := seen[c.Image]; ok {
+			continue
+		}
+		seen[c.Image] = struct{}{}
+		out = append(out, c.Image)
+	}
+	return out
+}
+
 // ---- per-kind wiring ----
 
 func (k *mqlK8sPod) usesImageDigest() (bool, error) {
@@ -200,4 +274,146 @@ func (k *mqlK8sCronjob) usesLatestTag() (bool, error) {
 func (k *mqlK8sCronjob) imageRegistries() ([]any, error) {
 	spec, err := k.securitySpec()
 	return stringsFromSpec(spec, err, specImageRegistries)
+}
+
+// ---- pull-policy and image-list per-kind wiring ----
+
+func (k *mqlK8sPod) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sPod) risksStaleImage() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sPod) containerImages() ([]any, error) {
+	spec, err := k.podSpecTyped()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sPod) unpinnedImages() ([]any, error) {
+	spec, err := k.podSpecTyped()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sDeployment) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sDeployment) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sDeployment) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sDeployment) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sDaemonset) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sDaemonset) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sDaemonset) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sDaemonset) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sStatefulset) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sStatefulset) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sStatefulset) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sStatefulset) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sReplicaset) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sReplicaset) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sReplicaset) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sReplicaset) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sJob) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sJob) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sJob) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sJob) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
+}
+
+func (k *mqlK8sCronjob) usesAlwaysImagePullPolicy() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesAlwaysImagePullPolicy)
+}
+
+func (k *mqlK8sCronjob) risksStaleImage() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specRisksStaleImage)
+}
+
+func (k *mqlK8sCronjob) containerImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specContainerImages)
+}
+
+func (k *mqlK8sCronjob) unpinnedImages() ([]any, error) {
+	spec, err := k.securitySpec()
+	return stringsFromSpec(spec, err, specUnpinnedImages)
 }

--- a/providers/k8s/resources/image_provenance_test.go
+++ b/providers/k8s/resources/image_provenance_test.go
@@ -87,3 +87,77 @@ func TestImageProvenanceRollups_Helpers(t *testing.T) {
 		assert.True(t, specUsesLatestTag(spec), "init busybox is implicit latest")
 	})
 }
+
+func TestImagePullProvenance_Fixtures(t *testing.T) {
+	k8s := workloadSecurityK8s(t)
+
+	t.Run("digest-pinned is never stale and lists no unpinned images", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "digest-pinned")
+		assert.False(t, d.GetRisksStaleImage().Data, "risksStaleImage")
+		assert.Empty(t, d.GetUnpinnedImages().Data, "unpinnedImages")
+		assert.Len(t, d.GetContainerImages().Data, 1, "containerImages")
+	})
+
+	t.Run("latest images default to Always pull", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "latest-image")
+		assert.True(t, d.GetUsesAlwaysImagePullPolicy().Data, "usesAlwaysImagePullPolicy")
+		assert.False(t, d.GetRisksStaleImage().Data, "risksStaleImage (Always pull)")
+		assert.ElementsMatch(t, []any{"nginx", "gcr.io/foo/bar:latest"}, d.GetUnpinnedImages().Data, "unpinnedImages")
+	})
+
+	t.Run("pinned tag with default policy risks staleness", func(t *testing.T) {
+		d := deploymentByName(t, k8s, "hardened") // nginx:1.25, no explicit pull policy
+		assert.True(t, d.GetRisksStaleImage().Data, "risksStaleImage")
+		assert.False(t, d.GetUsesAlwaysImagePullPolicy().Data, "usesAlwaysImagePullPolicy")
+		assert.ElementsMatch(t, []any{"nginx:1.25"}, d.GetUnpinnedImages().Data, "unpinnedImages")
+	})
+}
+
+func TestImagePullProvenance_Helpers(t *testing.T) {
+	digest := "nginx@sha256:" + zeros64
+
+	t.Run("effective pull policy defaults", func(t *testing.T) {
+		assert.Equal(t, corev1.PullAlways, effectivePullPolicy(corev1.Container{Image: "nginx"}), "implicit latest")
+		assert.Equal(t, corev1.PullIfNotPresent, effectivePullPolicy(corev1.Container{Image: "nginx:1.25"}), "pinned tag")
+		assert.Equal(t, corev1.PullNever, effectivePullPolicy(corev1.Container{Image: "nginx:1.25", ImagePullPolicy: corev1.PullNever}), "explicit wins")
+	})
+
+	t.Run("risksStaleImage", func(t *testing.T) {
+		staleSpec := &corev1.PodSpec{Containers: []corev1.Container{{Image: "nginx:1.25", ImagePullPolicy: corev1.PullIfNotPresent}}}
+		assert.True(t, specRisksStaleImage(staleSpec), "mutable tag + IfNotPresent")
+
+		freshSpec := &corev1.PodSpec{Containers: []corev1.Container{{Image: "nginx:1.25", ImagePullPolicy: corev1.PullAlways}}}
+		assert.False(t, specRisksStaleImage(freshSpec), "mutable tag + Always")
+
+		digestSpec := &corev1.PodSpec{Containers: []corev1.Container{{Image: digest, ImagePullPolicy: corev1.PullIfNotPresent}}}
+		assert.False(t, specRisksStaleImage(digestSpec), "digest is always exact")
+	})
+
+	t.Run("unparseable image does not count as Always pull", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{{Image: "UPPER CASE !! invalid"}}}
+		assert.Equal(t, corev1.PullIfNotPresent, effectivePullPolicy(spec.Containers[0]), "unparseable defaults to IfNotPresent")
+		assert.False(t, specUsesAlwaysImagePullPolicy(spec), "unparseable image is not Always")
+		assert.True(t, specRisksStaleImage(spec), "unparseable image is treated as a stale risk")
+	})
+
+	t.Run("usesAlwaysImagePullPolicy requires every container", func(t *testing.T) {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{
+			{Image: "a:1", ImagePullPolicy: corev1.PullAlways},
+			{Image: "b:1", ImagePullPolicy: corev1.PullIfNotPresent},
+		}}
+		assert.False(t, specUsesAlwaysImagePullPolicy(spec))
+		assert.False(t, specUsesAlwaysImagePullPolicy(nil))
+	})
+
+	t.Run("image lists dedup and split on pinning", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			InitContainers: []corev1.Container{{Image: "shared:1"}},
+			Containers: []corev1.Container{
+				{Image: "shared:1"},
+				{Image: digest},
+			},
+		}
+		assert.ElementsMatch(t, []any{"shared:1", digest}, specContainerImages(spec), "containerImages dedup")
+		assert.ElementsMatch(t, []any{"shared:1"}, specUnpinnedImages(spec), "unpinnedImages excludes digest")
+	})
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -448,6 +448,14 @@ private k8s.pod @defaults("namespace name created"){
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -682,6 +690,14 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -836,6 +852,14 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -989,6 +1013,14 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1150,6 +1182,14 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1291,6 +1331,14 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -1457,6 +1505,14 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   usesLatestTag() bool
   // Distinct registry domains the container images are pulled from
   imageRegistries() []string
+  // Whether every container uses imagePullPolicy Always (forces a registry re-pull, not a node cache)
+  usesAlwaysImagePullPolicy() bool
+  // Whether any container risks a stale or attacker-cached image: a mutable tag with a pull policy other than Always
+  risksStaleImage() bool
+  // Image references of all regular and init containers
+  containerImages() []string
+  // Image references that are not pinned by digest (mutable)
+  unpinnedImages() []string
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -881,6 +881,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.pod.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.pod.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.pod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetId()).ToDataRes(types.String)
 	},
@@ -1166,6 +1178,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.deployment.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.deployment.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -1343,6 +1367,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.daemonset.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.daemonset.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.daemonset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetId()).ToDataRes(types.String)
 	},
@@ -1516,6 +1552,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.statefulset.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.statefulset.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.statefulset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetId()).ToDataRes(types.String)
@@ -1706,6 +1754,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetImageRegistries()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.replicaset.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.replicaset.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
+	},
 	"k8s.replicaset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetId()).ToDataRes(types.String)
 	},
@@ -1864,6 +1924,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.job.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.job.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.job.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.job.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetId()).ToDataRes(types.String)
@@ -2059,6 +2131,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.imageRegistries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetImageRegistries()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.cronjob.usesAlwaysImagePullPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesAlwaysImagePullPolicy()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.risksStaleImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetRisksStaleImage()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.containerImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetContainerImages()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.cronjob.unpinnedImages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUnpinnedImages()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.cronjob.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetId()).ToDataRes(types.String)
@@ -5128,6 +5212,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5512,6 +5612,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5752,6 +5868,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5986,6 +6118,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6244,6 +6392,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6458,6 +6622,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.job.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.job.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6722,6 +6902,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.imageRegistries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).ImageRegistries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesAlwaysImagePullPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesAlwaysImagePullPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.risksStaleImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).RisksStaleImage, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.containerImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).ContainerImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.unpinnedImages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UnpinnedImages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12051,6 +12247,10 @@ type mqlK8sPod struct {
 	UsesImageDigest               plugin.TValue[bool]
 	UsesLatestTag                 plugin.TValue[bool]
 	ImageRegistries               plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy     plugin.TValue[bool]
+	RisksStaleImage               plugin.TValue[bool]
+	ContainerImages               plugin.TValue[[]any]
+	UnpinnedImages                plugin.TValue[[]any]
 	Id                            plugin.TValue[string]
 	Uid                           plugin.TValue[string]
 	ResourceVersion               plugin.TValue[string]
@@ -12292,6 +12492,30 @@ func (c *mqlK8sPod) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sPod) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sPod) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sPod) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 
@@ -12854,6 +13078,10 @@ type mqlK8sDeployment struct {
 	UsesImageDigest              plugin.TValue[bool]
 	UsesLatestTag                plugin.TValue[bool]
 	ImageRegistries              plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy    plugin.TValue[bool]
+	RisksStaleImage              plugin.TValue[bool]
+	ContainerImages              plugin.TValue[[]any]
+	UnpinnedImages               plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13089,6 +13317,30 @@ func (c *mqlK8sDeployment) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sDeployment) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sDeployment) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 
@@ -13347,6 +13599,10 @@ type mqlK8sDaemonset struct {
 	UsesImageDigest              plugin.TValue[bool]
 	UsesLatestTag                plugin.TValue[bool]
 	ImageRegistries              plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy    plugin.TValue[bool]
+	RisksStaleImage              plugin.TValue[bool]
+	ContainerImages              plugin.TValue[[]any]
+	UnpinnedImages               plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -13581,6 +13837,30 @@ func (c *mqlK8sDaemonset) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 
@@ -13833,6 +14113,10 @@ type mqlK8sStatefulset struct {
 	UsesImageDigest                      plugin.TValue[bool]
 	UsesLatestTag                        plugin.TValue[bool]
 	ImageRegistries                      plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy            plugin.TValue[bool]
+	RisksStaleImage                      plugin.TValue[bool]
+	ContainerImages                      plugin.TValue[[]any]
+	UnpinnedImages                       plugin.TValue[[]any]
 	Id                                   plugin.TValue[string]
 	Uid                                  plugin.TValue[string]
 	ResourceVersion                      plugin.TValue[string]
@@ -14072,6 +14356,30 @@ func (c *mqlK8sStatefulset) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 
@@ -14354,6 +14662,10 @@ type mqlK8sReplicaset struct {
 	UsesImageDigest              plugin.TValue[bool]
 	UsesLatestTag                plugin.TValue[bool]
 	ImageRegistries              plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy    plugin.TValue[bool]
+	RisksStaleImage              plugin.TValue[bool]
+	ContainerImages              plugin.TValue[[]any]
+	UnpinnedImages               plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -14586,6 +14898,30 @@ func (c *mqlK8sReplicaset) GetImageRegistries() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sReplicaset) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
+	})
+}
+
 func (c *mqlK8sReplicaset) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
@@ -14805,6 +15141,10 @@ type mqlK8sJob struct {
 	UsesImageDigest              plugin.TValue[bool]
 	UsesLatestTag                plugin.TValue[bool]
 	ImageRegistries              plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy    plugin.TValue[bool]
+	RisksStaleImage              plugin.TValue[bool]
+	ContainerImages              plugin.TValue[[]any]
+	UnpinnedImages               plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -15046,6 +15386,30 @@ func (c *mqlK8sJob) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sJob) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sJob) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sJob) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 
@@ -15340,6 +15704,10 @@ type mqlK8sCronjob struct {
 	UsesImageDigest              plugin.TValue[bool]
 	UsesLatestTag                plugin.TValue[bool]
 	ImageRegistries              plugin.TValue[[]any]
+	UsesAlwaysImagePullPolicy    plugin.TValue[bool]
+	RisksStaleImage              plugin.TValue[bool]
+	ContainerImages              plugin.TValue[[]any]
+	UnpinnedImages               plugin.TValue[[]any]
 	Id                           plugin.TValue[string]
 	Uid                          plugin.TValue[string]
 	ResourceVersion              plugin.TValue[string]
@@ -15571,6 +15939,30 @@ func (c *mqlK8sCronjob) GetUsesLatestTag() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetImageRegistries() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ImageRegistries, func() ([]any, error) {
 		return c.imageRegistries()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesAlwaysImagePullPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesAlwaysImagePullPolicy, func() (bool, error) {
+		return c.usesAlwaysImagePullPolicy()
+	})
+}
+
+func (c *mqlK8sCronjob) GetRisksStaleImage() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RisksStaleImage, func() (bool, error) {
+		return c.risksStaleImage()
+	})
+}
+
+func (c *mqlK8sCronjob) GetContainerImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ContainerImages, func() ([]any, error) {
+		return c.containerImages()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUnpinnedImages() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnpinnedImages, func() ([]any, error) {
+		return c.unpinnedImages()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -214,6 +214,7 @@ k8s.cronjob.annotations 9.0.0
 k8s.cronjob.automountServiceAccountToken 13.2.2
 k8s.cronjob.concurrencyPolicy 13.0.16
 k8s.cronjob.consumedSecrets 13.3.1
+k8s.cronjob.containerImages 13.3.1
 k8s.cronjob.containers 9.0.0
 k8s.cronjob.created 9.0.0
 k8s.cronjob.dropsAllCapabilities 13.2.2
@@ -246,6 +247,7 @@ k8s.cronjob.ownerReferences 13.2.2
 k8s.cronjob.podSecurityStandard 13.3.1
 k8s.cronjob.podSpec 9.0.0
 k8s.cronjob.resourceVersion 9.0.0
+k8s.cronjob.risksStaleImage 13.3.1
 k8s.cronjob.runsAsRoot 13.2.2
 k8s.cronjob.runsPrivileged 13.2.2
 k8s.cronjob.schedule 13.0.16
@@ -255,6 +257,8 @@ k8s.cronjob.successfulJobsHistoryLimit 13.0.16
 k8s.cronjob.suspend 13.0.16
 k8s.cronjob.timeZone 13.0.16
 k8s.cronjob.uid 9.0.0
+k8s.cronjob.unpinnedImages 13.3.1
+k8s.cronjob.usesAlwaysImagePullPolicy 13.3.1
 k8s.cronjob.usesHostNamespaces 13.2.2
 k8s.cronjob.usesHostPath 13.2.2
 k8s.cronjob.usesImageDigest 13.3.1
@@ -284,6 +288,7 @@ k8s.daemonset.automountServiceAccountToken 13.2.2
 k8s.daemonset.collisionCount 13.0.16
 k8s.daemonset.conditions 13.0.16
 k8s.daemonset.consumedSecrets 13.3.1
+k8s.daemonset.containerImages 13.3.1
 k8s.daemonset.containers 9.0.0
 k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
@@ -322,13 +327,16 @@ k8s.daemonset.podSpec 9.0.0
 k8s.daemonset.pods 13.0.16
 k8s.daemonset.resourceVersion 9.0.0
 k8s.daemonset.revisionHistoryLimit 13.0.16
+k8s.daemonset.risksStaleImage 13.3.1
 k8s.daemonset.runsAsRoot 13.2.2
 k8s.daemonset.runsPrivileged 13.2.2
 k8s.daemonset.securityContext 13.2.2
 k8s.daemonset.selector 13.0.16
 k8s.daemonset.uid 9.0.0
+k8s.daemonset.unpinnedImages 13.3.1
 k8s.daemonset.updateStrategy 13.0.16
 k8s.daemonset.updatedNumberScheduled 13.0.16
+k8s.daemonset.usesAlwaysImagePullPolicy 13.3.1
 k8s.daemonset.usesHostNamespaces 13.2.2
 k8s.daemonset.usesHostPath 13.2.2
 k8s.daemonset.usesImageDigest 13.3.1
@@ -345,6 +353,7 @@ k8s.deployment.availableReplicas 13.0.16
 k8s.deployment.collisionCount 13.0.16
 k8s.deployment.conditions 13.0.16
 k8s.deployment.consumedSecrets 13.3.1
+k8s.deployment.containerImages 13.3.1
 k8s.deployment.containers 9.0.0
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
@@ -382,6 +391,7 @@ k8s.deployment.readyReplicas 13.0.16
 k8s.deployment.replicas 13.0.16
 k8s.deployment.resourceVersion 9.0.0
 k8s.deployment.revisionHistoryLimit 13.0.16
+k8s.deployment.risksStaleImage 13.3.1
 k8s.deployment.runsAsRoot 13.2.2
 k8s.deployment.runsPrivileged 13.2.2
 k8s.deployment.securityContext 13.2.2
@@ -389,7 +399,9 @@ k8s.deployment.selector 13.0.16
 k8s.deployment.strategy 13.0.16
 k8s.deployment.uid 9.0.0
 k8s.deployment.unavailableReplicas 13.0.16
+k8s.deployment.unpinnedImages 13.3.1
 k8s.deployment.updatedReplicas 13.0.16
+k8s.deployment.usesAlwaysImagePullPolicy 13.3.1
 k8s.deployment.usesHostNamespaces 13.2.2
 k8s.deployment.usesHostPath 13.2.2
 k8s.deployment.usesImageDigest 13.3.1
@@ -663,6 +675,7 @@ k8s.job.completionTime 13.0.16
 k8s.job.completions 13.0.16
 k8s.job.conditions 13.0.16
 k8s.job.consumedSecrets 13.3.1
+k8s.job.containerImages 13.3.1
 k8s.job.containers 9.0.0
 k8s.job.created 9.0.0
 k8s.job.dropsAllCapabilities 13.2.2
@@ -698,6 +711,7 @@ k8s.job.podSpec 9.0.0
 k8s.job.pods 13.0.16
 k8s.job.ready 13.0.16
 k8s.job.resourceVersion 9.0.0
+k8s.job.risksStaleImage 13.3.1
 k8s.job.runsAsRoot 13.2.2
 k8s.job.runsPrivileged 13.2.2
 k8s.job.securityContext 13.2.2
@@ -708,6 +722,8 @@ k8s.job.suspend 13.0.16
 k8s.job.terminating 13.0.16
 k8s.job.ttlSecondsAfterFinished 13.0.16
 k8s.job.uid 9.0.0
+k8s.job.unpinnedImages 13.3.1
+k8s.job.usesAlwaysImagePullPolicy 13.3.1
 k8s.job.usesHostNamespaces 13.2.2
 k8s.job.usesHostPath 13.2.2
 k8s.job.usesImageDigest 13.3.1
@@ -943,6 +959,7 @@ k8s.pod.apiVersion 9.0.0
 k8s.pod.automountServiceAccountToken 13.0.16
 k8s.pod.conditions 13.0.16
 k8s.pod.consumedSecrets 13.3.1
+k8s.pod.containerImages 13.3.1
 k8s.pod.containerStatuses 11.1.110
 k8s.pod.containers 9.0.0
 k8s.pod.created 9.0.0
@@ -1002,6 +1019,7 @@ k8s.pod.reason 13.0.16
 k8s.pod.replicaSet 13.0.16
 k8s.pod.resourceVersion 9.0.0
 k8s.pod.restartPolicy 13.0.16
+k8s.pod.risksStaleImage 13.3.1
 k8s.pod.runningImageDigests 13.3.1
 k8s.pod.runsAsRoot 13.2.2
 k8s.pod.runsPrivileged 13.2.2
@@ -1018,6 +1036,8 @@ k8s.pod.terminationGracePeriodSeconds 13.0.16
 k8s.pod.tolerations 13.0.16
 k8s.pod.topologySpreadConstraints 13.0.16
 k8s.pod.uid 9.0.0
+k8s.pod.unpinnedImages 13.3.1
+k8s.pod.usesAlwaysImagePullPolicy 13.3.1
 k8s.pod.usesHostNamespaces 13.2.2
 k8s.pod.usesHostPath 13.2.2
 k8s.pod.usesImageDigest 13.3.1
@@ -1178,6 +1198,7 @@ k8s.replicaset.automountServiceAccountToken 13.2.2
 k8s.replicaset.availableReplicas 13.0.16
 k8s.replicaset.conditions 13.0.16
 k8s.replicaset.consumedSecrets 13.3.1
+k8s.replicaset.containerImages 13.3.1
 k8s.replicaset.containers 9.0.0
 k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
@@ -1213,11 +1234,14 @@ k8s.replicaset.pods 13.0.16
 k8s.replicaset.readyReplicas 13.0.16
 k8s.replicaset.replicas 13.0.16
 k8s.replicaset.resourceVersion 9.0.0
+k8s.replicaset.risksStaleImage 13.3.1
 k8s.replicaset.runsAsRoot 13.2.2
 k8s.replicaset.runsPrivileged 13.2.2
 k8s.replicaset.securityContext 13.2.2
 k8s.replicaset.selector 13.0.16
 k8s.replicaset.uid 9.0.0
+k8s.replicaset.unpinnedImages 13.3.1
+k8s.replicaset.usesAlwaysImagePullPolicy 13.3.1
 k8s.replicaset.usesHostNamespaces 13.2.2
 k8s.replicaset.usesHostPath 13.2.2
 k8s.replicaset.usesImageDigest 13.3.1
@@ -1333,6 +1357,7 @@ k8s.statefulset.availableReplicas 13.0.16
 k8s.statefulset.collisionCount 13.0.16
 k8s.statefulset.conditions 13.0.16
 k8s.statefulset.consumedSecrets 13.3.1
+k8s.statefulset.containerImages 13.3.1
 k8s.statefulset.containers 9.0.0
 k8s.statefulset.created 9.0.0
 k8s.statefulset.currentReplicas 13.0.16
@@ -1373,15 +1398,18 @@ k8s.statefulset.readyReplicas 13.0.16
 k8s.statefulset.replicas 13.0.16
 k8s.statefulset.resourceVersion 9.0.0
 k8s.statefulset.revisionHistoryLimit 13.0.16
+k8s.statefulset.risksStaleImage 13.3.1
 k8s.statefulset.runsAsRoot 13.2.2
 k8s.statefulset.runsPrivileged 13.2.2
 k8s.statefulset.securityContext 13.2.2
 k8s.statefulset.selector 13.0.16
 k8s.statefulset.serviceName 13.0.16
 k8s.statefulset.uid 9.0.0
+k8s.statefulset.unpinnedImages 13.3.1
 k8s.statefulset.updateRevision 13.0.16
 k8s.statefulset.updateStrategy 13.0.16
 k8s.statefulset.updatedReplicas 13.0.16
+k8s.statefulset.usesAlwaysImagePullPolicy 13.3.1
 k8s.statefulset.usesHostNamespaces 13.2.2
 k8s.statefulset.usesHostPath 13.2.2
 k8s.statefulset.usesImageDigest 13.3.1


### PR DESCRIPTION
## Summary

Deepens the image-provenance surface from #8589 with the **freshness / cache-poisoning** axis and **actionable image lists** on every workload kind (`pod`, `deployment`, `daemonset`, `statefulset`, `replicaset`, `job`, `cronjob`):

- **`usesAlwaysImagePullPolicy()`** — every container pulls on each start, forcing a registry re-pull and re-authorization rather than trusting a node-cached layer
- **`risksStaleImage()`** — any container uses a mutable (non-digest) tag with a pull policy other than `Always`, so the node may serve a stale or attacker-seeded cached image for that tag
- **`containerImages()`** — image references of all regular/init containers
- **`unpinnedImages()`** — the subset not pinned by digest (actionable companion to `usesImageDigest`)

```mql
k8s.deployments.where( risksStaleImage )
k8s.pods.flatMap( unpinnedImages )
```

## Details

- Pull policy is resolved to its **effective** value when unset — `Always` for `latest`/untagged images, `IfNotPresent` otherwise — matching kubelet defaulting, so the predicates reflect runtime reality rather than just the literal field.
- Reuses the `parseImageRef` / `imageContainers` helpers from #8589; only regular and init containers are considered.

## Why

`usesImageDigest` told you whether images are immutable; this tells you whether a *mutable* image can actually drift on the node — the practical supply-chain risk — and gives policies the exact list of offending images.

## Tests

Fixture coverage (digest-pinned → never stale; latest → defaults to Always; pinned tag with default policy → stale risk) plus helper tests for effective pull policy, the stale-image combination, all-containers-Always, and image-list dedup / pinning split. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)