### PR TITLE
🐛 helm: surface dropped rendered manifests and guard oversized downloads

### DIFF
--- a/providers/helm/connection/fetch.go
+++ b/providers/helm/connection/fetch.go
@@ -225,8 +225,9 @@ func resolveChartInRepo(repoURL, chartName, version, username, password string) 
 var chartHTTPClient = &http.Client{Timeout: 60 * time.Second}
 
 // maxChartDownloadSize caps a downloaded chart archive or repository index
-// (128 MiB) so a misbehaving repo can't exhaust memory.
-const maxChartDownloadSize = 128 << 20
+// (128 MiB) so a misbehaving repo can't exhaust memory. It is a var (not a
+// const) only so tests can lower it without downloading 128 MiB.
+var maxChartDownloadSize int64 = 128 << 20
 
 // httpGetBytes fetches a URL with optional basic auth, a request timeout,
 // and a bounded read.
@@ -253,7 +254,7 @@ func httpGetBytes(rawURL, username, password string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(data) > maxChartDownloadSize {
+	if int64(len(data)) > maxChartDownloadSize {
 		return nil, fmt.Errorf("response from %q exceeds the maximum allowed size of %d bytes", rawURL, maxChartDownloadSize)
 	}
 	return data, nil

--- a/providers/helm/connection/fetch.go
+++ b/providers/helm/connection/fetch.go
@@ -246,7 +246,17 @@ func httpGetBytes(rawURL, username, password string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch %q: status %d", rawURL, resp.StatusCode)
 	}
-	return io.ReadAll(io.LimitReader(resp.Body, maxChartDownloadSize))
+	// Read up to one byte past the cap so we can tell "exactly at the limit"
+	// from "exceeds the limit". io.LimitReader alone returns EOF at the cap
+	// with no error, silently truncating an oversized archive/index.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxChartDownloadSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxChartDownloadSize {
+		return nil, fmt.Errorf("response from %q exceeds the maximum allowed size of %d bytes", rawURL, maxChartDownloadSize)
+	}
+	return data, nil
 }
 
 // lastPathSegment returns the final path segment of a registry reference,

--- a/providers/helm/connection/fetch_test.go
+++ b/providers/helm/connection/fetch_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpGetBytes must reject a response that exceeds maxChartDownloadSize rather
+// than silently truncating it (io.LimitReader returns EOF at the cap with no
+// error). A body at or under the cap is returned intact.
+func TestHttpGetBytesSizeLimit(t *testing.T) {
+	orig := maxChartDownloadSize
+	maxChartDownloadSize = 64
+	defer func() { maxChartDownloadSize = orig }()
+	capN := int(maxChartDownloadSize)
+
+	t.Run("oversized response errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(strings.Repeat("A", capN+10)))
+		}))
+		defer srv.Close()
+
+		_, err := httpGetBytes(srv.URL, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maximum allowed size")
+	})
+
+	t.Run("body within the cap is returned intact", func(t *testing.T) {
+		body := strings.Repeat("B", capN)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(body))
+		}))
+		defer srv.Close()
+
+		data, err := httpGetBytes(srv.URL, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, body, string(data))
+	})
+}

--- a/providers/helm/resources/resource.go
+++ b/providers/helm/resources/resource.go
@@ -50,6 +50,9 @@ func parseK8sResources(runtime *plugin.Runtime, templateKey string, content stri
 
 		var obj map[string]any
 		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+			// A document that fails to parse would silently vanish from the
+			// audit (a policy could then pass vacuously); surface it.
+			log.Warn().Err(err).Str("templateKey", templateKey).Msg("helm: skipping rendered document that failed to parse")
 			continue
 		}
 
@@ -91,6 +94,7 @@ func parseK8sResources(runtime *plugin.Runtime, templateKey string, content stri
 
 		manifest, err := convert.JsonToDict(obj)
 		if err != nil {
+			log.Warn().Err(err).Str("templateKey", templateKey).Str("kind", kind).Msg("helm: skipping rendered resource that failed to convert")
 			continue
 		}
 

--- a/providers/helm/resources/resource_test.go
+++ b/providers/helm/resources/resource_test.go
@@ -426,3 +426,30 @@ func TestParseK8sResourcesDocumentSeparatorInValue(t *testing.T) {
 		require.Len(t, resources, 2)
 	})
 }
+
+// TestParseK8sResourcesSkipsMalformed ensures a rendered document that fails to
+// parse is skipped (and surfaced via a log) without dropping the valid
+// resources around it.
+func TestParseK8sResourcesSkipsMalformed(t *testing.T) {
+	yaml := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: good
+---
+- this is a yaml sequence, not a kubernetes object
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: also-good`
+
+	resources, err := parseK8sResources(newTestRuntime(), "mychart/templates/mixed.yaml", yaml, false)
+	require.NoError(t, err)
+	require.Len(t, resources, 2, "the malformed document is skipped; the two valid resources remain")
+
+	names := map[string]bool{}
+	for _, r := range resources {
+		names[r.(*mqlHelmResource).Name.Data] = true
+	}
+	assert.True(t, names["good"] && names["also-good"])
+}


### PR DESCRIPTION
## Summary

A bug audit of the helm provider found two silent-data-loss issues. The provider is otherwise solid (the `__id` schemes, YAML doc-splitting, `StateIsNull` handling, and temp-dir cleanup all check out).

## Fixes

**Dropped rendered manifests were silent (MEDIUM)** — `resources/resource.go`
`parseK8sResources` `continue`d past any rendered document that failed to `yaml.Unmarshal` or `convert.JsonToDict`, with no log line. For a static-analysis tool, a manifest that silently vanishes from the audit is a real correctness hazard — a policy like "every Deployment sets runAsNonRoot" passes vacuously if the offending Deployment failed to parse and disappeared. Now logs a warning (with the template key / kind) so dropped resources are observable. (The legitimate "non-K8s doc, no `kind`" skip stays silent.)

**Oversized downloads silently truncated (MEDIUM)** — `connection/fetch.go`
`httpGetBytes` used `io.ReadAll(io.LimitReader(body, maxChartDownloadSize))`, which returns EOF at the cap with **no error**. An oversized chart archive or `index.yaml` was silently truncated and handed to the loader/parser as if complete — a truncated `index.yaml` parses as valid-but-incomplete, making `resolveChartInRepo` "not find" a chart that's actually published past the cutoff. Now reads one byte past the cap and errors when the limit is exceeded.

## Deferred (needs care + test coverage)

The subchart `helm.resource → helm.template` cross-reference: `templateID = strings.Replace(templateKey, "/", ":", 1)` replaces only the **first** slash, so a subchart template key (`parent/charts/sub/templates/x.yaml`) doesn't match the subchart template's actual `__id` (`helm.template:sub:templates/x.yaml`), and the resource resolves an empty template stub. Aligning the two id schemes is best done with subchart-render test coverage, so I left it out of this PR rather than risk regressing the working single-chart path.

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_