### PR TITLE
🐛 yum: fix RHEL 6/7 release regex matching a literal pipe

### DIFF
--- a/providers/os/resources/yum.go
+++ b/providers/os/resources/yum.go
@@ -77,7 +77,7 @@ func (y *mqlYum) repos() ([]any, error) {
 	return mqlRepos, nil
 }
 
-var rhel67release = regexp.MustCompile(`^[6|7].*$`)
+var rhel67release = regexp.MustCompile(`^[67].*$`)
 
 func (y *mqlYum) vars() (map[string]any, error) {
 	conn := y.MqlRuntime.Connection.(shared.Connection)

--- a/providers/os/resources/yum_test.go
+++ b/providers/os/resources/yum_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRhel67ReleaseRegex(t *testing.T) {
+	tests := []struct {
+		release string
+		match   bool
+	}{
+		{"6", true},
+		{"6.5", true},
+		{"6Server", true},
+		{"7", true},
+		{"7.9", true},
+		// the old `^[6|7].*$` alternation also matched a literal pipe, which
+		// is what this regression guards against
+		{"|", false},
+		{"|garbage", false},
+		{"8", false},
+		{"5", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equalf(t, tt.match, rhel67release.MatchString(tt.release),
+			"rhel67release.MatchString(%q)", tt.release)
+	}
+}


### PR DESCRIPTION
## Bug

In `yum.go`:

```go
var rhel67release = regexp.MustCompile(`^[6|7].*$`)
```

Inside a character class `[...]`, `|` is a literal character, not alternation. `[6|7]` matches `6`, `7`, **or** `|`. The intent is to match RHEL major versions 6 or 7.

Low impact in practice (real platform version strings never start with `|`), but it's a latent correctness smell.

## Fix

Use `[67]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_