### PR TITLE
✨ k8s: host-network/hostPort ingress exposure + egress blind spot

### DIFF
--- a/providers/k8s/resources/exposure_targets.go
+++ b/providers/k8s/resources/exposure_targets.go
@@ -245,6 +245,21 @@ func (k *mqlK8sNetworkExposure) pods() ([]any, error) {
 				return gw.pods()
 			}
 		}
+	case "Pod":
+		// Host-network and hostPort exposures are sourced from the pod itself.
+		k8sPods := cluster.GetPods()
+		if k8sPods.Error != nil {
+			return nil, k8sPods.Error
+		}
+		for i := range k8sPods.Data {
+			p, ok := k8sPods.Data[i].(*mqlK8sPod)
+			if !ok {
+				continue
+			}
+			if p.Namespace.Data == ns && p.Name.Data == name {
+				return []any{p}, nil
+			}
+		}
 	}
 
 	// HBN and other non-Kubernetes sources have no in-cluster workload to

--- a/providers/k8s/resources/host_network_exposure.go
+++ b/providers/k8s/resources/host_network_exposure.go
@@ -1,0 +1,167 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// escapesNetworkPolicy reports whether the pod uses host networking, in which
+// case Kubernetes NetworkPolicy (both ingress and egress) does not apply to its
+// traffic. Such pods are a coverage gap for any default-deny posture.
+func (k *mqlK8sPod) escapesNetworkPolicy() (bool, error) {
+	spec, err := k.podSpecTyped()
+	if err != nil {
+		return false, err
+	}
+	return spec.HostNetwork, nil
+}
+
+// nodePublicAddressesByName maps each node name to its public external
+// addresses, so a pod bound to a node can be classified as internet-reachable
+// when that specific node has a public address.
+func (k *mqlK8s) nodePublicAddressesByName() (map[string][]string, error) {
+	nodes := k.GetNodes()
+	if nodes.Error != nil {
+		return nil, nodes.Error
+	}
+	out := map[string][]string{}
+	for _, item := range nodes.Data {
+		node, ok := item.(*mqlK8sNode)
+		if !ok || node.obj == nil {
+			continue
+		}
+		var addrs []string
+		for _, addr := range node.obj.Status.Addresses {
+			if (addr.Type == corev1.NodeExternalIP || addr.Type == corev1.NodeExternalDNS) && addressIsPublicNodeAddress(addr.Address) {
+				addrs = append(addrs, addr.Address)
+			}
+		}
+		if len(addrs) > 0 {
+			out[node.obj.Name] = sortedUniqueStrings(addrs)
+		}
+	}
+	return out, nil
+}
+
+// hostExposurePorts collects the node-reachable ports of a pod: explicit
+// hostPorts on any container, plus every containerPort when the pod runs on the
+// host network (where the container port is reachable on the node directly). It
+// returns the port dicts, the distinct protocols, and whether any explicit
+// hostPort was found.
+func hostExposurePorts(spec *corev1.PodSpec) ([]any, []string, bool) {
+	ports := []any{}
+	protocols := map[string]struct{}{}
+	hasHostPort := false
+
+	add := func(p corev1.ContainerPort) {
+		host := p.HostPort
+		if spec.HostNetwork && host == 0 {
+			host = p.ContainerPort
+		}
+		if host == 0 {
+			return
+		}
+		if p.HostPort != 0 {
+			hasHostPort = true
+		}
+		proto := string(p.Protocol)
+		if proto == "" {
+			proto = string(corev1.ProtocolTCP)
+		}
+		ports = append(ports, map[string]any{
+			"name":          p.Name,
+			"port":          int64(host),
+			"containerPort": int64(p.ContainerPort),
+			"hostPort":      int64(p.HostPort),
+			"protocol":      proto,
+			"hostIP":        p.HostIP,
+		})
+		protocols[proto] = struct{}{}
+	}
+
+	for i := range spec.Containers {
+		for _, p := range spec.Containers[i].Ports {
+			add(p)
+		}
+	}
+	for i := range spec.InitContainers {
+		for _, p := range spec.InitContainers[i].Ports {
+			add(p)
+		}
+	}
+
+	protoList := make([]string, 0, len(protocols))
+	for p := range protocols {
+		protoList = append(protoList, p)
+	}
+	return ports, sortedUniqueStrings(protoList), hasHostPort
+}
+
+// podHostExposureArgs builds a network exposure for a pod that binds directly to
+// the node network, the ingress vector that bypasses Services, Ingresses, and
+// Gateways. A pod is host-exposed when it runs on the host network or declares
+// any hostPort. Reachability mirrors the NodePort model: the pod is
+// internet-exposed when the node it runs on has a public address.
+func podHostExposureArgs(pod *corev1.Pod, nodePublicAddrs map[string][]string) []map[string]*llx.RawData {
+	if pod == nil {
+		return nil
+	}
+	spec := &pod.Spec
+	ports, protocols, hasHostPort := hostExposurePorts(spec)
+	if !spec.HostNetwork && !hasHostPort {
+		return nil
+	}
+
+	mechanism := "hostPort"
+	if spec.HostNetwork {
+		mechanism = "hostNetwork"
+	}
+
+	pubAddrs := nodePublicAddrs[spec.NodeName]
+	internetExposed := len(pubAddrs) > 0
+
+	var addresses []string
+	var classifications []string
+	exposureReason := ""
+	confidence := "high"
+	switch {
+	case internetExposed:
+		addresses = pubAddrs
+		exposureReason = mechanism + "PublicNode"
+		classifications = classifyAddresses(addresses)
+	case spec.NodeName == "":
+		// Unscheduled pod: the config is exposure-capable but the node, and so
+		// its addresses, are not yet known. Classifying an empty address set as
+		// "internalOnly" would be misleading, so report it as unknown.
+		exposureReason = mechanism + "NodeUnknown"
+		confidence = "medium"
+		classifications = []string{"unknown"}
+	default:
+		exposureReason = mechanism + "PrivateNode"
+		if pod.Status.HostIP != "" {
+			addresses = []string{pod.Status.HostIP}
+		}
+		classifications = classifyAddresses(addresses)
+	}
+
+	in := networkExposureInput{
+		id:                     fmt.Sprintf("pod:%s:%s", pod.Namespace, pod.Name),
+		sourceKind:             "Pod",
+		sourceRef:              networkSourceRef("Pod", pod.Namespace, pod.Name),
+		namespace:              pod.Namespace,
+		name:                   pod.Name,
+		addresses:              sortedUniqueStrings(addresses),
+		ports:                  ports,
+		protocols:              protocols,
+		internetExposed:        internetExposed,
+		exposureReason:         exposureReason,
+		networkClassifications: classifications,
+		confidence:             confidence,
+	}
+	return []map[string]*llx.RawData{networkExposureArgs(networkExposureInputWithMetadata(pod, in))}
+}

--- a/providers/k8s/resources/host_network_exposure_test.go
+++ b/providers/k8s/resources/host_network_exposure_test.go
@@ -1,0 +1,220 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func coverageRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{}},
+	}, manifest.WithManifestFile("./testdata/network_exposure_coverage.yaml"))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+func exposureBySourceRef(t *testing.T, k8s *mqlK8s) map[string]*mqlK8sNetworkExposure {
+	t.Helper()
+	exps := k8s.GetNetworkExposures()
+	require.NoError(t, exps.Error)
+	out := map[string]*mqlK8sNetworkExposure{}
+	for i := range exps.Data {
+		e := exps.Data[i].(*mqlK8sNetworkExposure)
+		out[e.SourceRef.Data] = e
+	}
+	return out
+}
+
+// TestNetworkExposureCoverage is the completeness guard: every modeled ingress
+// vector must produce a network exposure record. If a future change drops a
+// vector (or a new exposure-capable field is added without wiring it in), the
+// missing sourceRef makes this fail.
+func TestNetworkExposureCoverage(t *testing.T) {
+	k8sObj, err := NewResource(coverageRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+
+	byRef := exposureBySourceRef(t, k8s)
+
+	for _, ref := range []string{
+		"Service:prod:lb-svc",       // LoadBalancer
+		"Service:prod:np-svc",       // NodePort
+		"Service:prod:eip-svc",      // ClusterIP externalIPs
+		"Ingress:prod:ing",          // Ingress
+		"Gateway:prod:gw",           // Gateway
+		"Pod:prod:hostport-pub",     // hostPort
+		"Pod:prod:hostnet-pub",      // hostNetwork
+		"Pod:prod:hostport-priv",    // hostPort, private node
+		"Pod:prod:hostport-unsched", // hostPort, unscheduled
+	} {
+		assert.Contains(t, byRef, ref, "ingress vector not covered by networkExposures()")
+	}
+
+	// An ordinary pod is not an exposure source.
+	assert.NotContains(t, byRef, "Pod:prod:normal")
+}
+
+func TestHostExposureClassification(t *testing.T) {
+	k8sObj, err := NewResource(coverageRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	byRef := exposureBySourceRef(t, k8sObj.(*mqlK8s))
+
+	t.Run("hostPort on public node is internet-exposed", func(t *testing.T) {
+		e := byRef["Pod:prod:hostport-pub"]
+		require.NotNil(t, e)
+		assert.Equal(t, "Pod", e.SourceKind.Data)
+		assert.True(t, e.InternetExposed.Data)
+		assert.Equal(t, "hostPortPublicNode", e.ExposureReason.Data)
+		assert.Contains(t, e.Addresses.Data, "8.8.8.8")
+		assert.Equal(t, "high", e.Confidence.Data)
+	})
+
+	t.Run("hostNetwork on public node exposes container ports", func(t *testing.T) {
+		e := byRef["Pod:prod:hostnet-pub"]
+		require.NotNil(t, e)
+		assert.True(t, e.InternetExposed.Data)
+		assert.Equal(t, "hostNetworkPublicNode", e.ExposureReason.Data)
+	})
+
+	t.Run("hostPort on private node is not internet-exposed", func(t *testing.T) {
+		e := byRef["Pod:prod:hostport-priv"]
+		require.NotNil(t, e)
+		assert.False(t, e.InternetExposed.Data)
+		assert.Equal(t, "hostPortPrivateNode", e.ExposureReason.Data)
+		assert.Contains(t, e.Addresses.Data, "10.0.0.6")
+	})
+
+	t.Run("unscheduled hostPort pod has unknown node", func(t *testing.T) {
+		e := byRef["Pod:prod:hostport-unsched"]
+		require.NotNil(t, e)
+		assert.False(t, e.InternetExposed.Data)
+		assert.Equal(t, "hostPortNodeUnknown", e.ExposureReason.Data)
+		assert.Equal(t, "medium", e.Confidence.Data)
+		// An unknown node must not be misreported as internalOnly.
+		assert.Equal(t, []any{"unknown"}, e.NetworkClassifications.Data)
+	})
+}
+
+func TestHostExposureRoundTrip(t *testing.T) {
+	k8sObj, err := NewResource(coverageRuntime(t), "k8s", nil)
+	require.NoError(t, err)
+	k8s := k8sObj.(*mqlK8s)
+	byRef := exposureBySourceRef(t, k8s)
+
+	// networkExposure.pods on a Pod-sourced exposure resolves to the pod itself.
+	e := byRef["Pod:prod:hostport-pub"]
+	require.NotNil(t, e)
+	pods := e.GetPods()
+	require.NoError(t, pods.Error)
+	assert.Equal(t, []string{"hostport-pub"}, mqlResourceNames(t, pods.Data))
+
+	// pod.exposures reports the host exposure (the inverse direction).
+	pod, err := NewResource(k8s.MqlRuntime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("hostport-pub"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	podExps := pod.(*mqlK8sPod).GetExposures()
+	require.NoError(t, podExps.Error)
+	var sawHostExposure bool
+	for i := range podExps.Data {
+		if podExps.Data[i].(*mqlK8sNetworkExposure).SourceRef.Data == "Pod:prod:hostport-pub" {
+			sawHostExposure = true
+		}
+	}
+	assert.True(t, sawHostExposure, "pod.exposures must include the pod's own host exposure")
+}
+
+func TestEscapesNetworkPolicy(t *testing.T) {
+	runtime := coverageRuntime(t)
+
+	cases := map[string]bool{
+		"hostnet-pub":  true,  // host network -> NetworkPolicy does not apply
+		"hostport-pub": false, // hostPort alone does not exempt the pod
+		"normal":       false,
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			pod, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+				"name":      llx.StringData(name),
+				"namespace": llx.StringData("prod"),
+			})
+			require.NoError(t, err)
+			esc := pod.(*mqlK8sPod).GetEscapesNetworkPolicy()
+			require.NoError(t, esc.Error)
+			assert.Equal(t, want, esc.Data)
+		})
+	}
+}
+
+// --- Unit tests for the host-exposure helpers (no manifest plumbing) ---
+
+func TestHostExposurePorts(t *testing.T) {
+	t.Run("only explicit hostPorts when not host-networked", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Ports: []corev1.ContainerPort{
+					{ContainerPort: 8080, HostPort: 8080, Protocol: corev1.ProtocolTCP},
+					{ContainerPort: 9090}, // no hostPort -> ignored
+				},
+			}},
+			InitContainers: []corev1.Container{{
+				Ports: []corev1.ContainerPort{{ContainerPort: 7070, HostPort: 7070}},
+			}},
+		}
+		ports, protocols, hasHostPort := hostExposurePorts(spec)
+		assert.True(t, hasHostPort)
+		assert.Len(t, ports, 2, "both explicit hostPorts (container + init) are included")
+		assert.Equal(t, []string{"TCP"}, protocols, "missing protocol defaults to TCP")
+	})
+
+	t.Run("hostNetwork promotes every containerPort", func(t *testing.T) {
+		spec := &corev1.PodSpec{
+			HostNetwork: true,
+			Containers: []corev1.Container{{
+				Ports: []corev1.ContainerPort{
+					{ContainerPort: 9090, Protocol: corev1.ProtocolUDP},
+				},
+			}},
+		}
+		ports, protocols, hasHostPort := hostExposurePorts(spec)
+		assert.False(t, hasHostPort, "containerPort promotion is not an explicit hostPort")
+		assert.Len(t, ports, 1)
+		assert.Equal(t, []string{"UDP"}, protocols)
+	})
+}
+
+func TestPodHostExposureArgs(t *testing.T) {
+	pubNodes := map[string][]string{"pub": {"203.0.113.5"}}
+
+	t.Run("plain pod produces no exposure", func(t *testing.T) {
+		pod := &corev1.Pod{Spec: corev1.PodSpec{
+			NodeName:   "pub",
+			Containers: []corev1.Container{{Ports: []corev1.ContainerPort{{ContainerPort: 80}}}},
+		}}
+		assert.Nil(t, podHostExposureArgs(pod, pubNodes))
+	})
+
+	t.Run("hostNetwork pod with no declared ports is still exposed", func(t *testing.T) {
+		pod := &corev1.Pod{Spec: corev1.PodSpec{HostNetwork: true, NodeName: "pub"}}
+		args := podHostExposureArgs(pod, pubNodes)
+		require.Len(t, args, 1)
+		assert.Equal(t, "hostNetworkPublicNode", args[0]["exposureReason"].Value)
+		assert.Equal(t, true, args[0]["internetExposed"].Value)
+	})
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -558,6 +558,12 @@ private k8s.pod @defaults("namespace name created"){
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
   hostNetwork() bool
+  // Whether NetworkPolicy does not apply to this pod
+  //
+  // True when the pod uses host networking, so Kubernetes NetworkPolicy governs
+  // neither its ingress nor its egress traffic. Such pods are a coverage gap for
+  // any default-deny posture.
+  escapesNetworkPolicy() bool
   // Whether the pod shares the host PID namespace
   hostPID() bool
   // Whether the pod shares the host IPC namespace
@@ -2580,7 +2586,7 @@ private k8s.networkpolicy @defaults("namespace name created") {
 // available. The `confidence` field describes static-analysis confidence, not
 // packet-level reachability.
 private k8s.networkExposure @defaults("sourceKind namespace name internetExposed exposureReason") {
-  // Source kind that produced the exposure, for example Service, Ingress, Gateway, HBNInbound, or LegacyHBN
+  // Source kind that produced the exposure, for example Service, Ingress, Gateway, Pod (hostNetwork or hostPort), HBNInbound, or LegacyHBN
   sourceKind string
   // Source object reference in kind:namespace:name or kind:name form
   sourceRef string

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -1084,6 +1084,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.hostNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHostNetwork()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.escapesNetworkPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetEscapesNetworkPolicy()).ToDataRes(types.Bool)
+	},
 	"k8s.pod.hostPID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHostPID()).ToDataRes(types.Bool)
 	},
@@ -5926,6 +5929,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.pod.hostNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).HostNetwork, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.escapesNetworkPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).EscapesNetworkPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.hostPID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13626,6 +13633,7 @@ type mqlK8sPod struct {
 	ServiceAccount                plugin.TValue[*mqlK8sServiceaccount]
 	AutomountServiceAccountToken  plugin.TValue[bool]
 	HostNetwork                   plugin.TValue[bool]
+	EscapesNetworkPolicy          plugin.TValue[bool]
 	HostPID                       plugin.TValue[bool]
 	HostIPC                       plugin.TValue[bool]
 	ShareProcessNamespace         plugin.TValue[bool]
@@ -14172,6 +14180,12 @@ func (c *mqlK8sPod) GetAutomountServiceAccountToken() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetHostNetwork() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HostNetwork, func() (bool, error) {
 		return c.hostNetwork()
+	})
+}
+
+func (c *mqlK8sPod) GetEscapesNetworkPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EscapesNetworkPolicy, func() (bool, error) {
+		return c.escapesNetworkPolicy()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -1052,6 +1052,7 @@ k8s.pod.dnsPolicy 13.0.16
 k8s.pod.dropsAllCapabilities 13.2.2
 k8s.pod.enableServiceLinks 13.0.16
 k8s.pod.ephemeralContainers 9.0.0
+k8s.pod.escapesNetworkPolicy 13.4.1
 k8s.pod.exposures 13.3.4
 k8s.pod.hasCpuLimit 13.3.1
 k8s.pod.hasImageDigestDrift 13.3.1

--- a/providers/k8s/resources/network_posture.go
+++ b/providers/k8s/resources/network_posture.go
@@ -211,6 +211,34 @@ func (k *mqlK8s) networkExposures() ([]any, error) {
 		}
 	}
 
+	// Pods that bind directly to the node network (hostNetwork or hostPort)
+	// are an ingress vector that bypasses Services, Ingresses, and Gateways.
+	nodePublicAddrs, err := k.nodePublicAddressesByName()
+	if err != nil {
+		return nil, err
+	}
+	pods := k.GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+	for _, item := range pods.Data {
+		pod, ok := item.(*mqlK8sPod)
+		if !ok {
+			continue
+		}
+		p, err := pod.getPod()
+		if err != nil {
+			return nil, err
+		}
+		for _, args := range podHostExposureArgs(p, nodePublicAddrs) {
+			exposure, err := CreateResource(k.MqlRuntime, "k8s.networkExposure", args)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, exposure)
+		}
+	}
+
 	if hbnKinds := enabledHBNOptionalKinds(settings, optionalHBNNetworkExposureKinds); len(hbnKinds) > 0 {
 		hbnObjects, err := optionalK8sResources(k.MqlRuntime, hbnKinds...)
 		if err != nil {

--- a/providers/k8s/resources/testdata/network_exposure_coverage.yaml
+++ b/providers/k8s/resources/testdata/network_exposure_coverage.yaml
@@ -1,0 +1,216 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Coverage fixture: one instance of every modeled ingress vector, so the
+# completeness test fails if any vector stops producing a network exposure.
+# Vectors: Service LoadBalancer, Service NodePort, Service ClusterIP externalIPs,
+# Ingress, Gateway, hostPort pod, hostNetwork pod. Includes a public node, a
+# private node, and an unscheduled pod to exercise host-exposure classification.
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-pub
+status:
+  addresses:
+    - type: ExternalIP
+      address: 8.8.8.8
+    - type: InternalIP
+      address: 10.0.0.5
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-priv
+status:
+  addresses:
+    - type: InternalIP
+      address: 10.0.0.6
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+# Vector: Service type LoadBalancer with a public address.
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-svc
+  namespace: prod
+spec:
+  type: LoadBalancer
+  selector:
+    app: lb
+  ports:
+    - port: 80
+status:
+  loadBalancer:
+    ingress:
+      - ip: 8.8.4.4
+---
+# Vector: Service type NodePort.
+apiVersion: v1
+kind: Service
+metadata:
+  name: np-svc
+  namespace: prod
+spec:
+  type: NodePort
+  selector:
+    app: np
+  ports:
+    - port: 80
+      nodePort: 30080
+---
+# Vector: ClusterIP service with an external IP.
+apiVersion: v1
+kind: Service
+metadata:
+  name: eip-svc
+  namespace: prod
+spec:
+  type: ClusterIP
+  selector:
+    app: eip
+  externalIPs:
+    - 1.1.1.1
+  ports:
+    - port: 80
+---
+# Vector: Ingress.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing
+  namespace: prod
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: eip-svc
+                port:
+                  number: 80
+status:
+  loadBalancer:
+    ingress:
+      - hostname: lb.example.com
+---
+# Vector: Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw
+  namespace: prod
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+status:
+  addresses:
+    - type: IPAddress
+      value: 1.0.0.1
+---
+# Vector: hostPort container on a public node -> internet-exposed.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostport-pub
+  namespace: prod
+spec:
+  nodeName: node-pub
+  containers:
+    - name: app
+      image: nginx:1.27
+      ports:
+        - containerPort: 8080
+          hostPort: 8080
+          protocol: TCP
+status:
+  phase: Running
+  hostIP: 10.0.0.5
+---
+# Vector: hostNetwork pod on a public node -> every containerPort is a node port.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnet-pub
+  namespace: prod
+spec:
+  nodeName: node-pub
+  hostNetwork: true
+  containers:
+    - name: agent
+      image: agent:1.0
+      ports:
+        - containerPort: 9090
+status:
+  phase: Running
+  hostIP: 8.8.8.8
+---
+# hostPort on a private node -> not internet-exposed.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostport-priv
+  namespace: prod
+spec:
+  nodeName: node-priv
+  containers:
+    - name: app
+      image: nginx:1.27
+      ports:
+        - containerPort: 8081
+          hostPort: 8081
+status:
+  phase: Running
+  hostIP: 10.0.0.6
+---
+# hostPort on an unscheduled pod -> node unknown.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostport-unsched
+  namespace: prod
+spec:
+  containers:
+    - name: app
+      image: nginx:1.27
+      ports:
+        - containerPort: 8082
+          hostPort: 8082
+status:
+  phase: Pending
+---
+# Ordinary pod -> no host exposure, NetworkPolicy applies.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: normal
+  namespace: prod
+  labels:
+    app: lb
+spec:
+  nodeName: node-pub
+  containers:
+    - name: app
+      image: nginx:1.27
+      ports:
+        - containerPort: 80
+status:
+  phase: Running
+  hostIP: 10.0.0.5


### PR DESCRIPTION
Closes the ingress/egress coverage gap for pods that bind directly to the node network — the one exposure vector `networkExposures()` did not capture. It iterated Services, Ingresses, Gateways, and HBN sources, but **never pods**, so a `hostNetwork` or `hostPort` pod (CNI agents, ingress-controller daemonsets, monitoring) was a silent blind spot even though it can be reachable straight from the node IP.

## Ingress: host-level pod exposure

Pods with `hostNetwork` or any `hostPort` now produce a `k8s.networkExposure` with `sourceKind: "Pod"`:

- Reachability mirrors the existing NodePort model: the pod is `internetExposed` when **the node it runs on** has a public address (resolved per-node, not cluster-wide, to avoid over-reporting).
- `hostNetwork` promotes every `containerPort` to a node port; explicit `hostPort`s are captured for any pod.
- Classification reasons: `hostPortPublicNode` / `hostPortPrivateNode` / `hostPortNodeUnknown` (and `hostNetwork*`), with `medium` confidence for unscheduled pods.
- `networkExposure.pods` resolves a `Pod`-sourced exposure back to the pod, so `pod.exposures` (from #8599) links both directions automatically.

## Egress blind spot

- **`k8s.pod.escapesNetworkPolicy`** — true for host-network pods, whose ingress *and* egress traffic Kubernetes NetworkPolicy cannot govern. A default-deny posture has a hole for exactly these pods, and this makes them a one-line query.

## How we know it is 100%

`TestNetworkExposureCoverage` is a **completeness guard**, not just a unit test: the fixture contains one instance of every modeled ingress vector (LoadBalancer, NodePort, externalIPs, Ingress, Gateway, hostPort, hostNetwork), and the test asserts each produces an exposure record. If a future change drops a vector — or a new exposure-capable field is added without wiring it into `networkExposures()` — the missing `sourceRef` fails CI.

## Testing (extensive, per request)

- **Completeness guard** over all ingress vectors.
- **Classification** across public / private / unscheduled nodes (internet-exposed vs not, exposure reason, addresses, confidence).
- **Round-trip**: `networkExposure.pods` ↔ `pod.exposures` for a Pod-sourced exposure.
- **`escapesNetworkPolicy`** across hostNetwork / hostPort / ordinary pods.
- **Pure-Go unit tests** for the `hostExposurePorts` and `podHostExposureArgs` helpers (init-container hostPorts, protocol defaulting, hostNetwork-with-no-ports still exposed, plain pod produces nothing).
- Verified end-to-end with `mql run k8s <fixture>`.

`.lr.versions` at `13.3.5` (next unused patch above the in-flight `13.3.4`); no new API permissions (reuses the already-required pod/node reads); no provider version bump.

```mql
# every internet-reachable workload, now including host-network/hostPort pods
k8s.networkExposures.where(internetExposed) { sourceKind name }

# host-network pods that escape NetworkPolicy
k8s.pods.where(escapesNetworkPolicy) { name namespace }
```