### PR TITLE
🐛 fix iptables ParseStat error messages dropping context

### DIFF
--- a/providers/os/resources/iptables.go
+++ b/providers/os/resources/iptables.go
@@ -884,15 +884,15 @@ func ParseStat(lines []string, ipv6 bool) ([]Stat, error) {
 		}
 		ln, err := strconv.ParseInt(fields[0], 0, 64)
 		if err != nil {
-			return entries, fmt.Errorf(err.Error(), "could not parse line number")
+			return entries, fmt.Errorf("could not parse line number: %w", err)
 		}
 		pkts, err := strconv.ParseInt(fields[1], 0, 64)
 		if err != nil {
-			return entries, fmt.Errorf(err.Error(), "could not parse packets")
+			return entries, fmt.Errorf("could not parse packets: %w", err)
 		}
 		bts, err := strconv.ParseInt(fields[2], 0, 64)
 		if err != nil {
-			return entries, fmt.Errorf(err.Error(), "could not parse bytes")
+			return entries, fmt.Errorf("could not parse bytes: %w", err)
 		}
 		var opts string
 		// combine options if they exist

--- a/providers/os/resources/iptables_test.go
+++ b/providers/os/resources/iptables_test.go
@@ -59,6 +59,19 @@ func TestParseStat(t *testing.T) {
 		assert.Equal(t, "0.0.0.0/0", result[0].Destination)
 	})
 
+	t.Run("non-numeric line number yields a descriptive error", func(t *testing.T) {
+		lines := []string{
+			"Chain INPUT (policy ACCEPT 0 packets, 0 bytes)",
+			"num      pkts      bytes target     prot opt in     out     source               destination",
+			"X           0        0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0",
+		}
+		_, err := ParseStat(lines, false)
+		require.Error(t, err)
+		// The diagnostic context must survive (previously it was dropped because
+		// the message was passed as an unused fmt.Errorf argument).
+		assert.Contains(t, err.Error(), "could not parse line number")
+	})
+
 	t.Run("ipv6 with opt field", func(t *testing.T) {
 		lines := []string{
 			"Chain OUTPUT (policy DROP 227 packets, 12904 bytes)",


### PR DESCRIPTION
## Problem

The three numeric-parse failure paths in `ParseStat` were written as:

```go
return entries, fmt.Errorf(err.Error(), "could not parse line number")
```

`fmt.Errorf` treats its first argument as the format string, so this used the raw error text as the format and passed the descriptive `"could not parse line number"` as an argument that is never consumed. The intended context was silently dropped, and a `%` in the error text would have produced `%!`-style garbage. (It was also a `go vet` finding.)

## Fix

Use the standard `fmt.Errorf("...: %w", err)` form for all three (line number, packets, bytes) so the context is preserved and the underlying error is wrapped.

## Test

`TestParseStat/non-numeric line number yields a descriptive error` feeds a rule with a non-numeric line-number column and asserts the returned error contains `could not parse line number`. `go vet ./resources/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_