### PR TITLE
🐛 fix panic parsing PAM bracketed control with no module

### DIFF
--- a/providers/os/resources/pam/parser.go
+++ b/providers/os/resources/pam/parser.go
@@ -71,12 +71,23 @@ func complicatedParse(fields []string) (*PamLine, error) {
 	pamType := fields[0]
 	control := fields[1]
 	i := 2
-	for ; i < len(fields)-1; i++ {
+	closed := false
+	// Accumulate fields into the bracketed control until the closing `]`.
+	// The loop must be able to inspect the final field as well, otherwise a
+	// control that runs to the end of the line is never recognized as closed.
+	for ; i < len(fields); i++ {
 		str := fields[i]
 		control += " " + str
-		if str[len(str)-1:] == "]" {
+		if strings.HasSuffix(str, "]") {
+			closed = true
 			break
 		}
+	}
+	// The module is the token after the closing bracket. If the bracket was
+	// never closed, or there is no field after it, the line is malformed —
+	// return an error rather than indexing out of range.
+	if !closed || i+1 >= len(fields) {
+		return &PamLine{}, fmt.Errorf("invalid pam entry: %s", strings.Join(fields, " "))
 	}
 	module := fields[i+1]
 	options := []any{}

--- a/providers/os/resources/pam/parser_test.go
+++ b/providers/os/resources/pam/parser_test.go
@@ -117,6 +117,37 @@ func TestParseLine(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, result)
 	})
+
+	t.Run("bracketed control running to end of line does not panic", func(t *testing.T) {
+		// A bracketed control with no module following it is malformed; it must
+		// return an error rather than panic with an out-of-range index.
+		require.NotPanics(t, func() {
+			_, err := ParseLine("auth [success=1 default=ignore]")
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("unterminated bracketed control does not panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := ParseLine("auth [success=1 default=ignore pam_unix.so")
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("bracketed control with closing bracket in last token before module", func(t *testing.T) {
+		// Regression: the closing `]` lands in the final field that the loop
+		// previously refused to inspect.
+		line := "auth [success=1 default=ignore] pam_unix.so"
+		expected := &PamLine{
+			PamType: "auth",
+			Control: "[success=1 default=ignore]",
+			Module:  "pam_unix.so",
+			Options: []any{},
+		}
+		result, err := ParseLine(line)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
 }
 
 func parsePamContent(content string) ([]*PamLine, error) {


### PR DESCRIPTION
## Problem

`ParseLine` routes any `[...`-style control token to `complicatedParse`, which accumulated fields into the control until `len(fields)-1` and then unconditionally read `fields[i+1]` as the module:

```go
for ; i < len(fields)-1; i++ { ... }
module := fields[i+1]   // out of range when the control runs to end-of-line
```

So a line whose bracketed control runs to the end (`auth [success=1 default=ignore]`) — or an unterminated control (`auth [success=1 default=ignore`) — indexed out of range and **panicked**, crashing the entire `pam.entries` query on admin-editable `/etc/pam.d/*`. The loop also never inspected the final field, so a closing `]` in the last token before the module was mishandled.

## Fix

Let the loop inspect the final field, track whether the bracket actually closed, and return an `invalid pam entry` error (instead of indexing) when the bracket is unterminated or no module follows.

## Tests

Added cases asserting no panic + error for a control running to end-of-line and for an unterminated control, plus a regression case for a closing `]` in the last token before the module.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_