### PR TITLE
🐛 gcp: set null state in compute typed-ref accessors; guard subnet URL parse

### DIFF
--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -381,6 +381,9 @@ func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProje
 	params := strings.TrimPrefix(subnetUrl, "https://www.googleapis.com/compute/v1/")
 	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
 	parts := strings.Split(params, "/")
+	if len(parts) < 6 || parts[0] != "projects" || parts[2] != "regions" || parts[4] != "subnetworks" {
+		return nil, fmt.Errorf("unrecognized subnetwork reference: %q", subnetUrl)
+	}
 	resId := resourceId{Project: parts[1], Region: parts[3], Name: parts[5]}
 	// regionUrl is the full URL up to and including the region segment
 	regionUrl := "https://www.googleapis.com/compute/v1/projects/" + resId.Project + "/regions/" + resId.Region

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2778,7 +2778,14 @@ func (g *mqlGcpProjectComputeServiceAddress) network() (*mqlGcpProjectComputeSer
 		return nil, g.NetworkUrl.Error
 	}
 	networkUrl := g.NetworkUrl.Data
-	return getNetworkByUrl(networkUrl, g.MqlRuntime)
+	net, err := getNetworkByUrl(networkUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if net == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return net, nil
 }
 
 func (g *mqlGcpProjectComputeServiceAddress) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
@@ -2786,7 +2793,14 @@ func (g *mqlGcpProjectComputeServiceAddress) subnetwork() (*mqlGcpProjectCompute
 		return nil, g.SubnetworkUrl.Error
 	}
 	subnetUrl := g.SubnetworkUrl.Data
-	return getSubnetworkByUrl(subnetUrl, g.MqlRuntime)
+	subnet, err := getSubnetworkByUrl(subnetUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if subnet == nil {
+		g.Subnetwork.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return subnet, nil
 }
 
 func (g *mqlGcpProjectComputeServiceAddress) id() (string, error) {

--- a/providers/gcp/resources/compute_enrichments.go
+++ b/providers/gcp/resources/compute_enrichments.go
@@ -316,7 +316,14 @@ func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) sslPolicy() (*mqlGcpProjec
 		g.SslPolicy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	return getSslPolicyByUrl(url, g.MqlRuntime)
+	policy, err := getSslPolicyByUrl(url, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		g.SslPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return policy, nil
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) sslCertificates() ([]any, error) {

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -89,11 +89,25 @@ func (g *mqlGcpProjectComputeServiceInstanceGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	return getNetworkByUrl(g.NetworkUrl.Data, g.MqlRuntime)
+	net, err := getNetworkByUrl(g.NetworkUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if net == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return net, nil
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	return getSubnetworkByUrl(g.cacheSubnetworkUrl, g.MqlRuntime)
+	subnet, err := getSubnetworkByUrl(g.cacheSubnetworkUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if subnet == nil {
+		g.Subnetwork.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return subnet, nil
 }
 
 // Instance group managers

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -89,6 +89,9 @@ func (g *mqlGcpProjectComputeServiceInstanceGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) network() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if g.NetworkUrl.Error != nil {
+		return nil, g.NetworkUrl.Error
+	}
 	net, err := getNetworkByUrl(g.NetworkUrl.Data, g.MqlRuntime)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug

Several singular compute accessors return the result of `getNetworkByUrl` / `getSubnetworkByUrl` / `getSslPolicyByUrl` directly:

```go
func (g *mqlGcpProjectComputeServiceAddress) network() (*mqlGcpProjectComputeServiceNetwork, error) {
    ...
    return getNetworkByUrl(networkUrl, g.MqlRuntime)
}
```

Those helpers return `(nil, nil)` when the reference URL is empty (common for external addresses / instance groups) or unresolved. But the accessors never set the field `State` to `StateIsSet | StateIsNull`. Per the provider convention (CLAUDE.md), a singular resource accessor returning `nil, nil` without setting the null state risks a runtime panic / infinite re-fetch.

Fixed accessors:
- `compute.go`: `address.network()`, `address.subnetwork()`
- `compute_instance_groups_firewall_policies.go`: `instanceGroup.network()`, `instanceGroup.subnetwork()`
- `compute_enrichments.go`: `targetHttpsProxy.sslPolicy()` not-found path

Also hardened `getSubnetworkByUrl` (`common.go`): it indexed `parts[1]/parts[3]/parts[5]` with **no length check**, unlike its sibling `getNetworkByUrl`, so a malformed subnetwork URL could panic with index-out-of-range. Added the same length/shape guard.

## Note

The same direct-return pattern exists at other `getNetworkByUrl` call sites; this PR fixes the confirmed-reachable accessors and the helper bounds. The remaining sites can be swept in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_