### PR TITLE
🐛 gcp: give Cloud Run startup and liveness probes distinct ids

### DIFF
--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -842,7 +842,7 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 	return jobs, nil
 }
 
-func mqlContainerProbe(runtime *plugin.Runtime, probe *runpb.Probe, containerId string) (plugin.Resource, error) {
+func mqlContainerProbe(runtime *plugin.Runtime, probe *runpb.Probe, containerId string, probeName string) (plugin.Resource, error) {
 	if probe == nil {
 		return nil, nil
 	}
@@ -869,7 +869,7 @@ func mqlContainerProbe(runtime *plugin.Runtime, probe *runpb.Probe, containerId 
 	}
 
 	return CreateResource(runtime, "gcp.project.cloudRunService.container.probe", map[string]*llx.RawData{
-		"id":                  llx.StringData(fmt.Sprintf("%s/livenessProbe", containerId)),
+		"id":                  llx.StringData(fmt.Sprintf("%s/%s", containerId, probeName)),
 		"initialDelaySeconds": llx.IntData(int64(probe.InitialDelaySeconds)),
 		"timeoutSeconds":      llx.IntData(int64(probe.TimeoutSeconds)),
 		"periodSeconds":       llx.IntData(int64(probe.PeriodSeconds)),
@@ -982,12 +982,12 @@ func mqlContainers(runtime *plugin.Runtime, containers []*runpb.Container, templ
 		}
 
 		containerId := fmt.Sprintf("%s/container/%s", templateId, c.Name)
-		mqlLivenessProbe, err := mqlContainerProbe(runtime, c.LivenessProbe, containerId)
+		mqlLivenessProbe, err := mqlContainerProbe(runtime, c.LivenessProbe, containerId, "livenessProbe")
 		if err != nil {
 			return nil, err
 		}
 
-		mqlStartupProbe, err := mqlContainerProbe(runtime, c.StartupProbe, containerId)
+		mqlStartupProbe, err := mqlContainerProbe(runtime, c.StartupProbe, containerId, "startupProbe")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Bug

`cloudrun.go`, `mqlContainerProbe` hardcoded the `__id` suffix:

```go
return CreateResource(runtime, "gcp.project.cloudRunService.container.probe", map[string]*llx.RawData{
    "id": llx.StringData(fmt.Sprintf("%s/livenessProbe", containerId)),
    ...
```

Both the liveness and startup probes are created from the same `containerId`, so both got the id `<containerId>/livenessProbe`. Because the runtime caches by `resourceName + __id`, the startup probe's `CreateResource` returned the **cached liveness probe** — a container's `startupProbe` reported the liveness probe's data.

## Fix

Add a `probeName` parameter to `mqlContainerProbe` and use it in the id; pass `"livenessProbe"` / `"startupProbe"` at the two call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_