### PR TITLE
🎉 oci-13.12.1

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.12.0",
+	Version:         "13.12.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.12.1)
- 🐛 oci: resolve network security groups referenced only by OCID (#8714)
- 🧹 Update deps for mql and providers 20260624 (#8706)
- 🧹 Update deps for mql and providers 20260623 (#8690)