### PR TITLE
🧹 tailscale: clarify platform title as "Tailscale Organization"

### DIFF
--- a/providers/tailscale/connection/platforms.go
+++ b/providers/tailscale/connection/platforms.go
@@ -9,7 +9,7 @@ import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 var Platforms = []*plugin.PlatformInfo{
 	{
 		Name:    "tailscale-org",
-		Title:   "Tailscale",
+		Title:   "Tailscale Organization",
 		Family:  []string{"tailscale"},
 		Kind:    []string{"api"},
 		Runtime: []string{"tailscale"},


### PR DESCRIPTION
## Summary

Updates the `tailscale-org` platform display title from "Tailscale" to "Tailscale Organization" to more accurately describe what the asset represents (an organization/tailnet, not Tailscale as a whole).

## Changes

- `providers/tailscale/connection/platforms.go`: `Title` for the `tailscale-org` platform → "Tailscale Organization"