### PR TITLE
🐛 digitalocean: don't silently truncate paginated results on CurrentPage error

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -242,7 +242,7 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -276,7 +276,7 @@ func (r *mqlDigitalocean) firewalls() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -310,7 +310,7 @@ func (r *mqlDigitalocean) databases() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -369,7 +369,7 @@ func (r *mqlDigitalocean) domains() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -413,7 +413,7 @@ func (r *mqlDigitaloceanDomain) records() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -471,7 +471,7 @@ func (r *mqlDigitalocean) volumes() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.ListOptions.Page = page + 1
 	}
@@ -506,7 +506,7 @@ func (r *mqlDigitalocean) loadBalancers() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -555,7 +555,7 @@ func (r *mqlDigitalocean) vpcs() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -589,7 +589,7 @@ func (r *mqlDigitalocean) kubernetesClusters() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -632,7 +632,7 @@ func (r *mqlDigitalocean) projects() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -671,7 +671,7 @@ func (r *mqlDigitalocean) sshKeys() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -719,7 +719,7 @@ func (r *mqlDigitalocean) certificates() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}

--- a/providers/digitalocean/resources/digitalocean_databases.go
+++ b/providers/digitalocean/resources/digitalocean_databases.go
@@ -57,7 +57,9 @@ func (r *mqlDigitaloceanDatabase) fetchBackups() ([]godo.DatabaseBackup, error) 
 		}
 		page, perr := resp.Links.CurrentPage()
 		if perr != nil {
-			break
+			r.backupsErr = perr
+			r.backupsDone = true
+			return nil, perr
 		}
 		opt.Page = page + 1
 	}

--- a/providers/digitalocean/resources/discovery.go
+++ b/providers/digitalocean/resources/discovery.go
@@ -69,7 +69,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			}
 			page, err := resp.Links.CurrentPage()
 			if err != nil {
-				break
+				return nil, err
 			}
 			opt.Page = page + 1
 		}
@@ -95,7 +95,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			}
 			page, err := resp.Links.CurrentPage()
 			if err != nil {
-				break
+				return nil, err
 			}
 			opt.Page = page + 1
 		}
@@ -121,7 +121,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			}
 			page, err := resp.Links.CurrentPage()
 			if err != nil {
-				break
+				return nil, err
 			}
 			opt.Page = page + 1
 		}
@@ -147,7 +147,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			}
 			page, err := resp.Links.CurrentPage()
 			if err != nil {
-				break
+				return nil, err
 			}
 			opt.Page = page + 1
 		}

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -42,7 +42,7 @@ func (r *mqlDigitaloceanDatabase) users() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -88,7 +88,7 @@ func (r *mqlDigitaloceanDatabase) replicas() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -129,7 +129,7 @@ func (r *mqlDigitaloceanDatabase) pools() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -175,7 +175,7 @@ func (r *mqlDigitalocean) vpcPeerings() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -245,7 +245,7 @@ func (r *mqlDigitaloceanKubernetesCluster) nodePools() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -397,7 +397,7 @@ func (r *mqlDigitaloceanRegistry) garbageCollections() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -499,7 +499,7 @@ func (r *mqlDigitaloceanRegistryRepository) tags() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -529,7 +529,7 @@ func (r *mqlDigitaloceanRegistryRepository) manifests() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -622,7 +622,7 @@ func (r *mqlDigitalocean) reservedIPs() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -740,7 +740,7 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -813,7 +813,7 @@ func (r *mqlDigitalocean) alertPolicies() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -860,7 +860,7 @@ func (r *mqlDigitalocean) uptimeChecks() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -904,7 +904,7 @@ func (r *mqlDigitalocean) cdnEndpoints() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -947,7 +947,7 @@ func (r *mqlDigitalocean) tags() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}
@@ -1001,7 +1001,7 @@ func (r *mqlDigitalocean) spacesKeys() ([]interface{}, error) {
 		}
 		page, err := resp.Links.CurrentPage()
 		if err != nil {
-			break
+			return nil, err
 		}
 		opt.Page = page + 1
 	}


### PR DESCRIPTION
## Summary

While auditing the DigitalOcean and Hetzner providers for logic, pagination, performance, and nil-handling bugs, I found one genuinely defensible bug in the DigitalOcean provider's pagination loops.

Every paginated list accessor advances the page like this:

```go
if resp.Links == nil || resp.Links.IsLastPage() {
    break
}
page, err := resp.Links.CurrentPage()
if err != nil {
    break   // <-- swallows the error
}
opt.Page = page + 1
```

When `resp.Links.CurrentPage()` returns an error (godo parses the page number out of the `prev`/`next` link URL — a malformed/unexpected link makes it fail), the loop `break`s and the function returns the **partial** result accumulated so far **with a `nil` error**. The caller has no way to tell a complete list from a truncated one, so every resource on the remaining pages silently disappears.

For an inventory/security tool this is a correctness bug, not just a robustness nit: a policy can pass because a non-compliant resource that lived on page 2+ was never fetched, and nothing signals that the data was incomplete.

The codebase already demonstrates the correct handling in `digitalocean_security_scan.go`, which does `return nil, err` in the exact same spot. This PR makes the rest of the provider consistent with it.

## Changes

Replaced the `break` with `return nil, err` in the `CurrentPage()` error branch of all paginated accessors across:

- `digitalocean.go` (droplets, firewalls, databases, domains, records, volumes, loadBalancers, vpcs, kubernetesClusters, projects, sshKeys, certificates)
- `resources.go` (users, replicas, pools, vpcPeerings, nodePools, garbageCollections, manifests, reservedIPs, apps, alertPolicies, uptimeChecks, cdnEndpoints, tags, spacesKeys, …)
- `discovery.go` (database / kubernetes / loadBalancer / firewall discovery)
- `digitalocean_databases.go` (`fetchBackups` — also records the error on its `backupsErr`/`backupsDone` cache fields before returning, matching the existing error path so the cached-failure behavior stays consistent)

No schema or generated-code changes; the provider builds and `gofmt` is clean.

## Audit scope / notes

I reviewed both the DigitalOcean and Hetzner providers in full. A number of other candidate findings were investigated and dismissed after verification:

- **Hetzner**: all list calls go through the generic `paginate()` helper, pointer fields are consistently nil-guarded, and typed-ref accessors set `StateIsSet | StateIsNull` correctly. No defensible bugs found.
- **DO gradientai batch jobs**: `BatchEdge.Node` is a value type (`Node Batch`) in godo v1.196.0, so the per-edge access is not a nil-deref.
- **DO Functions (`ListNamespaces`/`ListTriggers`)**: no `ListOptions` parameter in the SDK — single-call by design, not missing pagination.
- **`resp == nil` guards on `images()`/`snapshots()`**: godo guarantees a non-nil response when `err == nil`, so the missing guard is not a live nil-deref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_