### PR TITLE
🐛 aws: fix swapped region/account in EC2 keypair ARN

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -752,7 +752,7 @@ func (a *mqlAwsEc2) getKeypairs(conn *connection.AwsConnection) []*jobpool.Job {
 				}
 				mqlKeypair, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Keypair,
 					map[string]*llx.RawData{
-						"arn":         llx.StringData(fmt.Sprintf(keypairArnPattern, conn.AccountId(), region, convert.ToValue(kp.KeyPairId))),
+						"arn":         llx.StringData(fmt.Sprintf(keypairArnPattern, region, conn.AccountId(), convert.ToValue(kp.KeyPairId))),
 						"fingerprint": llx.StringDataPtr(kp.KeyFingerprint),
 						"name":        llx.StringDataPtr(kp.KeyName),
 						"type":        llx.StringData(string(kp.KeyType)),
@@ -818,7 +818,7 @@ func initAwsEc2Keypair(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		args["type"] = llx.StringData(string(kp.KeyType))
 		args["tags"] = llx.MapData(toInterfaceMap(ec2TagsToMap(kp.Tags)), types.String)
 		args["region"] = llx.StringData(r)
-		args["arn"] = llx.StringData(fmt.Sprintf(keypairArnPattern, conn.AccountId(), r, convert.ToValue(kp.KeyPairId)))
+		args["arn"] = llx.StringData(fmt.Sprintf(keypairArnPattern, r, conn.AccountId(), convert.ToValue(kp.KeyPairId)))
 		args["createdAt"] = llx.TimeDataPtr(kp.CreateTime)
 
 		return args, nil, nil


### PR DESCRIPTION
## Bug

`aws_ec2.go` (both the list path and the by-name init path):

```go
"arn": llx.StringData(fmt.Sprintf(keypairArnPattern, conn.AccountId(), region, convert.ToValue(kp.KeyPairId)))
```

`keypairArnPattern = "arn:aws:ec2:%s:%s:keypair/%s"` is `<region>:<account>` — consistent with every other EC2 ARN pattern in `aws.go` (e.g. `ec2InstanceArnPattern`, used correctly elsewhere). Both keypair call sites pass `conn.AccountId(), region` — **swapped** — producing `arn:aws:ec2:<accountId>:<region>:keypair/...`.

The malformed value is exposed as `aws.ec2.keypair.arn`, is what `id()` returns, and is the resource's `__id` cache key — so any audit comparing or joining on the keypair ARN gets the wrong string.

## Fix

Pass `region, conn.AccountId()` in the correct order at both sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_