### PR TITLE
🐛 fix initKubelet returning a nil error on failure paths

### DIFF
--- a/providers/os/resources/kubelet.go
+++ b/providers/os/resources/kubelet.go
@@ -33,7 +33,7 @@ func initKubelet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 
 	kubeletFlagsData := p.GetFlags()
 	if kubeletFlagsData.Error != nil {
-		return nil, nil, err
+		return nil, nil, kubeletFlagsData.Error
 	}
 	kubeletFlags := kubeletFlagsData.Data
 
@@ -55,7 +55,7 @@ func initKubelet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	}
 	mqlFile, ok := f.(*mqlFile)
 	if !ok {
-		return nil, nil, err
+		return nil, nil, errors.New("kubelet config file resource has unexpected type")
 	}
 	args["configFile"] = llx.ResourceData(mqlFile, "file")
 


### PR DESCRIPTION
## Problem

`initKubelet` discarded real errors on two paths:

```go
kubeletFlagsData := p.GetFlags()
if kubeletFlagsData.Error != nil {
    return nil, nil, err   // err is nil here (from the earlier successful getKubeletProcess)
}
...
mqlFile, ok := f.(*mqlFile)
if !ok {
    return nil, nil, err   // err is nil here too
}
```

A `GetFlags()` failure therefore surfaced as `(nil, nil, nil)` — the init silently "succeeds" with the real error dropped. The type-assertion path had the same nil-`err` return.

## Fix

Return `kubeletFlagsData.Error` for the flags failure, and a real error for the (practically-unreachable) type-assertion failure.

## Testing note

The flags-error path can only be driven by mocking a kubelet process whose `flags` field resolution fails, which requires disproportionate process-level scaffolding; the type-assertion path can't fail in practice (`CreateResource("file")` always returns `*mqlFile`). I've confirmed the change builds and the existing `TestResource_K8sKubelet*` integration tests (happy path) still pass, so there's no regression. Happy to add a heavier mock-based test if you'd prefer.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_