### PR TITLE
⚡ aws: cut redundant API calls when scanning security-group assets

### DIFF
--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -148,41 +149,10 @@ func (a *mqlAwsCloudformation) getStacks(conn *connection.AwsConnection) []*jobp
 				}
 
 				for _, stack := range resp.Stacks {
-					capabilities := make([]any, len(stack.Capabilities))
-					for j, c := range stack.Capabilities {
-						capabilities[j] = string(c)
-					}
-
-					driftStatus := ""
-					if stack.DriftInformation != nil {
-						driftStatus = string(stack.DriftInformation.StackDriftStatus)
-					}
-
-					mqlStack, err := CreateResource(a.MqlRuntime, "aws.cloudformation.stack",
-						map[string]*llx.RawData{
-							"__id":                        llx.StringDataPtr(stack.StackId),
-							"stackId":                     llx.StringDataPtr(stack.StackId),
-							"name":                        llx.StringDataPtr(stack.StackName),
-							"region":                      llx.StringData(region),
-							"status":                      llx.StringData(string(stack.StackStatus)),
-							"statusReason":                llx.StringDataPtr(stack.StackStatusReason),
-							"description":                 llx.StringDataPtr(stack.Description),
-							"enableTerminationProtection": llx.BoolDataPtr(stack.EnableTerminationProtection),
-							"capabilities":                llx.ArrayData(capabilities, types.String),
-							"driftStatus":                 llx.StringData(normalizeDriftStatus(driftStatus)),
-							"roleArn":                     llx.StringData(aws.ToString(stack.RoleARN)),
-							"tags":                        llx.MapData(cfnTagsToMap(stack.Tags), types.String),
-							"createdAt":                   llx.TimeDataPtr(stack.CreationTime),
-							"updatedAt":                   llx.TimeDataPtr(stack.LastUpdatedTime),
-						})
+					mqlStackRes, err := buildCloudformationStackResource(a.MqlRuntime, region, stack)
 					if err != nil {
 						return nil, err
 					}
-					mqlStackRes := mqlStack.(*mqlAwsCloudformationStack)
-					mqlStackRes.cacheRoleArn = stack.RoleARN
-					mqlStackRes.cacheParameters = stack.Parameters
-					mqlStackRes.cacheOutputs = stack.Outputs
-					mqlStackRes.cacheNotificationArns = stack.NotificationARNs
 					res = append(res, mqlStackRes)
 				}
 
@@ -535,11 +505,55 @@ func managedByFromTags(tags map[string]any) string {
 	return ""
 }
 
+// buildCloudformationStackResource maps a single CloudFormation stack from the
+// API into an aws.cloudformation.stack resource, caching the fields that back
+// lazy-loaded accessors. Shared by the cross-region stack listing and the
+// targeted single-stack lookup.
+func buildCloudformationStackResource(runtime *plugin.Runtime, region string, stack cf_types.Stack) (*mqlAwsCloudformationStack, error) {
+	capabilities := make([]any, len(stack.Capabilities))
+	for j, c := range stack.Capabilities {
+		capabilities[j] = string(c)
+	}
+
+	driftStatus := ""
+	if stack.DriftInformation != nil {
+		driftStatus = string(stack.DriftInformation.StackDriftStatus)
+	}
+
+	mqlStack, err := CreateResource(runtime, "aws.cloudformation.stack",
+		map[string]*llx.RawData{
+			"__id":                        llx.StringDataPtr(stack.StackId),
+			"stackId":                     llx.StringDataPtr(stack.StackId),
+			"name":                        llx.StringDataPtr(stack.StackName),
+			"region":                      llx.StringData(region),
+			"status":                      llx.StringData(string(stack.StackStatus)),
+			"statusReason":                llx.StringDataPtr(stack.StackStatusReason),
+			"description":                 llx.StringDataPtr(stack.Description),
+			"enableTerminationProtection": llx.BoolDataPtr(stack.EnableTerminationProtection),
+			"capabilities":                llx.ArrayData(capabilities, types.String),
+			"driftStatus":                 llx.StringData(normalizeDriftStatus(driftStatus)),
+			"roleArn":                     llx.StringData(aws.ToString(stack.RoleARN)),
+			"tags":                        llx.MapData(cfnTagsToMap(stack.Tags), types.String),
+			"createdAt":                   llx.TimeDataPtr(stack.CreationTime),
+			"updatedAt":                   llx.TimeDataPtr(stack.LastUpdatedTime),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlStackRes := mqlStack.(*mqlAwsCloudformationStack)
+	mqlStackRes.cacheRoleArn = stack.RoleARN
+	mqlStackRes.cacheParameters = stack.Parameters
+	mqlStackRes.cacheOutputs = stack.Outputs
+	mqlStackRes.cacheNotificationArns = stack.NotificationARNs
+	return mqlStackRes, nil
+}
+
 // cloudformationStackForTags resolves the CloudFormation stack that manages a
-// resource from the AWS-injected `aws:cloudformation:stack-name` tag. It scans
-// the account's stacks (a cross-region list cached after first use) and matches
-// on stack name and region. Returns (nil, nil) when the resource is not part of
-// a stack; callers set the field's null state before returning.
+// resource from the AWS-injected `aws:cloudformation:stack-name` tag. It issues
+// a targeted DescribeStacks for that one stack in the resource's region instead
+// of listing every stack across the account. Returns (nil, nil) when the
+// resource is not part of a stack; callers set the field's null state before
+// returning.
 func cloudformationStackForTags(runtime *plugin.Runtime, region string, tags map[string]any) (*mqlAwsCloudformationStack, error) {
 	raw, ok := tags["aws:cloudformation:stack-name"]
 	if !ok {
@@ -550,22 +564,27 @@ func cloudformationStackForTags(runtime *plugin.Runtime, region string, tags map
 		return nil, nil
 	}
 
-	obj, err := CreateResource(runtime, ResourceAwsCloudformation, map[string]*llx.RawData{})
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.CloudFormation(region)
+	resp, err := svc.DescribeStacks(context.Background(), &cloudformation.DescribeStacksInput{
+		StackName: &name,
+	})
 	if err != nil {
+		// A stale tag can reference a deleted stack; DescribeStacks returns a
+		// ValidationError ("Stack with id <name> does not exist") in that case.
+		// Treat any access/lookup failure as "no stack" rather than failing the
+		// whole scan.
+		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+			return nil, nil
+		}
+		var oe interface{ ErrorCode() string }
+		if errors.As(err, &oe) && oe.ErrorCode() == "ValidationError" {
+			return nil, nil
+		}
 		return nil, err
 	}
-	stacks := obj.(*mqlAwsCloudformation).GetStacks()
-	if stacks.Error != nil {
-		return nil, stacks.Error
+	if len(resp.Stacks) == 0 {
+		return nil, nil
 	}
-	for _, s := range stacks.Data {
-		st, ok := s.(*mqlAwsCloudformationStack)
-		if !ok {
-			continue
-		}
-		if st.Name.Data == name && st.Region.Data == region {
-			return st, nil
-		}
-	}
-	return nil, nil
+	return buildCloudformationStackResource(runtime, region, resp.Stacks[0])
 }

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -466,23 +466,14 @@ func (a *mqlAwsEc2NetworkaclEntry) portRange() (*mqlAwsEc2NetworkaclEntryPortran
 }
 
 func (a *mqlAwsEc2Securitygroup) isAttachedToNetworkInterface() (bool, error) {
-	sgId := a.Id.Data
-	region := a.Region.Data
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.Ec2(region)
-	ctx := context.Background()
-
-	networkinterfaces, err := svc.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{Filters: []ec2types.Filter{
-		{Name: aws.String("group-id"), Values: []string{sgId}},
-	}})
-	if err != nil {
-		return false, err
+	// Reuse the cached networkInterfaces field (same group-id DescribeNetworkInterfaces
+	// call) so a policy that queries both this and networkInterfaces/instances only
+	// hits the API once.
+	nis := a.GetNetworkInterfaces()
+	if nis.Error != nil {
+		return false, nis.Error
 	}
-	if len(networkinterfaces.NetworkInterfaces) > 0 {
-		return true, nil
-	}
-	return false, nil
+	return len(nis.Data) > 0, nil
 }
 
 type mqlAwsEc2SecuritygroupInternal struct {


### PR DESCRIPTION
## What

Two reductions on the per-asset `aws-security-group` scan path:

1. **`isAttachedToNetworkInterface` reuses the cached `networkInterfaces` field** instead of issuing its own `DescribeNetworkInterfaces`. A policy that reads both this and `networkInterfaces`/`instances` now makes **one** `DescribeNetworkInterfaces` call per SG instead of two.

2. **`cloudformationStack` uses a targeted `DescribeStacks({StackName})`** in the resource's region instead of listing every stack in every region and filtering in memory (`getStacks` mapping logic extracted into a shared `buildCloudformationStackResource` helper). Stale tags pointing at a deleted stack resolve to null (ValidationError / access-denied / not-available all → `nil`) rather than failing the scan.

## Perf test (95 SG assets in a test account)

Raw `cnspec scan` wall-clock was **not usable** as a benchmark: the comparison run died on a Mondoo edge-platform timeout (`PolicyResolver/SynchronizeAssets: context deadline exceeded`) with ~15s CPU — platform sync latency dominates and swamps the provider delta. So change #1/#2 were isolated at the AWS-API level with `mql` (no platform):

```
mql run aws -c "aws.ec2.securityGroups { isAttachedToNetworkInterface networkInterfaces { id } }"
```

| provider | run 1 | run 2 | run 3 | median |
|----------|-------|-------|-------|--------|
| before   | 96.4s | 84.1s | 91.0s | **91.0s** |
| after    | 73.4s | 68.6s | 69.1s | **69.1s** |

**~24% faster (~22s)** on this path, clean separation (slowest *after* < fastest *before*). `DescribeNetworkInterfaces` calls halved (190 → 95).

## Note on change #2 vs #1

- **#2 (ENI dedupe)** is the unambiguous, measured win above.
- **#1 (`cloudformationStack`)** had **zero effect on the test account** — none of the 95 SGs carry the `aws:cloudformation:stack-name` tag, so the path never fires. It only matters for CloudFormation-managed SGs. Topology caveat worth a reviewer's eye: in a single-process `cnspec scan aws` run, child SG assets share the parent runtime's `aws.cloudformation` cache, so the old code already amortized the list-all to ~once; the targeted lookup is a clear win primarily in distributed/scan-only topologies (each asset its own process, no shared cache). It should be neutral-to-better in the common case and a large win in the distributed case, but it has not been measured against an account with cfn-tagged SGs.

## Test

- `go build ./resources/...`, `go vet`, `gofmt` clean
- `go test ./resources/` passes
- Live A/B as above