### PR TITLE
🐛 ansible: guard nil task/play accessors, list-form inventory hosts, and CLI args

### DIFF
--- a/providers/ansible/project/inventory.go
+++ b/providers/ansible/project/inventory.go
@@ -273,11 +273,20 @@ func walkYAMLGroup(b *inventoryBuilder, name string, body any) {
 		return
 	}
 
-	if hosts, ok := m["hosts"].(map[string]any); ok {
+	switch hosts := m["hosts"].(type) {
+	case map[string]any:
 		for host, hv := range hosts {
 			b.addHostToGroup(name, host)
 			if vars, ok := hv.(map[string]any); ok {
 				maps.Copy(b.host(host).Vars, vars)
+			}
+		}
+	case []any:
+		// Ansible also accepts a `hosts:` list (each element a hostname with
+		// no per-host vars); a map type-assertion alone silently dropped them.
+		for _, hv := range hosts {
+			if host, ok := hv.(string); ok && host != "" {
+				b.addHostToGroup(name, host)
 			}
 		}
 	}

--- a/providers/ansible/project/project_test.go
+++ b/providers/ansible/project/project_test.go
@@ -66,3 +66,33 @@ func TestSymlinkVarsEscapeSkipped(t *testing.T) {
 		}
 	}
 }
+
+// A YAML inventory written with `hosts:` as a list (each element a bare
+// hostname, which Ansible accepts) must be honored, not silently dropped by a
+// map-only type assertion.
+func TestInventoryYAMLListHosts(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "inventory.yml"),
+		[]byte("web:\n  hosts:\n    - web1\n    - web2\n"),
+		0o600,
+	))
+
+	inv, err := loadInventory(root)
+	require.NoError(t, err)
+	require.NotNil(t, inv)
+
+	groups := map[string]*InventoryGroup{}
+	for _, g := range inv.Groups {
+		groups[g.Name] = g
+	}
+	require.Contains(t, groups, "web")
+	assert.ElementsMatch(t, []string{"web1", "web2"}, groups["web"].Hosts)
+
+	hosts := map[string]*InventoryHost{}
+	for _, h := range inv.Hosts {
+		hosts[h.Name] = h
+	}
+	assert.Contains(t, hosts, "web1")
+	assert.Contains(t, hosts, "web2")
+}

--- a/providers/ansible/provider/provider.go
+++ b/providers/ansible/provider/provider.go
@@ -47,6 +47,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	// Do custom flag parsing here
+	if len(req.Args) == 0 {
+		return nil, errors.New("no ansible project path provided")
+	}
 	conf.Options["path"] = req.Args[0]
 
 	asset := inventory.Asset{

--- a/providers/ansible/resources/ansible.go
+++ b/providers/ansible/resources/ansible.go
@@ -83,6 +83,9 @@ type mqlAnsiblePlayInternal struct {
 // directives (when, tags, vars) and the resolved role. Standalone playbook
 // files resolve the role to null.
 func (r *mqlAnsiblePlay) roleApplications() ([]any, error) {
+	if r.play == nil {
+		return []any{}, nil
+	}
 	apps := r.play.RoleApplications()
 	out := make([]any, 0, len(apps))
 	for i, app := range apps {
@@ -158,6 +161,9 @@ func newMqlAnsibleHandlers(runtime *plugin.Runtime, parentID string, handlers []
 }
 
 func (r *mqlAnsiblePlay) handlers() ([]any, error) {
+	if r.play == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleHandlers(r.MqlRuntime, r.MqlID(), r.play.Handlers)
 }
 
@@ -217,34 +223,58 @@ type mqlAnsibleTaskInternal struct {
 }
 
 func (r *mqlAnsibleTask) module() (string, error) {
+	if r.task == nil {
+		return "", nil
+	}
 	return r.task.Module(), nil
 }
 
 func (r *mqlAnsibleTask) moduleArgs() (any, error) {
+	if r.task == nil {
+		return nil, nil
+	}
 	return normalizeDict(r.task.ModuleArgs()), nil
 }
 
 func (r *mqlAnsiblePlay) preTasks() ([]any, error) {
+	if r.play == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "preTasks", r.baseDir, r.play.PreTasks)
 }
 
 func (r *mqlAnsiblePlay) tasks() ([]any, error) {
+	if r.play == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "tasks", r.baseDir, r.play.Tasks)
 }
 
 func (r *mqlAnsiblePlay) postTasks() ([]any, error) {
+	if r.play == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "postTasks", r.baseDir, r.play.PostTasks)
 }
 
 func (r *mqlAnsibleTask) block() ([]any, error) {
+	if r.task == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "block", r.baseDir, r.task.Block)
 }
 
 func (r *mqlAnsibleTask) rescue() ([]any, error) {
+	if r.task == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "rescue", r.baseDir, r.task.Rescue)
 }
 
 func (r *mqlAnsibleTask) always() ([]any, error) {
+	if r.task == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "always", r.baseDir, r.task.Always)
 }
 
@@ -252,6 +282,9 @@ func (r *mqlAnsibleTask) always() ([]any, error) {
 // parsed tasks of the target file. A Jinja2-templated or unresolvable path
 // yields an empty list; the raw string fields remain authoritative.
 func (r *mqlAnsibleTask) importedTasks() ([]any, error) {
+	if r.task == nil {
+		return []any{}, nil
+	}
 	ref := firstNonEmpty(r.task.ImportTasks, r.task.IncludeTasks)
 	path := r.resolveRef(ref)
 	if path == "" {
@@ -272,6 +305,10 @@ func (r *mqlAnsibleTask) importedTasks() ([]any, error) {
 // reference to the parsed playbook. A Jinja2-templated or unresolvable path
 // yields null.
 func (r *mqlAnsibleTask) importedPlaybook() (*mqlAnsiblePlaybook, error) {
+	if r.task == nil {
+		r.ImportedPlaybook.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	ref := firstNonEmpty(r.task.ImportPlaybook, r.task.IncludePlaybook)
 	path := r.resolveRef(ref)
 	if path == "" {


### PR DESCRIPTION
## Summary

A bug audit of the ansible provider found a latent nil-deref class, a silent inventory data-loss case, and an unguarded CLI arg index. The provider is otherwise carefully written (good path-traversal guards, comma-ok assertions, `StateIsNull` on singular nil returns).

## Fixes

**Unguarded `r.task` / `r.play` dereferences (MEDIUM, latent)** — `resources/ansible.go`
The `ansible.task` and `ansible.play` computed accessors — `module`, `moduleArgs`, `block`, `rescue`, `always`, `importedTasks`, `importedPlaybook`, `preTasks`, `tasks`, `postTasks`, `handlers`, `roleApplications` — dereferenced the Internal `task`/`play` pointer with no nil check. Those pointers are populated only in the freshly-built path (`newMqlAnsibleTask`/`newMqlAnsiblePlay`), so a resource reconstructed via recording/replay (or resolved without its parser model) would panic. Added guards consistent with the existing `role()` accessor, which already nil-checks (the singular `importedPlaybook` sets `StateIsNull`).

**List-form inventory hosts silently dropped (LOW-MEDIUM)** — `project/inventory.go`
A YAML inventory group written with `hosts:` as a **list** (`hosts:\n  - web1\n  - web2`, which Ansible accepts) was dropped entirely — only the mapping form (`hosts: {web1: {...}}`) was handled, so the `[]any` type-assertion failed silently and the group's hosts vanished. Now handles both shapes.

**`ParseCLI` panics with no path arg (clear)** — `provider/provider.go`
`conf.Options["path"] = req.Args[0]` indexed with no length check; added a guard so invoking without a positional path returns an error instead of panicking (matching the other IaC providers).

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_