### PR TITLE
✨ k8s: surface services routing to external (non-pod) endpoints

### DIFF
--- a/providers/k8s/resources/external_endpoints.go
+++ b/providers/k8s/resources/external_endpoints.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+// externalEndpointAddresses returns the addresses of endpoints in the slice that
+// are not backed by an in-cluster pod. An endpoint is pod-backed when its
+// targetRef points at a Pod; anything else (no targetRef, or a non-Pod kind) is
+// a manually managed target that frequently lives outside the cluster.
+func externalEndpointAddresses(es *discoveryv1.EndpointSlice) []string {
+	if es == nil {
+		return nil
+	}
+	var out []string
+	for _, ep := range es.Endpoints {
+		if ep.TargetRef != nil && ep.TargetRef.Kind == "Pod" {
+			continue
+		}
+		out = append(out, ep.Addresses...)
+	}
+	return sortedUniqueStrings(out)
+}
+
+func (k *mqlK8sEndpointslice) externalAddresses() ([]any, error) {
+	return convert.SliceAnyToInterface(externalEndpointAddresses(k.obj)), nil
+}
+
+// serviceExternalEndpointAddresses unions the external endpoint addresses across
+// every EndpointSlice that backs the service.
+func (k *mqlK8sService) serviceExternalEndpointAddresses() ([]string, error) {
+	slices := k.GetEndpointSlices()
+	if slices.Error != nil {
+		return nil, slices.Error
+	}
+	var addrs []string
+	for i := range slices.Data {
+		es, ok := slices.Data[i].(*mqlK8sEndpointslice)
+		if !ok {
+			continue
+		}
+		addrs = append(addrs, externalEndpointAddresses(es.obj)...)
+	}
+	return sortedUniqueStrings(addrs), nil
+}
+
+func (k *mqlK8sService) externalEndpoints() ([]any, error) {
+	addrs, err := k.serviceExternalEndpointAddresses()
+	if err != nil {
+		return nil, err
+	}
+	return convert.SliceAnyToInterface(addrs), nil
+}
+
+func (k *mqlK8sService) routesToPublicEndpoint() (bool, error) {
+	addrs, err := k.serviceExternalEndpointAddresses()
+	if err != nil {
+		return false, err
+	}
+	for _, addr := range addrs {
+		if addressIsPublicNodeAddress(addr) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/providers/k8s/resources/external_endpoints_test.go
+++ b/providers/k8s/resources/external_endpoints_test.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func externalEndpointsRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{{}},
+	}, manifest.WithManifestFile("./testdata/external_endpoints.yaml"))
+	require.NoError(t, err)
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+func serviceByName(t *testing.T, runtime *plugin.Runtime, name string) *mqlK8sService {
+	t.Helper()
+	s, err := NewResource(runtime, "k8s.service", map[string]*llx.RawData{
+		"name":      llx.StringData(name),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	return s.(*mqlK8sService)
+}
+
+func TestEndpointSliceExternalAddresses(t *testing.T) {
+	runtime := externalEndpointsRuntime(t)
+
+	es, err := NewResource(runtime, "k8s.endpointslice", map[string]*llx.RawData{
+		"name":      llx.StringData("external-db-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	addrs := es.(*mqlK8sEndpointslice).GetExternalAddresses()
+	require.NoError(t, addrs.Error)
+	assert.Equal(t, []any{"8.8.8.8"}, addrs.Data)
+
+	// Pod-backed endpoints are not external.
+	podBacked, err := NewResource(runtime, "k8s.endpointslice", map[string]*llx.RawData{
+		"name":      llx.StringData("internal-app-1"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	pb := podBacked.(*mqlK8sEndpointslice).GetExternalAddresses()
+	require.NoError(t, pb.Error)
+	assert.Empty(t, pb.Data)
+}
+
+func TestServiceExternalEndpoints(t *testing.T) {
+	runtime := externalEndpointsRuntime(t)
+
+	tests := []struct {
+		name     string
+		external []any
+		toPublic bool
+	}{
+		{"external-db", []any{"8.8.8.8"}, true},   // public off-cluster target
+		{"private-ext", []any{"10.1.2.3"}, false}, // private off-cluster target
+		{"internal-app", nil, false},              // pod-backed, nothing external
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := serviceByName(t, runtime, tt.name)
+
+			ext := svc.GetExternalEndpoints()
+			require.NoError(t, ext.Error)
+			if tt.external == nil {
+				assert.Empty(t, ext.Data)
+			} else {
+				assert.Equal(t, tt.external, ext.Data)
+			}
+
+			pub := svc.GetRoutesToPublicEndpoint()
+			require.NoError(t, pub.Error)
+			assert.Equal(t, tt.toPublic, pub.Data)
+		})
+	}
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -2116,6 +2116,14 @@ private k8s.service @defaults("namespace name created") {
   endpointSlices() []k8s.endpointslice
   // Pods selected by the service's label selector (empty for selectorless and ExternalName services)
   pods() []k8s.pod
+  // Backend endpoint addresses that are not in-cluster pods
+  //
+  // Addresses from the service's EndpointSlices whose endpoints have no Pod
+  // targetRef, so the service forwards to manually managed targets that are
+  // often outside the cluster. Empty for an ordinary selector-backed service.
+  externalEndpoints() []string
+  // Whether the service forwards to a public, non-pod endpoint address
+  routesToPublicEndpoint() bool
   // Normalized network exposure records for this Service
   networkExposures() []k8s.networkExposure
 }
@@ -3214,6 +3222,11 @@ private k8s.endpointslice @defaults("namespace name addressType") {
   ports() []dict
   // The Service this slice backs (resolved from the kubernetes.io/service-name label)
   service() k8s.service
+  // Endpoint addresses not backed by an in-cluster pod
+  //
+  // Addresses of endpoints whose targetRef is not a Pod, i.e. manually managed
+  // targets. On a selectorless service these often point outside the cluster.
+  externalAddresses() []string
 }
 
 // Kubernetes AdmissionReview

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -2908,6 +2908,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.service.pods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
+	"k8s.service.externalEndpoints": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sService).GetExternalEndpoints()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.service.routesToPublicEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sService).GetRoutesToPublicEndpoint()).ToDataRes(types.Bool)
+	},
 	"k8s.service.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
@@ -4149,6 +4155,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.endpointslice.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEndpointslice).GetService()).ToDataRes(types.Resource("k8s.service"))
+	},
+	"k8s.endpointslice.externalAddresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEndpointslice).GetExternalAddresses()).ToDataRes(types.Array(types.String))
 	},
 	"k8s.admissionreview.request": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionreview).GetRequest()).ToDataRes(types.Resource("k8s.admissionrequest"))
@@ -8478,6 +8487,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sService).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.service.externalEndpoints": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sService).ExternalEndpoints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.service.routesToPublicEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sService).RoutesToPublicEndpoint, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.service.networkExposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sService).NetworkExposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -10248,6 +10265,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.endpointslice.service": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sEndpointslice).Service, ok = plugin.RawToTValue[*mqlK8sService](v.Value, v.Error)
+		return
+	},
+	"k8s.endpointslice.externalAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEndpointslice).ExternalAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.admissionreview.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19005,6 +19026,8 @@ type mqlK8sService struct {
 	LoadBalancerIngress           plugin.TValue[[]any]
 	EndpointSlices                plugin.TValue[[]any]
 	Pods                          plugin.TValue[[]any]
+	ExternalEndpoints             plugin.TValue[[]any]
+	RoutesToPublicEndpoint        plugin.TValue[bool]
 	NetworkExposures              plugin.TValue[[]any]
 }
 
@@ -19278,6 +19301,18 @@ func (c *mqlK8sService) GetPods() *plugin.TValue[[]any] {
 		}
 
 		return c.pods()
+	})
+}
+
+func (c *mqlK8sService) GetExternalEndpoints() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalEndpoints, func() ([]any, error) {
+		return c.externalEndpoints()
+	})
+}
+
+func (c *mqlK8sService) GetRoutesToPublicEndpoint() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RoutesToPublicEndpoint, func() (bool, error) {
+		return c.routesToPublicEndpoint()
 	})
 }
 
@@ -23458,22 +23493,23 @@ type mqlK8sEndpointslice struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlK8sEndpointsliceInternal
-	Id              plugin.TValue[string]
-	Uid             plugin.TValue[string]
-	ResourceVersion plugin.TValue[string]
-	Labels          plugin.TValue[map[string]any]
-	Annotations     plugin.TValue[map[string]any]
-	OwnerReferences plugin.TValue[[]any]
-	ManagedFields   plugin.TValue[[]any]
-	Name            plugin.TValue[string]
-	Namespace       plugin.TValue[string]
-	Kind            plugin.TValue[string]
-	Created         plugin.TValue[*time.Time]
-	Manifest        plugin.TValue[any]
-	AddressType     plugin.TValue[string]
-	Endpoints       plugin.TValue[[]any]
-	Ports           plugin.TValue[[]any]
-	Service         plugin.TValue[*mqlK8sService]
+	Id                plugin.TValue[string]
+	Uid               plugin.TValue[string]
+	ResourceVersion   plugin.TValue[string]
+	Labels            plugin.TValue[map[string]any]
+	Annotations       plugin.TValue[map[string]any]
+	OwnerReferences   plugin.TValue[[]any]
+	ManagedFields     plugin.TValue[[]any]
+	Name              plugin.TValue[string]
+	Namespace         plugin.TValue[string]
+	Kind              plugin.TValue[string]
+	Created           plugin.TValue[*time.Time]
+	Manifest          plugin.TValue[any]
+	AddressType       plugin.TValue[string]
+	Endpoints         plugin.TValue[[]any]
+	Ports             plugin.TValue[[]any]
+	Service           plugin.TValue[*mqlK8sService]
+	ExternalAddresses plugin.TValue[[]any]
 }
 
 // createK8sEndpointslice creates a new instance of this resource
@@ -23620,6 +23656,12 @@ func (c *mqlK8sEndpointslice) GetService() *plugin.TValue[*mqlK8sService] {
 		}
 
 		return c.service()
+	})
+}
+
+func (c *mqlK8sEndpointslice) GetExternalAddresses() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalAddresses, func() ([]any, error) {
+		return c.externalAddresses()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -460,6 +460,7 @@ k8s.endpointslice.addressType 11.1.139
 k8s.endpointslice.annotations 11.1.139
 k8s.endpointslice.created 11.1.139
 k8s.endpointslice.endpoints 11.1.139
+k8s.endpointslice.externalAddresses 13.4.1
 k8s.endpointslice.id 11.1.139
 k8s.endpointslice.kind 11.1.139
 k8s.endpointslice.labels 11.1.139
@@ -1423,6 +1424,7 @@ k8s.service.clusterIP 13.0.16
 k8s.service.clusterIPs 13.0.16
 k8s.service.created 9.0.0
 k8s.service.endpointSlices 13.0.16
+k8s.service.externalEndpoints 13.4.1
 k8s.service.externalIPs 13.0.16
 k8s.service.externalName 13.0.16
 k8s.service.externalTrafficPolicy 13.0.16
@@ -1447,6 +1449,7 @@ k8s.service.pods 13.3.3
 k8s.service.ports 13.0.16
 k8s.service.publishNotReadyAddresses 13.0.16
 k8s.service.resourceVersion 9.0.0
+k8s.service.routesToPublicEndpoint 13.4.1
 k8s.service.selector 13.0.16
 k8s.service.sessionAffinity 13.0.16
 k8s.service.sessionAffinityConfig 13.0.16

--- a/providers/k8s/resources/testdata/external_endpoints.yaml
+++ b/providers/k8s/resources/testdata/external_endpoints.yaml
@@ -1,0 +1,85 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fixture for external (non-pod) endpoint detection: selectorless services whose
+# EndpointSlices point at off-cluster IPs, versus an ordinary pod-backed service.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+# Selectorless service whose endpoints point at a public external IP.
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-db
+  namespace: prod
+spec:
+  ports:
+    - port: 5432
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: external-db-1
+  namespace: prod
+  labels:
+    kubernetes.io/service-name: external-db
+addressType: IPv4
+endpoints:
+  - addresses: ["8.8.8.8"]
+ports:
+  - port: 5432
+---
+# Selectorless service whose endpoints point at a private off-cluster IP.
+apiVersion: v1
+kind: Service
+metadata:
+  name: private-ext
+  namespace: prod
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: private-ext-1
+  namespace: prod
+  labels:
+    kubernetes.io/service-name: private-ext
+addressType: IPv4
+endpoints:
+  - addresses: ["10.1.2.3"]
+ports:
+  - port: 80
+---
+# Ordinary selector-backed service: endpoints are pods, nothing external.
+apiVersion: v1
+kind: Service
+metadata:
+  name: internal-app
+  namespace: prod
+spec:
+  selector:
+    app: internal
+  ports:
+    - port: 80
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: internal-app-1
+  namespace: prod
+  labels:
+    kubernetes.io/service-name: internal-app
+addressType: IPv4
+endpoints:
+  - addresses: ["10.0.0.5"]
+    targetRef:
+      kind: Pod
+      name: backend-1
+      namespace: prod
+ports:
+  - port: 80


### PR DESCRIPTION
Closes the last item in the ingress/egress taxonomy: a **selectorless Service whose EndpointSlices are hand-written to point at off-cluster IPs**. The *ingress* side of such a Service (its LoadBalancer/NodePort public address) was already captured by `networkExposures`, but the **backend-trust** signal — that the Service forwards traffic to addresses the cluster does not control — was invisible.

## What it adds

- **`k8s.endpointslice.externalAddresses`** — addresses of endpoints with no `Pod` targetRef (manually managed / off-cluster targets).
- **`k8s.service.externalEndpoints`** — the union of those addresses across the service's EndpointSlices; empty for an ordinary selector-backed service.
- **`k8s.service.routesToPublicEndpoint`** — whether any external endpoint address is a public IP. The headline data-flow / trust signal: a Service named like an internal dependency that actually forwards to a public address.

## Why this is the right shape

An endpoint is pod-backed when its `targetRef.Kind == "Pod"`; anything else (no targetRef, or a non-Pod kind) is a manually managed target. This is the IP-based analog of `ExternalName` services (which `networkExposures` already models). It is deliberately a backend-target signal rather than a new `networkExposure` record, so it does not muddy the inbound `internetExposed` semantics — it answers "where does this Service send traffic", which composes with the existing inbound model.

```mql
# services that forward to a public, off-cluster address
k8s.services.where(routesToPublicEndpoint) { name namespace externalEndpoints }
```

## Testing

Fixture-driven tests at both levels (EndpointSlice and Service) covering a public off-cluster target, a private off-cluster target, and an ordinary pod-backed service (nothing external). Verified end-to-end with `mql run k8s <fixture>`.

`.lr.versions` at `13.4.1`; no new API permissions (reuses the existing EndpointSlice reads); no provider version bump.