### PR TITLE
🐛 Windows: don't corrupt SQL Server PURL when no Database Engine Services package

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -913,10 +913,15 @@ func updateExchangePackage(pkgs []Package, latestExchangeCU Package) []Package {
 	for i, pkg := range pkgs {
 		if pkg.Name == "Microsoft Exchange Server" {
 			currentVersion := pkgs[i].Version
+			// Without a current version there is no `@<version>` to swap in the
+			// PURL; replacing the empty-anchored `"@"` would target the first `@`
+			// and corrupt the PURL, so skip the rewrite entirely.
+			if currentVersion == "" {
+				continue
+			}
 			pkgs[i].Version = latestExchangeCU.Version
 			log.Debug().Str("package", pkg.Name).Str("version", latestExchangeCU.Version).Msg("Updated Exchange package")
-			// Anchor on `@<version>` so an empty currentVersion can't prepend the
-			// new version to the PURL, and so we don't rewrite a substring match
+			// Anchor on `@<version>` so we don't rewrite a substring match
 			// elsewhere in the PURL.
 			pkgs[i].PUrl = strings.Replace(pkgs[i].PUrl, "@"+currentVersion, "@"+latestExchangeCU.Version, 1)
 		}

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -762,6 +762,15 @@ func updateMsSqlPackages(pkgs []Package, latestMsSqlUpdate Package) []Package {
 			break
 		}
 	}
+	// Without the Database Engine Services package there is no anchor version to
+	// match the other SQL Server packages against, so there is nothing to stamp.
+	// Bailing here also avoids a footgun below: strings.Replace with an empty
+	// `old` prepends `new` to the string, which would corrupt the PURL of any
+	// "SQL Server" product bundle entry that carries an empty DisplayVersion
+	// (e.g. "16.0.1150.1pkg:windows/windows/Microsoft%20SQL%20Server%202022...").
+	if currentVersion == "" {
+		return pkgs
+	}
 	// MSI registers SP-era SQL Server hotfix DisplayVersions with the SP level
 	// baked into the minor component (13.3.x for SP3, etc.). Microsoft's
 	// canonical product version uses .0 in the minor and encodes the SP in the
@@ -776,7 +785,9 @@ func updateMsSqlPackages(pkgs []Package, latestMsSqlUpdate Package) []Package {
 		if strings.Contains(pkg.Name, "SQL Server") && pkg.Version == currentVersion {
 			pkgs[i].Version = normalizedVersion
 			log.Debug().Str("package", pkg.Name).Str("version", normalizedVersion).Msg("Updated SQL Server package")
-			pkgs[i].PUrl = strings.Replace(pkgs[i].PUrl, currentVersion, normalizedVersion, 1)
+			// Replace only the version component (`@<version>`) so we never
+			// rewrite a matching substring elsewhere in the PURL (name, arch).
+			pkgs[i].PUrl = strings.Replace(pkgs[i].PUrl, "@"+currentVersion, "@"+normalizedVersion, 1)
 		}
 	}
 	return pkgs
@@ -904,7 +915,10 @@ func updateExchangePackage(pkgs []Package, latestExchangeCU Package) []Package {
 			currentVersion := pkgs[i].Version
 			pkgs[i].Version = latestExchangeCU.Version
 			log.Debug().Str("package", pkg.Name).Str("version", latestExchangeCU.Version).Msg("Updated Exchange package")
-			pkgs[i].PUrl = strings.Replace(pkgs[i].PUrl, currentVersion, latestExchangeCU.Version, 1)
+			// Anchor on `@<version>` so an empty currentVersion can't prepend the
+			// new version to the PURL, and so we don't rewrite a substring match
+			// elsewhere in the PURL.
+			pkgs[i].PUrl = strings.Replace(pkgs[i].PUrl, "@"+currentVersion, "@"+latestExchangeCU.Version, 1)
 		}
 	}
 	return pkgs

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -490,6 +490,33 @@ func TestFindAndUpdateMsSqlGDR_de_special_characters(t *testing.T) {
 	assert.Equal(t, "pkg:windows/windows/Not%20a%20hotfix@1.0.0?arch=x86", pkg.PUrl)
 }
 
+// TestUpdateMsSqlPackages_NoEngineServicesPackage guards against corrupting the
+// PURL of a "SQL Server" product bundle entry that carries an empty
+// DisplayVersion when no "Database Engine Services" package is present (so the
+// anchor version is empty). The buggy behavior prepended the update version to
+// the PURL (e.g. "16.0.1150.1pkg:windows/windows/Microsoft%20SQL%20Server...").
+func TestUpdateMsSqlPackages_NoEngineServicesPackage(t *testing.T) {
+	packages := []Package{
+		// Product bundle entry from the registry Uninstall key with an empty
+		// DisplayVersion. The PURL has no version component.
+		{Name: "Microsoft SQL Server 2022 (64-bit)", Version: "", PUrl: "pkg:windows/windows/Microsoft%20SQL%20Server%202022%20%2864-bit%29?arch=AMD64"},
+		{Name: "GDR 1150 for SQL Server 2022 (KB5042215) (64-bit)", Version: "16.0.1150.1", PUrl: "pkg:windows/windows/GDR%201150%20for%20SQL%20Server%202022%20%28KB5042215%29%20%2864-bit%29@16.0.1150.1?arch=AMD64"},
+	}
+
+	gdrUpdates := findMsSqlGdrUpdates(packages)
+	require.Len(t, gdrUpdates, 1, "expected 1 update")
+
+	updated := updateMsSqlPackages(packages, gdrUpdates[len(gdrUpdates)-1])
+
+	// Without a Database Engine Services anchor package, the bundle entry must be
+	// left untouched: its PURL must stay valid and not gain a prepended version.
+	pkg := findPkgByName(updated, "Microsoft SQL Server 2022 (64-bit)")
+	require.NotNil(t, pkg, "Microsoft SQL Server 2022 (64-bit) package should exist")
+	assert.Equal(t, "", pkg.Version, "expected bundle entry version to remain empty")
+	assert.Equal(t, "pkg:windows/windows/Microsoft%20SQL%20Server%202022%20%2864-bit%29?arch=AMD64", pkg.PUrl)
+	assert.True(t, strings.HasPrefix(pkg.PUrl, "pkg:"), "PURL must start with pkg:, not a version")
+}
+
 func TestNormalizeMsSqlVersion(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Problem

`updateMsSqlPackages` stamps the latest SQL Server hotfix/GDR version onto the
related SQL Server packages. It determines the "current" engine version from the
`SQL Server <year> Database Engine Services` package.

When that package is **absent** (e.g. client tools / bundle-only installs), the
anchor `currentVersion` stays empty. The match loop then matched any package
whose name contains `SQL Server` and whose `DisplayVersion` is empty — notably
the `Microsoft SQL Server 20XX (64-bit)` product bundle entry from the registry
Uninstall key, which often has no `DisplayVersion`.

`strings.Replace(purl, "", version, 1)` with an **empty `old` string prepends**
`version` to the front of the string, producing an invalid PURL such as:

```
16.0.1150.1pkg:windows/windows/Microsoft%20SQL%20Server%202022%20%2864-bit%29?arch=AMD64
```

Downstream consumers reject this (`first path segment in URL cannot contain colon`),
so the package is dropped.

## Fix

- Bail out of `updateMsSqlPackages` when there is no anchor version — there is
  nothing to stamp, and this avoids the empty-`old` `strings.Replace` footgun.
- Replace only the `@<version>` component of the PURL, so an empty version can
  never prepend and we never rewrite a matching substring elsewhere in the PURL.
- Apply the same `@`-anchored replacement to `updateExchangePackage`, which had
  the identical pattern.

## Test

Adds `TestUpdateMsSqlPackages_NoEngineServicesPackage` reproducing the
no-Database-Engine-Services case: the bundle entry's PURL must stay valid and
must not gain a prepended version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)