### PR TITLE
🐛 fix grub.cfg parser flushing entries before the opening brace

### DIFF
--- a/providers/os/resources/grub.go
+++ b/providers/os/resources/grub.go
@@ -276,6 +276,10 @@ func ParseGrubCfgEntries(r io.Reader) ([]GrubEntry, error) {
 	var entries []GrubEntry
 	var current *GrubEntry
 	depth := 0
+	// opened tracks whether the current entry's opening brace has been seen.
+	// GRUB allows the `{` on a line after `menuentry`, so until it appears we
+	// must not treat depth <= 0 as the entry having closed.
+	opened := false
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -288,8 +292,10 @@ func ParseGrubCfgEntries(r io.Reader) ([]GrubEntry, error) {
 			}
 			current = &GrubEntry{Title: m[1]}
 			depth = 0
+			opened = false
 			if strings.Contains(line, "{") {
 				depth = 1
+				opened = true
 			}
 			continue
 		}
@@ -315,11 +321,18 @@ func ParseGrubCfgEntries(r io.Reader) ([]GrubEntry, error) {
 
 		if current != nil {
 			if !isComment {
+				if strings.Contains(line, "{") {
+					opened = true
+				}
 				depth += strings.Count(line, "{") - strings.Count(line, "}")
-				if depth <= 0 {
+				// Only consider the entry closed once its opening brace has
+				// been seen; otherwise a blank or non-brace line before the
+				// `{` would prematurely flush an empty entry.
+				if opened && depth <= 0 {
 					entries = append(entries, *current)
 					current = nil
 					depth = 0
+					opened = false
 					continue
 				}
 			}

--- a/providers/os/resources/grub_test.go
+++ b/providers/os/resources/grub_test.go
@@ -146,6 +146,25 @@ func TestParseGrubCfgEntriesBraceOnNextLine(t *testing.T) {
 	assert.Contains(t, entries[0].Initrd, "initrd.img")
 }
 
+func TestParseGrubCfgEntriesBlankLineBeforeBrace(t *testing.T) {
+	// A blank line between `menuentry` and the opening brace must not cause the
+	// entry to be flushed before its linux/initrd lines are read.
+	input := `menuentry 'Test Entry'
+
+{
+	linux /vmlinuz root=/dev/sda1 ro
+	initrd /initrd.img
+}
+`
+	entries, err := ParseGrubCfgEntries(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, "Test Entry", entries[0].Title)
+	assert.Contains(t, entries[0].Cmdline, "vmlinuz")
+	assert.Contains(t, entries[0].Initrd, "initrd.img")
+}
+
 func TestParseGrubCfgEntriesDuplicateTitles(t *testing.T) {
 	input := `menuentry 'Ubuntu' {
 	linux /vmlinuz-5.4 root=/dev/sda1 ro


### PR DESCRIPTION
## Problem

When a `menuentry`/`submenu` line did not carry its opening `{` on the same line (GRUB permits the brace on a following line), `depth` stayed at `0`. A blank or non-brace line appearing before the brace then satisfied `depth <= 0` and flushed the entry immediately — before its `linux`/`initrd` lines were read — producing an entry with empty `Cmdline`/`Initrd`.

The existing `TestParseGrubCfgEntriesBraceOnNextLine` only covered the case where `{` is on the *immediately* following line, which happens to work, so the gap went unnoticed.

## Fix

Track whether the current entry's opening brace has actually been seen (`opened`), and only treat `depth <= 0` as the entry closing once it has.

## Test

`TestParseGrubCfgEntriesBlankLineBeforeBrace` parses a `menuentry` with a blank line before its `{` and asserts the entry's title, cmdline and initrd are all captured. All existing grub tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_