### PR TITLE
✨ ms365: add check-authoring helpers for licensing and role assignments

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -179,6 +179,14 @@ microsoft.tenant @defaults("name") {
   id string
   // Service plans associated with the tenant
   assignedPlans []dict
+  // Enabled service families on the tenant
+  //
+  // Distinct list of `service` names from `assignedPlans` whose
+  // `capabilityStatus` is `Enabled`, sorted alphabetically. Use this to gate
+  // license-dependent checks without digging through the `assignedPlans` dicts
+  // — for example `microsoft.tenant.enabledServicePlans.contains("AADPremiumService")`
+  // to confirm Microsoft Entra ID P1/P2 is active.
+  enabledServicePlans() []string
   // Provisioned plan
   provisionedPlans []dict
   // Tenant creation date and time
@@ -2464,6 +2472,19 @@ private microsoft.rolemanagement.roleassignment @defaults("id principalId") {
   roleDefinition() microsoft.rolemanagement.roledefinition
   // Service principal ID
   principalId string
+  // Principal type
+  //
+  // Short directory type of the assigned principal, derived from its
+  // `@odata.type` — typically `user`, `group`, or `servicePrincipal`. Empty
+  // when the API does not return the principal type. Use it to scope
+  // privileged-role audits, e.g. flag direct `user` assignments to
+  // Global Administrator.
+  principalType string
+  // Principal display name
+  //
+  // Display name of the assigned principal as returned by the directory.
+  // Empty when the API does not return a display name.
+  principalName string
   // Service principal
   principal dict
 }

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1129,6 +1129,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.tenant.assignedPlans": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftTenant).GetAssignedPlans()).ToDataRes(types.Array(types.Dict))
 	},
+	"microsoft.tenant.enabledServicePlans": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftTenant).GetEnabledServicePlans()).ToDataRes(types.Array(types.String))
+	},
 	"microsoft.tenant.provisionedPlans": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftTenant).GetProvisionedPlans()).ToDataRes(types.Array(types.Dict))
 	},
@@ -3387,6 +3390,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.rolemanagement.roleassignment.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"microsoft.rolemanagement.roleassignment.principalType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipalType()).ToDataRes(types.String)
+	},
+	"microsoft.rolemanagement.roleassignment.principalName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipalName()).ToDataRes(types.String)
 	},
 	"microsoft.rolemanagement.roleassignment.principal": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipal()).ToDataRes(types.Dict)
@@ -5888,6 +5897,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.tenant.assignedPlans": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftTenant).AssignedPlans, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.tenant.enabledServicePlans": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftTenant).EnabledServicePlans, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"microsoft.tenant.provisionedPlans": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9312,6 +9325,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.rolemanagement.roleassignment.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftRolemanagementRoleassignment).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.rolemanagement.roleassignment.principalType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftRolemanagementRoleassignment).PrincipalType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.rolemanagement.roleassignment.principalName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftRolemanagementRoleassignment).PrincipalName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.rolemanagement.roleassignment.principal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13406,6 +13427,7 @@ type mqlMicrosoftTenant struct {
 	mqlMicrosoftTenantInternal
 	Id                                   plugin.TValue[string]
 	AssignedPlans                        plugin.TValue[[]any]
+	EnabledServicePlans                  plugin.TValue[[]any]
 	ProvisionedPlans                     plugin.TValue[[]any]
 	CreatedDateTime                      plugin.TValue[*time.Time]
 	Name                                 plugin.TValue[string]
@@ -13469,6 +13491,12 @@ func (c *mqlMicrosoftTenant) GetId() *plugin.TValue[string] {
 
 func (c *mqlMicrosoftTenant) GetAssignedPlans() *plugin.TValue[[]any] {
 	return &c.AssignedPlans
+}
+
+func (c *mqlMicrosoftTenant) GetEnabledServicePlans() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EnabledServicePlans, func() ([]any, error) {
+		return c.enabledServicePlans()
+	})
 }
 
 func (c *mqlMicrosoftTenant) GetProvisionedPlans() *plugin.TValue[[]any] {
@@ -22373,6 +22401,8 @@ type mqlMicrosoftRolemanagementRoleassignment struct {
 	RoleDefinitionId plugin.TValue[string]
 	RoleDefinition   plugin.TValue[*mqlMicrosoftRolemanagementRoledefinition]
 	PrincipalId      plugin.TValue[string]
+	PrincipalType    plugin.TValue[string]
+	PrincipalName    plugin.TValue[string]
 	Principal        plugin.TValue[any]
 }
 
@@ -22439,6 +22469,14 @@ func (c *mqlMicrosoftRolemanagementRoleassignment) GetRoleDefinition() *plugin.T
 
 func (c *mqlMicrosoftRolemanagementRoleassignment) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlMicrosoftRolemanagementRoleassignment) GetPrincipalType() *plugin.TValue[string] {
+	return &c.PrincipalType
+}
+
+func (c *mqlMicrosoftRolemanagementRoleassignment) GetPrincipalName() *plugin.TValue[string] {
+	return &c.PrincipalName
 }
 
 func (c *mqlMicrosoftRolemanagementRoleassignment) GetPrincipal() *plugin.TValue[any] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -866,6 +866,8 @@ microsoft.rolemanagement.roleassignment 9.0.0
 microsoft.rolemanagement.roleassignment.id 9.0.0
 microsoft.rolemanagement.roleassignment.principal 9.0.0
 microsoft.rolemanagement.roleassignment.principalId 9.0.0
+microsoft.rolemanagement.roleassignment.principalName 13.7.2
+microsoft.rolemanagement.roleassignment.principalType 13.7.2
 microsoft.rolemanagement.roleassignment.roleDefinition 13.3.1
 microsoft.rolemanagement.roleassignment.roleDefinitionId 9.0.0
 microsoft.rolemanagement.roledefinition 9.0.0
@@ -1072,6 +1074,7 @@ microsoft.tenant.brandingInfo.useTransparentLightbox 11.1.76
 microsoft.tenant.countryLetterCode 11.2.1
 microsoft.tenant.createdAt 11.0.29
 microsoft.tenant.createdDateTime 11.0.29
+microsoft.tenant.enabledServicePlans 13.7.2
 microsoft.tenant.formsSettings 11.0.29
 microsoft.tenant.id 11.0.29
 microsoft.tenant.name 11.0.29

--- a/providers/ms365/resources/rolemanagement.go
+++ b/providers/ms365/resources/rolemanagement.go
@@ -236,15 +236,19 @@ func (a *mqlMicrosoftRolemanagementRoledefinition) assignments() ([]any, error) 
 
 	res := []any{}
 	for _, roleAssignment := range roleAssignments {
-		principal, err := convert.JsonToDict(newDirectoryPrincipal(roleAssignment.GetPrincipal()))
+		directoryPrincipal := roleAssignment.GetPrincipal()
+		principal, err := convert.JsonToDict(newDirectoryPrincipal(directoryPrincipal))
 		if err != nil {
 			return nil, err
 		}
+		principalType, principalName := directoryPrincipalInfo(directoryPrincipal)
 		mqlResource, err := CreateResource(a.MqlRuntime, "microsoft.rolemanagement.roleassignment",
 			map[string]*llx.RawData{
 				"id":               llx.StringDataPtr(roleAssignment.GetId()),
 				"roleDefinitionId": llx.StringDataPtr(roleAssignment.GetRoleDefinitionId()),
 				"principalId":      llx.StringDataPtr(roleAssignment.GetPrincipalId()),
+				"principalType":    llx.StringData(principalType),
+				"principalName":    llx.StringData(principalName),
 				"principal":        llx.DictData(principal),
 			})
 		if err != nil {

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -215,6 +215,41 @@ func newDirectoryPrincipal(p models.DirectoryObjectable) *DirectoryObject {
 	}
 }
 
+// directoryObjectDisplayName extracts a directory object's display name from
+// the additional-data bag the Graph SDK populates for $expand-ed references
+// (the base DirectoryObject type has no typed displayName accessor). It
+// tolerates the value being a string or *string and returns "" otherwise.
+func directoryObjectDisplayName(additionalData map[string]any) string {
+	v, ok := additionalData["displayName"]
+	if !ok {
+		return ""
+	}
+	switch name := v.(type) {
+	case string:
+		return name
+	case *string:
+		if name != nil {
+			return *name
+		}
+	}
+	return ""
+}
+
+// directoryPrincipalInfo derives the short principal type (e.g. "user",
+// "group", "servicePrincipal") and display name for a directory principal,
+// such as the assignee on a role assignment. Both values are best-effort and
+// return "" when the API omits them.
+func directoryPrincipalInfo(p models.DirectoryObjectable) (principalType string, principalName string) {
+	if p == nil {
+		return "", ""
+	}
+	if t := normalizeOwnerType(p.GetOdataType()); t != nil {
+		principalType = *t
+	}
+	principalName = directoryObjectDisplayName(p.GetAdditionalData())
+	return principalType, principalName
+}
+
 type PolicyBase struct {
 	DirectoryObject
 	// Description for this policy. Required.

--- a/providers/ms365/resources/structs_test.go
+++ b/providers/ms365/resources/structs_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"testing"
 
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,4 +15,57 @@ import (
 // dereference inside the constructor.
 func TestNewAdminConsentRequestPolicy_NilInput(t *testing.T) {
 	assert.Nil(t, newAdminConsentRequestPolicy(nil))
+}
+
+func TestDirectoryObjectDisplayName(t *testing.T) {
+	name := "Alice Admin"
+	tests := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{"nil map", nil, ""},
+		{"missing key", map[string]any{"other": "x"}, ""},
+		{"string value", map[string]any{"displayName": "Global Admins"}, "Global Admins"},
+		{"pointer value", map[string]any{"displayName": &name}, name},
+		{"nil pointer", map[string]any{"displayName": (*string)(nil)}, ""},
+		{"wrong type", map[string]any{"displayName": 42}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, directoryObjectDisplayName(tc.in))
+		})
+	}
+}
+
+func TestDirectoryPrincipalInfo(t *testing.T) {
+	t.Run("nil principal", func(t *testing.T) {
+		pt, pn := directoryPrincipalInfo(nil)
+		assert.Empty(t, pt)
+		assert.Empty(t, pn)
+	})
+
+	t.Run("user with display name", func(t *testing.T) {
+		p := models.NewDirectoryObject()
+		p.SetOdataType(ptr("#microsoft.graph.user"))
+		p.SetAdditionalData(map[string]any{"displayName": "Alice Admin"})
+		pt, pn := directoryPrincipalInfo(p)
+		assert.Equal(t, "user", pt)
+		assert.Equal(t, "Alice Admin", pn)
+	})
+
+	t.Run("group without display name", func(t *testing.T) {
+		p := models.NewDirectoryObject()
+		p.SetOdataType(ptr("#microsoft.graph.group"))
+		pt, pn := directoryPrincipalInfo(p)
+		assert.Equal(t, "group", pt)
+		assert.Empty(t, pn)
+	})
+
+	t.Run("missing odata type", func(t *testing.T) {
+		p := models.NewDirectoryObject()
+		pt, pn := directoryPrincipalInfo(p)
+		assert.Empty(t, pt)
+		assert.Empty(t, pn)
+	})
 }

--- a/providers/ms365/resources/tenant.go
+++ b/providers/ms365/resources/tenant.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/directory"
@@ -163,6 +165,48 @@ func newMicrosoftTenant(runtime *plugin.Runtime, org models.Organizationable) (*
 		return nil, err
 	}
 	return mqlResource.(*mqlMicrosoftTenant), nil
+}
+
+// enabledServicePlanServices returns the distinct, alphabetically sorted set of
+// service families from a tenant's assignedPlans whose capabilityStatus is
+// "Enabled". The input is the assignedPlans dict slice as stored on the
+// resource (each element a map with "service" and "capabilityStatus" keys);
+// entries that are not maps, lack an enabled status, or carry an empty service
+// name are skipped. It is the pure core of the enabledServicePlans() accessor.
+func enabledServicePlanServices(assignedPlans []any) []string {
+	seen := map[string]struct{}{}
+	for _, p := range assignedPlans {
+		plan, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		status, _ := plan["capabilityStatus"].(string)
+		if !strings.EqualFold(status, "Enabled") {
+			continue
+		}
+		service, _ := plan["service"].(string)
+		if service == "" {
+			continue
+		}
+		seen[service] = struct{}{}
+	}
+
+	services := make([]string, 0, len(seen))
+	for service := range seen {
+		services = append(services, service)
+	}
+	sort.Strings(services)
+	return services
+}
+
+// enabledServicePlans surfaces the tenant's enabled service families so checks
+// can gate on licensing without parsing the assignedPlans dicts by hand.
+func (a *mqlMicrosoftTenant) enabledServicePlans() ([]any, error) {
+	assignedPlans := a.GetAssignedPlans()
+	if assignedPlans.Error != nil {
+		return nil, assignedPlans.Error
+	}
+	return convert.SliceAnyToInterface(enabledServicePlanServices(assignedPlans.Data)), nil
 }
 
 // https://learn.microsoft.com/en-us/entra/identity/users/licensing-service-plan-reference

--- a/providers/ms365/resources/tenant_test.go
+++ b/providers/ms365/resources/tenant_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnabledServicePlanServices(t *testing.T) {
+	plan := func(service, status string) map[string]any {
+		return map[string]any{"service": service, "capabilityStatus": status}
+	}
+
+	tests := []struct {
+		name string
+		in   []any
+		want []string
+	}{
+		{"nil input", nil, []string{}},
+		{"empty input", []any{}, []string{}},
+		{
+			name: "only enabled plans are returned, sorted",
+			in: []any{
+				plan("exchange", "Enabled"),
+				plan("AADPremiumService", "Enabled"),
+			},
+			want: []string{"AADPremiumService", "exchange"},
+		},
+		{
+			name: "non-enabled statuses are dropped",
+			in: []any{
+				plan("exchange", "Enabled"),
+				plan("MicrosoftOffice", "Deleted"),
+				plan("SharePoint", "Suspended"),
+			},
+			want: []string{"exchange"},
+		},
+		{
+			name: "duplicate services collapse to one",
+			in: []any{
+				plan("exchange", "Enabled"),
+				plan("exchange", "Enabled"),
+			},
+			want: []string{"exchange"},
+		},
+		{
+			name: "status match is case-insensitive",
+			in: []any{
+				plan("exchange", "enabled"),
+				plan("AADPremiumService", "ENABLED"),
+			},
+			want: []string{"AADPremiumService", "exchange"},
+		},
+		{
+			name: "entries with empty service names are skipped",
+			in: []any{
+				plan("", "Enabled"),
+				plan("exchange", "Enabled"),
+			},
+			want: []string{"exchange"},
+		},
+		{
+			name: "non-map and malformed entries are skipped",
+			in: []any{
+				"not-a-map",
+				map[string]any{"service": 7, "capabilityStatus": "Enabled"},
+				map[string]any{"service": "exchange"}, // missing status
+				plan("exchange", "Enabled"),
+			},
+			want: []string{"exchange"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, enabledServicePlanServices(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
## What

Two small, additive helpers on the `ms365` provider that remove boilerplate from common Microsoft 365 security checks.

### 1. `microsoft.tenant.enabledServicePlans` → `[]string`
Distinct, alphabetically sorted list of `service` families from `assignedPlans` whose `capabilityStatus` is `Enabled`. Lets license-gated checks stop digging through the `assignedPlans` dicts:

```mql
// before
microsoft.tenant.assignedPlans.where(_['capabilityStatus'] == 'Enabled').map(_['service'])...
// after
microsoft.tenant.enabledServicePlans.contains("AADPremiumService")
```

### 2. `microsoft.rolemanagement.roleassignment.principalType` + `principalName`
Surface the assigned principal's short directory type (`user` / `group` / `servicePrincipal`, derived from its `@odata.type`) and display name, so privileged-role audits don't have to reason about an opaque `principalId`:

```mql
microsoft.rolemanagement.roleDefinitions
  .where(displayName == "Global Administrator")
  .assignments.where(principalType == "user") { principalName }
```

Both fields are best-effort and return empty when the Graph API omits the value.

## How

- New computed accessor `enabledServicePlans()` on `microsoft.tenant`, backed by the pure `enabledServicePlanServices()`.
- `assignments()` now enriches each role assignment via `directoryPrincipalInfo()`, which reuses the existing `normalizeOwnerType` for the `@odata.type` → short-type mapping and reads the display name from the principal's additional-data bag (`directoryObjectDisplayName()`).
- New `.lr.versions` entries at `13.7.2` (next patch after the current `13.7.1`).

## Tests

The non-trivial logic is deliberately factored into pure functions so it can be unit-tested without a live tenant. Table-driven unit tests cover all three:

- `TestEnabledServicePlanServices` — nil/empty/malformed inputs, case-insensitive status, dedup, sort, empty-service skipping
- `TestDirectoryObjectDisplayName` — string / `*string` / nil-pointer / wrong-type / missing-key
- `TestDirectoryPrincipalInfo` — nil principal, user-with-name, group-without-name, missing `@odata.type`

The full `providers/ms365/resources` suite passes, the provider builds clean, and generated code was regenerated via `mqlr generate`.

**Coverage boundary:** these are unit tests of the pure helpers. The thin Graph-facing wiring — `assignments()` populating `principalName` from a real `$expand`, and `enabledServicePlans()` reading a real org's `assignedPlans` — is **not** covered by automated tests and is intended for interactive verification against a live M365 tenant (consistent with this repo's convention for thin resource wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)