### PR TITLE
🧹 Bump patch version for mikrotik and nextdns

### DIFF
--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mikrotik",
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/nextdns/config/config.go
+++ b/providers/nextdns/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nextdns",
 	ID:              "go.mondoo.com/mql/providers/nextdns",
-	Version:         "13.0.2",
+	Version:         "13.0.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Patch bump to prepare both providers for release:

| Provider | Before | After |
|---|---|---|
| mikrotik | 13.0.0 | 13.0.1 |
| nextdns | 13.0.2 | 13.0.3 |

Changes since each provider's last release:

- **mikrotik** — RouterOS asset URL tree fix (#8719) and related work.
- **nextdns** — singular `nextdns.profile` resource (#8715), profile sub-resource name/field-path collision fix (#8717), and the account-not-scanned-by-default fix (#8718, if merged before release).

config.go-only change, following the established patch-bump convention (#8684).

🤖 Generated with [Claude Code](https://claude.com/claude-code)