### PR TITLE
🧹 Provide static platform support information across all providers

### DIFF
--- a/providers-sdk/v1/plugin/platform.go
+++ b/providers-sdk/v1/plugin/platform.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"slices"
+
+	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// Apply copies the static fields of the descriptor onto a runtime platform.
+//
+// Name and Family always come from the descriptor. Title is only set as a
+// default (a title already set at runtime wins). Kind and Runtime are set only
+// when the descriptor declares exactly one possible value; when several are
+// possible (the OS case) the connection-set value is left untouched, since the
+// connection is the sole authority for which one applies.
+func (pi *PlatformInfo) Apply(p *inventory.Platform) {
+	p.Name = pi.Name
+	if p.Title == "" {
+		p.Title = pi.Title
+	}
+	if len(pi.Family) > 0 {
+		p.Family = slices.Clone(pi.Family)
+	}
+	if len(pi.Kind) == 1 {
+		p.Kind = pi.Kind[0]
+	}
+	if len(pi.Runtime) == 1 {
+		p.Runtime = pi.Runtime[0]
+	}
+}
+
+// Consistent reports whether a runtime platform matches this descriptor: its
+// kind must be a member of the possible Kind set and its runtime a member of
+// the possible Runtime set. An empty set means that field is unconstrained.
+// Used by per-provider tests to guard against drift between the catalog and the
+// platforms the runtime actually emits.
+func (pi *PlatformInfo) Consistent(p *inventory.Platform) bool {
+	if len(pi.Kind) > 0 && p.Kind != "" && !slices.Contains(pi.Kind, p.Kind) {
+		return false
+	}
+	if len(pi.Runtime) > 0 && p.Runtime != "" && !slices.Contains(pi.Runtime, p.Runtime) {
+		return false
+	}
+	return true
+}
+
+// PlatformsByName indexes a platform catalog by name. Helper for providers that
+// want a lookup map from their declared Platforms slice.
+func PlatformsByName(platforms []*PlatformInfo) map[string]*PlatformInfo {
+	m := make(map[string]*PlatformInfo, len(platforms))
+	for _, p := range platforms {
+		m[p.Name] = p
+	}
+	return m
+}

--- a/providers-sdk/v1/plugin/platform.go
+++ b/providers-sdk/v1/plugin/platform.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"slices"
 
+	"github.com/rs/zerolog/log"
 	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
@@ -17,6 +18,17 @@ import (
 // possible (the OS case) the connection-set value is left untouched, since the
 // connection is the sole authority for which one applies.
 func (pi *PlatformInfo) Apply(p *inventory.Platform) {
+	if pi == nil {
+		// A nil descriptor means a caller passed a platform name that is not in
+		// the provider's catalog (typically a typo in a PlatformByName argument).
+		// Log it and fall back to an unknown platform instead of crashing.
+		log.Error().Msg("plugin.PlatformInfo.Apply called on a nil descriptor: the platform name is not present in the provider catalog")
+		p.Name = "unknown"
+		p.Title = "Unknown"
+		p.Kind = "unknown"
+		p.Runtime = "unknown"
+		return
+	}
 	p.Name = pi.Name
 	if p.Title == "" {
 		p.Title = pi.Title

--- a/providers-sdk/v1/plugin/platform_test.go
+++ b/providers-sdk/v1/plugin/platform_test.go
@@ -59,6 +59,19 @@ func TestPlatformInfoApply(t *testing.T) {
 		p.Family[0] = "mutated"
 		assert.Equal(t, "linux", fam[0], "descriptor family must not be mutated via the applied platform")
 	})
+
+	t.Run("a nil descriptor falls back to an unknown platform", func(t *testing.T) {
+		// PlatformByName returns nil for an unknown name; calling Apply on that
+		// (e.g. a typo'd platform name at a call site) must not nil-deref. It
+		// logs and falls back to an "unknown" platform instead.
+		var pi *PlatformInfo
+		p := &inventory.Platform{}
+		assert.NotPanics(t, func() { pi.Apply(p) })
+		assert.Equal(t, "unknown", p.Name)
+		assert.Equal(t, "Unknown", p.Title)
+		assert.Equal(t, "unknown", p.Kind)
+		assert.Equal(t, "unknown", p.Runtime)
+	})
 }
 
 func TestPlatformInfoConsistent(t *testing.T) {

--- a/providers-sdk/v1/plugin/platform_test.go
+++ b/providers-sdk/v1/plugin/platform_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformInfoApply(t *testing.T) {
+	t.Run("single-valued kind/runtime are set", func(t *testing.T) {
+		pi := &PlatformInfo{
+			Name:    "aws-s3-bucket",
+			Title:   "AWS S3 Bucket",
+			Kind:    []string{"aws-object"},
+			Runtime: []string{"aws"},
+		}
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.Equal(t, "aws-s3-bucket", p.Name)
+		assert.Equal(t, "AWS S3 Bucket", p.Title)
+		assert.Equal(t, "aws-object", p.Kind)
+		assert.Equal(t, "aws", p.Runtime)
+	})
+
+	t.Run("multi-valued kind/runtime are left to the connection", func(t *testing.T) {
+		pi := &PlatformInfo{
+			Name:    "ubuntu",
+			Family:  []string{"debian", "linux", "unix", "os"},
+			Kind:    []string{"baremetal", "virtualmachine", "container", "container-image"},
+			Runtime: []string{"docker-image", "docker"},
+		}
+		p := &inventory.Platform{Kind: "container", Runtime: "docker"}
+		pi.Apply(p)
+		assert.Equal(t, "ubuntu", p.Name)
+		assert.Equal(t, []string{"debian", "linux", "unix", "os"}, p.Family)
+		// connection-set values are preserved
+		assert.Equal(t, "container", p.Kind)
+		assert.Equal(t, "docker", p.Runtime)
+	})
+
+	t.Run("a runtime title wins over the catalog default", func(t *testing.T) {
+		pi := &PlatformInfo{Name: "ubuntu", Title: "Ubuntu"}
+		p := &inventory.Platform{Title: "Ubuntu 20.04 LTS"}
+		pi.Apply(p)
+		assert.Equal(t, "Ubuntu 20.04 LTS", p.Title)
+	})
+
+	t.Run("family is cloned, not aliased", func(t *testing.T) {
+		fam := []string{"linux", "unix", "os"}
+		pi := &PlatformInfo{Name: "x", Family: fam}
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		p.Family[0] = "mutated"
+		assert.Equal(t, "linux", fam[0], "descriptor family must not be mutated via the applied platform")
+	})
+}
+
+func TestPlatformInfoConsistent(t *testing.T) {
+	pi := &PlatformInfo{
+		Name:    "ubuntu",
+		Kind:    []string{"baremetal", "container"},
+		Runtime: []string{"docker"},
+	}
+	assert.True(t, pi.Consistent(&inventory.Platform{Kind: "container", Runtime: "docker"}))
+	assert.True(t, pi.Consistent(&inventory.Platform{}), "empty runtime platform is unconstrained")
+	assert.False(t, pi.Consistent(&inventory.Platform{Kind: "virtualmachine"}), "kind not in set")
+	assert.False(t, pi.Consistent(&inventory.Platform{Runtime: "podman"}), "runtime not in set")
+}
+
+func TestProviderPlatformsRoundTrip(t *testing.T) {
+	src := Provider{
+		Name:    "example",
+		ID:      "go.mondoo.com/example",
+		Version: "1.0.0",
+		Platforms: []*PlatformInfo{
+			{Name: "example", Title: "Example", Kind: []string{"api"}, Runtime: []string{"example"}},
+			{Name: "ubuntu", Family: []string{"debian", "linux"}, Kind: []string{"baremetal", "container"}},
+		},
+	}
+	data, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	// mirrors providers.(*Provider).LoadJSON which json.Unmarshals into Provider
+	var got Provider
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, src.Platforms, got.Platforms)
+}

--- a/providers-sdk/v1/plugin/start.go
+++ b/providers-sdk/v1/plugin/start.go
@@ -33,7 +33,30 @@ type Provider struct {
 	CrossProviderTypes []string
 	Connectors         []Connector
 	AssetUrlTrees      []*inventory.AssetUrlBranch
-	Maturity           string `json:",omitempty"`
+	// Platforms is the static catalog of platforms this provider can emit. It
+	// lets users see the supported platforms ahead of running, and lets the
+	// runtime construct platforms from a pre-defined descriptor instead of
+	// hardcoding name/family/kind/runtime inline.
+	Platforms []*PlatformInfo `json:",omitempty"`
+	Maturity  string          `json:",omitempty"`
+}
+
+// PlatformInfo is the static, pre-declarable description of one platform a
+// provider can emit. It captures the subset of inventory.Platform that is
+// known ahead of time. Dynamic fields (Arch, Build, Version, Metadata,
+// TechnologyUrlSegments, and often Title) are filled at runtime, not here.
+//
+// Kind and Runtime list ALL possible values the platform can take: cloud,
+// SaaS, and API platforms fix a single value per name, while OS platforms can
+// occur as several kinds/runtimes depending on the connection (e.g. the same
+// "ubuntu" may be baremetal, virtualmachine, container, or container-image).
+// The connection/detection picks the actual value at runtime.
+type PlatformInfo struct {
+	Name    string   `json:"name"`
+	Title   string   `json:"title,omitempty"`   // optional default title
+	Family  []string `json:"family,omitempty"`  // fixed family chain for this name
+	Kind    []string `json:"kind,omitempty"`    // set of possible kinds
+	Runtime []string `json:"runtime,omitempty"` // set of possible runtimes
 }
 
 type Connector struct {

--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
 	Version:         "13.1.2",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{
 		Name:    "activedirectory",
 		Use:     "activedirectory",

--- a/providers/activedirectory/provider/platforms.go
+++ b/providers/activedirectory/provider/platforms.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "activedirectory",
+		Title:   "Active Directory Domain Services",
+		Family:  []string{"directory-service"},
+		Kind:    []string{"api"},
+		Runtime: []string{"activedirectory"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/activedirectory/provider/platforms_test.go
+++ b/providers/activedirectory/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/activedirectory/provider/provider.go
+++ b/providers/activedirectory/provider/provider.go
@@ -232,14 +232,13 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.ActiveDirectoryConnection) error {
 	asset.Name = "Active Directory " + conn.FQDN()
-	asset.Platform = &inventory.Platform{
-		Name:                  "activedirectory",
-		Runtime:               "activedirectory",
-		Family:                []string{"directory-service"},
-		Kind:                  "api",
-		Title:                 "Active Directory Domain Services",
+	platform := &inventory.Platform{
 		TechnologyUrlSegments: []string{"directory-service", "activedirectory"},
 	}
+	if pi, ok := PlatformByName("activedirectory"); ok {
+		pi.Apply(platform)
+	}
+	asset.Platform = platform
 	asset.PlatformIds = []string{conn.PlatformId()}
 
 	return nil

--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
 	Version:         "13.2.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "ansible",

--- a/providers/ansible/provider/platforms.go
+++ b/providers/ansible/provider/platforms.go
@@ -1,0 +1,29 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:   "ansible-project",
+		Title:  "Ansible Project",
+		Family: []string{"ansible"},
+		Kind:   []string{"api"},
+	},
+	{
+		Name:   "ansible-playbook",
+		Title:  "Ansible Playbook",
+		Family: []string{"ansible"},
+		Kind:   []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/ansible/provider/platforms_test.go
+++ b/providers/ansible/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/ansible/provider/provider.go
+++ b/providers/ansible/provider/provider.go
@@ -129,21 +129,15 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AnsibleConnect
 	nameKind := "Ansible Playbook Static Analysis "
 	if conn.IsProject() {
 		asset.Platform = &inventory.Platform{
-			Name:                  "ansible-project",
-			Family:                []string{"ansible"},
-			Kind:                  "api",
-			Title:                 "Ansible Project",
 			TechnologyUrlSegments: []string{"iac", "ansible", "project"},
 		}
+		PlatformByName("ansible-project").Apply(asset.Platform)
 		nameKind = "Ansible Project Static Analysis "
 	} else {
 		asset.Platform = &inventory.Platform{
-			Name:                  "ansible-playbook",
-			Family:                []string{"ansible"},
-			Kind:                  "api",
-			Title:                 "Ansible Playbook",
 			TechnologyUrlSegments: []string{"iac", "ansible", "playbook"},
 		}
+		PlatformByName("ansible-playbook").Apply(asset.Platform)
 	}
 
 	projectPath, ok := asset.Connections[0].Options["path"]

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
 	Version:         "13.3.6",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "arista",

--- a/providers/arista/provider/platforms.go
+++ b/providers/arista/provider/platforms.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "arista-eos",
+		Title:   "Arista EOS",
+		Family:  []string{"arista"},
+		Kind:    []string{"network-device"},
+		Runtime: []string{"arista"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/arista/provider/platforms_test.go
+++ b/providers/arista/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/arista/provider/provider.go
+++ b/providers/arista/provider/provider.go
@@ -172,16 +172,15 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AristaConnecti
 		arch = aristaVersion.Architecture
 	}
 
-	asset.Platform = &inventory.Platform{
-		Name:                  "arista-eos",
+	platform := &inventory.Platform{
 		Version:               version,
 		Arch:                  arch,
-		Family:                []string{"arista"},
-		Kind:                  "network-device",
-		Title:                 "Arista EOS",
-		Runtime:               "arista",
 		TechnologyUrlSegments: []string{"network", "arista"},
 	}
+	if pi, ok := PlatformByName("arista-eos"); ok {
+		pi.Apply(platform)
+	}
+	asset.Platform = platform
 
 	eosClient := eos.NewEos(conn.Client())
 	hostname, err := eosClient.ShowHostname()

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -12,9 +12,10 @@ import (
 )
 
 var Config = plugin.Provider{
-	Name:    "atlassian",
-	ID:      "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version: "13.3.6",
+	Name:      "atlassian",
+	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
+	Version:   "13.3.6",
+	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,
 		"jira",

--- a/providers/atlassian/connection/platforms.go
+++ b/providers/atlassian/connection/platforms.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "atlassian-scim",
+		Title:   "Atlassian SCIM",
+		Kind:    []string{"api"},
+		Runtime: []string{"atlassian"},
+	},
+	{
+		Name:    "atlassian-admin",
+		Title:   "Atlassian Admin",
+		Kind:    []string{"api"},
+		Runtime: []string{"atlassian"},
+	},
+	{
+		Name:    "atlassian-jira",
+		Title:   "Atlassian Jira",
+		Kind:    []string{"api"},
+		Runtime: []string{"atlassian"},
+	},
+	{
+		Name:    "atlassian-confluence",
+		Title:   "Atlassian Confluence",
+		Kind:    []string{"api"},
+		Runtime: []string{"atlassian"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/atlassian/connection/platforms_test.go
+++ b/providers/atlassian/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/providers/aws/connection/awsec2ebsconn"
 	"go.mondoo.com/mql/v13/providers/aws/provider"
 	"go.mondoo.com/mql/v13/providers/aws/resources"
@@ -187,4 +188,5 @@ Notes:
 			},
 		},
 	},
+	Platforms: connection.Platforms,
 }

--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -10,22 +10,31 @@ func (a *AwsConnection) PlatformInfo() *inventory.Platform {
 }
 
 func GetPlatformForObject(platformName string, accountId string) *inventory.Platform {
-	if platformName != "aws" && platformName != "" {
+	if platformName == "" {
+		platformName = "aws"
+	}
+
+	// Fall back to a generic AWS object for names not in the static catalog, so
+	// new object types keep working before they are added to Platforms.
+	pi := PlatformByName(platformName)
+	if pi == nil {
 		return &inventory.Platform{
 			Name:                  platformName,
-			Title:                 getTitleForPlatformName(platformName),
+			Title:                 "Amazon Web Services",
 			Kind:                  "aws-object",
 			Runtime:               "aws",
 			TechnologyUrlSegments: getTechnologyUrlSegments(accountId, platformName),
 		}
 	}
-	return &inventory.Platform{
-		Name:                  "aws",
-		Title:                 "AWS Account",
-		Kind:                  "api",
-		Runtime:               "aws",
-		TechnologyUrlSegments: []string{"aws", accountId, "account"},
+
+	p := &inventory.Platform{}
+	pi.Apply(p)
+	if platformName == "aws" {
+		p.TechnologyUrlSegments = []string{"aws", accountId, "account"}
+	} else {
+		p.TechnologyUrlSegments = getTechnologyUrlSegments(accountId, platformName)
 	}
+	return p
 }
 
 func getTechnologyUrlSegments(accountId string, platformName string) []string {
@@ -110,88 +119,4 @@ func getServiceName(platformName string) string {
 		return "documentdb"
 	}
 	return "other"
-}
-
-func getTitleForPlatformName(name string) string {
-	switch name {
-	case "aws-s3-bucket":
-		return "AWS S3 Bucket"
-	case "aws-cloudtrail-trail":
-		return "AWS CloudTrail Trail"
-	case "aws-rds-dbinstance":
-		return "AWS RDS DB Instance"
-	case "aws-rds-dbcluster":
-		return "AWS RDS DB Cluster"
-	case "aws-dynamodb-table":
-		return "AWS DynamoDB Table"
-	case "aws-redshift-cluster":
-		return "AWS Redshift Cluster"
-	case "aws-vpc":
-		return "AWS VPC"
-	case "aws-security-group":
-		return "AWS Security Group"
-	case "aws-ebs-volume":
-		return "AWS EBS Volume"
-	case "aws-ebs-snapshot":
-		return "AWS EBS Snapshot"
-	case "aws-iam-user":
-		return "AWS IAM User"
-	case "aws-iam-group":
-		return "AWS IAM Group"
-	case "aws-cloudwatch-loggroup":
-		return "AWS CloudWatch Log Group"
-	case "aws-lambda-function":
-		return "AWS Lambda Function"
-	case "aws-ecs-container":
-		return "AWS ECS Container"
-	case "aws-efs-filesystem":
-		return "AWS EFS Filesystem"
-	case "aws-gateway-restapi":
-		return "AWS Gateway REST API"
-	case "aws-elb-loadbalancer":
-		return "AWS ELB Load Balancer"
-	case "aws-es-domain":
-		return "AWS ES Domain"
-	case "aws-opensearch-domain":
-		return "AWS OpenSearch Domain"
-	case "aws-kms-key":
-		return "AWS KMS Key"
-	case "aws-sagemaker-notebookinstance":
-		return "AWS SageMaker Notebook Instance"
-	case "aws-sagemaker-processingjob":
-		return "AWS SageMaker Processing Job"
-	case "aws-sagemaker-trainingjob":
-		return "AWS SageMaker Training Job"
-	case "aws-ec2-instance":
-		return "AWS EC2 Instance"
-	case "aws-ssm-instance":
-		return "AWS SSM Instance"
-	case "aws-ecr-image":
-		return "AWS ECR Image"
-	case "aws-ecr-repository":
-		return "AWS ECR Repository"
-	case "aws-ecs-taskdefinition":
-		return "AWS ECS Task Definition"
-	case "aws-route53-hostedzone":
-		return "AWS Route 53 Hosted Zone"
-	case "aws-msk-cluster":
-		return "AWS MSK Cluster"
-	case "aws-mq-broker":
-		return "AWS MQ Broker"
-	case "aws-eks-cluster":
-		return "AWS EKS Cluster"
-	case "aws-secretsmanager-secret":
-		return "AWS Secrets Manager Secret"
-	case "aws-elasticache-cluster":
-		return "AWS ElastiCache Cluster"
-	case "aws-cloudfront-distribution":
-		return "AWS CloudFront Distribution"
-	case "aws-neptune-cluster":
-		return "AWS Neptune Cluster"
-	case "aws-emr-cluster":
-		return "AWS EMR Cluster"
-	case "aws-documentdb-cluster":
-		return "AWS DocumentDB Cluster"
-	}
-	return "Amazon Web Services"
 }

--- a/providers/aws/connection/platforms.go
+++ b/providers/aws/connection/platforms.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms the AWS provider can emit via
+// GetPlatformForObject: the account root plus one entry per discoverable AWS
+// object type. Each object is an "aws-object" running in the "aws" runtime;
+// the account root is an "api" platform. This is the single source of truth for
+// both the provider config (config.Config.Platforms) and the runtime builder.
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "aws", Title: "AWS Account", Kind: []string{"api"}, Runtime: []string{"aws"}},
+	{Name: "aws-s3-bucket", Title: "AWS S3 Bucket", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-cloudtrail-trail", Title: "AWS CloudTrail Trail", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-rds-dbinstance", Title: "AWS RDS DB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-rds-dbcluster", Title: "AWS RDS DB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-dynamodb-table", Title: "AWS DynamoDB Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-redshift-cluster", Title: "AWS Redshift Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-vpc", Title: "AWS VPC", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-security-group", Title: "AWS Security Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ebs-volume", Title: "AWS EBS Volume", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ebs-snapshot", Title: "AWS EBS Snapshot", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-iam-user", Title: "AWS IAM User", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-iam-group", Title: "AWS IAM Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-cloudwatch-loggroup", Title: "AWS CloudWatch Log Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-lambda-function", Title: "AWS Lambda Function", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ecs-container", Title: "AWS ECS Container", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ecs-instance", Title: "AWS ECS Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-efs-filesystem", Title: "AWS EFS Filesystem", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-gateway-restapi", Title: "AWS Gateway REST API", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-elb-loadbalancer", Title: "AWS ELB Load Balancer", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-es-domain", Title: "AWS ES Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-opensearch-domain", Title: "AWS OpenSearch Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-kms-key", Title: "AWS KMS Key", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sagemaker-notebookinstance", Title: "AWS SageMaker Notebook Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sagemaker-processingjob", Title: "AWS SageMaker Processing Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sagemaker-trainingjob", Title: "AWS SageMaker Training Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ec2-instance", Title: "AWS EC2 Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ssm-instance", Title: "AWS SSM Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ecr-image", Title: "AWS ECR Image", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ecr-repository", Title: "AWS ECR Repository", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-ecs-taskdefinition", Title: "AWS ECS Task Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-route53-hostedzone", Title: "AWS Route 53 Hosted Zone", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-msk-cluster", Title: "AWS MSK Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-mq-broker", Title: "AWS MQ Broker", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-eks-cluster", Title: "AWS EKS Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-secretsmanager-secret", Title: "AWS Secrets Manager Secret", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-elasticache-cluster", Title: "AWS ElastiCache Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-cloudfront-distribution", Title: "AWS CloudFront Distribution", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-neptune-cluster", Title: "AWS Neptune Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-emr-cluster", Title: "AWS EMR Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-documentdb-cluster", Title: "AWS DocumentDB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static descriptor for a platform name, or nil if
+// the name is not in the catalog.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/aws/connection/platforms_test.go
+++ b/providers/aws/connection/platforms_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discoveryPlatformNames are the platform names the discovery code can hand to
+// GetPlatformForObject (the outputs of getPlatformName in
+// resources/discovery_conversion.go). Every one must be in the static catalog.
+// If discovery learns a new object type, add it here AND to Platforms.
+var discoveryPlatformNames = []string{
+	"aws-cloudfront-distribution", "aws-cloudtrail-trail", "aws-cloudwatch-loggroup",
+	"aws-documentdb-cluster", "aws-dynamodb-table", "aws-ebs-snapshot", "aws-ebs-volume",
+	"aws-ec2-instance", "aws-ecr-image", "aws-ecr-repository", "aws-ecs-container",
+	"aws-ecs-instance", "aws-ecs-taskdefinition", "aws-efs-filesystem", "aws-eks-cluster",
+	"aws-elasticache-cluster", "aws-elb-loadbalancer", "aws-emr-cluster", "aws-es-domain",
+	"aws-gateway-restapi", "aws-iam-group", "aws-iam-user", "aws-kms-key",
+	"aws-lambda-function", "aws-mq-broker", "aws-msk-cluster", "aws-neptune-cluster",
+	"aws-opensearch-domain", "aws-rds-dbcluster", "aws-rds-dbinstance", "aws-redshift-cluster",
+	"aws-route53-hostedzone", "aws-s3-bucket", "aws-sagemaker-notebookinstance",
+	"aws-sagemaker-processingjob", "aws-sagemaker-trainingjob", "aws-secretsmanager-secret",
+	"aws-security-group", "aws-ssm-instance", "aws-vpc",
+}
+
+func TestPlatformCatalogComplete(t *testing.T) {
+	// every discoverable name is in the catalog
+	for _, name := range discoveryPlatformNames {
+		assert.NotNil(t, PlatformByName(name), "discovery emits %q but it is not in the static catalog", name)
+	}
+
+	// every catalog entry is consistent with what the runtime builds for it
+	for _, pi := range Platforms {
+		p := GetPlatformForObject(pi.Name, "123456789012")
+		assert.Equal(t, pi.Name, p.Name)
+		assert.Equal(t, pi.Title, p.Title, "title drift for %q", pi.Name)
+		assert.True(t, pi.Consistent(p), "kind/runtime of %q not in declared set: kind=%q runtime=%q", pi.Name, p.Kind, p.Runtime)
+	}
+}
+
+func TestGetPlatformForObjectParity(t *testing.T) {
+	acc := "123456789012"
+
+	// account root: empty and explicit "aws" both yield the api platform
+	for _, name := range []string{"", "aws"} {
+		p := GetPlatformForObject(name, acc)
+		assert.Equal(t, "aws", p.Name)
+		assert.Equal(t, "AWS Account", p.Title)
+		assert.Equal(t, "api", p.Kind)
+		assert.Equal(t, "aws", p.Runtime)
+		assert.Equal(t, []string{"aws", acc, "account"}, p.TechnologyUrlSegments)
+	}
+
+	// a known object
+	p := GetPlatformForObject("aws-s3-bucket", acc)
+	assert.Equal(t, "aws-s3-bucket", p.Name)
+	assert.Equal(t, "AWS S3 Bucket", p.Title)
+	assert.Equal(t, "aws-object", p.Kind)
+	assert.Equal(t, "aws", p.Runtime)
+	assert.Equal(t, []string{"aws", acc, "s3"}, p.TechnologyUrlSegments)
+
+	// an unknown object name falls back to a generic AWS object
+	u := GetPlatformForObject("aws-brand-new-thing", acc)
+	require.Equal(t, "aws-brand-new-thing", u.Name)
+	assert.Equal(t, "Amazon Web Services", u.Title)
+	assert.Equal(t, "aws-object", u.Kind)
+	assert.Equal(t, "aws", u.Runtime)
+	assert.Equal(t, []string{"aws", acc, "other"}, u.TechnologyUrlSegments)
+}

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -12,9 +12,10 @@ import (
 )
 
 var Config = plugin.Provider{
-	Name:    "azure",
-	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.22.0",
+	Name:      "azure",
+	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
+	Version:   "13.22.0",
+	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -625,15 +625,13 @@ func subToAsset(subWithConfig subWithConfig) *inventory.Asset {
 	if sub.TenantID != nil {
 		tenantId = *sub.TenantID
 	}
+	platform := &inventory.Platform{
+		TechnologyUrlSegments: []string{"azure", tenantId, *sub.SubscriptionID, "account"},
+	}
+	PlatformByName("azure").Apply(platform)
 	return &inventory.Asset{
-		Id: platformId,
-		Platform: &inventory.Platform{
-			Title:                 "Azure Subscription",
-			Name:                  "azure",
-			Runtime:               "azure",
-			Kind:                  "api",
-			TechnologyUrlSegments: []string{"azure", tenantId, *sub.SubscriptionID, "account"},
-		},
+		Id:          platformId,
+		Platform:    platform,
 		Name:        fmt.Sprintf("Azure subscription %s", *sub.DisplayName),
 		Connections: []*inventory.Config{copyConf},
 		PlatformIds: []string{platformId},
@@ -777,16 +775,14 @@ func mqlObjectToAsset(mqlObject mqlObject, parentConf *inventory.Config, include
 	if includeObjectTypeInUrl {
 		assetUrl = append(assetUrl, mqlObject.azureObject.objectType)
 	}
+	platform := &inventory.Platform{
+		TechnologyUrlSegments: assetUrl,
+	}
+	PlatformByName(info.platform).Apply(platform)
 	return &inventory.Asset{
 		PlatformIds: []string{platformid, mqlObject.azureObject.id},
 		Name:        mqlObject.name,
-		Platform: &inventory.Platform{
-			Name:                  info.platform,
-			Title:                 info.title,
-			Kind:                  "azure-object",
-			Runtime:               "azure",
-			TechnologyUrlSegments: assetUrl,
-		},
+		Platform:    platform,
 		State:       inventory.State_STATE_ONLINE,
 		Labels:      addInformationalLabels(mqlObject.labels, mqlObject),
 		Connections: []*inventory.Config{cfg},

--- a/providers/azure/resources/platforms.go
+++ b/providers/azure/resources/platforms.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms the Azure provider can emit
+// during discovery: the subscription root plus one entry per discoverable Azure
+// object type. The subscription root is an "api" platform; each object is an
+// "azure-object", all running in the "azure" runtime. This is the single source
+// of truth for both the provider config (config.Config.Platforms) and the
+// runtime builders in discovery.go.
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "azure", Title: "Azure Subscription", Kind: []string{"api"}, Runtime: []string{"azure"}},
+	{Name: "azure-compute-vm", Title: "Azure Compute VM", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-compute-vm-api", Title: "Azure Compute VM", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-sql-server", Title: "Azure SQL Database Server", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-postgresql-server", Title: "Azure PostgreSQL Server", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-postgresql-flexible-server", Title: "Azure PostgreSQL Flexible Server", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-mysql-server", Title: "Azure MySQL Server", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-mysql-flexible-server", Title: "Azure MySQL Flexible Server", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-aks-cluster", Title: "Azure AKS Cluster", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-app-service-webapp", Title: "Azure App Service App", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-cache-redis-instance", Title: "Azure Cache for Redis Instance", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-batch-account", Title: "Azure Batch Account", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-storage-account", Title: "Azure Storage Account", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-storage-container", Title: "Azure Storage Account Container", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-network-security-group", Title: "Azure Network Security Group", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-virtual-network", Title: "Azure Virtual Network", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-application-gateway", Title: "Azure Application Gateway", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-firewall", Title: "Azure Firewall", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-function-app", Title: "Azure Function App", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-container-app", Title: "Azure Container App", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-keyvault-vault", Title: "Azure Key Vault", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-cosmosdb", Title: "Azure Cosmos DB Account", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-container-registry", Title: "Azure Container Registry", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-recovery-services-vault", Title: "Azure Recovery Services Vault", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-synapse-workspace", Title: "Azure Synapse Analytics Workspace", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-datafactory", Title: "Azure Data Factory", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static descriptor for a platform name, or nil if
+// the name is not in the catalog.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/azure/resources/platforms_test.go
+++ b/providers/azure/resources/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -16,6 +16,7 @@ var Config = plugin.Provider{
 	Version:         "13.3.4",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "bicep",

--- a/providers/bicep/provider/platforms.go
+++ b/providers/bicep/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "bicep",
+		Title:   "Azure Bicep",
+		Family:  []string{"bicep"},
+		Kind:    []string{"api"},
+		Runtime: []string{"bicep"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/bicep/provider/platforms_test.go
+++ b/providers/bicep/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/bicep/provider/provider.go
+++ b/providers/bicep/provider/provider.go
@@ -133,13 +133,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.BicepConnectio
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "bicep",
-		Family:                []string{"bicep"},
-		Runtime:               "bicep",
-		Kind:                  "api",
-		Title:                 "Azure Bicep",
 		TechnologyUrlSegments: []string{"iac", "bicep", "template"},
 	}
+	PlatformByName("bicep").Apply(asset.Platform)
 
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/claude",
 	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "claude",

--- a/providers/claude/connection/platform.go
+++ b/providers/claude/connection/platform.go
@@ -18,36 +18,27 @@ var (
 )
 
 func NewClaudeOrgPlatform(orgID string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "claude-organization",
-		Title:                 "Claude Organization",
-		Family:                []string{"claude"},
-		Kind:                  "api",
-		Runtime:               "claude",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"ai", "claude", "organization", orgID},
 	}
+	PlatformByName("claude-organization").Apply(p)
+	return p
 }
 
 func NewClaudeWorkspacePlatform(orgID, workspaceID string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "claude-workspace",
-		Title:                 "Claude Workspace",
-		Family:                []string{"claude"},
-		Kind:                  "api",
-		Runtime:               "claude",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"ai", "claude", "organization", orgID, "workspace", workspaceID},
 	}
+	PlatformByName("claude-workspace").Apply(p)
+	return p
 }
 
 func NewClaudeAPIPlatform(host string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "claude",
-		Title:                 "Claude",
-		Family:                []string{"claude"},
-		Kind:                  "api",
-		Runtime:               "claude",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"ai", "claude", host},
 	}
+	PlatformByName("claude").Apply(p)
+	return p
 }
 
 func NewClaudeOrgIdentifier(orgID string) string {

--- a/providers/claude/connection/platforms.go
+++ b/providers/claude/connection/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "claude-organization",
+		Title:   "Claude Organization",
+		Family:  []string{"claude"},
+		Kind:    []string{"api"},
+		Runtime: []string{"claude"},
+	},
+	{
+		Name:    "claude-workspace",
+		Title:   "Claude Workspace",
+		Family:  []string{"claude"},
+		Kind:    []string{"api"},
+		Runtime: []string{"claude"},
+	},
+	{
+		Name:    "claude",
+		Title:   "Claude",
+		Family:  []string{"claude"},
+		Kind:    []string{"api"},
+		Runtime: []string{"claude"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/claude/connection/platforms_test.go
+++ b/providers/claude/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/claude/go.mod
+++ b/providers/claude/go.mod
@@ -6,6 +6,7 @@ go 1.26.4
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.52.0
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -37,6 +38,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -73,6 +75,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -108,6 +111,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -13,6 +13,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
 	Version:         "13.5.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "cloudflare",

--- a/providers/cloudflare/connection/platform.go
+++ b/providers/cloudflare/connection/platform.go
@@ -20,22 +20,6 @@ var (
 	PlatformIdCloudflareAccount = "//platformid.api.mondoo.app/runtime/cloudflare/account/"
 )
 
-var CloudflareZonePlatform = inventory.Platform{
-	Name:    "cloudflare-zone",
-	Title:   "Cloudflare Zone",
-	Family:  []string{"cloudflare"},
-	Kind:    "api",
-	Runtime: "cloudflare",
-}
-
-var CloudflareAccountPlatform = inventory.Platform{
-	Name:    "cloudflare-account",
-	Title:   "Cloudflare Account",
-	Family:  []string{"cloudflare"},
-	Kind:    "api",
-	Runtime: "cloudflare",
-}
-
 func (c *CloudflareConnection) PlatformInfo() (*inventory.Platform, error) {
 	conf := c.asset.Connections[0]
 	if zoneName := conf.Options["zone"]; zoneName != "" {
@@ -49,15 +33,19 @@ func (c *CloudflareConnection) PlatformInfo() (*inventory.Platform, error) {
 }
 
 func NewCloudflareZonePlatform(zoneId string) *inventory.Platform {
-	pf := CloudflareZonePlatform
-	pf.TechnologyUrlSegments = []string{"saas", "cloudflare", "zone", zoneId}
-	return &pf
+	pf := &inventory.Platform{
+		TechnologyUrlSegments: []string{"saas", "cloudflare", "zone", zoneId},
+	}
+	PlatformByName("cloudflare-zone").Apply(pf)
+	return pf
 }
 
 func NewCloudflareAccountPlatform(accountId string) *inventory.Platform {
-	pf := CloudflareAccountPlatform
-	pf.TechnologyUrlSegments = []string{"saas", "cloudflare", "account", accountId}
-	return &pf
+	pf := &inventory.Platform{
+		TechnologyUrlSegments: []string{"saas", "cloudflare", "account", accountId},
+	}
+	PlatformByName("cloudflare-account").Apply(pf)
+	return pf
 }
 
 func NewCloudflareZoneIdentifier(zoneId string) string {

--- a/providers/cloudflare/connection/platforms.go
+++ b/providers/cloudflare/connection/platforms.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "cloudflare-zone",
+		Title:   "Cloudflare Zone",
+		Family:  []string{"cloudflare"},
+		Kind:    []string{"api"},
+		Runtime: []string{"cloudflare"},
+	},
+	{
+		Name:    "cloudflare-account",
+		Title:   "Cloudflare Account",
+		Family:  []string{"cloudflare"},
+		Kind:    []string{"api"},
+		Runtime: []string{"cloudflare"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/cloudflare/connection/platforms_test.go
+++ b/providers/cloudflare/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
 	Version:         "13.1.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "cloudformation",

--- a/providers/cloudformation/provider/platforms.go
+++ b/providers/cloudformation/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "cloudformation",
+		Title:   "AWS CloudFormation",
+		Family:  []string{"cloudformation"},
+		Kind:    []string{"api"},
+		Runtime: []string{"cloudformation"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/cloudformation/provider/platforms_test.go
+++ b/providers/cloudformation/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/cloudformation/provider/provider.go
+++ b/providers/cloudformation/provider/provider.go
@@ -134,13 +134,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.Cloudformation
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "cloudformation",
-		Family:                []string{"cloudformation"},
-		Runtime:               "cloudformation",
-		Kind:                  "api",
-		Title:                 "AWS CloudFormation",
 		TechnologyUrlSegments: []string{"iac", "cloudformation", "template"},
 	}
+	PlatformByName("cloudformation").Apply(asset.Platform)
 
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {

--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/datadog/connection"
 	"go.mondoo.com/mql/v13/providers/datadog/provider"
 )
 
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/datadog",
 	Version:         "13.0.11",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "datadog",

--- a/providers/datadog/connection/platforms.go
+++ b/providers/datadog/connection/platforms.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:   "datadog",
+		Title:  "Datadog",
+		Family: []string{"datadog"},
+		Kind:   []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/datadog/connection/platforms_test.go
+++ b/providers/datadog/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/datadog/go.mod
+++ b/providers/datadog/go.mod
@@ -7,6 +7,7 @@ go 1.26.4
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.61.0
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -37,6 +38,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -101,6 +104,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/datadog/provider/provider.go
+++ b/providers/datadog/provider/provider.go
@@ -135,12 +135,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.DatadogConnect
 	asset.Id = conn.Conf.Type
 	asset.Name = "Datadog Account"
 
-	asset.Platform = &inventory.Platform{
-		Name:   "datadog",
-		Family: []string{"datadog"},
-		Kind:   "api",
-		Title:  "Datadog",
-	}
+	asset.Platform = &inventory.Platform{}
+	connection.PlatformByName("datadog").Apply(asset.Platform)
 
 	platformId := "//platformid.api.mondoo.app/runtime/datadog"
 	if orgId := conn.OrgPublicId(); orgId != "" {

--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/depsdev/connection"
 	"go.mondoo.com/mql/v13/providers/depsdev/provider"
 )
 
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
 	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "depsdev",

--- a/providers/depsdev/connection/connection.go
+++ b/providers/depsdev/connection/connection.go
@@ -69,14 +69,11 @@ func (c *DepsDevConnection) Asset() *inventory.Asset {
 }
 
 func (c *DepsDevConnection) PlatformInfo() (*inventory.Platform, error) {
-	return &inventory.Platform{
-		Name:                  "depsdev",
-		Title:                 "deps.dev",
-		Family:                []string{"depsdev"},
-		Kind:                  "api",
-		Runtime:               "depsdev",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"oss", "depsdev"},
-	}, nil
+	}
+	PlatformByName("depsdev").Apply(p)
+	return p, nil
 }
 
 func (c *DepsDevConnection) Identifier() string {

--- a/providers/depsdev/connection/platforms.go
+++ b/providers/depsdev/connection/platforms.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "depsdev",
+		Title:   "deps.dev",
+		Family:  []string{"depsdev"},
+		Kind:    []string{"api"},
+		Runtime: []string{"depsdev"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/depsdev/connection/platforms_test.go
+++ b/providers/depsdev/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/depsdev/go.mod
+++ b/providers/depsdev/go.mod
@@ -7,6 +7,7 @@ go 1.26.4
 require (
 	github.com/cockroachdb/errors v1.14.0
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 	golang.org/x/mod v0.37.0
 )
@@ -36,6 +37,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -98,6 +101,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
 	Version:         "13.10.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "digitalocean",

--- a/providers/digitalocean/connection/platform.go
+++ b/providers/digitalocean/connection/platform.go
@@ -41,44 +41,42 @@ const (
 
 const platformIDBase = "//platformid.api.mondoo.app/runtime/digitalocean"
 
-func basePlatform(name, title string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:    name,
-		Title:   title,
-		Family:  []string{"digitalocean"},
-		Kind:    "api",
-		Runtime: "digitalocean",
-	}
+// basePlatform builds a runtime platform from the static catalog entry for the
+// given name, keeping the catalog (platforms.go) as the single source of truth.
+func basePlatform(name string) *inventory.Platform {
+	p := &inventory.Platform{}
+	PlatformByName(name).Apply(p)
+	return p
 }
 
 // AccountPlatform is the root DigitalOcean account asset.
 func AccountPlatform() *inventory.Platform {
-	return basePlatform("digitalocean", "DigitalOcean")
+	return basePlatform("digitalocean")
 }
 
 // DatabasePlatform is a single managed database cluster.
 func DatabasePlatform() *inventory.Platform {
-	return basePlatform("digitalocean-database", "DigitalOcean Database")
+	return basePlatform("digitalocean-database")
 }
 
 // KubernetesPlatform is a single DOKS cluster.
 func KubernetesPlatform() *inventory.Platform {
-	return basePlatform("digitalocean-kubernetes-cluster", "DigitalOcean Kubernetes Cluster")
+	return basePlatform("digitalocean-kubernetes-cluster")
 }
 
 // LoadBalancerPlatform is a single load balancer.
 func LoadBalancerPlatform() *inventory.Platform {
-	return basePlatform("digitalocean-loadbalancer", "DigitalOcean Load Balancer")
+	return basePlatform("digitalocean-loadbalancer")
 }
 
 // FirewallPlatform is a single cloud firewall.
 func FirewallPlatform() *inventory.Platform {
-	return basePlatform("digitalocean-firewall", "DigitalOcean Cloud Firewall")
+	return basePlatform("digitalocean-firewall")
 }
 
 // SpacesBucketPlatform is a single Spaces bucket.
 func SpacesBucketPlatform() *inventory.Platform {
-	return basePlatform("digitalocean-spaces-bucket", "DigitalOcean Spaces Bucket")
+	return basePlatform("digitalocean-spaces-bucket")
 }
 
 // NewAccountIdentifier builds the platform id for the account root. The

--- a/providers/digitalocean/connection/platforms.go
+++ b/providers/digitalocean/connection/platforms.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "digitalocean",
+		Title:   "DigitalOcean",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+	{
+		Name:    "digitalocean-database",
+		Title:   "DigitalOcean Database",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+	{
+		Name:    "digitalocean-kubernetes-cluster",
+		Title:   "DigitalOcean Kubernetes Cluster",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+	{
+		Name:    "digitalocean-loadbalancer",
+		Title:   "DigitalOcean Load Balancer",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+	{
+		Name:    "digitalocean-firewall",
+		Title:   "DigitalOcean Cloud Firewall",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+	{
+		Name:    "digitalocean-spaces-bucket",
+		Title:   "DigitalOcean Spaces Bucket",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/digitalocean/connection/platforms_test.go
+++ b/providers/digitalocean/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/equinix/connection"
 	"go.mondoo.com/mql/v13/providers/equinix/provider"
 )
 
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "equinix",

--- a/providers/equinix/connection/platforms.go
+++ b/providers/equinix/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:  "equinix",
+		Title: "Equinix Metal",
+		Kind:  []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/equinix/connection/platforms_test.go
+++ b/providers/equinix/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/equinix/go.mod
+++ b/providers/equinix/go.mod
@@ -7,6 +7,7 @@ go 1.26.4
 require (
 	github.com/packethost/packngo v0.31.0
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 	go.mondoo.com/ranger-rpc v0.8.0
 )
@@ -37,6 +38,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -98,6 +101,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/providers/gcp/connection/gcpinstancesnapshot"
 	"go.mondoo.com/mql/v13/providers/gcp/provider"
 	"go.mondoo.com/mql/v13/providers/gcp/resources"
@@ -175,4 +176,5 @@ Examples with the GCP project configured:
 			},
 		},
 	},
+	Platforms: connection.Platforms,
 }

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -85,7 +85,7 @@ func newGcpPlatform(name string) *inventory.Platform {
 
 func GetTitleForPlatformName(name string) string {
 	switch name {
-	case "gcp-organization":
+	case "gcp-org":
 		return "GCP Organization"
 	case "gcp-folder":
 		return "GCP Folder"

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -51,43 +51,36 @@ func (c *GcpConnection) ResourceID() string {
 func (c *GcpConnection) PlatformInfo() (*inventory.Platform, error) {
 	// TODO: this is a hack and we need to find a better way to do this
 	if c.opts.platformOverride != "" && c.opts.platformOverride != "gcp" {
-		return &inventory.Platform{
-			Name:    c.opts.platformOverride,
-			Title:   GetTitleForPlatformName(c.opts.platformOverride),
-			Family:  []string{"google"},
-			Kind:    "gcp-object",
-			Runtime: "gcp",
-		}, nil
+		return newGcpPlatform(c.opts.platformOverride), nil
 	}
 
 	switch c.ResourceType() {
 	case Organization:
-		return &inventory.Platform{
-			Name:    "gcp-org",
-			Title:   "GCP Organization",
-			Family:  []string{"google"},
-			Kind:    "gcp-object",
-			Runtime: "gcp",
-		}, nil
+		return newGcpPlatform("gcp-org"), nil
 	case Project:
-		return &inventory.Platform{
-			Name:    "gcp-project",
-			Title:   "GCP Project",
-			Family:  []string{"google"},
-			Kind:    "gcp-object",
-			Runtime: "gcp",
-		}, nil
+		return newGcpPlatform("gcp-project"), nil
 	case Folder:
-		return &inventory.Platform{
-			Name:    "gcp-folder",
-			Title:   "GCP Folder",
-			Family:  []string{"google"},
-			Kind:    "gcp-object",
-			Runtime: "gcp",
-		}, nil
+		return newGcpPlatform("gcp-folder"), nil
 	}
 
 	return nil, errors.New("unsupported resource type")
+}
+
+// newGcpPlatform builds a runtime platform from the static catalog. Names not
+// in the catalog fall back to a generic GCP object so new object types keep
+// working before they are added to Platforms.
+func newGcpPlatform(name string) *inventory.Platform {
+	pf := &inventory.Platform{}
+	if pi := PlatformByName(name); pi != nil {
+		pi.Apply(pf)
+		return pf
+	}
+	pf.Name = name
+	pf.Title = GetTitleForPlatformName(name)
+	pf.Family = []string{"google"}
+	pf.Kind = "gcp-object"
+	pf.Runtime = "gcp"
+	return pf
 }
 
 func GetTitleForPlatformName(name string) string {

--- a/providers/gcp/connection/platforms.go
+++ b/providers/gcp/connection/platforms.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// gcpPlatformNames is the set of platform names the GCP provider can emit: the
+// org/project/folder roots plus every discoverable GCP object type (the
+// platformOverride values set during discovery). Titles are sourced from
+// GetTitleForPlatformName so there is a single title source.
+var gcpPlatformNames = []string{
+	"gcp-org", "gcp-project", "gcp-folder",
+	"gcp-compute-image", "gcp-compute-network", "gcp-compute-subnetwork",
+	"gcp-compute-firewall", "gcp-compute-instance", "gcp-gke-cluster",
+	"gcp-storage-bucket", "gcp-bigquery-dataset",
+	"gcp-sql-mysql", "gcp-sql-postgresql", "gcp-sql-sqlserver",
+	"gcp-dns-zone", "gcp-kms-keyring",
+	"gcp-memorystore-redis", "gcp-memorystore-rediscluster", "gcp-memorystore-instance",
+	"gcp-artifactregistry-repository", "gcp-memcache-instance", "gcp-vertexai-job",
+	"gcp-secretmanager-secret",
+	"gcp-pubsub-topic", "gcp-pubsub-subscription", "gcp-pubsub-snapshot",
+	"gcp-cloudrun-service", "gcp-cloudrun-job", "gcp-cloud-function",
+	"gcp-dataproc-cluster", "gcp-alloydb-cluster", "gcp-spanner-instance",
+	"gcp-firestore-database", "gcp-bigtable-instance", "gcp-logging-bucket",
+	"gcp-apikey", "gcp-iam-service-account",
+}
+
+// Platforms is the static catalog of platforms the GCP provider can emit. Every
+// GCP platform is a "gcp-object" in the "google" family running in the "gcp"
+// runtime. Single source of truth for the provider config and the runtime
+// builder (see PlatformInfo / newGcpPlatform).
+var Platforms = func() []*plugin.PlatformInfo {
+	out := make([]*plugin.PlatformInfo, 0, len(gcpPlatformNames))
+	for _, name := range gcpPlatformNames {
+		title := GetTitleForPlatformName(name)
+		// gcp-org is not a GetTitleForPlatformName case (it returns the generic
+		// default); use the title the org resource-type path has always used.
+		if name == "gcp-org" {
+			title = "GCP Organization"
+		}
+		out = append(out, &plugin.PlatformInfo{
+			Name:    name,
+			Title:   title,
+			Family:  []string{"google"},
+			Kind:    []string{"gcp-object"},
+			Runtime: []string{"gcp"},
+		})
+	}
+	return out
+}()
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static descriptor for a platform name, or nil.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/gcp/connection/platforms.go
+++ b/providers/gcp/connection/platforms.go
@@ -33,15 +33,9 @@ var gcpPlatformNames = []string{
 var Platforms = func() []*plugin.PlatformInfo {
 	out := make([]*plugin.PlatformInfo, 0, len(gcpPlatformNames))
 	for _, name := range gcpPlatformNames {
-		title := GetTitleForPlatformName(name)
-		// gcp-org is not a GetTitleForPlatformName case (it returns the generic
-		// default); use the title the org resource-type path has always used.
-		if name == "gcp-org" {
-			title = "GCP Organization"
-		}
 		out = append(out, &plugin.PlatformInfo{
 			Name:    name,
-			Title:   title,
+			Title:   GetTitleForPlatformName(name),
 			Family:  []string{"google"},
 			Kind:    []string{"gcp-object"},
 			Runtime: []string{"gcp"},

--- a/providers/gcp/connection/platforms_test.go
+++ b/providers/gcp/connection/platforms_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGcpPlatformCatalog(t *testing.T) {
+	for _, pi := range Platforms {
+		assert.Equal(t, []string{"google"}, pi.Family, "family for %q", pi.Name)
+		assert.Equal(t, []string{"gcp-object"}, pi.Kind, "kind for %q", pi.Name)
+		assert.Equal(t, []string{"gcp"}, pi.Runtime, "runtime for %q", pi.Name)
+		assert.NotEmpty(t, pi.Title, "title for %q", pi.Name)
+		assert.NotEqual(t, "Google Cloud Platform", pi.Title, "generic fallback title leaked for %q", pi.Name)
+	}
+
+	// roots resolve via the catalog with the historical titles
+	org := newGcpPlatform("gcp-org")
+	assert.Equal(t, "gcp-org", org.Name)
+	assert.Equal(t, "GCP Organization", org.Title)
+	assert.Equal(t, "gcp-object", org.Kind)
+	assert.Equal(t, "gcp", org.Runtime)
+	assert.Equal(t, []string{"google"}, org.Family)
+
+	// a discovery override resolves to its catalog entry
+	inst := newGcpPlatform("gcp-compute-instance")
+	assert.Equal(t, "GCP Compute Instance", inst.Title)
+	assert.Equal(t, "gcp-object", inst.Kind)
+
+	// an unknown name falls back to a generic GCP object
+	u := newGcpPlatform("gcp-brand-new")
+	assert.Equal(t, "gcp-brand-new", u.Name)
+	assert.Equal(t, "Google Cloud Platform", u.Title)
+	assert.Equal(t, "gcp-object", u.Kind)
+	assert.Equal(t, "gcp", u.Runtime)
+}

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -130,4 +130,5 @@ Notes:
 			},
 		},
 	},
+	Platforms: connection.Platforms,
 }

--- a/providers/github/connection/platform.go
+++ b/providers/github/connection/platform.go
@@ -6,6 +6,7 @@ package connection
 import (
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 const (
@@ -18,29 +19,27 @@ const (
 	DiscoveryK8sManifests = "k8s-manifests"
 )
 
-var (
-	GithubRepoPlatform = inventory.Platform{
-		Name:    "github-repo",
-		Title:   "GitHub Repository",
-		Family:  []string{"github"},
-		Kind:    "api",
-		Runtime: "github",
-	}
-	GithubUserPlatform = inventory.Platform{
-		Name:    "github-user",
-		Title:   "GitHub User",
-		Family:  []string{"github"},
-		Kind:    "api",
-		Runtime: "github",
-	}
-	GithubOrgPlatform = inventory.Platform{
-		Name:    "github-org",
-		Title:   "GitHub Organization",
-		Family:  []string{"github"},
-		Kind:    "api",
-		Runtime: "github",
-	}
-)
+// Platforms is the static catalog of platforms the GitHub provider can emit.
+// It is the single source of truth for both the provider config and the
+// runtime platform builders (NewGithub*Platform).
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "github-org", Title: "GitHub Organization", Family: []string{"github"}, Kind: []string{"api"}, Runtime: []string{"github"}},
+	{Name: "github-user", Title: "GitHub User", Family: []string{"github"}, Kind: []string{"api"}, Runtime: []string{"github"}},
+	{Name: "github-repo", Title: "GitHub Repository", Family: []string{"github"}, Kind: []string{"api"}, Runtime: []string{"github"}},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static descriptor for a platform name, or nil.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}
+
+func newPlatform(name string) *inventory.Platform {
+	pf := &inventory.Platform{}
+	platformsByName[name].Apply(pf)
+	return pf
+}
 
 type OrganizationId struct {
 	Name string
@@ -74,21 +73,21 @@ func (c *GithubConnection) PlatformInfo() (*inventory.Platform, error) {
 }
 
 func NewGithubOrgPlatform(orgId string) *inventory.Platform {
-	pf := GithubOrgPlatform
+	pf := newPlatform("github-org")
 	pf.TechnologyUrlSegments = []string{"saas", "github", "organization", orgId, "organization"}
-	return &pf
+	return pf
 }
 
 func NewGithubUserPlatform(userId string) *inventory.Platform {
-	pf := GithubUserPlatform
+	pf := newPlatform("github-user")
 	pf.TechnologyUrlSegments = []string{"saas", "github", "user"}
-	return &pf
+	return pf
 }
 
 func NewGitHubRepoPlatform(owner, repo string) *inventory.Platform {
-	pf := GithubRepoPlatform
+	pf := newPlatform("github-repo")
 	pf.TechnologyUrlSegments = []string{"saas", "github", "organization", owner, "repository"}
-	return &pf
+	return pf
 }
 
 func NewGithubOrgIdentifier(orgId string) string {

--- a/providers/github/connection/platform_test.go
+++ b/providers/github/connection/platform_test.go
@@ -12,23 +12,28 @@ import (
 func TestNewGithubOrgPlatform(t *testing.T) {
 	pf := NewGithubOrgPlatform("mondoohq")
 	assert.NotNil(t, pf)
+	assert.Equal(t, "github-org", pf.Name)
+	assert.Equal(t, "GitHub Organization", pf.Title)
+	assert.Equal(t, "api", pf.Kind)
+	assert.Equal(t, "github", pf.Runtime)
+	assert.Equal(t, []string{"github"}, pf.Family)
 	assert.Equal(t, []string{"saas", "github", "organization", "mondoohq", "organization"}, pf.TechnologyUrlSegments)
-	// the helper must not mutate the package-level template
-	assert.Nil(t, GithubOrgPlatform.TechnologyUrlSegments)
 }
 
 func TestNewGithubUserPlatform(t *testing.T) {
 	pf := NewGithubUserPlatform("octocat")
 	assert.NotNil(t, pf)
+	assert.Equal(t, "github-user", pf.Name)
+	assert.Equal(t, "api", pf.Kind)
 	assert.Equal(t, []string{"saas", "github", "user"}, pf.TechnologyUrlSegments)
-	assert.Nil(t, GithubUserPlatform.TechnologyUrlSegments)
 }
 
 func TestNewGitHubRepoPlatform(t *testing.T) {
 	pf := NewGitHubRepoPlatform("mondoohq", "cnquery")
 	assert.NotNil(t, pf)
+	assert.Equal(t, "github-repo", pf.Name)
+	assert.Equal(t, "api", pf.Kind)
 	assert.Equal(t, []string{"saas", "github", "organization", "mondoohq", "repository"}, pf.TechnologyUrlSegments)
-	assert.Nil(t, GithubRepoPlatform.TechnologyUrlSegments)
 }
 
 func TestNewGithubOrgIdentifier(t *testing.T) {

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -18,6 +18,7 @@ var Config = plugin.Provider{
 		provider.GitlabGroupConnection,
 		provider.GitlabProjectConnection,
 	},
+	Platforms: provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "gitlab",

--- a/providers/gitlab/provider/platforms.go
+++ b/providers/gitlab/provider/platforms.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of every platform the GitLab provider can
+// emit. Dynamic fields (TechnologyUrlSegments) are added by the platform
+// builders.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "gitlab-group",
+		Title:   "GitLab Group",
+		Family:  []string{"gitlab"},
+		Kind:    []string{"api"},
+		Runtime: []string{"gitlab"},
+	},
+	{
+		Name:    "gitlab-project",
+		Title:   "GitLab Project",
+		Family:  []string{"gitlab"},
+		Kind:    []string{"api"},
+		Runtime: []string{"gitlab"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog descriptor for the given platform name,
+// or nil if it is not in the catalog.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/gitlab/provider/platforms_test.go
+++ b/providers/gitlab/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/gitlab/provider/provider.go
+++ b/providers/gitlab/provider/provider.go
@@ -176,25 +176,19 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func projectPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "gitlab-project",
-		Title:                 "GitLab Project",
-		Family:                []string{"gitlab"},
-		Kind:                  "api",
-		Runtime:               "gitlab",
+	pf := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "gitlab", "project"},
 	}
+	PlatformByName("gitlab-project").Apply(pf)
+	return pf
 }
 
 func groupPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "gitlab-group",
-		Title:                 "GitLab Group",
-		Family:                []string{"gitlab"},
-		Kind:                  "api",
-		Runtime:               "gitlab",
+	pf := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "gitlab", "group"},
 	}
+	PlatformByName("gitlab-group").Apply(pf)
+	return pf
 }
 
 func newGitLabGroupID(groupID int64) string {

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
 	Version:         "13.2.2",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "google-workspace",

--- a/providers/google-workspace/provider/platforms.go
+++ b/providers/google-workspace/provider/platforms.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "google-workspace",
+		Title:   "Google Workspace",
+		Family:  []string{"google"},
+		Kind:    []string{"api"},
+		Runtime: []string{"google-workspace"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/google-workspace/provider/platforms_test.go
+++ b/providers/google-workspace/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/google-workspace/provider/provider.go
+++ b/providers/google-workspace/provider/provider.go
@@ -205,14 +205,13 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GoogleWorkspac
 	} else {
 		asset.Name = fmt.Sprintf("Google Workspace %s (%s)", pd, conn.CustomerID())
 	}
-	asset.Platform = &inventory.Platform{
-		Name:                  "google-workspace",
-		Family:                []string{"google"},
-		Kind:                  "api",
-		Title:                 "Google Workspace",
-		Runtime:               "google-workspace",
+	platform := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "google-workspace", conn.CustomerID()},
 	}
+	if pi, ok := PlatformByName("google-workspace"); ok {
+		pi.Apply(platform)
+	}
+	asset.Platform = platform
 
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/googleworkspace/customer/" + conn.CustomerID()}
 	return nil

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/grafana/connection"
 	"go.mondoo.com/mql/v13/providers/grafana/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
 	Version:         "13.1.11",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "grafana",

--- a/providers/grafana/connection/connection.go
+++ b/providers/grafana/connection/connection.go
@@ -131,14 +131,11 @@ func (c *GrafanaConnection) Get(ctx context.Context, path string) (*http.Respons
 
 // grafanaOrgPlatform returns the canonical platform descriptor for a Grafana org.
 func grafanaOrgPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "grafana-org",
-		Title:                 "Grafana Organization",
-		Family:                []string{"grafana"},
-		Kind:                  "api",
-		Runtime:               "grafana",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "grafana", "org"},
 	}
+	PlatformByName("grafana-org").Apply(p)
+	return p
 }
 
 // PlatformInfo returns the platform descriptor for this connection.

--- a/providers/grafana/connection/platforms.go
+++ b/providers/grafana/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "grafana-org",
+		Title:   "Grafana Organization",
+		Family:  []string{"grafana"},
+		Kind:    []string{"api"},
+		Runtime: []string{"grafana"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/grafana/connection/platforms_test.go
+++ b/providers/grafana/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -16,6 +16,7 @@ var Config = plugin.Provider{
 	Version:         "13.3.2",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "helm",

--- a/providers/helm/provider/platforms.go
+++ b/providers/helm/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "helm",
+		Title:   "Helm Chart",
+		Family:  []string{"helm"},
+		Kind:    []string{"api"},
+		Runtime: []string{"helm"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/helm/provider/platforms_test.go
+++ b/providers/helm/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/helm/provider/provider.go
+++ b/providers/helm/provider/provider.go
@@ -176,13 +176,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HelmConnection
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "helm",
-		Family:                []string{"helm"},
-		Runtime:               "helm",
-		Kind:                  "api",
-		Title:                 "Helm Chart",
 		TechnologyUrlSegments: []string{"iac", "helm", "chart"},
 	}
+	PlatformByName("helm").Apply(asset.Platform)
 
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -16,6 +16,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/hetzner",
 	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "hetzner",

--- a/providers/hetzner/connection/connection.go
+++ b/providers/hetzner/connection/connection.go
@@ -81,14 +81,11 @@ func (c *HetznerConnection) Name() string            { return "hetzner" }
 func (c *HetznerConnection) Client() *hcloud.Client  { return c.client }
 
 func (c *HetznerConnection) PlatformInfo() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "hetzner-project",
-		Title:                 "Hetzner Cloud",
-		Family:                []string{"hetzner"},
-		Kind:                  "api",
-		Runtime:               "hetzner",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"cloud", "hetzner", "project"},
 	}
+	PlatformByName("hetzner-project").Apply(p)
+	return p
 }
 
 // Identifier returns a stable platform ID for the project. Hetzner Cloud has

--- a/providers/hetzner/connection/platform.go
+++ b/providers/hetzner/connection/platform.go
@@ -28,25 +28,22 @@ const (
 	OptionLoadBalancer = "loadbalancer"
 )
 
-func childPlatform(name, title, segment string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  name,
-		Title:                 title,
-		Family:                []string{"hetzner"},
-		Kind:                  "api",
-		Runtime:               "hetzner",
+func childPlatform(name, segment string) *inventory.Platform {
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"cloud", "hetzner", segment},
 	}
+	PlatformByName(name).Apply(p)
+	return p
 }
 
 // FirewallPlatform is a single Hetzner Cloud firewall.
 func FirewallPlatform() *inventory.Platform {
-	return childPlatform("hetzner-firewall", "Hetzner Cloud Firewall", "firewall")
+	return childPlatform("hetzner-firewall", "firewall")
 }
 
 // LoadBalancerPlatform is a single Hetzner Cloud load balancer.
 func LoadBalancerPlatform() *inventory.Platform {
-	return childPlatform("hetzner-loadbalancer", "Hetzner Cloud Load Balancer", "loadbalancer")
+	return childPlatform("hetzner-loadbalancer", "loadbalancer")
 }
 
 // NewFirewallIdentifier builds the platform id for a firewall, anchored

--- a/providers/hetzner/connection/platforms.go
+++ b/providers/hetzner/connection/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "hetzner-project",
+		Title:   "Hetzner Cloud",
+		Family:  []string{"hetzner"},
+		Kind:    []string{"api"},
+		Runtime: []string{"hetzner"},
+	},
+	{
+		Name:    "hetzner-firewall",
+		Title:   "Hetzner Cloud Firewall",
+		Family:  []string{"hetzner"},
+		Kind:    []string{"api"},
+		Runtime: []string{"hetzner"},
+	},
+	{
+		Name:    "hetzner-loadbalancer",
+		Title:   "Hetzner Cloud Load Balancer",
+		Family:  []string{"hetzner"},
+		Kind:    []string{"api"},
+		Runtime: []string{"hetzner"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/hetzner/connection/platforms_test.go
+++ b/providers/hetzner/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/huggingface/connection"
 	"go.mondoo.com/mql/v13/providers/huggingface/provider"
 )
 
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/huggingface",
 	Version:         "13.1.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:      "huggingface",

--- a/providers/huggingface/connection/connection.go
+++ b/providers/huggingface/connection/connection.go
@@ -79,23 +79,17 @@ var (
 )
 
 func NewHuggingfaceUserPlatform(name string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "huggingface-user",
-		Title:                 "Hugging Face User",
-		Family:                []string{"huggingface"},
-		Kind:                  "api",
-		Runtime:               "huggingface",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "huggingface", "user", name},
 	}
+	PlatformByName("huggingface-user").Apply(p)
+	return p
 }
 
 func NewHuggingfaceOrgPlatform(name string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "huggingface-org",
-		Title:                 "Hugging Face Organization",
-		Family:                []string{"huggingface"},
-		Kind:                  "api",
-		Runtime:               "huggingface",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "huggingface", "org", name},
 	}
+	PlatformByName("huggingface-org").Apply(p)
+	return p
 }

--- a/providers/huggingface/connection/platforms.go
+++ b/providers/huggingface/connection/platforms.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "huggingface-user",
+		Title:   "Hugging Face User",
+		Family:  []string{"huggingface"},
+		Kind:    []string{"api"},
+		Runtime: []string{"huggingface"},
+	},
+	{
+		Name:    "huggingface-org",
+		Title:   "Hugging Face Organization",
+		Family:  []string{"huggingface"},
+		Kind:    []string{"api"},
+		Runtime: []string{"huggingface"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/huggingface/connection/platforms_test.go
+++ b/providers/huggingface/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/huggingface/go.mod
+++ b/providers/huggingface/go.mod
@@ -4,7 +4,10 @@ replace go.mondoo.com/mql/v13 => ../..
 
 go 1.26.4
 
-require go.mondoo.com/mql/v13 v13.24.1
+require (
+	github.com/stretchr/testify v1.11.1
+	go.mondoo.com/mql/v13 v13.24.1
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -32,6 +35,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -95,6 +100,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -13,6 +13,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "ipinfo",

--- a/providers/ipinfo/go.mod
+++ b/providers/ipinfo/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cockroachdb/errors v1.14.0
 	github.com/ipinfo/go/v2 v2.14.0
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -36,6 +37,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -70,6 +72,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -98,6 +101,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/ipinfo/provider/platforms.go
+++ b/providers/ipinfo/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:   "ipinfo",
+		Title:  "ipinfo",
+		Family: []string{"ipinfo"},
+		Kind:   []string{"api"},
+		// Runtime is intentionally omitted: the runtime sets no Runtime on this platform.
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/ipinfo/provider/platforms_test.go
+++ b/providers/ipinfo/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/ipinfo/provider/provider.go
+++ b/providers/ipinfo/provider/provider.go
@@ -124,12 +124,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.IpinfoConnecti
 	asset.Id = conn.Conf.Type
 	asset.Name = conn.Conf.Host
 
-	asset.Platform = &inventory.Platform{
-		Name:   "ipinfo",
-		Family: []string{"ipinfo"},
-		Kind:   "api",
-		Title:  "ipinfo",
-	}
+	asset.Platform = &inventory.Platform{}
+	PlatformByName("ipinfo").Apply(asset.Platform)
 
 	// TODO: Add platform IDs
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/oci/"}

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "ipmi",

--- a/providers/ipmi/provider/platforms.go
+++ b/providers/ipmi/provider/platforms.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:  "ipmi",
+		Title: "IPMI",
+		Kind:  []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/ipmi/provider/platforms_test.go
+++ b/providers/ipmi/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/ipmi/provider/provider.go
+++ b/providers/ipmi/provider/provider.go
@@ -155,11 +155,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.IpmiConnection
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "ipmi",
-		Title:                 "IPMI",
-		Kind:                  "api",
 		TechnologyUrlSegments: []string{"network", "ipmi"},
 	}
+	PlatformByName("ipmi").Apply(asset.Platform)
 
 	identifier, err := conn.Identifier()
 	if err != nil {

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/jamf/connection"
 	"go.mondoo.com/mql/v13/providers/jamf/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/jamf",
 	Version:         "13.1.5",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "jamf",

--- a/providers/jamf/connection/connection.go
+++ b/providers/jamf/connection/connection.go
@@ -92,14 +92,11 @@ func (j *JamfConnection) Asset() *inventory.Asset {
 }
 
 func (j *JamfConnection) PlatformInfo() (*inventory.Platform, error) {
-	return &inventory.Platform{
-		Name:                  "jamf",
-		Title:                 "Jamf Pro",
-		Family:                []string{"jamf"},
-		Kind:                  "api",
-		Runtime:               "jamf",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"api", "jamf"},
-	}, nil
+	}
+	PlatformByName("jamf").Apply(p)
+	return p, nil
 }
 
 func (j *JamfConnection) Identifier() string {

--- a/providers/jamf/connection/platforms.go
+++ b/providers/jamf/connection/platforms.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "jamf",
+		Title:   "Jamf Pro",
+		Family:  []string{"jamf"},
+		Kind:    []string{"api"},
+		Runtime: []string{"jamf"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/jamf/connection/platforms_test.go
+++ b/providers/jamf/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
 	Version:         "13.5.2",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:    "k8s",

--- a/providers/k8s/resources/platforms.go
+++ b/providers/k8s/resources/platforms.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// objectRuntimes lists every connection runtime that can drive object
+// discovery. createPlatformData is called with conn.Runtime(), and the
+// discovering connection may be a cluster, manifest, or admission connection,
+// so any discovered object platform can carry any of these runtimes.
+var objectRuntimes = []string{"k8s-cluster", "k8s-manifest", "k8s-admission"}
+
+// Platforms is the static catalog of platforms this provider can emit.
+//
+// The connection-level platforms (k8s-cluster, k8s-manifest, k8s-admission)
+// are built in providers/k8s/connection/{api,manifest,admission}. The
+// k8s-object platforms are built by createPlatformData in discovery.go. The
+// k8s-admission name is emitted in two shapes: as a "code" connection platform
+// (admission connection) and as a "k8s-object" discovered platform (admission
+// review object), so it lists both kinds.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "k8s-cluster",
+		Title:   "Kubernetes Cluster",
+		Family:  []string{"k8s"},
+		Kind:    []string{"api"},
+		Runtime: []string{"k8s-cluster"},
+	},
+	{
+		Name:    "k8s-manifest",
+		Title:   "Kubernetes Manifest",
+		Family:  []string{"k8s"},
+		Kind:    []string{"code"},
+		Runtime: []string{"k8s-manifest"},
+	},
+	{
+		Name:    "k8s-admission",
+		Title:   "Kubernetes Admission",
+		Family:  []string{"k8s"},
+		Kind:    []string{"code", "k8s-object"},
+		Runtime: []string{"k8s-manifest", "k8s-admission", "k8s-cluster"},
+	},
+	{
+		Name:    "k8s-node",
+		Title:   "Kubernetes Node",
+		Family:  []string{"k8s"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-pod",
+		Title:   "Kubernetes Pod",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-cronjob",
+		Title:   "Kubernetes CronJob",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-statefulset",
+		Title:   "Kubernetes StatefulSet",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-deployment",
+		Title:   "Kubernetes Deployment",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-job",
+		Title:   "Kubernetes Job",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-replicaset",
+		Title:   "Kubernetes ReplicaSet",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-daemonset",
+		Title:   "Kubernetes DaemonSet",
+		Family:  []string{"k8s", "k8s-workload"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-ingress",
+		Title:   "Kubernetes Ingress",
+		Family:  []string{"k8s", "k8s-ingress"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-service",
+		Title:   "Kubernetes Service",
+		Family:  []string{"k8s", "k8s-service"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+	{
+		Name:    "k8s-namespace",
+		Title:   "Kubernetes Namespace",
+		Family:  []string{"k8s", "k8s-namespace"},
+		Kind:    []string{"k8s-object"},
+		Runtime: objectRuntimes,
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/k8s/resources/platforms_test.go
+++ b/providers/k8s/resources/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -16,6 +16,7 @@ var Config = plugin.Provider{
 	Version:         "13.1.5",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "kustomize",

--- a/providers/kustomize/provider/platforms.go
+++ b/providers/kustomize/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "kustomize",
+		Title:   "Kustomize",
+		Family:  []string{"kustomize"},
+		Kind:    []string{"api"},
+		Runtime: []string{"kustomize"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/kustomize/provider/platforms_test.go
+++ b/providers/kustomize/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/kustomize/provider/provider.go
+++ b/providers/kustomize/provider/provider.go
@@ -128,13 +128,9 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.KustomizeConnection) error {
 	asset.Platform = &inventory.Platform{
-		Name:                  "kustomize",
-		Family:                []string{"kustomize"},
-		Runtime:               "kustomize",
-		Kind:                  "api",
-		Title:                 "Kustomize",
 		TechnologyUrlSegments: []string{"iac", "kustomize", "overlay"},
 	}
+	PlatformByName("kustomize").Apply(asset.Platform)
 
 	projectPath, ok := asset.Connections[0].Options["path"]
 	if ok {

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
 	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:    "mikrotik",

--- a/providers/mikrotik/provider/platforms.go
+++ b/providers/mikrotik/provider/platforms.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "mikrotik",
+		Title:   "MikroTik RouterOS",
+		Family:  []string{"mikrotik"},
+		Kind:    []string{"api"},
+		Runtime: []string{"mikrotik"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/mikrotik/provider/platforms_test.go
+++ b/providers/mikrotik/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/mikrotik/provider/provider.go
+++ b/providers/mikrotik/provider/provider.go
@@ -181,13 +181,11 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.MikrotikConnec
 	version := resource["version"]
 
 	asset.Platform = &inventory.Platform{
-		Name:    "mikrotik",
-		Family:  []string{"mikrotik"},
-		Kind:    "api",
-		Runtime: "mikrotik",
-		Title:   "MikroTik RouterOS",
 		Version: version,
 		Labels:  map[string]string{},
+	}
+	if pi, ok := PlatformByName("mikrotik"); ok {
+		pi.Apply(asset.Platform)
 	}
 	if board := resource["board-name"]; board != "" {
 		asset.Platform.Labels["mikrotik.com/board-name"] = board

--- a/providers/mistral/config/config.go
+++ b/providers/mistral/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/mistral",
 	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "mistral",

--- a/providers/mistral/connection/platforms.go
+++ b/providers/mistral/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms emitted by the Mistral provider.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "mistral",
+		Title:   "Mistral AI",
+		Family:  []string{"mistral"},
+		Kind:    []string{"api"},
+		Runtime: []string{"mistral"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry with the given name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/mistral/connection/platforms_test.go
+++ b/providers/mistral/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/mistral/go.mod
+++ b/providers/mistral/go.mod
@@ -4,7 +4,10 @@ replace go.mondoo.com/mql/v13 => ../..
 
 go 1.26.4
 
-require go.mondoo.com/mql/v13 v13.24.1
+require (
+	github.com/stretchr/testify v1.11.1
+	go.mondoo.com/mql/v13 v13.24.1
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -32,6 +35,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -95,6 +100,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/mistral/provider/provider.go
+++ b/providers/mistral/provider/provider.go
@@ -141,13 +141,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.MistralConnect
 		asset.Name = "Mistral AI (" + workspace + ")"
 	}
 
-	asset.Platform = &inventory.Platform{
-		Name:    "mistral",
-		Family:  []string{"mistral"},
-		Kind:    "api",
-		Runtime: "mistral",
-		Title:   "Mistral AI",
-	}
+	asset.Platform = &inventory.Platform{}
+	connection.PlatformByName("mistral").Apply(asset.Platform)
 
 	platformID := "//platformid.api.mondoo.app/runtime/mistral"
 	if workspace != "" {

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -13,6 +13,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
 	Version:         "13.1.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "mondoo",

--- a/providers/mondoo/provider/platforms.go
+++ b/providers/mondoo/provider/platforms.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "mondoo-space",
+		Title:   "Mondoo Space",
+		Kind:    []string{"api"},
+		Runtime: []string{"mondoo"},
+	},
+	{
+		Name:    "mondoo-organization",
+		Title:   "Mondoo Organization",
+		Kind:    []string{"api"},
+		Runtime: []string{"mondoo"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/mondoo/provider/platforms_test.go
+++ b/providers/mondoo/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/mondoo/provider/provider.go
+++ b/providers/mondoo/provider/provider.go
@@ -107,22 +107,20 @@ func fillAsset(conn *connection.Connection, asset *inventory.Asset) {
 	if conn.Type == connection.ConnTypeSpace {
 		asset.Name = fmt.Sprintf("Mondoo Space %s", name)
 		asset.Platform = &inventory.Platform{
-			Name:    "mondoo-space",
-			Title:   "Mondoo Space",
-			Family:  []string{},
-			Kind:    "api",
-			Runtime: "mondoo",
-			Labels:  map[string]string{},
+			Family: []string{},
+			Labels: map[string]string{},
+		}
+		if pi, ok := PlatformByName("mondoo-space"); ok {
+			pi.Apply(asset.Platform)
 		}
 	} else if conn.Type == connection.ConnTypeOrganization {
 		asset.Name = fmt.Sprintf("Mondoo Organization %s", name)
 		asset.Platform = &inventory.Platform{
-			Name:    "mondoo-organization",
-			Title:   "Mondoo Organization",
-			Family:  []string{},
-			Kind:    "api",
-			Runtime: "mondoo",
-			Labels:  map[string]string{},
+			Family: []string{},
+			Labels: map[string]string{},
+		}
+		if pi, ok := PlatformByName("mondoo-organization"); ok {
+			pi.Apply(asset.Platform)
 		}
 	}
 }

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/ms365/connection"
 	"go.mondoo.com/mql/v13/providers/ms365/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
 	Version:         "13.8.2",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:    "ms365",

--- a/providers/ms365/connection/platforms.go
+++ b/providers/ms365/connection/platforms.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "ms365",
+		Title:   "Microsoft 365",
+		Family:  []string{""},
+		Kind:    []string{"api"},
+		Runtime: []string{"ms365"},
+	},
+	{
+		Name:    "microsoft365",
+		Title:   "Microsoft 365",
+		Kind:    []string{"api"},
+		Runtime: []string{"ms-graph"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/ms365/connection/platforms_test.go
+++ b/providers/ms365/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
 	Version:         "13.2.3",
 	ConnectionTypes: []string{provider.HostConnectionType},
+	Platforms:       provider.Platforms,
 	CrossProviderTypes: []string{
 		"go.mondoo.com/mql/providers/os",
 		"go.mondoo.com/mql/providers/k8s",

--- a/providers/network/provider/platforms.go
+++ b/providers/network/provider/platforms.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "host",
+		Title:   "Network Host",
+		Family:  []string{"network"},
+		Kind:    []string{"network"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/network/provider/platforms.go
+++ b/providers/network/provider/platforms.go
@@ -10,10 +10,10 @@ import (
 // Platforms is the static catalog of platforms this provider can emit.
 var Platforms = []*plugin.PlatformInfo{
 	{
-		Name:    "host",
-		Title:   "Network Host",
-		Family:  []string{"network"},
-		Kind:    []string{"network"},
+		Name:   "host",
+		Title:  "Network Host",
+		Family: []string{"network"},
+		Kind:   []string{"network"},
 	},
 }
 

--- a/providers/network/provider/platforms_test.go
+++ b/providers/network/provider/platforms_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		got, ok := PlatformByName(pi.Name)
+		require.True(t, ok, pi.Name)
+		assert.Same(t, pi, got, pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -205,13 +205,13 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HostConnection
 	} else {
 		asset.Name = conn.Conf.Host
 	}
-	asset.Platform = &inventory.Platform{
-		Name:                  "host",
-		Family:                []string{"network"},
-		Kind:                  "network",
-		Title:                 "Network Host",
+	platform := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "host"},
 	}
+	if pi, ok := PlatformByName("host"); ok {
+		pi.Apply(platform)
+	}
+	asset.Platform = platform
 
 	asset.Fqdn = conn.FQDN()
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/network/host/" + conn.Conf.Runtime + conn.Conf.Host}

--- a/providers/nextdns/config/config.go
+++ b/providers/nextdns/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/nextdns",
 	Version:         "13.0.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "nextdns",

--- a/providers/nextdns/connection/platform.go
+++ b/providers/nextdns/connection/platform.go
@@ -19,22 +19,6 @@ var (
 	PlatformIdNextdnsProfile = "//platformid.api.mondoo.app/runtime/nextdns/profile/"
 )
 
-var NextdnsAccountPlatform = inventory.Platform{
-	Name:    "nextdns-account",
-	Title:   "NextDNS Account",
-	Family:  []string{"nextdns"},
-	Kind:    "api",
-	Runtime: "nextdns",
-}
-
-var NextdnsProfilePlatform = inventory.Platform{
-	Name:    "nextdns-profile",
-	Title:   "NextDNS Profile",
-	Family:  []string{"nextdns"},
-	Kind:    "api",
-	Runtime: "nextdns",
-}
-
 // PlatformInfo returns the platform for the asset this connection is scoped to.
 // A connection carrying a profile option is a single profile; otherwise it is
 // the account root.
@@ -46,15 +30,19 @@ func (c *NextdnsConnection) PlatformInfo() *inventory.Platform {
 }
 
 func NewNextdnsAccountPlatform(accountID string) *inventory.Platform {
-	pf := NextdnsAccountPlatform
-	pf.TechnologyUrlSegments = []string{"saas", "nextdns", "account", accountID}
-	return &pf
+	pf := &inventory.Platform{
+		TechnologyUrlSegments: []string{"saas", "nextdns", "account", accountID},
+	}
+	PlatformByName("nextdns-account").Apply(pf)
+	return pf
 }
 
 func NewNextdnsProfilePlatform(profileID string) *inventory.Platform {
-	pf := NextdnsProfilePlatform
-	pf.TechnologyUrlSegments = []string{"saas", "nextdns", "profile", profileID}
-	return &pf
+	pf := &inventory.Platform{
+		TechnologyUrlSegments: []string{"saas", "nextdns", "profile", profileID},
+	}
+	PlatformByName("nextdns-profile").Apply(pf)
+	return pf
 }
 
 func NewNextdnsAccountIdentifier(accountID string) string {

--- a/providers/nextdns/connection/platforms.go
+++ b/providers/nextdns/connection/platforms.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "nextdns-account",
+		Title:   "NextDNS Account",
+		Family:  []string{"nextdns"},
+		Kind:    []string{"api"},
+		Runtime: []string{"nextdns"},
+	},
+	{
+		Name:    "nextdns-profile",
+		Title:   "NextDNS Profile",
+		Family:  []string{"nextdns"},
+		Kind:    []string{"api"},
+		Runtime: []string{"nextdns"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/nextdns/connection/platforms_test.go
+++ b/providers/nextdns/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/nextdns/go.mod
+++ b/providers/nextdns/go.mod
@@ -4,7 +4,10 @@ replace go.mondoo.com/mql/v13 => ../..
 
 go 1.26.4
 
-require go.mondoo.com/mql/v13 v13.24.1
+require (
+	github.com/stretchr/testify v1.11.1
+	go.mondoo.com/mql/v13 v13.24.1
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -32,6 +35,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -94,6 +99,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/nmap",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "nmap",

--- a/providers/nmap/connection/connection.go
+++ b/providers/nmap/connection/connection.go
@@ -44,36 +44,27 @@ func (c *NmapConnection) Asset() *inventory.Asset {
 }
 
 func nmapHostPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nmap-host",
-		Title:                 "Nmap Host",
-		Family:                []string{"nmap"},
-		Kind:                  "api",
-		Runtime:               "nmap",
+	pf := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "nmap", "host"},
 	}
+	PlatformByName("nmap-host").Apply(pf)
+	return pf
 }
 
 func nmapDomainPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nmap-domain",
-		Title:                 "Nmap Domain",
-		Family:                []string{"nmap"},
-		Kind:                  "api",
-		Runtime:               "nmap",
+	pf := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "nmap", "domain"},
 	}
+	PlatformByName("nmap-domain").Apply(pf)
+	return pf
 }
 
 func nmapPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nmap-org",
-		Title:                 "Nmap",
-		Family:                []string{"nmap"},
-		Kind:                  "api",
-		Runtime:               "nmap",
+	pf := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "nmap", "org"},
 	}
+	PlatformByName("nmap-org").Apply(pf)
+	return pf
 }
 
 func (c *NmapConnection) PlatformInfo() (*inventory.Platform, error) {

--- a/providers/nmap/connection/platforms.go
+++ b/providers/nmap/connection/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms emitted by the nmap provider.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "nmap-host",
+		Title:   "Nmap Host",
+		Family:  []string{"nmap"},
+		Kind:    []string{"api"},
+		Runtime: []string{"nmap"},
+	},
+	{
+		Name:    "nmap-domain",
+		Title:   "Nmap Domain",
+		Family:  []string{"nmap"},
+		Kind:    []string{"api"},
+		Runtime: []string{"nmap"},
+	},
+	{
+		Name:    "nmap-org",
+		Title:   "Nmap",
+		Family:  []string{"nmap"},
+		Kind:    []string{"api"},
+		Runtime: []string{"nmap"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/nmap/connection/platforms_test.go
+++ b/providers/nmap/connection/platforms_test.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, p := range Platforms {
+		require.NotEmpty(t, p.Name)
+		assert.Same(t, p, PlatformByName(p.Name))
+	}
+}
+
+func TestPlatformBuildersConsistent(t *testing.T) {
+	builders := map[string]func() *inventory.Platform{
+		"nmap-host":   nmapHostPlatform,
+		"nmap-domain": nmapDomainPlatform,
+		"nmap-org":    nmapPlatform,
+	}
+
+	for name, build := range builders {
+		entry := PlatformByName(name)
+		require.NotNil(t, entry, name)
+		pf := build()
+		assert.True(t, entry.Consistent(pf), name)
+		assert.Equal(t, entry.Title, pf.Title, name)
+	}
+}

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
 	Version:         "13.1.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "nutanix",

--- a/providers/nutanix/connection/platform.go
+++ b/providers/nutanix/connection/platform.go
@@ -59,36 +59,27 @@ func (c *NutanixConnection) PlatformIDs() []string {
 }
 
 func NewPrismCentralPlatform(endpoint string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nutanix-prism-central",
-		Title:                 "Nutanix Prism Central",
-		Family:                []string{Family},
-		Kind:                  "api",
-		Runtime:               "nutanix",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"virtualization", "nutanix", "prism-central", endpoint},
 	}
+	PlatformByName("nutanix-prism-central").Apply(p)
+	return p
 }
 
 func NewClusterPlatform(clusterId string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nutanix-cluster",
-		Title:                 "Nutanix Cluster",
-		Family:                []string{Family},
-		Kind:                  "api",
-		Runtime:               "nutanix",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"virtualization", "nutanix", "cluster", clusterId},
 	}
+	PlatformByName("nutanix-cluster").Apply(p)
+	return p
 }
 
 func NewNodePlatform(nodeId string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "nutanix-node",
-		Title:                 "Nutanix Node",
-		Family:                []string{Family},
-		Kind:                  inventory.AssetKindBaremetal,
-		Runtime:               "nutanix",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"virtualization", "nutanix", "node", nodeId},
 	}
+	PlatformByName("nutanix-node").Apply(p)
+	return p
 }
 
 func NewPrismCentralIdentifier(endpoint string) string {

--- a/providers/nutanix/connection/platforms.go
+++ b/providers/nutanix/connection/platforms.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "nutanix-prism-central",
+		Title:   "Nutanix Prism Central",
+		Family:  []string{Family},
+		Kind:    []string{"api"},
+		Runtime: []string{"nutanix"},
+	},
+	{
+		Name:    "nutanix-cluster",
+		Title:   "Nutanix Cluster",
+		Family:  []string{Family},
+		Kind:    []string{"api"},
+		Runtime: []string{"nutanix"},
+	},
+	{
+		Name:    "nutanix-node",
+		Title:   "Nutanix Node",
+		Family:  []string{Family},
+		Kind:    []string{inventory.AssetKindBaremetal},
+		Runtime: []string{"nutanix"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/nutanix/connection/platforms_test.go
+++ b/providers/nutanix/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/nutanix/go.mod
+++ b/providers/nutanix/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1
 	github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.2.2
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -39,6 +40,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -75,6 +77,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -105,6 +108,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
 	Version:         "13.12.1",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "oci",

--- a/providers/oci/provider/provider.go
+++ b/providers/oci/provider/provider.go
@@ -225,13 +225,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OciConnection)
 	}
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "oci",
-		Title:                 "Oracle Cloud Infrastructure",
-		Runtime:               "oci",
-		Kind:                  "api",
-		Family:                []string{"oci"},
 		TechnologyUrlSegments: []string{"oci", "tenancy"},
 	}
+	resources.PlatformByName("oci").Apply(asset.Platform)
 
 	platformID := "//platformid.api.mondoo.app/runtime/oci/" + conn.TenantID()
 	asset.PlatformIds = []string{platformID}

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -400,31 +400,6 @@ func getPlatformName(obj ociObject) string {
 	return ""
 }
 
-// getPlatformTitle returns the human-readable title displayed in cnspec/UI.
-func getPlatformTitle(platform string) string {
-	switch platform {
-	case "oci-network-securitylist":
-		return "OCI Network Security List"
-	case "oci-identity-user":
-		return "OCI Identity User"
-	case "oci-identity-policy":
-		return "OCI Identity Policy"
-	case "oci-objectstorage-bucket":
-		return "OCI Object Storage Bucket"
-	case "oci-apigateway-deployment":
-		return "OCI API Gateway Deployment"
-	case "oci-loadbalancer":
-		return "OCI Load Balancer"
-	case "oci-redis-cluster":
-		return "OCI Redis Cluster"
-	case "oci-vault-secret":
-		return "OCI Vault Secret"
-	case "oci-oke-cluster":
-		return "OCI OKE Cluster"
-	}
-	return ""
-}
-
 // ociObjectToAsset wraps an ociObject into an inventory.Asset suitable for
 // returning from Discover(). Returns nil if the object can't be mapped to a
 // known platform (discovery then skips it rather than emitting a broken asset).
@@ -447,16 +422,12 @@ func ociObjectToAsset(obj ociObject, name string, labels map[string]string, conn
 		inventory.WithParentConnectionId(conn.Conf.Id),
 	)
 	clonedConfig.PlatformId = platformID
+	platform := &inventory.Platform{}
+	PlatformByName(platformName).Apply(platform)
 	return &inventory.Asset{
 		PlatformIds: []string{platformID},
 		Name:        name,
-		Platform: &inventory.Platform{
-			Name:    platformName,
-			Title:   getPlatformTitle(platformName),
-			Runtime: "oci",
-			Kind:    "oci-object",
-			Family:  []string{"oci"},
-		},
+		Platform:    platform,
 		Labels:      labels,
 		Connections: []*inventory.Config{clonedConfig},
 	}

--- a/providers/oci/resources/platforms.go
+++ b/providers/oci/resources/platforms.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms the OCI provider can emit: the
+// tenancy root ("oci", an "api" platform) plus one entry per discoverable OCI
+// object type. Each object is an "oci-object" running in the "oci" runtime and
+// belongs to the "oci" family. This is the single source of truth for both the
+// provider config (config.Config.Platforms) and the runtime platform builders.
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "oci", Title: "Oracle Cloud Infrastructure", Family: []string{"oci"}, Kind: []string{"api"}, Runtime: []string{"oci"}},
+	{Name: "oci-network-securitylist", Title: "OCI Network Security List", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-identity-user", Title: "OCI Identity User", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-identity-policy", Title: "OCI Identity Policy", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-objectstorage-bucket", Title: "OCI Object Storage Bucket", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-apigateway-deployment", Title: "OCI API Gateway Deployment", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-loadbalancer", Title: "OCI Load Balancer", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-redis-cluster", Title: "OCI Redis Cluster", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-vault-secret", Title: "OCI Vault Secret", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-oke-cluster", Title: "OCI OKE Cluster", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static descriptor for a platform name, or nil if
+// the name is not in the catalog.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/oci/resources/platforms_test.go
+++ b/providers/oci/resources/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/okta/connection"
 	"go.mondoo.com/mql/v13/providers/okta/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
 	Version:         "13.3.1",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "okta",

--- a/providers/okta/connection/platforms.go
+++ b/providers/okta/connection/platforms.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "okta-org",
+		Title:   "Okta Organization",
+		Family:  []string{"okta"},
+		Kind:    []string{"api"},
+		Runtime: []string{"okta"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/okta/connection/platforms_test.go
+++ b/providers/okta/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/ollama",
 	Version:         "13.0.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:      "ollama",

--- a/providers/ollama/go.mod
+++ b/providers/ollama/go.mod
@@ -6,6 +6,7 @@ go 1.26.4
 
 require (
 	github.com/ollama/ollama v0.30.10
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -37,6 +38,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect

--- a/providers/ollama/provider/platforms.go
+++ b/providers/ollama/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "ollama",
+		Title:   "Ollama",
+		Family:  []string{"ollama"},
+		Kind:    []string{"api"},
+		Runtime: []string{"ollama"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/ollama/provider/platforms_test.go
+++ b/providers/ollama/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/ollama/provider/provider.go
+++ b/providers/ollama/provider/provider.go
@@ -123,13 +123,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OllamaConnecti
 
 	asset.Name = "Ollama (" + host + ")"
 	asset.Platform = &inventory.Platform{
-		Name:                  "ollama",
-		Title:                 "Ollama",
-		Family:                []string{"ollama"},
-		Kind:                  "api",
-		Runtime:               "ollama",
 		TechnologyUrlSegments: []string{"ai", "ollama", host},
 	}
+	PlatformByName("ollama").Apply(asset.Platform)
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/ollama/host/" + host}
 
 	return nil

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -13,6 +13,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "opcua",

--- a/providers/opcua/go.mod
+++ b/providers/opcua/go.mod
@@ -7,6 +7,7 @@ go 1.26.4
 require (
 	github.com/gopcua/opcua v0.9.0
 	github.com/mozillazg/go-slugify v0.2.0
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -36,6 +37,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -100,6 +103,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/opcua/provider/platforms.go
+++ b/providers/opcua/provider/platforms.go
@@ -1,0 +1,23 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:   "opcua",
+		Title:  "OPC UA",
+		Family: []string{"opcua"},
+		Kind:   []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/opcua/provider/platforms_test.go
+++ b/providers/opcua/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/opcua/provider/provider.go
+++ b/providers/opcua/provider/provider.go
@@ -127,12 +127,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 func (s *Service) detect(asset *inventory.Asset, conn *connection.OpcuaConnection) error {
 	asset.Name = conn.Conf.Host
 
-	asset.Platform = &inventory.Platform{
-		Name:   "opcua",
-		Family: []string{"opcua"},
-		Kind:   "api",
-		Title:  "OPC UA",
-	}
+	asset.Platform = &inventory.Platform{}
+	PlatformByName("opcua").Apply(asset.Platform)
 
 	// Add platform ID
 	endpoint := conn.Endpoint()

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/openai/connection"
 	"go.mondoo.com/mql/v13/providers/openai/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/openai",
 	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:      "openai",

--- a/providers/openai/connection/platforms.go
+++ b/providers/openai/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms emitted by the OpenAI provider.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "openai",
+		Title:   "OpenAI",
+		Family:  []string{"openai"},
+		Kind:    []string{"api"},
+		Runtime: []string{"openai"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry with the given name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/openai/connection/platforms_test.go
+++ b/providers/openai/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -6,6 +6,7 @@ go 1.26.4
 
 require (
 	github.com/openai/openai-go/v3 v3.41.0
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -35,6 +36,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -69,6 +71,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -102,6 +105,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/openai/provider/provider.go
+++ b/providers/openai/provider/provider.go
@@ -140,13 +140,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OpenaiConnecti
 	identifier := conn.Identifier()
 	asset.Name = name
 	asset.Platform = &inventory.Platform{
-		Name:                  "openai",
-		Title:                 "OpenAI",
-		Family:                []string{"openai"},
-		Kind:                  "api",
-		Runtime:               "openai",
 		TechnologyUrlSegments: []string{"ai", "openai", identifier},
 	}
+	connection.PlatformByName("openai").Apply(asset.Platform)
 
 	asset.PlatformIds = []string{conn.PlatformId()}
 

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
 	Version:         "13.6.0",
+	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/openstack/connection/platform.go
+++ b/providers/openstack/connection/platform.go
@@ -45,13 +45,9 @@ func (c *OpenstackConnection) scopeIdentifier() string {
 // mirroring the naming of other providers' object platforms (aws-security-group,
 // digitalocean-firewall).
 func SecurityGroupPlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:    "openstack-security-group",
-		Title:   "OpenStack Security Group",
-		Family:  []string{"openstack"},
-		Kind:    "api",
-		Runtime: "openstack",
-	}
+	p := &inventory.Platform{}
+	PlatformByName("openstack-security-group").Apply(p)
+	return p
 }
 
 // NewSecurityGroupIdentifier builds the platform id for a single security group,

--- a/providers/openstack/connection/platforms.go
+++ b/providers/openstack/connection/platforms.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "openstack-project",
+		Title:   "OpenStack Project",
+		Family:  []string{"openstack"},
+		Kind:    []string{"api"},
+		Runtime: []string{"openstack"},
+	},
+	{
+		Name:    "openstack-domain",
+		Title:   "OpenStack Domain",
+		Family:  []string{"openstack"},
+		Kind:    []string{"api"},
+		Runtime: []string{"openstack"},
+	},
+	{
+		Name:    "openstack-system",
+		Title:   "OpenStack System Scope",
+		Family:  []string{"openstack"},
+		Kind:    []string{"api"},
+		Runtime: []string{"openstack"},
+	},
+	{
+		Name:    "openstack-security-group",
+		Title:   "OpenStack Security Group",
+		Family:  []string{"openstack"},
+		Kind:    []string{"api"},
+		Runtime: []string{"openstack"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/openstack/connection/platforms_test.go
+++ b/providers/openstack/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/openstack/provider/provider.go
+++ b/providers/openstack/provider/provider.go
@@ -181,23 +181,18 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OpenstackConne
 		return nil
 	}
 
-	asset.Platform = &inventory.Platform{
-		Family:  []string{"openstack"},
-		Kind:    "api",
-		Runtime: "openstack",
-	}
+	asset.Platform = &inventory.Platform{}
 
+	var platformName string
 	switch {
 	case conn.ProjectID() != "":
-		asset.Platform.Name = "openstack-project"
-		asset.Platform.Title = "OpenStack Project"
+		platformName = "openstack-project"
 		asset.Id = connection.PlatformIdOpenstackProject + conn.ProjectID()
 		if asset.Name == "" {
 			asset.Name = "OpenStack project " + conn.ProjectID()
 		}
 	case conn.DomainID() != "":
-		asset.Platform.Name = "openstack-domain"
-		asset.Platform.Title = "OpenStack Domain"
+		platformName = "openstack-domain"
 		asset.Id = connection.PlatformIdOpenstackDomain + conn.DomainID()
 		if asset.Name == "" {
 			asset.Name = "OpenStack domain " + conn.DomainID()
@@ -208,13 +203,13 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OpenstackConne
 		// share an identity.
 		sum := sha256.Sum256([]byte(conn.AuthURL()))
 		fp := hex.EncodeToString(sum[:])
-		asset.Platform.Name = "openstack-system"
-		asset.Platform.Title = "OpenStack System Scope"
+		platformName = "openstack-system"
 		asset.Id = connection.PlatformIdOpenstackSystem + fp
 		if asset.Name == "" {
 			asset.Name = "OpenStack at " + conn.AuthURL()
 		}
 	}
+	connection.PlatformByName(platformName).Apply(asset.Platform)
 	asset.PlatformIds = []string{asset.Id}
 	return nil
 }

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -7,6 +7,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/detector"
 	"go.mondoo.com/mql/v13/providers/os/resources/discovery/docker_engine"
 )
 
@@ -419,4 +420,5 @@ Examples:
 			PathSegments: []string{"technology=iac", "category=dockerfile"},
 		},
 	},
+	Platforms: detector.CatalogPlatforms(),
 }

--- a/providers/os/detector/catalog.go
+++ b/providers/os/detector/catalog.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"slices"
+	"sort"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// osPlatformKinds is the closed set of kinds an operating-system platform can
+// be detected as. Which one applies is decided by the connection at runtime
+// (see detector/platform_resolver.go and provider/detector.go), not by the
+// platform name, so every OS entry carries the full set as its possible kinds.
+var osPlatformKinds = []string{
+	inventory.AssetKindBaremetal, // "baremetal"
+	inventory.AssetKindCloudVM,   // "virtualmachine"
+	"container",                  // running container
+	"container-image",            // container image layers
+}
+
+// CatalogPlatforms returns the static platform catalog for the OS provider,
+// derived from the live detector tree (osTree) so it stays in sync with the
+// platforms detection can actually produce. Each entry carries the platform
+// name and its family chain (leaf-first, matching the runtime-emitted
+// platform.Family order) plus the possible OS kinds.
+//
+// Runtime is intentionally left unconstrained: an OS platform's runtime is set
+// by the scanning context (ssh/local, a container engine, or a cloud provider
+// such as "aws-ec2-instance"), which spans providers and is open-ended, so it
+// cannot be enumerated as a closed set here.
+func CatalogPlatforms() []*plugin.PlatformInfo {
+	names := make([]string, 0, len(osTree))
+	for name := range osTree {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic output for a stable provider config
+
+	platforms := make([]*plugin.PlatformInfo, 0, len(names))
+	for _, name := range names {
+		// osTree stores parents root-first (["os","unix","linux","debian"]);
+		// the runtime emits them leaf-first (["debian","linux","unix","os"]).
+		family := slices.Clone(osTree[name])
+		slices.Reverse(family)
+
+		platforms = append(platforms, &plugin.PlatformInfo{
+			Name:   name,
+			Family: family,
+			Kind:   osPlatformKinds,
+		})
+	}
+	return platforms
+}

--- a/providers/os/detector/catalog_test.go
+++ b/providers/os/detector/catalog_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogPlatforms(t *testing.T) {
+	cat := CatalogPlatforms()
+	require.NotEmpty(t, cat)
+
+	// one entry per detector-tree leaf, no more, no less
+	assert.Len(t, cat, len(osTree))
+
+	byName := map[string]bool{}
+	for _, pi := range cat {
+		byName[pi.Name] = true
+		// runtime is unconstrained for OS; kinds are the closed set
+		assert.Empty(t, pi.Runtime, "OS runtime must stay unconstrained for %q", pi.Name)
+		assert.Equal(t, osPlatformKinds, pi.Kind, "kinds for %q", pi.Name)
+	}
+	for name := range osTree {
+		assert.True(t, byName[name], "tree leaf %q missing from catalog", name)
+	}
+
+	// a representative platform is present with the leaf-first family chain
+	// matching what the runtime emits (see resolvePlatform)
+	var ubuntu *struct {
+		fam []string
+	}
+	for _, pi := range cat {
+		if pi.Name == "ubuntu" {
+			ubuntu = &struct{ fam []string }{pi.Family}
+		}
+	}
+	require.NotNil(t, ubuntu, "ubuntu should be a catalogued platform")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, ubuntu.fam)
+}

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -6,12 +6,14 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/proxmox/connection"
 )
 
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
 	Version:         "0.2.2",
+	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/proxmox/connection/platforms.go
+++ b/providers/proxmox/connection/platforms.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "proxmox",
+		Title:   "Proxmox VE",
+		Family:  []string{"proxmox"},
+		Kind:    []string{"api"},
+		Runtime: []string{"proxmox"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) (*plugin.PlatformInfo, bool) {
+	p, ok := platformsByName[name]
+	return p, ok
+}

--- a/providers/proxmox/connection/platforms_test.go
+++ b/providers/proxmox/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+
+	pi, ok := PlatformByName("proxmox")
+	require.True(t, ok)
+
+	p := &inventory.Platform{}
+	pi.Apply(p)
+
+	require.True(t, pi.Consistent(p))
+	require.Equal(t, "Proxmox VE", p.Title)
+	require.Equal(t, pi.Title, p.Title)
+}

--- a/providers/proxmox/go.mod
+++ b/providers/proxmox/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/v13/providers/proxmox
 
 replace go.mondoo.com/mql/v13 => ../..
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/proxmox/go.mod
+++ b/providers/proxmox/go.mod
@@ -1,9 +1,12 @@
 module go.mondoo.com/mql/v13/providers/proxmox
 
+replace go.mondoo.com/mql/v13 => ../..
+
 go 1.26.3
 
 require (
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -33,6 +36,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -67,6 +71,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -95,6 +100,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/proxmox/go.sum
+++ b/providers/proxmox/go.sum
@@ -428,10 +428,10 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mondoo.com/mondoo-go v0.0.0-20260624002826-255868a855f8 h1:hS0kq4vMjLPQ7p1A4/u4CvWjv5XJr29Ln7mEmejuds4=
-go.mondoo.com/mondoo-go v0.0.0-20260624002826-255868a855f8/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.24.1 h1:9Z6B+Fo5Q5eTkl00E5WRRXsDIuKb6INR5CqVuTukCwA=
-go.mondoo.com/mql/v13 v13.24.1/go.mod h1:l0P8Sldc3LR7IhWOfcO74YeTnFO5ZCox1CsDTinGgWE=
+go.mondoo.com/mondoo-go v0.0.0-20260617003804-5f468d5f78e9 h1:QrlNtEyIsD3MJgUACCRm+JcBHFzsLNOXlZNsgZOJ6LQ=
+go.mondoo.com/mondoo-go v0.0.0-20260617003804-5f468d5f78e9/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
+go.mondoo.com/mql/v13 v13.24.0 h1:BPRpY314wNusMQAUA4gICz36ARRKSJU48QGYw7QnlL4=
+go.mondoo.com/mql/v13 v13.24.0/go.mod h1:LninkmjtuGTQVH+HdaB7oGgpM2fnu/I2KgavHb6l84M=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/providers/proxmox/go.sum
+++ b/providers/proxmox/go.sum
@@ -428,10 +428,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mondoo.com/mondoo-go v0.0.0-20260617003804-5f468d5f78e9 h1:QrlNtEyIsD3MJgUACCRm+JcBHFzsLNOXlZNsgZOJ6LQ=
-go.mondoo.com/mondoo-go v0.0.0-20260617003804-5f468d5f78e9/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.24.0 h1:BPRpY314wNusMQAUA4gICz36ARRKSJU48QGYw7QnlL4=
-go.mondoo.com/mql/v13 v13.24.0/go.mod h1:LninkmjtuGTQVH+HdaB7oGgpM2fnu/I2KgavHb6l84M=
+go.mondoo.com/mondoo-go v0.0.0-20260625124450-d02b3d289fd3 h1:0S7iC4E4q80f/FGPFPmcscBpVBzXrj5Pd0bwV3Oeu2k=
+go.mondoo.com/mondoo-go v0.0.0-20260625124450-d02b3d289fd3/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/providers/proxmox/provider/provider.go
+++ b/providers/proxmox/provider/provider.go
@@ -59,12 +59,9 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			req.Asset.Name = host
 		}
 
-		req.Asset.Platform = &inventory.Platform{
-			Name:    "proxmox",
-			Title:   "Proxmox VE",
-			Family:  []string{"proxmox"},
-			Kind:    "api",
-			Runtime: "proxmox",
+		req.Asset.Platform = &inventory.Platform{}
+		if pi, ok := connection.PlatformByName("proxmox"); ok {
+			pi.Apply(req.Asset.Platform)
 		}
 
 		req.Asset.PlatformIds = []string{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
 	Version:         "13.2.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "shodan",

--- a/providers/shodan/connection/platforms.go
+++ b/providers/shodan/connection/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms emitted by the shodan provider.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "shodan-host",
+		Title:   "Shodan Host",
+		Family:  []string{"shodan"},
+		Kind:    []string{"api"},
+		Runtime: []string{"shodan"},
+	},
+	{
+		Name:    "shodan-domain",
+		Title:   "Shodan Domain",
+		Family:  []string{"shodan"},
+		Kind:    []string{"api"},
+		Runtime: []string{"shodan"},
+	},
+	{
+		Name:    "shodan-org",
+		Title:   "Shodan",
+		Family:  []string{"shodan"},
+		Kind:    []string{"api"},
+		Runtime: []string{"shodan"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the static platform catalog entry for the given name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/shodan/connection/platforms_test.go
+++ b/providers/shodan/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/shodan/go.mod
+++ b/providers/shodan/go.mod
@@ -7,6 +7,7 @@ go 1.26.4
 require (
 	github.com/rs/zerolog v1.35.1
 	github.com/shadowscatcher/shodan v1.0.8
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -36,6 +37,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -70,6 +72,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -98,6 +101,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/slack/connection"
 	"go.mondoo.com/mql/v13/providers/slack/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
 	Version:         "13.1.13",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "slack",

--- a/providers/slack/connection/platforms.go
+++ b/providers/slack/connection/platforms.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "slack-team",
+		Title:   "Slack Team",
+		Family:  []string{"slack"},
+		Kind:    []string{"api"},
+		Runtime: []string{"slack"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/slack/connection/platforms_test.go
+++ b/providers/slack/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/snowflake/connection"
 	"go.mondoo.com/mql/v13/providers/snowflake/provider"
 )
 
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
 	Version:         "13.3.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "snowflake",

--- a/providers/snowflake/connection/platforms.go
+++ b/providers/snowflake/connection/platforms.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:   "snowflake",
+		Title:  "Snowflake",
+		Family: []string{"snowflake"},
+		Kind:   []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/snowflake/connection/platforms_test.go
+++ b/providers/snowflake/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/snowflake/go.mod
+++ b/providers/snowflake/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Snowflake-Labs/terraform-provider-snowflake v1.2.3
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/snowflakedb/gosnowflake v1.19.1
-	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 	go.mondoo.com/ranger-rpc v0.8.0
 	golang.org/x/crypto v0.53.0

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -17,6 +17,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/stackit",
 	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "stackit",

--- a/providers/stackit/connection/connection.go
+++ b/providers/stackit/connection/connection.go
@@ -424,14 +424,11 @@ func (c *StackitConnection) Asset() *inventory.Asset { return c.asset }
 func (c *StackitConnection) Name() string            { return "stackit" }
 
 func (c *StackitConnection) PlatformInfo() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "stackit-project",
-		Title:                 "STACKIT",
-		Family:                []string{"stackit"},
-		Kind:                  "api",
-		Runtime:               "stackit",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"cloud", "stackit", "project"},
 	}
+	PlatformByName("stackit-project").Apply(p)
+	return p
 }
 
 func (c *StackitConnection) Identifier() string {

--- a/providers/stackit/connection/platforms.go
+++ b/providers/stackit/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "stackit-project",
+		Title:   "STACKIT",
+		Family:  []string{"stackit"},
+		Kind:    []string{"api"},
+		Runtime: []string{"stackit"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/stackit/connection/platforms_test.go
+++ b/providers/stackit/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.13.0
 	github.com/stackitcloud/stackit-sdk-go/services/telemetrylink v0.2.0
 	github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter v0.3.0
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.24.1
 )
 
@@ -61,6 +62,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -95,6 +97,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -123,6 +126,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
 	Version:         "13.3.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "tailscale",

--- a/providers/tailscale/connection/connection.go
+++ b/providers/tailscale/connection/connection.go
@@ -165,14 +165,11 @@ func (t *TailscaleConnection) Client() *tsclient.Client {
 }
 
 func (t *TailscaleConnection) PlatformInfo() (*inventory.Platform, error) {
-	return &inventory.Platform{
-		Name:                  "tailscale-org",
-		Title:                 "Tailscale",
-		Family:                []string{"tailscale"},
-		Kind:                  "api",
-		Runtime:               "tailscale",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "tailscale", "org"},
-	}, nil
+	}
+	PlatformByName("tailscale-org").Apply(p)
+	return p, nil
 }
 
 func (t *TailscaleConnection) Identifier() string {
@@ -193,26 +190,20 @@ func NewTailscaleDeviceIdentifier(deviceId string) string {
 	return PlatformIdTailscaleDevice + deviceId
 }
 func NewTailscaleDevicePlatform(deviceId string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "tailscale-device",
-		Title:                 "Tailscale Device",
-		Family:                []string{"tailscale"},
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "tailscale", "device", deviceId},
-		Kind:                  "api",
-		Runtime:               "tailscale",
 	}
+	PlatformByName("tailscale-device").Apply(p)
+	return p
 }
 
 func NewTailscaleUserIdentifier(userId string) string {
 	return PlatformIdTailscaleUser + userId
 }
 func NewTailscaleUserPlatform(userId string) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "tailscale-user",
-		Title:                 "Tailscale User",
-		Family:                []string{"tailscale"},
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"network", "tailscale", "user", userId},
-		Kind:                  "api",
-		Runtime:               "tailscale",
 	}
+	PlatformByName("tailscale-user").Apply(p)
+	return p
 }

--- a/providers/tailscale/connection/platforms.go
+++ b/providers/tailscale/connection/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "tailscale-org",
+		Title:   "Tailscale",
+		Family:  []string{"tailscale"},
+		Kind:    []string{"api"},
+		Runtime: []string{"tailscale"},
+	},
+	{
+		Name:    "tailscale-device",
+		Title:   "Tailscale Device",
+		Family:  []string{"tailscale"},
+		Kind:    []string{"api"},
+		Runtime: []string{"tailscale"},
+	},
+	{
+		Name:    "tailscale-user",
+		Title:   "Tailscale User",
+		Family:  []string{"tailscale"},
+		Kind:    []string{"api"},
+		Runtime: []string{"tailscale"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/tailscale/connection/platforms_test.go
+++ b/providers/tailscale/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -10,9 +10,10 @@ import (
 )
 
 var Config = plugin.Provider{
-	Name:    "terraform",
-	ID:      "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version: "13.3.0",
+	Name:      "terraform",
+	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
+	Version:   "13.3.0",
+	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,
 		provider.PlanConnectionType,

--- a/providers/terraform/provider/detector.go
+++ b/providers/terraform/provider/detector.go
@@ -18,39 +18,24 @@ import (
 )
 
 func (s *Service) detect(asset *inventory.Asset, _ *connection.Connection) error {
-	var p *inventory.Platform
+	var name string
+	var techSegments []string
 	connType := asset.Connections[0].Type
 	switch connType {
 	case StateConnectionType:
-		p = &inventory.Platform{
-			Name:                  "terraform-state",
-			Title:                 "Terraform State",
-			Family:                []string{"terraform"},
-			Kind:                  "code",
-			Runtime:               "terraform",
-			TechnologyUrlSegments: []string{"iac", "terraform", "state"},
-		}
+		name = "terraform-state"
+		techSegments = []string{"iac", "terraform", "state"}
 	case PlanConnectionType:
-		p = &inventory.Platform{
-			Name:                  "terraform-plan",
-			Title:                 "Terraform Plan",
-			Family:                []string{"terraform"},
-			Kind:                  "code",
-			Runtime:               "terraform",
-			TechnologyUrlSegments: []string{"iac", "terraform", "plan"},
-		}
+		name = "terraform-plan"
+		techSegments = []string{"iac", "terraform", "plan"}
 	case HclConnectionType:
 		fallthrough
 	default:
-		p = &inventory.Platform{
-			Name:                  "terraform-hcl",
-			Title:                 "Terraform HCL",
-			Family:                []string{"terraform"},
-			Kind:                  "code",
-			Runtime:               "terraform",
-			TechnologyUrlSegments: []string{"iac", "terraform", "hcl"},
-		}
+		name = "terraform-hcl"
+		techSegments = []string{"iac", "terraform", "hcl"}
 	}
+	p := &inventory.Platform{TechnologyUrlSegments: techSegments}
+	PlatformByName(name).Apply(p)
 	asset.MergePlatform(p)
 
 	// we always prefer the git url since it is more reliable

--- a/providers/terraform/provider/platforms.go
+++ b/providers/terraform/provider/platforms.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "terraform-state",
+		Title:   "Terraform State",
+		Family:  []string{"terraform"},
+		Kind:    []string{"code"},
+		Runtime: []string{"terraform"},
+	},
+	{
+		Name:    "terraform-plan",
+		Title:   "Terraform Plan",
+		Family:  []string{"terraform"},
+		Kind:    []string{"code"},
+		Runtime: []string{"terraform"},
+	},
+	{
+		Name:    "terraform-hcl",
+		Title:   "Terraform HCL",
+		Family:  []string{"terraform"},
+		Kind:    []string{"code"},
+		Runtime: []string{"terraform"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/terraform/provider/platforms_test.go
+++ b/providers/terraform/provider/platforms_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+
+	for _, pi := range Platforms {
+		t.Run(pi.Name, func(t *testing.T) {
+			require.NotNil(t, PlatformByName(pi.Name))
+
+			p := &inventory.Platform{}
+			pi.Apply(p)
+			assert.True(t, pi.Consistent(p), "applied platform should be consistent with catalog entry")
+			assert.Equal(t, pi.Title, p.Title)
+			assert.Equal(t, pi.Name, p.Name)
+		})
+	}
+}

--- a/providers/together/config/config.go
+++ b/providers/together/config/config.go
@@ -14,6 +14,7 @@ var Config = plugin.Provider{
 	Name:            "together",
 	ID:              "go.mondoo.com/mql/providers/together",
 	Version:         "13.0.5",
+	Platforms:       provider.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/together/provider/platforms.go
+++ b/providers/together/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "together",
+		Title:   "Together AI",
+		Family:  []string{"together"},
+		Kind:    []string{"api"},
+		Runtime: []string{"together"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/together/provider/platforms_test.go
+++ b/providers/together/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/together/provider/provider.go
+++ b/providers/together/provider/provider.go
@@ -141,13 +141,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.TogetherConnec
 		asset.Name = "Together AI (" + project + ")"
 	}
 
-	asset.Platform = &inventory.Platform{
-		Name:    "together",
-		Family:  []string{"together"},
-		Kind:    "api",
-		Runtime: "together",
-		Title:   "Together AI",
-	}
+	asset.Platform = &inventory.Platform{}
+	PlatformByName("together").Apply(asset.Platform)
 
 	platformID := "//platformid.api.mondoo.app/runtime/together"
 	if project != "" {

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -13,6 +13,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
 	Version:         "13.0.18",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "vcd",

--- a/providers/vcd/provider/platforms.go
+++ b/providers/vcd/provider/platforms.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:  "vcd",
+		Title: "VMware Cloud Director",
+		Kind:  []string{"api"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/vcd/provider/platforms_test.go
+++ b/providers/vcd/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/vcd/provider/provider.go
+++ b/providers/vcd/provider/provider.go
@@ -154,8 +154,6 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.VcdConnection)
 	digits := vcdVersion.Version.Segments()
 
 	asset.Platform = &inventory.Platform{
-		Name:    "vcd",
-		Kind:    "api",
 		Title:   "VMware Cloud Director " + conn.Conf.Host,
 		Version: fmt.Sprintf("%d.%d.%d", digits[0], digits[1], digits[2]),
 		Build:   strconv.Itoa(digits[3]),
@@ -163,6 +161,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.VcdConnection)
 			"vcd.vmware.com/api-version": c.Client.APIVersion,
 		},
 	}
+	PlatformByName("vcd").Apply(asset.Platform)
 
 	// TODO: Add platform IDs
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/vcd/host/" + conn.Conf.Host}

--- a/providers/vllm/config/config.go
+++ b/providers/vllm/config/config.go
@@ -15,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/vllm",
 	Version:         "13.0.12",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "vllm",

--- a/providers/vllm/go.mod
+++ b/providers/vllm/go.mod
@@ -4,7 +4,10 @@ replace go.mondoo.com/mql/v13 => ../..
 
 go 1.26.4
 
-require go.mondoo.com/mql/v13 v13.24.1
+require (
+	github.com/stretchr/testify v1.11.1
+	go.mondoo.com/mql/v13 v13.24.1
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -32,6 +35,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.47.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
@@ -95,6 +100,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/vllm/provider/platforms.go
+++ b/providers/vllm/provider/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "vllm-server",
+		Title:   "vLLM Inference Server",
+		Family:  []string{"vllm"},
+		Kind:    []string{"api"},
+		Runtime: []string{"vllm"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/vllm/provider/platforms_test.go
+++ b/providers/vllm/provider/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/vllm/provider/provider.go
+++ b/providers/vllm/provider/provider.go
@@ -154,13 +154,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.VllmConnection
 	asset.Name = "vLLM " + conn.BaseURL()
 
 	asset.Platform = &inventory.Platform{
-		Name:                  "vllm-server",
-		Family:                []string{"vllm"},
-		Kind:                  "api",
-		Runtime:               "vllm",
-		Title:                 "vLLM Inference Server",
 		TechnologyUrlSegments: []string{"ai", "vllm", "server"},
 	}
+	PlatformByName("vllm-server").Apply(asset.Platform)
 
 	asset.Fqdn = conn.Conf.Host
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/vllm/server/" + conn.BaseURL()}

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/vsphere/connection"
 	"go.mondoo.com/mql/v13/providers/vsphere/provider"
 	"go.mondoo.com/mql/v13/providers/vsphere/resources"
 )
@@ -15,6 +16,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
 	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.ConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "vsphere",

--- a/providers/vsphere/connection/platforms.go
+++ b/providers/vsphere/connection/platforms.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    VspherePlatform,
+		Title:   "VMware vSphere",
+		Family:  []string{Family},
+		Kind:    []string{"api"},
+		Runtime: []string{"vsphere"},
+	},
+	{
+		Name:    EsxiPlatform,
+		Title:   "VMware ESXi",
+		Family:  []string{Family},
+		Kind:    []string{inventory.AssetKindBaremetal},
+		Runtime: []string{"vsphere-host"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/vsphere/connection/platforms_test.go
+++ b/providers/vsphere/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/vsphere/provider/provider.go
+++ b/providers/vsphere/provider/provider.go
@@ -177,15 +177,12 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.VsphereConnect
 
 	vSphereInfo := conn.Info()
 	asset.Platform = &inventory.Platform{
-		Name:                  connection.VspherePlatform,
-		Family:                []string{connection.Family},
 		Title:                 "VMware vSphere " + vSphereInfo.Version,
 		Version:               vSphereInfo.Version,
 		Build:                 vSphereInfo.Build,
-		Kind:                  "api",
-		Runtime:               "vsphere",
 		TechnologyUrlSegments: []string{"vmware", "vsphere", vSphereInfo.Version + "-" + vSphereInfo.Build},
 	}
+	connection.PlatformByName(connection.VspherePlatform).Apply(asset.Platform)
 
 	id, err := conn.Identifier()
 	if err != nil {

--- a/providers/vsphere/resources/discovery.go
+++ b/providers/vsphere/resources/discovery.go
@@ -140,18 +140,16 @@ func discoverDatacenter(conn *connection.VsphereConnection, datacenterResource *
 				}
 			}
 
+			hostPlatform := &inventory.Platform{
+				Version:               esxiVersion.Version,
+				Build:                 esxiVersion.Build,
+				TechnologyUrlSegments: []string{"vmware", "esxi", esxiVersion.Version + "-" + esxiVersion.Build},
+			}
+			connection.PlatformByName(connection.EsxiPlatform).Apply(hostPlatform)
+
 			assetList = append(assetList, &inventory.Asset{
-				Name: mqlHost.Name.Data,
-				Platform: &inventory.Platform{
-					Title:                 "VMware ESXi",
-					Name:                  connection.EsxiPlatform,
-					Version:               esxiVersion.Version,
-					Build:                 esxiVersion.Build,
-					Kind:                  inventory.AssetKindBaremetal,
-					Runtime:               "vsphere-host",
-					Family:                []string{connection.Family},
-					TechnologyUrlSegments: []string{"vmware", "esxi", esxiVersion.Version + "-" + esxiVersion.Build},
-				},
+				Name:        mqlHost.Name.Data,
+				Platform:    hostPlatform,
 				Connections: []*inventory.Config{clonedConfig}, // pass-in the parent connection config
 				Labels:      labels,
 				State:       hostPowerState(mqlHost),


### PR DESCRIPTION
Requires the providers to be built with this feature. After it's active, you can find platform info in the `.json` of the provider, eg for terraform:

```json
  "Platforms": [
    {
      "name": "terraform-state",
      "title": "Terraform State",
      "family": [
        "terraform"
      ],
      "kind": [
        "code"
      ],
      "runtime": [
        "terraform"
      ]
    },
    {
      "name": "terraform-plan",
      "title": "Terraform Plan",
      "family": [
        "terraform"
      ],
      "kind": [
        "code"
      ],
      "runtime": [
        "terraform"
      ]
    },
    {
      "name": "terraform-hcl",
      "title": "Terraform HCL",
      "family": [
        "terraform"
      ],
      "kind": [
        "code"
      ],
      "runtime": [
        "terraform"
      ]
    }
  ]
```