### PR TITLE
🐛 aws: check CreateResource errors for WAF Not/Or statements

### DIFF
--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -691,6 +691,9 @@ func createStatementResource(runtime *plugin.Runtime, statement *waftypes.Statem
 				"statement":   llx.ResourceData(notStatementMqlStatement, "aws.waf.rule.statement.notstatement"),
 				"ruleName":    llx.StringDataPtr(ruleName),
 			})
+			if err != nil {
+				return nil, err
+			}
 		}
 		if statement.OrStatement != nil {
 			kind = "OrStatement"
@@ -707,6 +710,9 @@ func createStatementResource(runtime *plugin.Runtime, statement *waftypes.Statem
 				"statements":  llx.ArrayData(statements, types.ResourceLike),
 				"ruleName":    llx.StringDataPtr(ruleName),
 			})
+			if err != nil {
+				return nil, err
+			}
 		}
 		if statement.RateBasedStatement != nil {
 			kind = "RateBasedStatement"


### PR DESCRIPTION
## Bug

`aws_waf.go`, `createStatementResource`:

```go
notstatement, err = CreateResource(runtime, "aws.waf.rule.statement.notstatement", ...)
}   // err never checked
...
orstatement, err = CreateResource(runtime, "aws.waf.rule.statement.orstatement", ...)
}   // err never checked
```

Unlike every other branch in this function, the `NotStatement` and `OrStatement` branches assign the `CreateResource` error to `err` but never test it. The function returns `mqlStatement, nil` at the end, so a failed `notstatement`/`orstatement` creation is silently swallowed and a possibly-nil sub-resource gets embedded in the parent statement.

## Fix

Check `err` after both `CreateResource` calls, matching the other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_