### PR TITLE
🐛 fix panic parsing /proc/cpuinfo cache size without a unit

### DIFF
--- a/providers/os/resources/procfs/cpu_info.go
+++ b/providers/os/resources/procfs/cpu_info.go
@@ -106,8 +106,8 @@ func ParseCpuInfo(r io.Reader) (*CpuInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-			// we expect cache size to be in kb
-			if strings.HasSuffix(strings.ToLower(value[1]), "mb") {
+			// we expect cache size to be in kb; only scale when a unit is present
+			if len(value) > 1 && strings.HasSuffix(strings.ToLower(value[1]), "mb") {
 				v = v * 1024
 			}
 			cpuinfo.Processors[i].CacheSize = v

--- a/providers/os/resources/procfs/cpu_info_test.go
+++ b/providers/os/resources/procfs/cpu_info_test.go
@@ -4,6 +4,7 @@
 package procfs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,4 +121,26 @@ func TestParseProcCpuArm(t *testing.T) {
 			proc2,
 		},
 	}, cpuInfo)
+}
+
+func TestParseCpuInfoCacheSizeWithoutUnit(t *testing.T) {
+	// A cache size value with no unit token must not panic on value[1].
+	input := "processor\t: 0\n" +
+		"cache size\t: 8192\n"
+
+	cpuInfo, err := ParseCpuInfo(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, cpuInfo.Processors, 1)
+	assert.Equal(t, int64(8192), cpuInfo.Processors[0].CacheSize)
+}
+
+func TestParseCpuInfoCacheSizeMB(t *testing.T) {
+	// A cache size in MB is scaled to KB.
+	input := "processor\t: 0\n" +
+		"cache size\t: 16 MB\n"
+
+	cpuInfo, err := ParseCpuInfo(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, cpuInfo.Processors, 1)
+	assert.Equal(t, int64(16*1024), cpuInfo.Processors[0].CacheSize)
 }


### PR DESCRIPTION
## Problem

The `cache size` handler in `ParseCpuInfo` split the value on a space and read `value[1]` to detect an `MB` unit, with no length check:

```go
value := strings.Split(raw, " ")
v, err := strconv.ParseInt(value[0], 10, 64)
...
if strings.HasSuffix(strings.ToLower(value[1]), "mb") {  // panics if no unit
```

A unit-less value (e.g. `cache size : 8192`) yields a 1-element slice and panics with index-out-of-range, aborting the whole query. Real `/proc/cpuinfo` normally includes `KB`, so this is latent but reachable on malformed/truncated input.

## Fix

Guard the unit check with `len(value) > 1`.

## Tests

- `TestParseCpuInfoCacheSizeWithoutUnit` — `cache size : 8192` (no unit) parses to `8192` without panic.
- `TestParseCpuInfoCacheSizeMB` — `cache size : 16 MB` is scaled to KB (`16384`).

Signed-off-by: Tim Smith &lt;tim@mondoo.com&gt;
Signed-off-by: Claude &lt;noreply@anthropic.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhtFCvk9ucVgLkwnF8iDJ)_