### PR TITLE
🐛 networkinterface: accept multi-digit interface indices

### DIFF
--- a/providers/os/resources/networkinterface/interface.go
+++ b/providers/os/resources/networkinterface/interface.go
@@ -150,7 +150,7 @@ func (i *LinuxInterfaceHandler) ParseIpAddr(r io.Reader) ([]Interface, error) {
 	interfaces := map[string]Interface{}
 
 	scanner := bufio.NewScanner(r)
-	ipaddrParse := regexp.MustCompile(`^(\d):\s([\w\d\./\:]+)\s*(inet|inet6)\s([\w\d\./\:]+)\s(.*)$`)
+	ipaddrParse := regexp.MustCompile(`^(\d+):\s([\w\d\./\:]+)\s*(inet|inet6)\s([\w\d\./\:]+)\s(.*)$`)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/providers/os/resources/networkinterface/interface_multidigit_test.go
+++ b/providers/os/resources/networkinterface/interface_multidigit_test.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package networkinterface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Interface indices routinely exceed 9 on real hosts (docker bridges,
+// veth pairs, cloud VMs with many NICs). The parser must accept
+// multi-digit indices instead of failing the whole enumeration.
+func TestParseIpAddrMultiDigitIndex(t *testing.T) {
+	input := "12: eth5    inet 10.0.0.5/24 brd 10.0.0.255 scope global eth5\\       valid_lft forever preferred_lft forever\n"
+
+	h := &LinuxInterfaceHandler{}
+	ifaces, err := h.ParseIpAddr(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, ifaces, 1)
+	assert.Equal(t, "eth5", ifaces[0].Name)
+	assert.Equal(t, 12, ifaces[0].Index)
+}


### PR DESCRIPTION
## Bug

`LinuxInterfaceHandler.ParseIpAddr` in `interface.go`:

```go
ipaddrParse := regexp.MustCompile(`^(\d):\s([\w\d\./\:]+)\s*(inet|inet6)\s([\w\d\./\:]+)\s(.*)$`)
...
if len(m) < 4 {
    return nil, fmt.Errorf("cannot parse ip: %s", line)
}
```

The interface-index capture is `(\d)` — exactly one digit. `ip -o addr show` prints the index as the first field, which routinely exceeds 9 on real hosts (Docker/Kubernetes nodes with many `veth*`/bridge interfaces, multi-NIC cloud VMs). A line like `10: eth0  inet ...` fails the regex, hits `len(m) < 4`, and the function returns a hard error — aborting **all** Linux interface enumeration, and the host-IP/route detection built on top of it. Tests only used indices 1–4, masking the bug.

## Fix

`^(\d+):`. Added a regression test driving `ParseIpAddr` with a double-digit index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_