### PR TITLE
🐛 kustomize: don't silently misclassify a valid patch file as empty

### DIFF
--- a/providers/kustomize/resources/kustomize_test.go
+++ b/providers/kustomize/resources/kustomize_test.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +48,39 @@ func TestReplacementTargetsWithoutFieldPaths(t *testing.T) {
 	targets, err := r.targets()
 	require.NoError(t, err)
 	assert.Len(t, targets, 3, "target with no fieldPaths must still emit one row")
+}
+
+// TestNewMqlKustomizePatchReadsFile ensures a patch that references a JSON6902
+// file (relative to the kustomization dir) is actually read and classified —
+// not silently misclassified as an empty strategic-merge patch — while a path
+// that escapes the directory is refused.
+func TestNewMqlKustomizePatchReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	patchBody := "- op: replace\n  path: /spec/replicas\n  value: 3\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "patch.yaml"), []byte(patchBody), 0o600))
+
+	t.Run("reads a contained patch file", func(t *testing.T) {
+		p, err := newMqlKustomizePatch(newTestRuntime(), dir, 0, &kustomizeTypes.Patch{Path: "patch.yaml"}, hintNone)
+		require.NoError(t, err)
+		assert.Equal(t, patchFormatJSON6902, p.format)
+
+		ops, err := p.operations()
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
+	})
+
+	t.Run("refuses a path escaping the kustomization dir", func(t *testing.T) {
+		// Write a would-be patch outside the kustomization directory.
+		outside := filepath.Join(filepath.Dir(dir), "escape.yaml")
+		require.NoError(t, os.WriteFile(outside, []byte(patchBody), 0o600))
+		defer os.Remove(outside)
+
+		p, err := newMqlKustomizePatch(newTestRuntime(), dir, 0, &kustomizeTypes.Patch{Path: "../escape.yaml"}, hintNone)
+		require.NoError(t, err)
+		// Not read -> falls back to an empty strategic-merge patch.
+		assert.Equal(t, patchFormatStrategicMerge, p.format)
+		ops, err := p.operations()
+		require.NoError(t, err)
+		assert.Empty(t, ops)
+	})
 }

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"gopkg.in/yaml.v3"
@@ -78,14 +79,32 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 		// containment check so a symlinked scan root (e.g. /tmp on macOS,
 		// which resolves to /private/tmp) doesn't cause false rejections.
 		full := filepath.Join(kustPath, p.Path)
-		base, baseErr := filepath.EvalSymlinks(kustPath)
-		resolved, resErr := filepath.EvalSymlinks(full)
-		if baseErr == nil && resErr == nil {
-			if rel, err := filepath.Rel(base, resolved); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				if data, err := os.ReadFile(resolved); err == nil {
-					raw = data
-				}
+		// Prefer symlink-resolved paths for the containment check (this catches
+		// a symlink inside the directory whose target escapes it). When symlink
+		// resolution fails for any reason other than the target being a
+		// resolvable escape — e.g. a broken/unresolvable symlink component in
+		// kustPath itself — fall back to a lexical containment check so a
+		// perfectly readable patch file isn't silently dropped and misclassified
+		// as an empty strategic-merge patch.
+		base, target := filepath.Clean(kustPath), filepath.Clean(full)
+		if rb, err1 := filepath.EvalSymlinks(kustPath); err1 == nil {
+			if rt, err2 := filepath.EvalSymlinks(full); err2 == nil {
+				base, target = rb, rt
 			}
+		}
+		if rel, err := filepath.Rel(base, target); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			data, readErr := os.ReadFile(target)
+			switch {
+			case readErr == nil:
+				raw = data
+			case !os.IsNotExist(readErr):
+				// A genuinely missing file is the expected best-effort case; any
+				// other read failure would silently misclassify the patch, so
+				// surface it.
+				log.Warn().Err(readErr).Str("path", p.Path).Msg("kustomize: could not read patch file; treating it as an empty patch")
+			}
+		} else {
+			log.Warn().Str("path", p.Path).Msg("kustomize: patch path escapes the kustomization directory; ignoring")
 		}
 	}
 


### PR DESCRIPTION
## Summary

A bug audit of the kustomize provider found one MEDIUM correctness issue in patch-file reading. The provider is otherwise notably defensive (comma-ok assertions, nil checks on `p.Target`/`r.Source`, per-resource skip on render errors, `__id` disambiguation by index).

## Fix

`resources/patch.go` — when a patch references a file (rather than inline content), the containment check required `filepath.EvalSymlinks` to succeed for **both** the kustomization directory and the candidate path:

```go
base, baseErr := filepath.EvalSymlinks(kustPath)
resolved, resErr := filepath.EvalSymlinks(full)
if baseErr == nil && resErr == nil { ... read ... }
```

`EvalSymlinks` errors if *any* path component doesn't exist. So if symlink resolution failed for a reason other than a resolvable escape — e.g. a broken/unresolvable symlink component in `kustPath` itself — the whole read was skipped and the patch was silently misclassified as an empty strategic-merge patch (zero operations). Audits over `patch.format` / `patch.operations` then saw nothing, with no warning.

Now:
- Prefer symlink-resolved paths for the containment check (still catches a symlink inside the dir whose target escapes it — that case resolves and is rejected).
- Fall back to a **lexical** containment check when symlink resolution fails, so a perfectly readable patch file isn't dropped.
- A genuinely missing file stays the silent best-effort case; any other read failure, or a path that escapes the directory, is now **logged** rather than vanishing.

Security note: a *working* malicious symlink (target outside the dir) still resolves via `EvalSymlinks` and is caught by the strict resolved-path containment check; the lexical fallback only applies when resolution fails, in which case the file isn't readable through that symlink anyway.

## Verification

`go build`, `go vet`, `go test ./...`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MQPNzTRjGVKGfadTTizW)_