### PR TITLE
🐛 macos: harddiskSleep ran the display-sleep command

### DIFF
--- a/providers/os/resources/macos.go
+++ b/providers/os/resources/macos.go
@@ -168,7 +168,7 @@ func (m *mqlMacosSystemsetup) displaySleep() (string, error) {
 }
 
 func (m *mqlMacosSystemsetup) harddiskSleep() (string, error) {
-	data, err := m.runCmd("systemsetup -getdisplaysleep")
+	data, err := m.runCmd("systemsetup -getharddisksleep")
 	return macos.SystemSetupCmdOutput{}.ParseHardDiskSleep(data), err
 }
 


### PR DESCRIPTION
## Bug

`macos.systemsetup.harddiskSleep` invoked the wrong `systemsetup` command:

```go
func (m *mqlMacosSystemsetup) harddiskSleep() (string, error) {
    data, err := m.runCmd("systemsetup -getdisplaysleep")  // wrong flag
    return macos.SystemSetupCmdOutput{}.ParseHardDiskSleep(data), err
}
```

It used `-getdisplaysleep` (the same flag the `displaySleep()` accessor right above uses) instead of `-getharddisksleep`, then fed that output into `ParseHardDiskSleep`. As a result the field reported the display-sleep setting, not the hard-disk-sleep setting. The correct command string `-getharddisksleep` is confirmed by `macos/systemsetup_test.go` and `macos/testdata/systemsetup.toml`.

## Fix

Run `systemsetup -getharddisksleep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_