### PR TITLE
🐛 fix files.find -maxdepth rendered in octal instead of decimal

### DIFF
--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -57,7 +57,8 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 
 	if depth != nil {
 		call.WriteString(" -maxdepth ")
-		call.WriteString(Octal2string(*depth))
+		// -maxdepth takes a decimal level count, not an octal value.
+		call.WriteString(strconv.FormatInt(*depth, 10))
 	}
 	return call.String()
 }

--- a/providers/os/resources/filesfind/unix_findcmd_test.go
+++ b/providers/os/resources/filesfind/unix_findcmd_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func ptrInt64(v int64) *int64 { return &v }
+
 func TestUnixFilesCmdGeneration(t *testing.T) {
 	tests := []struct {
 		From        string
@@ -24,6 +26,13 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 			From:        "/Users/john/.aws",
 			FileType:    "file",
 			ExpectedCmd: "find -L \"/Users/john/.aws\" -xdev -type f -perm -0",
+		},
+		{
+			// -maxdepth must be decimal: depth 12 stays 12, not octal 14.
+			From:        "/etc",
+			FileType:    "file",
+			Depth:       ptrInt64(12),
+			ExpectedCmd: "find -L \"/etc\" -xdev -type f -perm -0 -maxdepth 12",
 		},
 	}
 


### PR DESCRIPTION
## Problem

`BuildFilesFindCmd` formatted the `-maxdepth` value with `Octal2string` (`fmt.Sprintf("%o", …)`):

```go
call.WriteString(" -maxdepth ")
call.WriteString(Octal2string(*depth))
```

`find -maxdepth` takes a **decimal** level count, so `files.find(depth: 8)` emitted `-maxdepth 10`, `depth: 16` → `-maxdepth 20`, etc. — descending to the wrong number of directory levels on every unix target. Depths 0–7 coincide between octal and decimal, which hid it. The PowerShell builder already uses decimal (`strconv.FormatInt(*depth, 10)`).

## Fix

Render `-maxdepth` with `strconv.FormatInt(*depth, 10)`. (`Octal2string` remains correct for the `-perm` argument.)

## Test

Added a case to `TestUnixFilesCmdGeneration` asserting `depth: 12` produces `-maxdepth 12` (not octal `14`).

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_