### PR TITLE
✨ nextdns: expose a scoped singular nextdns.profile resource

### DIFF
--- a/providers/nextdns/resources/nextdns.lr
+++ b/providers/nextdns/resources/nextdns.lr
@@ -34,8 +34,10 @@ private nextdns.account @defaults("id") {
 // Examine a single NextDNS configuration profile: its security feeds,
 // privacy blocklists, parental-control rules, allow and deny lists, custom
 // DNS rewrites, logging settings, and setup endpoints. Select a profile by
-// `id`, for example `nextdns.profiles.where(id == "abc123")`.
-private nextdns.profile @defaults("id name") {
+// `id`, for example `nextdns.profiles.where(id == "abc123")`. When a scan is
+// scoped to a single profile, the top-level `nextdns.profile` resource
+// resolves to that profile.
+nextdns.profile @defaults("id name") {
   // Profile identifier (for example "abc123")
   id string
   // Display name of the profile

--- a/providers/nextdns/resources/nextdns.lr.go
+++ b/providers/nextdns/resources/nextdns.lr.go
@@ -45,7 +45,7 @@ func init() {
 			Create: createNextdnsAccount,
 		},
 		"nextdns.profile": {
-			// to override args, implement: initNextdnsProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initNextdnsProfile,
 			Create: createNextdnsProfile,
 		},
 		"nextdns.profile.security": {

--- a/providers/nextdns/resources/profile.go
+++ b/providers/nextdns/resources/profile.go
@@ -5,14 +5,46 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/nextdns/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// initNextdnsProfile resolves the top-level nextdns.profile resource. When the
+// scan is scoped to a single profile, it populates the profile from the
+// connection so checks can assert against `nextdns.profile` directly and have
+// findings attributed to that profile. An explicit `id` argument is honored as
+// well; without one, the connection must be scoped to a single profile.
+func initNextdnsProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if id, ok := args["id"]; ok && id.Value != nil && id.Value.(string) != "" {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.NextdnsConnection)
+	if conn.ProfileID() == "" {
+		return nil, nil, errors.New("nextdns.profile is only available when the scan is scoped to a single profile; use nextdns.profiles to enumerate every profile in an account")
+	}
+
+	profiles, err := fetchProfiles(conn)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(profiles) != 1 {
+		return nil, nil, errors.New("expected exactly one scoped NextDNS profile")
+	}
+
+	p := profiles[0]
+	args["id"] = llx.StringData(p.ID)
+	args["name"] = llx.StringData(p.Name)
+	args["fingerprint"] = llx.StringData(p.Fingerprint)
+	return args, nil, nil
+}
 
 // mqlNextdnsProfileInternal caches the full profile detail. Every section
 // (security, privacy, parentalControl, settings, setup, lists, rewrites) is


### PR DESCRIPTION
## Summary

Makes `nextdns.profile` a non-private, top-level resource with an initializer that resolves the connection-scoped profile — mirroring the existing `tailscale.device` pattern.

Today a profile can only be reached through the `nextdns.profiles` list. When a scan is scoped to a single profile (the `nextdns-profile` platform that discovery fans out), policies have to write `nextdns.profiles.all(...)` over a one-element list, which aggregates rather than asserting on the profile itself. This change lets checks address the profile directly:

```mql
nextdns.profile.security.threatIntelligenceFeeds == true
```

so each check runs against the single profile bound to the asset and findings are attributed to that profile.

## Changes

- `resources/nextdns.lr`: drop `private` from `nextdns.profile` and document the scoped top-level behavior.
- `resources/profile.go`: add `initNextdnsProfile`. With an explicit `id` it behaves as before; with no `id` it reads `conn.ProfileID()` and populates `id`/`name`/`fingerprint` from the connection (reusing `fetchProfiles`). On an account-wide scan (no scoped profile) it returns an actionable error pointing callers at `nextdns.profiles`.
- `resources/nextdns.lr.go`: regenerated — wires `Init: initNextdnsProfile`.

The `nextdns.profile.*` sub-resources (security, privacy, parentalControl, settings, setup, lists, rewrites) remain private and continue to be reached through the profile.

## Testing

- `go build ./main.go` — builds clean.
- `go vet ./resources/` — clean.
- Rebuilt and installed the provider locally; the companion cnspec policy (`mondoo-nextdns-security`) rewritten to use `nextdns.profile.*` lints as a valid bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)