### PR TITLE
🐛 gcp: pass projectId when resolving cloud function service accounts

### DIFF
--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -78,7 +78,7 @@ func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 			return nil, err
 		}
 
-		serviceConfig, err := fnV2ServiceConfig(g.MqlRuntime, fn.Name, fn.ServiceConfig)
+		serviceConfig, err := fnV2ServiceConfig(g.MqlRuntime, fn.Name, projectId, fn.ServiceConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +255,7 @@ func (g *mqlGcpProjectCloudFunctionV2BuildConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
-func fnV2ServiceConfig(runtime *plugin.Runtime, parentName string, cfg *functionspb.ServiceConfig) (*mqlGcpProjectCloudFunctionV2ServiceConfig, error) {
+func fnV2ServiceConfig(runtime *plugin.Runtime, parentName string, projectId string, cfg *functionspb.ServiceConfig) (*mqlGcpProjectCloudFunctionV2ServiceConfig, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -310,6 +310,7 @@ func fnV2ServiceConfig(runtime *plugin.Runtime, parentName string, cfg *function
 	// Populate Internal struct for cross-reference
 	sc := res.(*mqlGcpProjectCloudFunctionV2ServiceConfig)
 	sc.cacheServiceAccountEmail = cfg.ServiceAccountEmail
+	sc.cacheProjectId = projectId
 
 	return sc, nil
 }
@@ -320,6 +321,7 @@ func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) id() (string, error) {
 
 type mqlGcpProjectCloudFunctionV2ServiceConfigInternal struct {
 	cacheServiceAccountEmail string
+	cacheProjectId           string
 }
 
 func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) iamServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
@@ -329,7 +331,8 @@ func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) iamServiceAccount() (*mqlGcp
 		return nil, nil
 	}
 	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
-		"email": llx.StringData(email),
+		"email":     llx.StringData(email),
+		"projectId": llx.StringData(g.cacheProjectId),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -204,7 +204,8 @@ func (g *mqlGcpProjectCloudBuildServiceTrigger) iamServiceAccount() (*mqlGcpProj
 		email = sa[idx+1:]
 	}
 	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
-		"email": llx.StringData(email),
+		"email":     llx.StringData(email),
+		"projectId": llx.StringData(g.ProjectId.Data),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug

`cloudbuild.go`, `trigger.iamServiceAccount()`:

```go
res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
    "email": llx.StringData(email),
})
```

`initGcpProjectIamServiceServiceAccount` needs `projectId` to resolve the service account; without it the reference stays unpopulated. The sibling build accessor (`build.iamServiceAccount`) correctly passes both `email` and `projectId`.

## Fix

Pass the trigger's `ProjectId` alongside `email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_