### PR TITLE
🎉 aws-13.38.0, gcp-13.25.0, azure-13.21.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.37.0",
+	Version:         "13.38.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.20.0",
+	Version: "13.21.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.24.0",
+	Version: "13.25.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Minor version bumps for the aws, gcp, and azure providers.

| Provider | Bump | Old → New |
|---|---|---|
| aws | minor | 13.37.0 → 13.38.0 |
| gcp | minor | 13.24.0 → 13.25.0 |
| azure | minor | 13.20.0 → 13.21.0 |

## aws — 13.37.0 → 13.38.0
- 🐛 aws: set ECS container taskDefinitionArn to the task definition ARN (#8680)
- ⭐ aws: add internet-exposure analysis across resources (#8551)
- ⭐ aws: ec2.instance.exposure sub-resource (internet-exposure breakdown) (#8536)
- ⭐ aws: link IAM Access Analyzer findings to resources (observed exposure) (#8539)
- ⭐ aws: shared network.exposure sub-resource for RDS, DocumentDB, and ELB (#8538)
- ⭐ aws: trust, egress, and embedded-config exposure predicates (#8535)
- ⭐ aws: mitigation-context fields (exposed-and-undefended detection) (#8532)
- ⭐ aws: external-sharing fields for AMIs and snapshots (#8533)
- 🐛 aws: detect wide-CIDR and prefix-list public sources (fix false negatives) (#8531)
- ⭐ aws: NACL-aware reachability, Lambda Function URL + API Gateway exposure (#8527)
- ⭐ aws: consistent internet-exposure predicates (isPublic, rds internetReachable) (#8526)
- ⭐ aws: add managedBy provenance field for unmanaged-resource detection (#8517)
- ⭐ aws: computed instance internet-exposure (inPublicSubnet, internetReachable) (#8518)
- ⭐ aws: CloudFormation provenance, instance→LB backref, faster role usage (#8516)
- 🧹 deps: bump provider SDK dependencies (#8515)
- ✨ aws: add EKS control plane egress mode and Cognito domain TLS policy (#8514)
- ⭐ aws: add cross-resource edges for security policy authoring (#8513)
- 🐛 aws: fix wrong resource name and swallowed errors (#8459)
- 🧹 Update deps for mql and providers 20260622/20260623 (#8595, #8645)

## gcp — 13.24.0 → 13.25.0
- ⭐ gcp: compute instance network-exposure breakdown (#8544)
- ⭐ gcp: add internet-exposure analysis across resources (#8546)
- 🐛 gcp: sanitize and length-cap snapshot scanner disk names (#8440)
- 🐛 gcp: require --project-id/--zone for instance and snapshot scanning (#8439)
- 🧹 deps: bump provider SDK dependencies (#8515)
- 🧹 gcp: regression test for alert-policy filter parsing without a filter key (#8502)
- 🐛 gcp: fix nil-deref and panic crashes in resource collection (#8481)
- 🐛 gcp: request IAM policy schema v3 so conditional bindings are returned (#8483)
- 🐛 gcp: fix incorrect field and type mappings (#8482)
- 🐛 gcp: fix swallowed errors and over-strict error handling (#8484)
- ✨ Add expressive debug logging to GCP and Azure providers (#8366)
- 🧹 Update deps for mql and providers 20260615/20260622/20260623 (#8443, #8595, #8645)

## azure — 13.20.0 → 13.21.0
- ⭐ azure: add internet-exposure analysis across resources (#8549)
- 🐛 azure: re-land stranded review fixes + add regression tests (#8503)
- 🐛 azure: fix nil-deref and panic crashes in resource collection (#8486)
- 🐛 azure: fix swallowed errors and a discovery-target loop bug (#8489)
- 🐛 azure: fix security-posture detections returning wrong values (#8488)
- 🐛 azure: fix incorrect field/type mappings on flow logs and app sites (#8487)
- ✨ Add expressive debug logging to GCP and Azure providers (#8366)
- 🧹 Update deps for mql and providers 20260615/20260622/20260623 (#8443, #8595, #8645)
