### PR TITLE
🐛 fix mount option parsing dropping values that contain '='

### DIFF
--- a/providers/os/resources/mount/mount.go
+++ b/providers/os/resources/mount/mount.go
@@ -92,9 +92,12 @@ func parseOptions(opts string) map[string]string {
 	entries := strings.Split(opts, ",")
 	for i := range entries {
 		entry := entries[i]
-		keyval := strings.Split(entry, "=")
-		if len(keyval) == 2 {
-			res[strings.TrimSpace(keyval[0])] = strings.TrimSpace(keyval[1])
+		// Split on the first `=` only: option values can themselves contain
+		// `=` (e.g. SELinux context=...), and splitting on every `=` would
+		// drop such options instead of recording their value.
+		key, value, found := strings.Cut(entry, "=")
+		if found {
+			res[strings.TrimSpace(key)] = strings.TrimSpace(value)
 		} else {
 			res[strings.TrimSpace(entry)] = ""
 		}

--- a/providers/os/resources/mount/mount_internal_test.go
+++ b/providers/os/resources/mount/mount_internal_test.go
@@ -1,0 +1,29 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOptions(t *testing.T) {
+	t.Run("flags and simple key=value", func(t *testing.T) {
+		res := parseOptions("rw,relatime,seclabel,logbufs=8")
+		assert.Equal(t, "", res["rw"])
+		assert.Equal(t, "", res["relatime"])
+		assert.Equal(t, "", res["seclabel"])
+		assert.Equal(t, "8", res["logbufs"])
+	})
+
+	t.Run("value containing = is preserved", func(t *testing.T) {
+		// An option whose value itself contains `=` must keep its full value
+		// rather than being dropped to a valueless flag.
+		res := parseOptions("rw,context=a=b=c,nosuid")
+		assert.Equal(t, "a=b=c", res["context"])
+		assert.Equal(t, "", res["rw"])
+		assert.Equal(t, "", res["nosuid"])
+	})
+}


### PR DESCRIPTION
## Problem

`parseOptions` split each mount option on **every** `=` and only kept results with exactly two parts:

```go
keyval := strings.Split(entry, "=")
if len(keyval) == 2 {
    res[keyval[0]] = keyval[1]
} else {
    res[entry] = ""   // value with an extra '=' lands here, value lost
}
```

An option whose value itself contains `=` (e.g. a SELinux `context=...` spec, or any compound value) produced `len > 2` and was mis-stored as a valueless flag, silently losing the value. This feeds `mount.point.options` and the NFS `BuildMountInfo` path (`sec`, version, flags).

## Fix

Split on the first `=` only via `strings.Cut` — matching the deliberate first-separator approach the LUKS parser already uses.

## Test

`TestParseOptions` (internal) asserts simple flags and `key=value` still parse, and that an option value containing `=` (`context=a=b=c`) is preserved in full.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_