### PR TITLE
✨ google-workspace: expose admin policy settings via Cloud Identity Policy API

### DIFF
--- a/providers/google-workspace/connection/workspace.go
+++ b/providers/google-workspace/connection/workspace.go
@@ -39,6 +39,7 @@ var DefaultWorkspaceClientScopes = []string{
 	reports.AdminReportsUsageReadonlyScope,
 	cloudidentity.CloudIdentityGroupsReadonlyScope,
 	cloudidentity.CloudIdentityDevicesReadonlyScope,
+	cloudidentity.CloudIdentityPoliciesReadonlyScope,
 }
 
 func (c *GoogleWorkspaceConnection) GetWorkspaceCustomer(customerID string) (*directory.Customer, error) {

--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -12,11 +12,13 @@ option go_package = "go.mondoo.com/mql/v13/providers/google-workspace/resources"
 // registered domains and their verification state, the admin roles
 // and their privileges, the third-party OAuth-connected apps with
 // aggregated scopes, the user calendars together with their ACL
-// rules, and the managed endpoints (Chrome OS, Android, iOS, Windows,
+// rules, the managed endpoints (Chrome OS, Android, iOS, Windows,
 // macOS, Linux) reported through Google endpoint management and
-// endpoint verification — the surface auditors use for identity
-// hygiene, sharing reviews, 2-step-verification enforcement checks,
-// and device-compliance audits.
+// endpoint verification, and the admin-configured policy settings
+// resolved across the organization through the Cloud Identity Policy
+// API — the surface auditors use for identity hygiene, sharing
+// reviews, 2-step-verification enforcement checks, device-compliance
+// audits, and domain-wide security-posture review.
 googleworkspace {
   // Organizational units in the account hierarchy
   orgUnits() []googleworkspace.orgUnit
@@ -48,6 +50,8 @@ googleworkspace {
   // Convenience filter over `users` for MFA-coverage audits — active
   // (non-suspended, non-archived) users where `isEnrolledIn2Sv` is false.
   usersWithout2sv() []googleworkspace.user
+  // Admin-configured policy settings resolved across the organization
+  policies() []googleworkspace.policy
 }
 
 // Google Workspace calendar
@@ -762,4 +766,49 @@ private googleworkspace.endpoint.user @defaults("userEmail managementState") {
   firstSyncTime time
   // Last time the user synced with policies
   lastSyncTime time
+}
+
+// Google Workspace admin policy setting
+//
+// Examine a single policy setting resolved by the Cloud Identity Policy API —
+// the admin-configured settings that govern security posture across the
+// organization (2-step-verification enforcement, password strength and
+// length, session length, less-secure-app access, service on/off status,
+// and third-party app access), surfaced without navigating the Admin
+// Console. Each row is one resolved setting for one scope: `settingType`
+// names the setting (for example `settings/security.password` or
+// `settings/security.session_controls`), `value` carries the setting's
+// configured value as a dict (the schema varies per setting type), and
+// `orgUnit` / `group` report the organizational unit or group the setting
+// resolves to (empty when the policy applies customer-wide). `type`
+// distinguishes admin-configured policies (`ADMIN`) from Google's
+// system defaults (`SYSTEM`). Select by setting type — for example
+// `googleworkspace.policies.where(settingType == "settings/security.session_controls")`.
+// Requires a super-admin-impersonating service account with the
+// `cloud-identity.policies.readonly` scope.
+private googleworkspace.policy @defaults("settingType type orgUnit") {
+  // Resource name of the policy in the format policies/{policy}
+  name string
+  // The setting type identifier (for example settings/security.session_controls)
+  settingType string
+  // Policy type
+  //
+  // One of `ADMIN` (admin-configured) or `SYSTEM` (Google-managed default).
+  type string
+  // The organizational unit the policy resolves to (empty when customer-wide)
+  orgUnit string
+  // The group the policy resolves to (empty when not group-scoped)
+  group string
+  // The CEL query that defines which entities the policy applies to
+  //
+  // Empty for customer-wide policies. The `orgUnit` and `group` fields are
+  // decoded helpers extracted from this query.
+  query string
+  // The configured value of the setting
+  //
+  // The shape varies per `settingType`; kept as a dict because each setting
+  // carries its own schema. For example a `settings/security.session_controls`
+  // value carries `webSessionDuration`, while a `settings/security.password`
+  // value carries `allowedStrength`, `minimumLength`, and `enforceRequirementsAtLogin`.
+  value dict
 }

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -43,6 +43,7 @@ const (
 	ResourceGoogleworkspaceReportUsage          string = "googleworkspace.report.usage"
 	ResourceGoogleworkspaceEndpoint             string = "googleworkspace.endpoint"
 	ResourceGoogleworkspaceEndpointUser         string = "googleworkspace.endpoint.user"
+	ResourceGoogleworkspacePolicy               string = "googleworkspace.policy"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -157,6 +158,10 @@ func init() {
 			// to override args, implement: initGoogleworkspaceEndpointUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGoogleworkspaceEndpointUser,
 		},
+		"googleworkspace.policy": {
+			// to override args, implement: initGoogleworkspacePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGoogleworkspacePolicy,
+		},
 	}
 }
 
@@ -260,6 +265,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.usersWithout2sv": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspace).GetUsersWithout2sv()).ToDataRes(types.Array(types.Resource("googleworkspace.user")))
+	},
+	"googleworkspace.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspace).GetPolicies()).ToDataRes(types.Array(types.Resource("googleworkspace.policy")))
 	},
 	"googleworkspace.calendar.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceCalendar).GetId()).ToDataRes(types.String)
@@ -1011,6 +1019,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"googleworkspace.endpoint.user.lastSyncTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceEndpointUser).GetLastSyncTime()).ToDataRes(types.Time)
 	},
+	"googleworkspace.policy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetName()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.settingType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetSettingType()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetType()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.orgUnit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetOrgUnit()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.group": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetGroup()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.query": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetQuery()).ToDataRes(types.String)
+	},
+	"googleworkspace.policy.value": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspacePolicy).GetValue()).ToDataRes(types.Dict)
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -1069,6 +1098,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"googleworkspace.usersWithout2sv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspace).UsersWithout2sv, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspace).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.calendar.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2175,6 +2208,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGoogleworkspaceEndpointUser).LastSyncTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"googleworkspace.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"googleworkspace.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.settingType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).SettingType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.orgUnit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).OrgUnit, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).Group, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.query": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).Query, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.policy.value": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspacePolicy).Value, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 }
 
 func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
@@ -2215,6 +2280,7 @@ type mqlGoogleworkspace struct {
 	SuperAdmins     plugin.TValue[[]any]
 	SuspendedUsers  plugin.TValue[[]any]
 	UsersWithout2sv plugin.TValue[[]any]
+	Policies        plugin.TValue[[]any]
 }
 
 // createGoogleworkspace creates a new instance of this resource
@@ -2427,6 +2493,22 @@ func (c *mqlGoogleworkspace) GetUsersWithout2sv() *plugin.TValue[[]any] {
 		}
 
 		return c.usersWithout2sv()
+	})
+}
+
+func (c *mqlGoogleworkspace) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
 	})
 }
 
@@ -4901,4 +4983,83 @@ func (c *mqlGoogleworkspaceEndpointUser) GetFirstSyncTime() *plugin.TValue[*time
 
 func (c *mqlGoogleworkspaceEndpointUser) GetLastSyncTime() *plugin.TValue[*time.Time] {
 	return &c.LastSyncTime
+}
+
+// mqlGoogleworkspacePolicy for the googleworkspace.policy resource
+type mqlGoogleworkspacePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGoogleworkspacePolicyInternal it will be used here
+	Name        plugin.TValue[string]
+	SettingType plugin.TValue[string]
+	Type        plugin.TValue[string]
+	OrgUnit     plugin.TValue[string]
+	Group       plugin.TValue[string]
+	Query       plugin.TValue[string]
+	Value       plugin.TValue[any]
+}
+
+// createGoogleworkspacePolicy creates a new instance of this resource
+func createGoogleworkspacePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGoogleworkspacePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("googleworkspace.policy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGoogleworkspacePolicy) MqlName() string {
+	return "googleworkspace.policy"
+}
+
+func (c *mqlGoogleworkspacePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGoogleworkspacePolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlGoogleworkspacePolicy) GetSettingType() *plugin.TValue[string] {
+	return &c.SettingType
+}
+
+func (c *mqlGoogleworkspacePolicy) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlGoogleworkspacePolicy) GetOrgUnit() *plugin.TValue[string] {
+	return &c.OrgUnit
+}
+
+func (c *mqlGoogleworkspacePolicy) GetGroup() *plugin.TValue[string] {
+	return &c.Group
+}
+
+func (c *mqlGoogleworkspacePolicy) GetQuery() *plugin.TValue[string] {
+	return &c.Query
+}
+
+func (c *mqlGoogleworkspacePolicy) GetValue() *plugin.TValue[any] {
+	return &c.Value
 }

--- a/providers/google-workspace/resources/google-workspace.lr.versions
+++ b/providers/google-workspace/resources/google-workspace.lr.versions
@@ -134,6 +134,15 @@ googleworkspace.orgUnit.name 9.0.0
 googleworkspace.orgUnit.orgUnitPath 11.1.122
 googleworkspace.orgUnit.parentOrgUnitPath 11.1.122
 googleworkspace.orgUnits 9.0.0
+googleworkspace.policies 13.1.5
+googleworkspace.policy 13.1.5
+googleworkspace.policy.group 13.1.5
+googleworkspace.policy.name 13.1.5
+googleworkspace.policy.orgUnit 13.1.5
+googleworkspace.policy.query 13.1.5
+googleworkspace.policy.settingType 13.1.5
+googleworkspace.policy.type 13.1.5
+googleworkspace.policy.value 13.1.5
 googleworkspace.report.activity 9.0.0
 googleworkspace.report.activity.actor 9.0.0
 googleworkspace.report.activity.events 9.0.0

--- a/providers/google-workspace/resources/policies.go
+++ b/providers/google-workspace/resources/policies.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/google-workspace/connection"
+
+	cloudidentity "google.golang.org/api/cloudidentity/v1"
+)
+
+func (g *mqlGoogleworkspace) policies() ([]any, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
+	service, err := cloudIdentityService(conn, cloudidentity.CloudIdentityPoliciesReadonlyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	pageToken := ""
+	for {
+		call := service.Policies.List().PageSize(100)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range resp.Policies {
+			r, err := newMqlGoogleWorkspacePolicy(g.MqlRuntime, p)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, r)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	return res, nil
+}
+
+// policyData is the plain-struct projection of a cloudidentity.Policy used to
+// build the resource. Value is nil when the setting carried no value or its
+// JSON could not be decoded.
+type policyData struct {
+	Name        string
+	Type        string
+	SettingType string
+	OrgUnit     string
+	Group       string
+	Query       string
+	Value       map[string]any
+}
+
+// policyToData projects a cloudidentity.Policy into the plain fields the
+// resource exposes. Setting.Value is a googleapi.RawMessage carrying
+// setting-specific JSON; a decode failure means the wire shape drifted, so we
+// leave Value nil (surfaces as a null field) rather than failing the listing.
+func policyToData(entry *cloudidentity.Policy) policyData {
+	d := policyData{
+		Name: entry.Name,
+		Type: entry.Type,
+	}
+	if entry.PolicyQuery != nil {
+		d.OrgUnit = entry.PolicyQuery.OrgUnit
+		d.Group = entry.PolicyQuery.Group
+		d.Query = entry.PolicyQuery.Query
+	}
+	if entry.Setting != nil {
+		d.SettingType = entry.Setting.Type
+		if len(entry.Setting.Value) > 0 {
+			var v map[string]any
+			if err := json.Unmarshal(entry.Setting.Value, &v); err == nil {
+				d.Value = v
+			}
+		}
+	}
+	return d
+}
+
+func newMqlGoogleWorkspacePolicy(runtime *plugin.Runtime, entry *cloudidentity.Policy) (any, error) {
+	d := policyToData(entry)
+	args := map[string]*llx.RawData{
+		"name":        llx.StringData(d.Name),
+		"type":        llx.StringData(d.Type),
+		"settingType": llx.StringData(d.SettingType),
+		"orgUnit":     llx.StringData(d.OrgUnit),
+		"group":       llx.StringData(d.Group),
+		"query":       llx.StringData(d.Query),
+	}
+	if d.Value != nil {
+		args["value"] = llx.DictData(d.Value)
+	}
+
+	return CreateResource(runtime, "googleworkspace.policy", args)
+}
+
+func (g *mqlGoogleworkspacePolicy) id() (string, error) {
+	if g.Name.Error != nil {
+		return "", g.Name.Error
+	}
+	return "googleworkspace.policy/" + g.Name.Data, nil
+}

--- a/providers/google-workspace/resources/policies_test.go
+++ b/providers/google-workspace/resources/policies_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cloudidentity "google.golang.org/api/cloudidentity/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func TestPolicyToData(t *testing.T) {
+	t.Run("admin policy with org-unit scope and decoded value", func(t *testing.T) {
+		entry := &cloudidentity.Policy{
+			Name: "policies/abc123",
+			Type: "ADMIN",
+			PolicyQuery: &cloudidentity.PolicyQuery{
+				OrgUnit: "orgUnits/03ph8a2z1xdnme9",
+				Query:   "entity.org_units.exists(...)",
+			},
+			Setting: &cloudidentity.Setting{
+				Type:  "settings/security.session_controls",
+				Value: googleapi.RawMessage(`{"webSessionDuration":"36000s"}`),
+			},
+		}
+
+		d := policyToData(entry)
+		require.Equal(t, "policies/abc123", d.Name)
+		require.Equal(t, "ADMIN", d.Type)
+		require.Equal(t, "settings/security.session_controls", d.SettingType)
+		require.Equal(t, "orgUnits/03ph8a2z1xdnme9", d.OrgUnit)
+		require.Empty(t, d.Group)
+		require.Equal(t, "entity.org_units.exists(...)", d.Query)
+		require.Equal(t, map[string]any{"webSessionDuration": "36000s"}, d.Value)
+	})
+
+	t.Run("group-scoped policy", func(t *testing.T) {
+		entry := &cloudidentity.Policy{
+			Name:        "policies/grp",
+			Type:        "ADMIN",
+			PolicyQuery: &cloudidentity.PolicyQuery{Group: "groups/01234"},
+			Setting:     &cloudidentity.Setting{Type: "settings/security.password"},
+		}
+
+		d := policyToData(entry)
+		require.Equal(t, "groups/01234", d.Group)
+		require.Empty(t, d.OrgUnit)
+		require.Equal(t, "settings/security.password", d.SettingType)
+		// no value payload -> nil (surfaces as null field)
+		require.Nil(t, d.Value)
+	})
+
+	t.Run("nil PolicyQuery and nil Setting are tolerated", func(t *testing.T) {
+		d := policyToData(&cloudidentity.Policy{Name: "policies/x", Type: "SYSTEM"})
+		require.Equal(t, "policies/x", d.Name)
+		require.Equal(t, "SYSTEM", d.Type)
+		require.Empty(t, d.SettingType)
+		require.Empty(t, d.OrgUnit)
+		require.Empty(t, d.Group)
+		require.Nil(t, d.Value)
+	})
+
+	t.Run("invalid JSON value leaves Value nil without erroring", func(t *testing.T) {
+		entry := &cloudidentity.Policy{
+			Name:    "policies/bad",
+			Setting: &cloudidentity.Setting{Type: "settings/x", Value: googleapi.RawMessage(`not json`)},
+		}
+		d := policyToData(entry)
+		require.Equal(t, "settings/x", d.SettingType)
+		require.Nil(t, d.Value)
+	})
+}


### PR DESCRIPTION
## What

Adds `googleworkspace.policies` returning typed `googleworkspace.policy` rows resolved through the **Cloud Identity Policy API** (GA Feb 2025).

## Why

This surfaces admin-configured **security posture** — 2-step-verification enforcement, password strength/length, session length, less-secure-app access, service on/off status, and third-party app access — that previously required navigating the Admin Console and was **not queryable in mql at all**. It's the foundation for most CIS Google Workspace benchmark controls.

## Details

Each `googleworkspace.policy` row carries:
- `settingType` — the setting identifier (e.g. `settings/security.session_controls`)
- `value` — the resolved value as a `dict` (the schema varies per setting type)
- `orgUnit` / `group` — the scope the setting resolves to (empty when customer-wide)
- `type` — `ADMIN` (admin-configured) vs `SYSTEM` (Google default)

Adds the read-only `cloud-identity.policies.readonly` scope to the default scope set. Requires a super-admin-impersonating service account.

### Example
```mql
googleworkspace.policies.where(settingType == "settings/security.session_controls")
```

## Test plan
- Provider builds (`make providers/build/google-workspace`).
- Codegen up to date; new `.lr.versions` entries at `13.1.5` (next patch after shipped `13.1.4`).
- Interactive verification against a live tenant still pending (requires a super-admin service account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky72xoW7FijdYnQQp7D5Jq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky72xoW7FijdYnQQp7D5Jq)_