### PR TITLE
✨ shodan: add shodan.domain.hosts() to bridge domains to host data

### DIFF
--- a/providers/shodan/resources/domain.go
+++ b/providers/shodan/resources/domain.go
@@ -115,6 +115,50 @@ func (r *mqlShodanDomain) nsrecords() ([]any, error) {
 	return nil, r.fetchBaseInformation()
 }
 
+func (r *mqlShodanDomain) hosts() ([]any, error) {
+	nsrecords := r.GetNsrecords()
+	if nsrecords.Error != nil {
+		return nil, nsrecords.Error
+	}
+
+	// A and AAAA records carry the IP addresses the domain and its subdomains
+	// resolve to. Map each unique address to a Shodan host so callers can
+	// traverse from a domain to host-level data (ports, vulnerabilities, ...).
+	hosts := []any{}
+	seen := map[string]struct{}{}
+	for _, raw := range nsrecords.Data {
+		record, ok := raw.(*mqlShodanNsrecord)
+		if !ok {
+			continue
+		}
+
+		switch record.Type.Data {
+		case "A", "AAAA":
+		default:
+			continue
+		}
+
+		ip := record.Value.Data
+		if ip == "" {
+			continue
+		}
+		if _, dup := seen[ip]; dup {
+			continue
+		}
+		seen[ip] = struct{}{}
+
+		host, err := NewResource(r.MqlRuntime, "shodan.host", map[string]*llx.RawData{
+			"ip": llx.StringData(ip),
+		})
+		if err != nil {
+			return nil, err
+		}
+		hosts = append(hosts, host)
+	}
+
+	return hosts, nil
+}
+
 func (r *mqlShodanNsrecord) id() (string, error) {
 	id := "shodan.nsrecord/" + r.Domain.Data
 	if r.Subdomain.Data != "" {

--- a/providers/shodan/resources/shodan.lr
+++ b/providers/shodan/resources/shodan.lr
@@ -202,6 +202,8 @@ shodan.domain @defaults("name") {
   subdomains() []string
   // DNS NS records
   nsrecords() []shodan.nsrecord
+  // Hosts the domain and its subdomains resolve to, from A and AAAA records
+  hosts() []shodan.host
 }
 
 // Shodan Search Engine DNS NS record

--- a/providers/shodan/resources/shodan.lr.go
+++ b/providers/shodan/resources/shodan.lr.go
@@ -392,6 +392,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"shodan.domain.nsrecords": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlShodanDomain).GetNsrecords()).ToDataRes(types.Array(types.Resource("shodan.nsrecord")))
 	},
+	"shodan.domain.hosts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlShodanDomain).GetHosts()).ToDataRes(types.Array(types.Resource("shodan.host")))
+	},
 	"shodan.nsrecord.domain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlShodanNsrecord).GetDomain()).ToDataRes(types.String)
 	},
@@ -807,6 +810,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"shodan.domain.nsrecords": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlShodanDomain).Nsrecords, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"shodan.domain.hosts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlShodanDomain).Hosts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"shodan.nsrecord.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1621,6 +1628,7 @@ type mqlShodanDomain struct {
 	Tags       plugin.TValue[[]any]
 	Subdomains plugin.TValue[[]any]
 	Nsrecords  plugin.TValue[[]any]
+	Hosts      plugin.TValue[[]any]
 }
 
 // createShodanDomain creates a new instance of this resource
@@ -1689,6 +1697,22 @@ func (c *mqlShodanDomain) GetNsrecords() *plugin.TValue[[]any] {
 		}
 
 		return c.nsrecords()
+	})
+}
+
+func (c *mqlShodanDomain) GetHosts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Hosts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("shodan.domain", c.__id, "hosts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.hosts()
 	})
 }
 

--- a/providers/shodan/resources/shodan.lr.versions
+++ b/providers/shodan/resources/shodan.lr.versions
@@ -10,6 +10,7 @@ shodan.apiPlan.telnet 11.0.0
 shodan.apiPlan.unlocked 11.0.0
 shodan.apiPlan.unlockedLeft 11.0.0
 shodan.domain 11.0.0
+shodan.domain.hosts 13.1.2
 shodan.domain.name 11.0.0
 shodan.domain.nsrecords 11.0.0
 shodan.domain.subdomains 11.0.0


### PR DESCRIPTION
## What

Adds a `hosts()` field to the `shodan.domain` resource. It surfaces the IP addresses a domain and its subdomains resolve to — taken from the domain's `A` and `AAAA` DNS records, deduplicated — as typed `shodan.host` resources.

This bridges the two halves of the Shodan provider: previously a domain only exposed `tags`, `subdomains`, and `nsrecords`, with no way to reach the host-level data (ports, vulnerabilities, services) for the addresses behind it. Now you can traverse from a domain straight to its hosts:

```coffee
# every host the domain resolves to is free of known CVEs
shodan.domain("example.com").hosts.all(vulns == empty)

# ports exposed across all resolved hosts
shodan.domain("example.com").hosts.flatMap(ports)
```

## Implementation notes

- IPs are derived from the `nsrecords` already fetched by the existing `/dns/domain` call — **no extra API call** to enumerate them.
- Host references are created with `NewResource` (lazy), so a host's data is only fetched, and a query credit only spent, when a host field is actually accessed.
- Addresses are deduplicated, so a host backing many subdomains is returned once.
- Only `A`/`AAAA` records map to hosts; other record types are ignored.

## Schema

- `shodan.domain.hosts() []shodan.host` — new `.lr.versions` entry at `13.1.2` (provider is at `13.1.1`).

## Testing

- `make providers/build/shodan && make providers/install/shodan` succeed; the installed schema reports `shodan.domain.hosts` with element type `shodan.host`.
- A downstream cnspec policy that uses `shodan.domain.hosts.all(vulns == empty)` compiles and lints clean against the rebuilt provider.

⚠️ Live verification against the Shodan API (a real `SHODAN_TOKEN` scan of a domain) has **not** been run — no token was available in this environment. Worth a quick `mql shell shodan --domains <domain>` smoke test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)