### PR TITLE
🐛 avoid incorrect error-propagation on empty rawdata

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/protobuf/proto"
 )
@@ -765,17 +766,24 @@ func primitive2rawdataMapV2(m map[string]*Primitive) (map[string]any, error) {
 // RawData converts the primitive into the internal go-representation of the
 // data that can be used for computations
 func (p *Primitive) RawData() *RawData {
-	// An empty primitive (no type, value, array, or map) represents an
-	// unset/null value. Treat it as null rather than returning an error: a
-	// single untyped nested field must not abort conversion of its surrounding
-	// block or array, which would discard the entire collection (via
-	// primitive2array / primitive2rawdataMapV2) and surface as empty
-	// assessments — e.g. `list.all(...)` rendering no failing resources.
+	// A primitive with no type information is malformed: it is never produced
+	// deliberately (a genuine null is `NilPrimitive`, with Type == types.Nil).
+	// It only appears when an upstream layer — most often the compiler binding
+	// a predicate's value field to a resource that lacks it (see
+	// mqlc.addValueFieldChunks) — emits a broken primitive.
 	//
-	// This is defense in depth. The concrete known source of untyped fields —
-	// the compiler binding a predicate's value field to a nested `@context`
-	// resource that lacks it — is fixed at the root in mqlc.addValueFieldChunks.
+	// Behavior here is loud-and-narrow:
+	//   - narrow: coerce just this field to null instead of returning an error.
+	//     An error would propagate through primitive2array / primitive2rawdataMapV2
+	//     and discard the entire surrounding collection (parray2raw rewrites the
+	//     dropped slice to an empty `[]`), so one broken leaf would empty a whole
+	//     failing-resource list and surface as an empty assessment.
+	//   - loud: log it. Silently coercing to a fake-valid null is what made the
+	//     original compiler bug nearly impossible to find; logging keeps the
+	//     underlying (usually compiler) defect visible even though we degrade
+	//     gracefully for the surrounding data.
 	if p.GetType() == "" {
+		log.Error().Msg("llx: encountered a primitive with no type information, coercing to null (this indicates an upstream/compiler bug producing a malformed primitive)")
 		return &RawData{Type: types.Nil}
 	}
 

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -768,11 +768,13 @@ func (p *Primitive) RawData() *RawData {
 	// An empty primitive (no type, value, array, or map) represents an
 	// unset/null value. Treat it as null rather than returning an error: a
 	// single untyped nested field must not abort conversion of its surrounding
-	// block or array. Previously this error propagated through primitive2array /
-	// primitive2rawdataMapV2 and discarded the entire collection, which surfaced
-	// as empty assessments — e.g. `list.all(...)` over a resource with a
-	// `@context` field whose context had an unset sub-field would render no
-	// failing resources at all (and emit no SARIF locations).
+	// block or array, which would discard the entire collection (via
+	// primitive2array / primitive2rawdataMapV2) and surface as empty
+	// assessments — e.g. `list.all(...)` rendering no failing resources.
+	//
+	// This is defense in depth. The concrete known source of untyped fields —
+	// the compiler binding a predicate's value field to a nested `@context`
+	// resource that lacks it — is fixed at the root in mqlc.addValueFieldChunks.
 	if p.GetType() == "" {
 		return &RawData{Type: types.Nil}
 	}

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -765,9 +765,16 @@ func primitive2rawdataMapV2(m map[string]*Primitive) (map[string]any, error) {
 // RawData converts the primitive into the internal go-representation of the
 // data that can be used for computations
 func (p *Primitive) RawData() *RawData {
-	// FIXME: This is a stopgap. It points to an underlying problem that exists and needs fixing.
+	// An empty primitive (no type, value, array, or map) represents an
+	// unset/null value. Treat it as null rather than returning an error: a
+	// single untyped nested field must not abort conversion of its surrounding
+	// block or array. Previously this error propagated through primitive2array /
+	// primitive2rawdataMapV2 and discarded the entire collection, which surfaced
+	// as empty assessments — e.g. `list.all(...)` over a resource with a
+	// `@context` field whose context had an unset sub-field would render no
+	// failing resources at all (and emit no SARIF locations).
 	if p.GetType() == "" {
-		return &RawData{Error: errors.New("cannot convert primitive with NO type information")}
+		return &RawData{Type: types.Nil}
 	}
 
 	typ := types.Type(p.Type)

--- a/llx/data_conversions_test.go
+++ b/llx/data_conversions_test.go
@@ -75,3 +75,45 @@ func TestResultRawConversions(t *testing.T) {
 		})
 	}
 }
+
+// TestEmptyTypePrimitiveConvertsToNil ensures an empty (untyped) primitive is
+// converted to a Nil value instead of an error. An empty primitive represents
+// an unset/null value; erroring here used to abort conversion of the whole
+// surrounding array/map (see TestEmptyTypePrimitiveKeepsCollection).
+func TestEmptyTypePrimitiveConvertsToNil(t *testing.T) {
+	rd := (&llx.Primitive{}).RawData()
+	require.NoError(t, rd.Error)
+	assert.Equal(t, types.Nil, rd.Type)
+	assert.Nil(t, rd.Value)
+}
+
+// TestEmptyTypePrimitiveKeepsCollection is a regression test for empty
+// assessments: a single untyped nested field (e.g. an unset sub-field of a
+// resource's @context block) must not discard the entire surrounding array.
+// Previously RawData() errored on the untyped field and primitive2array /
+// primitive2rawdataMapV2 propagated that error, returning an empty slice — so
+// `list.all(...)` over @context resources rendered no failing resources at all.
+func TestEmptyTypePrimitiveKeepsCollection(t *testing.T) {
+	// A resource block whose nested context block carries an unset (untyped) field.
+	contextBlock := &llx.Primitive{
+		Type: string(types.Block),
+		Map: map[string]*llx.Primitive{
+			"path":  llx.StringPrimitive("main.tf"),
+			"range": {}, // untyped/null sub-field — the trigger
+		},
+	}
+	element := &llx.Primitive{
+		Type: string(types.Block),
+		Map: map[string]*llx.Primitive{
+			"name":    llx.StringPrimitive("resource"),
+			"context": contextBlock,
+		},
+	}
+	arr := llx.ArrayPrimitive([]*llx.Primitive{element, element, element}, types.Block)
+
+	rd := arr.RawData()
+	require.NoError(t, rd.Error)
+	got, ok := rd.Value.([]any)
+	require.True(t, ok, "expected the array to survive conversion")
+	assert.Len(t, got, 3, "the whole collection must be preserved, not emptied")
+}

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1789,8 +1789,9 @@ func (c *compiler) postCompile() {
 				expanded := c.expandResourceFields(chunk, typ, ref)
 				// when no defaults are defined or query isn't about a resource, no block was added
 				if expanded {
-					block.Datapoints = append(block.Datapoints, block.TailRef(ref))
-					c.addValueFieldChunks(ref)
+					autoExpandRef := block.TailRef(ref)
+					block.Datapoints = append(block.Datapoints, autoExpandRef)
+					c.addValueFieldChunks(ref, autoExpandRef)
 				}
 			default:
 				c.expandResourceFields(chunk, typ, ref)
@@ -1803,7 +1804,7 @@ func (c *compiler) postCompile() {
 // block for the default fields
 // This way, the actual data of the assessment automatically shows up in the output
 // of the assessment that failed the assessment
-func (c *compiler) addValueFieldChunks(ref uint64) {
+func (c *compiler) addValueFieldChunks(ref uint64, autoExpandRef uint64) {
 	var whereChunk *llx.Chunk
 
 	// find chunk with where/whereNot function
@@ -1964,8 +1965,23 @@ func (c *compiler) addValueFieldChunks(ref uint64) {
 		return true
 	})
 
-	defaultFieldsBlock := c.Result.CodeV2.Blocks[len(c.Result.CodeV2.Blocks)-1]
-	defaultFieldsRef := defaultFieldsBlock.HeadRef(c.Result.CodeV2.LastBlockRef())
+	// The default-fields block is the one referenced by the auto-expand `{}`
+	// chunk we just created for this list — NOT necessarily the last block.
+	// A resource with a `@context` annotation appends a further nested block
+	// (the context expansion), so `Blocks[len-1]` would wrongly target the
+	// context block and bind the predicate's value fields to the context
+	// resource (e.g. `file.context.criteria`), yielding an untyped/empty field
+	// that breaks the failing-resource list. Resolve the block from the chunk.
+	autoExpandChunk := c.Result.CodeV2.Chunk(autoExpandRef)
+	if autoExpandChunk == nil || autoExpandChunk.Function == nil || len(autoExpandChunk.Function.Args) == 0 {
+		return
+	}
+	defaultFieldsBlockRef, ok := autoExpandChunk.Function.Args[0].RawData().Value.(uint64)
+	if !ok {
+		return
+	}
+	defaultFieldsBlock := c.Result.CodeV2.Block(defaultFieldsBlockRef)
+	defaultFieldsRef := defaultFieldsBlock.HeadRef(defaultFieldsBlockRef)
 	defaultFieldsBlockTree := blockToFieldTree(defaultFieldsBlock, func(chunkIdx int, chunk *llx.Chunk) bool {
 		return true
 	})

--- a/providers/os/resources/assessment_context_test.go
+++ b/providers/os/resources/assessment_context_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// TestAssessment_ContextResourceListSurfacesFailures is an end-to-end regression
+// test for "empty assessments": a failing list assertion over a resource that
+// carries a `@context` annotation (here sshd.config.matchBlock) must surface the
+// failing resources in the assessment's `actual` value.
+//
+// The context block has sub-fields (e.g. range) that can be unset; an unset
+// sub-field serialized to an untyped primitive used to abort conversion of the
+// entire failing-resource list, leaving `actual` empty. Reporters (CLI, SARIF)
+// then showed no failing resources and no source locations.
+func TestAssessment_ContextResourceListSurfacesFailures(t *testing.T) {
+	bundle, err := x.Compile(`sshd.config.blocks.all(criteria == "nonexistent")`)
+	require.NoError(t, err)
+
+	results, err := x.ExecuteCode(bundle, nil)
+	require.NoError(t, err)
+
+	assessment := llx.Results2AssessmentLookupV2(bundle, func(s string) (*llx.RawResult, bool) {
+		r, ok := results[s]
+		return r, ok
+	})
+	require.NotNil(t, assessment)
+	require.False(t, assessment.Success, "the check is expected to fail")
+	require.NotEmpty(t, assessment.Results)
+
+	item := assessment.Results[0]
+	require.False(t, item.Success)
+	require.NotNil(t, item.Actual, "failing resources must be surfaced in actual")
+
+	rd := item.Actual.RawData()
+	require.NoError(t, rd.Error)
+	arr, ok := rd.Value.([]any)
+	require.True(t, ok, "actual should be the list of failing resources")
+	assert.NotEmpty(t, arr, "the failing-resource list must not be empty")
+}


### PR DESCRIPTION
1. Empty rawdata due to the way the conversion works was getting returned and then culled by the array-handling. This caused erroneous behavior in e.g. @context blocks to be culled from the results. This change makes it loud (with error) while retaining the nil-behavior that this entry has for the user.
2. The issue that sparked this was the incorrect handling of @context data on failures, i.e. the positioning of the codeblock in the compiler. fixed