### PR TITLE
✨ k8s: exposure→workload attack paths + secret hygiene predicates

### DIFF
--- a/providers/k8s/resources/exposure_targets.go
+++ b/providers/k8s/resources/exposure_targets.go
@@ -1,0 +1,297 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// serviceKey identifies a Service by namespace and name, used to deduplicate
+// backend references when resolving ingress and gateway routing targets.
+type serviceKey struct {
+	namespace string
+	name      string
+}
+
+func k8sCluster(runtime *plugin.Runtime) (*mqlK8s, error) {
+	o, err := CreateResource(runtime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return o.(*mqlK8s), nil
+}
+
+// pods returns the pods selected by the service's label selector. Selectorless
+// services (including ExternalName) select no pods.
+func (k *mqlK8sService) pods() ([]any, error) {
+	svc, err := k.getService()
+	if err != nil {
+		return nil, err
+	}
+	if len(svc.Spec.Selector) == 0 {
+		return []any{}, nil
+	}
+	return podsMatchingSelector(k.MqlRuntime, &metav1.LabelSelector{MatchLabels: svc.Spec.Selector}, svc.Namespace)
+}
+
+// services returns the services in the pod's namespace whose label selector
+// matches the pod, the reverse of k8s.service.pods.
+func (k *mqlK8sPod) services() ([]any, error) {
+	pod, err := k.getPod()
+	if err != nil {
+		return nil, err
+	}
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	svcs := cluster.GetServices()
+	if svcs.Error != nil {
+		return nil, svcs.Error
+	}
+
+	podLabels := labels.Set(pod.Labels)
+	out := []any{}
+	for i := range svcs.Data {
+		s, ok := svcs.Data[i].(*mqlK8sService)
+		if !ok {
+			continue
+		}
+		svc, err := s.getService()
+		if err != nil {
+			return nil, err
+		}
+		if svc.Namespace != pod.Namespace || len(svc.Spec.Selector) == 0 {
+			continue
+		}
+		if labels.SelectorFromSet(svc.Spec.Selector).Matches(podLabels) {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+// pods returns the pods behind the ingress, resolved through the services its
+// rules and default backend route to.
+func (k *mqlK8sIngress) pods() ([]any, error) {
+	ing, err := k.getIngress()
+	if err != nil {
+		return nil, err
+	}
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := map[serviceKey]struct{}{}
+	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+		keys[serviceKey{ing.Namespace, ing.Spec.DefaultBackend.Service.Name}] = struct{}{}
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service != nil {
+				keys[serviceKey{ing.Namespace, path.Backend.Service.Name}] = struct{}{}
+			}
+		}
+	}
+	return podsForServiceKeys(cluster, keys)
+}
+
+// pods returns the pods behind the gateway, resolved through the HTTPRoutes and
+// GRPCRoutes attached to it and the services their backend references route to.
+// Layer-4 routes (TCPRoute, TLSRoute, UDPRoute) are not folded in.
+func (k *mqlK8sGateway) pods() ([]any, error) {
+	gw := k.obj
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := map[serviceKey]struct{}{}
+
+	httpRoutes := cluster.GetHttpRoutes()
+	if httpRoutes.Error != nil {
+		return nil, httpRoutes.Error
+	}
+	for i := range httpRoutes.Data {
+		hr, ok := httpRoutes.Data[i].(*mqlK8sHttproute)
+		if !ok || hr.obj == nil {
+			continue
+		}
+		if !routeTargetsGateway(hr.obj.Spec.ParentRefs, hr.obj.Namespace, gw.Namespace, gw.Name) {
+			continue
+		}
+		for _, rule := range hr.obj.Spec.Rules {
+			for _, ref := range rule.BackendRefs {
+				addBackendServiceKey(keys, ref.BackendObjectReference, hr.obj.Namespace)
+			}
+		}
+	}
+
+	grpcRoutes := cluster.GetGrpcRoutes()
+	if grpcRoutes.Error != nil {
+		return nil, grpcRoutes.Error
+	}
+	for i := range grpcRoutes.Data {
+		gr, ok := grpcRoutes.Data[i].(*mqlK8sGrpcroute)
+		if !ok || gr.obj == nil {
+			continue
+		}
+		if !routeTargetsGateway(gr.obj.Spec.ParentRefs, gr.obj.Namespace, gw.Namespace, gw.Name) {
+			continue
+		}
+		for _, rule := range gr.obj.Spec.Rules {
+			for _, ref := range rule.BackendRefs {
+				addBackendServiceKey(keys, ref.BackendObjectReference, gr.obj.Namespace)
+			}
+		}
+	}
+
+	return podsForServiceKeys(cluster, keys)
+}
+
+// pods returns the pods behind a normalized network exposure by resolving its
+// source object (Service, Ingress, or Gateway) to the workloads behind it.
+func (k *mqlK8sNetworkExposure) pods() ([]any, error) {
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	ns := k.Namespace.Data
+	name := k.Name.Data
+
+	switch k.SourceKind.Data {
+	case "Service":
+		svcs := cluster.GetServices()
+		if svcs.Error != nil {
+			return nil, svcs.Error
+		}
+		for i := range svcs.Data {
+			s := svcs.Data[i].(*mqlK8sService)
+			if s.Namespace.Data == ns && s.Name.Data == name {
+				return s.pods()
+			}
+		}
+	case "Ingress":
+		ingresses := cluster.GetIngresses()
+		if ingresses.Error != nil {
+			return nil, ingresses.Error
+		}
+		for i := range ingresses.Data {
+			ing := ingresses.Data[i].(*mqlK8sIngress)
+			if ing.Namespace.Data == ns && ing.Name.Data == name {
+				return ing.pods()
+			}
+		}
+	case "Gateway":
+		gateways := cluster.GetGateways()
+		if gateways.Error != nil {
+			return nil, gateways.Error
+		}
+		for i := range gateways.Data {
+			gw := gateways.Data[i].(*mqlK8sGateway)
+			if gw.Namespace.Data == ns && gw.Name.Data == name {
+				return gw.pods()
+			}
+		}
+	}
+
+	// HBN and other non-Kubernetes sources have no in-cluster workload to
+	// resolve, and a source object can have been deleted while the exposure
+	// record lingers.
+	return []any{}, nil
+}
+
+// routeTargetsGateway reports whether any of the route's parentRefs binds it to
+// the given Gateway, applying the Gateway API defaults for the optional kind,
+// group, and namespace fields.
+func routeTargetsGateway(parentRefs []gatewayv1.ParentReference, routeNamespace, gatewayNamespace, gatewayName string) bool {
+	for _, ref := range parentRefs {
+		if ref.Kind != nil && string(*ref.Kind) != "Gateway" {
+			continue
+		}
+		if ref.Group != nil && string(*ref.Group) != "" && string(*ref.Group) != "gateway.networking.k8s.io" {
+			continue
+		}
+		if string(ref.Name) != gatewayName {
+			continue
+		}
+		ns := routeNamespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		if ns == gatewayNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// addBackendServiceKey records a backend reference as a Service key when it
+// points at a core-group Service, defaulting the namespace to the route's.
+func addBackendServiceKey(keys map[serviceKey]struct{}, ref gatewayv1.BackendObjectReference, routeNamespace string) {
+	if ref.Kind != nil && string(*ref.Kind) != "Service" {
+		return
+	}
+	if ref.Group != nil && string(*ref.Group) != "" {
+		return
+	}
+	if ref.Name == "" {
+		return
+	}
+	ns := routeNamespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	keys[serviceKey{ns, string(ref.Name)}] = struct{}{}
+}
+
+// podsForServiceKeys unions the pods of every service whose key is in the set,
+// deduplicating by pod id. It iterates the cluster's services in their stable
+// order so the result is deterministic.
+func podsForServiceKeys(cluster *mqlK8s, keys map[serviceKey]struct{}) ([]any, error) {
+	if len(keys) == 0 {
+		return []any{}, nil
+	}
+	svcs := cluster.GetServices()
+	if svcs.Error != nil {
+		return nil, svcs.Error
+	}
+
+	seen := map[string]struct{}{}
+	out := []any{}
+	for i := range svcs.Data {
+		s, ok := svcs.Data[i].(*mqlK8sService)
+		if !ok {
+			continue
+		}
+		svc, err := s.getService()
+		if err != nil {
+			return nil, err
+		}
+		if _, want := keys[serviceKey{svc.Namespace, svc.Name}]; !want {
+			continue
+		}
+		pods, err := s.pods()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range pods {
+			id := p.(*mqlK8sPod).MqlID()
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/exposure_targets.go
+++ b/providers/k8s/resources/exposure_targets.go
@@ -175,7 +175,10 @@ func (k *mqlK8sNetworkExposure) pods() ([]any, error) {
 			return nil, svcs.Error
 		}
 		for i := range svcs.Data {
-			s := svcs.Data[i].(*mqlK8sService)
+			s, ok := svcs.Data[i].(*mqlK8sService)
+			if !ok {
+				continue
+			}
 			if s.Namespace.Data == ns && s.Name.Data == name {
 				return s.pods()
 			}
@@ -186,7 +189,10 @@ func (k *mqlK8sNetworkExposure) pods() ([]any, error) {
 			return nil, ingresses.Error
 		}
 		for i := range ingresses.Data {
-			ing := ingresses.Data[i].(*mqlK8sIngress)
+			ing, ok := ingresses.Data[i].(*mqlK8sIngress)
+			if !ok {
+				continue
+			}
 			if ing.Namespace.Data == ns && ing.Name.Data == name {
 				return ing.pods()
 			}
@@ -197,7 +203,10 @@ func (k *mqlK8sNetworkExposure) pods() ([]any, error) {
 			return nil, gateways.Error
 		}
 		for i := range gateways.Data {
-			gw := gateways.Data[i].(*mqlK8sGateway)
+			gw, ok := gateways.Data[i].(*mqlK8sGateway)
+			if !ok {
+				continue
+			}
 			if gw.Namespace.Data == ns && gw.Name.Data == name {
 				return gw.pods()
 			}
@@ -285,7 +294,11 @@ func podsForServiceKeys(cluster *mqlK8s, keys map[serviceKey]struct{}) ([]any, e
 			return nil, err
 		}
 		for _, p := range pods {
-			id := p.(*mqlK8sPod).MqlID()
+			pod, ok := p.(*mqlK8sPod)
+			if !ok {
+				continue
+			}
+			id := pod.MqlID()
 			if _, dup := seen[id]; dup {
 				continue
 			}

--- a/providers/k8s/resources/exposure_targets_test.go
+++ b/providers/k8s/resources/exposure_targets_test.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func exposureRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{}},
+	}, manifest.WithManifestFile("./testdata/exposure_targets.yaml"))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+func TestServicePods(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	svc, err := NewResource(runtime, "k8s.service", map[string]*llx.RawData{
+		"name":      llx.StringData("web-svc"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pods := svc.(*mqlK8sService).GetPods()
+	require.NoError(t, pods.Error)
+	// Selects app=web in prod only — excludes other-1 and the same-labeled pod
+	// in the staging namespace.
+	assert.Equal(t, []string{"web-1", "web-2"}, mqlResourceNames(t, pods.Data))
+
+	// Selectorless service selects nothing.
+	headless, err := NewResource(runtime, "k8s.service", map[string]*llx.RawData{
+		"name":      llx.StringData("headless"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	hp := headless.(*mqlK8sService).GetPods()
+	require.NoError(t, hp.Error)
+	assert.Empty(t, hp.Data)
+}
+
+func TestPodServices(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	pod, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("web-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	svcs := pod.(*mqlK8sPod).GetServices()
+	require.NoError(t, svcs.Error)
+	assert.Equal(t, []string{"web-svc"}, mqlResourceNames(t, svcs.Data))
+
+	// A pod no service selects resolves to no services.
+	other, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("other-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	os := other.(*mqlK8sPod).GetServices()
+	require.NoError(t, os.Error)
+	assert.Empty(t, os.Data)
+}
+
+func TestIngressPods(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	ing, err := NewResource(runtime, "k8s.ingress", map[string]*llx.RawData{
+		"name":      llx.StringData("web-ing"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pods := ing.(*mqlK8sIngress).GetPods()
+	require.NoError(t, pods.Error)
+	assert.Equal(t, []string{"web-1", "web-2"}, mqlResourceNames(t, pods.Data))
+}
+
+func TestGatewayPods(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	gw, err := NewResource(runtime, "k8s.gateway", map[string]*llx.RawData{
+		"name":      llx.StringData("gw"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pods := gw.(*mqlK8sGateway).GetPods()
+	require.NoError(t, pods.Error)
+	// HTTPRoute and GRPCRoute both target web-svc; the backing pods dedup.
+	assert.Equal(t, []string{"web-1", "web-2"}, mqlResourceNames(t, pods.Data))
+}
+
+func TestNetworkExposurePods(t *testing.T) {
+	k8sObj, err := NewResource(exposureRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	exps := k8s.GetNetworkExposures()
+	require.NoError(t, exps.Error)
+
+	var serviceExposure *mqlK8sNetworkExposure
+	for i := range exps.Data {
+		e := exps.Data[i].(*mqlK8sNetworkExposure)
+		if e.SourceKind.Data == "Service" && e.Name.Data == "web-svc" {
+			serviceExposure = e
+			break
+		}
+	}
+	require.NotNil(t, serviceExposure, "expected a Service-sourced exposure for web-svc")
+
+	pods := serviceExposure.GetPods()
+	require.NoError(t, pods.Error)
+	assert.Equal(t, []string{"web-1", "web-2"}, mqlResourceNames(t, pods.Data))
+}
+
+func secretByName(t *testing.T, runtime *plugin.Runtime, name string) *mqlK8sSecret {
+	t.Helper()
+	s, err := NewResource(runtime, "k8s.secret", map[string]*llx.RawData{
+		"name":      llx.StringData(name),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	return s.(*mqlK8sSecret)
+}
+
+func TestSecretHygiene(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	tests := []struct {
+		name              string
+		serviceAccountTok bool
+		imagePull         bool
+		unused            bool
+	}{
+		// mounted by web-1
+		{"used-secret", false, false, false},
+		// image-pull secret referenced by web-1
+		{"pull", false, true, false},
+		// no pod and no service account reference it
+		{"orphan", false, false, true},
+		// referenced only by web-sa, so not orphaned despite no pod use
+		{"sa-token", true, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := secretByName(t, runtime, tt.name)
+
+			sat := s.GetIsServiceAccountToken()
+			require.NoError(t, sat.Error)
+			assert.Equal(t, tt.serviceAccountTok, sat.Data, "isServiceAccountToken")
+
+			ips := s.GetIsImagePullSecret()
+			require.NoError(t, ips.Error)
+			assert.Equal(t, tt.imagePull, ips.Data, "isImagePullSecret")
+
+			unused := s.GetIsUnused()
+			require.NoError(t, unused.Error)
+			assert.Equal(t, tt.unused, unused.Data, "isUnused")
+		})
+	}
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -524,6 +524,8 @@ private k8s.pod @defaults("namespace name created"){
   // kubelet resolved it to a concrete digest, so a restart or reschedule could
   // silently pull a different image for that tag.
   hasImageDigestDrift() bool
+  // Services whose label selector matches this pod
+  services() []k8s.service
   // Node the pod runs on
   node() k8s.node
   // Name of the node the pod is bound to
@@ -1926,6 +1928,16 @@ private k8s.secret @defaults("namespace name created") {
   certificates() []network.certificate
   // Pods that reference this Secret through volumes, env, envFrom, or imagePullSecrets
   usedBy() []k8s.pod
+  // Whether this is a service account token Secret (type kubernetes.io/service-account-token)
+  isServiceAccountToken() bool
+  // Whether this is an image-pull Secret (type kubernetes.io/dockercfg or kubernetes.io/dockerconfigjson)
+  isImagePullSecret() bool
+  // Whether no pod and no service account reference this Secret
+  //
+  // True when no pod consumes the Secret through a volume, environment
+  // variable, or image-pull reference, and no service account lists it among
+  // its tokens or image-pull secrets. A signal for orphaned credentials.
+  isUnused() bool
 }
 
 // Kubernetes ConfigMap
@@ -2044,6 +2056,8 @@ private k8s.service @defaults("namespace name created") {
   loadBalancerIngress() []dict
   // EndpointSlices that back this service (filtered by the kubernetes.io/service-name label)
   endpointSlices() []k8s.endpointslice
+  // Pods selected by the service's label selector (empty for selectorless and ExternalName services)
+  pods() []k8s.pod
   // Normalized network exposure records for this Service
   networkExposures() []k8s.networkExposure
 }
@@ -2157,6 +2171,8 @@ private k8s.ingress @defaults("namespace name created") {
   ingressClass() k8s.ingressclass
   // Load-balancer ingress entries published in status (ip, hostname, ports)
   loadBalancerIngress() []dict
+  // Pods behind the ingress, resolved through its backend services
+  pods() []k8s.pod
   // Normalized network exposure records for this Ingress
   networkExposures() []k8s.networkExposure
 }
@@ -2588,6 +2604,8 @@ private k8s.networkExposure @defaults("sourceKind namespace name internetExposed
   policyCoverage []string
   // Static-analysis confidence: high, medium, or low
   confidence string
+  // Pods behind this exposure, resolved through the source Service, Ingress, or Gateway
+  pods() []k8s.pod
 }
 
 // Normalized Kubernetes egress route
@@ -3326,6 +3344,8 @@ private k8s.gateway @defaults("namespace name gatewayClassName created") {
   listenerStatus []dict
   // Status conditions
   conditions []dict
+  // Pods behind the gateway, resolved through the HTTPRoutes and GRPCRoutes attached to it and their backend services
+  pods() []k8s.pod
   // Normalized network exposure records for this Gateway
   networkExposures() []k8s.networkExposure
 }

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -1033,6 +1033,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.hasImageDigestDrift": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHasImageDigestDrift()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.services": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetServices()).ToDataRes(types.Array(types.Resource("k8s.service")))
+	},
 	"k8s.pod.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetNode()).ToDataRes(types.Resource("k8s.node"))
 	},
@@ -2674,6 +2677,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.secret.usedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sSecret).GetUsedBy()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
+	"k8s.secret.isServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetIsServiceAccountToken()).ToDataRes(types.Bool)
+	},
+	"k8s.secret.isImagePullSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetIsImagePullSecret()).ToDataRes(types.Bool)
+	},
+	"k8s.secret.isUnused": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetIsUnused()).ToDataRes(types.Bool)
+	},
 	"k8s.configmap.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sConfigmap).GetId()).ToDataRes(types.String)
 	},
@@ -2818,6 +2830,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.service.endpointSlices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetEndpointSlices()).ToDataRes(types.Array(types.Resource("k8s.endpointslice")))
 	},
+	"k8s.service.pods": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sService).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
+	},
 	"k8s.service.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
@@ -2934,6 +2949,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.ingress.loadBalancerIngress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngress).GetLoadBalancerIngress()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.ingress.pods": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sIngress).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
 	"k8s.ingress.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngress).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
@@ -3402,6 +3420,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.networkExposure.confidence": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNetworkExposure).GetConfidence()).ToDataRes(types.String)
+	},
+	"k8s.networkExposure.pods": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNetworkExposure).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
 	"k8s.egressRoute.sourceRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEgressRoute).GetSourceRef()).ToDataRes(types.String)
@@ -4242,6 +4263,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.gateway.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGateway).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.gateway.pods": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sGateway).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
 	"k8s.gateway.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGateway).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
@@ -5825,6 +5849,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.pod.hasImageDigestDrift": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).HasImageDigestDrift, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.services": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).Services, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8059,6 +8087,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sSecret).UsedBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.secret.isServiceAccountToken": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).IsServiceAccountToken, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.secret.isImagePullSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).IsImagePullSecret, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.secret.isUnused": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).IsUnused, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.configmap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sConfigmap).__id, ok = v.Value.(string)
 		return
@@ -8259,6 +8299,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sService).EndpointSlices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.service.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sService).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.service.networkExposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sService).NetworkExposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -8441,6 +8485,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.ingress.loadBalancerIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sIngress).LoadBalancerIngress, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.ingress.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sIngress).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.ingress.networkExposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9105,6 +9153,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.networkExposure.confidence": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNetworkExposure).Confidence, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.networkExposure.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNetworkExposure).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.egressRoute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10301,6 +10353,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.gateway.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sGateway).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.gateway.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sGateway).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.gateway.networkExposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13532,6 +13588,7 @@ type mqlK8sPod struct {
 	ContainerStatuses             plugin.TValue[[]any]
 	RunningImageDigests           plugin.TValue[[]any]
 	HasImageDigestDrift           plugin.TValue[bool]
+	Services                      plugin.TValue[[]any]
 	Node                          plugin.TValue[*mqlK8sNode]
 	NodeName                      plugin.TValue[string]
 	NodeSelector                  plugin.TValue[map[string]any]
@@ -13941,6 +13998,22 @@ func (c *mqlK8sPod) GetRunningImageDigests() *plugin.TValue[[]any] {
 func (c *mqlK8sPod) GetHasImageDigestDrift() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasImageDigestDrift, func() (bool, error) {
 		return c.hasImageDigestDrift()
+	})
+}
+
+func (c *mqlK8sPod) GetServices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Services, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.pod", c.__id, "services")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.services()
 	})
 }
 
@@ -18187,21 +18260,24 @@ type mqlK8sSecret struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlK8sSecretInternal
-	Id              plugin.TValue[string]
-	Uid             plugin.TValue[string]
-	ResourceVersion plugin.TValue[string]
-	Labels          plugin.TValue[map[string]any]
-	Annotations     plugin.TValue[map[string]any]
-	OwnerReferences plugin.TValue[[]any]
-	ManagedFields   plugin.TValue[[]any]
-	Name            plugin.TValue[string]
-	Namespace       plugin.TValue[string]
-	Kind            plugin.TValue[string]
-	Created         plugin.TValue[*time.Time]
-	Manifest        plugin.TValue[any]
-	Type            plugin.TValue[string]
-	Certificates    plugin.TValue[[]any]
-	UsedBy          plugin.TValue[[]any]
+	Id                    plugin.TValue[string]
+	Uid                   plugin.TValue[string]
+	ResourceVersion       plugin.TValue[string]
+	Labels                plugin.TValue[map[string]any]
+	Annotations           plugin.TValue[map[string]any]
+	OwnerReferences       plugin.TValue[[]any]
+	ManagedFields         plugin.TValue[[]any]
+	Name                  plugin.TValue[string]
+	Namespace             plugin.TValue[string]
+	Kind                  plugin.TValue[string]
+	Created               plugin.TValue[*time.Time]
+	Manifest              plugin.TValue[any]
+	Type                  plugin.TValue[string]
+	Certificates          plugin.TValue[[]any]
+	UsedBy                plugin.TValue[[]any]
+	IsServiceAccountToken plugin.TValue[bool]
+	IsImagePullSecret     plugin.TValue[bool]
+	IsUnused              plugin.TValue[bool]
 }
 
 // createK8sSecret creates a new instance of this resource
@@ -18352,6 +18428,24 @@ func (c *mqlK8sSecret) GetUsedBy() *plugin.TValue[[]any] {
 		}
 
 		return c.usedBy()
+	})
+}
+
+func (c *mqlK8sSecret) GetIsServiceAccountToken() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsServiceAccountToken, func() (bool, error) {
+		return c.isServiceAccountToken()
+	})
+}
+
+func (c *mqlK8sSecret) GetIsImagePullSecret() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsImagePullSecret, func() (bool, error) {
+		return c.isImagePullSecret()
+	})
+}
+
+func (c *mqlK8sSecret) GetIsUnused() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsUnused, func() (bool, error) {
+		return c.isUnused()
 	})
 }
 
@@ -18550,6 +18644,7 @@ type mqlK8sService struct {
 	Ports                         plugin.TValue[[]any]
 	LoadBalancerIngress           plugin.TValue[[]any]
 	EndpointSlices                plugin.TValue[[]any]
+	Pods                          plugin.TValue[[]any]
 	NetworkExposures              plugin.TValue[[]any]
 }
 
@@ -18807,6 +18902,22 @@ func (c *mqlK8sService) GetEndpointSlices() *plugin.TValue[[]any] {
 		}
 
 		return c.endpointSlices()
+	})
+}
+
+func (c *mqlK8sService) GetPods() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Pods, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.service", c.__id, "pods")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.pods()
 	})
 }
 
@@ -19217,6 +19328,7 @@ type mqlK8sIngress struct {
 	IngressClassName    plugin.TValue[string]
 	IngressClass        plugin.TValue[*mqlK8sIngressclass]
 	LoadBalancerIngress plugin.TValue[[]any]
+	Pods                plugin.TValue[[]any]
 	NetworkExposures    plugin.TValue[[]any]
 }
 
@@ -19380,6 +19492,22 @@ func (c *mqlK8sIngress) GetIngressClass() *plugin.TValue[*mqlK8sIngressclass] {
 func (c *mqlK8sIngress) GetLoadBalancerIngress() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.LoadBalancerIngress, func() ([]any, error) {
 		return c.loadBalancerIngress()
+	})
+}
+
+func (c *mqlK8sIngress) GetPods() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Pods, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.ingress", c.__id, "pods")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.pods()
 	})
 }
 
@@ -20922,6 +21050,7 @@ type mqlK8sNetworkExposure struct {
 	Routes                 plugin.TValue[[]any]
 	PolicyCoverage         plugin.TValue[[]any]
 	Confidence             plugin.TValue[string]
+	Pods                   plugin.TValue[[]any]
 }
 
 // createK8sNetworkExposure creates a new instance of this resource
@@ -21027,6 +21156,22 @@ func (c *mqlK8sNetworkExposure) GetPolicyCoverage() *plugin.TValue[[]any] {
 
 func (c *mqlK8sNetworkExposure) GetConfidence() *plugin.TValue[string] {
 	return &c.Confidence
+}
+
+func (c *mqlK8sNetworkExposure) GetPods() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Pods, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.networkExposure", c.__id, "pods")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.pods()
+	})
 }
 
 // mqlK8sEgressRoute for the k8s.egressRoute resource
@@ -23700,6 +23845,7 @@ type mqlK8sGateway struct {
 	StatusAddresses  plugin.TValue[[]any]
 	ListenerStatus   plugin.TValue[[]any]
 	Conditions       plugin.TValue[[]any]
+	Pods             plugin.TValue[[]any]
 	NetworkExposures plugin.TValue[[]any]
 }
 
@@ -23860,6 +24006,22 @@ func (c *mqlK8sGateway) GetListenerStatus() *plugin.TValue[[]any] {
 
 func (c *mqlK8sGateway) GetConditions() *plugin.TValue[[]any] {
 	return &c.Conditions
+}
+
+func (c *mqlK8sGateway) GetPods() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Pods, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.gateway", c.__id, "pods")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.pods()
+	})
 }
 
 func (c *mqlK8sGateway) GetNetworkExposures() *plugin.TValue[[]any] {

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -511,6 +511,7 @@ k8s.gateway.name 13.0.16
 k8s.gateway.namespace 13.0.16
 k8s.gateway.networkExposures 13.3.2
 k8s.gateway.ownerReferences 13.2.2
+k8s.gateway.pods 13.3.1
 k8s.gateway.resourceVersion 13.0.16
 k8s.gateway.statusAddresses 13.0.16
 k8s.gateway.uid 13.0.16
@@ -615,6 +616,7 @@ k8s.ingress.name 9.0.0
 k8s.ingress.namespace 9.0.0
 k8s.ingress.networkExposures 13.3.2
 k8s.ingress.ownerReferences 13.2.2
+k8s.ingress.pods 13.3.1
 k8s.ingress.resourceVersion 9.0.0
 k8s.ingress.rules 9.0.0
 k8s.ingress.tls 9.0.0
@@ -868,6 +870,7 @@ k8s.networkExposure.namespace 13.3.2
 k8s.networkExposure.network 13.3.2
 k8s.networkExposure.networkClassifications 13.3.2
 k8s.networkExposure.owner 13.3.2
+k8s.networkExposure.pods 13.3.1
 k8s.networkExposure.policyCoverage 13.3.2
 k8s.networkExposure.ports 13.3.2
 k8s.networkExposure.protocols 13.3.2
@@ -1107,6 +1110,7 @@ k8s.pod.schedulerName 13.0.16
 k8s.pod.securityContext 13.0.16
 k8s.pod.serviceAccount 13.0.16
 k8s.pod.serviceAccountName 13.0.16
+k8s.pod.services 13.3.1
 k8s.pod.shareProcessNamespace 13.0.16
 k8s.pod.startTime 13.0.16
 k8s.pod.statefulSet 13.0.16
@@ -1374,6 +1378,9 @@ k8s.secret.annotations 9.0.0
 k8s.secret.certificates 9.0.2
 k8s.secret.created 9.0.0
 k8s.secret.id 9.0.0
+k8s.secret.isImagePullSecret 13.3.1
+k8s.secret.isServiceAccountToken 13.3.1
+k8s.secret.isUnused 13.3.1
 k8s.secret.kind 9.0.0
 k8s.secret.labels 9.0.0
 k8s.secret.managedFields 13.2.2
@@ -1414,6 +1421,7 @@ k8s.service.name 9.0.0
 k8s.service.namespace 9.0.0
 k8s.service.networkExposures 13.3.2
 k8s.service.ownerReferences 13.2.2
+k8s.service.pods 13.3.1
 k8s.service.ports 13.0.16
 k8s.service.publishNotReadyAddresses 13.0.16
 k8s.service.resourceVersion 9.0.0

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -511,7 +511,7 @@ k8s.gateway.name 13.0.16
 k8s.gateway.namespace 13.0.16
 k8s.gateway.networkExposures 13.3.2
 k8s.gateway.ownerReferences 13.2.2
-k8s.gateway.pods 13.3.1
+k8s.gateway.pods 13.3.3
 k8s.gateway.resourceVersion 13.0.16
 k8s.gateway.statusAddresses 13.0.16
 k8s.gateway.uid 13.0.16
@@ -616,7 +616,7 @@ k8s.ingress.name 9.0.0
 k8s.ingress.namespace 9.0.0
 k8s.ingress.networkExposures 13.3.2
 k8s.ingress.ownerReferences 13.2.2
-k8s.ingress.pods 13.3.1
+k8s.ingress.pods 13.3.3
 k8s.ingress.resourceVersion 9.0.0
 k8s.ingress.rules 9.0.0
 k8s.ingress.tls 9.0.0
@@ -870,7 +870,7 @@ k8s.networkExposure.namespace 13.3.2
 k8s.networkExposure.network 13.3.2
 k8s.networkExposure.networkClassifications 13.3.2
 k8s.networkExposure.owner 13.3.2
-k8s.networkExposure.pods 13.3.1
+k8s.networkExposure.pods 13.3.3
 k8s.networkExposure.policyCoverage 13.3.2
 k8s.networkExposure.ports 13.3.2
 k8s.networkExposure.protocols 13.3.2
@@ -1110,7 +1110,7 @@ k8s.pod.schedulerName 13.0.16
 k8s.pod.securityContext 13.0.16
 k8s.pod.serviceAccount 13.0.16
 k8s.pod.serviceAccountName 13.0.16
-k8s.pod.services 13.3.1
+k8s.pod.services 13.3.3
 k8s.pod.shareProcessNamespace 13.0.16
 k8s.pod.startTime 13.0.16
 k8s.pod.statefulSet 13.0.16
@@ -1378,9 +1378,9 @@ k8s.secret.annotations 9.0.0
 k8s.secret.certificates 9.0.2
 k8s.secret.created 9.0.0
 k8s.secret.id 9.0.0
-k8s.secret.isImagePullSecret 13.3.1
-k8s.secret.isServiceAccountToken 13.3.1
-k8s.secret.isUnused 13.3.1
+k8s.secret.isImagePullSecret 13.3.3
+k8s.secret.isServiceAccountToken 13.3.3
+k8s.secret.isUnused 13.3.3
 k8s.secret.kind 9.0.0
 k8s.secret.labels 9.0.0
 k8s.secret.managedFields 13.2.2
@@ -1421,7 +1421,7 @@ k8s.service.name 9.0.0
 k8s.service.namespace 9.0.0
 k8s.service.networkExposures 13.3.2
 k8s.service.ownerReferences 13.2.2
-k8s.service.pods 13.3.1
+k8s.service.pods 13.3.3
 k8s.service.ports 13.0.16
 k8s.service.publishNotReadyAddresses 13.0.16
 k8s.service.resourceVersion 9.0.0

--- a/providers/k8s/resources/secret_hygiene.go
+++ b/providers/k8s/resources/secret_hygiene.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (k *mqlK8sSecret) isServiceAccountToken() (bool, error) {
+	return k.Type.Data == string(corev1.SecretTypeServiceAccountToken), nil
+}
+
+func (k *mqlK8sSecret) isImagePullSecret() (bool, error) {
+	return k.Type.Data == string(corev1.SecretTypeDockercfg) ||
+		k.Type.Data == string(corev1.SecretTypeDockerConfigJson), nil
+}
+
+// isUnused reports whether nothing in the cluster references this Secret: no pod
+// consumes it (usedBy is empty) and no ServiceAccount in its namespace lists it
+// among its tokens or image-pull secrets. The ServiceAccount check keeps mounted
+// service-account-token secrets from being flagged as orphaned.
+func (k *mqlK8sSecret) isUnused() (bool, error) {
+	usedBy := k.GetUsedBy()
+	if usedBy.Error != nil {
+		return false, usedBy.Error
+	}
+	if len(usedBy.Data) > 0 {
+		return false, nil
+	}
+
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	sas := cluster.GetServiceaccounts()
+	if sas.Error != nil {
+		return false, sas.Error
+	}
+
+	name := k.Name.Data
+	namespace := k.Namespace.Data
+	for i := range sas.Data {
+		sa, ok := sas.Data[i].(*mqlK8sServiceaccount)
+		if !ok || sa.obj == nil || sa.obj.Namespace != namespace {
+			continue
+		}
+		for _, ref := range sa.obj.Secrets {
+			if ref.Name == name {
+				return false, nil
+			}
+		}
+		for _, ref := range sa.obj.ImagePullSecrets {
+			if ref.Name == name {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/providers/k8s/resources/testdata/exposure_targets.yaml
+++ b/providers/k8s/resources/testdata/exposure_targets.yaml
@@ -1,0 +1,236 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fixture for the exposure-to-workload edges (service.pods, pod.services,
+# ingress.pods, gateway.pods, networkExposure.pods) and the secret-hygiene
+# predicates (isServiceAccountToken, isImagePullSecret, isUnused).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging
+---
+# Two pods the web service selects, one pod it does not, plus a same-labeled pod
+# in another namespace (must be excluded by namespace scoping).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-1
+  namespace: prod
+  labels:
+    app: web
+spec:
+  serviceAccountName: web-sa
+  imagePullSecrets:
+    - name: pull
+  containers:
+    - name: web
+      image: nginx:1.27
+      volumeMounts:
+        - name: creds
+          mountPath: /etc/creds
+  volumes:
+    - name: creds
+      secret:
+        secretName: used-secret
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-2
+  namespace: prod
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: nginx:1.27
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: other-1
+  namespace: prod
+  labels:
+    app: other
+spec:
+  containers:
+    - name: other
+      image: busybox
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-staging
+  namespace: staging
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: nginx:1.27
+status:
+  phase: Running
+---
+# Public LoadBalancer service selecting app=web — produces a network exposure
+# whose pods() must resolve back to web-1 and web-2.
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: prod
+spec:
+  type: LoadBalancer
+  selector:
+    app: web
+  ports:
+    - port: 80
+      targetPort: 80
+status:
+  loadBalancer:
+    ingress:
+      - ip: 203.0.113.10
+---
+# Selectorless service — selects no pods.
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless
+  namespace: prod
+spec:
+  clusterIP: None
+  ports:
+    - port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-ing
+  namespace: prod
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-svc
+                port:
+                  number: 80
+status:
+  loadBalancer:
+    ingress:
+      - hostname: lb.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw
+  namespace: prod
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+status:
+  addresses:
+    - type: IPAddress
+      value: 203.0.113.20
+---
+# HTTPRoute bound to gw, routing to web-svc.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: web-route
+  namespace: prod
+spec:
+  parentRefs:
+    - name: gw
+  rules:
+    - backendRefs:
+        - name: web-svc
+          port: 80
+---
+# GRPCRoute bound to gw, also routing to web-svc (dedup must collapse the pods).
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-route
+  namespace: prod
+spec:
+  parentRefs:
+    - name: gw
+  rules:
+    - backendRefs:
+        - name: web-svc
+          port: 80
+---
+# Secret mounted by web-1 — used, not orphaned.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: used-secret
+  namespace: prod
+type: Opaque
+data:
+  key: dmFsdWU=
+---
+# Image-pull secret referenced by web-1.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull
+  namespace: prod
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30=
+---
+# Orphaned secret — no pod and no service account references it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orphan
+  namespace: prod
+type: Opaque
+data:
+  key: dmFsdWU=
+---
+# ServiceAccount token secret referenced only by a ServiceAccount, not a pod.
+# isUnused must be false because of the ServiceAccount reference.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sa-token
+  namespace: prod
+type: kubernetes.io/service-account-token
+data:
+  token: dG9rZW4=
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: web-sa
+  namespace: prod
+secrets:
+  - name: sa-token


### PR DESCRIPTION
Builds on the merged effective-access RBAC work (#8594) by adding the missing **network edge**: the ability to traverse from an internet-exposed Service, Ingress, or Gateway to the workloads behind it. Combined with a few secret-hygiene predicates, this turns separate signals (network posture, RBAC, workload hardening) into single-line attack-path queries.

## Exposure → workload edges

Reuse the existing `podsMatchingSelector` helper that already powers `deployment.pods`, etc.:

- **`k8s.service.pods`** — pods selected by the service's label selector (selectorless and ExternalName services select nothing)
- **`k8s.pod.services`** — reverse: the services whose selector matches the pod
- **`k8s.ingress.pods`** — pods behind the ingress, via its default backend and rule backend services
- **`k8s.gateway.pods`** — pods behind the gateway, via the HTTPRoutes and GRPCRoutes attached to it and their backend services (L4 TCP/TLS/UDP routes are not folded in)
- **`k8s.networkExposure.pods`** — resolves the exposure's source (Service, Ingress, or Gateway) to the backing pods; HBN/non-Kubernetes sources resolve to empty

## Secret hygiene (`k8s.secret`)

Building on the existing `type` + `usedBy`:

- **`isServiceAccountToken`** — `type == kubernetes.io/service-account-token`
- **`isImagePullSecret`** — `dockercfg` / `dockerconfigjson`
- **`isUnused`** — no pod **and** no ServiceAccount references the secret (the SA check keeps mounted token secrets from being flagged as orphaned)

## Why

The network source objects already linked *to* exposures, but there was no typed traversal from an exposure (or a Service) *to* the pods behind it — `sourceRef` was just a string and Service selectors lived only inside the `spec` dict. These edges close that gap.

```mql
# internet-exposed workloads that run privileged
k8s.networkExposures.where(internetExposed).all(pods.none(runsPrivileged))

# LoadBalancer services fronting a cluster-admin ServiceAccount
k8s.services.where(type == "LoadBalancer").pods { serviceAccount.isClusterAdmin }

# orphaned credentials
k8s.secrets.where(isUnused)
```

## Testing

New `testdata/exposure_targets.yaml` fixture and tests cover selector matching, namespace scoping, selectorless services, ingress/gateway/route resolution with dedup across HTTPRoute + GRPCRoute, the `networkExposure` dispatch (Service-sourced public LoadBalancer resolved end-to-end), and the three secret predicates. Verified end-to-end through the real executor with `mql run k8s <manifest>` for every edge, including the headline `networkExposures.where(internetExposed) { pods { serviceAccountName } }` attack-path query.

No schema-permission changes (all source lists were already required); `.lr.versions` entries at `13.3.1`; no provider version bump.