### PR TITLE
🐛 normalize systemd timer Persistent and socket Accept booleans

### DIFF
--- a/providers/os/resources/systemd_units.go
+++ b/providers/os/resources/systemd_units.go
@@ -137,7 +137,9 @@ func (t *mqlSystemdTimer) persistent() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return props["Persistent"] == "yes", nil
+	// `systemctl show` normalizes booleans to yes/no, but the filesystem-based
+	// path passes the unit file's raw value through, which may be true/1/on.
+	return parseYesNo(props["Persistent"], false), nil
 }
 
 // =============================================================================
@@ -280,7 +282,9 @@ func (s *mqlSystemdSocket) accept() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return props["Accept"] == "yes", nil
+	// `systemctl show` normalizes booleans to yes/no, but the filesystem-based
+	// path passes the unit file's raw value through, which may be true/1/on.
+	return parseYesNo(props["Accept"], false), nil
 }
 
 func (s *mqlSystemdSocket) listenAddresses() ([]any, error) {

--- a/providers/os/resources/systemd_units_internal_test.go
+++ b/providers/os/resources/systemd_units_internal_test.go
@@ -91,3 +91,45 @@ func TestInitSystemdSocketMissingResource(t *testing.T) {
 		})
 	}
 }
+
+func TestSystemdTimerPersistentBooleanForms(t *testing.T) {
+	// systemctl show emits "yes"/"no", but the filesystem path forwards the raw
+	// unit-file value, which may be true/1/on. All truthy forms must report true.
+	for _, v := range []string{"yes", "true", "1", "on"} {
+		timer := &mqlSystemdTimer{}
+		timer.fetched = true
+		timer.props = map[string]string{"Persistent": v}
+		got, err := timer.persistent()
+		require.NoError(t, err)
+		assert.True(t, got, "Persistent=%q should be true", v)
+	}
+
+	for _, v := range []string{"no", "false", "0", "off", ""} {
+		timer := &mqlSystemdTimer{}
+		timer.fetched = true
+		timer.props = map[string]string{"Persistent": v}
+		got, err := timer.persistent()
+		require.NoError(t, err)
+		assert.False(t, got, "Persistent=%q should be false", v)
+	}
+}
+
+func TestSystemdSocketAcceptBooleanForms(t *testing.T) {
+	for _, v := range []string{"yes", "true", "1", "on"} {
+		socket := &mqlSystemdSocket{}
+		socket.fetched = true
+		socket.props = map[string]string{"Accept": v}
+		got, err := socket.accept()
+		require.NoError(t, err)
+		assert.True(t, got, "Accept=%q should be true", v)
+	}
+
+	for _, v := range []string{"no", "false", "0", "off", ""} {
+		socket := &mqlSystemdSocket{}
+		socket.fetched = true
+		socket.props = map[string]string{"Accept": v}
+		got, err := socket.accept()
+		require.NoError(t, err)
+		assert.False(t, got, "Accept=%q should be false", v)
+	}
+}


### PR DESCRIPTION
## Problem

`mqlSystemdTimer.persistent()` and `mqlSystemdSocket.accept()` compared the property value with `== "yes"`:

```go
return props["Persistent"] == "yes", nil
return props["Accept"] == "yes", nil
```

`systemctl show` normalizes booleans to `yes`/`no`, so the command path is fine. But the **filesystem-based** path (`systemd_timer_fs.go` / `systemd_socket_fs.go`) forwards the unit file's raw value, and systemd accepts `true`/`1`/`on` (as well as `yes`) as truthy. A timer written `Persistent=true` therefore reported `false` on a filesystem scan, and likewise a socket `Accept=true`.

## Fix

Use the existing `parseYesNo` helper (already used by systemd-resolved parsing), which recognizes `yes`/`on`/`true`/`1` and their negatives, with a `false` fallback.

## Tests

`TestSystemdTimerPersistentBooleanForms` and `TestSystemdSocketAcceptBooleanForms` assert every truthy spelling (`yes`/`true`/`1`/`on`) returns true and every falsy/empty spelling returns false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_