### PR TITLE
🐛 fix /proc status parser writing PPid into the Pid field

### DIFF
--- a/providers/os/resources/procfs/processes.go
+++ b/providers/os/resources/procfs/processes.go
@@ -60,7 +60,7 @@ func ParseProcessStatus(input io.Reader) (*LinuxProcessStatus, error) {
 				continue
 			}
 		case "PPid":
-			if lps.Pid, err = strconv.ParseInt(value, 10, 64); err != nil {
+			if lps.PPid, err = strconv.ParseInt(value, 10, 64); err != nil {
 				log.Warn().Err(err).Str("key", key).Msg("process> could not parse value")
 				continue
 			}

--- a/providers/os/resources/procfs/processes_test.go
+++ b/providers/os/resources/procfs/processes_test.go
@@ -28,6 +28,24 @@ func TestParseProcessStatus(t *testing.T) {
 	assert.Equal(t, "bash", processStatus.Executable, "detected process name")
 }
 
+func TestParseProcessStatus_PidAndPPidDistinct(t *testing.T) {
+	// Pid and PPid must be parsed into their own fields; previously the PPid
+	// line was written into Pid, corrupting Pid and leaving PPid at 0.
+	status := "Name:\tsshd\n" +
+		"State:\tS (sleeping)\n" +
+		"Tgid:\t4242\n" +
+		"Ngid:\t0\n" +
+		"Pid:\t4242\n" +
+		"PPid:\t1\n"
+
+	processStatus, err := ParseProcessStatus(bytes.NewBufferString(status))
+	require.NoError(t, err)
+	require.NotNil(t, processStatus)
+
+	assert.Equal(t, int64(4242), processStatus.Pid, "Pid keeps the process id")
+	assert.Equal(t, int64(1), processStatus.PPid, "PPid holds the parent process id")
+}
+
 func TestParseProcessCmdline(t *testing.T) {
 	trans, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/process-pid1.toml"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

In `ParseProcessStatus`, the `PPid` case parsed into the wrong field:

```go
case "PPid":
    if lps.Pid, err = strconv.ParseInt(value, 10, 64); err != nil { ... }
```

Since `PPid` appears after `Pid` in `/proc/<pid>/status`, this overwrote the real PID with the parent PID and left the exported, JSON-tagged `PPid` field permanently `0` — corrupting both fields for any consumer of `LinuxProcessStatus`.

## Fix

Assign to `lps.PPid`.

## Test

`TestParseProcessStatus_PidAndPPidDistinct` parses a status snippet with `Pid: 4242` / `PPid: 1` and asserts each field holds its own value.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_