### PR TITLE
🐛 acr: close the token-exchange HTTP response body

### DIFF
--- a/providers/os/connection/container/acr/acr_auth_helper.go
+++ b/providers/os/connection/container/acr/acr_auth_helper.go
@@ -83,6 +83,7 @@ func (a *acrAuthHelper) getRefreshToken(ctx context.Context, serverUrl string) (
 	if err != nil {
 		return "", err
 	}
+	defer httpResp.Body.Close()
 	resp, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Bug

`connection/container/acr/acr_auth_helper.go`:

```go
httpResp, err := a.httpClient.Do(httpReq)
if err != nil {
    return "", err
}
resp, err := io.ReadAll(httpResp.Body)   // body never closed
```

`httpResp.Body` is never closed on any path, so every ACR refresh-token exchange leaks the response body (and its underlying socket) and prevents connection reuse.

## Fix

`defer httpResp.Body.Close()` immediately after the error check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_