### PR TITLE
🐛 fix panic on short lines in iptables ParseStat

### DIFF
--- a/providers/os/resources/iptables.go
+++ b/providers/os/resources/iptables.go
@@ -856,6 +856,13 @@ func ParseStat(lines []string, ipv6 bool) ([]Stat, error) {
 		line = strings.TrimSpace(line)
 		fields := strings.Fields(line)
 
+		// A rule needs at least the columns up to "source" (index 8); the IPv6
+		// opt-field heuristic below also reads fields[7]. Skip short/blank lines
+		// rather than indexing out of range and panicking on malformed output.
+		if len(fields) < 9 {
+			continue
+		}
+
 		// The ip6tables verbose output cannot be naively split due to the default "opt"
 		// field containing 2 single spaces.
 		if ipv6 {

--- a/providers/os/resources/iptables_test.go
+++ b/providers/os/resources/iptables_test.go
@@ -37,6 +37,28 @@ func TestParseStat(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 
+	t.Run("short/malformed lines are skipped without panicking", func(t *testing.T) {
+		lines := []string{
+			"Chain INPUT (policy ACCEPT 0 packets, 0 bytes)",
+			"num      pkts      bytes target     prot opt in     out     source               destination",
+			"",                              // blank line in the middle of a block
+			"1           0        0 ACCEPT", // truncated rule, fewer than 9 fields
+			"2           0        0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0",
+		}
+		var result []Stat
+		var err error
+		require.NotPanics(t, func() {
+			result, err = ParseStat(lines, false)
+		})
+		require.NoError(t, err)
+		// Only the well-formed rule survives; the blank and truncated lines are dropped.
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(2), result[0].LineNumber)
+		assert.Equal(t, "ACCEPT", result[0].Target)
+		assert.Equal(t, "0.0.0.0/0", result[0].Source)
+		assert.Equal(t, "0.0.0.0/0", result[0].Destination)
+	})
+
 	t.Run("ipv6 with opt field", func(t *testing.T) {
 		lines := []string{
 			"Chain OUTPUT (policy DROP 227 packets, 12904 bytes)",


### PR DESCRIPTION
## Problem

`ParseStat` in `iptables.go` read `fields[3]` … `fields[8]` (and `fields[7]` in the IPv6 opt-field heuristic) with no length check, while it *did* guard `fields[9]` with `len(fields) > 9`. Any `iptables -L` line that split into fewer than 9 fields — a blank line inside a chain block, or a truncated/non-standard rule line — caused an `index out of range` panic that aborted the entire query.

## Fix

Skip lines with fewer than 9 fields (the columns up to `source`), consistent with the existing guard on the `destination` column.

## Test

`TestParseStat/short/malformed lines are skipped without panicking` feeds a chain block containing a blank line and a truncated rule, and asserts parsing does not panic and only the well-formed rule is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_