### PR TITLE
🐛 ms365: drop stale ms365 entry from static platform catalog

### DIFF
--- a/providers/ms365/connection/platforms.go
+++ b/providers/ms365/connection/platforms.go
@@ -10,13 +10,6 @@ import (
 // Platforms is the static catalog of platforms this provider can emit.
 var Platforms = []*plugin.PlatformInfo{
 	{
-		Name:    "ms365",
-		Title:   "Microsoft 365",
-		Family:  []string{""},
-		Kind:    []string{"api"},
-		Runtime: []string{"ms365"},
-	},
-	{
 		Name:    "microsoft365",
 		Title:   "Microsoft 365",
 		Kind:    []string{"api"},


### PR DESCRIPTION
## Problem

We're seeing both `ms365` and `microsoft365` platforms reported again, reintroducing the inconsistency that #8735 fixed.

## Root cause

Two PRs landed the same day:

- **#8735** (merged 11:58) unified the **runtime** to report only `microsoft365` (runtime `ms-graph`) and dropped the stray empty `Family`.
- **#8722** (merged 14:33), a cross-provider sweep adding the static platform catalog (`config.Config.Platforms`), authored the ms365 entry from the **pre-#8735** view and re-listed *both* `ms365` (name `ms365`, runtime `ms365`, `Family: [""]`) and `microsoft365`.

The stale entry carried exactly the three attributes #8735 had just removed, so the provider once again **advertises two platforms** via the generated provider JSON `Platforms` block.

The runtime itself is fine — `detect()` and `discover()` both build from `ms365Platform()` → `microsoft365`, and nothing keys off `PlatformByName("ms365")`. The regression is purely in the static catalog.

## Fix

Drop the stale `ms365` entry, leaving only `microsoft365`, so the static catalog matches what the runtime actually emits. `TestPlatformCatalog` stays green (it iterates whatever's in `Platforms`); `PlatformByName` is otherwise unused at runtime.

Verified: `go build ./...` and `go test ./connection/ -run TestPlatformCatalog` pass. All other `"ms365"` literals (provider name, connection type, URL segments) are provider identity, which #8735 intentionally left unchanged.