### PR TITLE
🐛 lsof: stop process parsing after the file-descriptor section

### DIFF
--- a/providers/os/resources/lsof/lsof.go
+++ b/providers/os/resources/lsof/lsof.go
@@ -303,18 +303,20 @@ func (p *Process) parseFileLines(lines []string) error {
 func parseProcessLines(lines []string) (Process, error) {
 	p := Process{}
 	for index, line := range lines {
+		// File descriptors are the trailing section of a process block.
+		// parseFileLines consumes every remaining line, so we must stop
+		// the outer loop here — otherwise a later "f" line re-enters
+		// parseFileLines and duplicates the descriptors already parsed.
 		if strings.HasPrefix(line, "f") {
 			err := p.parseFileLines(lines[index:])
 			if err != nil {
 				return p, err
 			}
-		} else if strings.HasPrefix(line, "o") {
 			break
-		} else {
-			err := p.parseField(line)
-			if err != nil {
-				return p, err
-			}
+		}
+		err := p.parseField(line)
+		if err != nil {
+			return p, err
 		}
 	}
 	return p, nil

--- a/providers/os/resources/lsof/lsof_test.go
+++ b/providers/os/resources/lsof/lsof_test.go
@@ -111,6 +111,33 @@ TQS=0
 	assert.Equal(t, "10.184.10.188:64645->76.76.21.241:443", fd.Name)
 }
 
+func TestParseLsofFileDescriptorsWithoutOffsetField(t *testing.T) {
+	// lsof does not always emit an "o" (file offset) field — many socket
+	// file types omit it. With two descriptors and no offset line, the
+	// descriptors must not be duplicated.
+	s := `p37224
+cHyper Helper
+u501
+f24
+tIPv4
+PTCP
+n10.184.10.188:64647->76.76.21.61:443
+f25
+tIPv4
+PTCP
+n10.184.10.188:64645->76.76.21.241:443
+`
+
+	processes, err := Parse(strings.NewReader(s))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(processes))
+
+	process := processes[0]
+	require.Equal(t, 2, len(process.FileDescriptors))
+	assert.Equal(t, "24", process.FileDescriptors[0].FileDescriptor)
+	assert.Equal(t, "25", process.FileDescriptors[1].FileDescriptor)
+}
+
 func TestParseLsofTcpStateKeys(t *testing.T) {
 	// lsof spells these states SYN_RCVD and FIN_WAIT2 (no underscore before the
 	// digit); the mapping keys must match exactly or TcpState falls back to 0.


### PR DESCRIPTION
## Bug

`parseProcessLines` in `lsof.go`:

```go
for index, line := range lines {
    if strings.HasPrefix(line, "f") {
        err := p.parseFileLines(lines[index:])   // consumes ALL remaining lines
        ...
    } else if strings.HasPrefix(line, "o") {
        break                                     // accidental sentinel
    } else {
        err := p.parseField(line)
    }
}
```

On the first `f` (file descriptor) line, it hands the entire rest of the block to `parseFileLines`, which parses and appends every remaining descriptor. But the outer loop does **not** stop — it only stops because the `o` (file offset) branch breaks it. lsof's `-F` output omits the `o` field for many socket file types, so when it's absent the outer loop reaches the next `f` line and calls `parseFileLines` again on the tail, **duplicating** descriptors.

Reproduction: a process with two socket FDs and no `o` field yields 3 descriptors (the second FD appears twice). Existing tests passed only because their fixtures happened to contain `o0t0` lines.

## Fix

`break` out of the outer loop after `parseFileLines` consumes the trailing section (file descriptors are always the last section of a process block). Added a regression test with two descriptors and no offset field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_