### PR TITLE
🐛 bicep: bound expression-parser recursion + fix swallowed errors and an unchecked cast

### DIFF
--- a/providers/bicep/connection/connection.go
+++ b/providers/bicep/connection/connection.go
@@ -199,8 +199,16 @@ func findARMTemplate(dir string) *ARMTemplate {
 	}
 	for _, name := range candidates {
 		path := filepath.Join(dir, name)
-		if tmpl, err := loadARMTemplate(path); err == nil {
+		tmpl, err := loadARMTemplate(path)
+		if err == nil {
 			return tmpl
+		}
+		// A missing candidate is expected; a present-but-malformed template
+		// (invalid JSON or failing the deploymentTemplate check) is not — log
+		// it so a broken azuredeploy.json isn't silently indistinguishable
+		// from "no template here".
+		if !os.IsNotExist(err) {
+			log.Warn().Err(err).Str("path", path).Msg("failed to load ARM template candidate")
 		}
 	}
 	return nil

--- a/providers/bicep/resources/arm_template.go
+++ b/providers/bicep/resources/arm_template.go
@@ -61,7 +61,13 @@ func (t *mqlBicepTemplate) getARMTemplate() *connection.ARMTemplate {
 	}
 	// Re-fetch from connection when Internal struct wasn't populated
 	// (happens when resource is reconstructed via StoreData across gRPC).
-	conn := t.MqlRuntime.Connection.(*connection.BicepConnection)
+	// Guard the assertion: on a non-Bicep runtime (e.g. recording/replay)
+	// there's nothing to re-fetch — return nil rather than panicking, matching
+	// the comma-ok cast in id().
+	conn, ok := t.MqlRuntime.Connection.(*connection.BicepConnection)
+	if !ok {
+		return nil
+	}
 	tmpl := conn.ARMTemplate()
 	if tmpl != nil {
 		t.armTemplate = tmpl
@@ -299,7 +305,10 @@ func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, i
 	// Convert the manifest once, then peel `properties` out of the
 	// already-converted dict. JsonToDict walks every nested value, so a
 	// separate pass over obj["properties"] was redoing the same work.
-	manifest, _ := convert.JsonToDict(obj)
+	manifest, err := convert.JsonToDict(obj)
+	if err != nil {
+		log.Warn().Err(err).Str("name", name).Msg("failed to convert ARM template resource manifest")
+	}
 	var properties any
 	if manifest != nil {
 		properties = manifest["properties"]

--- a/providers/bicep/resources/expression.go
+++ b/providers/bicep/resources/expression.go
@@ -50,9 +50,26 @@ type exprNode struct {
 // bounded (literals, identifiers, member/index chains, function calls,
 // ternaries, arrays, and interpolated-string segments); this is structure
 // only, never evaluation.
+// maxExprDepth bounds recursion in the expression parser. Bicep expressions
+// are shallow in practice; the cap exists so a deeply nested, possibly
+// adversarial input (e.g. tens of thousands of nested parens / arrays /
+// interpolations in a single value) degrades to an `unknown` node instead of
+// driving super-linear work that wedges the query. See parsePrimary.
+const maxExprDepth = 200
+
 func parseExpression(raw string) *exprNode {
+	return parseExpressionDepth(raw, 0)
+}
+
+// parseExpressionDepth is parseExpression carrying the current recursion depth
+// across the new-parser boundary (sub-expressions and string interpolation
+// each start a fresh exprParser).
+func parseExpressionDepth(raw string, depth int) *exprNode {
 	trimmed := strings.TrimSpace(raw)
-	p := &exprParser{src: trimmed}
+	if depth > maxExprDepth {
+		return &exprNode{kind: exprKindUnknown, raw: trimmed}
+	}
+	p := &exprParser{src: trimmed, depth: depth}
 	node := p.parseTernary()
 	// If the parser couldn't consume the whole input, the expression is
 	// outside the supported grammar — fall back to "unknown" but keep the
@@ -70,8 +87,9 @@ func parseExpression(raw string) *exprNode {
 // package's string-aware scanState for skipping quoted literals when it
 // needs to find delimiters.
 type exprParser struct {
-	src string
-	pos int
+	src   string
+	pos   int
+	depth int
 }
 
 func (p *exprParser) atEnd() bool {
@@ -119,9 +137,9 @@ func (p *exprParser) parseTernary() *exprNode {
 		return p.parsePostfix()
 	}
 
-	cond := parseSubExpression(p.src[start:qPos])
-	thenNode := parseSubExpression(p.src[qPos+1 : cPos])
-	elseNode := parseSubExpression(p.src[cPos+1 : operandEnd])
+	cond := parseSubExpression(p.src[start:qPos], p.depth+1)
+	thenNode := parseSubExpression(p.src[qPos+1:cPos], p.depth+1)
+	elseNode := parseSubExpression(p.src[cPos+1:operandEnd], p.depth+1)
 	p.pos = operandEnd
 
 	return &exprNode{
@@ -165,8 +183,8 @@ func (p *exprParser) findTopLevelWithin(target byte, from, end int) int {
 // parseSubExpression parses a standalone sub-expression (a ternary branch or
 // condition). It never returns nil — anything outside the supported grammar
 // becomes an `unknown` node with raw preserved.
-func parseSubExpression(raw string) *exprNode {
-	return parseExpression(raw)
+func parseSubExpression(raw string, depth int) *exprNode {
+	return parseExpressionDepth(raw, depth)
 }
 
 // parsePostfix parses a primary expression followed by any chain of member
@@ -249,6 +267,14 @@ func (p *exprParser) parsePrimary() *exprNode {
 	if p.pos >= len(p.src) {
 		return nil
 	}
+	// parsePrimary is the choke point every nested operand descends through
+	// (parens, arrays). Bound the recursion so deeply nested input degrades to
+	// an unknown node rather than driving super-linear rescans.
+	p.depth++
+	defer func() { p.depth-- }()
+	if p.depth > maxExprDepth {
+		return nil
+	}
 	c := p.peek()
 
 	switch {
@@ -313,7 +339,7 @@ func (p *exprParser) parseString() *exprNode {
 			if !ok {
 				return nil
 			}
-			segments = append(segments, parseExpression(inner))
+			segments = append(segments, parseExpressionDepth(inner, p.depth+1))
 			continue
 		}
 		if ch == '\'' {

--- a/providers/bicep/resources/expression_test.go
+++ b/providers/bicep/resources/expression_test.go
@@ -4,7 +4,9 @@
 package resources
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -235,4 +237,31 @@ func TestParseExpressionRawAlwaysPopulated(t *testing.T) {
 	node := parseExpression("   resourceGroup().location   ")
 	assert.Equal(t, "resourceGroup().location", node.raw)
 	assert.Equal(t, exprKindPropertyAccess, node.kind)
+}
+
+// TestParseExpressionDeepNestingTerminates ensures deeply nested input is
+// bounded by the recursion-depth guard: it must return promptly (not hang on
+// super-linear rescans) and degrade to an unknown node rather than panicking
+// or stack-overflowing. Regression test for the quadratic-blowup DoS.
+func TestParseExpressionDeepNestingTerminates(t *testing.T) {
+	cases := map[string]string{
+		"nested parens":        strings.Repeat("(", 100000) + "1" + strings.Repeat(")", 100000),
+		"nested arrays":        strings.Repeat("[", 100000) + strings.Repeat("]", 100000),
+		"nested interpolation": strings.Repeat("'${", 50000) + "x" + strings.Repeat("}'", 50000),
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			done := make(chan *exprNode, 1)
+			go func() { done <- parseExpression(raw) }()
+			select {
+			case node := <-done:
+				// The guarantee is prompt termination (no super-linear rescans);
+				// the node is non-nil and the over-deep portion degraded to
+				// unknown rather than panicking or hanging.
+				require.NotNil(t, node)
+			case <-time.After(5 * time.Second):
+				t.Fatal("parseExpression did not terminate within 5s on deeply nested input")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

A bug audit of the bicep provider found one denial-of-service-class defect in the expression parser plus a few error-handling/robustness issues. The parser is otherwise notably panic-resistant (it fuzzed clean), so this is a small, targeted set.

## Fixes

### Expression-parser recursion blowup (DoS) — HIGH
`parseTernary` rescans the remaining source at every recursion level (`findOperandEnd` opens a fresh `scanState` and, inside a nested group, depth never returns to 0 until the matching close at the far end), and parens/arrays/interpolation each recurse one level per nesting character. The result is super-linear: a single `.bicep` value with tens of thousands of nested `(((…)))`, `[[[…]]]`, or `'${'${…}'}'` drives the query for **minutes** (measured clean quadratic scaling: 2k→31ms, 4k→121ms, 8k→483ms, 16k→1.9s; 200k hung >15s). It doesn't stack-overflow — it hangs.

Fix: a recursion-depth cap (`maxExprDepth = 200`) threaded across the sub-expression / string-interpolation new-parser boundary and enforced at `parsePrimary` (the choke point every nested operand descends through). Over-deep input now degrades to an `unknown` node promptly, consistent with the parser's existing "outside the grammar → unknown" contract. **Regression test added** — the deep-nesting cases now complete in <1s.

### Unchecked connection cast in `getARMTemplate` — MEDIUM
`getARMTemplate` did an unchecked `t.MqlRuntime.Connection.(*connection.BicepConnection)` — in the very method meant for the StoreData/gRPC-replay reconstruction path, where the runtime may not be a `*BicepConnection`. It would panic, and feeds `schema`/`parameters`/`variables`/`outputs`/`resources`. Now uses comma-ok and returns nil, matching the guarded cast 16 lines up in `id()`.

### Swallowed errors — MEDIUM
- **`findARMTemplate`** discarded every `loadARMTemplate` error, so a present-but-malformed `azuredeploy.json` (invalid JSON / failing the deploymentTemplate check) was indistinguishable from "no template here". Now logs non-`IsNotExist` errors.
- **`newMqlBicepTemplateResource`** swallowed the `convert.JsonToDict` error silently; now logs a warning, matching every other unmarshal in the file.

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean. The new `TestParseExpressionDeepNestingTerminates` guards against the DoS regression (5s termination bound on 100k-deep input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_