### PR TITLE
🐛 fix lsof TCP state keys and guard malformed T-fields

### DIFF
--- a/providers/os/resources/lsof/lsof.go
+++ b/providers/os/resources/lsof/lsof.go
@@ -165,9 +165,9 @@ func (f *FileDescriptor) NetworkFile() (string, int64, string, int64, error) {
 var lsofTcpStateMapping = map[string]int64{
 	"ESTABLISHED": 1,  // "established"
 	"SYN_SENT":    2,  //  "syn sent"
-	"SYN_RCDV":    3,  //  "syn recv"
+	"SYN_RCVD":    3,  //  "syn recv"
 	"FIN_WAIT1":   4,  //  "fin wait1"
-	"FIN_WAIT_2":  5,  //   "fin wait2",
+	"FIN_WAIT2":   5,  //   "fin wait2",
 	"TIME_WAIT":   6,  //  "time wait",
 	"CLOSED":      7,  // "close"
 	"CLOSE_WAIT":  8,  //   "close wait"
@@ -210,6 +210,11 @@ func (f *FileDescriptor) parseField(s string) error {
 		// TCP/TPI information
 		// we need to parse it separately
 		keyPair := tcpInfoRegex.FindStringSubmatch(value)
+		// A T-field that lacks `key=value` form yields no submatches; skip it
+		// rather than indexing out of range.
+		if len(keyPair) < 3 {
+			return nil
+		}
 		switch keyPair[1] {
 		case "QR":
 			f.TcpReadQueueSize = keyPair[2]

--- a/providers/os/resources/lsof/lsof_test.go
+++ b/providers/os/resources/lsof/lsof_test.go
@@ -111,6 +111,36 @@ TQS=0
 	assert.Equal(t, "10.184.10.188:64645->76.76.21.241:443", fd.Name)
 }
 
+func TestParseLsofTcpStateKeys(t *testing.T) {
+	// lsof spells these states SYN_RCVD and FIN_WAIT2 (no underscore before the
+	// digit); the mapping keys must match exactly or TcpState falls back to 0.
+	cases := map[string]int64{
+		"ESTABLISHED": 1,
+		"SYN_RCVD":    3,
+		"FIN_WAIT1":   4,
+		"FIN_WAIT2":   5,
+		"LISTEN":      10,
+	}
+	for state, want := range cases {
+		s := "p1\ncFoo\nu0\nf3\nPTCP\nn1.2.3.4:1->5.6.7.8:2\nTST=" + state + "\n"
+		processes, err := Parse(strings.NewReader(s))
+		require.NoError(t, err)
+		require.Len(t, processes, 1)
+		require.Len(t, processes[0].FileDescriptors, 1)
+		assert.Equal(t, want, processes[0].FileDescriptors[0].TcpState(), "state %q", state)
+	}
+}
+
+func TestParseLsofMalformedTcpField(t *testing.T) {
+	// A T-field without `key=value` form must be skipped, not panic.
+	s := "p1\ncFoo\nu0\nf3\nPTCP\nnname\nTmalformed\n"
+	require.NotPanics(t, func() {
+		processes, err := Parse(strings.NewReader(s))
+		require.NoError(t, err)
+		require.Len(t, processes, 1)
+	})
+}
+
 func TestParseEmpty(t *testing.T) {
 	processes, err := Parse(strings.NewReader(""))
 	if err != nil {


### PR DESCRIPTION
## Problem

Two keys in the lsof→TCP-state map were misspelled relative to lsof's actual output:

```go
"SYN_RCDV":    3,  // should be SYN_RCVD
"FIN_WAIT_2":  5,  // should be FIN_WAIT2 (cf. correctly-spelled FIN_WAIT1)
```

A socket in either state didn't match, so `TcpState()` returned `0` and `port.state` showed `"unknown"` on macOS/FreeBSD (which use the lsof-based path).

Separately, the `T` (TCP/TPI) field parser indexed `keyPair[1]` from `tcpInfoRegex.FindStringSubmatch(value)` without checking the match — a `T`-field lacking `key=value` form yields `nil` and panics.

## Fix

- Correct the two state keys to `SYN_RCVD` and `FIN_WAIT2`.
- Skip a `T`-field that doesn't match `key=value` instead of indexing out of range.

## Tests

- `TestParseLsofTcpStateKeys` asserts the state strings (incl. `SYN_RCVD`, `FIN_WAIT2`) map to the correct codes via `TcpState()`.
- `TestParseLsofMalformedTcpField` feeds a `T`-field with no `=` and asserts no panic.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_