### PR TITLE
🎉 Bump minor version for ms365, google-workspace, k8s, and activedirectory providers

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.0.13",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{{
 		Name:    "activedirectory",

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.1.4",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.4.0",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.7.1",
+	Version:         "13.8.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Bumps the minor version of four providers.

| Provider | Old | New |
|---|---|---|
| ms365 | 13.7.1 | **13.8.0** |
| google-workspace | 13.1.4 | **13.2.0** |
| k8s | 13.4.0 | **13.5.0** |
| activedirectory | 13.0.13 | **13.1.0** |

## Changes since last release

### ms365
- ✨ ms365: add check-authoring helpers for licensing and role assignments (#8613)
- ✨ ms365: add microsoft.user.isAdministrator (#8365)
- ✨ ms365: expose tenant-wide Intune device management settings (#8364)
- 🐛 ms365: fix nil-pointer derefs that crash the scan (#8490)
- 🐛 ms365: stop leaking Intune secret setting values in cleartext (#8491)
- 🐛 ms365: fix paginated reads that silently truncated results (#8492)
- 🐛 ms365: fix index map data race and swallowed/nil-policy errors (#8493)
- 🐛 ms365: fix filter caching collision on microsoft.identityAndAccess (#8363)
- 🐛 ms365: clear error for direct authenticationMethodConfiguration query (#8352)
- 🧹 ms365: regression test for Intune secret setting redaction (#8501)
- 🧹 dep updates (#8595, #8443) and CI spell-check swap (#8461)

### google-workspace
- ✨ google-workspace: expose Chrome OS and mobile device posture (#8610)
- ✨ google-workspace: expose admin policy settings via Cloud Identity Policy API (#8608)
- ✨ google-workspace: security-query helpers and typed group/usage settings (#8611)
- 🐛 google-workspace: fix over-strict usage-report error, app merge, ACL id (#8494)
- 🧹 dep updates (#8595)

### k8s
- ✨ k8s: surface services routing to external (non-pod) endpoints (#8604)
- ✨ k8s: AppArmor, sysctl, and procMount hardening predicates on workloads (#8603)
- ✨ k8s: model host-network/hostPort ingress exposure + egress blind spot (#8601)
- 🧹 dep updates (#8595)

### activedirectory
- 🐛 activedirectory: auto-generate krb5 config for Kerberos when no krb5.conf (#8596)
- 🧹 dep updates (#8595, #8443)
