### PR TITLE
🐛 aws: case-insensitive Redshift cluster multiAZ check

### DIFF
--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
@@ -131,7 +132,7 @@ func (a *mqlAwsRedshift) getClusters(conn *connection.AwsConnection) []*jobpool.
 							"vpcId":                            llx.StringDataPtr(cluster.VpcId),
 							"clusterAvailabilityStatus":        llx.StringDataPtr(cluster.ClusterAvailabilityStatus),
 							"totalStorageCapacityInMegaBytes":  llx.IntDataDefault(cluster.TotalStorageCapacityInMegaBytes, 0),
-							"multiAZ":                          llx.BoolData(convert.ToValue(cluster.MultiAZ) == "enabled"),
+							"multiAZ":                          llx.BoolData(strings.EqualFold(convert.ToValue(cluster.MultiAZ), "enabled")),
 							"manualSnapshotRetentionPeriod":    llx.IntDataDefault(cluster.ManualSnapshotRetentionPeriod, 0),
 							"ipAddressType":                    llx.StringDataPtr(cluster.IpAddressType),
 							"maintenanceTrackName":             llx.StringDataPtr(cluster.MaintenanceTrackName),


### PR DESCRIPTION
## Bug

`aws_redshift.go`:

```go
"multiAZ": llx.BoolData(convert.ToValue(cluster.MultiAZ) == "enabled"),
```

`cluster.MultiAZ` is a free-form `*string`, and AWS Redshift returns it capitalized (`"Enabled"` / `"Disabled"`). Comparing against the lowercase literal `"enabled"` therefore evaluates to `false` for **every** Multi-AZ cluster — an availability-posture field silently reported as always-false.

## Fix

`strings.EqualFold(convert.ToValue(cluster.MultiAZ), "enabled")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_