### PR TITLE
🎉 tailscale-13.3.4

### DIFF
--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.3.3",
+	Version:         "13.3.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
## Tailscale provider patch release: 13.3.3 → 13.3.4

Bumps the tailscale provider version in `config.go`.

### Changes since 13.3.3
- 🧹 tailscale: clarify platform title as "Tailscale Organization" (#8742)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)