### PR TITLE
🐛 fix out-of-range index in AIX ps uid parse error path

### DIFF
--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -189,7 +189,7 @@ func ParseAixPsResult(input io.Reader) ([]*ProcessEntry, error) {
 		}
 		uid, err := strconv.ParseInt(m[7], 10, 64)
 		if err != nil {
-			log.Error().Err(err).Msg("cannot parse unix uid " + m[9])
+			log.Error().Err(err).Msg("cannot parse unix uid " + m[7])
 			continue
 		}
 

--- a/providers/os/resources/processes/unixps_test.go
+++ b/providers/os/resources/processes/unixps_test.go
@@ -137,6 +137,18 @@ func TestAixPSProcessParser(t *testing.T) {
 	assert.Equal(t, int64(0), found.Uid, "process uid detected")
 }
 
+func TestAixPSProcessParser_NonNumericUid(t *testing.T) {
+	// A row whose uid column is non-numeric hits the uid-parse-error branch.
+	// That branch previously referenced m[9] — out of range for the 8-group
+	// AIX regex — and panicked; it must now skip the row cleanly.
+	input := " 1234 0.1 0.2 4096 pts/0 00:00:01 root /usr/sbin/sshd\n"
+	require.NotPanics(t, func() {
+		procs, err := processes.ParseAixPsResult(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Empty(t, procs)
+	})
+}
+
 func TestParseFindSocketLine(t *testing.T) {
 	fi, err := os.Open("./testdata/find_printf_nginx_container.txt")
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

`ParseAixPsResult` validates that `AIX_PS_REGEX` produced exactly 9 submatch elements (`m[0..8]`, 8 capture groups), but the uid-parse-error branch logged `m[9]`:

```go
uid, err := strconv.ParseInt(m[7], 10, 64)
if err != nil {
    log.Error().Err(err).Msg("cannot parse unix uid " + m[9]) // index out of range
    continue
}
```

So a row with a non-numeric uid column panicked instead of being skipped. The `m[9]` reference was copy-pasted from the 9-group UNIX block above it.

## Fix

Log `m[7]` (the uid field that failed to parse).

## Test

`TestAixPSProcessParser_NonNumericUid` feeds an AIX `ps` row with a non-numeric uid and asserts it's skipped without panicking. The existing `TestAixPSProcessParser` (27-process fixture) still passes.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_