### PR TITLE
🐛 fix usb device filter checking DeviceClass instead of LocationID

### DIFF
--- a/providers/os/resources/usb.go
+++ b/providers/os/resources/usb.go
@@ -48,14 +48,12 @@ func (d *mqlUsb) listMacos() ([]any, error) {
 	var devices []usb.USBDevice
 	usb.ParseMacosIORegData(plistData, &devices)
 
+	// A device's LocationID is used as the usb.device resource's unique __id, so
+	// devices without one are skipped to avoid blank/colliding cache keys.
+	devices = usbDevicesWithLocation(devices)
+
 	mqlUsbDevices := make([]any, 0, len(devices))
 	for _, device := range devices {
-
-		if device.DeviceClass == "" {
-			// Skip devices without a location ID
-			continue
-		}
-
 		entry, err := CreateResource(d.MqlRuntime, "usb.device", map[string]*llx.RawData{
 			"__id":         llx.StringData(device.LocationID),
 			"vendorId":     llx.StringData(device.VendorID),
@@ -79,4 +77,19 @@ func (d *mqlUsb) listMacos() ([]any, error) {
 	}
 
 	return mqlUsbDevices, nil
+}
+
+// usbDevicesWithLocation keeps only devices that report a LocationID, which is
+// required as the usb.device resource's unique __id. Devices may legitimately
+// report an empty DeviceClass (class is often defined per-interface on
+// composite devices), so the LocationID — not the class — is the right filter.
+func usbDevicesWithLocation(devices []usb.USBDevice) []usb.USBDevice {
+	res := make([]usb.USBDevice, 0, len(devices))
+	for _, device := range devices {
+		if device.LocationID == "" {
+			continue
+		}
+		res = append(res, device)
+	}
+	return res
 }

--- a/providers/os/resources/usb_internal_test.go
+++ b/providers/os/resources/usb_internal_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers/os/resources/usb"
+)
+
+func TestUsbDevicesWithLocation(t *testing.T) {
+	devices := []usb.USBDevice{
+		// Composite device: empty DeviceClass but a valid LocationID — must be kept.
+		{Name: "composite", LocationID: "0x14100000", DeviceClass: ""},
+		// Has a class but no LocationID — must be dropped (blank __id otherwise).
+		{Name: "no-location", LocationID: "", DeviceClass: "9"},
+		{Name: "normal", LocationID: "0x14200000", DeviceClass: "0"},
+	}
+
+	got := usbDevicesWithLocation(devices)
+
+	names := make([]string, 0, len(got))
+	for _, d := range got {
+		names = append(names, d.Name)
+		assert.NotEmpty(t, d.LocationID)
+	}
+	assert.ElementsMatch(t, []string{"composite", "normal"}, names)
+}


### PR DESCRIPTION
## Problem

`listMacos` skipped USB devices based on the wrong field:

```go
if device.DeviceClass == "" {
    // Skip devices without a location ID   <-- comment says LocationID
    continue
}
...
"__id": llx.StringData(device.LocationID),
```

The `__id` is built from `LocationID` and the comment says LocationID, but the guard checked `DeviceClass`. Consequences:
- Composite / per-interface USB devices (which legitimately report an empty `bDeviceClass` — class is defined per interface) were **dropped**.
- Devices with an empty `LocationID` slipped through and **collided on a blank `__id`**, overwriting each other in the resource cache.

## Fix

Filter on `LocationID` via a small `usbDevicesWithLocation` helper.

## Test

`TestUsbDevicesWithLocation` (internal) asserts a composite device (empty `DeviceClass`, valid `LocationID`) is kept and a device with an empty `LocationID` is dropped.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_