### PR TITLE
✨ k8s: AppArmor, sysctl, and procMount hardening predicates on workloads

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -438,6 +438,12 @@ private k8s.pod @defaults("namespace name created"){
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -690,6 +696,12 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -852,6 +864,12 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -1013,6 +1031,12 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -1182,6 +1206,12 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -1331,6 +1361,12 @@ private k8s.job @defaults("namespace name succeeded failed created") {
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)
@@ -1505,6 +1541,12 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") {
   // (container-level setting wins over the pod default). An unset or Unconfined
   // profile on any container makes this false.
   hasSeccompProfile() bool
+  // Whether any container runs with an Unconfined AppArmor profile
+  usesUnconfinedAppArmor() bool
+  // Whether the pod requests a sysctl outside the kubelet safe set
+  hasUnsafeSysctls() bool
+  // Whether any container sets procMount to Unmasked
+  usesUnmaskedProcMount() bool
   // Whether every container sets a CPU limit (regular and init containers)
   hasCpuLimit() bool
   // Whether every container sets a memory limit (regular and init containers)

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -922,6 +922,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.pod.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
+	},
 	"k8s.pod.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHasCpuLimit()).ToDataRes(types.Bool)
 	},
@@ -1228,6 +1237,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.deployment.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
+	},
 	"k8s.deployment.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetHasCpuLimit()).ToDataRes(types.Bool)
 	},
@@ -1417,6 +1435,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.daemonset.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
+	},
 	"k8s.daemonset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetHasCpuLimit()).ToDataRes(types.Bool)
 	},
@@ -1602,6 +1629,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
 	},
 	"k8s.statefulset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetHasCpuLimit()).ToDataRes(types.Bool)
@@ -1804,6 +1840,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetHasSeccompProfile()).ToDataRes(types.Bool)
 	},
+	"k8s.replicaset.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
+	},
 	"k8s.replicaset.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetHasCpuLimit()).ToDataRes(types.Bool)
 	},
@@ -1974,6 +2019,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.job.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.job.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.job.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
 	},
 	"k8s.job.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetHasCpuLimit()).ToDataRes(types.Bool)
@@ -2181,6 +2235,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetHasSeccompProfile()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.usesUnconfinedAppArmor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesUnconfinedAppArmor()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.hasUnsafeSysctls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHasUnsafeSysctls()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.usesUnmaskedProcMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetUsesUnmaskedProcMount()).ToDataRes(types.Bool)
 	},
 	"k8s.cronjob.hasCpuLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetHasCpuLimit()).ToDataRes(types.Bool)
@@ -5715,6 +5778,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -6127,6 +6202,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -6383,6 +6470,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -6633,6 +6732,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6907,6 +7018,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).HasCpuLimit, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -7137,6 +7260,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.job.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7417,6 +7552,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.hasSeccompProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).HasSeccompProfile, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesUnconfinedAppArmor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesUnconfinedAppArmor, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.hasUnsafeSysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HasUnsafeSysctls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.usesUnmaskedProcMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).UsesUnmaskedProcMount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.hasCpuLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13579,6 +13726,9 @@ type mqlK8sPod struct {
 	UsesHostPath                  plugin.TValue[bool]
 	UsesUnconfinedSeccomp         plugin.TValue[bool]
 	HasSeccompProfile             plugin.TValue[bool]
+	UsesUnconfinedAppArmor        plugin.TValue[bool]
+	HasUnsafeSysctls              plugin.TValue[bool]
+	UsesUnmaskedProcMount         plugin.TValue[bool]
 	HasCpuLimit                   plugin.TValue[bool]
 	HasMemoryLimit                plugin.TValue[bool]
 	HasResourceLimits             plugin.TValue[bool]
@@ -13762,6 +13912,24 @@ func (c *mqlK8sPod) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sPod) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sPod) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -14451,6 +14619,9 @@ type mqlK8sDeployment struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	UsesUnconfinedAppArmor       plugin.TValue[bool]
+	HasUnsafeSysctls             plugin.TValue[bool]
+	UsesUnmaskedProcMount        plugin.TValue[bool]
 	HasCpuLimit                  plugin.TValue[bool]
 	HasMemoryLimit               plugin.TValue[bool]
 	HasResourceLimits            plugin.TValue[bool]
@@ -14625,6 +14796,24 @@ func (c *mqlK8sDeployment) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sDeployment) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sDeployment) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -14972,6 +15161,9 @@ type mqlK8sDaemonset struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	UsesUnconfinedAppArmor       plugin.TValue[bool]
+	HasUnsafeSysctls             plugin.TValue[bool]
+	UsesUnmaskedProcMount        plugin.TValue[bool]
 	HasCpuLimit                  plugin.TValue[bool]
 	HasMemoryLimit               plugin.TValue[bool]
 	HasResourceLimits            plugin.TValue[bool]
@@ -15145,6 +15337,24 @@ func (c *mqlK8sDaemonset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -15486,6 +15696,9 @@ type mqlK8sStatefulset struct {
 	UsesHostPath                         plugin.TValue[bool]
 	UsesUnconfinedSeccomp                plugin.TValue[bool]
 	HasSeccompProfile                    plugin.TValue[bool]
+	UsesUnconfinedAppArmor               plugin.TValue[bool]
+	HasUnsafeSysctls                     plugin.TValue[bool]
+	UsesUnmaskedProcMount                plugin.TValue[bool]
 	HasCpuLimit                          plugin.TValue[bool]
 	HasMemoryLimit                       plugin.TValue[bool]
 	HasResourceLimits                    plugin.TValue[bool]
@@ -15664,6 +15877,24 @@ func (c *mqlK8sStatefulset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -16035,6 +16266,9 @@ type mqlK8sReplicaset struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	UsesUnconfinedAppArmor       plugin.TValue[bool]
+	HasUnsafeSysctls             plugin.TValue[bool]
+	UsesUnmaskedProcMount        plugin.TValue[bool]
 	HasCpuLimit                  plugin.TValue[bool]
 	HasMemoryLimit               plugin.TValue[bool]
 	HasResourceLimits            plugin.TValue[bool]
@@ -16203,6 +16437,24 @@ func (c *mqlK8sReplicaset) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -16514,6 +16766,9 @@ type mqlK8sJob struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	UsesUnconfinedAppArmor       plugin.TValue[bool]
+	HasUnsafeSysctls             plugin.TValue[bool]
+	UsesUnmaskedProcMount        plugin.TValue[bool]
 	HasCpuLimit                  plugin.TValue[bool]
 	HasMemoryLimit               plugin.TValue[bool]
 	HasResourceLimits            plugin.TValue[bool]
@@ -16694,6 +16949,24 @@ func (c *mqlK8sJob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sJob) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sJob) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 
@@ -17077,6 +17350,9 @@ type mqlK8sCronjob struct {
 	UsesHostPath                 plugin.TValue[bool]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
+	UsesUnconfinedAppArmor       plugin.TValue[bool]
+	HasUnsafeSysctls             plugin.TValue[bool]
+	UsesUnmaskedProcMount        plugin.TValue[bool]
 	HasCpuLimit                  plugin.TValue[bool]
 	HasMemoryLimit               plugin.TValue[bool]
 	HasResourceLimits            plugin.TValue[bool]
@@ -17247,6 +17523,24 @@ func (c *mqlK8sCronjob) GetUsesUnconfinedSeccomp() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetHasSeccompProfile() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSeccompProfile, func() (bool, error) {
 		return c.hasSeccompProfile()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesUnconfinedAppArmor() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnconfinedAppArmor, func() (bool, error) {
+		return c.usesUnconfinedAppArmor()
+	})
+}
+
+func (c *mqlK8sCronjob) GetHasUnsafeSysctls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUnsafeSysctls, func() (bool, error) {
+		return c.hasUnsafeSysctls()
+	})
+}
+
+func (c *mqlK8sCronjob) GetUsesUnmaskedProcMount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesUnmaskedProcMount, func() (bool, error) {
+		return c.usesUnmaskedProcMount()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -233,6 +233,7 @@ k8s.cronjob.hasMemoryLimit 13.3.1
 k8s.cronjob.hasResourceLimits 13.3.1
 k8s.cronjob.hasResourceRequests 13.3.1
 k8s.cronjob.hasSeccompProfile 13.3.1
+k8s.cronjob.hasUnsafeSysctls 13.4.1
 k8s.cronjob.hasWritableRootFilesystem 13.2.2
 k8s.cronjob.hostIPC 13.2.2
 k8s.cronjob.hostNetwork 13.2.2
@@ -273,7 +274,9 @@ k8s.cronjob.usesHostPath 13.2.2
 k8s.cronjob.usesImageDigest 13.3.1
 k8s.cronjob.usesLatestTag 13.3.1
 k8s.cronjob.usesSecretsAsEnv 13.3.1
+k8s.cronjob.usesUnconfinedAppArmor 13.4.1
 k8s.cronjob.usesUnconfinedSeccomp 13.3.1
+k8s.cronjob.usesUnmaskedProcMount 13.4.1
 k8s.cronjobs 9.0.0
 k8s.customresource 9.0.0
 k8s.customresource.annotations 9.0.0
@@ -308,6 +311,7 @@ k8s.daemonset.hasMemoryLimit 13.3.1
 k8s.daemonset.hasResourceLimits 13.3.1
 k8s.daemonset.hasResourceRequests 13.3.1
 k8s.daemonset.hasSeccompProfile 13.3.1
+k8s.daemonset.hasUnsafeSysctls 13.4.1
 k8s.daemonset.hasWritableRootFilesystem 13.2.2
 k8s.daemonset.hostIPC 13.2.2
 k8s.daemonset.hostNetwork 13.2.2
@@ -351,7 +355,9 @@ k8s.daemonset.usesHostPath 13.2.2
 k8s.daemonset.usesImageDigest 13.3.1
 k8s.daemonset.usesLatestTag 13.3.1
 k8s.daemonset.usesSecretsAsEnv 13.3.1
+k8s.daemonset.usesUnconfinedAppArmor 13.4.1
 k8s.daemonset.usesUnconfinedSeccomp 13.3.1
+k8s.daemonset.usesUnmaskedProcMount 13.4.1
 k8s.daemonsets 9.0.0
 k8s.deployment 9.0.0
 k8s.deployment.addedCapabilities 13.2.2
@@ -372,6 +378,7 @@ k8s.deployment.hasMemoryLimit 13.3.1
 k8s.deployment.hasResourceLimits 13.3.1
 k8s.deployment.hasResourceRequests 13.3.1
 k8s.deployment.hasSeccompProfile 13.3.1
+k8s.deployment.hasUnsafeSysctls 13.4.1
 k8s.deployment.hasWritableRootFilesystem 13.2.2
 k8s.deployment.hostIPC 13.2.2
 k8s.deployment.hostNetwork 13.2.2
@@ -416,7 +423,9 @@ k8s.deployment.usesHostPath 13.2.2
 k8s.deployment.usesImageDigest 13.3.1
 k8s.deployment.usesLatestTag 13.3.1
 k8s.deployment.usesSecretsAsEnv 13.3.1
+k8s.deployment.usesUnconfinedAppArmor 13.4.1
 k8s.deployment.usesUnconfinedSeccomp 13.3.1
+k8s.deployment.usesUnmaskedProcMount 13.4.1
 k8s.deployments 9.0.0
 k8s.egressNat 13.3.2
 k8s.egressNat.addresses 13.3.2
@@ -726,6 +735,7 @@ k8s.job.hasMemoryLimit 13.3.1
 k8s.job.hasResourceLimits 13.3.1
 k8s.job.hasResourceRequests 13.3.1
 k8s.job.hasSeccompProfile 13.3.1
+k8s.job.hasUnsafeSysctls 13.4.1
 k8s.job.hasWritableRootFilesystem 13.2.2
 k8s.job.hostIPC 13.2.2
 k8s.job.hostNetwork 13.2.2
@@ -769,7 +779,9 @@ k8s.job.usesHostPath 13.2.2
 k8s.job.usesImageDigest 13.3.1
 k8s.job.usesLatestTag 13.3.1
 k8s.job.usesSecretsAsEnv 13.3.1
+k8s.job.usesUnconfinedAppArmor 13.4.1
 k8s.job.usesUnconfinedSeccomp 13.3.1
+k8s.job.usesUnmaskedProcMount 13.4.1
 k8s.jobs 9.0.0
 k8s.lease 13.0.16
 k8s.lease.acquireTime 13.0.16
@@ -1060,6 +1072,7 @@ k8s.pod.hasMemoryLimit 13.3.1
 k8s.pod.hasResourceLimits 13.3.1
 k8s.pod.hasResourceRequests 13.3.1
 k8s.pod.hasSeccompProfile 13.3.1
+k8s.pod.hasUnsafeSysctls 13.4.1
 k8s.pod.hasWritableRootFilesystem 13.2.2
 k8s.pod.hostAliases 13.0.16
 k8s.pod.hostIP 13.0.16
@@ -1128,7 +1141,9 @@ k8s.pod.usesHostPath 13.2.2
 k8s.pod.usesImageDigest 13.3.1
 k8s.pod.usesLatestTag 13.3.1
 k8s.pod.usesSecretsAsEnv 13.3.1
+k8s.pod.usesUnconfinedAppArmor 13.4.1
 k8s.pod.usesUnconfinedSeccomp 13.3.1
+k8s.pod.usesUnmaskedProcMount 13.4.1
 k8s.podDisruptionBudgets 13.0.16
 k8s.poddisruptionbudget 13.0.16
 k8s.poddisruptionbudget.annotations 13.0.16
@@ -1313,6 +1328,7 @@ k8s.replicaset.hasMemoryLimit 13.3.1
 k8s.replicaset.hasResourceLimits 13.3.1
 k8s.replicaset.hasResourceRequests 13.3.1
 k8s.replicaset.hasSeccompProfile 13.3.1
+k8s.replicaset.hasUnsafeSysctls 13.4.1
 k8s.replicaset.hasWritableRootFilesystem 13.2.2
 k8s.replicaset.hostIPC 13.2.2
 k8s.replicaset.hostNetwork 13.2.2
@@ -1351,7 +1367,9 @@ k8s.replicaset.usesHostPath 13.2.2
 k8s.replicaset.usesImageDigest 13.3.1
 k8s.replicaset.usesLatestTag 13.3.1
 k8s.replicaset.usesSecretsAsEnv 13.3.1
+k8s.replicaset.usesUnconfinedAppArmor 13.4.1
 k8s.replicaset.usesUnconfinedSeccomp 13.3.1
+k8s.replicaset.usesUnmaskedProcMount 13.4.1
 k8s.replicasets 9.0.0
 k8s.resourceQuotas 11.1.139
 k8s.resourcequota 11.1.139
@@ -1480,6 +1498,7 @@ k8s.statefulset.hasMemoryLimit 13.3.1
 k8s.statefulset.hasResourceLimits 13.3.1
 k8s.statefulset.hasResourceRequests 13.3.1
 k8s.statefulset.hasSeccompProfile 13.3.1
+k8s.statefulset.hasUnsafeSysctls 13.4.1
 k8s.statefulset.hasWritableRootFilesystem 13.2.2
 k8s.statefulset.hostIPC 13.2.2
 k8s.statefulset.hostNetwork 13.2.2
@@ -1526,7 +1545,9 @@ k8s.statefulset.usesHostPath 13.2.2
 k8s.statefulset.usesImageDigest 13.3.1
 k8s.statefulset.usesLatestTag 13.3.1
 k8s.statefulset.usesSecretsAsEnv 13.3.1
+k8s.statefulset.usesUnconfinedAppArmor 13.4.1
 k8s.statefulset.usesUnconfinedSeccomp 13.3.1
+k8s.statefulset.usesUnmaskedProcMount 13.4.1
 k8s.statefulsets 9.0.0
 k8s.storageClasses 11.1.139
 k8s.storageclass 11.1.139

--- a/providers/k8s/resources/securitycontext_hardening.go
+++ b/providers/k8s/resources/securitycontext_hardening.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// The Pod Security Standards baseline helpers in pod_security_standards.go
+// (specBaselineAppArmor, specBaselineProcMount, specBaselineSysctls) report
+// compliance. These expose the inverse as standalone predicates so a workload
+// can be audited for a single hardening dimension without computing the full
+// podSecurityStandard level.
+
+// specUsesUnconfinedAppArmor reports whether any container (or the pod) runs
+// with an explicitly Unconfined AppArmor profile.
+func specUsesUnconfinedAppArmor(spec *corev1.PodSpec) bool {
+	return !specBaselineAppArmor(spec)
+}
+
+// specUsesUnmaskedProcMount reports whether any container sets procMount to a
+// value other than Default (i.e. Unmasked), which exposes masked /proc paths.
+func specUsesUnmaskedProcMount(spec *corev1.PodSpec) bool {
+	return !specBaselineProcMount(spec)
+}
+
+// specHasUnsafeSysctls reports whether the pod requests any sysctl outside the
+// kubelet's safe set.
+func specHasUnsafeSysctls(spec *corev1.PodSpec) bool {
+	return !specBaselineSysctls(spec)
+}
+
+func (k *mqlK8sPod) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sPod) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sPod) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sDeployment) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sDeployment) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sDeployment) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sDaemonset) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sDaemonset) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sDaemonset) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sStatefulset) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sStatefulset) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sStatefulset) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sReplicaset) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sReplicaset) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sReplicaset) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sJob) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sJob) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sJob) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}
+
+func (k *mqlK8sCronjob) usesUnconfinedAppArmor() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnconfinedAppArmor)
+}
+
+func (k *mqlK8sCronjob) usesUnmaskedProcMount() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specUsesUnmaskedProcMount)
+}
+
+func (k *mqlK8sCronjob) hasUnsafeSysctls() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHasUnsafeSysctls)
+}

--- a/providers/k8s/resources/securitycontext_hardening_test.go
+++ b/providers/k8s/resources/securitycontext_hardening_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestSecurityContextHardeningSpec covers the spec-level predicates directly,
+// mutating a compliant spec to introduce exactly one violation at a time.
+func TestSecurityContextHardeningSpec(t *testing.T) {
+	t.Run("compliant spec trips nothing", func(t *testing.T) {
+		s := restrictedSpec()
+		assert.False(t, specUsesUnconfinedAppArmor(s))
+		assert.False(t, specUsesUnmaskedProcMount(s))
+		assert.False(t, specHasUnsafeSysctls(s))
+	})
+
+	t.Run("unconfined AppArmor", func(t *testing.T) {
+		s := restrictedSpec()
+		container(s).AppArmorProfile = &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined}
+		assert.True(t, specUsesUnconfinedAppArmor(s))
+	})
+
+	t.Run("unmasked procMount", func(t *testing.T) {
+		s := restrictedSpec()
+		pm := corev1.UnmaskedProcMount
+		container(s).ProcMount = &pm
+		assert.True(t, specUsesUnmaskedProcMount(s))
+	})
+
+	t.Run("unsafe sysctl", func(t *testing.T) {
+		s := restrictedSpec()
+		s.SecurityContext.Sysctls = []corev1.Sysctl{{Name: "kernel.msgmax", Value: "65536"}}
+		assert.True(t, specHasUnsafeSysctls(s))
+	})
+
+	t.Run("safe sysctl is allowed", func(t *testing.T) {
+		s := restrictedSpec()
+		s.SecurityContext.Sysctls = []corev1.Sysctl{{Name: "net.ipv4.tcp_syncookies", Value: "1"}}
+		assert.False(t, specHasUnsafeSysctls(s))
+	})
+}
+
+func hardeningRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{}},
+	}, manifest.WithManifestFile("./testdata/securitycontext_hardening.yaml"))
+	require.NoError(t, err)
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+// TestSecurityContextHardeningWiring confirms the predicates resolve through the
+// runtime for a Pod (podSpecTyped accessor) and a Deployment (securitySpec
+// accessor).
+func TestSecurityContextHardeningWiring(t *testing.T) {
+	runtime := hardeningRuntime(t)
+
+	violator, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("violator"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	vp := violator.(*mqlK8sPod)
+	for field, tv := range map[string]*plugin.TValue[bool]{
+		"usesUnconfinedAppArmor": vp.GetUsesUnconfinedAppArmor(),
+		"usesUnmaskedProcMount":  vp.GetUsesUnmaskedProcMount(),
+		"hasUnsafeSysctls":       vp.GetHasUnsafeSysctls(),
+	} {
+		require.NoError(t, tv.Error, field)
+		assert.True(t, tv.Data, field)
+	}
+
+	clean, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData("clean"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	cp := clean.(*mqlK8sPod)
+	for field, tv := range map[string]*plugin.TValue[bool]{
+		"usesUnconfinedAppArmor": cp.GetUsesUnconfinedAppArmor(),
+		"usesUnmaskedProcMount":  cp.GetUsesUnmaskedProcMount(),
+		"hasUnsafeSysctls":       cp.GetHasUnsafeSysctls(),
+	} {
+		require.NoError(t, tv.Error, field)
+		assert.False(t, tv.Data, field)
+	}
+
+	// Controller spec accessor (securitySpec) path.
+	deploy, err := NewResource(runtime, "k8s.deployment", map[string]*llx.RawData{
+		"name":      llx.StringData("deploy-violator"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	aa := deploy.(*mqlK8sDeployment).GetUsesUnconfinedAppArmor()
+	require.NoError(t, aa.Error)
+	assert.True(t, aa.Data)
+}

--- a/providers/k8s/resources/testdata/securitycontext_hardening.yaml
+++ b/providers/k8s/resources/testdata/securitycontext_hardening.yaml
@@ -1,0 +1,72 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fixture for the securityContext hardening predicates (usesUnconfinedAppArmor,
+# hasUnsafeSysctls, usesUnmaskedProcMount) across a Pod and a Deployment, which
+# resolve their pod spec through different accessors.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+# Violates all three hardening dimensions at once.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: violator
+  namespace: prod
+spec:
+  securityContext:
+    sysctls:
+      - name: kernel.msgmax
+        value: "65536"
+  containers:
+    - name: app
+      image: nginx:1.27
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+        procMount: Unmasked
+status:
+  phase: Running
+---
+# Compliant pod: confined AppArmor, default procMount, no unsafe sysctls.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean
+  namespace: prod
+spec:
+  containers:
+    - name: app
+      image: nginx:1.27
+      securityContext:
+        appArmorProfile:
+          type: RuntimeDefault
+status:
+  phase: Running
+---
+# Deployment whose template runs Unconfined AppArmor, to exercise the controller
+# spec accessor.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-violator
+  namespace: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deploy-violator
+  template:
+    metadata:
+      labels:
+        app: deploy-violator
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27
+          securityContext:
+            appArmorProfile:
+              type: Unconfined


### PR DESCRIPTION
Closes the remaining Pod Security Standards / CIS workload-hardening dimensions that had no standalone predicate. We already model privileged, runAsRoot, capabilities, seccomp, and readonly-rootfs — but AppArmor, sysctls, and procMount were only evaluated *inside* the `podSecurityStandard` level computation, with no way to audit a single dimension directly.

## What it adds

Three predicates on pods and every workload controller (deployment, daemonset, statefulset, replicaset, job, cronjob):

- **`usesUnconfinedAppArmor`** — a container or the pod runs with an explicitly `Unconfined` AppArmor profile
- **`hasUnsafeSysctls`** — the pod requests a sysctl outside the kubelet safe set
- **`usesUnmaskedProcMount`** — a container sets `procMount: Unmasked`

## Design

Each predicate wraps the existing PSS baseline helpers (`specBaselineAppArmor` / `specBaselineProcMount` / `specBaselineSysctls`) rather than re-parsing the spec, so the detection logic stays shared with `podSecurityStandard` and can't drift. The fan-out across the seven workload types follows the established `boolFromSpec` pattern used by the existing securityContext predicates.

```mql
k8s.pods.where(usesUnconfinedAppArmor || hasUnsafeSysctls || usesUnmaskedProcMount) { name namespace }
k8s.deployments.where(usesUnmaskedProcMount) { name }
```

## Testing

- **Spec-level unit tests** for each dimension (compliant baseline, each violation in isolation, and safe-vs-unsafe sysctl) reusing the existing `restrictedSpec()` helper.
- **Manifest wiring test** that resolves the predicates through the runtime for a Pod (the `podSpecTyped` accessor) and a Deployment (the `securitySpec` accessor), covering both spec-resolution paths.
- Verified end-to-end with `mql run k8s <fixture>`.

`.lr.versions` at `13.4.1` (the generator's `IncPatch` of the released `13.4.0`); no new API permissions (pure spec analysis on the already-required workload reads); no provider version bump.