### PR TITLE
🐛 openstack: normalize optional-service error handling

### DIFF
--- a/providers/openstack/resources/dns.go
+++ b/providers/openstack/resources/dns.go
@@ -43,7 +43,10 @@ func (o *mqlOpenstack) dnsZones() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.DNSClient()
 	if err != nil {
-		return []any{}, nil
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
 	}
 	pages, err := zones.List(client, zones.ListOpts{}).AllPages(ctx())
 	if err != nil {
@@ -102,7 +105,10 @@ func (r *mqlOpenstackDnsZone) recordsets() ([]any, error) {
 	c := conn(r.MqlRuntime)
 	client, err := c.DNSClient()
 	if err != nil {
-		return []any{}, nil
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
 	}
 	pages, err := recordsets.ListByZone(client, r.Id.Data, recordsets.ListOpts{}).AllPages(ctx())
 	if err != nil {

--- a/providers/openstack/resources/images.go
+++ b/providers/openstack/resources/images.go
@@ -47,6 +47,9 @@ func (o *mqlOpenstack) images() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.ImageClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := images.List(client, images.ListOpts{}).AllPages(ctx())
@@ -183,6 +186,9 @@ func (r *mqlOpenstackImage) members() ([]any, error) {
 	c := conn(r.MqlRuntime)
 	client, err := c.ImageClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := members.List(client, r.Id.Data).AllPages(ctx())

--- a/providers/openstack/resources/keymanager.go
+++ b/providers/openstack/resources/keymanager.go
@@ -64,6 +64,9 @@ func (o *mqlOpenstack) secrets() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.KeyManagerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := secrets.List(client, secrets.ListOpts{}).AllPages(ctx())
@@ -174,6 +177,9 @@ func (o *mqlOpenstack) secretContainers() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.KeyManagerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := containers.List(client, containers.ListOpts{}).AllPages(ctx())
@@ -354,6 +360,9 @@ func (o *mqlOpenstack) secretOrders() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.KeyManagerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := orders.List(client, orders.ListOpts{}).AllPages(ctx())

--- a/providers/openstack/resources/octavia.go
+++ b/providers/openstack/resources/octavia.go
@@ -128,6 +128,9 @@ func (o *mqlOpenstack) loadBalancers() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.LoadBalancerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := loadbalancers.List(client, loadbalancers.ListOpts{}).AllPages(ctx())
@@ -298,6 +301,9 @@ func (o *mqlOpenstack) listeners() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.LoadBalancerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := listeners.List(client, listeners.ListOpts{}).AllPages(ctx())
@@ -508,6 +514,9 @@ func (o *mqlOpenstack) pools() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.LoadBalancerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := pools.List(client, pools.ListOpts{}).AllPages(ctx())
@@ -793,6 +802,9 @@ func (o *mqlOpenstack) healthMonitors() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.LoadBalancerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := monitors.List(client, monitors.ListOpts{}).AllPages(ctx())
@@ -910,6 +922,9 @@ func (o *mqlOpenstack) l7Policies() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.LoadBalancerClient()
 	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 	pages, err := l7policies.List(client, l7policies.ListOpts{}).AllPages(ctx())

--- a/providers/openstack/resources/swift.go
+++ b/providers/openstack/resources/swift.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 	"sync"
 
@@ -25,8 +26,11 @@ func (o *mqlOpenstack) objectStorageAccount() (*mqlOpenstackObjectstorageAccount
 	c := conn(o.MqlRuntime)
 	client, err := c.ObjectStorageClient()
 	if err != nil {
-		o.ObjectStorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		if serviceMissing(err) {
+			o.ObjectStorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
 	}
 	getResult := accounts.Get(ctx(), client, accounts.GetOpts{})
 	resHdr, err := getResult.Extract()
@@ -106,7 +110,10 @@ func (o *mqlOpenstack) objectStorageContainers() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.ObjectStorageClient()
 	if err != nil {
-		return []any{}, nil
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
 	}
 	pages, err := containers.List(client, containers.ListOpts{}).AllPages(ctx())
 	if err != nil {
@@ -153,7 +160,10 @@ func (r *mqlOpenstackObjectstorageContainer) fetchHeader() (*containers.GetHeade
 	header, err := getResult.Extract()
 	if err != nil {
 		// 404 means the container was just deleted; treat as empty rather than failing the query.
-		if respErr, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok && (respErr.Actual == 401 || respErr.Actual == 403 || respErr.Actual == 404) {
+		// gophercloud frequently wraps ErrUnexpectedResponseCode, so use errors.As, not a
+		// direct type assertion (which misses wrapped errors and would fail the query).
+		var respErr gophercloud.ErrUnexpectedResponseCode
+		if errors.As(err, &respErr) && (respErr.Actual == 401 || respErr.Actual == 403 || respErr.Actual == 404) {
 			r.headerFetched = true
 			r.headerMeta = map[string]string{}
 			return nil, r.headerMeta, nil
@@ -250,7 +260,10 @@ func (r *mqlOpenstackObjectstorageContainer) objects() ([]any, error) {
 	c := conn(r.MqlRuntime)
 	client, err := c.ObjectStorageClient()
 	if err != nil {
-		return []any{}, nil
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
 	}
 	pages, err := objects.List(client, r.Name.Data, objects.ListOpts{}).AllPages(ctx())
 	if err != nil {


### PR DESCRIPTION
## Summary

OpenStack clouds run different subsets of services, so resource accessors for *optional* services must treat an absent service as "no data" (empty result) rather than failing the whole query — and must not swallow genuine errors. Most accessors already do this via the `serviceMissing()` helper (heat, trove, magnum, ironic, manila, placement, block-storage quota), but an audit found several that diverged in **two opposite directions**, both bugs:

### 1. Hard-failed on a missing service
`keymanager` (`secrets`, `secretContainers`, `secretOrders`), `images` (`images`, `members`), and `octavia` (`loadBalancers`, `listeners`, `pools`, `healthMonitors`, `l7Policies`) returned the raw `ErrEndpointNotFound` from client construction. On a cloud that doesn't run **Barbican / Glance-as-a-separate-endpoint / Octavia**, querying these resources failed the entire MQL query instead of returning empty — even though the same query against heat/trove/etc. degrades gracefully.

### 2. Swallowed *all* client errors
`dns` (`dnsZones`, `recordsets`) and `swift` (`objectStorageAccount`, `objectStorageContainers`, `objects`) returned an empty result on *any* client-construction error, silently hiding real auth/network failures as "zero results" — the opposite over-correction.

Both now use the canonical pattern already established across the provider:

```go
client, err := c.XxxClient()
if err != nil {
    if serviceMissing(err) {
        return []any{}, nil   // service not deployed → no data
    }
    return nil, err           // real error → surface it
}
```

### 3. Wrapped-error mismatch in swift `fetchHeader`
It classified a 401/403/404 with a **direct type assertion** on `gophercloud.ErrUnexpectedResponseCode`. gophercloud commonly *wraps* that error, so the assertion missed wrapped cases and turned a just-deleted/forbidden container into a hard query failure. Switched to `errors.As`, matching the rest of the provider (and added the `errors` import).

## Scope / why these and not others

Core services (Keystone identity, Nova compute, Neutron network, Cinder block storage) are always present, so their accessors correctly return errors directly and were left unchanged. Only the genuinely-optional-service accessors are touched.

## Audit notes

I reviewed the full provider (~29k LOC across 22 resource files). Pagination is correct everywhere (every list path uses `AllPages(ctx())`), nil handling and singular-accessor `StateIsNull` bookkeeping are compliant, and role-assignment scope mapping is correct. A few lower-confidence items were investigated and **not** included as they're design-intent-dependent rather than clear defects (e.g. the exposure verdict treats only broad `/8`-or-wider CIDRs as "public" and ignores protocol/port — deliberately conservative per its doc-comments; keystone `user.roles()` uses effective assignments while `group.roles()` uses direct grants). Happy to follow up on any of those if you'd like them treated as bugs.

## Verification

`go build`, `go vet`, `go test ./resources/...`, and `gofmt -l` all clean. Not exercised against a live OpenStack cloud (no credentials in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_