### PR TITLE
🐛 gcp: fix cloud function v2 kmsKey typed-reference arg key

### DIFF
--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -152,7 +152,7 @@ func (g *mqlGcpProjectCloudFunctionV2) kmsKey() (*mqlGcpProjectKmsServiceKeyring
 		return nil, nil
 	}
 	res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey", map[string]*llx.RawData{
-		"resourceName": llx.StringData(keyName),
+		"resourcePath": llx.StringData(keyName),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug

`cloud_functions_v2.go`, `kmsKey()`:

```go
res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey", map[string]*llx.RawData{
    "resourceName": llx.StringData(keyName),
})
```

`initGcpProjectKmsServiceKeyringCryptokey` (kms.go) reads `args["resourcePath"]` and returns the resource **unresolved** when it's absent. Passing the key path under `"resourceName"` means `gcp.project.cloudFunctionV2.kmsKey` resolves to an empty/unpopulated cryptokey. The V1 sibling (`cloud_functions.go`) correctly passes `"resourcePath"`.

## Fix

Use the `"resourcePath"` arg key, matching the cryptokey init and the V1 function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_