### PR TITLE
🟢 gcp: fix fnV2ServiceConfig test build failure (CI from #8706)

### DIFF
--- a/providers/gcp/resources/cloud_functions_v2_test.go
+++ b/providers/gcp/resources/cloud_functions_v2_test.go
@@ -21,7 +21,7 @@ func TestFnV2BuildConfig(t *testing.T) {
 
 func TestFnV2ServiceConfig(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
-		result, err := fnV2ServiceConfig(nil, "parent", nil)
+		result, err := fnV2ServiceConfig(nil, "parent", "", nil)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})


### PR DESCRIPTION
## Problem

The `go-test` CI job is failing on `main` (introduced via the deps-update PR #8706 run, but the root cause predates it). The GCP provider's resources package fails to build:

```
resources/cloud_functions_v2_test.go:24:51: not enough arguments in call to fnV2ServiceConfig
  have (nil, string, nil)
  want (*plugin.Runtime, string, string, *functionspb.ServiceConfig)
```

## Root cause

PR #8672 ("gcp: pass projectId when resolving cloud function service accounts") added a `projectId string` parameter to `fnV2ServiceConfig`, but did not update `TestFnV2ServiceConfig`, which still called it with three arguments. This is a build failure for the whole `providers/gcp/resources` test package.

## Fix

Pass an empty `projectId` in the test call. Since the test input `cfg` is `nil`, `fnV2ServiceConfig` returns early before the value is used, so `""` is appropriate — this matches the sibling `TestFnV2EventTrigger`, which already passes `""` for the same parameter.

## Verification

```
go test ./resources/ -run 'TestFnV2'
ok  	go.mondoo.com/mql/v13/providers/gcp/resources
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzKXdgnUBmn7gmuEcRxGVN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzKXdgnUBmn7gmuEcRxGVN)_