### PR TITLE
🐛 fix panic parsing malformed auditd `-a` syscall rules

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -327,7 +327,14 @@ func (s *mqlAuditdRules) parse(content string, errors *multierr.Errors) {
 				resourceName = "auditd.rule.syscall"
 				arr := strings.SplitN(v, ",", 2)
 				args["action"] = llx.StringData(arr[0])
-				args["list"] = llx.StringData(arr[1])
+				// A well-formed rule is `-a action,list`, but malformed rules
+				// (e.g. `-a always` with no list) carry no comma; guard the
+				// optional second segment so we don't panic on bad input.
+				if len(arr) > 1 {
+					args["list"] = llx.StringData(arr[1])
+				} else {
+					args["list"] = llx.StringData("")
+				}
 
 			case "-F":
 				rawFields = append(rawFields, v)

--- a/providers/os/resources/auditd_internal_test.go
+++ b/providers/os/resources/auditd_internal_test.go
@@ -152,6 +152,26 @@ func TestNormalizeAuditdConfigFields(t *testing.T) {
 	})
 }
 
+func TestAuditdSyscallRuleMalformedAction(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	// A malformed `-a` rule carries no comma (the list segment is missing).
+	// Parsing must not panic; the action is captured and the list is empty.
+	content := "-a always -S execve -k t\n"
+
+	var errs multierr.Errors
+	require.NotPanics(t, func() {
+		rules.parse(content, &errs)
+	})
+	require.NoError(t, errs.Deduplicate())
+	require.Len(t, rules.Syscalls.Data, 1)
+
+	r := rules.Syscalls.Data[0].(*mqlAuditdRuleSyscall)
+	assert.Equal(t, "always", r.Action.Data)
+	assert.Equal(t, "", r.List.Data)
+}
+
 func TestAuditdControlRuleParsing(t *testing.T) {
 	runtime := newAuditdRulesTestRuntime(t)
 	rules := &mqlAuditdRules{MqlRuntime: runtime}


### PR DESCRIPTION
## Problem

In `auditd.go`, the `-a` syscall-rule handler split the value on the first comma and unconditionally read the second element:

```go
arr := strings.SplitN(v, ",", 2)
args["action"] = llx.StringData(arr[0])
args["list"]   = llx.StringData(arr[1]) // panics when v has no comma
```

A well-formed rule is `-a action,list`, but a malformed rule such as `-a always` (missing the list segment) splits into a single element, so `arr[1]` panicked with index-out-of-range and aborted the entire query. Audit rule files are operator-controllable, so a single bad line could crash an otherwise valid scan.

## Fix

Guard the optional second segment and default the list to an empty string when it is absent.

## Test

`TestAuditdSyscallRuleMalformedAction` parses `-a always ...` and asserts the parser does not panic, captures the action, and leaves the list empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_