### PR TITLE
🐛 azure: guard LinuxFxVersion split to avoid index-out-of-range panic

### DIFF
--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -285,7 +285,11 @@ func computeWebAppStack(runtime *plugin.Runtime, config *mqlAzureSubscriptionWeb
 
 		fxversion := strings.Split(*properties.LinuxFxVersion, "|")
 		runtimeInfo.Name = strings.ToLower(fxversion[0])
-		runtimeInfo.MinorVersion = strings.ToLower(fxversion[1])
+		// Some LinuxFxVersion values (e.g. a bare "DOCKER" or a custom image
+		// string) have no "|version" suffix; only read it when present.
+		if len(fxversion) > 1 {
+			runtimeInfo.MinorVersion = strings.ToLower(fxversion[1])
+		}
 	} else {
 		metadataMap, ok := metadata.(map[string]any)
 		if !ok {


### PR DESCRIPTION
## Bug

`web.go`, web-app stack detection:

```go
if properties.LinuxFxVersion != nil && len(*properties.LinuxFxVersion) > 0 {
    ...
    fxversion := strings.Split(*properties.LinuxFxVersion, "|")
    runtimeInfo.Name = strings.ToLower(fxversion[0])
    runtimeInfo.MinorVersion = strings.ToLower(fxversion[1])   // panics if no "|"
}
```

It guards only that `*LinuxFxVersion` is non-empty, then unconditionally reads `fxversion[1]`. A `LinuxFxVersion` with no `|` separator (a bare value such as `"DOCKER"`, or a custom-image string without the standard `RUNTIME|version` shape) makes `Split` return a length-1 slice, so `fxversion[1]` panics — crashing the `appsite.stack` / `appslot.stack` query for that site.

## Fix

Only read the minor-version element when the split produced it (`len(fxversion) > 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_