### PR TITLE
✨ depsdev: expose version licenses, links, registries, SLSA provenance, and related projects

### DIFF
--- a/providers/depsdev/resources/api.go
+++ b/providers/depsdev/resources/api.go
@@ -43,9 +43,20 @@ type depsDevVersionResponse struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
 	} `json:"versionKey"`
-	IsDefault       bool      `json:"isDefault"`
-	PublishedAt     time.Time `json:"publishedAt"`
-	Licenses        []string  `json:"licenses"`
+	IsDefault   bool      `json:"isDefault"`
+	PublishedAt time.Time `json:"publishedAt"`
+	Licenses    []string  `json:"licenses"`
+	Links       []struct {
+		Label string `json:"label"`
+		URL   string `json:"url"`
+	} `json:"links"`
+	Registries      []string `json:"registries"`
+	SlsaProvenances []struct {
+		SourceRepository string `json:"sourceRepository"`
+		Commit           string `json:"commit"`
+		URL              string `json:"url"`
+		Verified         bool   `json:"verified"`
+	} `json:"slsaProvenances"`
 	RelatedProjects []struct {
 		ProjectKey struct {
 			ID string `json:"id"`

--- a/providers/depsdev/resources/depsdev.lr
+++ b/providers/depsdev/resources/depsdev.lr
@@ -46,7 +46,28 @@ private depsdev.packageVersion @defaults("version publishedAt") {
   // Whether this is the default version
   isDefault bool
   // SPDX license identifiers
-  licenses []string
+  licenses() []string
+  // Source and metadata links keyed by label (e.g. SOURCE_REPO, ISSUE_TRACKER, ORIGIN)
+  links() map[string]string
+  // Package registries where this version is published
+  registries() []string
+  // SLSA build provenance attestations
+  //
+  // Each entry records the sourceRepository, commit, url, and verified
+  // flag of a build provenance attestation recorded for this version.
+  slsaProvenances() []dict
+  // Projects related to this version (e.g. source repository, issue tracker)
+  relatedProjects() []depsdev.relatedProject
+}
+
+// deps.dev related project
+private depsdev.relatedProject @defaults("relationType") {
+  // Relationship type (e.g. SOURCE_REPO, ISSUE_TRACKER, ORIGIN)
+  relationType string
+  // How the relationship was determined (e.g. GO_ORIGIN, SLSA_PROVENANCE)
+  relationProvenance string
+  // Related source project
+  project() depsdev.project
 }
 
 // deps.dev upstream source project (GitHub / GitLab repository)

--- a/providers/depsdev/resources/depsdev.lr
+++ b/providers/depsdev/resources/depsdev.lr
@@ -60,7 +60,7 @@ private depsdev.packageVersion @defaults("version publishedAt") {
   relatedProjects() []depsdev.relatedProject
 }
 
-// deps.dev related project
+// deps.dev package version related project
 private depsdev.relatedProject @defaults("relationType") {
   // Relationship type (e.g. SOURCE_REPO, ISSUE_TRACKER, ORIGIN)
   relationType string

--- a/providers/depsdev/resources/depsdev.lr.go
+++ b/providers/depsdev/resources/depsdev.lr.go
@@ -19,6 +19,7 @@ const (
 	ResourceDepsdev               string = "depsdev"
 	ResourceDepsdevPackage        string = "depsdev.package"
 	ResourceDepsdevPackageVersion string = "depsdev.packageVersion"
+	ResourceDepsdevRelatedProject string = "depsdev.relatedProject"
 	ResourceDepsdevProject        string = "depsdev.project"
 	ResourceDepsdevScorecard      string = "depsdev.scorecard"
 	ResourceDepsdevScorecardCheck string = "depsdev.scorecardCheck"
@@ -39,6 +40,10 @@ func init() {
 		"depsdev.packageVersion": {
 			// to override args, implement: initDepsdevPackageVersion(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDepsdevPackageVersion,
+		},
+		"depsdev.relatedProject": {
+			// to override args, implement: initDepsdevRelatedProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDepsdevRelatedProject,
 		},
 		"depsdev.project": {
 			Init:   initDepsdevProject,
@@ -156,6 +161,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"depsdev.packageVersion.licenses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDepsdevPackageVersion).GetLicenses()).ToDataRes(types.Array(types.String))
 	},
+	"depsdev.packageVersion.links": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevPackageVersion).GetLinks()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"depsdev.packageVersion.registries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevPackageVersion).GetRegistries()).ToDataRes(types.Array(types.String))
+	},
+	"depsdev.packageVersion.slsaProvenances": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevPackageVersion).GetSlsaProvenances()).ToDataRes(types.Array(types.Dict))
+	},
+	"depsdev.packageVersion.relatedProjects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevPackageVersion).GetRelatedProjects()).ToDataRes(types.Array(types.Resource("depsdev.relatedProject")))
+	},
+	"depsdev.relatedProject.relationType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevRelatedProject).GetRelationType()).ToDataRes(types.String)
+	},
+	"depsdev.relatedProject.relationProvenance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevRelatedProject).GetRelationProvenance()).ToDataRes(types.String)
+	},
+	"depsdev.relatedProject.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDepsdevRelatedProject).GetProject()).ToDataRes(types.Resource("depsdev.project"))
+	},
 	"depsdev.project.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDepsdevProject).GetId()).ToDataRes(types.String)
 	},
@@ -270,6 +296,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"depsdev.packageVersion.licenses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDepsdevPackageVersion).Licenses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"depsdev.packageVersion.links": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevPackageVersion).Links, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"depsdev.packageVersion.registries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevPackageVersion).Registries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"depsdev.packageVersion.slsaProvenances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevPackageVersion).SlsaProvenances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"depsdev.packageVersion.relatedProjects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevPackageVersion).RelatedProjects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"depsdev.relatedProject.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevRelatedProject).__id, ok = v.Value.(string)
+		return
+	},
+	"depsdev.relatedProject.relationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevRelatedProject).RelationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"depsdev.relatedProject.relationProvenance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevRelatedProject).RelationProvenance, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"depsdev.relatedProject.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDepsdevRelatedProject).Project, ok = plugin.RawToTValue[*mqlDepsdevProject](v.Value, v.Error)
 		return
 	},
 	"depsdev.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -540,10 +598,14 @@ type mqlDepsdevPackageVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDepsdevPackageVersionInternal
-	Version     plugin.TValue[string]
-	PublishedAt plugin.TValue[*time.Time]
-	IsDefault   plugin.TValue[bool]
-	Licenses    plugin.TValue[[]any]
+	Version         plugin.TValue[string]
+	PublishedAt     plugin.TValue[*time.Time]
+	IsDefault       plugin.TValue[bool]
+	Licenses        plugin.TValue[[]any]
+	Links           plugin.TValue[map[string]any]
+	Registries      plugin.TValue[[]any]
+	SlsaProvenances plugin.TValue[[]any]
+	RelatedProjects plugin.TValue[[]any]
 }
 
 // createDepsdevPackageVersion creates a new instance of this resource
@@ -596,7 +658,114 @@ func (c *mqlDepsdevPackageVersion) GetIsDefault() *plugin.TValue[bool] {
 }
 
 func (c *mqlDepsdevPackageVersion) GetLicenses() *plugin.TValue[[]any] {
-	return &c.Licenses
+	return plugin.GetOrCompute[[]any](&c.Licenses, func() ([]any, error) {
+		return c.licenses()
+	})
+}
+
+func (c *mqlDepsdevPackageVersion) GetLinks() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Links, func() (map[string]any, error) {
+		return c.links()
+	})
+}
+
+func (c *mqlDepsdevPackageVersion) GetRegistries() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Registries, func() ([]any, error) {
+		return c.registries()
+	})
+}
+
+func (c *mqlDepsdevPackageVersion) GetSlsaProvenances() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SlsaProvenances, func() ([]any, error) {
+		return c.slsaProvenances()
+	})
+}
+
+func (c *mqlDepsdevPackageVersion) GetRelatedProjects() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RelatedProjects, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("depsdev.packageVersion", c.__id, "relatedProjects")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.relatedProjects()
+	})
+}
+
+// mqlDepsdevRelatedProject for the depsdev.relatedProject resource
+type mqlDepsdevRelatedProject struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlDepsdevRelatedProjectInternal
+	RelationType       plugin.TValue[string]
+	RelationProvenance plugin.TValue[string]
+	Project            plugin.TValue[*mqlDepsdevProject]
+}
+
+// createDepsdevRelatedProject creates a new instance of this resource
+func createDepsdevRelatedProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDepsdevRelatedProject{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("depsdev.relatedProject", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDepsdevRelatedProject) MqlName() string {
+	return "depsdev.relatedProject"
+}
+
+func (c *mqlDepsdevRelatedProject) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDepsdevRelatedProject) GetRelationType() *plugin.TValue[string] {
+	return &c.RelationType
+}
+
+func (c *mqlDepsdevRelatedProject) GetRelationProvenance() *plugin.TValue[string] {
+	return &c.RelationProvenance
+}
+
+func (c *mqlDepsdevRelatedProject) GetProject() *plugin.TValue[*mqlDepsdevProject] {
+	return plugin.GetOrCompute[*mqlDepsdevProject](&c.Project, func() (*mqlDepsdevProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("depsdev.relatedProject", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDepsdevProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 // mqlDepsdevProject for the depsdev.project resource

--- a/providers/depsdev/resources/depsdev.lr.versions
+++ b/providers/depsdev/resources/depsdev.lr.versions
@@ -12,7 +12,11 @@ depsdev.package.versions 13.0.1
 depsdev.packageVersion 13.0.1
 depsdev.packageVersion.isDefault 13.0.1
 depsdev.packageVersion.licenses 13.0.1
+depsdev.packageVersion.links 13.0.20
 depsdev.packageVersion.publishedAt 13.0.1
+depsdev.packageVersion.registries 13.0.20
+depsdev.packageVersion.relatedProjects 13.0.20
+depsdev.packageVersion.slsaProvenances 13.0.20
 depsdev.packageVersion.version 13.0.1
 depsdev.packages 13.0.1
 depsdev.project 13.0.1
@@ -25,6 +29,10 @@ depsdev.project.license 13.0.1
 depsdev.project.openIssuesCount 13.0.1
 depsdev.project.scorecard 13.0.1
 depsdev.project.starsCount 13.0.1
+depsdev.relatedProject 13.0.20
+depsdev.relatedProject.project 13.0.20
+depsdev.relatedProject.relationProvenance 13.0.20
+depsdev.relatedProject.relationType 13.0.20
 depsdev.scorecard 13.0.1
 depsdev.scorecard.checks 13.0.1
 depsdev.scorecard.date 13.0.1

--- a/providers/depsdev/resources/package.go
+++ b/providers/depsdev/resources/package.go
@@ -73,7 +73,12 @@ func (r *mqlDepsdevPackage) fetchPackageInfo() error {
 	for _, v := range pkg.Versions {
 		publishedAt := v.PublishedAt
 
+		// Pass __id explicitly: CreateResource calls id() before packageName is
+		// set below, so id() would otherwise build a key with an empty package
+		// name and collide across packages that share a version string.
+		vid := "depsdev.packageVersion/" + r.Name.Data + "@" + v.VersionKey.Version
 		vr, err := CreateResource(r.MqlRuntime, "depsdev.packageVersion", map[string]*llx.RawData{
+			"__id":        llx.StringData(vid),
 			"version":     llx.StringData(v.VersionKey.Version),
 			"publishedAt": llx.TimeData(publishedAt),
 			"isDefault":   llx.BoolData(v.IsDefault),
@@ -238,7 +243,11 @@ func (r *mqlDepsdevPackageVersion) fetchVersionDetail() error {
 	versionID := r.packageName + "@" + r.Version.Data
 	related := make([]any, 0, len(ver.RelatedProjects))
 	for _, rp := range ver.RelatedProjects {
+		// Pass __id explicitly: CreateResource calls id() before the Internal
+		// fields below are set, so id() cannot build the key from them.
+		id := "depsdev.relatedProject/" + versionID + "/" + rp.RelationType + "/" + rp.ProjectKey.ID
 		res, err := CreateResource(r.MqlRuntime, "depsdev.relatedProject", map[string]*llx.RawData{
+			"__id":               llx.StringData(id),
 			"relationType":       llx.StringData(rp.RelationType),
 			"relationProvenance": llx.StringData(rp.RelationProvenance),
 		})

--- a/providers/depsdev/resources/package.go
+++ b/providers/depsdev/resources/package.go
@@ -20,6 +20,13 @@ type mqlDepsdevPackageInternal struct {
 
 type mqlDepsdevPackageVersionInternal struct {
 	packageName string
+	fetched     bool
+	lock        sync.Mutex
+}
+
+type mqlDepsdevRelatedProjectInternal struct {
+	projectID string
+	versionID string
 }
 
 func initDepsdevPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -70,7 +77,6 @@ func (r *mqlDepsdevPackage) fetchPackageInfo() error {
 			"version":     llx.StringData(v.VersionKey.Version),
 			"publishedAt": llx.TimeData(publishedAt),
 			"isDefault":   llx.BoolData(v.IsDefault),
-			"licenses":    llx.ArrayData([]any{}, "\x09"), // licenses are not in the package endpoint
 		})
 		if err != nil {
 			return err
@@ -142,28 +148,151 @@ func (r *mqlDepsdevPackage) project() (*mqlDepsdevProject, error) {
 		return nil, err
 	}
 
-	// Find the first related project
+	// Prefer the source repository relation; fall back to the first related
+	// project with a non-empty id.
+	projectID := ""
 	for _, rp := range ver.RelatedProjects {
-		projectID := rp.ProjectKey.ID
-		if projectID == "" {
+		if rp.ProjectKey.ID == "" {
 			continue
 		}
-
-		res, err := NewResource(r.MqlRuntime, "depsdev.project", map[string]*llx.RawData{
-			"id": llx.StringData(projectID),
-		})
-		if err != nil {
-			return nil, err
+		if rp.RelationType == "SOURCE_REPO" {
+			projectID = rp.ProjectKey.ID
+			break
 		}
-		return res.(*mqlDepsdevProject), nil
+		if projectID == "" {
+			projectID = rp.ProjectKey.ID
+		}
 	}
 
-	r.Project.State = plugin.StateIsNull | plugin.StateIsSet
-	return nil, nil
+	if projectID == "" {
+		r.Project.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	res, err := NewResource(r.MqlRuntime, "depsdev.project", map[string]*llx.RawData{
+		"id": llx.StringData(projectID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDepsdevProject), nil
 }
 
 // depsdev.packageVersion
 
 func (r *mqlDepsdevPackageVersion) id() (string, error) {
 	return "depsdev.packageVersion/" + r.packageName + "@" + r.Version.Data, nil
+}
+
+// fetchVersionDetail fetches the version detail from deps.dev and populates
+// licenses, links, registries, slsaProvenances, and relatedProjects in one call.
+func (r *mqlDepsdevPackageVersion) fetchVersionDetail() error {
+	if r.fetched {
+		return nil
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(*connection.DepsDevConnection)
+
+	ver, err := fetchVersion(conn.HttpClient, r.packageName, r.Version.Data)
+	if err != nil {
+		return err
+	}
+
+	licenses := make([]any, 0, len(ver.Licenses))
+	for _, l := range ver.Licenses {
+		licenses = append(licenses, l)
+	}
+	r.Licenses = plugin.TValue[[]any]{Data: licenses, State: plugin.StateIsSet}
+
+	links := map[string]any{}
+	for _, lk := range ver.Links {
+		if lk.Label == "" {
+			continue
+		}
+		links[lk.Label] = lk.URL
+	}
+	r.Links = plugin.TValue[map[string]any]{Data: links, State: plugin.StateIsSet}
+
+	registries := make([]any, 0, len(ver.Registries))
+	for _, rg := range ver.Registries {
+		registries = append(registries, rg)
+	}
+	r.Registries = plugin.TValue[[]any]{Data: registries, State: plugin.StateIsSet}
+
+	provenances := make([]any, 0, len(ver.SlsaProvenances))
+	for _, p := range ver.SlsaProvenances {
+		provenances = append(provenances, map[string]any{
+			"sourceRepository": p.SourceRepository,
+			"commit":           p.Commit,
+			"url":              p.URL,
+			"verified":         p.Verified,
+		})
+	}
+	r.SlsaProvenances = plugin.TValue[[]any]{Data: provenances, State: plugin.StateIsSet}
+
+	versionID := r.packageName + "@" + r.Version.Data
+	related := make([]any, 0, len(ver.RelatedProjects))
+	for _, rp := range ver.RelatedProjects {
+		res, err := CreateResource(r.MqlRuntime, "depsdev.relatedProject", map[string]*llx.RawData{
+			"relationType":       llx.StringData(rp.RelationType),
+			"relationProvenance": llx.StringData(rp.RelationProvenance),
+		})
+		if err != nil {
+			return err
+		}
+		mqlRp := res.(*mqlDepsdevRelatedProject)
+		mqlRp.projectID = rp.ProjectKey.ID
+		mqlRp.versionID = versionID
+		related = append(related, res)
+	}
+	r.RelatedProjects = plugin.TValue[[]any]{Data: related, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func (r *mqlDepsdevPackageVersion) licenses() ([]any, error) {
+	return nil, r.fetchVersionDetail()
+}
+
+func (r *mqlDepsdevPackageVersion) links() (map[string]any, error) {
+	return nil, r.fetchVersionDetail()
+}
+
+func (r *mqlDepsdevPackageVersion) registries() ([]any, error) {
+	return nil, r.fetchVersionDetail()
+}
+
+func (r *mqlDepsdevPackageVersion) slsaProvenances() ([]any, error) {
+	return nil, r.fetchVersionDetail()
+}
+
+func (r *mqlDepsdevPackageVersion) relatedProjects() ([]any, error) {
+	return nil, r.fetchVersionDetail()
+}
+
+// depsdev.relatedProject
+
+func (r *mqlDepsdevRelatedProject) id() (string, error) {
+	return "depsdev.relatedProject/" + r.versionID + "/" + r.RelationType.Data + "/" + r.projectID, nil
+}
+
+func (r *mqlDepsdevRelatedProject) project() (*mqlDepsdevProject, error) {
+	if r.projectID == "" {
+		r.Project.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	res, err := NewResource(r.MqlRuntime, "depsdev.project", map[string]*llx.RawData{
+		"id": llx.StringData(r.projectID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDepsdevProject), nil
 }


### PR DESCRIPTION
## What

Expands `depsdev.packageVersion` with five new fields, all sourced from the deps.dev `GetVersion` endpoint through a single shared lazy fetch (one HTTP call populates all five):

| Field | Type | Notes |
|---|---|---|
| `licenses` | `[]string` | **Bug fix** — was always empty before (see below) |
| `links` | `map[string]string` | Keyed by label (`SOURCE_REPO`, `ISSUE_TRACKER`, `ORIGIN`, ...) |
| `registries` | `[]string` | Registries the version is published to |
| `slsaProvenances` | `[]dict` | Build provenance attestations (`sourceRepository`, `commit`, `url`, `verified`) |
| `relatedProjects` | `[]depsdev.relatedProject` | New sub-resource: `relationType`, `relationProvenance`, typed `project()` |

The new `depsdev.relatedProject` resource exists to hold a typed `project()` reference (meeting the nested-typed-ref bar for a sub-resource), so you can traverse from a version straight into the upstream project:

```mql
depsdev.packages {
  name
  versions.where(isDefault).first {
    licenses
    links
    relatedProjects { relationType project { id starsCount } }
  }
}
```

## Bugs fixed

1. **`depsdev.packageVersion.licenses` was always empty.** The field was set to `[]` at creation (`// licenses are not in the package endpoint`) and `GetVersion` — which does return licenses — was never consulted. It is now a computed field backed by the version-detail fetch. Verified live: `github.com/rs/zerolog@v1.31.0` now reports `["MIT"]`.

2. **`depsdev.package.project()` ignored the relation type.** It returned the first related project of any type, so a package whose first relation was an issue tracker would surface that instead of the source repo. It now prefers the `SOURCE_REPO` relation, falling back to the first non-empty entry.

3. **Cache-key collisions from `id()` reading fields set after `CreateResource`** (two resources, same root cause):
   - `depsdev.relatedProject` (new code, caught in review): `CreateResource` computes `__id` via `id()` before the `projectID`/`versionID` Internal fields are assigned.
   - `depsdev.packageVersion` (pre-existing, surfaced while verifying the above): `packageName` is assigned after `CreateResource`, so `id()` produced `depsdev.packageVersion/@<version>` with an empty package name. Any two modules sharing a version string collided — e.g. `cockroachdb/errors` and `rs/zerolog` both have `v1.14.0`, so in a multi-package query `zerolog.versions.where(isDefault).first` silently returned cockroachdb's version object (and `stretchr/testify` came back `null`).

   Both are fixed by passing `__id` explicitly in the `CreateResource` args so the generated code never calls `id()` with unset fields. Note: this class of bug is invisible in single-resource queries (separate queries have separate caches) and only manifests when multiple instances are materialized in one query.

## Not changed (deliberately)

- `slsaProvenances` is modeled as `[]dict` rather than a sub-resource: it has no natural ID, and its only typed-ref candidate (`sourceRepository`) is redundant with `relatedProjects`. It's also empty in practice for Go modules (the provider is Go-only today). Revisit if/when the provider covers npm/PyPI, where provenance is populated.
- `depsdev.project.archived()` keeps a manual double-check that is effectively dead code — `GetOrCompute` already caches and honors the proactive `StateIsNull` for non-GitHub projects. Harmless; left to avoid churn.
- Larger missing data (not bugs, future work): per-version `isDeprecated`/`deprecatedReason`, vulnerability `advisoryKeys`, the resolved dependency graph, CAPSLOCK capabilities.

## Testing

- `go build ./...`, `go vet`, and `go test ./...` pass for the provider.
- Generated code (`.lr.go`, `.lr.versions`) regenerated with `mqlr generate`; new `.lr.versions` entries are at `13.0.20` (next patch after the provider's current `13.0.19`). The changed `licenses` entry keeps its original version (stored → computed is not a version bump).
- Verified end-to-end against the live deps.dev API with the installed `mql` binary. A single query over all `go.mod` deps now resolves each package to its own data: `zerolog → rs/zerolog` (v1.35.1), `testify → stretchr/testify` (v1.11.1), `mql → mondoohq/cnquery`, instead of collapsing to the first package. `licenses`, `links`, `registries`, `slsaProvenances`, and `relatedProjects` all populate, and `relatedProject.project()` resolves to a real `depsdev.project`.
