### PR TITLE
feat: expose state on mondoo.asset

### DIFF
--- a/providers/mondoo/resources/mondoo.lr
+++ b/providers/mondoo/resources/mondoo.lr
@@ -53,6 +53,11 @@ private mondoo.asset @defaults("name platform") {
   mrn string
   // Platform name
   platform string
+  // Asset lifecycle state
+  //
+  // One of UNKNOWN, ERROR, DELETED, PENDING, RUNNING, STOPPING, STOPPED,
+  // SHUTDOWN, TERMINATED, REBOOT, ONLINE, or OFFLINE.
+  state string
   // Annotations associated with this asset
   annotations map[string]string
   // Labels associated with this asset

--- a/providers/mondoo/resources/mondoo.lr.go
+++ b/providers/mondoo/resources/mondoo.lr.go
@@ -148,6 +148,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mondoo.asset.platform": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMondooAsset).GetPlatform()).ToDataRes(types.String)
 	},
+	"mondoo.asset.state": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMondooAsset).GetState()).ToDataRes(types.String)
+	},
 	"mondoo.asset.annotations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMondooAsset).GetAnnotations()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -241,6 +244,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mondoo.asset.platform": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMondooAsset).Platform, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mondoo.asset.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMondooAsset).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"mondoo.asset.annotations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -501,6 +508,7 @@ type mqlMondooAsset struct {
 	Name                plugin.TValue[string]
 	Mrn                 plugin.TValue[string]
 	Platform            plugin.TValue[string]
+	State               plugin.TValue[string]
 	Annotations         plugin.TValue[map[string]any]
 	Labels              plugin.TValue[map[string]any]
 	UpdatedAt           plugin.TValue[*time.Time]
@@ -557,6 +565,10 @@ func (c *mqlMondooAsset) GetMrn() *plugin.TValue[string] {
 
 func (c *mqlMondooAsset) GetPlatform() *plugin.TValue[string] {
 	return &c.Platform
+}
+
+func (c *mqlMondooAsset) GetState() *plugin.TValue[string] {
+	return &c.State
 }
 
 func (c *mqlMondooAsset) GetAnnotations() *plugin.TValue[map[string]any] {

--- a/providers/mondoo/resources/mondoo.lr.versions
+++ b/providers/mondoo/resources/mondoo.lr.versions
@@ -11,6 +11,7 @@ mondoo.asset.platform 11.0.0
 mondoo.asset.resources 11.0.0
 mondoo.asset.scoreGrade 11.0.0
 mondoo.asset.scoreValue 11.0.0
+mondoo.asset.state 13.1.7
 mondoo.asset.updatedAt 11.0.0
 mondoo.client 11.1.0
 mondoo.client.mrn 11.1.0

--- a/providers/mondoo/resources/mondoo_assets.go
+++ b/providers/mondoo/resources/mondoo_assets.go
@@ -57,6 +57,7 @@ func initMondooAsset(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["name"] = llx.StringData(asset.Name)
 	args["mrn"] = llx.StringData(asset.Mrn)
 	args["platform"] = llx.StringData(asset.AssetType)
+	args["state"] = llx.StringData(asset.State)
 	args["annotations"] = llx.MapData(keyvals2map(asset.Annotations), types.Map(types.String, types.String))
 	args["labels"] = llx.MapData(keyvals2map(asset.Labels), types.Map(types.String, types.String))
 	args["updatedAt"] = llx.TimeDataPtr(string2time(asset.UpdatedAt))

--- a/providers/mondoo/resources/mondoo_space.go
+++ b/providers/mondoo/resources/mondoo_space.go
@@ -84,6 +84,7 @@ func (m *mqlMondooSpace) assets() ([]any, error) {
 				"name":                llx.StringData(e.Node.Name),
 				"mrn":                 llx.StringData(e.Node.Mrn),
 				"platform":            llx.StringData(e.Node.AssetType),
+				"state":               llx.StringData(e.Node.State),
 				"annotations":         llx.MapData(keyvals2map(e.Node.Annotations), types.Map(types.String, types.String)),
 				"labels":              llx.MapData(keyvals2map(e.Node.Labels), types.Map(types.String, types.String)),
 				"updatedAt":           llx.TimeDataPtr(string2time(e.Node.UpdatedAt)),


### PR DESCRIPTION
## What

Exposes a new `state` field on the `mondoo.asset` resource, reporting the asset's lifecycle state.

## Why

The asset state was **already being fetched** from the Mondoo GraphQL API — both query paths declared `State string` on their asset structs (`gqlAsset` and the `assets()` resolver node) — but the value was silently discarded. This wires it through to MQL so audits can query it.

## Changes

- **`mondoo.lr`** — add `state string` field to `mondoo.asset`, documented with the SDK enum values (`UNKNOWN, ERROR, DELETED, PENDING, RUNNING, STOPPING, STOPPED, SHUTDOWN, TERMINATED, REBOOT, ONLINE, OFFLINE`).
- **`mondoo.lr.versions`** — `mondoo.asset.state 13.1.7` (next patch after the provider's current `13.1.6`).
- **`mondoo_assets.go`** — map `state` in `initMondooAsset` (single-asset-by-MRN path).
- **`mondoo_space.go`** — map `state` in the `assets()` resolver (space-listing path).
- Regenerated `mondoo.lr.go`.

No new GraphQL query was needed — only mapping of already-fetched data.

## Testing

```
mql run mondoo -c "mondoo.space.assets { name platform state }"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)