### PR TITLE
🐛 oci: resolve network security groups referenced only by OCID

### DIFF
--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -46,6 +46,19 @@ func isOcid(s string) bool {
 	return strings.HasPrefix(s, "ocid1.")
 }
 
+// ociRegionFromOCID extracts the region from an OCI resource OCID. OCIDs have
+// the shape ocid1.<resourceType>.<realm>.<region>.<uniqueID>, so the region is
+// the fourth dot-separated segment (e.g. "us-sanjose-1"). It is empty for
+// global resources (ocid1.user.oc1..aaaa). Returns "" when the OCID is
+// malformed or carries no region; callers should fall back to a known region.
+func ociRegionFromOCID(ocid string) string {
+	parts := strings.Split(ocid, ".")
+	if len(parts) < 5 {
+		return ""
+	}
+	return parts[3]
+}
+
 func jobErr(err error) []*jobpool.Job {
 	return []*jobpool.Job{{Err: err}}
 }

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -768,6 +768,82 @@ func (o *mqlOciNetworkNetworkSecurityGroup) id() (string, error) {
 	return "oci.network.networkSecurityGroup/" + o.Id.Data, nil
 }
 
+// initOciNetworkNetworkSecurityGroup populates a network security group that was
+// referenced only by OCID — the shape produced by the typed securityGroups()
+// accessors (load balancer, compute VNIC, database) and by the exposure()
+// analysis. Without this, such a resource carried only its id: every other
+// field reported "no type information", and fetchSecurityRules built its client
+// with an empty region (region is only set on the enumerated path), producing a
+// malformed "iaas..oraclecloud.com" endpoint. The region is recovered from the
+// OCID so the group can be fetched regardless of the compartment it lives in.
+func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// Already fully populated (enumerated path) — nothing to fetch.
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	if args["id"] == nil {
+		return nil, nil, errors.New("id required to fetch oci.network.networkSecurityGroup")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok || id == "" {
+		return nil, nil, errors.New("id required to fetch oci.network.networkSecurityGroup")
+	}
+
+	region := ociRegionFromOCID(id)
+	if region == "" {
+		return nil, nil, errors.New("could not determine region from network security group ocid: " + id)
+	}
+
+	conn, ok := runtime.Connection.(*connection.OciConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid oci connection")
+	}
+	svc, err := conn.NetworkClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := svc.GetNetworkSecurityGroup(context.Background(), core.GetNetworkSecurityGroupRequest{
+		NetworkSecurityGroupId: common.String(id),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	nsg := resp.NetworkSecurityGroup
+
+	var created *time.Time
+	if nsg.TimeCreated != nil {
+		created = &nsg.TimeCreated.Time
+	}
+
+	freeformTags := make(map[string]interface{})
+	for k, v := range nsg.FreeformTags {
+		freeformTags[k] = v
+	}
+
+	definedTags := make(map[string]interface{})
+	for k, v := range nsg.DefinedTags {
+		definedTags[k] = v
+	}
+
+	mqlInstance, err := CreateResource(runtime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
+		"id":            llx.StringDataPtr(nsg.Id),
+		"name":          llx.StringDataPtr(nsg.DisplayName),
+		"compartmentID": llx.StringDataPtr(nsg.CompartmentId),
+		"state":         llx.StringData(string(nsg.LifecycleState)),
+		"created":       llx.TimeDataPtr(created),
+		"freeformTags":  llx.MapData(freeformTags, types.String),
+		"definedTags":   llx.MapData(definedTags, types.Any),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlNsg := mqlInstance.(*mqlOciNetworkNetworkSecurityGroup)
+	mqlNsg.region = region
+	mqlNsg.cacheVcnId = stringValue(nsg.VcnId)
+	return args, mqlNsg, nil
+}
+
 func (o *mqlOciNetworkNetworkSecurityGroup) vcn() (*mqlOciNetworkVcn, error) {
 	if o.cacheVcnId == "" {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -777,8 +777,10 @@ func (o *mqlOciNetworkNetworkSecurityGroup) id() (string, error) {
 // malformed "iaas..oraclecloud.com" endpoint. The region is recovered from the
 // OCID so the group can be fetched regardless of the compartment it lives in.
 func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	// Already fully populated (enumerated path) — nothing to fetch.
-	if len(args) > 1 {
+	// Already populated (a caller passed the full field set) — nothing to
+	// fetch. `name` is always set alongside `id` on the populated path, so its
+	// presence distinguishes a fully-built group from a bare id reference.
+	if args["name"] != nil {
 		return args, nil, nil
 	}
 	if args["id"] == nil {

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -301,7 +301,7 @@ func init() {
 			Create: createOciNetworkSecurityList,
 		},
 		"oci.network.networkSecurityGroup": {
-			// to override args, implement: initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciNetworkNetworkSecurityGroup,
 			Create: createOciNetworkNetworkSecurityGroup,
 		},
 		"oci.network.internetGateway": {


### PR DESCRIPTION
## What

The OCI typed `securityGroups()` accessors (load balancer, compute VNIC, database) and the new `exposure()` analysis build an `oci.network.networkSecurityGroup` from just its OCID via `NewResource`. There was **no init** for that resource, so a group reached that way carried only its `id`:

- every other field (`name`, `state`, ...) resolved to `cannot convert primitive with NO type information`, and
- `fetchSecurityRules` built its VirtualNetwork client with an **empty region** (region is only set on the enumerated path), producing a malformed `https://iaas..oraclecloud.com/...` endpoint that failed DNS resolution.

The net effect: **`exposure()` errored on every compute instance and load balancer**, and `securityGroups()` returned unusable husks.

## Fix

Add `initOciNetworkNetworkSecurityGroup`, which:
1. recovers the region from the OCID (`ocid1.networksecuritygroup.oc1.<region>.<unique>`),
2. fetches the group with `GetNetworkSecurityGroup`, and
3. populates the resource (mirroring the enumerated path) plus its cached `region` and VCN id.

A direct `Get` is used rather than list-and-match because OCI only lists NSGs in the tenancy root compartment. New helper `ociRegionFromOCID` extracts the region segment.

No schema change (no `.lr.versions` bump); `oci.lr.go` regenerated only to wire the new `Init`.

## Verification

Found and verified during a provider-verification run against live OCI infrastructure (a compute instance + load balancer with a public IP and an NSG admitting `0.0.0.0/0:80`). Before: `exposure` errored with `dial tcp: lookup iaas..oraclecloud.com: no such host`. After:

- `oci.compute.instance.exposure` → `internetReachable: true`, `hasPublicIp: true`, `securityGroupAllowsIngress: true`, `openIngressRules` lists the `0.0.0.0/0` rule
- `oci.loadBalancer.loadBalancer.exposure` → resolves identically
- `oci.loadBalancer.loadBalancer.securityGroups { name }` → `mql-pr-verify-nsg` (no longer a husk)