### PR TITLE
🎉 shodan-13.2.0

### DIFF
--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.1.10",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
## Shodan provider release: 13.1.10 → 13.2.0

Minor version bump for the shodan provider to ship the new domain-to-host bridge.

### Changes since 13.1.10

- ✨ Add `shodan.domain.hosts()` to bridge domains to host data (#8605)

### Dependency maintenance

- 🧹 Update deps for mql and providers 20260622 (#8595)
- 🧹 Update deps for mql and providers 20260615 (#8443)