### PR TITLE
🎉 k8s-13.4.0

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.3.0",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### k8s (13.4.0)
- ✨ k8s: pod.exposures back-ref + secret certificate-expiry predicates (#8599)
- ✨ k8s: exposure→workload attack paths + secret hygiene predicates (#8598)
- ✨ k8s: effective-access RBAC (k8s.rbacSubjects + k8s.rbac.whoCan) (#8594)
- feat(k8s): model Kubernetes network posture (#8593)
- ✨ k8s: authoritative RBAC via SubjectAccessReview (k8s.accessReview) (#8592)
- k8s: add image pull-policy and unpinned-image provenance rollups (#8590)
- k8s: expose running image digests and digest drift on pods (#8591)
- k8s: add image-provenance rollups to workloads (#8589)
- k8s: add admission-enforcement posture predicates (#8588)
- k8s: add Secret-consumption rollups to workloads (#8587)
- k8s: add container resource-limit rollups to workloads (#8586)
- k8s: add effective-access rollups to service accounts (#8585)
- k8s: add RBAC binding-level access rollups (#8584)
- k8s: compute Pod Security Standards level for workloads (#8582)
- 🐛 k8s: fix admission DELETE panic, discovery error swallowing, and SA nil deref (#8578)
- k8s: add seccomp profile rollup predicates to workloads (#8581)