### PR TITLE
fix(os/filesfind): shell-quote the find -name argument

### DIFF
--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -22,6 +22,13 @@ func Octal2string(o int64) string {
 	return fmt.Sprintf("%o", o)
 }
 
+// shellSingleQuote wraps s in single quotes so the shell passes it to the
+// command verbatim, with no glob, variable, or command-substitution expansion.
+// Any single quote in s is escaped by closing, inserting an escaped quote, then reopening.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, permission int64, search string, depth *int64) string {
 	var call strings.Builder
 	call.WriteString("find -L ")
@@ -39,10 +46,8 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 	}
 
 	if regex != "" {
-		// TODO: we need to escape regex here
-		call.WriteString(" -regex '")
-		call.WriteString(regex)
-		call.WriteString("'")
+		call.WriteString(" -regex ")
+		call.WriteString(shellSingleQuote(regex))
 	}
 
 	if permission != 0o777 {
@@ -52,7 +57,9 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 
 	if search != "" {
 		call.WriteString(" -name ")
-		call.WriteString(search)
+		// Single-quote the pattern so the shell passes it to find verbatim,
+		// with no glob, variable, or command-substitution expansion.
+		call.WriteString(shellSingleQuote(search))
 	}
 
 	if depth != nil {

--- a/providers/os/resources/filesfind/unix_findcmd_test.go
+++ b/providers/os/resources/filesfind/unix_findcmd_test.go
@@ -34,6 +34,42 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 			Depth:       ptrInt64(12),
 			ExpectedCmd: "find -L \"/etc\" -xdev -type f -perm -0 -maxdepth 12",
 		},
+		{
+			// -name is single-quoted so glob characters reach find instead of being expanded by the shell.
+			From:        "/etc",
+			FileType:    "file",
+			Search:      "*.conf",
+			ExpectedCmd: "find -L \"/etc\" -xdev -type f -perm -0 -name '*.conf'",
+		},
+		{
+			// dotfile glob plus depth: the leading-dot pattern must reach find intact alongside -maxdepth.
+			From:        "/home/user",
+			FileType:    "file",
+			Search:      ".*",
+			Depth:       ptrInt64(1),
+			ExpectedCmd: "find -L \"/home/user\" -xdev -type f -perm -0 -name '.*' -maxdepth 1",
+		},
+		{
+			// single quotes prevent shell variable/command expansion of the name pattern.
+			From:        "/etc",
+			FileType:    "file",
+			Search:      "$HOME*",
+			ExpectedCmd: "find -L \"/etc\" -xdev -type f -perm -0 -name '$HOME*'",
+		},
+		{
+			// an embedded single quote is escaped with the '\'' idiom.
+			From:        "/etc",
+			FileType:    "file",
+			Search:      "a'b",
+			ExpectedCmd: "find -L \"/etc\" -xdev -type f -perm -0 -name 'a'\\''b'",
+		},
+		{
+			// regex is single-quoted as well (previously an unaddressed TODO).
+			From:        "/etc",
+			FileType:    "file",
+			Regex:       ".*\\.conf$",
+			ExpectedCmd: "find -L \"/etc\" -xdev -type f -regex '.*\\.conf$' -perm -0",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Shell-quote the `-name`/`search` **and** `-regex` arguments in `BuildFilesFindCmd`
(`providers/os/resources/filesfind/unix_findcmd.go`) via a shared
`shellSingleQuote` helper.

## Why

`from` was quoted (`strconv.Quote`), but:
- `name`/`search` was emitted bare (`-name <search>`), and
- `regex` was single-quoted without escaping (it carried a `// TODO: we need to escape regex here`).

A pattern containing glob characters, spaces, shell variables, or command
substitution was therefore expanded/split by the shell before `find` ran:

| input | bad result |
|-------|-----------|
| `-name .*` | shell-expanded against the caller's CWD -> wrong matches |
| `-name my file` | `find: paths must precede expression: 'file'` |
| `-name $HOME*` | shell variable expansion |

Fixes #8646.

## Change

```go
func shellSingleQuote(s string) string {
	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
}
```

Single quotes prevent **all** shell interpretation (glob, `$VAR`, `$(...)`,
backticks); an embedded single quote is escaped with the standard
close/escape/reopen idiom. Applied to both `-name` and `-regex`.

## Tests

`go test ./providers/os/resources/filesfind/...` passes, with cases covering
glob (`*.conf`), dotfile + depth (`.*` + `depth: 1`), shell variable (`$HOME*`),
embedded single quote (`a'b`), and a regex pattern. The Windows/PowerShell
builder already passes the name via a quoted here-string variable and is
unaffected.
