### PR TITLE
🐛 gcp: make bigtable cluster, bigquery routine & dns recordset ids unique

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -682,11 +682,18 @@ func (g *mqlGcpProjectBigqueryServiceDataset) routines() ([]any, error) {
 }
 
 func (g *mqlGcpProjectBigqueryServiceRoutine) id() (string, error) {
+	if g.ProjectId.Error != nil {
+		return "", g.ProjectId.Error
+	}
+	if g.DatasetId.Error != nil {
+		return "", g.DatasetId.Error
+	}
 	if g.Id.Error != nil {
 		return "", g.Id.Error
 	}
-	name := g.Id.Data
-	return "gcp.project.bigqueryService.routine/" + name, nil
+	// Routine IDs are unique only within a dataset, so qualify with
+	// project + dataset (matches the model/table ids).
+	return fmt.Sprintf("gcp.project.bigqueryService.routine/%s/%s/%s", g.ProjectId.Data, g.DatasetId.Data, g.Id.Data), nil
 }
 
 func entityTypeToString(entityType bigquery.EntityType) string {

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -284,10 +284,15 @@ func (g *mqlGcpProjectBigtableServiceCluster) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
 	}
+	if g.InstanceName.Error != nil {
+		return "", g.InstanceName.Error
+	}
 	if g.Name.Error != nil {
 		return "", g.Name.Error
 	}
-	return fmt.Sprintf("gcp.project/%s/bigtableService/cluster/%s", g.ProjectId.Data, g.Name.Data), nil
+	// Cluster names are unique only within an instance, so the instance must
+	// be part of the cache key (matches the table/appProfile/backup ids).
+	return fmt.Sprintf("gcp.project/%s/bigtableService/%s/cluster/%s", g.ProjectId.Data, g.InstanceName.Data, g.Name.Data), nil
 }
 
 type mqlGcpProjectBigtableServiceClusterInternal struct {

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -529,8 +529,14 @@ func (g *mqlGcpProjectDnsServiceRecordset) id() (string, error) {
 	if g.Name.Error != nil {
 		return "", g.Name.Error
 	}
-	id := g.Name.Data
-	return "gcp.project.dnsService.recordset/" + projectId + "/" + id, nil
+	if g.Type.Error != nil {
+		return "", g.Type.Error
+	}
+	// A managed zone can hold several record sets that share a name but
+	// differ by type (e.g. an A and an MX record for the same domain), so
+	// the type must be part of the key. The authoritative cache key set at
+	// creation also includes the managed zone for cross-zone uniqueness.
+	return "gcp.project.dnsService.recordset/" + projectId + "/" + g.Name.Data + "/" + g.Type.Data, nil
 }
 
 func (g *mqlGcpProjectDnsServiceManagedzone) dnsSecAlgorithmWeak() (bool, error) {
@@ -656,6 +662,9 @@ func (g *mqlGcpProjectDnsServiceManagedzone) recordSets() ([]any, error) {
 			rSet := page.Rrsets[i]
 
 			mqlDnsPolicy, err := CreateResource(g.MqlRuntime, "gcp.project.dnsService.recordset", map[string]*llx.RawData{
+				// Record sets are keyed by (zone, name, type); include all
+				// three so records that share a name don't alias in the cache.
+				"__id":             llx.StringData("gcp.project.dnsService.recordset/" + projectId + "/" + managedZone + "/" + rSet.Name + "/" + rSet.Type),
 				"projectId":        llx.StringData(projectId),
 				"name":             llx.StringData(rSet.Name),
 				"rrdatas":          llx.ArrayData(convert.SliceAnyToInterface(rSet.Rrdatas), types.String),


### PR DESCRIPTION
## Bug

Three sub-resource `__id` builders omit a parent-scoping field, so sibling resources collide in the runtime resource cache (`resourceName + "\x00" + __id`) — the second instance aliases the first, silently dropping or duplicating data:

1. **Bigtable cluster** (`bigtable.go`): `id()` used `projectId` + cluster `Name` only. Cluster names are unique only *within an instance*, so two instances with a same-named cluster collide. The struct already carries `InstanceName`, used correctly by the sibling `table`/`appProfile`/`backup` ids. → added `InstanceName`.
2. **BigQuery routine** (`bigquery.go`): `id()` used the bare routine id. Routine ids are unique only *within a dataset*. The sibling `model`/`table` ids qualify with `projectId`/`datasetId`. → added `projectId` + `datasetId`.
3. **DNS recordset** (`dns.go`): `id()` used `projectId` + `name` only. A managed zone routinely holds multiple record sets sharing a name but differing by `type` (e.g. A + MX for one domain); GCP keys them by (zone, name, type). → added `type` to `id()`, and set a zone-qualified `__id` at creation for cross-zone uniqueness.

## Impact

Audits that enumerate these resources (e.g. per-instance Bigtable clusters, DNS SPF/DMARC/DNSSEC record checks) could undercount or return the wrong sibling's data.

Each fix mirrors the parent-qualified pattern already used by neighboring resources in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_