### PR TITLE
🐛 fix mikrotik asset URL tree to use category key

### DIFF
--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -71,7 +71,7 @@ Examples:
 	},
 	AssetUrlTrees: []*inventory.AssetUrlBranch{
 		{
-			PathSegments: []string{"technology=network", "provider=mikrotik"},
+			PathSegments: []string{"technology=network", "category=mikrotik"},
 			Key:          "kind",
 			Title:        "MikroTik Kind",
 			Values: map[string]*inventory.AssetUrlBranch{


### PR DESCRIPTION
## Problem

The `mikrotik` provider declares its asset URL tree under `technology=network` with a **`provider=mikrotik`** segment:

```go
PathSegments: []string{"technology=network", "provider=mikrotik"},
```

But the base asset URL schema (`providers.LoadAssetUrlSchema`) fixes the child key of `technology=network` to **`category`**. Every other network provider follows this — e.g. `arista` → `category=arista`, `ipmi` → `category=ipmi`.

Because of the mismatch, merging all installed provider schemas fails:

```
asset url path key is invalid (expected 'category', got 'provider')
```

This isn't mikrotik-specific in impact: **any** consumer that calls `providers.LoadAssetUrlSchema()` over a provider set that includes mikrotik fails hard. In the Mondoo server this surfaced as a policy DB migration / boot failure once mikrotik was added to the bundled provider list (CI red on mondoohq/server).

## Fix

Switch the segment to `category=mikrotik`, matching the schema's reserved key and the other network providers.

```diff
- PathSegments: []string{"technology=network", "provider=mikrotik"},
+ PathSegments: []string{"technology=network", "category=mikrotik"},
```

The generated `dist/mikrotik.json` (gitignored build artifact) regenerates from this config during release; verified locally via `go run ./gen/main.go .` that the published JSON now emits `category=mikrotik`, and `providers.LoadAssetUrlSchema()` then loads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)