### PR TITLE
🐛 nextdns: don't scan the account asset by default

### DIFF
--- a/providers/nextdns/provider/provider.go
+++ b/providers/nextdns/provider/provider.go
@@ -159,9 +159,15 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.NextdnsConnect
 		return nil
 	}
 
+	// Without a profile scope the connection points at the whole account, which
+	// serves only as a discovery hub. The NextDNS API exposes no account-level
+	// resources worth scanning (the account id is a synthetic fingerprint of the
+	// API key), so the root is left without platform IDs and is not scanned
+	// itself — the scanner skips assets that have none. Discovery enumerates the
+	// profiles to scan, and a scannable account asset is emitted only when it is
+	// an explicit discovery target (`--discover accounts` or `--discover all`).
 	accountID := conn.AccountID()
 	asset.Id = accountID
-	asset.PlatformIds = []string{connection.NewNextdnsAccountIdentifier(accountID)}
 	if asset.Name == "" {
 		asset.Name = "NextDNS Account"
 	}


### PR DESCRIPTION
## Problem

`cnspec scan nextdns` still scans the **NextDNS Account** asset by default, even though #8712 removed it from the default (`auto`) discovery list. Against a profile-scoped policy the account then fails with:

```
error: rpc error: code = InvalidArgument desc = asset doesn't support any policies
```

```
$ cnspec scan nextdns --api-key <key> --policy-bundle mondoo-nextdns-security.mql.yaml
Asset: (NextDNS Account) NextDNS Account     <-- unwanted
Asset: (NextDNS Profile) ...
Scanned 6 assets
```

## Root cause

#8712 only changed the **discovery list** (`handleTargets` omits accounts for `auto`). But the account was never coming from discovery in the default case — it's the **root connection asset**. When a connection isn't scoped to a single profile, `detect()` stamps the root asset with account platform IDs:

```go
accountID := conn.AccountID()
asset.Id = accountID
asset.PlatformIds = []string{connection.NewNextdnsAccountIdentifier(accountID)} // <-- always scannable
```

The scanner scans any asset with platform IDs ([`local_scanner.go`](https://github.com/mondoohq/cnspec/blob/main/policy/scan/local_scanner.go) skips only those with none), so the root account was always scanned alongside the discovered profiles.

## Fix

Treat the unscoped root as a pure **discovery hub** — leave it without platform IDs so the scanner skips it. Profiles to scan come from discovery, and a scannable account asset is still emitted by `Discover()` when the account is an explicit target (`--discover accounts` / `--discover all`). The single-profile scope path (root carries profile platform IDs) is unchanged.

## Verification (live account)

| Command | Assets scanned |
|---|---|
| `cnspec scan nextdns` (default `auto`) | 5 profiles, **no account** ✅ |
| `--discover accounts` | account only ✅ |
| `--discover all` | account + 5 profiles ✅ |

No more `asset doesn't support any policies` errors on the default scan.

Rides into the not-yet-released 13.0.2 (no schema change, so no version bump or `.lr.versions` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)