### PR TITLE
🐛 fix fstab parser aborting on indented comments and blank lines

### DIFF
--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -91,8 +91,9 @@ func ParseFstab(file io.Reader) ([]FstabEntry, error) {
 
 	var entries []FstabEntry
 	for scanner.Scan() {
-		line := scanner.Text()
-		// Skip comments and empty lines
+		line := strings.TrimSpace(scanner.Text())
+		// Skip comments and empty lines, including indented comments and
+		// whitespace-only lines (both are valid in /etc/fstab).
 		if line == "" || line[0] == '#' {
 			continue
 		}

--- a/providers/os/resources/fstab_test.go
+++ b/providers/os/resources/fstab_test.go
@@ -157,4 +157,27 @@ UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4   defaults  0      A` // no
 		require.Error(t, err)
 		require.Nil(t, entries)
 	})
+
+	t.Run("indented comments and blank lines are skipped", func(t *testing.T) {
+		testdata := "# leading comment\n" +
+			"\t# indented comment with a tab\n" +
+			"   # indented comment with spaces\n" +
+			"   \t  \n" + // whitespace-only line
+			"\n" + // empty line
+			"  UUID=0a3407de-014b-458b-b5c1-848e92a327a3 / ext4 defaults 0 1\n"
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=0a3407de-014b-458b-b5c1-848e92a327a3",
+			Mountpoint: "/",
+			Fstype:     "ext4",
+			Options:    []string{"defaults"},
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(1),
+		}, entries[0])
+	})
 }


### PR DESCRIPTION
## Problem

`ParseFstab` tested the comment/empty condition on the **untrimmed** line:

```go
line := scanner.Text()
if line == "" || line[0] == '#' { continue }
record := strings.Fields(line)
if len(record) < 4 { return nil, errors.New("invalid fstab entry") }
```

A line with leading whitespace before `#` (e.g. `\t# managed by ...`), or a whitespace-only line, was not recognized as a comment/blank. It fell through to `strings.Fields`, failed the `len(record) < 4` check, and returned an error that **aborted parsing of the entire fstab file**. Indented comments and blank-ish lines are perfectly valid in `/etc/fstab`.

## Fix

Trim the line before the comment/empty check so indented comments and whitespace-only lines are skipped. Genuinely malformed data rows (fewer than 4 fields) still error as before.

## Test

`TestFstabEntries/indented comments and blank lines are skipped` parses a file mixing leading, tab-indented and space-indented comments, a whitespace-only line, and an empty line, and asserts the one real entry is returned without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_