### PR TITLE
🐛 fix auditd config error reporting empty field name

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -104,22 +104,32 @@ func (s *mqlAuditdConfig) parse(file *mqlFile) error {
 		return s.Params.Error
 	}
 
+	normalized, err := normalizeAuditdConfigFields(fields)
+	maps.Copy(res, normalized)
+	s.Params.Error = err
+	return err
+}
+
+// normalizeAuditdConfigFields lowercases the keys of the parsed auditd config,
+// downcases the values of boolean/enum keywords, and reports any field whose
+// value is not a string.
+func normalizeAuditdConfigFields(fields map[string]any) (map[string]any, error) {
+	res := make(map[string]any, len(fields))
 	var errs multierr.Errors
 	for k, v := range fields {
 		key := strings.ToLower(k)
-		if s, ok := v.(string); ok {
-			if slices.Contains(auditdDowncaseKeywords, key) {
-				res[key] = strings.ToLower(s)
-			} else {
-				res[key] = s
-			}
+		s, ok := v.(string)
+		if !ok {
+			errs.Add(fmt.Errorf("can't parse field '%s', value is %+v", k, v))
+			continue
+		}
+		if slices.Contains(auditdDowncaseKeywords, key) {
+			res[key] = strings.ToLower(s)
 		} else {
-			errs.Add(fmt.Errorf("can't parse field '"+s+"', value is %+v", v))
+			res[key] = s
 		}
 	}
-
-	s.Params.Error = errs.Deduplicate()
-	return s.Params.Error
+	return res, errs.Deduplicate()
 }
 
 func (s *mqlAuditdConfig) params(file *mqlFile) (map[string]any, error) {

--- a/providers/os/resources/auditd_internal_test.go
+++ b/providers/os/resources/auditd_internal_test.go
@@ -130,6 +130,28 @@ func TestAuditdSyscallRuleRepeatedFlags(t *testing.T) {
 	assert.Equal(t, []any{"open", "openat", "creat"}, r.Syscalls.Data)
 }
 
+func TestNormalizeAuditdConfigFields(t *testing.T) {
+	t.Run("lowercases keys and downcases enum values", func(t *testing.T) {
+		res, err := normalizeAuditdConfigFields(map[string]any{
+			"Log_Format": "ENABLED",
+			"Log_File":   "/var/log/audit/audit.log",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "enabled", res["log_format"])
+		// log_file is not a downcase keyword, so its value is preserved verbatim.
+		assert.Equal(t, "/var/log/audit/audit.log", res["log_file"])
+	})
+
+	t.Run("reports the offending field name for non-string values", func(t *testing.T) {
+		_, err := normalizeAuditdConfigFields(map[string]any{
+			"broken": map[string]any{"nested": "value"},
+		})
+		require.Error(t, err)
+		// The error must name the field that failed (`broken`), not an empty string.
+		assert.Contains(t, err.Error(), "broken")
+	})
+}
+
 func TestAuditdControlRuleParsing(t *testing.T) {
 	runtime := newAuditdRulesTestRuntime(t)
 	rules := &mqlAuditdRules{MqlRuntime: runtime}


### PR DESCRIPTION
## Problem

When a parsed auditd config field had a non-string value, the error message used the wrong variable:

```go
if s, ok := v.(string); ok {
    ...
} else {
    errs.Add(fmt.Errorf("can't parse field '"+s+"', value is %+v", v))
}
```

In the `else` branch the type assertion failed, so `s` is always the empty string (Go scopes the `if`-init variable to the `else`). Every such error read `can't parse field '', value is ...`, hiding which field actually failed. It should report the field key `k`.

## Fix

Extract the field-normalization loop into a pure helper `normalizeAuditdConfigFields` and report the actual field key (`%s`, `k`). This also makes the branch unit-testable, which it wasn't before (`ParseIni` only ever produces string values through the normal `parse()` path).

## Test

`TestNormalizeAuditdConfigFields` covers the happy path (key lowercasing + enum-value downcasing) and asserts that a non-string value produces an error naming the offending field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_