### PR TITLE
🐛 fix authorized_keys line number counting only key entries

### DIFF
--- a/providers/os/resources/authorizedkeys/authorizedkeys.go
+++ b/providers/os/resources/authorizedkeys/authorizedkeys.go
@@ -30,8 +30,12 @@ func Parse(r io.Reader) ([]Entry, error) {
 	res := []Entry{}
 	scanner := bufio.NewScanner(r)
 
-	lineNo := int64(1)
+	// lineNo tracks the physical 1-based line in the file, so it must advance
+	// for skipped blank/comment lines too — Entry.Line is meant to locate the
+	// key in the file, not count key entries.
+	lineNo := int64(0)
 	for scanner.Scan() {
+		lineNo++
 		line := scanner.Text()
 
 		in := strings.TrimSpace(line)
@@ -50,7 +54,6 @@ func Parse(r io.Reader) ([]Entry, error) {
 			Label:   comment,
 			Options: options,
 		})
-		lineNo++
 	}
 	return res, nil
 }

--- a/providers/os/resources/authorizedkeys/authorizedkeys_test.go
+++ b/providers/os/resources/authorizedkeys/authorizedkeys_test.go
@@ -32,5 +32,10 @@ no-touch-required sk-ecdsa-sha2-nistp256@openssh.com AAAAB3NzaC1yc2EAAAADAQABAAA
 	assert.Equal(t, "user@example.net", entries[0].Label)
 	assert.Equal(t, "ssh-rsa", entries[0].Key.Type())
 
+	// Line is the physical 1-based line in the file: the first key sits on
+	// line 3 (after a leading blank line and a comment), and the next on line 4.
+	assert.Equal(t, int64(3), entries[0].Line)
+	assert.Equal(t, int64(4), entries[1].Line)
+
 	assert.Equal(t, "AAAAB3NzaC1yc2EAAAADAQABAAACAQDYuKamN4JXNYmolm+A9hM+xYanupG1VgbM/k0NwPiIPUdiU82IPbP7bunsngnOatSDyCrKrhL9FV3wuHFFBX0QE9KpS8bcIcT3ySsi3wgYV95P7anb7YhliDDx2w/QB97kCnAKjGFS1yphS6px0i9B29tGVJa22ODs/hebIKUCYKC9/+fnZ+bIqte1HctDP2lDBzMa/7j8BUXSwnTDXtAuEz5eSMIpv1ZdUdaSuO8xFbB0xrBHQJKuqboLPo3NSOCg6uhopO6GucZuNLJnqVLkyEPTKH0nv/8smz/q3v1GOGz8ZS0DIpkretKZmRB1VDhNqsAiOAWUTmg56xO7VZnlEvQRtyG8qyQHjlj6SDGtvxPDY58lz5nhIV9K6L7gHrOIcbSif5ZCt0e4DrKGaYXgH+mwIh2TMC2OCU6Xr6FRVQ9fBhilqMXuFIIezShN0hZb6mUCLkLVOzBBRKuz17S2a8twsuxix7ixqJPsIF3sI88tbxrFkSGSM02dhrmyZbkMr586rktVBB4T+8A28HJr4l9jkU0uk3l3le5bMcXhEuDkJUBnwEXEXfZa8Lw4sg2VuFgw0Ah0kw0/mAorpsFahXstNgrHhy3HoPKDCw/a/sXL4+fE72I1L96Lb7HOxTrdhEGnd65W4mPlTnbGW9YDQqTfZgRlpuffqQuWWYXolw==", entries[0].Base64Key())
 }


### PR DESCRIPTION
## Problem

`Parse` incremented `lineNo` only after a successfully-parsed key, and the blank/comment-line `continue` bypassed the increment:

```go
lineNo := int64(1)
for scanner.Scan() {
    ...
    if len(in) == 0 || in[0] == '#' { continue }  // skips increment
    ...
    res = append(res, Entry{Line: lineNo, ...})
    lineNo++   // only on a parsed key
}
```

So `Entry.Line` was a 1-based **count of key entries**, not the physical file line. A key preceded by comments/blank lines got the wrong number (e.g. the first key after a comment block reported line 1), and the entry `id()` (`path:line`) inherited the wrong value. The schema documents `line` as the line of the key.

## Fix

Increment `lineNo` once per physical line read (including skipped blank/comment lines).

## Test

Extended `TestAuthorizedKeyParser` to assert the first key (after a leading blank line + comment) is on line 3 and the next on line 4 — both were `1`/`2` under the old counter.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_