### PR TITLE
⚡ aws: targeted single-resource init for filter-in-memory asset types

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -88,7 +88,11 @@ func Is400AccessDeniedError(err error) bool {
 func isResourceNotFoundError(err error) bool {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
-		return strings.Contains(ae.ErrorCode(), "NotFound")
+		code := ae.ErrorCode()
+		// Most services use a "*NotFound*" code (e.g. RepositoryNotFoundException,
+		// LoadBalancerNotFound, ResourceNotFoundException); a few use a "NoSuch*"
+		// code instead (e.g. NoSuchEntity, NoSuchBucket).
+		return strings.Contains(code, "NotFound") || strings.HasPrefix(code, "NoSuch")
 	}
 	return false
 }

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	smithy "github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/transport/http"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -76,6 +77,18 @@ func Is400AccessDeniedError(err error) bool {
 			strings.Contains(respErr.Error(), "UnauthorizedOperation") ||
 			strings.Contains(respErr.Error(), "AuthorizationError")
 		return statusCodeMatches && errorMessageMatches
+	}
+	return false
+}
+
+// isResourceNotFoundError reports whether err is an AWS "not found" API error
+// (e.g. LoadBalancerNotFound, RepositoryNotFoundException). Targeted single-
+// resource init lookups use it to fall through to their list-scan fallback for
+// stale ARNs instead of hard-failing the resolution.
+func isResourceNotFoundError(err error) bool {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return strings.Contains(ae.ErrorCode(), "NotFound")
 	}
 	return false
 }

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.38.1",
-  "generated_at": "2026-06-25T17:02:25+03:00",
+  "generated_at": "2026-06-25T20:43:02-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -147,6 +147,7 @@
     "cloudtrail:GetEventDataStore",
     "cloudtrail:GetEventSelectors",
     "cloudtrail:GetInsightSelectors",
+    "cloudtrail:GetTrail",
     "cloudtrail:GetTrailStatus",
     "cloudtrail:ListChannels",
     "cloudtrail:ListEventDataStores",
@@ -1792,6 +1793,12 @@
       "permission": "cloudtrail:GetInsightSelectors",
       "service": "cloudtrail",
       "action": "GetInsightSelectors",
+      "source_file": "aws_cloudtrail.go"
+    },
+    {
+      "permission": "cloudtrail:GetTrail",
+      "service": "cloudtrail",
+      "action": "GetTrail",
       "source_file": "aws_cloudtrail.go"
     },
     {

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 
@@ -60,21 +61,52 @@ func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	// construct arn of cloudtrail if missing
-	var arn string
+	var arnVal string
 	if args["arn"] != nil {
-		arn = args["arn"].Value.(string)
+		arnVal = args["arn"].Value.(string)
 	} else {
 		nameVal := args["name"].Value.(string)
-		arn = fmt.Sprintf(s3ArnPattern, nameVal)
+		arnVal = fmt.Sprintf(s3ArnPattern, nameVal)
 	}
 
-	if arn == "" {
+	if arnVal == "" {
 		return nil, nil, errors.New("arn or name required to fetch aws cloudtrail trail")
 	}
 
-	log.Debug().Str("arn", arn).Msg("init cloudtrail trail with arn")
+	log.Debug().Str("arn", arnVal).Msg("init cloudtrail trail with arn")
 
-	// load all s3 buckets
+	// Targeted lookup: derive the home region from the ARN and fetch just this
+	// one trail instead of describing every trail in every region.
+	var region string
+	if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "trail/") {
+		region = parsed.Region
+	}
+	if args["region"] != nil {
+		if r, ok := args["region"].Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+	if region != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Cloudtrail(region)
+		resp, err := svc.GetTrail(context.Background(), &cloudtrail.GetTrailInput{Name: &arnVal})
+		if err != nil {
+			if !Is400AccessDeniedError(err) {
+				var notFound *types.TrailNotFoundException
+				if !errors.As(err, &notFound) {
+					return nil, nil, err
+				}
+			}
+		} else if resp.Trail != nil {
+			trail, err := buildCloudtrailTrailResource(runtime, *resp.Trail)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, trail, nil
+		}
+	}
+
+	// Fallback: scan all trails (e.g. when the ARN carries no usable region).
 	obj, err := CreateResource(runtime, "aws.cloudtrail", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
@@ -88,11 +120,40 @@ func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	for _, rawResource := range rawResources.Data {
 		trail := rawResource.(*mqlAwsCloudtrailTrail)
-		if trail.Arn.Data == arn {
+		if trail.Arn.Data == arnVal {
 			return args, trail, nil
 		}
 	}
 	return args, nil, errors.New("cloudtrail trail does not exist")
+}
+
+// buildCloudtrailTrailResource maps an SDK trail into an aws.cloudtrail.trail
+// resource and primes the trailCache so the status / event-selector lazy
+// accessors resolve against the same data. Shared by the list path and the
+// targeted init lookup.
+func buildCloudtrailTrailResource(runtime *plugin.Runtime, trail types.Trail) (*mqlAwsCloudtrailTrail, error) {
+	args := map[string]*llx.RawData{
+		"arn":                        llx.StringDataPtr(trail.TrailARN),
+		"name":                       llx.StringDataPtr(trail.Name),
+		"isMultiRegionTrail":         llx.BoolDataPtr(trail.IsMultiRegionTrail),
+		"isOrganizationTrail":        llx.BoolDataPtr(trail.IsOrganizationTrail),
+		"logFileValidationEnabled":   llx.BoolDataPtr(trail.LogFileValidationEnabled),
+		"includeGlobalServiceEvents": llx.BoolDataPtr(trail.IncludeGlobalServiceEvents),
+		"snsTopicARN":                llx.StringDataPtr(trail.SnsTopicARN),
+		"cloudWatchLogsRoleArn":      llx.StringDataPtr(trail.CloudWatchLogsRoleArn),
+		"cloudWatchLogsLogGroupArn":  llx.StringDataPtr(trail.CloudWatchLogsLogGroupArn),
+		"region":                     llx.StringDataPtr(trail.HomeRegion),
+		"hasInsightSelectors":        llx.BoolDataPtr(trail.HasInsightSelectors),
+		"hasCustomEventSelectors":    llx.BoolDataPtr(trail.HasCustomEventSelectors),
+	}
+
+	mqlTrail, err := CreateResource(runtime, "aws.cloudtrail.trail", args)
+	if err != nil {
+		return nil, err
+	}
+	cast := mqlTrail.(*mqlAwsCloudtrailTrail)
+	cast.trailCache = trail
+	return cast, nil
 }
 
 type mqlAwsCloudtrailTrailInternal struct {
@@ -132,26 +193,10 @@ func (a *mqlAwsCloudtrail) getTrails(conn *connection.AwsConnection) []*jobpool.
 				if region != convert.ToValue(trail.HomeRegion) {
 					continue
 				}
-				args := map[string]*llx.RawData{
-					"arn":                        llx.StringDataPtr(trail.TrailARN),
-					"name":                       llx.StringDataPtr(trail.Name),
-					"isMultiRegionTrail":         llx.BoolDataPtr(trail.IsMultiRegionTrail),
-					"isOrganizationTrail":        llx.BoolDataPtr(trail.IsOrganizationTrail),
-					"logFileValidationEnabled":   llx.BoolDataPtr(trail.LogFileValidationEnabled),
-					"includeGlobalServiceEvents": llx.BoolDataPtr(trail.IncludeGlobalServiceEvents),
-					"snsTopicARN":                llx.StringDataPtr(trail.SnsTopicARN),
-					"cloudWatchLogsRoleArn":      llx.StringDataPtr(trail.CloudWatchLogsRoleArn),
-					"cloudWatchLogsLogGroupArn":  llx.StringDataPtr(trail.CloudWatchLogsLogGroupArn),
-					"region":                     llx.StringDataPtr(trail.HomeRegion),
-					"hasInsightSelectors":        llx.BoolDataPtr(trail.HasInsightSelectors),
-					"hasCustomEventSelectors":    llx.BoolDataPtr(trail.HasCustomEventSelectors),
-				}
-
-				mqlTrail, err := CreateResource(a.MqlRuntime, "aws.cloudtrail.trail", args)
+				mqlTrail, err := buildCloudtrailTrailResource(a.MqlRuntime, trail)
 				if err != nil {
 					return nil, err
 				}
-				mqlTrail.(*mqlAwsCloudtrailTrail).trailCache = trail
 
 				res = append(res, mqlTrail)
 			}

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -602,48 +603,15 @@ func (a *mqlAwsCloudwatch) getLogGroups(conn *connection.AwsConnection) []*jobpo
 						}
 					}
 
-					args := make(map[string]*llx.RawData)
-					args["arn"] = llx.StringDataPtr(loggroup.Arn)
-					args["name"] = llx.StringDataPtr(loggroup.LogGroupName)
-					args["region"] = llx.StringData(region)
-					args["retentionInDays"] = llx.IntDataDefault(loggroup.RetentionInDays, 0)
-					args["dataProtectionStatus"] = llx.StringData(string(loggroup.DataProtectionStatus))
-					args["deletionProtectionEnabled"] = llx.BoolDataPtr(loggroup.DeletionProtectionEnabled)
-					args["logGroupClass"] = llx.StringData(string(loggroup.LogGroupClass))
-					args["storedBytes"] = llx.IntDataDefault(loggroup.StoredBytes, 0)
-
-					inherited := make([]any, 0, len(loggroup.InheritedProperties))
-					for _, ip := range loggroup.InheritedProperties {
-						inherited = append(inherited, string(ip))
-					}
-					args["inheritedProperties"] = llx.ArrayData(inherited, types.String)
-
-					// add kms key if there is one
-					if loggroup.KmsKeyId != nil {
-						mqlKeyResource, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
-							map[string]*llx.RawData{
-								"arn": llx.StringDataPtr(loggroup.KmsKeyId),
-							})
-						if err != nil {
-							args["kmsKey"] = llx.NilData
-						} else {
-							mqlKey := mqlKeyResource.(*mqlAwsKmsKey)
-							args["kmsKey"] = llx.ResourceData(mqlKey, mqlKey.MqlName())
-						}
-					} else {
-						args["kmsKey"] = llx.NilData
-					}
-
-					mqlLogGroup, err := CreateResource(a.MqlRuntime, ResourceAwsCloudwatchLoggroup, args)
+					lg, err := buildLogGroupResource(a.MqlRuntime, region, loggroup)
 					if err != nil {
 						return nil, err
 					}
-					lg := mqlLogGroup.(*mqlAwsCloudwatchLoggroup)
 					if groupTags != nil {
 						lg.cacheTags = groupTags
 						lg.tagsFetched = true
 					}
-					res = append(res, mqlLogGroup)
+					res = append(res, lg)
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -651,6 +619,48 @@ func (a *mqlAwsCloudwatch) getLogGroups(conn *connection.AwsConnection) []*jobpo
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+// buildLogGroupResource maps an SDK log group into an aws.cloudwatch.loggroup
+// resource. Shared by the list path and the targeted init lookup.
+func buildLogGroupResource(runtime *plugin.Runtime, region string, loggroup cloudwatchlogstypes.LogGroup) (*mqlAwsCloudwatchLoggroup, error) {
+	args := make(map[string]*llx.RawData)
+	args["arn"] = llx.StringDataPtr(loggroup.Arn)
+	args["name"] = llx.StringDataPtr(loggroup.LogGroupName)
+	args["region"] = llx.StringData(region)
+	args["retentionInDays"] = llx.IntDataDefault(loggroup.RetentionInDays, 0)
+	args["dataProtectionStatus"] = llx.StringData(string(loggroup.DataProtectionStatus))
+	args["deletionProtectionEnabled"] = llx.BoolDataPtr(loggroup.DeletionProtectionEnabled)
+	args["logGroupClass"] = llx.StringData(string(loggroup.LogGroupClass))
+	args["storedBytes"] = llx.IntDataDefault(loggroup.StoredBytes, 0)
+
+	inherited := make([]any, 0, len(loggroup.InheritedProperties))
+	for _, ip := range loggroup.InheritedProperties {
+		inherited = append(inherited, string(ip))
+	}
+	args["inheritedProperties"] = llx.ArrayData(inherited, types.String)
+
+	// add kms key if there is one
+	if loggroup.KmsKeyId != nil {
+		mqlKeyResource, err := NewResource(runtime, ResourceAwsKmsKey,
+			map[string]*llx.RawData{
+				"arn": llx.StringDataPtr(loggroup.KmsKeyId),
+			})
+		if err != nil {
+			args["kmsKey"] = llx.NilData
+		} else {
+			mqlKey := mqlKeyResource.(*mqlAwsKmsKey)
+			args["kmsKey"] = llx.ResourceData(mqlKey, mqlKey.MqlName())
+		}
+	} else {
+		args["kmsKey"] = llx.NilData
+	}
+
+	mqlLogGroup, err := CreateResource(runtime, ResourceAwsCloudwatchLoggroup, args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlLogGroup.(*mqlAwsCloudwatchLoggroup), nil
 }
 
 func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -668,6 +678,51 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, errors.New("arn required to fetch cloudwatch log group")
 	}
 
+	conn := runtime.Connection.(*connection.AwsConnection)
+	arnVal := args["arn"].Value.(string)
+
+	// Targeted lookup: derive the region + group name from the ARN and fetch
+	// just this one log group (by name prefix) instead of describing every log
+	// group in every region. Only attempt this for log groups owned by the
+	// account we're connected to; cross-account references fall through to the
+	// scan + placeholder path below.
+	region := ""
+	name := ""
+	sameAccount := true
+	if parsed, parseErr := arn.Parse(arnVal); parseErr == nil {
+		region = parsed.Region
+		name = strings.TrimSuffix(strings.TrimPrefix(parsed.Resource, "log-group:"), ":*")
+		sameAccount = parsed.AccountID == "" || parsed.AccountID == conn.AccountId()
+	}
+	if args["region"] != nil {
+		if r, ok := args["region"].Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+	if region != "" && name != "" && sameAccount {
+		svc := conn.CloudwatchLogs(region)
+		out, err := svc.DescribeLogGroups(context.Background(), &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: &name,
+		})
+		if err != nil {
+			if !Is400AccessDeniedError(err) {
+				return nil, nil, err
+			}
+		} else {
+			for i := range out.LogGroups {
+				if convert.ToValue(out.LogGroups[i].LogGroupName) == name {
+					lg, err := buildLogGroupResource(runtime, region, out.LogGroups[i])
+					if err != nil {
+						return nil, nil, err
+					}
+					return args, lg, nil
+				}
+			}
+		}
+	}
+
+	// Fallback: scan all log groups (e.g. cross-account references or when the
+	// ARN carries no usable region).
 	obj, err := CreateResource(runtime, "aws.cloudwatch", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
@@ -678,7 +733,6 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	// CloudWatch's DescribeLogGroups returns ARNs with a trailing ":*" suffix;
 	// other AWS services (e.g. EventBridge Pipes LogConfiguration) return the
 	// bare ARN without it. Compare both with and without the suffix so init
@@ -696,15 +750,14 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	// If the log group is in a different account (e.g., organizational trail referencing
 	// a log group in the management account), create a placeholder resource with basic
 	// info extracted from the ARN instead of failing.
-	conn := runtime.Connection.(*connection.AwsConnection)
 	if parsedArn, parseErr := arn.Parse(arnVal); parseErr == nil && parsedArn.AccountID != conn.AccountId() {
 		log.Warn().Str("arn", arnVal).Str("currentAccount", conn.AccountId()).Str("logGroupAccount", parsedArn.AccountID).Msg("cross-account CloudWatch log group reference")
-		region, groupName := parseLogGroupArn(arnVal)
-		if region == "" || groupName == "" {
+		grpRegion, groupName := parseLogGroupArn(arnVal)
+		if grpRegion == "" || groupName == "" {
 			return nil, nil, errors.New("cloudwatch log group does not exist")
 		}
 		args["name"] = llx.StringData(groupName)
-		args["region"] = llx.StringData(region)
+		args["region"] = llx.StringData(grpRegion)
 		args["retentionInDays"] = llx.IntData(-1)
 		args["storedBytes"] = llx.IntData(-1)
 		args["dataProtectionStatus"] = llx.StringData("")

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -701,14 +701,21 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 	if region != "" && name != "" && sameAccount {
 		svc := conn.CloudwatchLogs(region)
-		out, err := svc.DescribeLogGroups(context.Background(), &cloudwatchlogs.DescribeLogGroupsInput{
+		// DescribeLogGroups only filters by name *prefix*, so other groups can
+		// share this group's prefix and the exact match may land on a later
+		// page. Paginate and match exactly; on access-denied fall through to the
+		// scan + placeholder path below.
+		paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(svc, &cloudwatchlogs.DescribeLogGroupsInput{
 			LogGroupNamePrefix: &name,
 		})
-		if err != nil {
-			if !Is400AccessDeniedError(err) {
+		for paginator.HasMorePages() {
+			out, err := paginator.NextPage(context.Background())
+			if err != nil {
+				if Is400AccessDeniedError(err) {
+					break
+				}
 				return nil, nil, err
 			}
-		} else {
 			for i := range out.LogGroups {
 				if convert.ToValue(out.LogGroups[i].LogGroupName) == name {
 					lg, err := buildLogGroupResource(runtime, region, out.LogGroups[i])

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -6,10 +6,12 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/cockroachdb/errors"
@@ -340,7 +342,46 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("arn required to fetch dynamodb table")
 	}
 
-	// load all rds db instances
+	arnVal := args["arn"].Value.(string)
+
+	// No API call is required: the DynamoDB table ARN
+	// (arn:aws:dynamodb:<region>:<acct>:table/<name>) carries both the region
+	// and the table name, and the list path only constructs a shell (arn / name
+	// / region / id) - the heavy fields lazy-load via fetchDetail->DescribeTable.
+	// So derive region + name from the ARN and build the shell directly instead
+	// of fanning ListTables across every region and scanning in memory.
+	var region, tableName string
+	if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "table/") {
+		region = parsed.Region
+		tableName = strings.TrimPrefix(parsed.Resource, "table/")
+	}
+	if args["region"] != nil {
+		if r, ok := args["region"].Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+	if args["name"] != nil {
+		if n, ok := args["name"].Value.(string); ok && n != "" {
+			tableName = n
+		}
+	}
+
+	if region != "" && tableName != "" {
+		table, err := CreateResource(runtime, "aws.dynamodb.table",
+			map[string]*llx.RawData{
+				"arn":    llx.StringData(arnVal),
+				"name":   llx.StringData(tableName),
+				"region": llx.StringData(region),
+				"id":     llx.StringData(""),
+			})
+		if err != nil {
+			return nil, nil, err
+		}
+		return args, table, nil
+	}
+
+	// Fallback: scan the cached list (e.g. when the ARN can't be parsed and
+	// there's no region hint).
 	obj, err := CreateResource(runtime, "aws.dynamodb", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
@@ -352,7 +393,6 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsDynamodbTable)
 		if dbInstance.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
@@ -197,27 +199,7 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 						return nil, err
 					}
 					for _, r := range repoResp.Repositories {
-						imageScanOnPush := false
-						if r.ImageScanningConfiguration != nil {
-							imageScanOnPush = r.ImageScanningConfiguration.ScanOnPush
-						}
-						var encryptionType string
-						if r.EncryptionConfiguration != nil {
-							encryptionType = string(r.EncryptionConfiguration.EncryptionType)
-						}
-						mqlRepoResource, err := CreateResource(a.MqlRuntime, ResourceAwsEcrRepository,
-							map[string]*llx.RawData{
-								"arn":                llx.StringDataPtr(r.RepositoryArn),
-								"name":               llx.StringDataPtr(r.RepositoryName),
-								"uri":                llx.StringDataPtr(r.RepositoryUri),
-								"registryId":         llx.StringDataPtr(r.RegistryId),
-								"public":             llx.BoolData(false),
-								"region":             llx.StringData(region),
-								"imageScanOnPush":    llx.BoolData(imageScanOnPush),
-								"imageTagMutability": llx.StringData(string(r.ImageTagMutability)),
-								"encryptionType":     llx.StringData(encryptionType),
-								"createdAt":          llx.TimeDataPtr(r.CreatedAt),
-							})
+						mqlRepoResource, err := buildEcrPrivateRepositoryResource(a.MqlRuntime, region, r)
 						if err != nil {
 							return nil, err
 						}
@@ -572,22 +554,7 @@ func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 			}
 
 			for _, r := range repoResp.Repositories {
-				mqlRepoResource, err := CreateResource(a.MqlRuntime, ResourceAwsEcrRepository,
-					map[string]*llx.RawData{
-						"arn":        llx.StringDataPtr(r.RepositoryArn),
-						"name":       llx.StringDataPtr(r.RepositoryName),
-						"uri":        llx.StringDataPtr(r.RepositoryUri),
-						"registryId": llx.StringDataPtr(r.RegistryId),
-						"public":     llx.BoolData(true),
-						"region":     llx.StringData("us-east-1"),
-						// Public ECR does not support scan-on-push, uses immutable tags,
-						// and always uses AES256 encryption. These are platform-enforced
-						// defaults (not returned by the public ECR DescribeRepositories API).
-						"imageScanOnPush":    llx.BoolData(false),
-						"imageTagMutability": llx.StringData("IMMUTABLE"),
-						"encryptionType":     llx.StringData("AES256"),
-						"createdAt":          llx.TimeDataPtr(r.CreatedAt),
-					})
+				mqlRepoResource, err := buildEcrPublicRepositoryResource(a.MqlRuntime, r)
 				if err != nil {
 					return nil, err
 				}
@@ -597,6 +564,57 @@ func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func buildEcrPrivateRepositoryResource(runtime *plugin.Runtime, region string, r ecrtypes.Repository) (*mqlAwsEcrRepository, error) {
+	imageScanOnPush := false
+	if r.ImageScanningConfiguration != nil {
+		imageScanOnPush = r.ImageScanningConfiguration.ScanOnPush
+	}
+	var encryptionType string
+	if r.EncryptionConfiguration != nil {
+		encryptionType = string(r.EncryptionConfiguration.EncryptionType)
+	}
+	mqlRepoResource, err := CreateResource(runtime, ResourceAwsEcrRepository,
+		map[string]*llx.RawData{
+			"arn":                llx.StringDataPtr(r.RepositoryArn),
+			"name":               llx.StringDataPtr(r.RepositoryName),
+			"uri":                llx.StringDataPtr(r.RepositoryUri),
+			"registryId":         llx.StringDataPtr(r.RegistryId),
+			"public":             llx.BoolData(false),
+			"region":             llx.StringData(region),
+			"imageScanOnPush":    llx.BoolData(imageScanOnPush),
+			"imageTagMutability": llx.StringData(string(r.ImageTagMutability)),
+			"encryptionType":     llx.StringData(encryptionType),
+			"createdAt":          llx.TimeDataPtr(r.CreatedAt),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlRepoResource.(*mqlAwsEcrRepository), nil
+}
+
+func buildEcrPublicRepositoryResource(runtime *plugin.Runtime, r ecrpublic_types.Repository) (*mqlAwsEcrRepository, error) {
+	mqlRepoResource, err := CreateResource(runtime, ResourceAwsEcrRepository,
+		map[string]*llx.RawData{
+			"arn":        llx.StringDataPtr(r.RepositoryArn),
+			"name":       llx.StringDataPtr(r.RepositoryName),
+			"uri":        llx.StringDataPtr(r.RepositoryUri),
+			"registryId": llx.StringDataPtr(r.RegistryId),
+			"public":     llx.BoolData(true),
+			"region":     llx.StringData("us-east-1"),
+			// Public ECR does not support scan-on-push, uses immutable tags,
+			// and always uses AES256 encryption. These are platform-enforced
+			// defaults (not returned by the public ECR DescribeRepositories API).
+			"imageScanOnPush":    llx.BoolData(false),
+			"imageTagMutability": llx.StringData("IMMUTABLE"),
+			"encryptionType":     llx.StringData("AES256"),
+			"createdAt":          llx.TimeDataPtr(r.CreatedAt),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlRepoResource.(*mqlAwsEcrRepository), nil
 }
 
 type mqlAwsEcrRepositoryInternal struct {
@@ -920,6 +938,55 @@ func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("arn or name required to fetch ecr repository")
 	}
 
+	// When an ARN is supplied, the registry kind (private vs public), region,
+	// and repository name are all encoded in it, so we can issue a single
+	// targeted DescribeRepositories call instead of listing every repository in
+	// every region (plus all public repos).
+	if args["arn"] != nil {
+		arnVal, _ := args["arn"].Value.(string)
+		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "repository/") {
+			name := strings.TrimPrefix(parsed.Resource, "repository/")
+			conn := runtime.Connection.(*connection.AwsConnection)
+			switch parsed.Service {
+			case "ecr-public":
+				svc := conn.EcrPublic("us-east-1") // only supported for us-east-1
+				resp, err := svc.DescribeRepositories(context.Background(), &ecrpublic.DescribeRepositoriesInput{
+					RegistryId:      aws.String(conn.AccountId()),
+					RepositoryNames: []string{name},
+				}, withEcrPublicDescribeRetries)
+				if err != nil {
+					return nil, nil, err
+				}
+				if len(resp.Repositories) > 0 {
+					r, err := buildEcrPublicRepositoryResource(runtime, resp.Repositories[0])
+					if err != nil {
+						return nil, nil, err
+					}
+					return args, r, nil
+				}
+				return nil, nil, errors.New("ecr repository does not exist")
+			case "ecr":
+				svc := conn.Ecr(parsed.Region)
+				resp, err := svc.DescribeRepositories(context.Background(), &ecr.DescribeRepositoriesInput{
+					RepositoryNames: []string{name},
+				}, withEcrDescribeRetries)
+				if err != nil {
+					return nil, nil, err
+				}
+				if len(resp.Repositories) > 0 {
+					r, err := buildEcrPrivateRepositoryResource(runtime, parsed.Region, resp.Repositories[0])
+					if err != nil {
+						return nil, nil, err
+					}
+					return args, r, nil
+				}
+				return nil, nil, errors.New("ecr repository does not exist")
+			}
+		}
+	}
+
+	// Fallback: list private + public repositories and scan (e.g. when called
+	// with only a name and no ARN to branch the registry kind on).
 	obj, err := CreateResource(runtime, ResourceAwsEcr, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -955,38 +955,42 @@ func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 					RepositoryNames: []string{name},
 				}, withEcrPublicDescribeRetries)
 				if err != nil {
-					return nil, nil, err
-				}
-				if len(resp.Repositories) > 0 {
+					// Surface unexpected errors; on access-denied or a stale ARN
+					// (RepositoryNotFoundException) fall through to the list-scan.
+					if !Is400AccessDeniedError(err) && !isResourceNotFoundError(err) {
+						return nil, nil, err
+					}
+				} else if len(resp.Repositories) > 0 {
 					r, err := buildEcrPublicRepositoryResource(runtime, resp.Repositories[0])
 					if err != nil {
 						return nil, nil, err
 					}
 					return args, r, nil
 				}
-				return nil, nil, errors.New("ecr repository does not exist")
 			case "ecr":
 				svc := conn.Ecr(parsed.Region)
 				resp, err := svc.DescribeRepositories(context.Background(), &ecr.DescribeRepositoriesInput{
 					RepositoryNames: []string{name},
 				}, withEcrDescribeRetries)
 				if err != nil {
-					return nil, nil, err
-				}
-				if len(resp.Repositories) > 0 {
+					// Surface unexpected errors; on access-denied or a stale ARN
+					// (RepositoryNotFoundException) fall through to the list-scan.
+					if !Is400AccessDeniedError(err) && !isResourceNotFoundError(err) {
+						return nil, nil, err
+					}
+				} else if len(resp.Repositories) > 0 {
 					r, err := buildEcrPrivateRepositoryResource(runtime, parsed.Region, resp.Repositories[0])
 					if err != nil {
 						return nil, nil, err
 					}
 					return args, r, nil
 				}
-				return nil, nil, errors.New("ecr repository does not exist")
 			}
 		}
 	}
 
 	// Fallback: list private + public repositories and scan (e.g. when called
-	// with only a name and no ARN to branch the registry kind on).
+	// with only a name and no ARN, or the targeted lookup was denied/not found).
 	obj, err := CreateResource(runtime, ResourceAwsEcr, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/aws/smithy-go/transport/http"
@@ -77,31 +79,10 @@ func (a *mqlAwsEfs) getFilesystems(conn *connection.AwsConnection) []*jobpool.Jo
 						continue
 					}
 
-					var sizeInBytes int64
-					if fs.SizeInBytes != nil {
-						sizeInBytes = fs.SizeInBytes.Value
-					}
-
-					args := map[string]*llx.RawData{
-						"id":               llx.StringDataPtr(fs.FileSystemId),
-						"arn":              llx.StringDataPtr(fs.FileSystemArn),
-						"name":             llx.StringDataPtr(fs.Name),
-						"encrypted":        llx.BoolData(convert.ToValue(fs.Encrypted)),
-						"region":           llx.StringData(region),
-						"availabilityZone": llx.StringDataPtr(fs.AvailabilityZoneName),
-						"createdAt":        llx.TimeDataPtr(fs.CreationTime),
-						"tags":             llx.MapData(efsTagsToMap(fs.Tags), types.String),
-						"performanceMode":  llx.StringData(string(fs.PerformanceMode)),
-						"throughputMode":   llx.StringData(string(fs.ThroughputMode)),
-						"sizeInBytes":      llx.IntData(sizeInBytes),
-						"lifecycleState":   llx.StringData(string(fs.LifeCycleState)),
-					}
-					mqlFilesystem, err := CreateResource(a.MqlRuntime, "aws.efs.filesystem", args)
+					mqlFilesystem, err := buildEfsFilesystemResource(a.MqlRuntime, region, fs)
 					if err != nil {
 						return nil, err
 					}
-					mqlFilesystem.(*mqlAwsEfsFilesystem).cacheKmsKeyID = fs.KmsKeyId
-					mqlFilesystem.(*mqlAwsEfsFilesystem).cacheFileSystemProtection = fs.FileSystemProtection
 
 					res = append(res, mqlFilesystem)
 				}
@@ -116,6 +97,36 @@ func (a *mqlAwsEfs) getFilesystems(conn *connection.AwsConnection) []*jobpool.Jo
 type mqlAwsEfsFilesystemInternal struct {
 	cacheKmsKeyID             *string
 	cacheFileSystemProtection *efstypes.FileSystemProtectionDescription
+}
+
+func buildEfsFilesystemResource(runtime *plugin.Runtime, region string, fs efstypes.FileSystemDescription) (*mqlAwsEfsFilesystem, error) {
+	var sizeInBytes int64
+	if fs.SizeInBytes != nil {
+		sizeInBytes = fs.SizeInBytes.Value
+	}
+
+	args := map[string]*llx.RawData{
+		"id":               llx.StringDataPtr(fs.FileSystemId),
+		"arn":              llx.StringDataPtr(fs.FileSystemArn),
+		"name":             llx.StringDataPtr(fs.Name),
+		"encrypted":        llx.BoolData(convert.ToValue(fs.Encrypted)),
+		"region":           llx.StringData(region),
+		"availabilityZone": llx.StringDataPtr(fs.AvailabilityZoneName),
+		"createdAt":        llx.TimeDataPtr(fs.CreationTime),
+		"tags":             llx.MapData(efsTagsToMap(fs.Tags), types.String),
+		"performanceMode":  llx.StringData(string(fs.PerformanceMode)),
+		"throughputMode":   llx.StringData(string(fs.ThroughputMode)),
+		"sizeInBytes":      llx.IntData(sizeInBytes),
+		"lifecycleState":   llx.StringData(string(fs.LifeCycleState)),
+	}
+	mqlFilesystem, err := CreateResource(runtime, "aws.efs.filesystem", args)
+	if err != nil {
+		return nil, err
+	}
+	fsResource := mqlFilesystem.(*mqlAwsEfsFilesystem)
+	fsResource.cacheKmsKeyID = fs.KmsKeyId
+	fsResource.cacheFileSystemProtection = fs.FileSystemProtection
+	return fsResource, nil
 }
 
 func (a *mqlAwsEfsFilesystem) kmsKey() (*mqlAwsKmsKey, error) {
@@ -147,7 +158,37 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("arn required to fetch efs filesystem")
 	}
 
-	// load all efs filesystems
+	arnVal := args["arn"].Value.(string)
+
+	// Derive region + filesystem id for a single targeted DescribeFileSystems
+	// call instead of listing every filesystem in every region.
+	var region, fsId string
+	if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "file-system/") {
+		region = parsed.Region
+		fsId = strings.TrimPrefix(parsed.Resource, "file-system/")
+	}
+
+	if region != "" && fsId != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Efs(region)
+		resp, err := svc.DescribeFileSystems(context.Background(), &efs.DescribeFileSystemsInput{
+			FileSystemId: &fsId,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resp.FileSystems) > 0 {
+			fs, err := buildEfsFilesystemResource(runtime, region, resp.FileSystems[0])
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, fs, nil
+		}
+		return nil, nil, errors.New("efs filesystem does not exist")
+	}
+
+	// Fallback: scan the cached list when the ARN can't be parsed for a
+	// targeted lookup.
 	obj, err := CreateResource(runtime, "aws.efs", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
@@ -159,7 +200,6 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		fs := rawResource.(*mqlAwsEfsFilesystem)
 		if fs.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -392,16 +392,18 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 					LoadBalancerNames: []string{name},
 				})
 				if err != nil {
-					return nil, nil, err
-				}
-				if len(resp.LoadBalancerDescriptions) > 0 {
+					// Surface unexpected errors; on access-denied or a stale ARN
+					// (deleted LB) fall through to the list-scan fallback below.
+					if !Is400AccessDeniedError(err) && !isResourceNotFoundError(err) {
+						return nil, nil, err
+					}
+				} else if len(resp.LoadBalancerDescriptions) > 0 {
 					lb, err := buildElbClassicLoadBalancerResource(runtime, region, conn.AccountId(), resp.LoadBalancerDescriptions[0])
 					if err != nil {
 						return nil, nil, err
 					}
 					return args, lb, nil
 				}
-				return nil, nil, errors.New("elb load balancer does not exist")
 			}
 		} else {
 			svc := conn.Elbv2(region)
@@ -409,20 +411,23 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 				LoadBalancerArns: []string{arnVal},
 			})
 			if err != nil {
-				return nil, nil, err
-			}
-			if len(resp.LoadBalancers) > 0 {
+				// Surface unexpected errors; on access-denied or a stale ARN
+				// (deleted LB) fall through to the list-scan fallback below.
+				if !Is400AccessDeniedError(err) && !isResourceNotFoundError(err) {
+					return nil, nil, err
+				}
+			} else if len(resp.LoadBalancers) > 0 {
 				lb, err := buildElbV2LoadBalancerResource(runtime, region, conn.AccountId(), resp.LoadBalancers[0])
 				if err != nil {
 					return nil, nil, err
 				}
 				return args, lb, nil
 			}
-			return nil, nil, errors.New("elb load balancer does not exist")
 		}
 	}
 
-	// Fallback: no region hint, scan the cached lists.
+	// Fallback: no region hint (or the targeted lookup was denied/not found),
+	// scan the cached lists.
 	obj, err := CreateResource(runtime, ResourceAwsElb, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -73,72 +73,13 @@ func (a *mqlAwsElb) getClassicLoadBalancers(conn *connection.AwsConnection) []*j
 				}
 
 				for _, lb := range lbs.LoadBalancerDescriptions {
-					jsonListeners, err := convert.JsonToDictSlice(lb.ListenerDescriptions)
-					if err != nil {
-						return nil, err
-					}
-					healthCheck, err := convert.JsonToDict(lb.HealthCheck)
-					if err != nil {
-						return nil, err
-					}
-					lbName := convert.ToValue(lb.LoadBalancerName)
-
-					availabilityZones := []any{}
-					for _, zone := range lb.AvailabilityZones {
-						availabilityZones = append(availabilityZones, zone)
-					}
-
-					sgs := []any{}
-					for _, sg := range lb.SecurityGroups {
-						mqlSg, err := NewResource(a.MqlRuntime, ResourceAwsEc2Securitygroup,
-							map[string]*llx.RawData{
-								"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, conn.AccountId(), sg)),
-							})
-						if err != nil {
-							// When tag filters are active, the security group may not be in the
-							// filtered list. Log and continue rather than failing the entire LB.
-							log.Debug().Str("sg", sg).Err(err).Msg("could not resolve security group for classic ELB")
-							continue
-						}
-						sgs = append(sgs, mqlSg)
-					}
-
-					args := map[string]*llx.RawData{
-						"arn":                  llx.StringData(fmt.Sprintf(elbv1LbArnPattern, region, conn.AccountId(), lbName)),
-						"availabilityZones":    llx.ArrayData(availabilityZones, types.String),
-						"createdAt":            llx.TimeDataPtr(lb.CreatedTime),
-						"dnsName":              llx.StringDataPtr(lb.DNSName),
-						"elbType":              llx.StringData("classic"),
-						"hostedZoneId":         llx.StringDataPtr(lb.CanonicalHostedZoneNameID),
-						"healthCheck":          llx.DictData(healthCheck),
-						"listenerDescriptions": llx.AnyData(jsonListeners),
-						"name":                 llx.StringDataPtr(lb.LoadBalancerName),
-						"region":               llx.StringData(region),
-						"scheme":               llx.StringDataPtr(lb.Scheme),
-						"securityGroups":       llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
-						"vpc":                  llx.NilData,
-					}
-
-					if lb.VPCId != nil {
-						mqlVpc, err := NewResource(a.MqlRuntime, ResourceAwsVpc,
-							map[string]*llx.RawData{
-								"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, region, conn.AccountId(), convert.ToValue(lb.VPCId))),
-							})
-						if err != nil {
-							// When tag filters are active, the VPC may not be in the filtered list.
-							log.Debug().Str("vpcId", convert.ToValue(lb.VPCId)).Err(err).Msg("could not resolve VPC for classic ELB")
-						} else {
-							args["vpc"] = llx.ResourceData(mqlVpc, mqlVpc.MqlName())
-						}
-					}
-
-					mqlLb, err := CreateResource(a.MqlRuntime, ResourceAwsElbLoadbalancer, args)
+					mqlLb, err := buildElbClassicLoadBalancerResource(a.MqlRuntime, region, conn.AccountId(), lb)
 					if err != nil {
 						return nil, err
 					}
 					// keeps the tags lazy unless the filters need to be evaluated
 					if conn.Filters.General.HasTags() {
-						tags, err := mqlLb.(*mqlAwsElbLoadbalancer).tags()
+						tags, err := mqlLb.tags()
 						if err != nil {
 							return nil, err
 						}
@@ -155,6 +96,73 @@ func (a *mqlAwsElb) getClassicLoadBalancers(conn *connection.AwsConnection) []*j
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+func buildElbClassicLoadBalancerResource(runtime *plugin.Runtime, region, accountID string, lb elbv1types.LoadBalancerDescription) (*mqlAwsElbLoadbalancer, error) {
+	jsonListeners, err := convert.JsonToDictSlice(lb.ListenerDescriptions)
+	if err != nil {
+		return nil, err
+	}
+	healthCheck, err := convert.JsonToDict(lb.HealthCheck)
+	if err != nil {
+		return nil, err
+	}
+	lbName := convert.ToValue(lb.LoadBalancerName)
+
+	availabilityZones := []any{}
+	for _, zone := range lb.AvailabilityZones {
+		availabilityZones = append(availabilityZones, zone)
+	}
+
+	sgs := []any{}
+	for _, sg := range lb.SecurityGroups {
+		mqlSg, err := NewResource(runtime, ResourceAwsEc2Securitygroup,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, accountID, sg)),
+			})
+		if err != nil {
+			// When tag filters are active, the security group may not be in the
+			// filtered list. Log and continue rather than failing the entire LB.
+			log.Debug().Str("sg", sg).Err(err).Msg("could not resolve security group for classic ELB")
+			continue
+		}
+		sgs = append(sgs, mqlSg)
+	}
+
+	args := map[string]*llx.RawData{
+		"arn":                  llx.StringData(fmt.Sprintf(elbv1LbArnPattern, region, accountID, lbName)),
+		"availabilityZones":    llx.ArrayData(availabilityZones, types.String),
+		"createdAt":            llx.TimeDataPtr(lb.CreatedTime),
+		"dnsName":              llx.StringDataPtr(lb.DNSName),
+		"elbType":              llx.StringData("classic"),
+		"hostedZoneId":         llx.StringDataPtr(lb.CanonicalHostedZoneNameID),
+		"healthCheck":          llx.DictData(healthCheck),
+		"listenerDescriptions": llx.AnyData(jsonListeners),
+		"name":                 llx.StringDataPtr(lb.LoadBalancerName),
+		"region":               llx.StringData(region),
+		"scheme":               llx.StringDataPtr(lb.Scheme),
+		"securityGroups":       llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
+		"vpc":                  llx.NilData,
+	}
+
+	if lb.VPCId != nil {
+		mqlVpc, err := NewResource(runtime, ResourceAwsVpc,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, region, accountID, convert.ToValue(lb.VPCId))),
+			})
+		if err != nil {
+			// When tag filters are active, the VPC may not be in the filtered list.
+			log.Debug().Str("vpcId", convert.ToValue(lb.VPCId)).Err(err).Msg("could not resolve VPC for classic ELB")
+		} else {
+			args["vpc"] = llx.ResourceData(mqlVpc, mqlVpc.MqlName())
+		}
+	}
+
+	mqlLb, err := CreateResource(runtime, ResourceAwsElbLoadbalancer, args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlLb.(*mqlAwsElbLoadbalancer), nil
 }
 
 func (a *mqlAwsElbLoadbalancer) id() (string, error) {
@@ -250,63 +258,13 @@ func (a *mqlAwsElb) getLoadBalancers(conn *connection.AwsConnection) []*jobpool.
 				}
 
 				for _, lb := range lbs.LoadBalancers {
-					availabilityZones := []any{}
-					for _, zone := range lb.AvailabilityZones {
-						availabilityZones = append(availabilityZones, convert.ToValue(zone.ZoneName))
-					}
-
-					sgs := []any{}
-					for _, sg := range lb.SecurityGroups {
-						mqlSg, err := NewResource(a.MqlRuntime, ResourceAwsEc2Securitygroup,
-							map[string]*llx.RawData{
-								"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, conn.AccountId(), sg)),
-							})
-						if err != nil {
-							// When tag filters are active, the security group may not be in the
-							// filtered list. Log and continue rather than failing the entire LB.
-							log.Debug().Str("sg", sg).Err(err).Msg("could not resolve security group for ELB")
-							continue
-						}
-						sgs = append(sgs, mqlSg)
-					}
-
-					args := map[string]*llx.RawData{
-						"arn":               llx.StringDataPtr(lb.LoadBalancerArn),
-						"availabilityZones": llx.ArrayData(availabilityZones, types.String),
-						"createdAt":         llx.TimeDataPtr(lb.CreatedTime),
-						"dnsName":           llx.StringDataPtr(lb.DNSName),
-						"hostedZoneId":      llx.StringDataPtr(lb.CanonicalHostedZoneId),
-						"name":              llx.StringDataPtr(lb.LoadBalancerName),
-						"scheme":            llx.StringData(string(lb.Scheme)),
-						"securityGroups":    llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
-						"elbType":           llx.StringData(string(lb.Type)),
-						"ipAddressType":     llx.StringData(string(lb.IpAddressType)),
-						"region":            llx.StringData(region),
-						"vpc":               llx.NilData, // set vpc to nil as default, if vpc is not set
-						"healthCheck":       llx.NilData, // classic ELB only; ALB/NLB have no LB-level health check
-					}
-
-					if lb.VpcId != nil {
-						mqlVpc, err := NewResource(a.MqlRuntime, ResourceAwsVpc,
-							map[string]*llx.RawData{
-								"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, region, conn.AccountId(), convert.ToValue(lb.VpcId))),
-							})
-						if err != nil {
-							// When tag filters are active, the VPC may not be in the filtered list.
-							log.Debug().Str("vpcId", convert.ToValue(lb.VpcId)).Err(err).Msg("could not resolve VPC for ELB")
-						} else {
-							// update the vpc setting
-							args["vpc"] = llx.ResourceData(mqlVpc, mqlVpc.MqlName())
-						}
-					}
-
-					mqlLb, err := CreateResource(a.MqlRuntime, ResourceAwsElbLoadbalancer, args)
+					mqlLb, err := buildElbV2LoadBalancerResource(a.MqlRuntime, region, conn.AccountId(), lb)
 					if err != nil {
 						return nil, err
 					}
 					// keeps the tags lazy unless the filters need to be evaluated
 					if conn.Filters.General.HasTags() {
-						tags, err := mqlLb.(*mqlAwsElbLoadbalancer).tags()
+						tags, err := mqlLb.tags()
 						if err != nil {
 							return nil, err
 						}
@@ -323,6 +281,64 @@ func (a *mqlAwsElb) getLoadBalancers(conn *connection.AwsConnection) []*jobpool.
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+func buildElbV2LoadBalancerResource(runtime *plugin.Runtime, region, accountID string, lb elbtypes.LoadBalancer) (*mqlAwsElbLoadbalancer, error) {
+	availabilityZones := []any{}
+	for _, zone := range lb.AvailabilityZones {
+		availabilityZones = append(availabilityZones, convert.ToValue(zone.ZoneName))
+	}
+
+	sgs := []any{}
+	for _, sg := range lb.SecurityGroups {
+		mqlSg, err := NewResource(runtime, ResourceAwsEc2Securitygroup,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, accountID, sg)),
+			})
+		if err != nil {
+			// When tag filters are active, the security group may not be in the
+			// filtered list. Log and continue rather than failing the entire LB.
+			log.Debug().Str("sg", sg).Err(err).Msg("could not resolve security group for ELB")
+			continue
+		}
+		sgs = append(sgs, mqlSg)
+	}
+
+	args := map[string]*llx.RawData{
+		"arn":               llx.StringDataPtr(lb.LoadBalancerArn),
+		"availabilityZones": llx.ArrayData(availabilityZones, types.String),
+		"createdAt":         llx.TimeDataPtr(lb.CreatedTime),
+		"dnsName":           llx.StringDataPtr(lb.DNSName),
+		"hostedZoneId":      llx.StringDataPtr(lb.CanonicalHostedZoneId),
+		"name":              llx.StringDataPtr(lb.LoadBalancerName),
+		"scheme":            llx.StringData(string(lb.Scheme)),
+		"securityGroups":    llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
+		"elbType":           llx.StringData(string(lb.Type)),
+		"ipAddressType":     llx.StringData(string(lb.IpAddressType)),
+		"region":            llx.StringData(region),
+		"vpc":               llx.NilData, // set vpc to nil as default, if vpc is not set
+		"healthCheck":       llx.NilData, // classic ELB only; ALB/NLB have no LB-level health check
+	}
+
+	if lb.VpcId != nil {
+		mqlVpc, err := NewResource(runtime, ResourceAwsVpc,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, region, accountID, convert.ToValue(lb.VpcId))),
+			})
+		if err != nil {
+			// When tag filters are active, the VPC may not be in the filtered list.
+			log.Debug().Str("vpcId", convert.ToValue(lb.VpcId)).Err(err).Msg("could not resolve VPC for ELB")
+		} else {
+			// update the vpc setting
+			args["vpc"] = llx.ResourceData(mqlVpc, mqlVpc.MqlName())
+		}
+	}
+
+	mqlLb, err := CreateResource(runtime, ResourceAwsElbLoadbalancer, args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlLb.(*mqlAwsElbLoadbalancer), nil
 }
 
 func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -350,6 +366,63 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, errors.New("elb load balancer does not exist")
 	}
 
+	// Issue a single targeted Describe against the ARN's region instead of
+	// listing every load balancer in every region. ELBv2 (app/net/gateway) and
+	// classic ELB live in different APIs; discriminate by the ARN form.
+	region, err := GetRegionFromArn(arnVal)
+	if err == nil && region != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		if isV1LoadBalancerArn(arnVal) {
+			// Classic ELB: the synthetic ARN encodes the name as
+			// loadbalancer/classic/<name>.
+			name := ""
+			if args["name"] != nil {
+				if n, ok := args["name"].Value.(string); ok {
+					name = n
+				}
+			}
+			if name == "" {
+				if parsed, perr := arn.Parse(arnVal); perr == nil {
+					name = strings.TrimPrefix(parsed.Resource, "loadbalancer/classic/")
+				}
+			}
+			if name != "" {
+				svc := conn.Elb(region)
+				resp, err := svc.DescribeLoadBalancers(context.Background(), &elasticloadbalancing.DescribeLoadBalancersInput{
+					LoadBalancerNames: []string{name},
+				})
+				if err != nil {
+					return nil, nil, err
+				}
+				if len(resp.LoadBalancerDescriptions) > 0 {
+					lb, err := buildElbClassicLoadBalancerResource(runtime, region, conn.AccountId(), resp.LoadBalancerDescriptions[0])
+					if err != nil {
+						return nil, nil, err
+					}
+					return args, lb, nil
+				}
+				return nil, nil, errors.New("elb load balancer does not exist")
+			}
+		} else {
+			svc := conn.Elbv2(region)
+			resp, err := svc.DescribeLoadBalancers(context.Background(), &elasticloadbalancingv2.DescribeLoadBalancersInput{
+				LoadBalancerArns: []string{arnVal},
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(resp.LoadBalancers) > 0 {
+				lb, err := buildElbV2LoadBalancerResource(runtime, region, conn.AccountId(), resp.LoadBalancers[0])
+				if err != nil {
+					return nil, nil, err
+				}
+				return args, lb, nil
+			}
+			return nil, nil, errors.New("elb load balancer does not exist")
+		}
+	}
+
+	// Fallback: no region hint, scan the cached lists.
 	obj, err := CreateResource(runtime, ResourceAwsElb, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -369,9 +369,7 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		if err != nil {
 			// Fall through to the list-scan fallback on not-found / access-denied;
 			// surface any other error.
-			var respErr *http.ResponseError
-			notFound := errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404
-			if !notFound && !Is400AccessDeniedError(err) {
+			if !isResourceNotFoundError(err) && !Is400AccessDeniedError(err) {
 				return nil, nil, err
 			}
 		} else if resp.Configuration != nil {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -83,14 +83,6 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 					tagsByArn = batchFetchLambdaTags(ctx, svc, functionsResp.Functions)
 				}
 				for _, function := range functionsResp.Functions {
-					vpcConfigJson, err := convert.JsonToDict(function.VpcConfig)
-					if err != nil {
-						return nil, err
-					}
-					var dlqTarget string
-					if function.DeadLetterConfig != nil {
-						dlqTarget = convert.ToValue(function.DeadLetterConfig.TargetArn)
-					}
 					var tags map[string]string
 					if conn.Filters.General.HasTags() {
 						// nil means batchFetchLambdaTags hit a per-function error;
@@ -104,147 +96,15 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 						}
 					}
 
-					// Convert architectures to []any
-					architectures := make([]any, len(function.Architectures))
-					for i, arch := range function.Architectures {
-						architectures[i] = string(arch)
-					}
-
-					// Get ephemeral storage size (defaults to 512 MB if not set)
-					var ephemeralStorageSize int64 = 512
-					if function.EphemeralStorage != nil && function.EphemeralStorage.Size != nil {
-						ephemeralStorageSize = int64(*function.EphemeralStorage.Size)
-					}
-
-					var tracingMode string
-					if function.TracingConfig != nil {
-						tracingMode = string(function.TracingConfig.Mode)
-					}
-
-					var lastModifiedAt *time.Time
-					if function.LastModified != nil {
-						if t, err := time.Parse("2006-01-02T15:04:05.000-0700", *function.LastModified); err == nil {
-							lastModifiedAt = &t
-						}
-					}
-
-					// Extract SnapStart fields
-					var snapStartApplyOn, snapStartOptimizationStatus string
-					if function.SnapStart != nil {
-						snapStartApplyOn = string(function.SnapStart.ApplyOn)
-						snapStartOptimizationStatus = string(function.SnapStart.OptimizationStatus)
-					}
-
-					// Extract environment variables
-					envVars := map[string]any{}
-					if function.Environment != nil && function.Environment.Variables != nil {
-						for k, v := range function.Environment.Variables {
-							envVars[k] = v
-						}
-					}
-
-					// Convert file system configs to dict slice
-					fileSystemConfigs, err := convert.JsonToDictSlice(function.FileSystemConfigs)
+					f, err := newLambdaFunctionResource(a.MqlRuntime, region, conn.AccountId(), function)
 					if err != nil {
 						return nil, err
-					}
-
-					funcArn := convert.ToValue(function.FunctionArn)
-
-					// Create logging config sub-resource
-					var loggingConfigResource plugin.Resource
-					if function.LoggingConfig != nil {
-						lc, err := CreateResource(a.MqlRuntime, "aws.lambda.function.loggingConfig",
-							map[string]*llx.RawData{
-								"__id":                llx.StringData(funcArn + "/loggingConfig"),
-								"logFormat":           llx.StringData(string(function.LoggingConfig.LogFormat)),
-								"applicationLogLevel": llx.StringData(string(function.LoggingConfig.ApplicationLogLevel)),
-								"systemLogLevel":      llx.StringData(string(function.LoggingConfig.SystemLogLevel)),
-								"logGroup":            llx.StringDataPtr(function.LoggingConfig.LogGroup),
-							})
-						if err != nil {
-							return nil, err
-						}
-						loggingConfigResource = lc.(plugin.Resource)
-					}
-
-					// Create layer sub-resources
-					layers := make([]any, 0, len(function.Layers))
-					for _, layer := range function.Layers {
-						mqlLayer, err := CreateResource(a.MqlRuntime, "aws.lambda.function.layer",
-							map[string]*llx.RawData{
-								"__id":                     llx.StringDataPtr(layer.Arn),
-								"arn":                      llx.StringDataPtr(layer.Arn),
-								"codeSize":                 llx.IntData(layer.CodeSize),
-								"signingJobArn":            llx.StringDataPtr(layer.SigningJobArn),
-								"signingProfileVersionArn": llx.StringDataPtr(layer.SigningProfileVersionArn),
-							})
-						if err != nil {
-							return nil, err
-						}
-						layers = append(layers, mqlLayer)
-					}
-
-					args := map[string]*llx.RawData{
-						"arn":                         llx.StringDataPtr(function.FunctionArn),
-						"name":                        llx.StringDataPtr(function.FunctionName),
-						"runtime":                     llx.StringData(string(function.Runtime)),
-						"dlqTargetArn":                llx.StringData(dlqTarget),
-						"vpcConfig":                   llx.MapData(vpcConfigJson, types.Any),
-						"region":                      llx.StringData(region),
-						"architectures":               llx.ArrayData(architectures, types.String),
-						"ephemeralStorageSize":        llx.IntData(ephemeralStorageSize),
-						"memorySize":                  llx.IntDataDefault(function.MemorySize, 0),
-						"timeout":                     llx.IntDataDefault(function.Timeout, 3),
-						"handler":                     llx.StringDataPtr(function.Handler),
-						"tracingMode":                 llx.StringData(tracingMode),
-						"packageType":                 llx.StringData(string(function.PackageType)),
-						"codeSha256":                  llx.StringDataPtr(function.CodeSha256),
-						"description":                 llx.StringDataPtr(function.Description),
-						"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
-						"state":                       llx.StringData(string(function.State)),
-						"codeSize":                    llx.IntData(function.CodeSize),
-						"stateReason":                 llx.StringDataPtr(function.StateReason),
-						"lastUpdateStatus":            llx.StringData(string(function.LastUpdateStatus)),
-						"lastUpdateStatusReason":      llx.StringDataPtr(function.LastUpdateStatusReason),
-						"kmsKeyArn":                   llx.StringDataPtr(function.KMSKeyArn),
-						"environment":                 llx.MapData(envVars, types.String),
-						"snapStartApplyOn":            llx.StringData(snapStartApplyOn),
-						"snapStartOptimizationStatus": llx.StringData(snapStartOptimizationStatus),
-						"fileSystemConfigs":           llx.ArrayData(fileSystemConfigs, types.Dict),
-						"signingProfileVersionArn":    llx.StringDataPtr(function.SigningProfileVersionArn),
-						"signingJobArn":               llx.StringDataPtr(function.SigningJobArn),
-						"layers":                      llx.ArrayData(layers, types.Resource("aws.lambda.function.layer")),
-					}
-
-					if loggingConfigResource != nil {
-						args["loggingConfig"] = llx.ResourceData(loggingConfigResource, "aws.lambda.function.loggingConfig")
-					} else {
-						args["loggingConfig"] = llx.NilData
-					}
-
-					mqlFunc, err := CreateResource(a.MqlRuntime, "aws.lambda.function", args)
-					if err != nil {
-						return nil, err
-					}
-					f := mqlFunc.(*mqlAwsLambdaFunction)
-					f.cacheRoleArn = function.Role
-					f.region = region
-					f.accountID = conn.AccountId()
-					if function.VpcConfig != nil {
-						f.cacheVpcId = function.VpcConfig.VpcId
-						f.cacheSubnetIds = function.VpcConfig.SubnetIds
-						var sgArns []string
-						for _, sgId := range function.VpcConfig.SecurityGroupIds {
-							sgArns = append(sgArns, NewSecurityGroupArn(region, conn.AccountId(), sgId))
-						}
-						f.setSecurityGroupArns(sgArns)
 					}
 					if tags != nil {
 						f.cacheTags = tags
 						f.tagsFetched = true
 					}
-					res = append(res, mqlFunc)
+					res = append(res, f)
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -298,6 +158,160 @@ func getLambdaArn(name string, region string, accountId string) string {
 	}.String()
 }
 
+// newLambdaFunctionResource maps an SDK FunctionConfiguration into an
+// aws.lambda.function resource, building its sub-resources (loggingConfig,
+// layers) and priming every Internal cache (role ARN, region, account, VPC)
+// that the lazy accessors depend on. Shared by the list path and the targeted
+// init lookup.
+func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID string, function lambdatypes.FunctionConfiguration) (*mqlAwsLambdaFunction, error) {
+	vpcConfigJson, err := convert.JsonToDict(function.VpcConfig)
+	if err != nil {
+		return nil, err
+	}
+	var dlqTarget string
+	if function.DeadLetterConfig != nil {
+		dlqTarget = convert.ToValue(function.DeadLetterConfig.TargetArn)
+	}
+
+	// Convert architectures to []any
+	architectures := make([]any, len(function.Architectures))
+	for i, arch := range function.Architectures {
+		architectures[i] = string(arch)
+	}
+
+	// Get ephemeral storage size (defaults to 512 MB if not set)
+	var ephemeralStorageSize int64 = 512
+	if function.EphemeralStorage != nil && function.EphemeralStorage.Size != nil {
+		ephemeralStorageSize = int64(*function.EphemeralStorage.Size)
+	}
+
+	var tracingMode string
+	if function.TracingConfig != nil {
+		tracingMode = string(function.TracingConfig.Mode)
+	}
+
+	var lastModifiedAt *time.Time
+	if function.LastModified != nil {
+		if t, err := time.Parse("2006-01-02T15:04:05.000-0700", *function.LastModified); err == nil {
+			lastModifiedAt = &t
+		}
+	}
+
+	// Extract SnapStart fields
+	var snapStartApplyOn, snapStartOptimizationStatus string
+	if function.SnapStart != nil {
+		snapStartApplyOn = string(function.SnapStart.ApplyOn)
+		snapStartOptimizationStatus = string(function.SnapStart.OptimizationStatus)
+	}
+
+	// Extract environment variables
+	envVars := map[string]any{}
+	if function.Environment != nil && function.Environment.Variables != nil {
+		for k, v := range function.Environment.Variables {
+			envVars[k] = v
+		}
+	}
+
+	// Convert file system configs to dict slice
+	fileSystemConfigs, err := convert.JsonToDictSlice(function.FileSystemConfigs)
+	if err != nil {
+		return nil, err
+	}
+
+	funcArn := convert.ToValue(function.FunctionArn)
+
+	// Create logging config sub-resource
+	var loggingConfigResource plugin.Resource
+	if function.LoggingConfig != nil {
+		lc, err := CreateResource(runtime, "aws.lambda.function.loggingConfig",
+			map[string]*llx.RawData{
+				"__id":                llx.StringData(funcArn + "/loggingConfig"),
+				"logFormat":           llx.StringData(string(function.LoggingConfig.LogFormat)),
+				"applicationLogLevel": llx.StringData(string(function.LoggingConfig.ApplicationLogLevel)),
+				"systemLogLevel":      llx.StringData(string(function.LoggingConfig.SystemLogLevel)),
+				"logGroup":            llx.StringDataPtr(function.LoggingConfig.LogGroup),
+			})
+		if err != nil {
+			return nil, err
+		}
+		loggingConfigResource = lc.(plugin.Resource)
+	}
+
+	// Create layer sub-resources
+	layers := make([]any, 0, len(function.Layers))
+	for _, layer := range function.Layers {
+		mqlLayer, err := CreateResource(runtime, "aws.lambda.function.layer",
+			map[string]*llx.RawData{
+				"__id":                     llx.StringDataPtr(layer.Arn),
+				"arn":                      llx.StringDataPtr(layer.Arn),
+				"codeSize":                 llx.IntData(layer.CodeSize),
+				"signingJobArn":            llx.StringDataPtr(layer.SigningJobArn),
+				"signingProfileVersionArn": llx.StringDataPtr(layer.SigningProfileVersionArn),
+			})
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, mqlLayer)
+	}
+
+	args := map[string]*llx.RawData{
+		"arn":                         llx.StringDataPtr(function.FunctionArn),
+		"name":                        llx.StringDataPtr(function.FunctionName),
+		"runtime":                     llx.StringData(string(function.Runtime)),
+		"dlqTargetArn":                llx.StringData(dlqTarget),
+		"vpcConfig":                   llx.MapData(vpcConfigJson, types.Any),
+		"region":                      llx.StringData(region),
+		"architectures":               llx.ArrayData(architectures, types.String),
+		"ephemeralStorageSize":        llx.IntData(ephemeralStorageSize),
+		"memorySize":                  llx.IntDataDefault(function.MemorySize, 0),
+		"timeout":                     llx.IntDataDefault(function.Timeout, 3),
+		"handler":                     llx.StringDataPtr(function.Handler),
+		"tracingMode":                 llx.StringData(tracingMode),
+		"packageType":                 llx.StringData(string(function.PackageType)),
+		"codeSha256":                  llx.StringDataPtr(function.CodeSha256),
+		"description":                 llx.StringDataPtr(function.Description),
+		"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
+		"state":                       llx.StringData(string(function.State)),
+		"codeSize":                    llx.IntData(function.CodeSize),
+		"stateReason":                 llx.StringDataPtr(function.StateReason),
+		"lastUpdateStatus":            llx.StringData(string(function.LastUpdateStatus)),
+		"lastUpdateStatusReason":      llx.StringDataPtr(function.LastUpdateStatusReason),
+		"kmsKeyArn":                   llx.StringDataPtr(function.KMSKeyArn),
+		"environment":                 llx.MapData(envVars, types.String),
+		"snapStartApplyOn":            llx.StringData(snapStartApplyOn),
+		"snapStartOptimizationStatus": llx.StringData(snapStartOptimizationStatus),
+		"fileSystemConfigs":           llx.ArrayData(fileSystemConfigs, types.Dict),
+		"signingProfileVersionArn":    llx.StringDataPtr(function.SigningProfileVersionArn),
+		"signingJobArn":               llx.StringDataPtr(function.SigningJobArn),
+		"layers":                      llx.ArrayData(layers, types.Resource("aws.lambda.function.layer")),
+	}
+
+	if loggingConfigResource != nil {
+		args["loggingConfig"] = llx.ResourceData(loggingConfigResource, "aws.lambda.function.loggingConfig")
+	} else {
+		args["loggingConfig"] = llx.NilData
+	}
+
+	mqlFunc, err := CreateResource(runtime, "aws.lambda.function", args)
+	if err != nil {
+		return nil, err
+	}
+	f := mqlFunc.(*mqlAwsLambdaFunction)
+	f.cacheRoleArn = function.Role
+	f.region = region
+	f.accountID = accountID
+	if function.VpcConfig != nil {
+		f.cacheVpcId = function.VpcConfig.VpcId
+		f.cacheSubnetIds = function.VpcConfig.SubnetIds
+		var sgArns []string
+		for _, sgId := range function.VpcConfig.SecurityGroupIds {
+			sgArns = append(sgArns, NewSecurityGroupArn(region, accountID, sgId))
+		}
+		f.setSecurityGroupArns(sgArns)
+	}
+	return f, nil
+}
+
 func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -310,19 +324,19 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		}
 	}
 
-	name := args["name"]
-	region := args["region"]
+	nameArg := args["name"]
+	regionArg := args["region"]
 
 	var arnVal string
 	if args["arn"] == nil {
-		if name == nil {
+		if nameArg == nil {
 			return nil, nil, errors.New("name required to fetch lambda function")
 		}
-		if region == nil {
+		if regionArg == nil {
 			return nil, nil, errors.New("region required to fetch lambda function")
 		}
 		conn := runtime.Connection.(*connection.AwsConnection)
-		arnVal = getLambdaArn(name.String(), region.String(), conn.AccountId())
+		arnVal = getLambdaArn(nameArg.String(), regionArg.String(), conn.AccountId())
 		if arnVal == "" {
 			return nil, nil, errors.New("arn required to fetch lambda function")
 		}
@@ -330,7 +344,47 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		arnVal = args["arn"].Value.(string)
 	}
 
-	// load all lambda functions
+	// Targeted lookup: derive the region + function name from the ARN and fetch
+	// just this one function instead of listing every function in every region.
+	region := ""
+	funcName := ""
+	if parsed, parseErr := arn.Parse(arnVal); parseErr == nil && strings.HasPrefix(parsed.Resource, "function:") {
+		region = parsed.Region
+		funcName = strings.TrimPrefix(parsed.Resource, "function:")
+	}
+	if regionArg != nil {
+		if r, ok := regionArg.Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+	if nameArg != nil {
+		if n, ok := nameArg.Value.(string); ok && n != "" {
+			funcName = n
+		}
+	}
+	if region != "" && funcName != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Lambda(region)
+		resp, err := svc.GetFunction(context.Background(), &lambda.GetFunctionInput{FunctionName: &funcName})
+		if err != nil {
+			// Fall through to the list-scan fallback on not-found / access-denied;
+			// surface any other error.
+			var respErr *http.ResponseError
+			notFound := errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404
+			if !notFound && !Is400AccessDeniedError(err) {
+				return nil, nil, err
+			}
+		} else if resp.Configuration != nil {
+			f, err := newLambdaFunctionResource(runtime, region, conn.AccountId(), *resp.Configuration)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, f, nil
+		}
+	}
+
+	// Fallback: scan all functions (e.g. cross-account references or when the
+	// ARN carries no usable region).
 	obj, err := CreateResource(runtime, "aws.lambda", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -177,54 +177,47 @@ func initAwsS3Bucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return nil, nil, errors.New("arn or name required to fetch aws s3 bucket")
 	}
 
-	// construct arn of bucket name if missing
-	var arnVal string
+	// Resolve the bucket name and ARN. The bucket name is encoded directly in
+	// the ARN (arn:aws:s3:::<name>), so we can build the resource without
+	// listing every bucket in every region. Per-bucket fields lazy-load.
+	var arnVal, name string
 	if args["arn"] != nil {
 		arnVal = args["arn"].Value.(string)
 		parsed, err := arn.Parse(arnVal)
 		if err != nil || parsed.Service != "s3" {
 			return nil, nil, errors.Newf("not a valid bucket ARN '%s'", arnVal)
 		}
+		name = parsed.Resource
 	} else {
-		nameVal := args["name"].Value.(string)
-		arnVal = fmt.Sprintf(s3ArnPattern, nameVal)
+		name = args["name"].Value.(string)
+		arnVal = fmt.Sprintf(s3ArnPattern, name)
 	}
 	log.Debug().Str("arn", arnVal).Msg("init s3 bucket with arn")
 
-	// load all s3 buckets
-	obj, err := runtime.CreateResource(runtime, "aws.s3", map[string]*llx.RawData{})
-	if err != nil {
-		return nil, nil, err
+	// A single HeadBucket confirms existence without listing every bucket in
+	// every region. It is possible for a resource to reference a
+	// non-existent/deleted bucket; recording exists=false lets per-bucket field
+	// accessors short-circuit instead of erroring. A non-404 error (e.g. a
+	// cross-region redirect or access-denied) still means the bucket exists.
+	exists := true
+	conn := runtime.Connection.(*connection.AwsConnection)
+	if _, err := conn.S3("").HeadBucket(context.Background(), &s3.HeadBucketInput{
+		Bucket: aws.String(name),
+	}); err != nil && isNotFoundForS3(err) {
+		exists = false
+		log.Debug().Msgf("no bucket found for %s", arnVal)
 	}
-	awsS3 := obj.(*mqlAwsS3)
 
-	rawResources := awsS3.GetBuckets()
-	if rawResources.Error != nil {
-		return nil, nil, rawResources.Error
-	}
-
-	// iterate over security groups and find the one with the arn
-	for _, rawResource := range rawResources.Data {
-		bucket := rawResource.(*mqlAwsS3Bucket)
-		if bucket.Arn.Data == arnVal {
-			return args, bucket, nil
-		}
-	}
-	// it is possible for a resource to reference a non-existent/deleted bucket, so here we
-	// create the object, noting that it no longer exists but is still recorded as part of some resources
-	splitArn := strings.Split(arnVal, ":::")
-	if len(splitArn) != 2 {
-		return args, nil, nil
-	}
-	name := splitArn[1]
-	log.Debug().Msgf("no bucket found for %s", arnVal)
-	mqlAwsS3Bucket, err := CreateResource(runtime, "aws.s3.bucket",
+	mqlAwsS3Bucket, err := CreateResource(runtime, ResourceAwsS3Bucket,
 		map[string]*llx.RawData{
 			"arn":    llx.StringData(arnVal),
 			"name":   llx.StringData(name),
-			"exists": llx.BoolData(false),
+			"exists": llx.BoolData(exists),
 		})
-	return nil, mqlAwsS3Bucket, err
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlAwsS3Bucket, nil
 }
 
 func (a *mqlAwsS3Bucket) id() (string, error) {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -28,6 +28,34 @@ func (a *mqlAwsVpc) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func buildVpcResource(runtime *plugin.Runtime, region, accountID string, vpc vpctypes.Vpc) (*mqlAwsVpc, error) {
+	tagsMap := ec2TagsToMap(vpc.Tags)
+	name := tagsMap["Name"]
+	mqlVpc, err := CreateResource(runtime, ResourceAwsVpc,
+		map[string]*llx.RawData{
+			"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, region, accountID, convert.ToValue(vpc.VpcId))),
+			"cidrBlock":       llx.StringDataPtr(vpc.CidrBlock),
+			"dhcpOptionsId":   llx.StringDataPtr(vpc.DhcpOptionsId),
+			"id":              llx.StringDataPtr(vpc.VpcId),
+			"instanceTenancy": llx.StringData(string(vpc.InstanceTenancy)),
+			"isDefault":       llx.BoolData(convert.ToValue(vpc.IsDefault)),
+			"name":            llx.StringData(name),
+			"region":          llx.StringData(region),
+			"state":           llx.StringData(string(vpc.State)),
+			"tags":            llx.MapData(toInterfaceMap(tagsMap), types.String),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlVpcRes := mqlVpc.(*mqlAwsVpc)
+	if vpc.BlockPublicAccessStates != nil {
+		mqlVpcRes.InternetGatewayBlockMode = plugin.TValue[string]{Data: string(vpc.BlockPublicAccessStates.InternetGatewayBlockMode), State: plugin.StateIsSet}
+	}
+	mqlVpcRes.cacheCidrBlockAssociations = vpc.CidrBlockAssociationSet
+	mqlVpcRes.cacheIpv6CidrBlockAssociations = vpc.Ipv6CidrBlockAssociationSet
+	return mqlVpcRes, nil
+}
+
 func (a *mqlAws) vpcs() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}
@@ -81,30 +109,11 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 						continue
 					}
 
-					name := tagsMap["Name"]
-					mqlVpc, err := CreateResource(a.MqlRuntime, ResourceAwsVpc,
-						map[string]*llx.RawData{
-							"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, region, conn.AccountId(), convert.ToValue(vpc.VpcId))),
-							"cidrBlock":       llx.StringDataPtr(vpc.CidrBlock),
-							"dhcpOptionsId":   llx.StringDataPtr(vpc.DhcpOptionsId),
-							"id":              llx.StringDataPtr(vpc.VpcId),
-							"instanceTenancy": llx.StringData(string(vpc.InstanceTenancy)),
-							"isDefault":       llx.BoolData(convert.ToValue(vpc.IsDefault)),
-							"name":            llx.StringData(name),
-							"region":          llx.StringData(region),
-							"state":           llx.StringData(string(vpc.State)),
-							"tags":            llx.MapData(toInterfaceMap(ec2TagsToMap(vpc.Tags)), types.String),
-						})
+					mqlVpc, err := buildVpcResource(a.MqlRuntime, region, conn.AccountId(), vpc)
 					if err != nil {
 						log.Error().Msg(err.Error())
 						continue
 					}
-					if vpc.BlockPublicAccessStates != nil {
-						mqlVpc.(*mqlAwsVpc).InternetGatewayBlockMode = plugin.TValue[string]{Data: string(vpc.BlockPublicAccessStates.InternetGatewayBlockMode), State: plugin.StateIsSet}
-					}
-					mqlVpcRes := mqlVpc.(*mqlAwsVpc)
-					mqlVpcRes.cacheCidrBlockAssociations = vpc.CidrBlockAssociationSet
-					mqlVpcRes.cacheIpv6CidrBlockAssociations = vpc.Ipv6CidrBlockAssociationSet
 					res = append(res, mqlVpc)
 				}
 			}
@@ -1109,25 +1118,73 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	return nil, nil, errors.New("subnet not found")
 }
 
+// deriveVpcTarget resolves the region and VPC id to look up. It pulls the ARN
+// from the asset identifier when args are empty, then derives the id from the
+// ARN's resource segment or an explicit "id" arg — never from the asset name
+// (which may be a "Name" tag, not the vpc-id), keeping asset-name-vs-id
+// resolution correct. It may populate args["arn"] from the asset identifier.
+func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (region, vpcId string) {
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["arn"] = llx.StringData(ids.arn)
+		}
+	}
+	if args["arn"] != nil {
+		arnVal := args["arn"].Value.(string)
+		// The VPC ARN uses a custom shape, vpcArnPattern =
+		// "arn:aws:vpc:<region>:<acct>:id/<vpc-id>", so the id lives behind an
+		// "id/" prefix (not the standard "vpc/").
+		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "id/") {
+			region = parsed.Region
+			vpcId = strings.TrimPrefix(parsed.Resource, "id/")
+		}
+	}
+	if args["id"] != nil && vpcId == "" {
+		vpcId = args["id"].Value.(string)
+	}
+	if args["region"] != nil {
+		if r, ok := args["region"].Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+	return region, vpcId
+}
+
 func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil {
-			// Only use the ARN from asset identifiers. The asset name may be
-			// the VPC's "Name" tag (e.g. "my-vpc") rather than the VPC ID
-			// (e.g. "vpc-0abc123"), so it cannot be used as the "id" arg.
-			args["arn"] = llx.StringData(ids.arn)
-		}
-	}
+	// Derive region + vpcId for a single targeted DescribeVpcs call instead of
+	// listing every VPC in every region. This also pulls the ARN from the asset
+	// identifier when args are empty.
+	region, vpcId := deriveVpcTarget(runtime, args)
 
 	if args["arn"] == nil && args["id"] == nil {
 		return nil, nil, errors.New("arn or id required to fetch aws vpc")
 	}
 
-	// load all vpcs
+	if region != "" && vpcId != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Ec2(region)
+		resp, err := svc.DescribeVpcs(context.Background(), &ec2.DescribeVpcsInput{
+			VpcIds: []string{vpcId},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resp.Vpcs) > 0 {
+			vpc, err := buildVpcResource(runtime, region, conn.AccountId(), resp.Vpcs[0])
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, vpc, nil
+		}
+		return nil, nil, errors.New("vpc does not exist")
+	}
+
+	// Fallback: scan the cached list (e.g. when called with just an opaque id
+	// and no region hint).
 	obj, err := CreateResource(runtime, "aws", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_vpc_init_test.go
+++ b/providers/aws/resources/aws_vpc_init_test.go
@@ -56,7 +56,7 @@ func testAwsRuntime(assetName string, platformIds []string, vpcs []*mqlAwsVpc) *
 func TestInitAwsVpc(t *testing.T) {
 	const (
 		vpcId  = "vpc-0abc123def456"
-		vpcArn = "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0abc123def456"
+		vpcArn = "arn:aws:vpc:us-east-1:123456789012:id/vpc-0abc123def456"
 		region = "us-east-1"
 	)
 
@@ -66,11 +66,12 @@ func TestInitAwsVpc(t *testing.T) {
 		Region: plugin.TValue[string]{Data: region, State: plugin.StateIsSet},
 	}
 
-	t.Run("resolves VPC by ARN when asset name is a tag (not VPC ID)", func(t *testing.T) {
+	t.Run("derives VPC id from ARN when asset name is a tag (not VPC ID)", func(t *testing.T) {
 		// This is the bug scenario: during discovery, MqlObjectToAsset
 		// overrides the asset name with the VPC's "Name" tag.  The old
 		// code set args["id"] = ids.name (the tag), then tried to match
 		// against vpc.Id.Data (the real VPC ID) — which never matched.
+		// deriveVpcTarget must derive the id from the ARN, never the name.
 		tagName := "scottford-upgrade-eks-container-escape-demo-02c1-vpc"
 		runtime := testAwsRuntime(
 			tagName,
@@ -82,17 +83,13 @@ func TestInitAwsVpc(t *testing.T) {
 		)
 
 		args := map[string]*llx.RawData{}
-		resultArgs, resource, err := initAwsVpc(runtime, args)
-		require.NoError(t, err)
-		require.NotNil(t, resource)
-
-		vpc := resource.(*mqlAwsVpc)
-		assert.Equal(t, vpcId, vpc.Id.Data)
-		assert.Equal(t, vpcArn, vpc.Arn.Data)
-		assert.Equal(t, vpcArn, resultArgs["arn"].Value.(string))
+		region, gotVpcId := deriveVpcTarget(runtime, args)
+		assert.Equal(t, "us-east-1", region)
+		assert.Equal(t, vpcId, gotVpcId)
+		assert.Equal(t, vpcArn, args["arn"].Value.(string))
 	})
 
-	t.Run("resolves VPC by ARN when asset name matches VPC ID", func(t *testing.T) {
+	t.Run("derives VPC id from ARN when asset name matches VPC ID", func(t *testing.T) {
 		// When there's no "Name" tag, the asset name IS the VPC ID.
 		runtime := testAwsRuntime(
 			vpcId,
@@ -104,12 +101,18 @@ func TestInitAwsVpc(t *testing.T) {
 		)
 
 		args := map[string]*llx.RawData{}
-		_, resource, err := initAwsVpc(runtime, args)
-		require.NoError(t, err)
-		require.NotNil(t, resource)
+		region, gotVpcId := deriveVpcTarget(runtime, args)
+		assert.Equal(t, "us-east-1", region)
+		assert.Equal(t, vpcId, gotVpcId)
+	})
 
-		vpc := resource.(*mqlAwsVpc)
-		assert.Equal(t, vpcId, vpc.Id.Data)
+	t.Run("derives region and id from an explicit arn arg", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
+
+		args := map[string]*llx.RawData{"arn": llx.StringData(vpcArn)}
+		region, gotVpcId := deriveVpcTarget(runtime, args)
+		assert.Equal(t, "us-east-1", region)
+		assert.Equal(t, vpcId, gotVpcId)
 	})
 
 	t.Run("resolves VPC by explicit id arg", func(t *testing.T) {
@@ -124,20 +127,6 @@ func TestInitAwsVpc(t *testing.T) {
 
 		vpc := resource.(*mqlAwsVpc)
 		assert.Equal(t, vpcId, vpc.Id.Data)
-	})
-
-	t.Run("resolves VPC by explicit arn arg", func(t *testing.T) {
-		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
-
-		args := map[string]*llx.RawData{
-			"arn": llx.StringData(vpcArn),
-		}
-		_, resource, err := initAwsVpc(runtime, args)
-		require.NoError(t, err)
-		require.NotNil(t, resource)
-
-		vpc := resource.(*mqlAwsVpc)
-		assert.Equal(t, vpcArn, vpc.Arn.Data)
 	})
 
 	t.Run("returns error when VPC not found", func(t *testing.T) {


### PR DESCRIPTION
## What

When a discovered AWS asset is scanned, mql calls the resource's `init` to resolve that one asset by ARN. For nine asset types the init was **filter-in-memory**: it listed every resource of that type across every region, then scanned in Go for the ARN match — `O(regions × resources)` of wasted API work *per scanned asset*.

Each init now parses region + id from the asset ARN and issues a **single targeted `Describe`/`Get`** (or, for S3 and DynamoDB, builds directly from the ARN with no list call at all), mirroring the already-fixed security-group init. The cross-region list-scan is kept only as a fallback for callers with no ARN/region hint. The list-path resource construction was extracted into shared `build*` helpers used by both the list path and the targeted init, so the two can't drift.

Asset types converted: `aws.vpc`, `aws.lambda.function`, `aws.dynamodb.table`, `aws.s3.bucket`, `aws.efs.filesystem`, `aws.ecr.repository`, `aws.elb.loadbalancer` (ELBv2 + classic), `aws.cloudwatch.loggroup`, `aws.cloudtrail.trail`.

## Benchmark

Per-asset resolve by ARN (`mql run aws --discover none -c 'aws.<resource>(arn: "…") { … }'`, best of 3). `--discover none` removes the ~50s multi-service auto-discovery floor so the init cost is visible. BEFORE = clean main, AFTER = this branch, same test account:

| asset type | BEFORE | AFTER | improvement |
|------------|--------|-------|-------------|
| dynamodb.table | 1.92s | 0.32s | **~83%** |
| s3.bucket | 2.00s | 0.37s | **~82%** |
| efs.filesystem | 1.96s | 0.41s | **~79%** |
| ecr.repository | 2.21s | 0.58s | **~74%** |
| lambda.function | 2.05s | 0.67s | **~67%** |
| vpc | 2.07s | 1.23s | **~41%** |

The ~2s BEFORE is the all-region list fan-out; AFTER is a single targeted call (the residual time is the ~0.3s fixed connection overhead plus one round-trip; `vpc` is higher only because its sole instance here lives in `ap-south-1`). The win compounds in real scans: every discovered asset of these types previously paid the full fan-out.

`aws.elb.loadbalancer`, `aws.cloudwatch.loggroup`, and `aws.cloudtrail.trail` get the identical transform but have no singular top-level MQL accessor, so they can't be measured with this by-ARN harness; their init only fires through the per-asset scan path.

## Notes

- Adds `cloudtrail:GetTrail` to `aws.permissions.json` (the new targeted CloudTrail lookup). No other permission changes; S3 `HeadBucket` maps to an already-required `s3:ListBucket`.
- The S3 init now does one `HeadBucket` to preserve the `exists=false` determination for references to deleted buckets (instead of the old all-region `ListBuckets`).
- `initAwsVpc` derivation extracted into a pure `deriveVpcTarget` helper; the existing `aws_vpc_init_test.go` regression test (asset-name-tag-vs-id) was updated to cover it, since the targeted path now makes a live API call the unit test can't mock.

## Test

- `go build ./resources/...`, `go vet`, `gofmt` clean
- `go test ./resources/` passes (incl. updated `TestInitAwsVpc`)
- Live by-ARN resolves verified to return correct data via the targeted path (vpc, dynamodb, ecr, …)