### PR TITLE
🐛 docker: close the file reader before following a symlink

### DIFF
--- a/providers/os/connection/docker/file.go
+++ b/providers/os/connection/docker/file.go
@@ -134,9 +134,17 @@ func (f *File) WriteString(s string) (ret int, err error) {
 
 func (f *File) getFileDockerReader(path string) (io.ReadCloser, container.PathStat, error) {
 	res, err := f.dockerClient.CopyFromContainer(context.Background(), f.container, client.CopyFromContainerOptions{SourcePath: path})
+	if err != nil {
+		return res.Content, res.Stat, err
+	}
 
 	// follow symlink if stat.LinkTarget is set
 	if len(res.Stat.LinkTarget) > 0 {
+		// close the reader we just opened before following the link,
+		// otherwise each symlink hop leaks the tar stream / connection
+		if res.Content != nil {
+			res.Content.Close()
+		}
 		return f.getFileDockerReader(res.Stat.LinkTarget)
 	}
 

--- a/providers/os/connection/docker/file.go
+++ b/providers/os/connection/docker/file.go
@@ -132,7 +132,21 @@ func (f *File) WriteString(s string) (ret int, err error) {
 	return 0, errors.New("not implemented")
 }
 
+// maxSymlinkDepth caps how many symlinks we follow before giving up,
+// mirroring the Linux kernel's limit. It guards against symlink cycles
+// (e.g. A->B->A) that would otherwise recurse forever, overflow the
+// stack, and leak a reader on every frame.
+const maxSymlinkDepth = 40
+
 func (f *File) getFileDockerReader(path string) (io.ReadCloser, container.PathStat, error) {
+	return f.getFileDockerReaderFollow(path, 0)
+}
+
+func (f *File) getFileDockerReaderFollow(path string, depth int) (io.ReadCloser, container.PathStat, error) {
+	if depth > maxSymlinkDepth {
+		return nil, container.PathStat{}, fmt.Errorf("too many levels of symbolic links: %s", path)
+	}
+
 	res, err := f.dockerClient.CopyFromContainer(context.Background(), f.container, client.CopyFromContainerOptions{SourcePath: path})
 	if err != nil {
 		return res.Content, res.Stat, err
@@ -145,7 +159,7 @@ func (f *File) getFileDockerReader(path string) (io.ReadCloser, container.PathSt
 		if res.Content != nil {
 			res.Content.Close()
 		}
-		return f.getFileDockerReader(res.Stat.LinkTarget)
+		return f.getFileDockerReaderFollow(res.Stat.LinkTarget, depth+1)
 	}
 
 	return res.Content, res.Stat, err


### PR DESCRIPTION
## Bug

`connection/docker/file.go`:

```go
r, stat, err := f.dockerClient.CopyFromContainer(context.Background(), f.container, path)

// follow symlink if stat.LinkTarget is set
if len(stat.LinkTarget) > 0 {
    return f.getFileDockerReader(stat.LinkTarget)   // original r never closed
}

return r, stat, err
```

On a symlink, the already-opened reader `r` (a Docker API tar stream / HTTP body) is discarded without `Close()` before recursing. Each symlink resolution leaks one reader/connection.

## Fix

Return early on error, then close `r` before following the link target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_