### PR TITLE
🐛 cloudformation: parse scalar Transform; guard CLI args and connections

### DIFF
--- a/providers/cloudformation/connection/connection.go
+++ b/providers/cloudformation/connection/connection.go
@@ -31,6 +31,9 @@ func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *invent
 		asset:      asset,
 	}
 	// initialize your connection here
+	if len(asset.Connections) == 0 {
+		return nil, errors.New("no connection options for asset")
+	}
 	cc := asset.Connections[0]
 	path := cc.Options["path"]
 	conn.path = path

--- a/providers/cloudformation/provider/provider.go
+++ b/providers/cloudformation/provider/provider.go
@@ -47,6 +47,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	// Do custom flag parsing here
+	if len(req.Args) == 0 {
+		return nil, errors.New("no cloudformation template path provided")
+	}
 	conf.Options["path"] = req.Args[0]
 
 	asset := inventory.Asset{

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -243,6 +243,17 @@ func TestCloudformationResources(t *testing.T) {
 		assert.Equal(t, []any{"MyMacro", "AWS::Serverless"}, tpl.Transform.Data)
 	})
 
+	t.Run("cloudformation scalar transform (SAM)", func(t *testing.T) {
+		// The canonical SAM header `Transform: AWS::Serverless-2016-10-31` is a
+		// scalar YAML node (no Content). It must surface as a single-element
+		// list rather than null.
+		path := "../testdata/transform-scalar.yaml"
+		tpl, err := loadTemplate(path)
+		require.NoError(t, err)
+
+		assert.Equal(t, []any{"AWS::Serverless-2016-10-31"}, tpl.Transform.Data)
+	})
+
 	t.Run("cloudformation resource policies + metadata", func(t *testing.T) {
 		tpl, err := loadTemplate("../testdata/policies.yaml")
 		require.NoError(t, err)

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -52,12 +52,23 @@ func initCloudformationTemplate(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 
 	transform, err := template.GetSection(cft.Transform)
-	if err == nil && len(transform.Content) > 0 {
+	if err == nil && transform != nil {
+		// Transform is commonly a single scalar (the canonical SAM header
+		// `Transform: AWS::Serverless-2016-10-31`), but may also be a list.
+		// A scalar YAML node has no Content, so handle both shapes.
 		var entries []string
-		for _, entry := range transform.Content {
-			entries = append(entries, entry.Value)
+		if transform.Kind == yaml.ScalarNode {
+			if transform.Value != "" {
+				entries = append(entries, transform.Value)
+			}
+		} else {
+			for _, entry := range transform.Content {
+				entries = append(entries, entry.Value)
+			}
 		}
-		args["transform"] = llx.ArrayData(convert.SliceAnyToInterface(entries), types.String)
+		if len(entries) > 0 {
+			args["transform"] = llx.ArrayData(convert.SliceAnyToInterface(entries), types.String)
+		}
 	}
 
 	return args, nil, nil

--- a/providers/cloudformation/testdata/transform-scalar.yaml
+++ b/providers/cloudformation/testdata/transform-scalar.yaml
@@ -1,0 +1,7 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x


### PR DESCRIPTION
## Summary

A bug audit of the cloudformation provider found one impactful correctness bug and two unguarded slice indices.

## Fixes

**SAM `Transform` silently dropped (HIGH)** — `resources/template.go`
The `Transform` section was only read when its YAML node had `Content`:
```go
if err == nil && len(transform.Content) > 0 { ... }
```
A scalar YAML node has no `Content`, and the canonical SAM header is a scalar — `Transform: AWS::Serverless-2016-10-31`. So every plain SAM template reported `transform == null` instead of `["AWS::Serverless-2016-10-31"]`; only the list form (`Transform: [A, B]`) was handled. The `.lr` field is `transform []string`, so the single-element-array form is the intended representation. Now handles both scalar and list shapes.

**`ParseCLI` panics with no path arg (HIGH)** — `provider/provider.go`
`conf.Options["path"] = req.Args[0]` indexed with no length check → index-out-of-range panic when invoked without a positional path. The sibling helm/bicep providers guard this exact case; added the guard.

**`NewCloudformationConnection` panics on empty connections (MEDIUM)** — `connection/connection.go`
`cc := asset.Connections[0]` indexed with no length check in the constructor. Added a guard so a malformed asset returns an error rather than panicking.

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_