### PR TITLE
🐛 azure: compare managed-identity principal IDs by value, not TValue struct

### DIFF
--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -309,7 +309,10 @@ func (a *mqlAzureSubscriptionAuthorizationService) managedIdentities() ([]any, e
 			assignedRoles := []any{}
 			for i := range roleAssignments {
 				roleAssignment := roleAssignments[i].(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment)
-				if roleAssignment.PrincipalId == mqlManagedIdentity.PrincipalId {
+				// Compare the principal ID values, not the whole TValue structs
+				// (which also carry State/Error and would only match when those
+				// happen to be identical too).
+				if roleAssignment.PrincipalId.Data == mqlManagedIdentity.PrincipalId.Data {
 					assignedRoles = append(assignedRoles, roleAssignment)
 				}
 			}


### PR DESCRIPTION
## Bug

`iam.go`, associating role assignments with a managed identity:

```go
for i := range roleAssignments {
    roleAssignment := roleAssignments[i].(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment)
    if roleAssignment.PrincipalId == mqlManagedIdentity.PrincipalId {
        assignedRoles = append(assignedRoles, roleAssignment)
    }
}
```

`PrincipalId` is `plugin.TValue[string]` (`{Data string; State State; Error error}`), so `==` compares the **entire struct** — `Data`, `State`, and `Error` — not the principal-ID string. The intended security-relevant match (managed identity → its role assignments) only holds when `State`/`Error` also coincide. It works in the common path but is fragile: if either field resolves with a different state (e.g. a null/absent principal id → `StateIsSet|StateIsNull`), the structs compare unequal and the identity's assigned roles silently drop off.

## Fix

Compare `.Data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_