### PR TITLE
🐛 aws: guard nil export in dynamodb export.table()

### DIFF
--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -243,6 +243,10 @@ func (a *mqlAwsDynamodbExport) table() (*mqlAwsDynamodbTable, error) {
 	if err != nil {
 		return nil, err
 	}
+	if exp == nil {
+		a.Table.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	if exp.TableArn == nil || *exp.TableArn == "" {
 		a.Table.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil


### PR DESCRIPTION
## Bug

`aws_dynamodb.go`, `mqlAwsDynamodbExport.table()`:

```go
exp, err := a.fetchExport()
if err != nil {
    return nil, err
}
if exp.TableArn == nil || *exp.TableArn == "" {   // panics if exp == nil
```

`fetchExport()` returns `(nil, nil)` on the access-denied path (`Is400AccessDeniedError` → `a.fetched = true; return nil, nil`). Every other accessor on this resource (`s3Bucket`, `kmsKey`, `status`, …) guards `if exp == nil` first, but `table()` dereferences `exp.TableArn` directly — so a `DescribeExport` access-denied panics the query with a nil pointer dereference.

## Fix

Add the `if exp == nil` guard (set the field null state and return nil), matching the sibling accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_