### PR TITLE
🐛 os: fix files.find(type: "link") missing valid symlinks

### DIFF
--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -41,7 +41,15 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 	if fileType != "" {
 		t, ok := findTypes[fileType]
 		if ok {
-			call.WriteString(" -type " + t)
+			// We run `find -L`, which follows symlinks. Under -L, `-type l`
+			// only matches dangling links because valid links are resolved to
+			// their target's type. `-xtype l` matches the symlink itself
+			// regardless of where it points, so searching for links works.
+			if t == "l" {
+				call.WriteString(" -xtype l")
+			} else {
+				call.WriteString(" -type " + t)
+			}
 		}
 	}
 

--- a/providers/os/resources/filesfind/unix_findcmd_test.go
+++ b/providers/os/resources/filesfind/unix_findcmd_test.go
@@ -70,6 +70,15 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 			Regex:       ".*\\.conf$",
 			ExpectedCmd: "find -L \"/etc\" -xdev -type f -regex '.*\\.conf$' -perm -0",
 		},
+		{
+			// Because we run `find -L` (follow symlinks), `-type l` only matches
+			// dangling links — valid links are resolved to their target's type.
+			// `-xtype l` matches the symlink itself regardless of its target, so
+			// `files.find(type: "link")` returns every symlink as users expect.
+			From:        "/home/user",
+			FileType:    "link",
+			ExpectedCmd: "find -L \"/home/user\" -xdev -xtype l -perm -0",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

`files.find(from: "...", type: "link")` returned no results for symlinks that point at an existing file or directory. Only dangling/broken links were ever returned.

The unix command backend builds `find -L ...`, and `-L` follows symlinks. Under `-L`, `-type l` resolves each symlink to its target's type before testing, so a valid symlink is reported as `f`/`d` — never `l`. Switching to `-xtype l` matches the symlink itself regardless of where it points, while preserving the `-L` traversal behavior (descending into symlinked directories) that `-L` was originally added for.

This aligns the command backend with the native `fsutil.FindFiles` backend, which already produces the correct result.

## Why

On hosts where local connections use the command backend (`RunCommand` capability), `files.find(type: "link")` could not find any symlink that resolves to an existing target — e.g. a `.netrc -> netrc` symlink was silently omitted. Only broken links showed up.

## Testing

- Added a unit test asserting `find -L ... -xtype l` is generated for `type: "link"`.
- Verified interactively with the rebuilt provider: `files.find(type: "link")` now returns valid symlinks (`.zshrc`, `.zshenv`, `.config/nvim`, ...) in addition to broken ones, where it previously returned only broken links.