### PR TITLE
🐛 terraform: fix panics and swallowed errors on malformed plan/state/HCL

### DIFF
--- a/providers/terraform/provider/bugfix_test.go
+++ b/providers/terraform/provider/bugfix_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ParseCLI must not panic on an empty argument list (it used to index
+// req.Args[0] unconditionally).
+func TestParseCLI_NoArgs(t *testing.T) {
+	srv := &Service{Service: plugin.NewService()}
+	_, err := srv.ParseCLI(&plugin.ParseCLIReq{Connector: "terraform"})
+	require.Error(t, err)
+}
+
+// A state file with `values` present but no `root_module` (e.g. outputs-only)
+// must not panic dereferencing a nil RootModule; modules/resources resolve to
+// empty and rootModule to null.
+func TestResource_TfstateNoRootModule(t *testing.T) {
+	srv, connRes := newTestService(StateConnectionType, "./testdata/tfstate/state_no_root_module.json")
+	require.NotEmpty(t, srv)
+
+	dataResp, err := srv.GetData(&plugin.DataReq{
+		Connection: connRes.Id,
+		Resource:   "terraform.state",
+	})
+	require.NoError(t, err)
+	resourceId := string(dataResp.Data.Value)
+
+	for _, field := range []string{"modules", "resources"} {
+		resp, err := srv.GetData(&plugin.DataReq{
+			Connection: connRes.Id,
+			Resource:   "terraform.state",
+			ResourceId: resourceId,
+			Field:      field,
+		})
+		require.NoError(t, err, "field %q must not error", field)
+		assert.Equal(t, 0, len(resp.Data.Array), "field %q must be empty", field)
+	}
+}

--- a/providers/terraform/provider/provider.go
+++ b/providers/terraform/provider/provider.go
@@ -55,6 +55,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	// and later on decide which thing to call based on the conn.Type
 	// below in this file we already have something similar:
 	// tc.Options["asset-type"] == "state"
+	if len(req.Args) == 0 {
+		return nil, errors.New("no arguments provided, use 'state <path>', 'plan <path>', 'hcl <path>', or a path")
+	}
 	action := req.Args[0]
 	switch action {
 	case CLIPlan, CLIHcl, CLIState:

--- a/providers/terraform/provider/testdata/tfstate/state_no_root_module.json
+++ b/providers/terraform/provider/testdata/tfstate/state_no_root_module.json
@@ -1,0 +1,9 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.6.0",
+  "values": {
+    "outputs": {
+      "example": { "sensitive": false, "value": "hello", "type": "string" }
+    }
+  }
+}

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -493,11 +493,27 @@ func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	var res []any
 	for i := range resources {
 		r := resources[i]
-		if matchResource != nil && !matchResource(r.Labels.Data[0].(string)) {
-			continue
+		// A resource block carries two labels (type, name), but a malformed
+		// config (e.g. `resource {}` or `resource "type" {}`) parses fine via
+		// the native HCL parser, which does not enforce label arity. Guard the
+		// label indices and assertions so a filtered query doesn't panic.
+		if matchResource != nil {
+			if len(r.Labels.Data) < 1 {
+				continue
+			}
+			s, ok := r.Labels.Data[0].(string)
+			if !ok || !matchResource(s) {
+				continue
+			}
 		}
-		if matchName != nil && !matchName(r.Labels.Data[1].(string)) {
-			continue
+		if matchName != nil {
+			if len(r.Labels.Data) < 2 {
+				continue
+			}
+			s, ok := r.Labels.Data[1].(string)
+			if !ok || !matchName(s) {
+				continue
+			}
 		}
 		res = append(res, r)
 	}
@@ -1079,7 +1095,12 @@ func (t *mqlTerraformFile) blocks() ([]any, error) {
 	}
 
 	files := parser.Files()
-	file := files[p]
+	file, ok := files[p]
+	if !ok || file == nil {
+		// The requested path isn't a parsed HCL file (unknown path, .tf.json,
+		// or case mismatch); there are no blocks to list rather than a panic.
+		return []any{}, nil
+	}
 	return listHclBlocks(t.MqlRuntime, file.Body, file)
 }
 

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -152,7 +152,7 @@ func (t *mqlTerraformPlanResourceChange) id() (string, error) {
 
 func (t *mqlTerraformPlanProposedChange) id() (string, error) {
 	id := t.Address
-	return "terraform.plan.resourceChange/address/" + id.Data, nil
+	return "terraform.plan.proposedChange/address/" + id.Data, nil
 }
 
 func (t *mqlTerraformPlanConfiguration) id() (string, error) {
@@ -189,7 +189,9 @@ func (t *mqlTerraformPlanConfiguration) providerConfig() ([]any, error) {
 	}
 
 	pc := PlanConfiguration{}
-	err = json.Unmarshal(plan.Configuration, &pc)
+	if err = json.Unmarshal(plan.Configuration, &pc); err != nil {
+		return nil, err
+	}
 
 	res := []any{}
 	for i := range pc.ProviderConfig {
@@ -221,7 +223,9 @@ func (t *mqlTerraformPlanConfiguration) resources() ([]any, error) {
 	}
 
 	pc := PlanConfiguration{}
-	err = json.Unmarshal(plan.Configuration, &pc)
+	if err = json.Unmarshal(plan.Configuration, &pc); err != nil {
+		return nil, err
+	}
 
 	res := []any{}
 	for i := range pc.RootModule.Resources {

--- a/providers/terraform/resources/tfstate.go
+++ b/providers/terraform/resources/tfstate.go
@@ -72,7 +72,11 @@ func (t *mqlTerraformState) rootModule() (*mqlTerraformStateModule, error) {
 		return nil, err
 	}
 
-	if state.Values == nil {
+	// A state with `values` present but no `root_module` (e.g. outputs-only or
+	// a trimmed state) decodes to a non-nil Values with a nil RootModule;
+	// guard both so we don't dereference nil.
+	if state.Values == nil || state.Values.RootModule == nil {
+		t.RootModule.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -90,8 +94,8 @@ func (t *mqlTerraformState) modules() ([]any, error) {
 		return nil, err
 	}
 
-	if state.Values == nil {
-		return nil, nil
+	if state.Values == nil || state.Values.RootModule == nil {
+		return []any{}, nil
 	}
 
 	// resolve all tfstate modules
@@ -121,8 +125,8 @@ func (t *mqlTerraformState) resources() ([]any, error) {
 		return nil, err
 	}
 
-	if providerState.Values == nil {
-		return nil, nil
+	if providerState.Values == nil || providerState.Values.RootModule == nil {
+		return []any{}, nil
 	}
 
 	// resolve all tfstate resources, to achieve this we need to walk all modules


### PR DESCRIPTION
## Summary

A bug audit of the terraform provider found several accessors that **panic** or **silently lose data** on inputs that parse successfully but don't match the shapes the code assumes. These are the high-confidence, low-risk fixes.

## Fixes

**Panics (HIGH):**
- **`terraform.resources(resource:/name:)`** panicked on a resource block with fewer than two labels (`resources/hcl.go`). The native HCL parser doesn't enforce label arity, so `resource {}` (0 labels) or `resource "type" {}` (1 label) parses fine, then `r.Labels.Data[0]`/`[1]` indexed out of bounds with unchecked `.(string)` assertions. Now guards label count + comma-ok.
- **`terraform.state.rootModule` / `modules` / `resources`** dereferenced `state.Values.RootModule` without a nil check (`resources/tfstate.go`). A state with `values` present but no `root_module` (outputs-only, or a trimmed state) decodes to a non-nil `Values` with a nil `RootModule` → panic in `WalkChildModules`. Now guarded (`rootModule` sets `StateIsNull`).
- **`terraform.file(path).blocks`** panicked on an unknown / `.tf.json` / case-mismatched path (`resources/hcl.go`): the `files` map miss yielded a nil `*hcl.File` and `file.Body` dereferenced nil. Now returns an empty list.
- **`ParseCLI`** indexed `req.Args[0]` with no length check (`provider/provider.go`), panicking when invoked with no positional argument.

**Swallowed errors / correctness (HIGH/trivial):**
- **`terraform.plan.providerConfig` / `resources`** assigned the `json.Unmarshal(plan.Configuration, …)` error and never checked it (`resources/tfplan.go`), so a malformed `configuration` block silently returned an empty list instead of an error.
- **`terraform.plan.proposedChange.id()`** returned a `terraform.plan.resourceChange/...` prefix copy-pasted from `resourceChange`; corrected to `proposedChange`.

## Deliberately deferred (need a design decision, not in this PR)

The audit also surfaced items I left out because they're behavior tradeoffs or need a scheme redesign rather than a clear fix:
- **Directory-mode HCL parse errors are swallowed** (`connection/hcl_manifest.go` ignores the `WalkDir` return). Propagating them makes a single malformed `.tf` (or a corrupt vendored `.terraform/modules/modules.json`) abort the whole scan — a lenient-skip vs. fail-loud decision worth making explicitly.
- **`blocksByName` / `terraformID` collision** (labels-only keys: `data "x" "y"` vs `resource "x" "y"`, and all no-label blocks → `""`). The key format is load-bearing for reference resolution in `listRelatedBlocks` (`aws_instance.foo` → `aws_instance\x00foo`), so fixing it needs a reference-scheme redesign.
- **Deposed-object `__id` collision** in plan `resourceChange` / state `resource` (keyed on `Address` only) — needs the deposed key plumbed through the connection structs.

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean. Not exercised against live terraform plan/state files (none in this environment) — the fixes are defensive guards verified against the code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_