### PR TITLE
✨ k8s: running image digests & digest drift on pods (runtime truth)

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -484,6 +484,18 @@ private k8s.pod @defaults("namespace name created"){
   containers() []k8s.container
   // Container statuses
   containerStatuses() []k8s.containerStatus
+  // Running image digests
+  //
+  // Unique sha256 digests actually running in this pod, as resolved by the
+  // kubelet from container statuses. Carries a digest even when the spec used a
+  // mutable tag, so it reflects what is really executing rather than declared.
+  runningImageDigests() []string
+  // Whether a running image has drifted from its spec reference
+  //
+  // True when a container's spec references a mutable tag (not a digest) but the
+  // kubelet resolved it to a concrete digest, so a restart or reschedule could
+  // silently pull a different image for that tag.
+  hasImageDigestDrift() bool
   // Node the pod runs on
   node() k8s.node
   // Name of the node the pod is bound to

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -935,6 +935,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.containerStatuses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetContainerStatuses()).ToDataRes(types.Array(types.Resource("k8s.containerStatus")))
 	},
+	"k8s.pod.runningImageDigests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetRunningImageDigests()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.pod.hasImageDigestDrift": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasImageDigestDrift()).ToDataRes(types.Bool)
+	},
 	"k8s.pod.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetNode()).ToDataRes(types.Resource("k8s.node"))
 	},
@@ -5192,6 +5198,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.pod.containerStatuses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).ContainerStatuses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.runningImageDigests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).RunningImageDigests, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasImageDigestDrift": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasImageDigestDrift, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12055,6 +12069,8 @@ type mqlK8sPod struct {
 	InitContainers                plugin.TValue[[]any]
 	Containers                    plugin.TValue[[]any]
 	ContainerStatuses             plugin.TValue[[]any]
+	RunningImageDigests           plugin.TValue[[]any]
+	HasImageDigestDrift           plugin.TValue[bool]
 	Node                          plugin.TValue[*mqlK8sNode]
 	NodeName                      plugin.TValue[string]
 	NodeSelector                  plugin.TValue[map[string]any]
@@ -12428,6 +12444,18 @@ func (c *mqlK8sPod) GetContainerStatuses() *plugin.TValue[[]any] {
 		}
 
 		return c.containerStatuses()
+	})
+}
+
+func (c *mqlK8sPod) GetRunningImageDigests() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RunningImageDigests, func() ([]any, error) {
+		return c.runningImageDigests()
+	})
+}
+
+func (c *mqlK8sPod) GetHasImageDigestDrift() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasImageDigestDrift, func() (bool, error) {
+		return c.hasImageDigestDrift()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -954,6 +954,7 @@ k8s.pod.dropsAllCapabilities 13.2.2
 k8s.pod.enableServiceLinks 13.0.16
 k8s.pod.ephemeralContainers 9.0.0
 k8s.pod.hasCpuLimit 13.3.1
+k8s.pod.hasImageDigestDrift 13.3.1
 k8s.pod.hasMemoryLimit 13.3.1
 k8s.pod.hasResourceLimits 13.3.1
 k8s.pod.hasResourceRequests 13.3.1
@@ -1001,6 +1002,7 @@ k8s.pod.reason 13.0.16
 k8s.pod.replicaSet 13.0.16
 k8s.pod.resourceVersion 9.0.0
 k8s.pod.restartPolicy 13.0.16
+k8s.pod.runningImageDigests 13.3.1
 k8s.pod.runsAsRoot 13.2.2
 k8s.pod.runsPrivileged 13.2.2
 k8s.pod.runtimeClassName 13.0.16

--- a/providers/k8s/resources/pod_runtime.go
+++ b/providers/k8s/resources/pod_runtime.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// This file exposes runtime truth from a pod's status, as opposed to what its
+// spec declares. The kubelet records the image it actually resolved and pulled
+// in status.containerStatuses[].imageID, which carries a digest even when the
+// spec used a mutable tag — letting us report what is really running and detect
+// drift between the (mutable) spec reference and the running image.
+//
+// These live on k8s.pod because status is a property of the running object;
+// controllers describe desired state and carry no container statuses.
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// imageDigest extracts the "sha256:..." digest from a status imageID, which may
+// take forms like "docker-pullable://repo@sha256:..", "repo@sha256:..", or a
+// bare "sha256:..". Returns "" when no digest is present.
+func imageDigest(imageID string) string {
+	if i := strings.Index(imageID, "@sha256:"); i >= 0 {
+		return imageID[i+1:]
+	}
+	if i := strings.Index(imageID, "sha256:"); i >= 0 {
+		return imageID[i:]
+	}
+	return ""
+}
+
+// runtimeContainerStatuses returns the regular and init container statuses, the
+// steady-state containers (ephemeral debug containers are excluded, matching the
+// image-provenance scope).
+func runtimeContainerStatuses(pod *corev1.Pod) []corev1.ContainerStatus {
+	out := make([]corev1.ContainerStatus, 0, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
+	out = append(out, pod.Status.ContainerStatuses...)
+	out = append(out, pod.Status.InitContainerStatuses...)
+	return out
+}
+
+func (k *mqlK8sPod) runningImageDigests() ([]any, error) {
+	pod, err := k.getPod()
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	out := []any{}
+	for _, cs := range runtimeContainerStatuses(pod) {
+		d := imageDigest(cs.ImageID)
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// hasImageDigestDrift reports whether any container runs an unpinned image: the
+// spec references a mutable tag (not a digest) yet the kubelet resolved it to a
+// concrete digest. A restart or reschedule could silently pull a different image
+// for that tag. Digest-pinned spec references can never drift.
+func (k *mqlK8sPod) hasImageDigestDrift() (bool, error) {
+	pod, err := k.getPod()
+	if err != nil {
+		return false, err
+	}
+
+	runningDigest := map[string]string{}
+	for _, cs := range runtimeContainerStatuses(pod) {
+		runningDigest[cs.Name] = imageDigest(cs.ImageID)
+	}
+
+	specContainers := make([]corev1.Container, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	specContainers = append(specContainers, pod.Spec.Containers...)
+	specContainers = append(specContainers, pod.Spec.InitContainers...)
+
+	for _, c := range specContainers {
+		if ref := parseImageRef(c.Image); ref.ok && ref.digested {
+			continue
+		}
+		if runningDigest[c.Name] != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/providers/k8s/resources/pod_runtime_test.go
+++ b/providers/k8s/resources/pod_runtime_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/shared"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+const (
+	digest1 = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	digest2 = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+func podRuntimeK8s(t *testing.T) *mqlK8s {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Options: map[string]string{shared.OPTION_NAMESPACE: "default"}},
+		},
+	}, manifest.WithManifestFile("./testdata/pod-runtime.yaml"))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+
+	obj, err := NewResource(runtime, "k8s", nil)
+	require.NoError(t, err)
+	return obj.(*mqlK8s)
+}
+
+func podByNameRuntime(t *testing.T, k8s *mqlK8s, name string) *mqlK8sPod {
+	t.Helper()
+	pods := k8s.GetPods()
+	require.NoError(t, pods.Error)
+	for i := range pods.Data {
+		p := pods.Data[i].(*mqlK8sPod)
+		if p.GetName().Data == name {
+			return p
+		}
+	}
+	require.FailNowf(t, "pod not found", "pod %q not found", name)
+	return nil
+}
+
+func TestPodRuntimeImageDigests(t *testing.T) {
+	k8s := podRuntimeK8s(t)
+
+	t.Run("mutable tag resolved to a digest drifts", func(t *testing.T) {
+		p := podByNameRuntime(t, k8s, "drift-pod")
+		assert.ElementsMatch(t, []any{digest1, digest2}, p.GetRunningImageDigests().Data, "runningImageDigests")
+		assert.True(t, p.GetHasImageDigestDrift().Data, "hasImageDigestDrift")
+	})
+
+	t.Run("digest-pinned spec never drifts", func(t *testing.T) {
+		p := podByNameRuntime(t, k8s, "pinned-pod")
+		assert.ElementsMatch(t, []any{digest1}, p.GetRunningImageDigests().Data, "runningImageDigests")
+		assert.False(t, p.GetHasImageDigestDrift().Data, "hasImageDigestDrift")
+	})
+
+	t.Run("no status yields no digests and no drift", func(t *testing.T) {
+		p := podByNameRuntime(t, k8s, "no-status-pod")
+		assert.Empty(t, p.GetRunningImageDigests().Data, "runningImageDigests")
+		assert.False(t, p.GetHasImageDigestDrift().Data, "hasImageDigestDrift")
+	})
+}
+
+func TestImageDigestParsing(t *testing.T) {
+	cases := map[string]string{
+		"docker-pullable://nginx@" + digest1: digest1, // containerd/docker pullable form
+		"nginx@" + digest1:                   digest1, // bare repo@digest
+		digest1:                              digest1, // bare digest
+		"nginx:1.25":                         "",      // tag only, no digest
+		"":                                   "",      // empty
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, imageDigest(in), "imageDigest(%q)", in)
+	}
+}

--- a/providers/k8s/resources/testdata/pod-runtime.yaml
+++ b/providers/k8s/resources/testdata/pod-runtime.yaml
@@ -1,0 +1,59 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Exercises runtime image-digest truth from pod status.
+---
+# Mutable tag in spec, but the kubelet resolved it to a concrete digest: drift.
+# A second container is digest-pinned in spec and never drifts.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: drift-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25
+  - name: pinned
+    image: redis@sha256:2222222222222222222222222222222222222222222222222222222222222222
+status:
+  containerStatuses:
+  - name: app
+    image: nginx:1.25
+    imageID: docker-pullable://nginx@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    ready: true
+    restartCount: 0
+  - name: pinned
+    image: redis@sha256:2222222222222222222222222222222222222222222222222222222222222222
+    imageID: docker-pullable://redis@sha256:2222222222222222222222222222222222222222222222222222222222222222
+    ready: true
+    restartCount: 0
+---
+# Spec is digest-pinned, so no drift even though it is running.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pinned-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: nginx@sha256:1111111111111111111111111111111111111111111111111111111111111111
+status:
+  containerStatuses:
+  - name: app
+    image: nginx@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    imageID: docker-pullable://nginx@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    ready: true
+    restartCount: 0
+---
+# No status (e.g. a not-yet-scheduled pod): no running digests, no drift.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-status-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25


### PR DESCRIPTION
## Summary

Our image-provenance rollups (#8589/#8590) evaluate what the **spec declares**. This adds **runtime truth** to `k8s.pod` — what the kubelet actually resolved and pulled, from `status.containerStatuses[].imageID` (which carries a digest even when the spec used a mutable tag):

- **`runningImageDigests()`** — the `sha256:` digests actually running, deduped
- **`hasImageDigestDrift()`** — a container runs an unpinned (mutable-tag) image that the kubelet resolved to a concrete digest, so a restart/reschedule could silently pull a different image for that tag

```mql
k8s.pods.where( hasImageDigestDrift )
k8s.pods { name runningImageDigests }
```

## Design notes

- These live on **`k8s.pod`** because `status` is a property of the *running* object; controllers describe desired state and carry no container statuses (reaching their pods would need the cross-resource selector engine, out of scope here).
- **Degrades cleanly:** on a manifest scan with no `status`, `runningImageDigests` is empty and `hasImageDigestDrift` is false.
- Only regular and init containers are considered (matching the image-provenance scope); reuses `parseImageRef` from #8589.

## Why

`usesImageDigest` answers "is this *declared* immutable?" — this answers "what is *actually* running, and can it change under me?" That's the ground truth a mutable tag hides.

## Tests

Fixture with a drifting pod (mutable tag → resolved digest), a digest-pinned pod, and a status-less pod; plus `imageDigest` parsing unit tests for the pullable form, bare `repo@digest`, bare digest, tag-only, and empty. Full `providers/k8s` suite, `go vet`, and `gofmt` clean. Generated files regenerated via the `lr` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)