### PR TITLE
🐛 python: read package dedup map by File to match the write

### DIFF
--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -146,7 +146,7 @@ func pythonPackageDetailsWithDependenciesToResource(
 	newPyPkgDetails python.PackageDetails,
 	pythonPackageResourceMap map[string]plugin.Resource,
 ) (any, error) {
-	res := pythonPackageResourceMap[newPyPkgDetails.Name]
+	res := pythonPackageResourceMap[newPyPkgDetails.File]
 	if res != nil {
 		// already created the pythonPackage resource
 		return res, nil


### PR DESCRIPTION
## Bug

In `python.go`, `pythonPackageDetailsWithDependenciesToResource` reads the dedup map by `Name` but writes it by `File`:

```go
res := pythonPackageResourceMap[newPyPkgDetails.Name]  // read by Name
if res != nil {
    return res, nil
}
r, err := newMqlPythonPackage(runtime, newPyPkgDetails)
...
// name is not guaranteed to be unique, so we use the file path as the key
pythonPackageResourceMap[newPyPkgDetails.File] = r     // write by File
```

Because the key written is never the key read, the early-return cache can essentially never hit, so `newMqlPythonPackage` is called redundantly for packages already processed in the same `packages()`/`toplevel()` invocation. The inline comment explicitly states `File` is the intended key (Name isn't unique), and the resource `id` is `ppd.File` — so the read side is the side that's wrong.

## Fix

Read by `File` to match the write and the resource id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_