### PR TITLE
🐛 fix nil-pointer panic in macOS dscl user enumeration

### DIFF
--- a/providers/os/resources/users/dscl.go
+++ b/providers/os/resources/users/dscl.go
@@ -100,7 +100,9 @@ func (s *OSXUserManager) List() ([]*User, error) {
 		return nil, err
 	}
 	for k := range m {
-		users[k].Shell = m[k]
+		if u, ok := users[k]; ok {
+			u.Shell = m[k]
+		}
 	}
 
 	// fetch home
@@ -114,7 +116,9 @@ func (s *OSXUserManager) List() ([]*User, error) {
 		return nil, err
 	}
 	for k := range m {
-		users[k].Home = m[k]
+		if u, ok := users[k]; ok {
+			u.Home = m[k]
+		}
 	}
 
 	// fetch usernames
@@ -128,7 +132,9 @@ func (s *OSXUserManager) List() ([]*User, error) {
 		return nil, err
 	}
 	for k := range m {
-		users[k].Description = m[k]
+		if u, ok := users[k]; ok {
+			u.Description = m[k]
+		}
 	}
 
 	// fetch gid
@@ -142,11 +148,15 @@ func (s *OSXUserManager) List() ([]*User, error) {
 		return nil, err
 	}
 	for k := range m {
+		u, ok := users[k]
+		if !ok {
+			continue
+		}
 		gid, err := strconv.ParseInt(m[k], 10, 0)
 		if err != nil {
 			log.Error().Err(err).Str("user", k).Msg("could not parse gid")
 		}
-		users[k].Gid = gid
+		u.Gid = gid
 	}
 
 	// convert map to slice

--- a/providers/os/resources/users/dscl_internal_test.go
+++ b/providers/os/resources/users/dscl_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+)
+
+// The dscl lists are fetched independently, so a later list (e.g. UserShell)
+// can contain a record that the UniqueID list did not. List() must not panic
+// when indexing the user map for such a key.
+func TestOSXUserManagerList_SkewedLists(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"dscl . -list /Users UniqueID": {
+				Stdout: "root 0\n_www 70\n",
+			},
+			// UserShell lists an extra user `ghost` that is absent from UniqueID.
+			"dscl . -list /Users UserShell": {
+				Stdout: "root /bin/sh\n_www /usr/bin/false\nghost /bin/zsh\n",
+			},
+			"dscl . -list /Users NFSHomeDirectory": {
+				Stdout: "root /var/root\n_www /Library/WebServer\n",
+			},
+			"dscl . -list /Users RealName": {
+				Stdout: "root System Administrator\n_www World Wide Web Server\n",
+			},
+			"dscl . -list /Users PrimaryGroupID": {
+				Stdout: "root 0\n_www 70\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	mgr := &OSXUserManager{conn: conn}
+
+	var list []*User
+	require.NotPanics(t, func() {
+		list, err = mgr.List()
+	})
+	require.NoError(t, err)
+
+	// Only the users present in the UniqueID list are materialized; the extra
+	// `ghost` shell entry is ignored rather than panicking.
+	require.Len(t, list, 2)
+
+	byName := map[string]*User{}
+	for _, u := range list {
+		byName[u.Name] = u
+	}
+	require.Contains(t, byName, "root")
+	require.Contains(t, byName, "_www")
+	require.NotContains(t, byName, "ghost")
+
+	assert.Equal(t, "/usr/bin/false", byName["_www"].Shell)
+	assert.Equal(t, "/Library/WebServer", byName["_www"].Home)
+	assert.Equal(t, int64(70), byName["_www"].Gid)
+}


### PR DESCRIPTION
## Problem

`OSXUserManager.List()` builds its `users` map solely from the first dscl list (`dscl . -list /Users UniqueID`), then indexes `users[k]` in four follow-up loops (`UserShell`, `NFSHomeDirectory`, `RealName`, `PrimaryGroupID`) with no existence check:

```go
for k := range m {
    users[k].Shell = m[k] // users[k] is nil if k wasn't in the UniqueID list → panic
}
```

If any later list returns a record absent from the UniqueID list — a user with no `UniqueID`, or any skew between the independently-run dscl queries — `users[k]` is `nil` and the field assignment panics, crashing user enumeration on macOS.

## Fix

Guard each follow-up assignment with a map-existence check (`if u, ok := users[k]; ok { ... }`).

## Test

`TestOSXUserManagerList_SkewedLists` drives `List()` with a mock connection whose `UserShell` list contains an extra `ghost` user missing from `UniqueID`, and asserts `List()` does not panic, ignores the orphan entry, and still populates the known users' fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_