### PR TITLE
🐛 awsebs: fix inverted error check when reading set-hostname

### DIFF
--- a/providers/os/id/awsebs/unix_ebs.go
+++ b/providers/os/id/awsebs/unix_ebs.go
@@ -42,7 +42,7 @@ func (m *ebsMetadata) unixMetadata() (any, error) {
 				FQDN     string `json:"fqdn"`
 				Hostname string `json:"hostname"`
 			}
-			if err := json.Unmarshal(setHostnameData, &setHostname); err != nil {
+			if err := json.Unmarshal(setHostnameData, &setHostname); err == nil {
 				mdata["hostname"] = setHostname.FQDN
 			}
 		}


### PR DESCRIPTION
## Bug

`id/awsebs/unix_ebs.go`, in the cloud `set-hostname` fallback:

```go
if err := json.Unmarshal(setHostnameData, &setHostname); err != nil {
    mdata["hostname"] = setHostname.FQDN
}
```

The condition is inverted — the body runs only when unmarshalling **fails**, at which point `setHostname.FQDN` is `""`. On success the parsed FQDN is never assigned. So this `/var/lib/cloud/data/set-hostname` fallback can only ever write an empty hostname.

## Fix

`err == nil`.

(No unit test added: exercising this branch requires a fully mocked connection — a filesystem containing `/var/lib/cloud/data/set-hostname` *and* a failing `hostname.Hostname()` primary path — which is disproportionate for a one-line inverted-condition fix. Verified by build and inspection.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_