### PR TITLE
🐛 fix OOM during container image scanning

### DIFF
--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -143,16 +143,13 @@ func (s *Service) doGetRuntime(id uint32) (*Runtime, error) {
 }
 
 func (s *Service) Disconnect(req *DisconnectReq) (*DisconnectRes, error) {
-	var remaining int
-	func() {
-		s.runtimesLock.Lock()
-		defer s.runtimesLock.Unlock()
-		s.doDisconnect(req.Connection)
-		remaining = len(s.runtimes)
-		if remaining == 0 {
-			s.Flush()
-		}
-	}()
+	s.runtimesLock.Lock()
+	s.doDisconnect(req.Connection)
+	remaining := len(s.runtimes)
+	if remaining == 0 {
+		s.Flush()
+	}
+	s.runtimesLock.Unlock()
 
 	debug.FreeOSMemory()
 
@@ -173,12 +170,12 @@ func (s *Service) Disconnect(req *DisconnectReq) (*DisconnectRes, error) {
 			if err != nil {
 				log.Error().Err(err).Str("path", path).Msg("failed to create heap profile file")
 			} else {
-				defer f.Close()
 				if err := pprof.WriteHeapProfile(f); err != nil {
 					log.Error().Err(err).Msg("failed to write heap profile")
 				} else {
 					log.Info().Str("path", path).Msg("wrote heap profile after disconnect")
 				}
+				f.Close()
 			}
 		}
 	}

--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -5,12 +5,17 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	goruntime "runtime"
+	"runtime/debug"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	sync "sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	llx "go.mondoo.com/mql/v13/llx"
 	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/memoize"
@@ -138,13 +143,46 @@ func (s *Service) doGetRuntime(id uint32) (*Runtime, error) {
 }
 
 func (s *Service) Disconnect(req *DisconnectReq) (*DisconnectRes, error) {
-	s.runtimesLock.Lock()
-	defer s.runtimesLock.Unlock()
-	s.doDisconnect(req.Connection)
-	if len(s.runtimes) == 0 {
-		// flush our memoizer when there are no more connected runtimes
-		s.Flush()
+	var remaining int
+	func() {
+		s.runtimesLock.Lock()
+		defer s.runtimesLock.Unlock()
+		s.doDisconnect(req.Connection)
+		remaining = len(s.runtimes)
+		if remaining == 0 {
+			s.Flush()
+		}
+	}()
+
+	debug.FreeOSMemory()
+
+	if os.Getenv("DEBUG_PROVIDER_MEMORY") != "" {
+		var m goruntime.MemStats
+		goruntime.ReadMemStats(&m)
+		log.Info().
+			Int("remaining_runtimes", remaining).
+			Uint64("heap_alloc_mb", m.Alloc/1024/1024).
+			Uint64("heap_sys_mb", m.HeapSys/1024/1024).
+			Uint64("heap_inuse_mb", m.HeapInuse/1024/1024).
+			Uint64("total_alloc_mb", m.TotalAlloc/1024/1024).
+			Msg("provider memory stats after disconnect")
+
+		if remaining == 0 {
+			path := fmt.Sprintf("/tmp/provider_heap_%d_conn%d.pprof", os.Getpid(), req.Connection)
+			f, err := os.Create(path)
+			if err != nil {
+				log.Error().Err(err).Str("path", path).Msg("failed to create heap profile file")
+			} else {
+				defer f.Close()
+				if err := pprof.WriteHeapProfile(f); err != nil {
+					log.Error().Err(err).Msg("failed to write heap profile")
+				} else {
+					log.Info().Str("path", path).Msg("wrote heap profile after disconnect")
+				}
+			}
+		}
 	}
+
 	return &DisconnectRes{}, nil
 }
 

--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -142,14 +142,18 @@ func (s *Service) doGetRuntime(id uint32) (*Runtime, error) {
 	return nil, errors.New("connection " + strconv.FormatUint(uint64(id), 10) + " not found")
 }
 
-func (s *Service) Disconnect(req *DisconnectReq) (*DisconnectRes, error) {
+func (s *Service) disconnectRuntime(id uint32) int {
 	s.runtimesLock.Lock()
-	s.doDisconnect(req.Connection)
-	remaining := len(s.runtimes)
-	if remaining == 0 {
+	defer s.runtimesLock.Unlock()
+	s.doDisconnect(id)
+	if len(s.runtimes) == 0 {
 		s.Flush()
 	}
-	s.runtimesLock.Unlock()
+	return len(s.runtimes)
+}
+
+func (s *Service) Disconnect(req *DisconnectReq) (*DisconnectRes, error) {
+	remaining := s.disconnectRuntime(req.Connection)
 
 	debug.FreeOSMemory()
 

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -209,29 +209,30 @@ func (c *coordinator) RemoveRuntime(runtime *Runtime) {
 		}
 	}
 
-	// Shutdown any providers that are not being used anymore.
-	// We have runtimes that are used for initialising a scan, but are not
-	// used for the actual scan. They reference no providers, so shouldn't affect
-	// the shutdown of providers.
-	uprocessedRuntimeWithProviders := false
-	for _, rt := range c.unprocessedRuntimes {
-		if rt.Provider != nil {
-			uprocessedRuntimeWithProviders = true
+	// Shut down providers that are no longer referenced by any runtime.
+	// Build a set of provider IDs still in use.
+	usedProviders := map[string]bool{}
+	for _, rt := range c.runtimes {
+		for _, id := range rt.ConnectedProviderIDs() {
+			usedProviders[id] = true
 		}
 	}
-	if len(c.runtimes) == 0 && !uprocessedRuntimeWithProviders {
-		for _, p := range c.runningByID {
-			log.Debug().Msg("shutting down unused provider " + p.Name)
+	for _, rt := range c.unprocessedRuntimes {
+		for _, id := range rt.ConnectedProviderIDs() {
+			usedProviders[id] = true
+		}
+	}
+
+	for _, p := range c.runningByID {
+		if p.isCloseOrShutdown() {
+			log.Warn().Str("provider", p.Name).Msg("removing closed provider")
+			delete(c.runningByID, p.ID)
+			continue
+		}
+		if !usedProviders[p.ID] {
+			log.Debug().Msg("shutting down idle provider " + p.Name)
 			if err := c.stop(p); err != nil {
 				log.Warn().Err(err).Str("provider", p.Name).Msg("failed to shut down provider")
-			}
-		}
-	} else {
-		// Check for killed/crashed providers and remove them from the list of running providers
-		for _, p := range c.runningByID {
-			if p.isCloseOrShutdown() {
-				log.Warn().Str("provider", p.Name).Msg("removing closed provider")
-				delete(c.runningByID, p.ID)
 			}
 		}
 	}

--- a/providers/coordinator_test.go
+++ b/providers/coordinator_test.go
@@ -265,10 +265,10 @@ func TestRemoveRuntime_UsedProvider(t *testing.T) {
 		},
 	}
 
-	// Setup another provider with the same runtime
+	// Setup another runtime that also uses provider1
 	r2 := &Runtime{
 		providers: map[string]*ConnectedProvider{
-			"provider2": {Instance: p1},
+			"provider1": {Instance: p1},
 		},
 		Provider: &ConnectedProvider{
 			Instance: p1,

--- a/providers/os/connection/tar/connection.go
+++ b/providers/os/connection/tar/connection.go
@@ -131,6 +131,9 @@ func (c *Connection) Close() {
 	if c.closeFN != nil {
 		c.closeFN()
 	}
+	if c.fs != nil {
+		c.fs.FileMap = nil
+	}
 }
 
 func (c *Connection) Load(stream io.Reader) error {


### PR DESCRIPTION
## Summary

Container image scanning in the Mondoo Operator OOM-killed at 18-20 out of 35 images
with a 1Gi memory limit. Three changes address the root causes:

- **Clear tar filesystem on connection Close** (`providers/os/connection/tar/connection.go`):
  `tar.Connection.Close()` now nils out `fs.FileMap` immediately, freeing the in-memory
  container filesystem (~1-3 MB per image) instead of waiting for GC to collect the
  entire runtime. Profiling showed `tar.Connection.Load` accounted for 83% of the OS
  provider's retained heap.

- **Return memory to OS after provider disconnect** (`providers-sdk/v1/plugin/service.go`):
  Calls `debug.FreeOSMemory()` after disconnecting a runtime so the Go runtime promptly
  returns freed pages to the OS. Without this, freed heap stays mapped and counts against
  the cgroup memory limit even though it's unused. Also adds optional heap profiling
  gated behind `DEBUG_PROVIDER_MEMORY` for future diagnostics.

- **Shut down idle providers eagerly** (`providers/coordinator.go`):
  `RemoveRuntime` now builds a set of provider IDs still referenced by active runtimes
  and shuts down any provider not in that set. Previously, providers were only shut down
  when ALL runtimes were gone, keeping idle provider subprocesses alive for the entire
  scan duration.

### Root cause

The scan pipeline pre-connects assets to providers ahead of the active scan worker
(controlled by `maxConnections`, default 50). For container images, each connection
calls `tar.Connection.Load()` which reads all tar headers (file paths, sizes, permissions — one `*tar.Header` per file in the image) into memory as a lookup index. With 35 target images and a limit of 50, all 35 filesystems were
loaded simultaneously in the provider subprocess.

Provider heap profile confirmed `tar.Connection.Load` = 83% of retained heap:
```
42,678 kB total inuse_space
19,460 kB (45.6%)  archive/tar.(*Reader).readHeader
 7,680 kB (18.0%)  archive/tar.(*parser).parseString
 4,203 kB  (9.9%)  tar.(*Connection).Load
 4,096 kB  (9.6%)  tar.(*lazybuf).string
```

Additionally, `tar.Connection.Close()` did not release `fs.FileMap` — the in-memory
filesystem stayed allocated until GC collected the entire runtime.

### Measurements

Container image scanning against 35 target images (mixed distros) in a 1Gi cgroup:

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Assets completed | 18-20/35 (OOM) | **35/35** | Fixed |
| Cgroup growth rate | 15.4 MB/asset | **7.7 MB/asset** | -50% |
| Peak cgroup at 35 assets | OOM | **352 MB** | |

Memory still grows ~7.7 MB/asset due to `AggregateReporter` accumulating full
`policy.Report` objects (~4.5 MB/asset) that are already uploaded individually. That's
a separate optimization — at the current rate, the 1Gi limit supports ~100 images.

## Test plan

- [ ] Existing unit tests pass
- [x] Container image scan completes all 35 images within 1Gi memory limit
- [x] `DEBUG_PROVIDER_MEMORY=1` produces heap profiles and stats in provider logs
- [x] Provider subprocesses are cleaned up after last runtime disconnects
