### PR TITLE
🧹 Regenerate permissions.json for aws, azure, gcp

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.37.0",
-  "generated_at": "2026-06-23T12:59:19-06:00",
+  "version": "13.38.0",
+  "generated_at": "2026-06-23T15:34:34-06:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.19.1",
-  "generated_at": "2026-06-12T17:40:19-07:00",
+  "version": "13.21.0",
+  "generated_at": "2026-06-23T15:34:34-06:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.23.1",
-  "generated_at": "2026-06-12T17:40:19-07:00",
+  "version": "13.25.0",
+  "generated_at": "2026-06-23T15:34:34-06:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",


### PR DESCRIPTION
## Summary

Regenerates the `*.permissions.json` manifests for the AWS, Azure, and GCP providers so their `version` fields match the current provider versions.

- aws: `13.37.0` → `13.38.0`
- azure: `13.19.1` → `13.21.0`
- gcp: `13.23.1` → `13.25.0`

Only the `version` and `generated_at` metadata changed — the permission lists themselves are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)