### PR TITLE
🐛 aws: don't swallow non-404 errors in efs filesystem.backupPolicy()

### DIFF
--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -180,12 +180,13 @@ func (a *mqlAwsEfsFilesystem) backupPolicy() (any, error) {
 	backupPolicy, err := svc.DescribeBackupPolicy(ctx, &efs.DescribeBackupPolicyInput{
 		FileSystemId: &id,
 	})
-	var respErr *http.ResponseError
-	if err != nil && errors.As(err, &respErr) {
-		if respErr.HTTPStatusCode() == 404 {
+	if err != nil {
+		// A 404 means the filesystem has no backup policy; treat as absent.
+		// Any other error (403, 5xx, …) must propagate, not be swallowed.
+		var respErr *http.ResponseError
+		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
 			return nil, nil
 		}
-	} else if err != nil {
 		return nil, err
 	}
 	res, err := convert.JsonToDict(backupPolicy)


### PR DESCRIPTION
## Bug

`aws_efs.go`, `backupPolicy()`:

```go
var respErr *http.ResponseError
if err != nil && errors.As(err, &respErr) {
    if respErr.HTTPStatusCode() == 404 {
        return nil, nil
    }
    // non-404 ResponseError falls through here ↓
} else if err != nil {
    return nil, err
}
res, err := convert.JsonToDict(backupPolicy)   // runs on a nil/partial response
```

When `err` is a `*http.ResponseError` with a non-404 status (e.g. 403 or 5xx), the first `if` is taken, the inner 404 check fails, and execution falls through to `convert.JsonToDict(backupPolicy)` on a nil/partial response — the real error is silently turned into an empty backup policy. (The `else if err != nil` can never catch it because the outer `if` already matched.)

## Fix

Restructure so only a 404 `ResponseError` returns `(nil, nil)`; every other error propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_