### PR TITLE
🐛 ms365: report platform name microsoft365 consistently

### DIFF
--- a/providers/ms365/provider/provider.go
+++ b/providers/ms365/provider/provider.go
@@ -148,15 +148,22 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	return runtime.Connection.(*connection.Ms365Connection), nil
 }
 
-func (s *Service) detect(asset *inventory.Asset, conn *connection.Ms365Connection) error {
-	asset.Platform = &inventory.Platform{
-		Name:                  "ms365",
-		Runtime:               "ms365",
-		Family:                []string{""},
+// ms365Platform returns the platform descriptor reported for a Microsoft 365
+// asset. Both the directly-connected asset (detect) and the discovered tenant
+// asset (discover) use this so the reported platform name stays consistent
+// regardless of whether discovery ran.
+func ms365Platform() *inventory.Platform {
+	return &inventory.Platform{
+		Name:                  "microsoft365",
+		Runtime:               "ms-graph",
 		Kind:                  "api",
 		Title:                 "Microsoft 365",
 		TechnologyUrlSegments: []string{"saas", "ms365"},
 	}
+}
+
+func (s *Service) detect(asset *inventory.Asset, conn *connection.Ms365Connection) error {
+	asset.Platform = ms365Platform()
 
 	return nil
 }
@@ -175,13 +182,7 @@ func (s *Service) discover(conn *connection.Ms365Connection, conf *inventory.Con
 	tenantAsset := &inventory.Asset{
 		PlatformIds: []string{identifier},
 		Name:        "Microsoft 365 tenant " + conn.TenantId(),
-		Platform: &inventory.Platform{
-			Name:                  "microsoft365",
-			Title:                 "Microsoft 365",
-			Runtime:               "ms-graph",
-			Kind:                  "api",
-			TechnologyUrlSegments: []string{"saas", "ms365"},
-		},
+		Platform:    ms365Platform(),
 		Connections: []*inventory.Config{conf.Clone()}, // pass-in the current config
 		Labels: map[string]string{
 			"azure.com/tenant": conn.TenantId(),


### PR DESCRIPTION
## Problem

The ms365 provider reports two different platform names for the same thing depending on the code path:

- `detect()` (the directly-connected asset) stamps the platform `Name: "ms365"`, `Runtime: "ms365"`.
- `discover()` (the discovered tenant asset) stamps the platform `Name: "microsoft365"`, `Runtime: "ms-graph"`.

Because discovery defaults to `auto`, a normal scan reports the discovered tenant asset (`microsoft365`). But with discovery disabled the root connection asset is scanned and reports `ms365` instead. So the platform name a scan sends upstream flips based on whether discovery ran. `ms365` is the unintended one.

## Fix

Both paths now build the platform through a single shared `ms365Platform()` helper, so they can't drift again. The canonical platform is `microsoft365` / `ms-graph` for every ms365 asset, regardless of discovery. The stray `Family: []string{""}` that only `detect()` set is also dropped.

## Scope / not changed

The `ms365` strings that are the **provider/connection identity** are intentionally left as-is (provider name, connection type, and the `//platformid.api.mondoo.app/runtime/ms365/tenant/<id>` platform-id namespace) — those are correct and unrelated to the reported platform name. The platform-id namespace is left untouched to avoid re-keying existing assets; any rename there is a separate, server-coordinated change.

No mql content keys on the `"ms365"` platform name, so nothing downstream breaks.