### PR TITLE
✨ google-workspace: expose admin role assignments

### DIFF
--- a/providers/google-workspace/resources/google-workspace.go
+++ b/providers/google-workspace/resources/google-workspace.go
@@ -34,6 +34,20 @@ type mqlGoogleworkspaceInternal struct {
 	usersByEmail     map[string]*mqlGoogleworkspaceUser
 	usersByEmailErr  error
 
+	// usersById indexes the customer's users by their unique directory ID so
+	// role-assignment accessors (assignedTo is an ID, not an email) resolve to
+	// a typed user via a single shared Users.List instead of one Get per
+	// assignment.
+	usersByIdOnce sync.Once
+	usersById     map[string]*mqlGoogleworkspaceUser
+	usersByIdErr  error
+
+	// rolesById indexes the customer's admin roles by ID so role-assignment
+	// accessors resolve roleId -> role via a single shared Roles.List.
+	rolesByIdOnce sync.Once
+	rolesById     map[int64]*mqlGoogleworkspaceRole
+	rolesByIdErr  error
+
 	// usageReportsOnce guards a single batched UserUsageReport.Get("all", date)
 	// fetch that returns every user's usage report. user.usageReport() and
 	// report.users.list() both look up by primary email instead of issuing
@@ -65,6 +79,58 @@ func (g *mqlGoogleworkspace) userByEmail(email string) (*mqlGoogleworkspaceUser,
 		return nil, g.usersByEmailErr
 	}
 	return g.usersByEmail[email], nil
+}
+
+func (g *mqlGoogleworkspace) userById(id string) (*mqlGoogleworkspaceUser, error) {
+	g.usersByIdOnce.Do(func() {
+		// Go through GetUsers() so the lazily-computed users field is resolved
+		// even when the caller never touched googleworkspace.users directly.
+		users := g.GetUsers()
+		if users.Error != nil {
+			g.usersByIdErr = users.Error
+			return
+		}
+		m := make(map[string]*mqlGoogleworkspaceUser, len(users.Data))
+		for _, u := range users.Data {
+			user := u.(*mqlGoogleworkspaceUser)
+			if user.Id.Error != nil {
+				g.usersByIdErr = user.Id.Error
+				return
+			}
+			m[user.Id.Data] = user
+		}
+		g.usersById = m
+	})
+	if g.usersByIdErr != nil {
+		return nil, g.usersByIdErr
+	}
+	return g.usersById[id], nil
+}
+
+func (g *mqlGoogleworkspace) roleById(id int64) (*mqlGoogleworkspaceRole, error) {
+	g.rolesByIdOnce.Do(func() {
+		// Go through GetRoles() so the lazily-computed roles field is resolved
+		// even when the caller never touched googleworkspace.roles directly.
+		roles := g.GetRoles()
+		if roles.Error != nil {
+			g.rolesByIdErr = roles.Error
+			return
+		}
+		m := make(map[int64]*mqlGoogleworkspaceRole, len(roles.Data))
+		for _, r := range roles.Data {
+			role := r.(*mqlGoogleworkspaceRole)
+			if role.Id.Error != nil {
+				g.rolesByIdErr = role.Id.Error
+				return
+			}
+			m[role.Id.Data] = role
+		}
+		g.rolesById = m
+	})
+	if g.rolesByIdErr != nil {
+		return nil, g.rolesByIdErr
+	}
+	return g.rolesById[id], nil
 }
 
 func (r *mqlGoogleworkspace) id() (string, error) {

--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -56,6 +56,8 @@ googleworkspace {
   chromeOsDevices() []googleworkspace.chromeOsDevice
   // Mobile devices (Android, iOS, Google Sync) managed by the organization
   mobileDevices() []googleworkspace.mobileDevice
+  // Admin role assignments to users and groups across the organization
+  roleAssignments() []googleworkspace.role.assignment
 }
 
 // Google Workspace calendar
@@ -240,6 +242,12 @@ private googleworkspace.user @defaults("primaryEmail") {
   // is registered. High-signal for audits scoping which identities can SSH
   // into GCE / POSIX-linked hosts.
   hasSshKeys() bool
+  // Admin roles assigned to the user
+  //
+  // Resolves the user's admin role assignments to their role definitions —
+  // the effective administrative privilege the user holds, including
+  // delegated admin roles that the `isAdmin` super-admin flag does not cover.
+  adminRoles() []googleworkspace.role
 }
 
 // Secondary email address attached to a Google Workspace user
@@ -551,6 +559,48 @@ private googleworkspace.role @defaults("name") {
   privileges []dict
   // The set of privileges as typed entries with `privilegeName` and `serviceId`
   rolePrivileges []googleworkspace.role.privilege
+  // Assignments of this role to users and groups
+  assignments() []googleworkspace.role.assignment
+}
+
+// Google Workspace admin role assignment
+//
+// Examine a single assignment of an admin role to a user or group — the
+// binding that actually grants administrative privilege, as opposed to the
+// `googleworkspace.role` definition that only describes a privilege set.
+// `assignedTo` is the unique ID of the assignee and `assigneeType` reports
+// whether it is a user or a group; `user()` resolves the assignee to a typed
+// `googleworkspace.user` when it is a user, and `role()` resolves the assigned
+// role. `scopeType` and `orgUnitId` report whether the grant is customer-wide
+// or scoped to an organizational unit. This is the surface for "who holds
+// super admin" and least-privilege reviews — for example
+// `googleworkspace.roleAssignments.where(assigneeType == "user")`.
+private googleworkspace.role.assignment @defaults("assignedTo assigneeType scopeType") {
+  // The unique ID of the role assignment
+  id string
+  // The ID of the assigned role (joins to googleworkspace.role.id)
+  roleId int
+  // The unique ID of the entity the role is assigned to (user, group, or service account)
+  assignedTo string
+  // The type of the assignee
+  //
+  // One of `user` or `group`.
+  assigneeType string
+  // The scope at which the role is granted
+  //
+  // One of `CUSTOMER` (customer-wide) or `ORG_UNIT` (scoped to an organizational unit).
+  scopeType string
+  // The organizational unit ID the assignment is scoped to (empty when CUSTOMER-scoped)
+  orgUnitId string
+  // The condition associated with this role assignment (empty when unconditional)
+  //
+  // When set, the role only takes effect when the accessed resource meets the
+  // condition — currently used to scope grants to or away from security groups.
+  condition string
+  // The user the role is assigned to (null when the assignee is a group)
+  user() googleworkspace.user
+  // The assigned role
+  role() googleworkspace.role
 }
 
 // Google Workspace role privilege

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -36,6 +36,7 @@ const (
 	ResourceGoogleworkspaceGroupSettingsConfig  string = "googleworkspace.group.settingsConfig"
 	ResourceGoogleworkspaceMember               string = "googleworkspace.member"
 	ResourceGoogleworkspaceRole                 string = "googleworkspace.role"
+	ResourceGoogleworkspaceRoleAssignment       string = "googleworkspace.role.assignment"
 	ResourceGoogleworkspaceRolePrivilege        string = "googleworkspace.role.privilege"
 	ResourceGoogleworkspaceReportApps           string = "googleworkspace.report.apps"
 	ResourceGoogleworkspaceReportActivity       string = "googleworkspace.report.activity"
@@ -131,6 +132,10 @@ func init() {
 		"googleworkspace.role": {
 			// to override args, implement: initGoogleworkspaceRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGoogleworkspaceRole,
+		},
+		"googleworkspace.role.assignment": {
+			// to override args, implement: initGoogleworkspaceRoleAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGoogleworkspaceRoleAssignment,
 		},
 		"googleworkspace.role.privilege": {
 			// to override args, implement: initGoogleworkspaceRolePrivilege(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -284,6 +289,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.mobileDevices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspace).GetMobileDevices()).ToDataRes(types.Array(types.Resource("googleworkspace.mobileDevice")))
+	},
+	"googleworkspace.roleAssignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspace).GetRoleAssignments()).ToDataRes(types.Array(types.Resource("googleworkspace.role.assignment")))
 	},
 	"googleworkspace.calendar.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceCalendar).GetId()).ToDataRes(types.String)
@@ -485,6 +493,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.user.hasSshKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceUser).GetHasSshKeys()).ToDataRes(types.Bool)
+	},
+	"googleworkspace.user.adminRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceUser).GetAdminRoles()).ToDataRes(types.Array(types.Resource("googleworkspace.role")))
 	},
 	"googleworkspace.user.email.address": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceUserEmail).GetAddress()).ToDataRes(types.String)
@@ -794,6 +805,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.role.rolePrivileges": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceRole).GetRolePrivileges()).ToDataRes(types.Array(types.Resource("googleworkspace.role.privilege")))
+	},
+	"googleworkspace.role.assignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRole).GetAssignments()).ToDataRes(types.Array(types.Resource("googleworkspace.role.assignment")))
+	},
+	"googleworkspace.role.assignment.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetId()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.roleId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetRoleId()).ToDataRes(types.Int)
+	},
+	"googleworkspace.role.assignment.assignedTo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetAssignedTo()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.assigneeType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetAssigneeType()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.scopeType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetScopeType()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.orgUnitId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetOrgUnitId()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.condition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetCondition()).ToDataRes(types.String)
+	},
+	"googleworkspace.role.assignment.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetUser()).ToDataRes(types.Resource("googleworkspace.user"))
+	},
+	"googleworkspace.role.assignment.role": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceRoleAssignment).GetRole()).ToDataRes(types.Resource("googleworkspace.role"))
 	},
 	"googleworkspace.role.privilege.privilegeName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceRolePrivilege).GetPrivilegeName()).ToDataRes(types.String)
@@ -1287,6 +1328,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGoogleworkspace).MobileDevices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"googleworkspace.roleAssignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspace).RoleAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"googleworkspace.calendar.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceCalendar).__id, ok = v.Value.(string)
 		return
@@ -1577,6 +1622,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"googleworkspace.user.hasSshKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceUser).HasSshKeys, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.user.adminRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceUser).AdminRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.user.email.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2041,6 +2090,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"googleworkspace.role.rolePrivileges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceRole).RolePrivileges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRole).Assignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).__id, ok = v.Value.(string)
+		return
+	},
+	"googleworkspace.role.assignment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.roleId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).RoleId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.assignedTo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).AssignedTo, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.assigneeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).AssigneeType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.scopeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).ScopeType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.orgUnitId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).OrgUnitId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).User, ok = plugin.RawToTValue[*mqlGoogleworkspaceUser](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.role.assignment.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceRoleAssignment).Role, ok = plugin.RawToTValue[*mqlGoogleworkspaceRole](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.role.privilege.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2686,6 +2779,7 @@ type mqlGoogleworkspace struct {
 	Policies        plugin.TValue[[]any]
 	ChromeOsDevices plugin.TValue[[]any]
 	MobileDevices   plugin.TValue[[]any]
+	RoleAssignments plugin.TValue[[]any]
 }
 
 // createGoogleworkspace creates a new instance of this resource
@@ -2946,6 +3040,22 @@ func (c *mqlGoogleworkspace) GetMobileDevices() *plugin.TValue[[]any] {
 		}
 
 		return c.mobileDevices()
+	})
+}
+
+func (c *mqlGoogleworkspace) GetRoleAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoleAssignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace", c.__id, "roleAssignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roleAssignments()
 	})
 }
 
@@ -3342,6 +3452,7 @@ type mqlGoogleworkspaceUser struct {
 	Tokens                     plugin.TValue[[]any]
 	HasRecoveryConfigured      plugin.TValue[bool]
 	HasSshKeys                 plugin.TValue[bool]
+	AdminRoles                 plugin.TValue[[]any]
 }
 
 // createGoogleworkspaceUser creates a new instance of this resource
@@ -3570,6 +3681,22 @@ func (c *mqlGoogleworkspaceUser) GetHasRecoveryConfigured() *plugin.TValue[bool]
 func (c *mqlGoogleworkspaceUser) GetHasSshKeys() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasSshKeys, func() (bool, error) {
 		return c.hasSshKeys()
+	})
+}
+
+func (c *mqlGoogleworkspaceUser) GetAdminRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AdminRoles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace.user", c.__id, "adminRoles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.adminRoles()
 	})
 }
 
@@ -4593,6 +4720,7 @@ type mqlGoogleworkspaceRole struct {
 	IsSuperAdminRole plugin.TValue[bool]
 	Privileges       plugin.TValue[[]any]
 	RolePrivileges   plugin.TValue[[]any]
+	Assignments      plugin.TValue[[]any]
 }
 
 // createGoogleworkspaceRole creates a new instance of this resource
@@ -4658,6 +4786,135 @@ func (c *mqlGoogleworkspaceRole) GetPrivileges() *plugin.TValue[[]any] {
 
 func (c *mqlGoogleworkspaceRole) GetRolePrivileges() *plugin.TValue[[]any] {
 	return &c.RolePrivileges
+}
+
+func (c *mqlGoogleworkspaceRole) GetAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Assignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace.role", c.__id, "assignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.assignments()
+	})
+}
+
+// mqlGoogleworkspaceRoleAssignment for the googleworkspace.role.assignment resource
+type mqlGoogleworkspaceRoleAssignment struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGoogleworkspaceRoleAssignmentInternal it will be used here
+	Id           plugin.TValue[string]
+	RoleId       plugin.TValue[int64]
+	AssignedTo   plugin.TValue[string]
+	AssigneeType plugin.TValue[string]
+	ScopeType    plugin.TValue[string]
+	OrgUnitId    plugin.TValue[string]
+	Condition    plugin.TValue[string]
+	User         plugin.TValue[*mqlGoogleworkspaceUser]
+	Role         plugin.TValue[*mqlGoogleworkspaceRole]
+}
+
+// createGoogleworkspaceRoleAssignment creates a new instance of this resource
+func createGoogleworkspaceRoleAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGoogleworkspaceRoleAssignment{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("googleworkspace.role.assignment", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) MqlName() string {
+	return "googleworkspace.role.assignment"
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetRoleId() *plugin.TValue[int64] {
+	return &c.RoleId
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetAssignedTo() *plugin.TValue[string] {
+	return &c.AssignedTo
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetAssigneeType() *plugin.TValue[string] {
+	return &c.AssigneeType
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetScopeType() *plugin.TValue[string] {
+	return &c.ScopeType
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetOrgUnitId() *plugin.TValue[string] {
+	return &c.OrgUnitId
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetCondition() *plugin.TValue[string] {
+	return &c.Condition
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetUser() *plugin.TValue[*mqlGoogleworkspaceUser] {
+	return plugin.GetOrCompute[*mqlGoogleworkspaceUser](&c.User, func() (*mqlGoogleworkspaceUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace.role.assignment", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGoogleworkspaceUser), nil
+			}
+		}
+
+		return c.user()
+	})
+}
+
+func (c *mqlGoogleworkspaceRoleAssignment) GetRole() *plugin.TValue[*mqlGoogleworkspaceRole] {
+	return plugin.GetOrCompute[*mqlGoogleworkspaceRole](&c.Role, func() (*mqlGoogleworkspaceRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace.role.assignment", c.__id, "role")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGoogleworkspaceRole), nil
+			}
+		}
+
+		return c.role()
+	})
 }
 
 // mqlGoogleworkspaceRolePrivilege for the googleworkspace.role.privilege resource

--- a/providers/google-workspace/resources/google-workspace.lr.versions
+++ b/providers/google-workspace/resources/google-workspace.lr.versions
@@ -235,6 +235,17 @@ googleworkspace.report.usage.userEmail 9.0.0
 googleworkspace.report.users 9.0.0
 googleworkspace.report.users.list 9.0.0
 googleworkspace.role 9.0.0
+googleworkspace.role.assignment 13.1.5
+googleworkspace.role.assignment.assignedTo 13.1.5
+googleworkspace.role.assignment.assigneeType 13.1.5
+googleworkspace.role.assignment.condition 13.1.5
+googleworkspace.role.assignment.id 13.1.5
+googleworkspace.role.assignment.orgUnitId 13.1.5
+googleworkspace.role.assignment.role 13.1.5
+googleworkspace.role.assignment.roleId 13.1.5
+googleworkspace.role.assignment.scopeType 13.1.5
+googleworkspace.role.assignment.user 13.1.5
+googleworkspace.role.assignments 13.1.5
 googleworkspace.role.description 9.0.0
 googleworkspace.role.id 9.0.0
 googleworkspace.role.isSuperAdminRole 9.0.0
@@ -245,6 +256,7 @@ googleworkspace.role.privilege.privilegeName 13.0.14
 googleworkspace.role.privilege.serviceId 13.0.14
 googleworkspace.role.privileges 9.0.0
 googleworkspace.role.rolePrivileges 13.0.14
+googleworkspace.roleAssignments 13.1.5
 googleworkspace.roles 9.0.0
 googleworkspace.superAdmins 13.1.5
 googleworkspace.suspendedUsers 13.1.5
@@ -271,6 +283,7 @@ googleworkspace.user.address.sourceIsStructured 13.0.14
 googleworkspace.user.address.streetAddress 13.0.14
 googleworkspace.user.address.type 13.0.14
 googleworkspace.user.addresses 13.0.14
+googleworkspace.user.adminRoles 13.1.5
 googleworkspace.user.agreedToTerms 9.0.0
 googleworkspace.user.aliases 9.0.0
 googleworkspace.user.archived 9.0.0

--- a/providers/google-workspace/resources/role_assignments.go
+++ b/providers/google-workspace/resources/role_assignments.go
@@ -1,0 +1,208 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/google-workspace/connection"
+	directory "google.golang.org/api/admin/directory/v1"
+)
+
+// listRoleAssignments runs a paginated RoleAssignments.List, applying the
+// optional roleId / userKey filters the directory API supports, and maps
+// every assignment to a typed resource.
+func listRoleAssignments(runtime *plugin.Runtime, roleId, userKey string) ([]any, error) {
+	conn := runtime.Connection.(*connection.GoogleWorkspaceConnection)
+	directoryService, err := directoryService(conn, directory.AdminDirectoryRolemanagementReadonlyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	pageToken := ""
+	for {
+		call := directoryService.RoleAssignments.List(conn.CustomerID()).MaxResults(200)
+		if roleId != "" {
+			call = call.RoleId(roleId)
+		}
+		if userKey != "" {
+			call = call.UserKey(userKey)
+		}
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		assignments, err := call.Do()
+		if err != nil {
+			return nil, err
+		}
+		for i := range assignments.Items {
+			r, err := newMqlGoogleWorkspaceRoleAssignment(runtime, assignments.Items[i])
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, r)
+		}
+		if assignments.NextPageToken == "" {
+			break
+		}
+		pageToken = assignments.NextPageToken
+	}
+	return res, nil
+}
+
+// roleAssignmentData is the plain-struct projection of a
+// directory.RoleAssignment used to build the resource.
+type roleAssignmentData struct {
+	ID           string
+	RoleID       int64
+	AssignedTo   string
+	AssigneeType string
+	ScopeType    string
+	OrgUnitID    string
+	Condition    string
+}
+
+// roleAssignmentToData projects a directory.RoleAssignment into the plain
+// fields the resource exposes. RoleAssignmentId / RoleId are int64 on the SDK
+// (string-encoded on the wire); the id field renders the assignment id as a
+// decimal string.
+func roleAssignmentToData(entry *directory.RoleAssignment) roleAssignmentData {
+	return roleAssignmentData{
+		ID:           strconv.FormatInt(entry.RoleAssignmentId, 10),
+		RoleID:       entry.RoleId,
+		AssignedTo:   entry.AssignedTo,
+		AssigneeType: entry.AssigneeType,
+		ScopeType:    entry.ScopeType,
+		OrgUnitID:    entry.OrgUnitId,
+		Condition:    entry.Condition,
+	}
+}
+
+// isUserAssignee reports whether a role assignment's assignee is a user (as
+// opposed to a group or service account). The directory API returns the
+// assignee type lowercased.
+func isUserAssignee(assigneeType string) bool {
+	return assigneeType == "user"
+}
+
+func newMqlGoogleWorkspaceRoleAssignment(runtime *plugin.Runtime, entry *directory.RoleAssignment) (any, error) {
+	d := roleAssignmentToData(entry)
+	return CreateResource(runtime, "googleworkspace.role.assignment", map[string]*llx.RawData{
+		"id":           llx.StringData(d.ID),
+		"roleId":       llx.IntData(d.RoleID),
+		"assignedTo":   llx.StringData(d.AssignedTo),
+		"assigneeType": llx.StringData(d.AssigneeType),
+		"scopeType":    llx.StringData(d.ScopeType),
+		"orgUnitId":    llx.StringData(d.OrgUnitID),
+		"condition":    llx.StringData(d.Condition),
+	})
+}
+
+func (g *mqlGoogleworkspaceRoleAssignment) id() (string, error) {
+	if g.Id.Error != nil {
+		return "", g.Id.Error
+	}
+	return "googleworkspace.role.assignment/" + g.Id.Data, nil
+}
+
+func (g *mqlGoogleworkspace) roleAssignments() ([]any, error) {
+	return listRoleAssignments(g.MqlRuntime, "", "")
+}
+
+func (g *mqlGoogleworkspaceRole) assignments() ([]any, error) {
+	if g.Id.Error != nil {
+		return nil, g.Id.Error
+	}
+	return listRoleAssignments(g.MqlRuntime, strconv.FormatInt(g.Id.Data, 10), "")
+}
+
+func (g *mqlGoogleworkspaceRoleAssignment) role() (*mqlGoogleworkspaceRole, error) {
+	if g.RoleId.Error != nil {
+		return nil, g.RoleId.Error
+	}
+	parent, err := workspaceResource(g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	role, err := parent.roleById(g.RoleId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		g.Role.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
+}
+
+func (g *mqlGoogleworkspaceRoleAssignment) user() (*mqlGoogleworkspaceUser, error) {
+	if g.AssigneeType.Error != nil {
+		return nil, g.AssigneeType.Error
+	}
+	// assignedTo is an entity ID; only resolve it as a user when the assignee
+	// is actually a user (it can also be a group or service account).
+	if !isUserAssignee(g.AssigneeType.Data) {
+		g.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	if g.AssignedTo.Error != nil {
+		return nil, g.AssignedTo.Error
+	}
+
+	parent, err := workspaceResource(g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	user, err := parent.userById(g.AssignedTo.Data)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		g.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return user, nil
+}
+
+func (g *mqlGoogleworkspaceUser) adminRoles() ([]any, error) {
+	if g.Id.Error != nil {
+		return nil, g.Id.Error
+	}
+	assignments, err := listRoleAssignments(g.MqlRuntime, "", g.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	parent, err := workspaceResource(g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	seen := map[int64]struct{}{}
+	for _, a := range assignments {
+		assignment := a.(*mqlGoogleworkspaceRoleAssignment)
+		if assignment.RoleId.Error != nil {
+			return nil, assignment.RoleId.Error
+		}
+		roleId := assignment.RoleId.Data
+		if _, dup := seen[roleId]; dup {
+			continue
+		}
+		seen[roleId] = struct{}{}
+
+		role, err := parent.roleById(roleId)
+		if err != nil {
+			return nil, err
+		}
+		if role == nil {
+			continue
+		}
+		res = append(res, role)
+	}
+	return res, nil
+}

--- a/providers/google-workspace/resources/role_assignments_test.go
+++ b/providers/google-workspace/resources/role_assignments_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	directory "google.golang.org/api/admin/directory/v1"
+)
+
+func TestRoleAssignmentToData(t *testing.T) {
+	entry := &directory.RoleAssignment{
+		RoleAssignmentId: 9876543210,
+		RoleId:           12345,
+		AssignedTo:       "103456789012345678901",
+		AssigneeType:     "user",
+		ScopeType:        "ORG_UNIT",
+		OrgUnitId:        "03ph8a2z1xdnme9",
+		Condition:        "api.getAttribute('...')",
+	}
+
+	d := roleAssignmentToData(entry)
+	// int64 ids render as decimal strings (no scientific notation / truncation)
+	require.Equal(t, "9876543210", d.ID)
+	require.Equal(t, int64(12345), d.RoleID)
+	require.Equal(t, "103456789012345678901", d.AssignedTo)
+	require.Equal(t, "user", d.AssigneeType)
+	require.Equal(t, "ORG_UNIT", d.ScopeType)
+	require.Equal(t, "03ph8a2z1xdnme9", d.OrgUnitID)
+	require.Equal(t, "api.getAttribute('...')", d.Condition)
+}
+
+func TestRoleAssignmentToData_GroupAssignee(t *testing.T) {
+	d := roleAssignmentToData(&directory.RoleAssignment{
+		RoleAssignmentId: 1,
+		RoleId:           2,
+		AssignedTo:       "01234567890",
+		AssigneeType:     "group",
+		ScopeType:        "CUSTOMER",
+	})
+	require.Equal(t, "group", d.AssigneeType)
+	require.Empty(t, d.OrgUnitID)
+	require.Empty(t, d.Condition)
+}
+
+func TestIsUserAssignee(t *testing.T) {
+	require.True(t, isUserAssignee("user"))
+	require.False(t, isUserAssignee("group"))
+	require.False(t, isUserAssignee("USER")) // API returns lowercase; guard against case drift
+	require.False(t, isUserAssignee(""))
+}


### PR DESCRIPTION
## What

Exposes the **binding layer** that actually grants administrative privilege, separate from the `googleworkspace.role` definition that only describes a privilege set.

- `googleworkspace.roleAssignments` — every admin role assignment in the customer (who holds which role, at what scope).
- `googleworkspace.role.assignments` — assignments of a specific role.
- `googleworkspace.user.adminRoles` — resolves a user's assignments to their role definitions, **including delegated admin roles that the `isAdmin` super-admin flag does not cover**.

## Why

Today "find privileged users" only works for super admins via `users.where(isAdmin)`; delegated admins with scoped roles were invisible. This closes the most important privileged-access audit gap.

## Details

The new `googleworkspace.role.assignment` resource carries `assignedTo`, `assigneeType`, `scopeType`, `orgUnitId`, and `condition`, plus typed `user()` and `role()` accessors. Assignments resolve roles and users through single shared `Roles.List` / `Users.List` indexes on the parent to avoid per-assignment API calls. Uses the existing `admin.directory.rolemanagement.readonly` scope (no new scopes).

### Example
```mql
googleworkspace.roleAssignments.where(assigneeType == "user") { assignedTo role.name scopeType }
```

## Test plan
- Provider builds (`make providers/build/google-workspace`).
- Codegen up to date; new `.lr.versions` entries at `13.1.5`.
- Interactive verification against a live tenant still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky72xoW7FijdYnQQp7D5Jq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky72xoW7FijdYnQQp7D5Jq)_