### PR TITLE
🐛 packages: drop empty-name appx entries instead of leaving holes

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -164,7 +164,7 @@ func ParseWindowsAppxPackages(platform *inventory.Platform, input io.Reader) ([]
 		return nil, err
 	}
 
-	pkgs := []Package{}
+	pkgs := make([]Package, 0, len(appxPackages))
 	for _, p := range appxPackages {
 		if p.Name == "" {
 			continue

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -164,12 +164,12 @@ func ParseWindowsAppxPackages(platform *inventory.Platform, input io.Reader) ([]
 		return nil, err
 	}
 
-	pkgs := make([]Package, len(appxPackages))
-	for i, p := range appxPackages {
+	pkgs := []Package{}
+	for _, p := range appxPackages {
 		if p.Name == "" {
 			continue
 		}
-		pkgs[i] = p.toPackage(platform)
+		pkgs = append(pkgs, p.toPackage(platform))
 	}
 	return pkgs, nil
 }

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -78,6 +78,25 @@ func TestWindowsAppPackagesParserWithPSPath(t *testing.T) {
 	assert.Equal(t, "x86", x86Pkg.Arch, "Wow6432Node path package should have x86 arch")
 }
 
+func TestWindowsAppxPackagesParserSkipsEmptyNames(t *testing.T) {
+	pf := &inventory.Platform{Name: "windows", Arch: "x86", Family: []string{"windows"}}
+
+	// the middle entry has an empty Name and must be omitted entirely,
+	// not turned into a zero-value Package hole
+	const data = `[
+		{"Name":"Microsoft.WindowsCalculator","Version":"1.0.0.0","Architecture":0,"Publisher":"CN=Microsoft"},
+		{"Name":"","Version":"","Architecture":0,"Publisher":""},
+		{"Name":"Microsoft.WindowsStore","Version":"2.0.0.0","Architecture":0,"Publisher":"CN=Microsoft"}
+	]`
+
+	pkgs, err := ParseWindowsAppxPackages(pf, strings.NewReader(data))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(pkgs), "empty-name entry should be skipped, no holes")
+	for _, p := range pkgs {
+		assert.NotEmpty(t, p.Name, "no empty/zero-value package should be present")
+	}
+}
+
 func TestWindowsAppxPackagesParser(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{


### PR DESCRIPTION
## Bug

`ParseWindowsAppxPackages` in `windows_packages.go`:

```go
pkgs := make([]Package, len(appxPackages))
for i, p := range appxPackages {
    if p.Name == "" {
        continue
    }
    pkgs[i] = p.toPackage(platform)
}
return pkgs, nil
```

The slice is pre-sized to `len(appxPackages)` and written by index `i`. When an entry has an empty `Name`, the loop `continue`s but never assigns `pkgs[i]`, leaving a zero-value `Package{}` hole. Any `Get-AppxPackage` entry with a missing `Name` produces a bogus empty package (no name/version/purl) in the output / SBOM instead of being omitted.

The sibling `ParseWindowsAppPackages` does this correctly with `[]Package{}` + `append`.

## Fix

Use the append pattern so skipped entries are truly omitted. Added a regression test with an empty-name entry between two valid ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_