### PR TITLE
logger/stackdriver: support common labels on log entries

### DIFF
--- a/logger/stackdriver/stackdriver.go
+++ b/logger/stackdriver/stackdriver.go
@@ -23,16 +23,43 @@ var logLevelMap = map[zerolog.Level]logging.Severity{
 	zerolog.TraceLevel: logging.Debug,
 }
 
+// Option configures the stackdriver writer.
+type Option func(*options)
+
+type options struct {
+	labels map[string]string
+}
+
+// WithLabels attaches the given key/value labels to every log entry written by
+// this writer (via logging.CommonLabels). Useful to tag logs with metadata such
+// as environment, team, or asset identifiers so they can be filtered in the GCP
+// Logs Explorer (e.g. `labels.env = "prod"`).
+func WithLabels(labels map[string]string) Option {
+	return func(o *options) {
+		o.labels = labels
+	}
+}
+
 // https://pkg.go.dev/cloud.google.com/go/logging
 // by default, everything is logged async, only zerolog fatal messages are logged synchronously
-func NewStackdriverWriter(projectID string, logID string) (zerolog.LevelWriter, error) {
+func NewStackdriverWriter(projectID string, logID string, opts ...Option) (zerolog.LevelWriter, error) {
+	o := &options{}
+	for _, fn := range opts {
+		fn(o)
+	}
+
 	client, err := logging.NewClient(context.Background(), projectID)
 	if err != nil {
 		return nil, err
 	}
 
+	var loggerOpts []logging.LoggerOption
+	if len(o.labels) > 0 {
+		loggerOpts = append(loggerOpts, logging.CommonLabels(o.labels))
+	}
+
 	return &stackdriverWriter{
-		logger: client.Logger(logID),
+		logger: client.Logger(logID, loggerOpts...),
 	}, nil
 }
 

--- a/logger/stackdriver/stackdriver_test.go
+++ b/logger/stackdriver/stackdriver_test.go
@@ -3,6 +3,26 @@
 
 package stackdriver
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithLabels(t *testing.T) {
+	t.Run("sets labels on options", func(t *testing.T) {
+		labels := map[string]string{"env": "prod", "team": "security"}
+		o := &options{}
+		WithLabels(labels)(o)
+		assert.Equal(t, labels, o.labels)
+	})
+
+	t.Run("no options leaves labels empty", func(t *testing.T) {
+		o := &options{}
+		assert.Empty(t, o.labels)
+	})
+}
+
 //import (
 //	"errors"
 //	"github.com/rs/zerolog/log"


### PR DESCRIPTION
## Summary

Adds a functional-option API to `NewStackdriverWriter` so callers can attach key/value **labels** to every log entry sent to Google Cloud Logging (Stackdriver), via `logging.CommonLabels`.

This lets logs be tagged with metadata such as environment, team, or asset identifiers, and filtered in the GCP Logs Explorer (e.g. `labels.env = "prod"`).

## API

```go
// before (still works — backward compatible)
w, err := stackdriver.NewStackdriverWriter(projectID, logID)

// now, optionally with labels
w, err := stackdriver.NewStackdriverWriter(projectID, logID,
    stackdriver.WithLabels(map[string]string{"env": "prod", "team": "security"}),
)
```

Labels are applied as **common labels** on the logger, so every entry written carries them.

## Notes

- Backward compatible: the existing two-argument call site continues to work unchanged.
- Consumed by cnspec to expose config-driven Stackdriver logging (`log.writer: stackdriver` + `log.stackdriver.labels`) — that wiring lands in the cnspec repo separately and needs this version.

## Test plan

- [x] `go test ./logger/stackdriver/` — added `TestWithLabels` (no GCP credentials required)
- [x] `go build ./logger/stackdriver/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)