### PR TITLE
🐛 awsec2: validate snapshot IDs with the snapshot regex, not the instance regex

### DIFF
--- a/providers/os/id/awsec2/id.go
+++ b/providers/os/id/awsec2/id.go
@@ -91,7 +91,7 @@ func ParseMondooSnapshotID(path string) (*MondooSnapshotId, error) {
 }
 
 func IsValidMondooSnapshotId(path string) bool {
-	return VALID_MONDOO_INSTANCE_ID.MatchString(path)
+	return VALID_MONDOO_SNAPSHOT_ID.MatchString(path)
 }
 
 var VALID_MONDOO_ACCOUNT_ID = regexp.MustCompile(`^//platformid.api.mondoo.app/runtime/aws/accounts/\d{12}$`)

--- a/providers/os/id/awsec2/id_test.go
+++ b/providers/os/id/awsec2/id_test.go
@@ -27,6 +27,21 @@ func TestParseInstanceId(t *testing.T) {
 	assert.Error(t, err, "invalid aws ec2 instance id")
 }
 
+func TestParseSnapshotId(t *testing.T) {
+	path := "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/185972265011/regions/us-east-1/snapshots/snap-07f67838ada5879af"
+	id, err := ParseMondooSnapshotID(path)
+	require.NoError(t, err)
+	assert.Equal(t, "185972265011", id.Account)
+	assert.Equal(t, "us-east-1", id.Region)
+	assert.Equal(t, "snap-07f67838ada5879af", id.Id)
+
+	// an instance id must NOT validate as a snapshot id
+	instancePath := "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/185972265011/regions/us-east-1/instances/i-07f67838ada5879af"
+	assert.False(t, IsValidMondooSnapshotId(instancePath))
+	_, err = ParseMondooSnapshotID(instancePath)
+	assert.Error(t, err)
+}
+
 func TestParseAccountId(t *testing.T) {
 	path := "//platformid.api.mondoo.app/runtime/aws/accounts/185972265011"
 	accountID, err := ParseMondooAccountID(path)


### PR DESCRIPTION
## Bug

`id/awsec2/id.go`:

```go
func IsValidMondooSnapshotId(path string) bool {
    return VALID_MONDOO_INSTANCE_ID.MatchString(path)
}
```

Copy-paste bug: snapshot-ID validation matched against `VALID_MONDOO_INSTANCE_ID` (the `.../instances/...` pattern) instead of `VALID_MONDOO_SNAPSHOT_ID` (the `.../snapshots/...` pattern defined right above it). `ParseMondooSnapshotID` therefore **rejects every legitimate snapshot ID** (real snapshot paths contain `snapshots`, not `instances`) and would spuriously accept an instance-shaped ID. The sibling `IsValidMondooVolumeId` does it correctly.

## Fix

Use `VALID_MONDOO_SNAPSHOT_ID`. Added a regression test that parses a real snapshot ID and asserts an instance ID does **not** validate as a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_