### PR TITLE
🐛 aws: resolve ELB target-group EC2 instances (fix empty instance→LB backref)

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.37.0",
-  "generated_at": "2026-06-18T22:07:05-06:00",
+  "generated_at": "2026-06-23T12:59:19-06:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -369,6 +369,7 @@
     "elasticloadbalancing:DescribeTags",
     "elasticloadbalancing:DescribeTargetGroupAttributes",
     "elasticloadbalancing:DescribeTargetGroups",
+    "elasticloadbalancing:DescribeTargetHealth",
     "elasticmapreduce:DescribeCluster",
     "elasticmapreduce:DescribeSecurityConfiguration",
     "elasticmapreduce:DescribeStep",
@@ -3159,6 +3160,12 @@
       "permission": "elasticloadbalancing:DescribeTargetGroups",
       "service": "elasticloadbalancing",
       "action": "DescribeTargetGroups",
+      "source_file": "aws_elb.go"
+    },
+    {
+      "permission": "elasticloadbalancing:DescribeTargetHealth",
+      "service": "elasticloadbalancing",
+      "action": "DescribeTargetHealth",
       "source_file": "aws_elb.go"
     },
     {

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -837,8 +837,49 @@ func (a *mqlAwsElbLoadbalancer) instances() ([]any, error) {
 }
 
 func (a *mqlAwsElbTargetgroup) ec2Targets() ([]any, error) {
-	// TODO
-	return nil, nil
+	// Only instance-type target groups register EC2 instances; ip and lambda
+	// target groups resolve to other resource kinds, so there is nothing to do.
+	if a.targetGroup.TargetType != "" && a.targetGroup.TargetType != elbtypes.TargetTypeEnumInstance {
+		return []any{}, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	region := a.region
+	svc := conn.Elbv2(region)
+	ctx := context.Background()
+
+	resp, err := svc.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(a.Arn.Data),
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	res := []any{}
+	for _, desc := range resp.TargetHealthDescriptions {
+		if desc.Target == nil || desc.Target.Id == nil {
+			continue
+		}
+		// instance-type targets register the instance ID (i-...); ip-type
+		// targets register an IP address, which is not an EC2 instance.
+		instanceID := *desc.Target.Id
+		if !strings.HasPrefix(instanceID, "i-") {
+			continue
+		}
+		mqlInst, err := NewResource(a.MqlRuntime, ResourceAwsEc2Instance,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(ec2InstanceArnPattern, region, conn.AccountId(), instanceID)),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlInst)
+	}
+	return res, nil
 }
 
 func (a *mqlAwsElbTargetgroup) lambdaTargets() ([]any, error) {


### PR DESCRIPTION
## What

`aws.elb.targetgroup.ec2Targets()` was an unimplemented stub (`// TODO; return nil, nil`). Because the instance→load-balancer backref resolves target-group membership through this accessor, it only worked for **classic ELBs** (which register instances directly). For **Application and Network Load Balancers** — which register instances through target groups — resolution silently returned empty.

This surfaced during live verification of the AWS internet-exposure feature (release PR #8648): two new fields returned `[]` for an instance fronted by an internet-facing ALB, even though the instance was a registered target:

- `aws.ec2.instance.loadBalancers`
- `aws.ec2.instance.exposure.internetFacingLoadBalancers`

## Fix

Implement `ec2Targets()` to call `DescribeTargetHealth` on the target group and resolve each instance-type target to an `aws.ec2.instance`, using the same ARN pattern the classic `instances()` accessor already uses. ip- and lambda-type target groups are skipped (their targets are not EC2 instances). Adds the `elasticloadbalancing:DescribeTargetHealth` IAM permission.

## Verification

Built and run against a live internet-facing ALB (`mql-verify-alb`) with a registered EC2 instance:

**Before:** `loadBalancers: []`, `exposure.internetFacingLoadBalancers: []`

**After:**
```
loadBalancers: [{ name: "mql-verify-alb", scheme: "internet-facing" }]
exposure.internetFacingLoadBalancers: [{ name: "mql-verify-alb", scheme: "internet-facing" }]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)