### PR TITLE
🐛 aws: resolve SageMaker endpoint config by its real config name

### DIFF
--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -117,13 +117,19 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 }
 
 func (a *mqlAwsSagemakerEndpoint) config() (map[string]any, error) {
-	name := a.Name.Data
+	// The endpoint config has its own name, distinct from the endpoint name;
+	// resolve it via DescribeEndpoint rather than assuming they're equal.
+	details, err := a.fetchDetails()
+	if err != nil {
+		return nil, err
+	}
+
 	region := a.Region.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Sagemaker(region)
 	ctx := context.Background()
-	config, err := svc.DescribeEndpointConfig(ctx, &sagemaker.DescribeEndpointConfigInput{EndpointConfigName: &name})
+	config, err := svc.DescribeEndpointConfig(ctx, &sagemaker.DescribeEndpointConfigInput{EndpointConfigName: details.EndpointConfigName})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Bug

`aws_sagemaker.go`, `mqlAwsSagemakerEndpoint.config()`:

```go
name := a.Name.Data   // the ENDPOINT name
...
config, err := svc.DescribeEndpointConfig(ctx, &sagemaker.DescribeEndpointConfigInput{EndpointConfigName: &name})
```

`a.Name.Data` is the endpoint name, but `DescribeEndpointConfig` expects the endpoint **config** name — a distinct identifier that generally differs from the endpoint name. So `aws.sagemaker.endpoint.config` returns a `ValidationException`/not-found for essentially every real endpoint.

The correct config name is `DescribeEndpoint(...).EndpointConfigName`, which the same file already fetches via `fetchDetails()` (used by `endpointConfigName()`, `dataCaptureConfig()`, etc.).

## Fix

Resolve the endpoint config name through `fetchDetails()` and pass `details.EndpointConfigName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_