### PR TITLE
🐛 fix unbounded recursion on apache Include cycles

### DIFF
--- a/providers/os/resources/apache2/parser.go
+++ b/providers/os/resources/apache2/parser.go
@@ -109,11 +109,16 @@ func ParseWithGlob(rootPath string, fileContent fileContentFunc, globExpand glob
 		Params: map[string]any{},
 	}
 
-	parseWithGlobRecursive(cfg, rootPath, content, fileContent, globExpand, working)
+	// visited guards against include cycles (a file that includes itself, or a
+	// loop across files), which would otherwise recurse until the stack
+	// overflows. The root file is seeded as already-visited.
+	visited := map[string]bool{rootPath: true}
+
+	parseWithGlobRecursive(cfg, rootPath, content, fileContent, globExpand, working, visited)
 	return cfg, nil
 }
 
-func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent fileContentFunc, globExpand globExpandFunc, vars map[string]string) {
+func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent fileContentFunc, globExpand globExpandFunc, vars map[string]string, visited map[string]bool) {
 	lines := splitAndClean(content)
 	i := 0
 	for i < len(lines) {
@@ -156,7 +161,7 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 		case "include", "includeoptional":
 			cfg.Includes = append(cfg.Includes, value)
 			if globExpand != nil && fileContent != nil {
-				expandInclude(cfg, value, fileContent, globExpand, keyLower == "includeoptional", vars)
+				expandInclude(cfg, value, fileContent, globExpand, keyLower == "includeoptional", vars, visited)
 			}
 		case "loadmodule":
 			parts := strings.Fields(value)
@@ -257,7 +262,7 @@ func splitDefine(s string) (string, string, bool) {
 	return name, val, true
 }
 
-func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, globExpand globExpandFunc, optional bool, vars map[string]string) {
+func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, globExpand globExpandFunc, optional bool, vars map[string]string, visited map[string]bool) {
 	paths, err := globExpand(pattern)
 	if err != nil {
 		if !optional {
@@ -267,6 +272,12 @@ func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, glo
 	}
 
 	for _, p := range paths {
+		// Skip files already parsed to avoid infinite recursion on include cycles.
+		if visited[p] {
+			continue
+		}
+		visited[p] = true
+
 		content, err := fileContent(p)
 		if err != nil {
 			if !optional {
@@ -274,7 +285,7 @@ func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, glo
 			}
 			continue
 		}
-		parseWithGlobRecursive(cfg, p, content, fileContent, globExpand, vars)
+		parseWithGlobRecursive(cfg, p, content, fileContent, globExpand, vars, visited)
 	}
 }
 

--- a/providers/os/resources/apache2/parser_test.go
+++ b/providers/os/resources/apache2/parser_test.go
@@ -255,6 +255,56 @@ ServerSignature Off
 	assert.Equal(t, "Off", cfg.Params["ServerSignature"])
 }
 
+func TestParseWithGlobIncludeCycle(t *testing.T) {
+	// Two files that include each other (and the root re-including itself) must
+	// not recurse forever — the visited guard breaks the cycle.
+	files := map[string]string{
+		"/etc/httpd/conf/httpd.conf": `
+ServerName main.example.com
+Include conf.d/a.conf
+`,
+		"/etc/httpd/conf.d/a.conf": `
+ServerTokens Prod
+Include conf.d/b.conf
+`,
+		"/etc/httpd/conf.d/b.conf": `
+ServerSignature Off
+Include conf.d/a.conf
+Include conf/httpd.conf
+`,
+	}
+
+	fileContent := func(path string) (string, error) {
+		if c, ok := files[path]; ok {
+			return c, nil
+		}
+		return "", &fileNotFoundError{path: path}
+	}
+	globExpand := func(pattern string) ([]string, error) {
+		switch pattern {
+		case "conf.d/a.conf":
+			return []string{"/etc/httpd/conf.d/a.conf"}, nil
+		case "conf.d/b.conf":
+			return []string{"/etc/httpd/conf.d/b.conf"}, nil
+		case "conf/httpd.conf":
+			return []string{"/etc/httpd/conf/httpd.conf"}, nil
+		}
+		return nil, nil
+	}
+
+	var cfg *Config
+	var err error
+	require.NotPanics(t, func() {
+		cfg, err = ParseWithGlob("/etc/httpd/conf/httpd.conf", fileContent, globExpand, nil)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	// Each file is still parsed exactly once.
+	assert.Equal(t, "main.example.com", cfg.Params["ServerName"])
+	assert.Equal(t, "Prod", cfg.Params["ServerTokens"])
+	assert.Equal(t, "Off", cfg.Params["ServerSignature"])
+}
+
 func TestParseVirtualHostNestedBlocks(t *testing.T) {
 	content := `
 <VirtualHost *:443>


### PR DESCRIPTION
## Problem

`parseWithGlobRecursive` expanded `Include`/`IncludeOptional` directives by re-parsing each globbed file (`expandInclude` → `parseWithGlobRecursive`) with **no record of already-visited files**. An Apache config that includes itself — directly, or through a loop across files — recurses until the goroutine stack overflows and crashes the provider. Self/cyclic includes are a real-world misconfiguration. The nginx parser already guards this with a `visited` set.

## Fix

Thread a `visited` map through `ParseWithGlob` → `parseWithGlobRecursive` → `expandInclude`, seed it with the root file, and skip any path already parsed.

## Test

`TestParseWithGlobIncludeCycle` builds three files that include each other (and the root re-including itself) and asserts parsing returns without panicking, with each file parsed exactly once. Existing `TestParseWithGlob` still passes.

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_