### PR TITLE
🐛 fix sudoers user specs dropped when `=` is attached to the host

### DIFF
--- a/providers/os/resources/sudoers/sudoers.go
+++ b/providers/os/resources/sudoers/sudoers.go
@@ -401,21 +401,18 @@ func parseLine(line string) *parsedLine {
 			remaining = strings.TrimSpace(line[runasEnd+1:])
 		}
 	} else {
-		// No runas specification, need to find where host ends
-		// Look for the first whitespace after the second token
-		parts := smartSplit(line)
-		if len(parts) < 3 {
+		// No runas specification. The first `=` separates the "user host"
+		// portion from the command spec, and whitespace around it is optional
+		// (e.g. `root ALL=ALL` or `bob ALL=/bin/ls`). Splitting on whitespace
+		// alone misreads (or drops) these specs, so split on `=` here and
+		// reuse the shared user/host logic below — analogous to how the runas
+		// branch splits around `=(...)`.
+		eq := strings.Index(line, "=")
+		if eq == -1 {
 			return nil
 		}
-
-		// First part is user, second is host, rest is commands
-		result.users = splitAndTrim(parts[0], ",")
-		result.hosts = splitAndTrim(parts[1], ",")
-		remaining = strings.Join(parts[2:], " ")
-
-		// Extract tags and commands from remaining
-		extractTagsAndCommands(result, remaining)
-		return result
+		beforeRunas = strings.TrimSpace(line[:eq])
+		remaining = strings.TrimSpace(line[eq+1:])
 	}
 
 	// For lines with runas, split beforeRunas to get user and host

--- a/providers/os/resources/sudoers/sudoers_test.go
+++ b/providers/os/resources/sudoers/sudoers_test.go
@@ -25,6 +25,47 @@ func TestParseLine_BasicUserSpec(t *testing.T) {
 	assert.Equal(t, []string{"ALL"}, parsed.Commands)
 }
 
+func TestParseLine_NoRunasAllCommands(t *testing.T) {
+	// A user spec with no runas list and no whitespace around `=`. This is
+	// valid sudoers (`user host=command`) and must not be dropped.
+	line := "root ALL=ALL"
+	parsed := sudoers.ToParsedLine(sudoers.ParseLine(line))
+
+	require.NotNil(t, parsed)
+	assert.Equal(t, "user_spec", parsed.EntryType)
+	assert.Equal(t, []string{"root"}, parsed.Users)
+	assert.Equal(t, []string{"ALL"}, parsed.Hosts)
+	assert.Empty(t, parsed.RunasUsers)
+	assert.Equal(t, []string{"ALL"}, parsed.Commands)
+}
+
+func TestParseLine_NoRunasSpecificCommand(t *testing.T) {
+	// No runas list, host followed directly by `=` and a specific command.
+	line := "bob server1=/usr/bin/ls"
+	parsed := sudoers.ToParsedLine(sudoers.ParseLine(line))
+
+	require.NotNil(t, parsed)
+	assert.Equal(t, "user_spec", parsed.EntryType)
+	assert.Equal(t, []string{"bob"}, parsed.Users)
+	assert.Equal(t, []string{"server1"}, parsed.Hosts)
+	assert.Empty(t, parsed.RunasUsers)
+	assert.Equal(t, []string{"/usr/bin/ls"}, parsed.Commands)
+}
+
+func TestParseLine_NoRunasWithTag(t *testing.T) {
+	// No runas list, but a NOPASSWD tag attached after `host=`.
+	line := "john ALL=NOPASSWD: /usr/bin/systemctl"
+	parsed := sudoers.ToParsedLine(sudoers.ParseLine(line))
+
+	require.NotNil(t, parsed)
+	assert.Equal(t, "user_spec", parsed.EntryType)
+	assert.Equal(t, []string{"john"}, parsed.Users)
+	assert.Equal(t, []string{"ALL"}, parsed.Hosts)
+	assert.Empty(t, parsed.RunasUsers)
+	assert.Equal(t, []string{"NOPASSWD"}, parsed.Tags)
+	assert.Equal(t, []string{"/usr/bin/systemctl"}, parsed.Commands)
+}
+
 func TestParseLine_GroupSpec(t *testing.T) {
 	line := "%sudo ALL=(ALL:ALL) ALL"
 	parsed := sudoers.ToParsedLine(sudoers.ParseLine(line))


### PR DESCRIPTION
## Problem

The no-runas branch of `parseLine` (sudoers specs without a `=(...)` runas list) split the line on whitespace only and required ≥3 tokens:

```go
parts := smartSplit(line)        // splits on spaces only, never on `=`
if len(parts) < 3 { return nil }
result.users = splitAndTrim(parts[0], ",")
result.hosts = splitAndTrim(parts[1], ",")
remaining = strings.Join(parts[2:], " ")
```

sudoers permits the `=` to be attached directly to the host with no surrounding whitespace. So:

- `root ALL=ALL` / `bob server1=/usr/bin/ls` → 2 whitespace tokens → `return nil`, **silently dropped**. A policy enumerating `sudoers.userSpecs` under-reports privilege grants.
- `john ALL=NOPASSWD: ALL` → 3 tokens, but the host is mis-set to `ALL=NOPASSWD:`.

## Fix

In the no-runas branch, split the line on the first `=` (the host/command separator, whose surrounding whitespace is optional) into a "user host" part and the command spec, then reuse the existing shared user/host parsing below — mirroring how the runas branch already splits around `=(...)`. A line with no `=` at all is not a valid user spec and returns nil.

## Tests

Added `TestParseLine_NoRunasAllCommands` (`root ALL=ALL`), `TestParseLine_NoRunasSpecificCommand` (`bob server1=/usr/bin/ls`), and `TestParseLine_NoRunasWithTag` (`john ALL=NOPASSWD: /usr/bin/systemctl`). All existing `=(...)` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_