### PR TITLE
🐛 asset_vuln: avoid nil deref panic on unparseable advisory dates

### DIFF
--- a/providers/os/resources/asset_vuln.go
+++ b/providers/os/resources/asset_vuln.go
@@ -206,8 +206,8 @@ func (a *mqlPlatformAdvisories) list() ([]any, error) {
 			"mrn":         llx.StringData(advisory.Mrn),
 			"title":       llx.StringData(advisory.Title),
 			"description": llx.StringData(advisory.Description),
-			"published":   llx.TimeData(*published),
-			"modified":    llx.TimeData(*modified),
+			"published":   llx.TimeDataPtr(published),
+			"modified":    llx.TimeDataPtr(modified),
 			"worstScore":  llx.ResourceData(cvssScore, "audit.cvss"),
 		})
 		if err != nil {


### PR DESCRIPTION
## Bug

In `asset_vuln.go`, `(*mqlPlatformAdvisories).list()` parses advisory timestamps into `*time.Time` that remain `nil` when parsing fails, then dereferences them unconditionally:

```go
var published *time.Time
parsedTime, err := time.Parse(time.RFC3339, advisory.Published)
if err == nil {
    published = &parsedTime
}
// ... same for modified ...

CreateResource(a.MqlRuntime, "audit.advisory", map[string]*llx.RawData{
    ...
    "published": llx.TimeData(*published),  // nil deref if parse failed
    "modified":  llx.TimeData(*modified),   // nil deref if parse failed
})
```

When an advisory has a missing or non-RFC3339 `Published`/`Modified` value, `published`/`modified` stay `nil` and `*published` panics with a nil pointer dereference, crashing the whole query.

Every sibling path already uses the nil-safe helper: the CVE path in this same file (`llx.TimeDataPtr(published)`) and `vulnmgmt.go`. `llx.TimeDataPtr` returns `NilData` for a nil pointer.

## Fix

Use `llx.TimeDataPtr(published)` / `llx.TimeDataPtr(modified)`, matching the CVE path directly below it. Malformed timestamps now yield a null date instead of a panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_