### PR TITLE
✨ terraform: resolve variables

### DIFF
--- a/feature_string.go
+++ b/feature_string.go
@@ -24,11 +24,12 @@ func _() {
 	_ = x[AutoUpdateEngine-14]
 	_ = x[BiosUUIDAsID-15]
 	_ = x[ExchangeTokenForToken-16]
+	_ = x[TerraformResolveVars-17]
 }
 
-const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsIDExchangeTokenForToken"
+const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsIDExchangeTokenForTokenTerraformResolveVars"
 
-var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229, 250}
+var _Feature_index = [...]uint16{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229, 250, 270}
 
 func (i Feature) String() string {
 	idx := int(i) - 1

--- a/features.go
+++ b/features.go
@@ -92,9 +92,14 @@ const (
 	// status: new
 	ExchangeTokenForToken Feature = 16
 
+	// Resolve var.* and local.* references in Terraform HCL block arguments to their effective values (variable defaults overridden by .tfvars, locals evaluated from those). Unresolvable references fall back to their reference string; the unresolved view stays available via terraform.block.argumentReferences.
+	// start:  v13.x
+	// status: new
+	TerraformResolveVars Feature = 17
+
 	// Placeholder to indicate how many feature flags exist. This number
 	// is changing with every new feature and cannot be used as a featureflag itself.
-	MAX_FEATURES byte = 17
+	MAX_FEATURES byte = 18
 )
 
 var FeaturesValue = map[string]Feature{
@@ -114,6 +119,7 @@ var FeaturesValue = map[string]Feature{
 	"AutoUpdateEngine":      AutoUpdateEngine,
 	"BiosUUIDAsID":          BiosUUIDAsID,
 	"ExchangeTokenForToken": ExchangeTokenForToken,
+	"TerraformResolveVars":  TerraformResolveVars,
 }
 
 // DefaultFeatures are a set of default flags that are active
@@ -131,4 +137,5 @@ var AvailableFeatures = Features{
 	byte(AutoUpdateEngine),
 	byte(BiosUUIDAsID),
 	byte(ExchangeTokenForToken),
+	byte(TerraformResolveVars),
 }

--- a/features.yaml
+++ b/features.yaml
@@ -93,3 +93,8 @@ Features:
   idx: 16
   start: v13.x
   status: new
+- id: TerraformResolveVars
+  desc: "Resolve var.* and local.* references in Terraform HCL block arguments to their effective values (variable defaults overridden by .tfvars, locals evaluated from those). Unresolvable references fall back to their reference string; the unresolved view stays available via terraform.block.argumentReferences."
+  idx: 17
+  start: v13.x
+  status: new

--- a/providers/terraform/connection/connection.go
+++ b/providers/terraform/connection/connection.go
@@ -4,6 +4,8 @@
 package connection
 
 import (
+	"sync"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -29,6 +31,25 @@ type Connection struct {
 	state           *State
 	plan            *Plan
 	closer          func()
+
+	// features carries the active MQL feature flags (encoded bitset) for this
+	// connection. Used to gate behaviors like Terraform variable resolution.
+	features []byte
+
+	// varCtx memoizes the resolved var.*/local.* evaluation context so it is
+	// built only once per connection. Guarded by varCtxOnce.
+	varCtx     *hcl.EvalContext
+	varCtxOnce sync.Once
+}
+
+// SetFeatures stores the active MQL feature-flag bitset on the connection.
+func (c *Connection) SetFeatures(features []byte) {
+	c.features = features
+}
+
+// Features returns the active MQL feature-flag bitset for this connection.
+func (c *Connection) Features() []byte {
+	return c.features
 }
 
 func (c *Connection) Close() {

--- a/providers/terraform/connection/hcl_vars.go
+++ b/providers/terraform/connection/hcl_vars.go
@@ -1,0 +1,121 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// hclEvalFunctions returns the function table used when evaluating HCL
+// expressions for variable/local resolution. It mirrors the small set
+// supported by the resource layer so resolution stays consistent.
+func hclEvalFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		"jsondecode": stdlib.JSONDecodeFunc,
+		"jsonencode": stdlib.JSONEncodeFunc,
+	}
+}
+
+// VariableEvalContext lazily builds and caches an hcl.EvalContext that resolves
+// var.* and local.* references for this connection.
+//
+// Variable values come from `variable` block defaults, overridden by values in
+// .tfvars / .tfvars.json (Terraform precedence). Locals are then evaluated from
+// those, using a bounded multi-pass fixpoint so that locals referencing other
+// locals (or variables) resolve regardless of declaration order. References
+// that cannot be resolved statically (data sources, resource attributes,
+// circular locals, missing values) are simply left out of the context, so the
+// caller falls back to surfacing them as reference strings.
+//
+// It returns nil for assets without an HCL parser (plan/state).
+func (c *Connection) VariableEvalContext() *hcl.EvalContext {
+	c.varCtxOnce.Do(func() {
+		c.varCtx = c.buildVariableEvalContext()
+	})
+	return c.varCtx
+}
+
+func (c *Connection) buildVariableEvalContext() *hcl.EvalContext {
+	if c.parsed == nil {
+		return nil
+	}
+
+	// base context used to evaluate variable defaults and tfvars; these must not
+	// reference other vars/locals, so an empty (functions-only) context is right.
+	baseCtx := &hcl.EvalContext{Functions: hclEvalFunctions()}
+
+	vars := map[string]cty.Value{}
+	localExprs := map[string]hcl.Expression{}
+
+	for _, file := range c.parsed.Files() {
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			// .tf.json and other non-native bodies are not walked here; their
+			// vars/locals stay unresolved (surfaced as reference strings).
+			continue
+		}
+		for _, block := range body.Blocks {
+			switch block.Type {
+			case "variable":
+				if len(block.Labels) == 0 {
+					continue
+				}
+				if attr, ok := block.Body.Attributes["default"]; ok {
+					if v, diags := attr.Expr.Value(baseCtx); !diags.HasErrors() {
+						vars[block.Labels[0]] = v
+					}
+				}
+			case "locals":
+				for name, attr := range block.Body.Attributes {
+					localExprs[name] = attr.Expr
+				}
+			}
+		}
+	}
+
+	// .tfvars values override variable defaults.
+	for name, attr := range c.tfVars {
+		if v, diags := attr.Expr.Value(baseCtx); !diags.HasErrors() {
+			vars[name] = v
+		}
+	}
+
+	ctx := &hcl.EvalContext{
+		Functions: hclEvalFunctions(),
+		Variables: map[string]cty.Value{},
+	}
+	if len(vars) > 0 {
+		ctx.Variables["var"] = cty.ObjectVal(vars)
+	}
+
+	// Resolve locals with a bounded fixpoint: each pass evaluates the
+	// not-yet-resolved locals against the context built so far, adding any that
+	// now succeed. We stop early once a pass makes no progress. The pass cap
+	// (number of locals) bounds even a fully chained set of locals.
+	locals := map[string]cty.Value{}
+	for pass := 0; pass <= len(localExprs); pass++ {
+		progress := false
+		for name, expr := range localExprs {
+			if _, done := locals[name]; done {
+				continue
+			}
+			if v, diags := expr.Value(ctx); !diags.HasErrors() {
+				locals[name] = v
+				progress = true
+			}
+		}
+		if len(locals) > 0 {
+			ctx.Variables["local"] = cty.ObjectVal(locals)
+		}
+		if !progress {
+			break
+		}
+	}
+
+	return ctx
+}

--- a/providers/terraform/connection/hcl_vars.go
+++ b/providers/terraform/connection/hcl_vars.go
@@ -11,10 +11,11 @@ import (
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 )
 
-// hclEvalFunctions returns the function table used when evaluating HCL
-// expressions for variable/local resolution. It mirrors the small set
-// supported by the resource layer so resolution stays consistent.
-func hclEvalFunctions() map[string]function.Function {
+// HCLEvalFunctions returns the function table used when evaluating HCL
+// expressions. It is the single source of truth shared by both variable/local
+// resolution here and expression evaluation in the resource layer, so the two
+// can never diverge.
+func HCLEvalFunctions() map[string]function.Function {
 	return map[string]function.Function{
 		"jsondecode": stdlib.JSONDecodeFunc,
 		"jsonencode": stdlib.JSONEncodeFunc,
@@ -47,7 +48,7 @@ func (c *Connection) buildVariableEvalContext() *hcl.EvalContext {
 
 	// base context used to evaluate variable defaults and tfvars; these must not
 	// reference other vars/locals, so an empty (functions-only) context is right.
-	baseCtx := &hcl.EvalContext{Functions: hclEvalFunctions()}
+	baseCtx := &hcl.EvalContext{Functions: HCLEvalFunctions()}
 
 	vars := map[string]cty.Value{}
 	localExprs := map[string]hcl.Expression{}
@@ -86,7 +87,7 @@ func (c *Connection) buildVariableEvalContext() *hcl.EvalContext {
 	}
 
 	ctx := &hcl.EvalContext{
-		Functions: hclEvalFunctions(),
+		Functions: HCLEvalFunctions(),
 		Variables: map[string]cty.Value{},
 	}
 	if len(vars) > 0 {
@@ -98,7 +99,7 @@ func (c *Connection) buildVariableEvalContext() *hcl.EvalContext {
 	// now succeed. We stop early once a pass makes no progress. The pass cap
 	// (number of locals) bounds even a fully chained set of locals.
 	locals := map[string]cty.Value{}
-	for pass := 0; pass <= len(localExprs); pass++ {
+	for pass := 0; pass < len(localExprs); pass++ {
 		progress := false
 		for name, expr := range localExprs {
 			if _, done := locals[name]; done {

--- a/providers/terraform/connection/hcl_vars_test.go
+++ b/providers/terraform/connection/hcl_vars_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tfVarsFromString(t *testing.T, src string) map[string]*hcl.Attribute {
+	t.Helper()
+	f, diags := hclsyntax.ParseConfig([]byte(src), "test.tfvars", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "tfvars parse errors: %s", diags.Error())
+	attrs, diags := f.Body.JustAttributes()
+	require.False(t, diags.HasErrors(), "tfvars attribute errors: %s", diags.Error())
+	return attrs
+}
+
+func TestVariableEvalContext(t *testing.T) {
+	parser := hclparse.NewParser()
+	_, diags := parser.ParseHCL([]byte(`
+variable "bucket_acl" { default = "public-read" }
+variable "env"        { default = "prod" }
+variable "no_default" { type = string }
+
+locals {
+  acl   = var.env == "prod" ? "private" : "public-read"
+  chain = local.acl
+}
+`), "main.tf")
+	require.False(t, diags.HasErrors(), "hcl parse errors: %s", diags.Error())
+
+	// .tfvars overrides the variable default (Terraform precedence).
+	c := &Connection{
+		parsed: parser,
+		tfVars: tfVarsFromString(t, `bucket_acl = "log-delivery-write"`),
+	}
+
+	ctx := c.VariableEvalContext()
+	require.NotNil(t, ctx)
+
+	vars := ctx.Variables["var"]
+	require.False(t, vars.IsNull())
+	assert.Equal(t, "log-delivery-write", vars.GetAttr("bucket_acl").AsString(), "tfvars should override the default")
+	assert.Equal(t, "prod", vars.GetAttr("env").AsString(), "default should be used when no tfvars value")
+	// a variable without a default and without a tfvars value is absent.
+	assert.False(t, vars.Type().HasAttribute("no_default"))
+
+	locals := ctx.Variables["local"]
+	require.False(t, locals.IsNull())
+	assert.Equal(t, "private", locals.GetAttr("acl").AsString(), "local should resolve via var")
+	assert.Equal(t, "private", locals.GetAttr("chain").AsString(), "local-referencing-local should resolve via fixpoint")
+
+	// memoized: a second call returns the same context.
+	assert.Same(t, ctx, c.VariableEvalContext())
+}
+
+// TestVariableEvalContext_NoParser ensures plan/state assets (no HCL parser)
+// produce a nil context rather than panicking.
+func TestVariableEvalContext_NoParser(t *testing.T) {
+	c := &Connection{}
+	assert.Nil(t, c.VariableEvalContext())
+}

--- a/providers/terraform/provider/provider.go
+++ b/providers/terraform/provider/provider.go
@@ -168,6 +168,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			return nil, plugin.ErrUnsupportedProvider
 		}
 
+		conn.SetFeatures(req.Features)
+
 		var upstream *upstream.UpstreamClient
 		if req.Upstream != nil && !req.Upstream.Incognito {
 			upstream, err = req.Upstream.InitClient(context.Background())

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
+	mql "go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/checksums"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -60,7 +61,7 @@ func (t *mqlTerraform) files() ([]any, error) {
 
 func (t *mqlTerraform) tfvars() (any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
-	return hclAttributesToDict(conn.TfVars())
+	return hclAttributesToDict(conn.TfVars(), nil)
 }
 
 func (t *mqlTerraform) modules() ([]any, error) {
@@ -521,7 +522,23 @@ func (t *mqlTerraformBlock) attributes() (map[string]any, error) {
 
 	// do not handle diag information here, it also throws errors for blocks nearby
 	attributes, _ := hclBlock.Body.JustAttributes()
-	return hclAttributesToDict(attributes)
+	return hclAttributesToDict(attributes, t.evalContext())
+}
+
+// evalContext returns the HCL evaluation context used to resolve this block's
+// argument expressions. When the TerraformResolveVars feature flag is
+// active, it returns the connection's context that resolves var.*/local.*
+// references; otherwise it returns nil, preserving the historical behavior of
+// surfacing those references as strings.
+func (t *mqlTerraformBlock) evalContext() *hcl.EvalContext {
+	conn, ok := t.MqlRuntime.Connection.(*connection.Connection)
+	if !ok || conn == nil {
+		return nil
+	}
+	if !mql.Features(conn.Features()).IsActive(mql.TerraformResolveVars) {
+		return nil
+	}
+	return conn.VariableEvalContext()
 }
 
 func (t *mqlTerraformBlock) arguments() (map[string]any, error) {
@@ -537,7 +554,26 @@ func (t *mqlTerraformBlock) arguments() (map[string]any, error) {
 
 	// do not handle diag information here, it also throws errors for blocks nearby
 	attributes, _ := hclBlock.Body.JustAttributes()
-	return hclResolvedAttributesToDict(attributes)
+	return hclResolvedAttributesToDict(attributes, t.evalContext())
+}
+
+// argumentReferences returns the block's arguments with variable and local
+// references left unresolved (e.g. "var.bucket_acl"), regardless of the
+// TerraformResolveVars feature flag. Use it to inspect that a value is
+// parameterized even when arguments() resolves to the effective value.
+func (t *mqlTerraformBlock) argumentReferences() (map[string]any, error) {
+	var hclBlock *hcl.Block
+	if t.block.State == plugin.StateIsSet {
+		hclBlock = t.block.Data
+	} else {
+		if t.block.Error != nil {
+			return nil, t.block.Error
+		}
+		return nil, errors.New("cannot get hcl block")
+	}
+
+	attributes, _ := hclBlock.Body.JustAttributes()
+	return hclResolvedAttributesToDict(attributes, nil)
 }
 
 // hclBodyToValuesDict folds an HCL block body into a single dict in the same
@@ -546,7 +582,7 @@ func (t *mqlTerraformBlock) arguments() (map[string]any, error) {
 // list-of-maps keyed by its block type (recursively). This lets one MQL body
 // run against terraform-hcl, terraform-plan, and terraform-state assets
 // instead of three separately-written variants.
-func hclBodyToValuesDict(rawBody hcl.Body) (map[string]any, error) {
+func hclBodyToValuesDict(rawBody hcl.Body, ctx *hcl.EvalContext) (map[string]any, error) {
 	dict := map[string]any{}
 
 	body, ok := rawBody.(*hclsyntax.Body)
@@ -554,14 +590,14 @@ func hclBodyToValuesDict(rawBody hcl.Body) (map[string]any, error) {
 		// .tf.json and other non-native bodies: best effort, attributes only.
 		// Nested-block traversal needs a schema we don't have here.
 		attributes, _ := rawBody.JustAttributes()
-		return hclResolvedAttributesToDict(attributes)
+		return hclResolvedAttributesToDict(attributes, ctx)
 	}
 
 	attributes := make(map[string]*hcl.Attribute, len(body.Attributes))
 	for name, attr := range body.Attributes {
 		attributes[name] = attr.AsHCLAttribute()
 	}
-	resolved, err := hclResolvedAttributesToDict(attributes)
+	resolved, err := hclResolvedAttributesToDict(attributes, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +606,7 @@ func hclBodyToValuesDict(rawBody hcl.Body) (map[string]any, error) {
 	}
 
 	for _, block := range body.Blocks {
-		child, err := hclBodyToValuesDict(block.Body)
+		child, err := hclBodyToValuesDict(block.Body, ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -588,28 +624,36 @@ func (t *mqlTerraformBlock) values() (map[string]any, error) {
 		}
 		return nil, errors.New("cannot get hcl block")
 	}
-	return hclBodyToValuesDict(t.block.Data.Body)
+	return hclBodyToValuesDict(t.block.Data.Body, t.evalContext())
 }
 
-func hclResolvedAttributesToDict(attributes map[string]*hcl.Attribute) (map[string]any, error) {
+// hclEvalContextOrDefault returns ctx when it carries resolved variable/local
+// values, or a functions-only context (the historical, no-resolution behavior)
+// when ctx is nil.
+func hclEvalContextOrDefault(ctx *hcl.EvalContext) *hcl.EvalContext {
+	if ctx != nil {
+		return ctx
+	}
+	return &hcl.EvalContext{Functions: hclFunctions()}
+}
+
+func hclResolvedAttributesToDict(attributes map[string]*hcl.Attribute, ctx *hcl.EvalContext) (map[string]any, error) {
+	ctx = hclEvalContextOrDefault(ctx)
 	dict := map[string]any{}
 	for k := range attributes {
-		dict[k] = getCtyValue(attributes[k].Expr, &hcl.EvalContext{
-			Functions: hclFunctions(),
-		})
+		dict[k] = getCtyValue(attributes[k].Expr, ctx)
 	}
 	return dict, nil
 }
 
-func hclAttributesToDict(attributes map[string]*hcl.Attribute) (map[string]any, error) {
+func hclAttributesToDict(attributes map[string]*hcl.Attribute, ctx *hcl.EvalContext) (map[string]any, error) {
+	ctx = hclEvalContextOrDefault(ctx)
 	dict := map[string]any{}
 	for k := range attributes {
 		val, _ := attributes[k].Expr.Value(nil)
 		dict[k] = map[string]any{
-			"value": getCtyValue(attributes[k].Expr, &hcl.EvalContext{
-				Functions: hclFunctions(),
-			}),
-			"type": typeexpr.TypeString(val.Type()),
+			"value": getCtyValue(attributes[k].Expr, ctx),
+			"type":  typeexpr.TypeString(val.Type()),
 		}
 	}
 
@@ -637,6 +681,44 @@ func appendCtyResult(out *[]any, v any) {
 	}
 }
 
+// ctyValueToGo converts a fully-evaluated cty.Value into the plain Go types
+// used in the resource dict (string/bool/float64, []any, map[string]any). It
+// mirrors the scalar handling in getCtyValue's LiteralValueExpr case and
+// recurses into collections. Null/unknown values become nil.
+func ctyValueToGo(val cty.Value) any {
+	if val.IsNull() || !val.IsKnown() {
+		return nil
+	}
+
+	ty := val.Type()
+	switch {
+	case ty == cty.String:
+		return val.AsString()
+	case ty == cty.Bool:
+		return val.True()
+	case ty == cty.Number:
+		f, _ := val.AsBigFloat().Float64()
+		return f
+	case ty.IsListType() || ty.IsSetType() || ty.IsTupleType():
+		res := []any{}
+		for it := val.ElementIterator(); it.Next(); {
+			_, ev := it.Element()
+			res = append(res, ctyValueToGo(ev))
+		}
+		return res
+	case ty.IsMapType() || ty.IsObjectType():
+		res := map[string]any{}
+		for it := val.ElementIterator(); it.Next(); {
+			ek, ev := it.Element()
+			res[ek.AsString()] = ctyValueToGo(ev)
+		}
+		return res
+	default:
+		log.Warn().Msgf("unknown cty type %s", ty.GoString())
+		return nil
+	}
+}
+
 func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 	switch t := expr.(type) {
 	case *hclsyntax.TupleConsExpr:
@@ -652,6 +734,16 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return results
 	case *hclsyntax.ScopeTraversalExpr:
+		// When the eval context carries resolved var.*/local.* values (the
+		// TerraformResolveVars feature flag), resolve the traversal to its
+		// effective value. If it can't be resolved (no such variable/local,
+		// data/resource references, …), fall back to surfacing the reference as
+		// a dotted string below.
+		if ctx != nil && len(ctx.Variables) > 0 {
+			if val, diags := t.Value(ctx); !diags.HasErrors() {
+				return ctyValueToGo(val)
+			}
+		}
 		traversal := t.Variables()
 		res := []string{}
 		for i := range traversal {
@@ -779,6 +871,16 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 	case *hclsyntax.TemplateExpr:
 		// walk the parts of the expression to ensure that it has a literal value
+
+		// When the eval context carries resolved var.*/local.* values, a fully
+		// interpolated template (e.g. "app-${var.env}-bucket") can collapse to a
+		// single string. Attempt that first; otherwise fall back to surfacing the
+		// individual parts/references below (the historical behavior when off).
+		if len(ctx.Variables) > 0 {
+			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.Type() == cty.String {
+				return subVal.AsString()
+			}
+		}
 
 		if len(t.Parts) == 1 {
 			return getCtyValue(t.Parts[0], ctx)
@@ -1060,7 +1162,7 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 			requireProviderBlock := getBlockByName(hb, "required_providers")
 			if requireProviderBlock != nil {
 				attributes, _ := requireProviderBlock.Body.JustAttributes()
-				dict, err := hclResolvedAttributesToDict(attributes)
+				dict, err := hclResolvedAttributesToDict(attributes, nil)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -1095,7 +1197,7 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 			backendBlock := getBlockByName(hb, "backend")
 			if backendBlock != nil {
 				attributes, _ := backendBlock.Body.JustAttributes()
-				dict, err := hclResolvedAttributesToDict(attributes)
+				dict, err := hclResolvedAttributesToDict(attributes, nil)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
-	"github.com/zclconf/go-cty/cty/function/stdlib"
 	mql "go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/checksums"
 	"go.mondoo.com/mql/v13/llx"
@@ -61,6 +60,10 @@ func (t *mqlTerraform) files() ([]any, error) {
 
 func (t *mqlTerraform) tfvars() (any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
+	// .tfvars files hold the raw input values for variables, so they are
+	// surfaced verbatim here — we intentionally pass a nil eval context rather
+	// than resolving var.*/local.* references. (Variable resolution against
+	// these values happens in arguments() via the connection's eval context.)
 	return hclAttributesToDict(conn.TfVars(), nil)
 }
 
@@ -660,11 +663,11 @@ func hclAttributesToDict(attributes map[string]*hcl.Attribute, ctx *hcl.EvalCont
 	return dict, nil
 }
 
+// hclFunctions returns the HCL function table. It delegates to
+// connection.HCLEvalFunctions so expression evaluation here stays in lockstep
+// with the variable/local resolution done in the connection layer.
 func hclFunctions() map[string]function.Function {
-	return map[string]function.Function{
-		"jsondecode": stdlib.JSONDecodeFunc,
-		"jsonencode": stdlib.JSONEncodeFunc,
-	}
+	return connection.HCLEvalFunctions()
 }
 
 // appendCtyResult flattens nested []any results from getCtyValue into a single
@@ -876,7 +879,7 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		// interpolated template (e.g. "app-${var.env}-bucket") can collapse to a
 		// single string. Attempt that first; otherwise fall back to surfacing the
 		// individual parts/references below (the historical behavior when off).
-		if len(ctx.Variables) > 0 {
+		if ctx != nil && len(ctx.Variables) > 0 {
 			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.Type() == cty.String {
 				return subVal.AsString()
 			}

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/terraform/connection"
 )
@@ -138,7 +139,7 @@ func containsString(v any, target string) bool {
 // nil result.
 func TestGetCtyValue_ForExpr_Tuple(t *testing.T) {
 	attrs := parseAttrs(t, `vpc_security_group_ids = [for sg in data.aws_security_group.ec2 : sg.id]`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["vpc_security_group_ids"]
@@ -157,7 +158,7 @@ subnet_id_by_az_suffix = {
   zone => data.aws_subnet.ec2[zone].id
 }
 `)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["subnet_id_by_az_suffix"]
@@ -171,7 +172,7 @@ subnet_id_by_az_suffix = {
 // of an empty list.
 func TestGetCtyValue_ConditionalExpr_UnboundVars(t *testing.T) {
 	attrs := parseAttrs(t, `ami_id = var.disaster_recovery_mode ? var.disaster_recovery_ami_id : data.aws_ami.shared_image.id`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["ami_id"]
@@ -184,11 +185,95 @@ func TestGetCtyValue_ConditionalExpr_UnboundVars(t *testing.T) {
 		"result should reference data.aws_ami.shared_image.id, got: %#v", v)
 }
 
+// resolvingCtx builds an eval context with resolved var.*/local.* values,
+// mimicking what Connection.VariableEvalContext produces when the
+// TerraformResolveVars feature flag is active.
+func resolvingCtx(vars, locals map[string]cty.Value) *hcl.EvalContext {
+	ctx := &hcl.EvalContext{Functions: hclFunctions(), Variables: map[string]cty.Value{}}
+	if len(vars) > 0 {
+		ctx.Variables["var"] = cty.ObjectVal(vars)
+	}
+	if len(locals) > 0 {
+		ctx.Variables["local"] = cty.ObjectVal(locals)
+	}
+	return ctx
+}
+
+// TestResolveVariables_Scalar verifies that a var.* reference resolves to the
+// variable's effective value when the resolving context is supplied.
+func TestResolveVariables_Scalar(t *testing.T) {
+	attrs := parseAttrs(t, `acl = var.bucket_acl`)
+	ctx := resolvingCtx(map[string]cty.Value{"bucket_acl": cty.StringVal("public-read")}, nil)
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "public-read", got["acl"])
+}
+
+// TestResolveVariables_Local verifies local.* references resolve too.
+func TestResolveVariables_Local(t *testing.T) {
+	attrs := parseAttrs(t, `acl = local.acl`)
+	ctx := resolvingCtx(nil, map[string]cty.Value{"acl": cty.StringVal("private")})
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "private", got["acl"])
+}
+
+// TestResolveVariables_Types verifies non-string cty values convert to the
+// expected Go types (bool, number, list).
+func TestResolveVariables_Types(t *testing.T) {
+	ctx := resolvingCtx(map[string]cty.Value{
+		"enabled": cty.False,
+		"port":    cty.NumberIntVal(22),
+		"cidrs":   cty.ListVal([]cty.Value{cty.StringVal("0.0.0.0/0")}),
+		"tags":    cty.ObjectVal(map[string]cty.Value{"env": cty.StringVal("prod")}),
+	}, nil)
+	attrs := parseAttrs(t, `
+encrypted   = var.enabled
+from_port   = var.port
+cidr_blocks = var.cidrs
+env         = var.tags.env
+`)
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, false, got["encrypted"])
+	assert.Equal(t, float64(22), got["from_port"])
+	assert.Equal(t, []any{"0.0.0.0/0"}, got["cidr_blocks"])
+	assert.Equal(t, "prod", got["env"], "nested attribute access should resolve")
+}
+
+// TestResolveVariables_Fallback verifies that an unresolvable reference (no
+// such variable, or a data/resource ref) still falls back to the reference
+// string even when a resolving context is supplied.
+func TestResolveVariables_Fallback(t *testing.T) {
+	ctx := resolvingCtx(map[string]cty.Value{"bucket_acl": cty.StringVal("public-read")}, nil)
+
+	missing := parseAttrs(t, `acl = var.missing`)
+	got, err := hclResolvedAttributesToDict(missing, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "var.missing", got["acl"], "unknown var should fall back to reference string")
+
+	dataRef := parseAttrs(t, `ami = data.aws_ami.x.id`)
+	got, err = hclResolvedAttributesToDict(dataRef, ctx)
+	require.NoError(t, err)
+	assert.True(t, containsString(got["ami"], "data.aws_ami.x.id"),
+		"data references must still surface as a reference string, got: %#v", got["ami"])
+}
+
+// TestResolveVariables_TemplateInterpolation verifies a var embedded in a
+// string template resolves the whole string.
+func TestResolveVariables_TemplateInterpolation(t *testing.T) {
+	ctx := resolvingCtx(map[string]cty.Value{"env": cty.StringVal("prod")}, nil)
+	attrs := parseAttrs(t, `name = "app-${var.env}-bucket"`)
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "app-prod-bucket", got["name"])
+}
+
 // TestGetCtyValue_IndexExpr verifies that index expressions
 // like `m[k]` traverse into both the collection and the key.
 func TestGetCtyValue_IndexExpr(t *testing.T) {
 	attrs := parseAttrs(t, `subnet_id = local.subnet_id_by_az_suffix[local.az_suffix]`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["subnet_id"]
@@ -201,7 +286,7 @@ func TestGetCtyValue_IndexExpr(t *testing.T) {
 // like `var.x == "y"` surface their operand references.
 func TestGetCtyValue_BinaryOp(t *testing.T) {
 	attrs := parseAttrs(t, `match = var.availability_zone == "account_based"`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["match"]
@@ -214,7 +299,7 @@ func TestGetCtyValue_BinaryOp(t *testing.T) {
 // (e.g. result of an index/splat followed by `.field`) flow through.
 func TestGetCtyValue_RelativeTraversal(t *testing.T) {
 	attrs := parseAttrs(t, `first_id = random_shuffle.ec2.result[0]`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["first_id"]
@@ -227,7 +312,7 @@ func TestGetCtyValue_RelativeTraversal(t *testing.T) {
 // `data.aws_instances.all[*].id` surface the source reference.
 func TestGetCtyValue_SplatExpr(t *testing.T) {
 	attrs := parseAttrs(t, `instance_ids = data.aws_instances.all[*].id`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 
 	v := got["instance_ids"]
@@ -241,7 +326,7 @@ func TestGetCtyValue_SplatExpr(t *testing.T) {
 // — we only fall back to reference collection when evaluation fails.
 func TestGetCtyValue_StaticTernaryStillEvaluates(t *testing.T) {
 	attrs := parseAttrs(t, `pick = true ? "yes" : "no"`)
-	got, err := hclResolvedAttributesToDict(attrs)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
 	require.NoError(t, err)
 	assert.True(t, containsString(got["pick"], "yes"),
 		"static ternary should evaluate to 'yes', got: %#v", got["pick"])
@@ -273,7 +358,7 @@ locals {
 	for name, a := range localsBlock.Body.Attributes {
 		hclAttrs[name] = a.AsHCLAttribute()
 	}
-	dict, err := hclAttributesToDict(hclAttrs)
+	dict, err := hclAttributesToDict(hclAttrs, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, dict["subnet_id_by_az_suffix"])
@@ -320,7 +405,7 @@ resource "aws_eks_cluster" "example" {
 }
 `)
 
-	values, err := hclBodyToValuesDict(body)
+	values, err := hclBodyToValuesDict(body, nil)
 	require.NoError(t, err)
 
 	// Scalar arguments stay as direct values.
@@ -366,7 +451,7 @@ resource "google_sql_database_instance" "example" {
 }
 `)
 
-	values, err := hclBodyToValuesDict(body)
+	values, err := hclBodyToValuesDict(body, nil)
 	require.NoError(t, err)
 
 	settings, ok := values["settings"].([]any)

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -95,6 +95,8 @@ private terraform.block @defaults("type labels") @context("terraform.context") {
   end terraform.fileposition
   // Block arguments
   arguments() dict
+  // Block arguments with variable and local references left unresolved (e.g. "var.bucket_acl"), regardless of the TerraformResolveVars feature flag
+  argumentReferences() dict
   // Arguments with child blocks folded in as lists-of-maps, mirroring the plan (change.after) and state (values) shape
   values() dict
   // Raw block attributes

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -260,6 +260,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"terraform.block.arguments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetArguments()).ToDataRes(types.Dict)
 	},
+	"terraform.block.argumentReferences": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTerraformBlock).GetArgumentReferences()).ToDataRes(types.Dict)
+	},
 	"terraform.block.values": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformBlock).GetValues()).ToDataRes(types.Dict)
 	},
@@ -602,6 +605,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"terraform.block.arguments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTerraformBlock).Arguments, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"terraform.block.argumentReferences": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTerraformBlock).ArgumentReferences, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"terraform.block.values": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1375,20 +1382,21 @@ type mqlTerraformBlock struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlTerraformBlockInternal
-	Type         plugin.TValue[string]
-	Labels       plugin.TValue[[]any]
-	NameLabel    plugin.TValue[string]
-	ResourceType plugin.TValue[string]
-	ResourceName plugin.TValue[string]
-	Start        plugin.TValue[*mqlTerraformFileposition]
-	End          plugin.TValue[*mqlTerraformFileposition]
-	Arguments    plugin.TValue[any]
-	Values       plugin.TValue[any]
-	Attributes   plugin.TValue[any]
-	Blocks       plugin.TValue[[]any]
-	Related      plugin.TValue[[]any]
-	Snippet      plugin.TValue[string]
-	Context      plugin.TValue[*mqlTerraformContext]
+	Type               plugin.TValue[string]
+	Labels             plugin.TValue[[]any]
+	NameLabel          plugin.TValue[string]
+	ResourceType       plugin.TValue[string]
+	ResourceName       plugin.TValue[string]
+	Start              plugin.TValue[*mqlTerraformFileposition]
+	End                plugin.TValue[*mqlTerraformFileposition]
+	Arguments          plugin.TValue[any]
+	ArgumentReferences plugin.TValue[any]
+	Values             plugin.TValue[any]
+	Attributes         plugin.TValue[any]
+	Blocks             plugin.TValue[[]any]
+	Related            plugin.TValue[[]any]
+	Snippet            plugin.TValue[string]
+	Context            plugin.TValue[*mqlTerraformContext]
 }
 
 // createTerraformBlock creates a new instance of this resource
@@ -1465,6 +1473,12 @@ func (c *mqlTerraformBlock) GetEnd() *plugin.TValue[*mqlTerraformFileposition] {
 func (c *mqlTerraformBlock) GetArguments() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Arguments, func() (any, error) {
 		return c.arguments()
+	})
+}
+
+func (c *mqlTerraformBlock) GetArgumentReferences() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.ArgumentReferences, func() (any, error) {
+		return c.argumentReferences()
 	})
 }
 

--- a/providers/terraform/resources/terraform.lr.versions
+++ b/providers/terraform/resources/terraform.lr.versions
@@ -3,6 +3,7 @@
 
 terraform 9.0.0
 terraform.block 9.0.0
+terraform.block.argumentReferences 13.2.4
 terraform.block.arguments 9.0.0
 terraform.block.attributes 9.0.0
 terraform.block.blocks 9.0.0


### PR DESCRIPTION
Activate via MONDOO_FEATURES=TerraformResolveVariables.

Example:

```tf
locals {
  # public unless this is prod
  effective_acl = var.env == "prod" ? "private" : var.bucket_acl
}

resource "aws_s3_bucket" "logs" {
  bucket = "app-${var.env}-logs"
  acl    = local.effective_acl
}

resource "aws_s3_bucket" "assets" {
  bucket = "app-assets"
  acl    = var.bucket_acl        # resolves to "public-read"
}

variable "bucket_acl" {
  type    = string
  default = "public-read"        # insecure default
}

variable "env" {
  type    = string
  default = "prod"
}
```

Command:

```
mql run terraform ./tfvars -c "terraform.resources.map(arguments)"
```

Before:

```
terraform.resources.map: [
  0: {
    acl: "local.effective_acl"
    bucket: [
      0: "app-"
      1: "var.env"
      2: "-logs"
    ]
  }
  1: {
    acl: "var.bucket_acl"
    bucket: "app-assets"
  }
]
```

After:

```
terraform.resources.map: [
  0: {
    acl: "private"
    bucket: "app-prod-logs"
  }
  1: {
    acl: "public-read"
    bucket: "app-assets"
  }
]
```