### PR TITLE
🐛 fix fragile /etc/shadow parsing using encoding/csv

### DIFF
--- a/providers/os/resources/shadow/shadow.go
+++ b/providers/os/resources/shadow/shadow.go
@@ -4,12 +4,17 @@
 package shadow
 
 import (
-	"encoding/csv"
+	"bufio"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// shadowFieldCount is the number of colon-separated fields in an /etc/shadow
+// entry: name:password:lastchange:min:max:warn:inactive:expire:reserved.
+const shadowFieldCount = 9
 
 type ShadowEntry struct {
 	User         string
@@ -26,16 +31,24 @@ type ShadowEntry struct {
 func ParseShadow(r io.Reader) ([]ShadowEntry, error) {
 	res := []ShadowEntry{}
 
-	csvReader := csv.NewReader(r)
-	csvReader.Comma = ':'
-	for {
-		record, err := csvReader.Read()
-		if err == io.EOF {
-			break
+	// /etc/shadow is a simple line-oriented, colon-separated file. We split on
+	// ':' directly rather than using encoding/csv: csv treats `"` as a quote
+	// character (corrupting password hashes that contain one) and locks the
+	// field count to the first record (erroring the whole file on any skew).
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
-		if err != nil {
-			return nil, err
+
+		// At most shadowFieldCount fields so an unexpected ':' in the final
+		// reserved field stays attached to it rather than overflowing.
+		record := strings.SplitN(line, ":", shadowFieldCount)
+		if len(record) < shadowFieldCount {
+			return nil, fmt.Errorf("invalid shadow entry, expected %d fields but got %d", shadowFieldCount, len(record))
 		}
+
 		// the /etc/shadow file gives the count of days since jan 1, 1970
 		start := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 		var lastChangedTime *time.Time
@@ -61,6 +74,9 @@ func ParseShadow(r io.Reader) ([]ShadowEntry, error) {
 			ExpiryDates:  strings.TrimSpace(record[7]),
 			Reserved:     strings.TrimSpace(record[8]),
 		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
 	}
 
 	return res, nil

--- a/providers/os/resources/shadow/shadow_test.go
+++ b/providers/os/resources/shadow/shadow_test.go
@@ -4,6 +4,7 @@
 package shadow_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,33 @@ func TestParseShadow(t *testing.T) {
 	}
 	found := findUser(shadowEntries, "chris")
 	assert.Equal(t, expected, found)
+}
+
+func TestParseShadow_PasswordWithDoubleQuote(t *testing.T) {
+	// A double quote anywhere in the line must be treated literally. The old
+	// csv-based parser interpreted it as a CSV quote and corrupted the entry.
+	input := `alice:$6$ab"cd$hashvalue:18900:0:99999:7:::
+bob:!:18900:0:99999:7:::
+`
+	entries, err := shadow.ParseShadow(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	alice := findUser(entries, "alice")
+	require.NotNil(t, alice)
+	assert.Equal(t, `$6$ab"cd$hashvalue`, alice.Password)
+
+	bob := findUser(entries, "bob")
+	require.NotNil(t, bob)
+	assert.Equal(t, "!", bob.Password)
+}
+
+func TestParseShadow_ShortLineErrors(t *testing.T) {
+	// A line with fewer than 9 fields must produce an error rather than panic.
+	input := "broken:x:18900\n"
+	_, err := shadow.ParseShadow(strings.NewReader(input))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid shadow entry")
 }
 
 func findUser(shadowEntries []shadow.ShadowEntry, user string) *shadow.ShadowEntry {


### PR DESCRIPTION
## Problem

`ParseShadow` used `encoding/csv` with `Comma = ':'`, which is a poor fit for `/etc/shadow`:

1. csv treats `"` as a quote character — a password hash containing a `"` corrupts the parse or errors.
2. `record[8]` was indexed unconditionally; a malformed first line with fewer than 9 fields panics with index-out-of-range.
3. With the default `FieldsPerRecord`, csv locks the field count to the first record and errors the **entire** file on any single line with a different count.

## Fix

Parse line-by-line, splitting on `:` with `strings.SplitN(line, ":", 9)` and an explicit nine-field guard — mirroring the existing `etcpasswd.go` / `etcgroups.go` parsers. Quotes are now literal, a short line yields a clear error instead of a panic, and the `SplitN` cap keeps any stray `:` attached to the trailing reserved field.

## Tests

- `TestParseShadow_PasswordWithDoubleQuote` — a hash containing `"` is preserved verbatim.
- `TestParseShadow_ShortLineErrors` — a line with fewer than 9 fields returns an `invalid shadow entry` error without panicking.

The existing `TestParseShadow` (27-entry debian fixture) and the `shadow.list` resource test continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_