### PR TITLE
🐛 fix sshd time-value conversion ignoring keyword case

### DIFF
--- a/providers/os/resources/sshd/parser.go
+++ b/providers/os/resources/sshd/parser.go
@@ -15,9 +15,12 @@ type SshdLine struct {
 	args string
 }
 
+// sshd_config keywords are case-insensitive, and ParseLine sees the raw
+// keyword before it is canonicalized to its mixed-case form, so the lookup
+// keys are stored lowercased and compared against the lowercased keyword.
 var keysWithTimeValue = map[string]int{
-	"ClientAliveInterval": 1,
-	"LoginGraceTime":      1,
+	"clientaliveinterval": 1,
+	"logingracetime":      1,
 }
 
 // ParseLine parses a single line of the sshd_config file
@@ -40,7 +43,7 @@ func ParseLine(s []rune) (SshdLine, error) {
 		return l, err
 	}
 
-	if _, ok := keysWithTimeValue[l.key]; ok {
+	if _, ok := keysWithTimeValue[strings.ToLower(l.key)]; ok {
 		duration, err := time.ParseDuration(l.args)
 		if err == nil {
 			l.args = fmt.Sprintf("%.0f", duration.Seconds())

--- a/providers/os/resources/sshd/parser_test.go
+++ b/providers/os/resources/sshd/parser_test.go
@@ -110,4 +110,20 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, SshdLine{key: "key", args: "2h10m42s"}, line)
 	})
+
+	// sshd_config keywords are case-insensitive, so the time-value conversion
+	// must apply regardless of how the keyword is cased in the file.
+	t.Run("time value converted for lowercase keyword", func(t *testing.T) {
+		text := []rune("logingracetime 1m")
+		line, err := ParseLine(text)
+		require.NoError(t, err)
+		require.Equal(t, SshdLine{key: "logingracetime", args: "60"}, line)
+	})
+
+	t.Run("time value converted for uppercase keyword", func(t *testing.T) {
+		text := []rune("CLIENTALIVEINTERVAL 5m")
+		line, err := ParseLine(text)
+		require.NoError(t, err)
+		require.Equal(t, SshdLine{key: "CLIENTALIVEINTERVAL", args: "300"}, line)
+	})
 }


### PR DESCRIPTION
## Problem

sshd_config keywords are case-insensitive, but the time-value conversion in `sshd/parser.go` used the raw keyword for its lookup:

```go
var keysWithTimeValue = map[string]int{"ClientAliveInterval": 1, "LoginGraceTime": 1}
...
if _, ok := keysWithTimeValue[l.key]; ok { ... "5m" -> "300" ... }
```

Keyword canonicalization to the mixed-case form only happens **later** in `ParseBlocks`/`ParseBlocksWithGlobRecursive`, after `ParseLine` has already returned. So a config written `logingracetime 1m` or `CLIENTALIVEINTERVAL 5m` (valid, lowercase/uppercase) skipped the seconds conversion and stored `"1m"`/`"5m"` verbatim, breaking any numeric policy check against those directives.

## Fix

Store the lookup keys lowercased and compare against `strings.ToLower(l.key)`.

## Test

Added `time value converted for lowercase keyword` and `... uppercase keyword` cases asserting `logingracetime 1m` → `60` and `CLIENTALIVEINTERVAL 5m` → `300`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_