### PR TITLE
✨ k8s: pod.exposures back-ref + secret certificate-expiry predicates

### DIFF
--- a/providers/k8s/resources/exposure_targets.go
+++ b/providers/k8s/resources/exposure_targets.go
@@ -76,6 +76,40 @@ func (k *mqlK8sPod) services() ([]any, error) {
 	return out, nil
 }
 
+// exposures returns the network exposures that route to this pod, the inverse of
+// k8s.networkExposure.pods. It lets a query pivot from a risky workload to the
+// internet exposure that reaches it.
+func (k *mqlK8sPod) exposures() ([]any, error) {
+	cluster, err := k8sCluster(k.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	exps := cluster.GetNetworkExposures()
+	if exps.Error != nil {
+		return nil, exps.Error
+	}
+
+	podID := k.MqlID()
+	out := []any{}
+	for i := range exps.Data {
+		exp, ok := exps.Data[i].(*mqlK8sNetworkExposure)
+		if !ok {
+			continue
+		}
+		pods, err := exp.pods()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range pods {
+			if mp, ok := p.(*mqlK8sPod); ok && mp.MqlID() == podID {
+				out = append(out, exp)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
 // pods returns the pods behind the ingress, resolved through the services its
 // rules and default backend route to.
 func (k *mqlK8sIngress) pods() ([]any, error) {

--- a/providers/k8s/resources/exposure_targets_test.go
+++ b/providers/k8s/resources/exposure_targets_test.go
@@ -4,7 +4,14 @@
 package resources
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +20,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
 	"go.mondoo.com/mql/v13/utils/syncx"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func exposureRuntime(t *testing.T) *plugin.Runtime {
@@ -171,4 +179,115 @@ func TestSecretHygiene(t *testing.T) {
 			assert.Equal(t, tt.unused, unused.Data, "isUnused")
 		})
 	}
+}
+
+func TestPodExposures(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	// web-1 sits behind the public web-svc (and the ingress/gateway routing to
+	// it), so it must report at least the Service-sourced exposure.
+	web, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("web-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	exps := web.(*mqlK8sPod).GetExposures()
+	require.NoError(t, exps.Error)
+
+	var sawServiceExposure bool
+	for i := range exps.Data {
+		e := exps.Data[i].(*mqlK8sNetworkExposure)
+		if e.SourceKind.Data == "Service" && e.Name.Data == "web-svc" {
+			sawServiceExposure = true
+		}
+	}
+	assert.True(t, sawServiceExposure, "web-1 must report the web-svc Service exposure")
+
+	// other-1 is selected by no service, so nothing exposes it.
+	other, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("other-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	otherExps := other.(*mqlK8sPod).GetExposures()
+	require.NoError(t, otherExps.Error)
+	assert.Empty(t, otherExps.Data)
+}
+
+// testCertPEM generates a self-signed certificate that expires at notAfter.
+func testCertPEM(t *testing.T, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func tlsSecret(certPEM []byte) *mqlK8sSecret {
+	s := &mqlK8sSecret{}
+	s.obj = &corev1.Secret{
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{"tls.crt": certPEM},
+	}
+	return s
+}
+
+func TestSecretCertificateExpiry(t *testing.T) {
+	valid := testCertPEM(t, time.Now().Add(90*24*time.Hour))
+	expired := testCertPEM(t, time.Now().Add(-1*time.Hour))
+
+	t.Run("valid certificate", func(t *testing.T) {
+		s := tlsSecret(valid)
+		he, err := s.hasExpiredCertificate()
+		require.NoError(t, err)
+		assert.False(t, he)
+
+		exp, err := s.certificateExpiry()
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+		assert.True(t, exp.After(time.Now()))
+	})
+
+	t.Run("expired certificate", func(t *testing.T) {
+		s := tlsSecret(expired)
+		he, err := s.hasExpiredCertificate()
+		require.NoError(t, err)
+		assert.True(t, he)
+	})
+
+	t.Run("chain reports earliest expiry and any expired", func(t *testing.T) {
+		chain := append(append([]byte{}, valid...), expired...)
+		s := tlsSecret(chain)
+
+		he, err := s.hasExpiredCertificate()
+		require.NoError(t, err)
+		assert.True(t, he, "a chain with one expired cert is expired")
+
+		exp, err := s.certificateExpiry()
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+		assert.True(t, exp.Before(time.Now()), "earliest expiry is the already-expired cert")
+	})
+
+	t.Run("non-TLS secret has no certificates", func(t *testing.T) {
+		s := &mqlK8sSecret{}
+		s.obj = &corev1.Secret{
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{"key": []byte("value")},
+		}
+		he, err := s.hasExpiredCertificate()
+		require.NoError(t, err)
+		assert.False(t, he)
+
+		exp, err := s.certificateExpiry()
+		require.NoError(t, err)
+		assert.Nil(t, exp)
+	})
 }

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -526,6 +526,8 @@ private k8s.pod @defaults("namespace name created"){
   hasImageDigestDrift() bool
   // Services whose label selector matches this pod
   services() []k8s.service
+  // Network exposures that route to this pod through a Service, Ingress, or Gateway
+  exposures() []k8s.networkExposure
   // Node the pod runs on
   node() k8s.node
   // Name of the node the pod is bound to
@@ -1938,6 +1940,14 @@ private k8s.secret @defaults("namespace name created") {
   // variable, or image-pull reference, and no service account lists it among
   // its tokens or image-pull secrets. A signal for orphaned credentials.
   isUnused() bool
+  // Whether the secret holds a TLS certificate that has expired
+  hasExpiredCertificate() bool
+  // Earliest expiry among the secret's TLS certificates
+  //
+  // The notAfter of the soonest-expiring certificate in the tls.crt chain, so a
+  // single comparison covers the whole chain. Null when the secret holds no
+  // certificate.
+  certificateExpiry() time
 }
 
 // Kubernetes ConfigMap

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -1036,6 +1036,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.services": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetServices()).ToDataRes(types.Array(types.Resource("k8s.service")))
 	},
+	"k8s.pod.exposures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
+	},
 	"k8s.pod.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetNode()).ToDataRes(types.Resource("k8s.node"))
 	},
@@ -2685,6 +2688,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.secret.isUnused": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sSecret).GetIsUnused()).ToDataRes(types.Bool)
+	},
+	"k8s.secret.hasExpiredCertificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetHasExpiredCertificate()).ToDataRes(types.Bool)
+	},
+	"k8s.secret.certificateExpiry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetCertificateExpiry()).ToDataRes(types.Time)
 	},
 	"k8s.configmap.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sConfigmap).GetId()).ToDataRes(types.String)
@@ -5855,6 +5864,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).Services, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.exposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).Exposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).Node, ok = plugin.RawToTValue[*mqlK8sNode](v.Value, v.Error)
 		return
@@ -8097,6 +8110,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.secret.isUnused": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sSecret).IsUnused, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.secret.hasExpiredCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).HasExpiredCertificate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.secret.certificateExpiry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).CertificateExpiry, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"k8s.configmap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13589,6 +13610,7 @@ type mqlK8sPod struct {
 	RunningImageDigests           plugin.TValue[[]any]
 	HasImageDigestDrift           plugin.TValue[bool]
 	Services                      plugin.TValue[[]any]
+	Exposures                     plugin.TValue[[]any]
 	Node                          plugin.TValue[*mqlK8sNode]
 	NodeName                      plugin.TValue[string]
 	NodeSelector                  plugin.TValue[map[string]any]
@@ -14014,6 +14036,22 @@ func (c *mqlK8sPod) GetServices() *plugin.TValue[[]any] {
 		}
 
 		return c.services()
+	})
+}
+
+func (c *mqlK8sPod) GetExposures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Exposures, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.pod", c.__id, "exposures")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.exposures()
 	})
 }
 
@@ -18278,6 +18316,8 @@ type mqlK8sSecret struct {
 	IsServiceAccountToken plugin.TValue[bool]
 	IsImagePullSecret     plugin.TValue[bool]
 	IsUnused              plugin.TValue[bool]
+	HasExpiredCertificate plugin.TValue[bool]
+	CertificateExpiry     plugin.TValue[*time.Time]
 }
 
 // createK8sSecret creates a new instance of this resource
@@ -18446,6 +18486,18 @@ func (c *mqlK8sSecret) GetIsImagePullSecret() *plugin.TValue[bool] {
 func (c *mqlK8sSecret) GetIsUnused() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsUnused, func() (bool, error) {
 		return c.isUnused()
+	})
+}
+
+func (c *mqlK8sSecret) GetHasExpiredCertificate() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasExpiredCertificate, func() (bool, error) {
+		return c.hasExpiredCertificate()
+	})
+}
+
+func (c *mqlK8sSecret) GetCertificateExpiry() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CertificateExpiry, func() (*time.Time, error) {
+		return c.certificateExpiry()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -1052,6 +1052,7 @@ k8s.pod.dnsPolicy 13.0.16
 k8s.pod.dropsAllCapabilities 13.2.2
 k8s.pod.enableServiceLinks 13.0.16
 k8s.pod.ephemeralContainers 9.0.0
+k8s.pod.exposures 13.3.4
 k8s.pod.hasCpuLimit 13.3.1
 k8s.pod.hasImageDigestDrift 13.3.1
 k8s.pod.hasMemoryLimit 13.3.1
@@ -1375,8 +1376,10 @@ k8s.rolebindings 9.0.0
 k8s.roles 9.0.0
 k8s.secret 9.0.0
 k8s.secret.annotations 9.0.0
+k8s.secret.certificateExpiry 13.3.4
 k8s.secret.certificates 9.0.2
 k8s.secret.created 9.0.0
+k8s.secret.hasExpiredCertificate 13.3.4
 k8s.secret.id 9.0.0
 k8s.secret.isImagePullSecret 13.3.3
 k8s.secret.isServiceAccountToken 13.3.3

--- a/providers/k8s/resources/secret_hygiene.go
+++ b/providers/k8s/resources/secret_hygiene.go
@@ -4,6 +4,10 @@
 package resources
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -57,4 +61,61 @@ func (k *mqlK8sSecret) isUnused() (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// tlsCertificates parses the certificates in the secret's tls.crt chain. It
+// returns nil for non-TLS secrets and skips any PEM block that is not a
+// parseable certificate rather than failing the whole query.
+func (k *mqlK8sSecret) tlsCertificates() []*x509.Certificate {
+	if k.obj == nil || k.obj.Type != corev1.SecretTypeTLS {
+		return nil
+	}
+	raw, ok := k.obj.Data["tls.crt"]
+	if !ok {
+		return nil
+	}
+
+	var certs []*x509.Certificate
+	rest := raw
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			certs = append(certs, cert)
+		}
+	}
+	return certs
+}
+
+func (k *mqlK8sSecret) hasExpiredCertificate() (bool, error) {
+	now := time.Now()
+	for _, cert := range k.tlsCertificates() {
+		if now.After(cert.NotAfter) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// certificateExpiry returns the earliest notAfter across the secret's
+// certificates, the binding constraint for the chain. It is null when the
+// secret holds no certificate.
+func (k *mqlK8sSecret) certificateExpiry() (*time.Time, error) {
+	certs := k.tlsCertificates()
+	if len(certs) == 0 {
+		return nil, nil
+	}
+	earliest := certs[0].NotAfter
+	for _, cert := range certs[1:] {
+		if cert.NotAfter.Before(earliest) {
+			earliest = cert.NotAfter
+		}
+	}
+	return &earliest, nil
 }


### PR DESCRIPTION
Small, every-cluster polish that completes the exposure attack-path graph (#8598) and adds certificate hygiene on top of the existing secret model.

## What it adds

- **`k8s.pod.exposures`** — the network exposures (Service, Ingress, or Gateway) that route to this pod, the inverse of `k8s.networkExposure.pods` from #8598. Lets a query pivot from a risky workload *to* the internet exposure that reaches it, closing the graph symmetry (we shipped `pod.services` but not the exposure back-ref).
- **`k8s.secret.hasExpiredCertificate`** / **`k8s.secret.certificateExpiry`** — parse the `tls.crt` chain and report whether any certificate has expired and the earliest `notAfter` (the binding constraint for the whole chain; null when the secret holds no certificate).

## Notes

- The certificate data is parsed directly from the secret's PEM with `crypto/x509`, independent of the network provider. `secret.certificates()` returns cross-provider shared resources that can't be read from Go in this package, and the raw `tls.crt` bytes are already on hand, so a direct parse is the clean, self-contained path.
- No new API permissions (reuses the already-required reads); `.lr.versions` entries at `13.3.4` (next unused patch above the in-flight `13.3.3`, so the fields don't appear to predate their resources); no provider version bump.

```mql
# privileged workloads that are NOT internet-exposed (and the inverse for triage)
k8s.pods.where(runsPrivileged).all(exposures.none(internetExposed))

# TLS secrets expiring within 30 days
k8s.secrets.where(certificateExpiry != null && certificateExpiry < time.now + time.day * 30)
```

## Testing

`pod.exposures` is tested against the existing `exposure_targets.yaml` fixture (a pod behind a public Service/Ingress/Gateway reports them; a pod nothing selects reports none) and verified end-to-end with `mql run k8s` (web-1 pivots to all three exposures). The certificate predicates are tested against generated valid, expired, mixed-chain, and non-TLS secrets so expiry is deterministic.