### PR TITLE
🧹 macos: drop no-op prefix trim in systemsetup ParseDate

### DIFF
--- a/providers/os/resources/macos/systemsetup.go
+++ b/providers/os/resources/macos/systemsetup.go
@@ -8,7 +8,9 @@ import "strings"
 type SystemSetupCmdOutput struct{}
 
 func (s SystemSetupCmdOutput) ParseDate(in string) string {
-	return strings.TrimSpace(strings.TrimPrefix(in, "Time:"))
+	// systemsetup -getdate emits a bare date (e.g. "6/23/2026") with no label,
+	// unlike its sibling getters, so there's no prefix to strip.
+	return strings.TrimSpace(in)
 }
 
 func (s SystemSetupCmdOutput) ParseTime(in string) string {


### PR DESCRIPTION
## What

`systemsetup -getdate` emits a **bare date** (e.g. `6/23/2026`) with no label, unlike its sibling getters (`-gettime` → `Time: ...`, `-gettimezone` → `Time Zone: ...`, etc.).

`ParseDate` was stripping a `"Time:"` prefix — a copy-paste leftover from `ParseTime`:

```go
func (s SystemSetupCmdOutput) ParseDate(in string) string {
	return strings.TrimSpace(strings.TrimPrefix(in, "Time:"))
}
```

Since real `-getdate` output carries no prefix, that `TrimPrefix` was always a no-op and `macos.systemsetup.date` already returned the date correctly. **This was never a bug.**

## Change

Drop the trim to a plain `TrimSpace`. The existing test fixture (a bare `8/4/2021`) already matches real output, so it's left untouched.

Co-Authored-By: Claude Opus 4.8