### PR TITLE
🧹 nextdns: don't discover the account asset by default

### DIFF
--- a/providers/nextdns/resources/discovery.go
+++ b/providers/nextdns/resources/discovery.go
@@ -69,9 +69,20 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 }
 
 func handleTargets(targets []string) []string {
-	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll, connection.DiscoveryAuto) {
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAll) {
 		return []string{
 			connection.DiscoveryAccounts,
+			connection.DiscoveryProfiles,
+		}
+	}
+	// "auto" is the default, and it intentionally omits the account asset. The
+	// NextDNS API currently exposes no account-level information (no
+	// subscription status, 2FA status, or owner email; the account id is only a
+	// synthetic fingerprint of the API key), so discovering the account by
+	// default would just add an empty asset. It stays reachable through an
+	// explicit `--discover accounts` (or `--discover all`).
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryAuto) {
+		return []string{
 			connection.DiscoveryProfiles,
 		}
 	}


### PR DESCRIPTION
## What

`auto` discovery (the default) no longer surfaces the `nextdns.account` asset. The account is now only discovered via `--discover all` or an explicit `--discover accounts`.

## Why

The NextDNS API-key API (`api.nextdns.io`) exposes **no account-level information** — it's entirely profile-scoped (`/profiles`, `/profiles/:id/analytics/*`, `/profiles/:id/logs`). There is no endpoint for subscription status, 2FA status, or the owner's email; those live only behind the cookie-authenticated web dashboard, which an API key cannot reach. The account `id` we expose is just a synthetic SHA-256 fingerprint of the API key.

So discovering the account during a default scan only adds an empty grouping asset. This keeps it opt-in instead.

## Change

Split `handleTargets` in `discovery.go`:

- `auto` (default) → profiles only
- `all` → account + profiles (unchanged)
- explicit `--discover accounts` → still works

A comment records that the account currently provides no information via the API.