### PR TITLE
🐛 fix dscacheutil group parser logging and bogus gid handling

### DIFF
--- a/providers/os/resources/groups/dscache.go
+++ b/providers/os/resources/groups/dscache.go
@@ -56,7 +56,11 @@ func ParseDscacheutilResult(input io.Reader) ([]*Group, error) {
 		case "gid":
 			gid, err := strconv.ParseInt(m[2], 10, 0)
 			if err != nil {
-				log.Error().Err(err).Str("group", m[0]).Msg("could not parse gid")
+				// m[0] is the whole matched line, not the group name; log the
+				// group's name and the offending value instead. Skip recording
+				// a bogus ID/gid so the malformed entry is dropped by add().
+				log.Error().Err(err).Str("group", group.Name).Str("value", m[2]).Msg("could not parse gid")
+				continue
 			}
 			group.ID = m[2]
 			group.Gid = gid

--- a/providers/os/resources/groups/dscache_test.go
+++ b/providers/os/resources/groups/dscache_test.go
@@ -4,9 +4,11 @@
 package groups_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
 	"go.mondoo.com/mql/v13/providers/os/resources/groups"
@@ -36,4 +38,27 @@ func TestParseDscacheutilResult(t *testing.T) {
 	assert.Equal(t, int64(216), grp.Gid, "detected group id")
 	assert.Equal(t, "_postgres", grp.Name, "detected group name")
 	assert.Equal(t, []string{"_devicemgr", "_calendar", "_teamsserver", "_xserverdocs"}, grp.Members, "detected group members")
+}
+
+func TestParseDscacheutilResult_InvalidGid(t *testing.T) {
+	// A group whose gid cannot be parsed must be dropped rather than recorded
+	// with a bogus (unparseable) ID and gid 0.
+	input := `name: brokengroup
+password: *
+gid: notanumber
+users: alice
+
+name: validgroup
+password: *
+gid: 501
+users: bob carol
+`
+	res, err := groups.ParseDscacheutilResult(strings.NewReader(input))
+	require.NoError(t, err)
+
+	require.Len(t, res, 1)
+	assert.Equal(t, "validgroup", res[0].Name)
+	assert.Equal(t, int64(501), res[0].Gid)
+	assert.Equal(t, "501", res[0].ID)
+	assert.Nil(t, findGroup(res, "notanumber"))
 }


### PR DESCRIPTION
## Problem

In `ParseDscacheutilResult`, the `gid` branch:

```go
gid, err := strconv.ParseInt(m[2], 10, 0)
if err != nil {
    log.Error().Err(err).Str("group", m[0]).Msg("could not parse gid")
}
group.ID = m[2]   // recorded even on parse failure
group.Gid = gid   // 0 on failure
```

`m[0]` is the whole matched line (e.g. `gid: 395`), not the group name, so the `"group"` log field is misleading. And on a parse failure the code still recorded `group.ID` with the unparseable value and `Gid = 0`, surfacing a group with a bogus ID.

## Fix

Log the group's actual name plus the offending value, and `continue` on failure so the ID/gid aren't recorded — `add()` then drops the entry (it requires a non-empty `ID`).

## Test

`TestParseDscacheutilResult_InvalidGid` parses two groups, one with `gid: notanumber`, and asserts the malformed group is dropped while the valid one is returned intact. The existing `TestParseDscacheutilResult` continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_