### PR TITLE
🐛 aws: set ECS container taskDefinitionArn to the task-definition ARN

### DIFF
--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -621,7 +621,7 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 				"runtimeId":          llx.StringDataPtr(c.RuntimeId),
 				"status":             llx.StringDataPtr(c.LastStatus),
 				"taskArn":            llx.StringData(t.Arn.Data),
-				"taskDefinitionArn":  llx.StringData(t.Arn.Data),
+				"taskDefinitionArn":  llx.StringDataPtr(t.taskDefArn),
 				"memorySoftLimit":    llx.StringDataPtr(c.MemoryReservation),
 				"memoryHardLimit":    llx.StringDataPtr(c.Memory),
 				"reason":             llx.StringDataPtr(c.Reason),


### PR DESCRIPTION
## Bug

`aws_ecs.go`, building the `aws.ecs.container` resource:

```go
"taskArn":           llx.StringData(t.Arn.Data),
"taskDefinitionArn": llx.StringData(t.Arn.Data),   // copy-paste: should be the task DEFINITION arn
```

Both fields get the task ARN. The container's `taskDefinition()` accessor then calls `DescribeTaskDefinition` with a *task* ARN, which AWS rejects — so the typed reference is broken for every ECS container. The correct task-definition ARN is already cached on the task as `t.taskDefArn` (populated at task creation and used correctly by the task's own `definition()`/`arn` paths).

## Fix

Set `taskDefinitionArn` from `t.taskDefArn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_