### PR TITLE
:star: Update azure SDK deps to latest stable majors + expose resource.systemData

### DIFF
--- a/providers/azure/connection/client_subscriptions.go
+++ b/providers/azure/connection/client_subscriptions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 )
 
 type SubscriptionsFilter struct {

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -53,8 +53,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy v1.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.15.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securityinsights/armsecurityinsights v1.2.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -158,8 +158,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 h1:guyQA4b8XB2sbJZXzUnOF9mn0WDBv/ZT7me9wTipKtE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1/go.mod h1:8h8yhzh9o+0HeSIhUxYny+rEQajScrfIpNktvgYG3Q8=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0 h1:LXGvNeGX6VLx1S+wk3bbWrYWZuVow84Mny4T1I0CgBw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0/go.mod h1:IJLGVEPS/CqR2k0Q+EzmHqus1F69g5TCYzLFSWUM0Yw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2 v2.0.0 h1:TPaLKUUZw3XUaQy5aU+ApHXFKB2VnTWUA0xufkvFDE8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2 v2.0.0/go.mod h1:Rn/a97OKDAoOGvk5/OFjqObHHqWyoMMVSGtikqbKcAg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0 h1:zBdabY8pMSMLPb1XJnFSEdJi9Bd0h+VMjh1uU8B6Yp8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0/go.mod h1:Y2Q3nB3UfSnG9nALOpPAjflXPM3jL/n2ZmYIu2Occ9g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.15.0 h1:5tRv65ZzstkUCQYFAcw2XtXkqxJdJ0ut1T0gyU1JB34=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -211,6 +211,8 @@ private azure.subscription.resource @defaults("id name location") {
   createdTime time
   // When the resource was last changed
   changedTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Resource Manager system metadata

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2359,6 +2359,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.resource.changedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionResource).GetChangedTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.resource.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionResource).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.systemData.createdBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSystemData).GetCreatedBy()).ToDataRes(types.String)
 	},
@@ -15815,6 +15818,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.resource.changedTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionResource).ChangedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.resource.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionResource).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.systemData.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35985,7 +35992,7 @@ func (c *mqlAzureSubscriptionResourcegroup) GetDeployments() *plugin.TValue[[]an
 type mqlAzureSubscriptionResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionResourceInternal it will be used here
+	mqlAzureSubscriptionResourceInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Kind              plugin.TValue[string]
@@ -35999,6 +36006,7 @@ type mqlAzureSubscriptionResource struct {
 	ProvisioningState plugin.TValue[string]
 	CreatedTime       plugin.TValue[*time.Time]
 	ChangedTime       plugin.TValue[*time.Time]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionResource creates a new instance of this resource
@@ -36088,6 +36096,22 @@ func (c *mqlAzureSubscriptionResource) GetCreatedTime() *plugin.TValue[*time.Tim
 
 func (c *mqlAzureSubscriptionResource) GetChangedTime() *plugin.TValue[*time.Time] {
 	return &c.ChangedTime
+}
+
+func (c *mqlAzureSubscriptionResource) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.resource", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSystemData for the azure.subscription.systemData resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3766,6 +3766,7 @@ azure.subscription.resource.name 9.0.0
 azure.subscription.resource.plan 9.0.0
 azure.subscription.resource.provisioningState 9.0.0
 azure.subscription.resource.sku 9.0.0
+azure.subscription.resource.systemMetadata 13.21.2
 azure.subscription.resource.tags 9.0.0
 azure.subscription.resource.type 9.0.0
 azure.subscription.resourceGroups 11.4.28

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.21.0",
-  "generated_at": "2026-06-23T15:34:34-06:00",
+  "version": "13.21.1",
+  "generated_at": "2026-06-25T11:58:23-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/mql/v13/llx"

--- a/providers/azure/resources/resource_groups.go
+++ b/providers/azure/resources/resource_groups.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 
-	azureres "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
+	azureres "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
 )
 
 func (a *mqlAzureSubscription) resourceGroups() ([]any, error) {

--- a/providers/azure/resources/resources.go
+++ b/providers/azure/resources/resources.go
@@ -12,8 +12,12 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 
-	azureres "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
+	azureres "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
 )
+
+type mqlAzureSubscriptionResourceInternal struct {
+	cacheSystemData any
+}
 
 func (a *mqlAzureSubscription) resources() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -56,6 +60,11 @@ func (a *mqlAzureSubscription) resources() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			sysData, err := convert.JsonToDict(resource.SystemData)
+			if err != nil {
+				return nil, err
+			}
 			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.resource",
 				map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(resource.ID),
@@ -75,6 +84,7 @@ func (a *mqlAzureSubscription) resources() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlAzure.(*mqlAzureSubscriptionResource).cacheSystemData = sysData
 			res = append(res, mqlAzure)
 		}
 	}

--- a/providers/azure/resources/subscription.go
+++ b/providers/azure/resources/subscription.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/systemdata.go
+++ b/providers/azure/resources/systemdata.go
@@ -66,6 +66,10 @@ func systemMetadataFromRaw(runtime *plugin.Runtime, parentID string, raw any, fi
 	return sd, nil
 }
 
+func (a *mqlAzureSubscriptionResource) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionComputeServiceVm) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
 }


### PR DESCRIPTION
## What

Rebased onto current `main`. Refreshes the azure provider's remaining out-of-date Azure SDK majors, and uses one of those bumps to close a gap left by the recent provenance work (#8355).

### Dependency bumps
| Module | Old → New | Kind |
|---|---|---|
| `resourcemanager/resources/armresources` | `v3.0.1 → v4.0.0` | major |
| `resourcemanager/resources/armsubscriptions` | `v1.3.0 → v2.0.0` | major |

`armcompute/v8` is already at `v8.1.0` on main, so it's no longer part of this PR.

Both majors' CHANGELOG "Breaking Changes" sections only **remove filter/error structs we don't reference** (`GenericResourceFilter`, `Resource`, `SubResource`, `ErrorResponse`, `OperationAutoGenerated`, …) — verified by grepping every removed type (zero hits). The only required call-site change was updating import paths to `/v4` and `/v2`. No deprecations introduced (`staticcheck SA1019` clean on the changed packages). Beta-only new majors of other modules were left in place per a stable-only policy.

### New: typed `azure.subscription.resource.systemMetadata`
PR #8355 added a typed `azure.subscription.systemData` resource and a `systemMetadata()` accessor across many resources, **but not on `azure.subscription.resource`** — because `GenericResourceExpanded.SystemData` didn't exist until armresources v4. This PR unlocks it and fills the gap:

```
azure.subscription.resources.where(name == "...") { name systemMetadata { createdBy createdByType createdAt lastModifiedBy } }
  systemMetadata: {
    createdBy: "user@contoso.onmicrosoft.com"
    createdByType: "User"          # User | Application | ManagedIdentity | Key
    createdAt: 2023-10-05T06:52:20Z
    lastModifiedBy: "..."
  }
```

Implemented the consistent way: a `cacheSystemData` field on `mqlAzureSubscriptionResourceInternal`, populated in the creator via `convert.JsonToDict(resource.SystemData)`, and a `systemMetadata()` method reusing the existing `systemMetadataFromRaw` helper in `systemdata.go`. **No new `systemData dict` field** — that pattern is deprecated on main; this follows the typed convention.

ARM-native provenance answers the **who** behind a resource (the existing `createdTime`/`changedTime` only give the *when*) — useful for "human vs automation created this" audits.

## Testing
- `go build ./... && go vet ./... && go test ./resources/...` ✓
- `gofmt` clean; codegen (`.lr.go` / `.lr.versions`) regenerated and committed
- `go.mod`/`go.sum` tidy (sum verification preserved)
- **Live-verified** against real Azure:
  - populated case: `systemMetadata` resolves with typed `createdAt` (a real `time`) and all identity fields for resource types that emit it (e.g. `MoveCollection`)
  - null case: resources Azure doesn't populate (e.g. storage accounts) return `systemMetadata: null` — no panic
- `azure.permissions.json` unchanged (no new API calls)

> Coverage caveat: `systemMetadata` is **partial** — many Azure resource types return no system metadata, and it captures the *authenticating identity*, not the IaC tool (so it distinguishes `User` from `Application`/`ManagedIdentity`, but not Terraform from Bicep).

> Provider `Version` in `config/config.go` is intentionally **not** bumped (release flow). New `.lr.versions` entry uses the next patch, `13.21.2`.
