### PR TITLE
🐛 fix kubelet manifest-url-header reading a stray tab key

### DIFF
--- a/providers/os/resources/kubelet_flags_internal_test.go
+++ b/providers/os/resources/kubelet_flags_internal_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeDeprecatedFlagsIntoConfig_ManifestURLHeader(t *testing.T) {
+	// The --manifest-url-header flag must be read from its own key (not a
+	// stray tab key, which previously panicked) and parsed into the config.
+	cfg := map[string]any{}
+	flags := map[string]any{
+		"manifest-url-header": "X-Custom-Header:value,Other:thing",
+	}
+
+	require.NotPanics(t, func() {
+		err := mergeDeprecatedFlagsIntoConfig(cfg, flags)
+		require.NoError(t, err)
+	})
+
+	headers, ok := cfg["staticPodURLHeader"].(map[string]any)
+	require.True(t, ok, "staticPodURLHeader should be set as a dict")
+	assert.Equal(t, "value", headers["X-Custom-Header"])
+	assert.Equal(t, "thing", headers["Other"])
+}
+
+func TestMergeDeprecatedFlagsIntoConfig_ManifestURLHeaderColonValue(t *testing.T) {
+	// A header value may itself contain colons (e.g. a bearer token). SplitN
+	// with a limit of 2 must keep everything after the first colon as the value.
+	cfg := map[string]any{}
+	flags := map[string]any{
+		"manifest-url-header": "Authorization:Bearer token:abc",
+	}
+
+	require.NotPanics(t, func() {
+		err := mergeDeprecatedFlagsIntoConfig(cfg, flags)
+		require.NoError(t, err)
+	})
+
+	headers, ok := cfg["staticPodURLHeader"].(map[string]any)
+	require.True(t, ok, "staticPodURLHeader should be set as a dict")
+	assert.Equal(t, "Bearer token:abc", headers["Authorization"])
+}
+
+func TestMergeDeprecatedFlagsIntoConfig_ManifestURLHeaderMalformed(t *testing.T) {
+	// A header token without a colon must be skipped, not panic.
+	cfg := map[string]any{}
+	flags := map[string]any{"manifest-url-header": "no-colon-here"}
+
+	require.NotPanics(t, func() {
+		err := mergeDeprecatedFlagsIntoConfig(cfg, flags)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Regression test for the kubelet `--manifest-url-header` parser, which previously read from a stray tab key (`flags["\t"]`) and could panic.

The source fix landed via #8612, which reshaped the `manifest-url-header` handler in `kubelet_flags.go` to read the flag value directly and split each header with `SplitN(":", 2)` plus a length guard. This PR adds `kubelet_flags_internal_test.go` covering:

- a well-formed multi-header value,
- a value whose header value itself contains colons (bearer-token style), confirming `SplitN(..., 2)` keeps the remainder,
- a malformed colon-less token that must be skipped rather than panic.