### PR TITLE
🌟 os: read per-user registry hives (HKCU) natively

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.29.0",
+	Version: "13.29.1",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/os/connection/local/local.go
+++ b/providers/os/connection/local/local.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/connection/ssh/cat"
+	"go.mondoo.com/mql/v13/providers/os/registry"
 )
 
 type LocalConnection struct {
@@ -25,6 +27,39 @@ type LocalConnection struct {
 	fs    afero.Fs
 	Sudo  *inventory.Sudo
 	asset *inventory.Asset
+
+	// registryHandler lazily loads per-user registry hives (NTUSER.DAT) on
+	// Windows so resources can read another user's HKCU without an active
+	// session. Loaded hives are unloaded in Close().
+	registryHandler     *registry.RegistryHandler
+	registryHandlerLock sync.Mutex
+}
+
+// UserHiveRegistryHandler returns the connection-scoped RegistryHandler used to
+// load and read per-user registry hives, creating it on first use. Hives loaded
+// through it stay loaded for the lifetime of the connection (so repeated reads
+// across many checks share a single `reg load`) and are unloaded in Close().
+func (p *LocalConnection) UserHiveRegistryHandler() *registry.RegistryHandler {
+	p.registryHandlerLock.Lock()
+	defer p.registryHandlerLock.Unlock()
+	if p.registryHandler == nil {
+		p.registryHandler = registry.NewRegistryHandler()
+	}
+	return p.registryHandler
+}
+
+// Close unloads any per-user registry hives loaded during the scan. It satisfies
+// the plugin.Closer interface and is invoked when the provider shuts down the
+// connection.
+func (p *LocalConnection) Close() {
+	p.registryHandlerLock.Lock()
+	defer p.registryHandlerLock.Unlock()
+	if p.registryHandler != nil {
+		if err := p.registryHandler.UnloadSubkeys(); err != nil {
+			log.Debug().Err(err).Msg("could not unload user registry hives")
+		}
+		p.registryHandler = nil
+	}
 }
 
 func NewConnection(id uint32, conf *inventory.Config, asset *inventory.Asset) *LocalConnection {

--- a/providers/os/registry/registryhandler.go
+++ b/providers/os/registry/registryhandler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -59,6 +60,82 @@ func (r *RegistryHandler) LoadSubkey(registryId, filepath string) error {
 // we combine this with the prefix to get a subkey like "TmpReg_SOFTWARE"
 func buildSubKeyPath(registryId string) string {
 	return fmt.Sprintf("%s_%s", subkeyPrefix, registryId)
+}
+
+// userRegistryID derives a stable registry id for a per-user hive from the
+// user's SID. The leading "USER_" namespaces it away from the KnownRegistryFiles
+// ids (SOFTWARE, SYSTEM, ...) so the two never collide.
+func userRegistryID(sid string) string {
+	return "USER_" + sid
+}
+
+// LoadUserHive loads a per-user NTUSER.DAT hive into the handler, keyed by the
+// user's SID. Unlike LoadSubkey it is not restricted to KnownRegistryFiles — the
+// caller supplies an arbitrary NTUSER.DAT path (typically user.ntuserDat), which
+// is how we read the registry of a user who is not currently logged in (no live
+// HKEY_USERS\<sid> hive). Loading is idempotent: a hive already loaded for the
+// SID is a no-op, so concurrent reads of the same user coalesce onto one load.
+func (r *RegistryHandler) LoadUserHive(sid, filepath string) error {
+	if sid == "" {
+		return errors.New("cannot load user hive: empty sid")
+	}
+	if filepath == "" {
+		return errors.New("cannot load user hive: empty NTUSER.DAT path")
+	}
+	if runtime.GOOS != "windows" {
+		return errors.New("loading of registry subkeys is only supported on windows")
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	id := userRegistryID(sid)
+	if _, ok := r.registries[id]; ok {
+		return nil
+	}
+	key := buildSubKeyPath(id)
+	if err := LoadRegistrySubkey(key, filepath); err != nil {
+		return err
+	}
+	r.registries[id] = key
+	return nil
+}
+
+// GetUserHiveKeyItems returns the registry items at `path` (relative to the hive
+// root) for a user hive previously loaded with LoadUserHive.
+func (r *RegistryHandler) GetUserHiveKeyItems(sid, path string) ([]RegistryKeyItem, error) {
+	regPath, err := r.userHiveKeyPath(sid, path)
+	if err != nil {
+		return nil, err
+	}
+	return GetNativeRegistryKeyItems(regPath)
+}
+
+// GetUserHiveKeyChildren returns the child keys at `path` (relative to the hive
+// root) for a user hive previously loaded with LoadUserHive.
+func (r *RegistryHandler) GetUserHiveKeyChildren(sid, path string) ([]RegistryKeyChild, error) {
+	regPath, err := r.userHiveKeyPath(sid, path)
+	if err != nil {
+		return nil, err
+	}
+	return GetNativeRegistryKeyChildren(regPath)
+}
+
+// userHiveKeyPath builds the fully-qualified HKLM path to `path` under the loaded
+// user hive for `sid`. Loaded hives are mounted under HKLM (see getRegistryPath),
+// so we always prefix with HKLM here.
+func (r *RegistryHandler) userHiveKeyPath(sid, path string) (string, error) {
+	r.lock.Lock()
+	regRoot, ok := r.registries[userRegistryID(sid)]
+	r.lock.Unlock()
+	if !ok {
+		return "", fmt.Errorf("registry hive for %s not loaded", sid)
+	}
+	root := fmt.Sprintf("HKLM\\%s", regRoot)
+	path = strings.Trim(path, "\\")
+	if path == "" {
+		return root, nil
+	}
+	return fmt.Sprintf("%s\\%s", root, path), nil
 }
 
 // Unloads all the subkeys, that were loaded by the handler.

--- a/providers/os/registry/registryhandler_test.go
+++ b/providers/os/registry/registryhandler_test.go
@@ -42,3 +42,45 @@ func TestGetRegistryKeyPath(t *testing.T) {
 		require.Equal(t, "HKLM\\TMPREG_SOFTWARE\\Microsoft\\Windows", path)
 	})
 }
+
+func TestUserRegistryID(t *testing.T) {
+	// per-user ids are namespaced so they never collide with KnownRegistryFiles
+	require.Equal(t, "USER_S-1-5-21-1-2-3-1001", userRegistryID("S-1-5-21-1-2-3-1001"))
+	require.Equal(t, "TMPREG_USER_S-1-5-21-1-2-3-1001", buildSubKeyPath(userRegistryID("S-1-5-21-1-2-3-1001")))
+}
+
+func TestUserHiveKeyPath(t *testing.T) {
+	sid := "S-1-5-21-1-2-3-1001"
+
+	t.Run("hive not loaded", func(t *testing.T) {
+		rh := NewRegistryHandler()
+		_, err := rh.userHiveKeyPath(sid, "Software\\Policies")
+		require.Error(t, err)
+	})
+
+	t.Run("hive loaded", func(t *testing.T) {
+		rh := NewRegistryHandler()
+		rh.registries[userRegistryID(sid)] = buildSubKeyPath(userRegistryID(sid))
+
+		// sub-path under the hive
+		path, err := rh.userHiveKeyPath(sid, "Software\\Policies\\Microsoft")
+		require.NoError(t, err)
+		require.Equal(t, "HKLM\\TMPREG_USER_"+sid+"\\Software\\Policies\\Microsoft", path)
+
+		// leading/trailing backslashes are trimmed
+		path, err = rh.userHiveKeyPath(sid, "\\Software\\")
+		require.NoError(t, err)
+		require.Equal(t, "HKLM\\TMPREG_USER_"+sid+"\\Software", path)
+
+		// empty sub-path resolves to the hive root
+		path, err = rh.userHiveKeyPath(sid, "")
+		require.NoError(t, err)
+		require.Equal(t, "HKLM\\TMPREG_USER_"+sid, path)
+	})
+}
+
+func TestLoadUserHive_Validation(t *testing.T) {
+	rh := NewRegistryHandler()
+	require.Error(t, rh.LoadUserHive("", "C:\\Users\\x\\NTUSER.DAT"), "empty sid must error")
+	require.Error(t, rh.LoadUserHive("S-1-5-21-1-2-3-1001", ""), "empty NTUSER.DAT path must error")
+}

--- a/providers/os/registry/registrykey_unix.go
+++ b/providers/os/registry/registrykey_unix.go
@@ -9,6 +9,13 @@ package registry
 import "errors"
 
 // non-windows stubs
+
+// IsUserHiveLoaded always reports false on non-windows platforms — there is no
+// HKEY_USERS to inspect.
+func IsUserHiveLoaded(sid string) bool {
+	return false
+}
+
 func GetNativeRegistryKeyItems(path string) ([]RegistryKeyItem, error) {
 	return nil, errors.New("native registry key items not supported on non-windows platforms")
 }

--- a/providers/os/registry/registrykey_windows.go
+++ b/providers/os/registry/registrykey_windows.go
@@ -43,6 +43,22 @@ func parseRegistryKeyPath(path string) (registry.Key, string, error) {
 	return registry.LOCAL_MACHINE, "", errors.New("invalid registry key hive: " + path)
 }
 
+// IsUserHiveLoaded reports whether the given user's registry hive is currently
+// loaded under HKEY_USERS. This is true while the user has an active logon
+// session; for logged-off users the hive must be loaded from NTUSER.DAT (see
+// RegistryHandler.LoadUserHive) before it can be read.
+func IsUserHiveLoaded(sid string) bool {
+	if sid == "" {
+		return false
+	}
+	regKey, err := registry.OpenKey(registry.USERS, sid, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	regKey.Close()
+	return true
+}
+
 func GetNativeRegistryKeyItems(path string) ([]RegistryKeyItem, error) {
 	log.Debug().Str("path", path).Msg("search registry key values using native registry api")
 	key, path, err := parseRegistryKeyPath(path)

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -757,6 +757,14 @@ user @defaults("name uid gid") {
   group(gid) group
   // Whether the user is currently logged in
   loggedIn() bool
+  // Path to this user's NTUSER.DAT registry hive file (Windows)
+  //
+  // The per-user registry hive on disk, located at `<home>\NTUSER.DAT`. Pass
+  // it together with `sid` to `registrykey`/`registrykey.property` to read a
+  // user's HKCU settings even when their hive is not loaded — for example a
+  // SYSTEM scan running with no interactive session. Empty on non-Windows
+  // platforms or when the home directory is unknown.
+  ntuserDat(home) string
 }
 
 // Private key on disk
@@ -4886,9 +4894,23 @@ private apt.repo @defaults("type url distribution") {
 //
 // Examine items, child keys, and existence at a given registry path
 registrykey @defaults("path") {
-  init(path string)
+  init(path string, userSid? string, ntuserDat? string)
   // Registry key path
   path string
+  // SID of the user whose registry hive to read
+  //
+  // Optional. When set, `path` is interpreted relative to that user's
+  // per-user registry (HKCU): the loaded `HKEY_USERS\<sid>` hive when the
+  // user is logged in, otherwise the profile's `NTUSER.DAT` (see `ntuserDat`)
+  // loaded on demand. Leave empty to treat `path` as an absolute registry
+  // path.
+  userSid string
+  // Path to the user's NTUSER.DAT hive file
+  //
+  // Optional. Used with `userSid` to read a user's registry when their hive
+  // is not currently loaded — for example a SYSTEM scan running with no
+  // interactive session. Typically populated from `user.ntuserDat`.
+  ntuserDat string
   // Whether the property exists
   exists() bool
   // Properties of the registry key as a name-to-value map
@@ -4909,11 +4931,21 @@ registrykey @defaults("path") {
 // and the parsed `data`. Initialize by path and name to look up a specific
 // value, or iterate from `registrykey.items()`.
 registrykey.property @defaults("path name") {
-  init(path string, name string)
+  init(path string, name string, userSid? string, ntuserDat? string)
   // Registry key path
   path string
   // Registry key name
   name string
+  // SID of the user whose registry hive to read
+  //
+  // Optional. Forwarded to the underlying `registrykey` so `path` resolves
+  // against that user's per-user registry (HKCU). See `registrykey.userSid`.
+  userSid string
+  // Path to the user's NTUSER.DAT hive file
+  //
+  // Optional. Forwarded to the underlying `registrykey`. See
+  // `registrykey.ntuserDat`.
+  ntuserDat string
   // Whether the property exists
   exists() bool
   // Registry property value as a string

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3086,6 +3086,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"user.loggedIn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlUser).GetLoggedIn()).ToDataRes(types.Bool)
 	},
+	"user.ntuserDat": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlUser).GetNtuserDat()).ToDataRes(types.String)
+	},
 	"privatekey.pem": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPrivatekey).GetPem()).ToDataRes(types.String)
 	},
@@ -6692,6 +6695,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"registrykey.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRegistrykey).GetPath()).ToDataRes(types.String)
 	},
+	"registrykey.userSid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRegistrykey).GetUserSid()).ToDataRes(types.String)
+	},
+	"registrykey.ntuserDat": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRegistrykey).GetNtuserDat()).ToDataRes(types.String)
+	},
 	"registrykey.exists": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRegistrykey).GetExists()).ToDataRes(types.Bool)
 	},
@@ -6709,6 +6718,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"registrykey.property.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRegistrykeyProperty).GetName()).ToDataRes(types.String)
+	},
+	"registrykey.property.userSid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRegistrykeyProperty).GetUserSid()).ToDataRes(types.String)
+	},
+	"registrykey.property.ntuserDat": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRegistrykeyProperty).GetNtuserDat()).ToDataRes(types.String)
 	},
 	"registrykey.property.exists": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRegistrykeyProperty).GetExists()).ToDataRes(types.Bool)
@@ -12484,6 +12499,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlUser).LoggedIn, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"user.ntuserDat": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlUser).NtuserDat, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"privatekey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPrivatekey).__id, ok = v.Value.(string)
 		return
@@ -18044,6 +18063,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlRegistrykey).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"registrykey.userSid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRegistrykey).UserSid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"registrykey.ntuserDat": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRegistrykey).NtuserDat, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"registrykey.exists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlRegistrykey).Exists, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -18070,6 +18097,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"registrykey.property.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlRegistrykeyProperty).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"registrykey.property.userSid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRegistrykeyProperty).UserSid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"registrykey.property.ntuserDat": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRegistrykeyProperty).NtuserDat, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"registrykey.property.exists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28803,6 +28838,7 @@ type mqlUser struct {
 	Sshkeys        plugin.TValue[[]any]
 	Group          plugin.TValue[*mqlGroup]
 	LoggedIn       plugin.TValue[bool]
+	NtuserDat      plugin.TValue[string]
 }
 
 // createUser creates a new instance of this resource
@@ -28931,6 +28967,17 @@ func (c *mqlUser) GetGroup() *plugin.TValue[*mqlGroup] {
 func (c *mqlUser) GetLoggedIn() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.LoggedIn, func() (bool, error) {
 		return c.loggedIn()
+	})
+}
+
+func (c *mqlUser) GetNtuserDat() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.NtuserDat, func() (string, error) {
+		vargHome := c.GetHome()
+		if vargHome.Error != nil {
+			return "", vargHome.Error
+		}
+
+		return c.ntuserDat(vargHome.Data)
 	})
 }
 
@@ -45817,6 +45864,8 @@ type mqlRegistrykey struct {
 	__id       string
 	// optional: if you define mqlRegistrykeyInternal it will be used here
 	Path       plugin.TValue[string]
+	UserSid    plugin.TValue[string]
+	NtuserDat  plugin.TValue[string]
 	Exists     plugin.TValue[bool]
 	Properties plugin.TValue[map[string]any]
 	Items      plugin.TValue[[]any]
@@ -45864,6 +45913,14 @@ func (c *mqlRegistrykey) GetPath() *plugin.TValue[string] {
 	return &c.Path
 }
 
+func (c *mqlRegistrykey) GetUserSid() *plugin.TValue[string] {
+	return &c.UserSid
+}
+
+func (c *mqlRegistrykey) GetNtuserDat() *plugin.TValue[string] {
+	return &c.NtuserDat
+}
+
 func (c *mqlRegistrykey) GetExists() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Exists, func() (bool, error) {
 		return c.exists()
@@ -45903,12 +45960,14 @@ type mqlRegistrykeyProperty struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlRegistrykeyPropertyInternal it will be used here
-	Path   plugin.TValue[string]
-	Name   plugin.TValue[string]
-	Exists plugin.TValue[bool]
-	Value  plugin.TValue[string]
-	Type   plugin.TValue[string]
-	Data   plugin.TValue[any]
+	Path      plugin.TValue[string]
+	Name      plugin.TValue[string]
+	UserSid   plugin.TValue[string]
+	NtuserDat plugin.TValue[string]
+	Exists    plugin.TValue[bool]
+	Value     plugin.TValue[string]
+	Type      plugin.TValue[string]
+	Data      plugin.TValue[any]
 }
 
 // createRegistrykeyProperty creates a new instance of this resource
@@ -45954,6 +46013,14 @@ func (c *mqlRegistrykeyProperty) GetPath() *plugin.TValue[string] {
 
 func (c *mqlRegistrykeyProperty) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlRegistrykeyProperty) GetUserSid() *plugin.TValue[string] {
+	return &c.UserSid
+}
+
+func (c *mqlRegistrykeyProperty) GetNtuserDat() *plugin.TValue[string] {
+	return &c.NtuserDat
 }
 
 func (c *mqlRegistrykeyProperty) GetExists() *plugin.TValue[bool] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2171,15 +2171,19 @@ registrykey 9.0.1
 registrykey.children 9.0.1
 registrykey.exists 9.0.1
 registrykey.items 9.0.1
+registrykey.ntuserDat 13.29.1
 registrykey.path 9.0.1
 registrykey.properties 9.0.1
 registrykey.property 9.0.1
 registrykey.property.data 9.0.1
 registrykey.property.exists 9.0.1
 registrykey.property.name 9.0.1
+registrykey.property.ntuserDat 13.29.1
 registrykey.property.path 9.0.1
 registrykey.property.type 9.0.1
+registrykey.property.userSid 13.29.1
 registrykey.property.value 9.0.1
+registrykey.userSid 13.29.1
 roo 13.13.1
 roo.configPath 13.13.1
 roo.skill 13.13.1
@@ -2641,6 +2645,7 @@ user.group 9.0.0
 user.home 9.0.0
 user.loggedIn 13.7.1
 user.name 9.0.0
+user.ntuserDat 13.29.1
 user.shell 9.0.0
 user.sid 9.0.0
 user.sshkeys 9.0.0

--- a/providers/os/resources/registrykey.go
+++ b/providers/os/resources/registrykey.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
@@ -18,12 +19,105 @@ import (
 	"go.mondoo.com/ranger-rpc/status"
 )
 
+// userHiveLoader is implemented by connections that can load a user's NTUSER.DAT
+// hive on demand (currently the local connection on Windows). registrykey uses it
+// to read the HKCU of a user who is not logged in.
+type userHiveLoader interface {
+	UserHiveRegistryHandler() *registry.RegistryHandler
+}
+
+// userHivePath builds the absolute HKEY_USERS path for a SID's hive plus an
+// optional sub-path, e.g. ("S-1-5-21-…", "Software\\X") -> "HKEY_USERS\\S-1-5-21-…\\Software\\X".
+func userHivePath(sid, subPath string) string {
+	subPath = strings.Trim(subPath, "\\")
+	if subPath == "" {
+		return `HKEY_USERS\` + sid
+	}
+	return `HKEY_USERS\` + sid + `\` + subPath
+}
+
 func (k *mqlRegistrykey) id() (string, error) {
+	// When reading a per-user hive, `path` is relative to that user's HKCU and is
+	// shared across users — fold the SID into the id so each user's key (and the
+	// properties derived from it) caches separately.
+	if k.UserSid.Data != "" {
+		return userHivePath(k.UserSid.Data, k.Path.Data), nil
+	}
 	return k.Path.Data, nil
+}
+
+// isUserHive reports whether this key targets a specific user's registry hive.
+func (k *mqlRegistrykey) isUserHive() bool {
+	return k.UserSid.Data != ""
+}
+
+// userHiveReader resolves how to read this key's per-user hive natively on a
+// local Windows host. It returns either a non-empty livePath to read directly
+// (the user is logged in, so HKEY_USERS\<sid> is live) or a non-nil handler to
+// read sub-paths through (the hive was loaded from NTUSER.DAT). When the hive
+// can't be read at all — no loader, missing NTUSER.DAT, or a load failure — it
+// returns ok=false, and callers treat the key as absent rather than erroring, so
+// a check degrades to a vacuous pass instead of a false positive.
+func (k *mqlRegistrykey) userHiveReader(conn shared.Connection) (livePath string, rh *registry.RegistryHandler, ok bool) {
+	sid := k.UserSid.Data
+	if registry.IsUserHiveLoaded(sid) {
+		return userHivePath(sid, k.Path.Data), nil, true
+	}
+	loader, isLoader := conn.(userHiveLoader)
+	if !isLoader || k.NtuserDat.Data == "" {
+		return "", nil, false
+	}
+	h := loader.UserHiveRegistryHandler()
+	if err := h.LoadUserHive(sid, k.NtuserDat.Data); err != nil {
+		log.Debug().Err(err).Str("sid", sid).Str("ntuserDat", k.NtuserDat.Data).
+			Msg("could not load user registry hive")
+		return "", nil, false
+	}
+	return "", h, true
+}
+
+func (k *mqlRegistrykey) nativeUserHiveItems(conn shared.Connection) ([]registry.RegistryKeyItem, error) {
+	livePath, rh, ok := k.userHiveReader(conn)
+	if !ok {
+		return nil, nil
+	}
+	if rh != nil {
+		return rh.GetUserHiveKeyItems(k.UserSid.Data, k.Path.Data)
+	}
+	return registry.GetNativeRegistryKeyItems(livePath)
+}
+
+func (k *mqlRegistrykey) nativeUserHiveChildren(conn shared.Connection) ([]registry.RegistryKeyChild, error) {
+	livePath, rh, ok := k.userHiveReader(conn)
+	if !ok {
+		return nil, nil
+	}
+	if rh != nil {
+		return rh.GetUserHiveKeyChildren(k.UserSid.Data, k.Path.Data)
+	}
+	return registry.GetNativeRegistryKeyChildren(livePath)
 }
 
 func (k *mqlRegistrykey) exists() (bool, error) {
 	conn := k.MqlRuntime.Connection.(shared.Connection)
+
+	// per-user hive read: resolve against the live HKEY_USERS\<sid> hive or the
+	// profile's NTUSER.DAT loaded on demand (local Windows), else fall back to the
+	// live hive over PowerShell (remote).
+	if k.isUserHive() {
+		if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
+			items, err := k.nativeUserHiveItems(conn)
+			if err != nil {
+				if std, ok := status.FromError(err); ok && std.Code() == codes.NotFound {
+					return false, nil
+				}
+				return false, err
+			}
+			return len(items) > 0, nil
+		}
+		return k.powershellExists(userHivePath(k.UserSid.Data, k.Path.Data))
+	}
+
 	// if we are running locally on windows, we can use native api
 	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
 		items, err := registry.GetNativeRegistryKeyItems(k.Path.Data)
@@ -39,7 +133,14 @@ func (k *mqlRegistrykey) exists() (bool, error) {
 		}
 	}
 
-	script := powershell.Encode(registry.GetRegistryKeyItemScript(k.Path.Data))
+	return k.powershellExists(k.Path.Data)
+}
+
+// powershellExists checks key existence at an absolute registry path by running
+// the PowerShell probe through the command resource (used for remote targets and
+// as the non-native fallback).
+func (k *mqlRegistrykey) powershellExists(path string) (bool, error) {
+	script := powershell.Encode(registry.GetRegistryKeyItemScript(path))
 	o, err := CreateResource(k.MqlRuntime, "command", map[string]*llx.RawData{
 		"command": llx.StringData(script),
 	})
@@ -70,14 +171,27 @@ func (k *mqlRegistrykey) exists() (bool, error) {
 
 // GetEntries returns a list of registry key property resources
 func (k *mqlRegistrykey) getEntries() ([]registry.RegistryKeyItem, error) {
-	// if we are running locally on windows, we can use native api
 	conn := k.MqlRuntime.Connection.(shared.Connection)
+
+	if k.isUserHive() {
+		if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
+			return k.nativeUserHiveItems(conn)
+		}
+		return k.powershellItems(userHivePath(k.UserSid.Data, k.Path.Data))
+	}
+
+	// if we are running locally on windows, we can use native api
 	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
 		return registry.GetNativeRegistryKeyItems(k.Path.Data)
 	}
 
-	// parse the output of the powershell script
-	script := powershell.Encode(registry.GetRegistryKeyItemScript(k.Path.Data))
+	return k.powershellItems(k.Path.Data)
+}
+
+// powershellItems reads the values of a key at an absolute registry path via the
+// PowerShell command resource (used for remote targets and the non-native fallback).
+func (k *mqlRegistrykey) powershellItems(path string) ([]registry.RegistryKeyItem, error) {
+	script := powershell.Encode(registry.GetRegistryKeyItemScript(path))
 	o, err := CreateResource(k.MqlRuntime, "command", map[string]*llx.RawData{
 		"command": llx.StringData(script),
 	})
@@ -143,16 +257,20 @@ func (k *mqlRegistrykey) items() ([]any, error) {
 		return nil, nil
 	}
 
-	// create MQL mount entry resources for each mount
+	// create a registry property resource for each value. userSid/ntuserDat are
+	// carried over so each property's id stays user-distinct (the path alone is
+	// shared across users) and so direct reads resolve the same hive.
 	items := make([]any, len(entries))
 	for i, entry := range entries {
 		o, err := CreateResource(k.MqlRuntime, "registrykey.property", map[string]*llx.RawData{
-			"path":   llx.StringData(k.Path.Data),
-			"name":   llx.StringData(entry.Key),
-			"value":  llx.StringData(entry.String()),
-			"type":   llx.StringData(entry.Kind()),
-			"data":   llx.DictData(entry.GetRawValue()),
-			"exists": llx.BoolData(true),
+			"path":      llx.StringData(k.Path.Data),
+			"name":      llx.StringData(entry.Key),
+			"value":     llx.StringData(entry.String()),
+			"type":      llx.StringData(entry.Kind()),
+			"data":      llx.DictData(entry.GetRawValue()),
+			"exists":    llx.BoolData(true),
+			"userSid":   llx.StringData(k.UserSid.Data),
+			"ntuserDat": llx.StringData(k.NtuserDat.Data),
 		})
 		if err != nil {
 			return nil, err
@@ -168,38 +286,19 @@ func (k *mqlRegistrykey) children() ([]any, error) {
 	conn := k.MqlRuntime.Connection.(shared.Connection)
 	res := []any{}
 	var children []registry.RegistryKeyChild
-	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
-		var err error
+	var err error
+	switch {
+	case k.isUserHive() && conn.Type() == shared.Type_Local && runtime.GOOS == "windows":
+		children, err = k.nativeUserHiveChildren(conn)
+	case k.isUserHive():
+		children, err = k.powershellChildren(userHivePath(k.UserSid.Data, k.Path.Data))
+	case conn.Type() == shared.Type_Local && runtime.GOOS == "windows":
 		children, err = registry.GetNativeRegistryKeyChildren(k.Path.Data)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// parse powershell script
-		script := powershell.Encode(registry.GetRegistryKeyChildItemsScript(k.Path.Data))
-		o, err := CreateResource(k.MqlRuntime, "command", map[string]*llx.RawData{
-			"command": llx.StringData(script),
-		})
-		if err != nil {
-			return res, err
-		}
-		cmd := o.(*mqlCommand)
-		exitcode := cmd.GetExitcode()
-		if exitcode.Error != nil {
-			return nil, exitcode.Error
-		}
-		if exitcode.Data != 0 {
-			return nil, errors.New("could not retrieve registry key")
-		}
-
-		stdout := cmd.GetStdout()
-		if stdout.Error != nil {
-			return res, stdout.Error
-		}
-		children, err = registry.ParsePowershellRegistryKeyChildren(strings.NewReader(stdout.Data))
-		if err != nil {
-			return nil, err
-		}
+	default:
+		children, err = k.powershellChildren(k.Path.Data)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	for i := range children {
@@ -210,13 +309,46 @@ func (k *mqlRegistrykey) children() ([]any, error) {
 	return res, nil
 }
 
+// powershellChildren reads the child keys at an absolute registry path via the
+// PowerShell command resource (used for remote targets and the non-native fallback).
+func (k *mqlRegistrykey) powershellChildren(path string) ([]registry.RegistryKeyChild, error) {
+	script := powershell.Encode(registry.GetRegistryKeyChildItemsScript(path))
+	o, err := CreateResource(k.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData(script),
+	})
+	if err != nil {
+		return nil, err
+	}
+	cmd := o.(*mqlCommand)
+	exitcode := cmd.GetExitcode()
+	if exitcode.Error != nil {
+		return nil, exitcode.Error
+	}
+	if exitcode.Data != 0 {
+		return nil, errors.New("could not retrieve registry key")
+	}
+
+	stdout := cmd.GetStdout()
+	if stdout.Error != nil {
+		return nil, stdout.Error
+	}
+	return registry.ParsePowershellRegistryKeyChildren(strings.NewReader(stdout.Data))
+}
+
 func (p *mqlRegistrykeyProperty) id() (string, error) {
+	// Fold the SID in for per-user hive reads — see mqlRegistrykey.id.
+	if p.UserSid.Data != "" {
+		return userHivePath(p.UserSid.Data, p.Path.Data) + " - " + p.Name.Data, nil
+	}
 	return p.Path.Data + " - " + p.Name.Data, nil
 }
 
 func initRegistrykeyProperty(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	// we either get an init with path+name or it is all initialized
-	if len(args) > 2 {
+	// If the resolved fields are already present (e.g. the property was built
+	// internally by registrykey.items), it is fully initialized — nothing to look
+	// up. Otherwise we only have the selectors (path, name, and optional userSid/
+	// ntuserDat) and need to resolve the value below.
+	if args["exists"] != nil || args["data"] != nil {
 		return args, nil, nil
 	}
 
@@ -230,10 +362,16 @@ func initRegistrykeyProperty(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return args, nil, nil
 	}
 
-	// create resource here, but do not use it yet
-	obj, err := CreateResource(runtime, "registrykey", map[string]*llx.RawData{
-		"path": path,
-	})
+	// create resource here, but do not use it yet. Forward the per-user hive
+	// selectors so the lookup resolves against the right hive.
+	regArgs := map[string]*llx.RawData{"path": path}
+	if v := args["userSid"]; v != nil {
+		regArgs["userSid"] = v
+	}
+	if v := args["ntuserDat"]; v != nil {
+		regArgs["ntuserDat"] = v
+	}
+	obj, err := CreateResource(runtime, "registrykey", regArgs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/os/resources/registrykey_internal_test.go
+++ b/providers/os/resources/registrykey_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 // When a registrykey.property is created without its fields pre-populated by
@@ -32,4 +33,81 @@ func TestRegistrykeyProperty_FallbacksFailGracefully(t *testing.T) {
 	typ, err := p.compute_type()
 	require.NoError(t, err)
 	require.Equal(t, "", typ)
+}
+
+func TestUserHivePath(t *testing.T) {
+	sid := "S-1-5-21-1-2-3-1001"
+	tests := []struct {
+		name    string
+		subPath string
+		want    string
+	}{
+		{"root", "", `HKEY_USERS\` + sid},
+		{"sub-path", `Software\Policies\Microsoft`, `HKEY_USERS\` + sid + `\Software\Policies\Microsoft`},
+		{"trims surrounding backslashes", `\Software\`, `HKEY_USERS\` + sid + `\Software`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, userHivePath(sid, tc.subPath))
+		})
+	}
+}
+
+// The id of a per-user key/property folds in the SID so that two users reading
+// the same hive-relative path cache (and report) separately.
+func TestRegistrykeyID_PerUser(t *testing.T) {
+	t.Run("plain key keeps the absolute path as id", func(t *testing.T) {
+		k := &mqlRegistrykey{Path: plugin.TValue[string]{Data: `HKLM\Software\Foo`}}
+		id, err := k.id()
+		require.NoError(t, err)
+		require.Equal(t, `HKLM\Software\Foo`, id)
+	})
+
+	t.Run("per-user key folds the SID into the id", func(t *testing.T) {
+		a := &mqlRegistrykey{
+			Path:    plugin.TValue[string]{Data: `Software\Policies`},
+			UserSid: plugin.TValue[string]{Data: "S-1-5-21-1-2-3-1001"},
+		}
+		b := &mqlRegistrykey{
+			Path:    plugin.TValue[string]{Data: `Software\Policies`},
+			UserSid: plugin.TValue[string]{Data: "S-1-5-21-1-2-3-1002"},
+		}
+		idA, err := a.id()
+		require.NoError(t, err)
+		idB, err := b.id()
+		require.NoError(t, err)
+		require.Equal(t, `HKEY_USERS\S-1-5-21-1-2-3-1001\Software\Policies`, idA)
+		require.NotEqual(t, idA, idB, "different users with the same hive path must have distinct ids")
+	})
+}
+
+func TestRegistrykeyPropertyID_PerUser(t *testing.T) {
+	t.Run("plain property", func(t *testing.T) {
+		p := &mqlRegistrykeyProperty{
+			Path: plugin.TValue[string]{Data: `HKLM\Software\Foo`},
+			Name: plugin.TValue[string]{Data: "Bar"},
+		}
+		id, err := p.id()
+		require.NoError(t, err)
+		require.Equal(t, `HKLM\Software\Foo - Bar`, id)
+	})
+
+	t.Run("per-user property folds the SID into the id", func(t *testing.T) {
+		a := &mqlRegistrykeyProperty{
+			Path:    plugin.TValue[string]{Data: `Software\Policies`},
+			Name:    plugin.TValue[string]{Data: "Bar"},
+			UserSid: plugin.TValue[string]{Data: "S-1-5-21-1-2-3-1001"},
+		}
+		b := &mqlRegistrykeyProperty{
+			Path:    plugin.TValue[string]{Data: `Software\Policies`},
+			Name:    plugin.TValue[string]{Data: "Bar"},
+			UserSid: plugin.TValue[string]{Data: "S-1-5-21-1-2-3-1002"},
+		}
+		idA, err := a.id()
+		require.NoError(t, err)
+		idB, err := b.id()
+		require.NoError(t, err)
+		require.Equal(t, `HKEY_USERS\S-1-5-21-1-2-3-1001\Software\Policies - Bar`, idA)
+		require.NotEqual(t, idA, idB, "different users with the same property must have distinct ids")
+	})
 }

--- a/providers/os/resources/registrykey_test.go
+++ b/providers/os/resources/registrykey_test.go
@@ -86,3 +86,29 @@ func TestResource_Registrykey(t *testing.T) {
 		}
 	})
 }
+
+func TestResource_RegistrykeyPerUserHive(t *testing.T) {
+	// A per-user read (userSid + ntuserDat) must resolve cleanly even when the
+	// hive can't be read (here: the mock has no recording for it). It degrades to
+	// "not present" rather than erroring, so callers don't get a false positive.
+	t.Run("property in an unreadable user hive does not exist", func(t *testing.T) {
+		res := testWindowsQuery(t, `registrykey.property(userSid: 'S-1-5-21-1-2-3-1001', ntuserDat: 'C:\Users\test\NTUSER.DAT', path: 'Software\Policies\Microsoft\Windows\CloudContent', name: 'DisableThirdPartySuggestions').exists`)
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, false, res[0].Data.Value)
+	})
+
+	t.Run("path is interpreted relative to the user hive", func(t *testing.T) {
+		res := testWindowsQuery(t, `registrykey(userSid: 'S-1-5-21-1-2-3-1001', ntuserDat: 'C:\Users\test\NTUSER.DAT', path: 'Software\Policies').path`)
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, `Software\Policies`, res[0].Data.Value)
+	})
+
+	t.Run("userSid is exposed on the key", func(t *testing.T) {
+		res := testWindowsQuery(t, `registrykey(userSid: 'S-1-5-21-1-2-3-1001', ntuserDat: 'C:\Users\test\NTUSER.DAT', path: 'Software\Policies').userSid`)
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "S-1-5-21-1-2-3-1001", res[0].Data.Value)
+	})
+}

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -101,6 +101,25 @@ func (u *mqlUser) authorizedkeys(home string) (*mqlAuthorizedkeys, error) {
 	return ak.(*mqlAuthorizedkeys), nil
 }
 
+// ntuserDat resolves the on-disk per-user registry hive at <home>\NTUSER.DAT for
+// Windows accounts, so resources like registrykey can read a user's HKCU even
+// when the user is not logged in. Empty on non-Windows platforms or when the home
+// directory is unknown.
+func (u *mqlUser) ntuserDat(home string) (string, error) {
+	conn, ok := u.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return "", nil
+	}
+	pf := conn.Asset().Platform
+	if pf == nil || !pf.IsFamily("windows") {
+		return "", nil
+	}
+	if home == "" {
+		return "", nil
+	}
+	return strings.TrimRight(home, `\`) + `\NTUSER.DAT`, nil
+}
+
 type mqlUsersInternal struct {
 	lock        sync.Mutex
 	usersByID   map[int64]*mqlUser


### PR DESCRIPTION
## Summary

Adds a native way to read a **specific user's HKCU** registry. Today, policies that need a per-user setting (e.g. CIS Windows §19.x *User Configuration*) shell out to `Get-CimInstance Win32_UserProfile`, build `HKEY_USERS\<SID>\...` paths by hand, and can only read a hive that is **currently loaded** — i.e. while that user is logged in. Scheduled scans run as `SYSTEM` with no interactive session, so those reads come back empty and the checks either false-positive or pass vacuously.

This gives the resources a first-class way to do it:

- **`user.ntuserDat`** resolves `<home>\NTUSER.DAT` for Windows accounts (empty elsewhere). The `users` resource already unions `Get-LocalUser` with the `ProfileList` registry, so it carries `sid` + `home` for every profile — including the built-in Administrator (RID 500) and domain/AAD profile SIDs.
- **`registrykey` / `registrykey.property`** gain optional init args **`userSid`** + **`ntuserDat`**. When `userSid` is set, `path` is interpreted **relative to that user's HKCU**.

## Behaviour

For a per-user read on a **local Windows** host:
1. If `HKEY_USERS\<sid>` is loaded (user logged in) → read it live.
2. Otherwise → load the profile's `NTUSER.DAT` on demand through a **connection-scoped** `RegistryHandler`, read it, and unload at connection `Close()` (a new `plugin.Closer`). Hives load once and are shared across all checks in the scan.

If the hive can't be read at all (no NTUSER.DAT, load failure) it degrades to **"not present"** rather than erroring, so a check fails gracefully instead of false-positiving. The SID is folded into the resource `id` so two users reading the same hive-relative path cache (and report) separately.

The `reg load` path is **windows-only** (build-tagged, matching the existing `RegistryHandler`). Remote targets (WinRM) fall back to reading the live `HKEY_USERS\<sid>` hive over PowerShell, as before.

## Example

```mql
users.where(sid == /^S-1-5-21-[0-9]+-[0-9]+-[0-9]+-[0-9]{3,}$/).all(
  registrykey.property(
    userSid: sid, ntuserDat: ntuserDat,
    path: 'Software\Policies\Microsoft\Windows\CloudContent',
    name: 'ConfigureWindowsSpotlight'
  ).data == 2
)
```

vs. the old `powershell(Get-CimInstance …Win32_UserProfile…)` + manual `HKEY_USERS\<SID>` skeleton.

## Implementation

- `providers/os/resources/os.lr` — `user.ntuserDat`; optional `userSid`/`ntuserDat` on `registrykey` and `registrykey.property` (regenerated `os.lr.go`, versioned `13.29.1`).
- `providers/os/resources/registrykey.go` — hive-aware `exists`/`getEntries`/`children`; SID-aware `id`; `initRegistrykeyProperty` forwards the hive selectors. PowerShell read paths factored into helpers.
- `providers/os/resources/user.go` — `ntuserDat` resolver.
- `providers/os/registry/` — `RegistryHandler.LoadUserHive` / `GetUserHiveKey{Items,Children}` (not restricted to `KnownRegistryFiles`); `IsUserHiveLoaded` (windows + non-windows stub).
- `providers/os/connection/local/local.go` — connection-scoped handler + `Close()`.

## Tests

- `registry`: `userRegistryID`, `userHiveKeyPath` (loaded / not-loaded / trimming), `LoadUserHive` validation.
- `resources`: `userHivePath`, SID-distinct `id` for keys and properties, and MQL-level checks that a per-user read resolves cleanly (and reports not-present) on the Windows mock.
- `go build` linux **and** `GOOS=windows`, `go vet`, full `registry` + `resources` suites pass.

## Verification gap

The offline `reg load NTUSER.DAT` path is windows-build-tagged and can't run on a Linux CI box. It compiles for windows and all unit tests pass, but the end-to-end offline-hive load should be validated on a real Windows host — ideally a `SYSTEM`-context scan against a logged-off profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)