### PR TITLE
✨ Add checkpoint provider to defaults

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -147,6 +147,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"checkpoint": {
+		Provider: &plugin.Provider{
+			Name:            "checkpoint",
+			ID:              "go.mondoo.com/cnquery/providers/checkpoint",
+			ConnectionTypes: []string{"checkpoint"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "checkpoint",
+					Use:   "checkpoint",
+					Short: "a Check Point Security Management server",
+				},
+			},
+		},
+	},
+
 	"claude": {
 		Provider: &plugin.Provider{
 			Name:            "claude",


### PR DESCRIPTION
Adds the Check Point Security Management provider to the `DefaultProviders` map in `providers/defaults.go`.

The `checkpoint` provider is introduced in [mql-enterprise-providers#621](https://github.com/mondoohq/mql-enterprise-providers/pull/621). Because it lives in the separate enterprise repo, it is not picked up by `make providers/defaults` (which only scans in-repo providers), so the entry is added here manually.

Values mirror the provider's `config/config.go`:
- **ID** `go.mondoo.com/cnquery/providers/checkpoint`
- **ConnectionType** `checkpoint`
- **Connector** `checkpoint` — "a Check Point Security Management server"

This keeps the provider discoverable in air-gapped environments where there's no other way to learn which provider handles a given connection.