### PR TITLE
🐛 k8s: handle comma-separated staged namespace filters

### DIFF
--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -94,8 +94,8 @@ func Discover(runtime *plugin.Runtime, features mql.Features) (*inventory.Invent
 	if _, ok := invConfig.Options[plugin.OptionStagedDiscovery]; ok {
 		// If a namespace is already set, we're in stage 2 (workload discovery
 		// for that namespace). Otherwise it's stage 1 (cluster + namespaces).
-		if invConfig.Options[shared.OPTION_NAMESPACE] != "" {
-			return discoverNamespaceStage(runtime, conn, invConfig, features)
+		if nsName, ok := namespaceStageName(invConfig); ok {
+			return discoverNamespaceStage(runtime, conn, invConfig, features, nsName)
 		}
 		return discoverClusterStage(runtime, conn, invConfig, features)
 	}
@@ -265,7 +265,7 @@ func discoverClusterStage(runtime *plugin.Runtime, conn shared.Connection, invCo
 //
 // Only workloads are returned here — the namespace asset itself was already
 // emitted by stage 1 with platform IDs and is already known to the client.
-func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, invConfig *inventory.Config, features mql.Features) (*inventory.Inventory, error) {
+func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, invConfig *inventory.Config, features mql.Features, nsName string) (*inventory.Inventory, error) {
 	in := &inventory.Inventory{Spec: &inventory.InventorySpec{
 		Assets: []*inventory.Asset{},
 	}}
@@ -273,8 +273,6 @@ func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, inv
 	if invConfig.Discover == nil || len(invConfig.Discover.Targets) == 0 {
 		return in, nil
 	}
-
-	nsName := invConfig.Options[shared.OPTION_NAMESPACE]
 
 	res, err := runtime.CreateResource(runtime, "k8s", nil)
 	if err != nil {
@@ -1402,13 +1400,33 @@ func resourceFilters(cfg *inventory.Config) (*ResourceFilters, error) {
 func setNamespaceFilters(cfg *inventory.Config) NamespaceFilterOpts {
 	nsFilter := NamespaceFilterOpts{}
 	if include, ok := cfg.Options[shared.OPTION_NAMESPACE]; ok && len(include) > 0 {
-		nsFilter.include = strings.Split(include, ",")
+		nsFilter.include = namespaceFilterValues(include)
 	}
 
 	if exclude, ok := cfg.Options[shared.OPTION_NAMESPACE_EXCLUDE]; ok && len(exclude) > 0 {
-		nsFilter.exclude = strings.Split(exclude, ",")
+		nsFilter.exclude = namespaceFilterValues(exclude)
 	}
 	return nsFilter
+}
+
+func namespaceStageName(cfg *inventory.Config) (string, bool) {
+	namespaces := namespaceFilterValues(cfg.Options[shared.OPTION_NAMESPACE])
+	if len(namespaces) != 1 {
+		return "", false
+	}
+	return namespaces[0], true
+}
+
+func namespaceFilterValues(value string) []string {
+	values := strings.Split(value, ",")
+	res := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			res = append(res, value)
+		}
+	}
+	return res
 }
 
 func assetName(ns, name string) string {

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -1409,6 +1409,9 @@ func setNamespaceFilters(cfg *inventory.Config) NamespaceFilterOpts {
 	return nsFilter
 }
 
+// namespaceStageName returns a namespace only when the config targets exactly
+// one namespace, which indicates staged discovery should run the namespace stage.
+// Empty or multi-namespace filters fall through to cluster-stage discovery.
 func namespaceStageName(cfg *inventory.Config) (string, bool) {
 	namespaces := namespaceFilterValues(cfg.Options[shared.OPTION_NAMESPACE])
 	if len(namespaces) != 1 {

--- a/providers/k8s/resources/discovery_test.go
+++ b/providers/k8s/resources/discovery_test.go
@@ -1,0 +1,148 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/shared"
+	sharedres "go.mondoo.com/mql/v13/providers/k8s/connection/shared/resources"
+	"go.mondoo.com/mql/v13/utils/syncx"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestDiscoverStagedDiscoveryWithCommaSeparatedNamespacesStartsClusterStage(t *testing.T) {
+	cfg := &inventory.Config{
+		Type: "k8s",
+		Options: map[string]string{
+			plugin.OptionStagedDiscovery: "",
+			shared.OPTION_NAMESPACE:      "team-a,team-b",
+		},
+		Discover: &inventory.Discovery{
+			Targets: []string{DiscoveryNamespaces},
+		},
+	}
+	asset := &inventory.Asset{
+		Name:        "K8s Cluster test",
+		Connections: []*inventory.Config{cfg},
+	}
+	conn := &namespaceDiscoveryConnection{
+		Connection: plugin.NewConnection(1, asset),
+		asset:      asset,
+		namespaces: []corev1.Namespace{
+			newTestNamespace("team-a", "uid-team-a"),
+			newTestNamespace("team-b", "uid-team-b"),
+		},
+	}
+	pluginRuntime := &plugin.Runtime{
+		Resources:  &syncx.Map[plugin.Resource]{},
+		Connection: conn,
+	}
+	pluginRuntime.CreateResource = func(runtime *plugin.Runtime, name string, args map[string]*llx.RawData) (plugin.Resource, error) {
+		return &mqlK8s{MqlRuntime: runtime}, nil
+	}
+
+	inv, err := Discover(pluginRuntime, mql.Features{})
+	require.NoError(t, err)
+	require.Len(t, inv.Spec.Assets, 2)
+	require.Empty(t, conn.namespaceGetCalls)
+	require.Equal(t, "team-a", inv.Spec.Assets[0].Connections[0].Options[shared.OPTION_NAMESPACE])
+	require.Equal(t, "team-b", inv.Spec.Assets[1].Connections[0].Options[shared.OPTION_NAMESPACE])
+}
+
+func newTestNamespace(name, uid string) corev1.Namespace {
+	return corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID(uid),
+		},
+	}
+}
+
+type namespaceDiscoveryConnection struct {
+	plugin.Connection
+	asset             *inventory.Asset
+	namespaces        []corev1.Namespace
+	namespaceGetCalls []string
+}
+
+func (c *namespaceDiscoveryConnection) Name() string {
+	return c.asset.Name
+}
+
+func (c *namespaceDiscoveryConnection) Runtime() string {
+	return "k8s-cluster"
+}
+
+func (c *namespaceDiscoveryConnection) Resources(kind string, name string, namespace string) (*shared.ResourceResult, error) {
+	return nil, fmt.Errorf("unexpected resource lookup %s/%s/%s", kind, namespace, name)
+}
+
+func (c *namespaceDiscoveryConnection) ServerVersion() *version.Info {
+	return nil
+}
+
+func (c *namespaceDiscoveryConnection) SupportedResourceTypes() (*sharedres.ApiResourceIndex, error) {
+	return nil, nil
+}
+
+func (c *namespaceDiscoveryConnection) Platform() *inventory.Platform {
+	return &inventory.Platform{
+		Name:    "k8s-cluster",
+		Family:  []string{"k8s"},
+		Kind:    "api",
+		Runtime: c.Runtime(),
+		Title:   "Kubernetes Cluster",
+	}
+}
+
+func (c *namespaceDiscoveryConnection) Asset() *inventory.Asset {
+	return c.asset
+}
+
+func (c *namespaceDiscoveryConnection) AssetId() (string, error) {
+	return shared.NewPlatformId("cluster-uid"), nil
+}
+
+func (c *namespaceDiscoveryConnection) BasePlatformId() (string, error) {
+	return shared.IdPrefix, nil
+}
+
+func (c *namespaceDiscoveryConnection) AdmissionReviews() ([]admissionv1.AdmissionReview, error) {
+	return []admissionv1.AdmissionReview{}, nil
+}
+
+func (c *namespaceDiscoveryConnection) Namespace(name string) (*corev1.Namespace, error) {
+	c.namespaceGetCalls = append(c.namespaceGetCalls, name)
+	for i := range c.namespaces {
+		if c.namespaces[i].Name == name {
+			return &c.namespaces[i], nil
+		}
+	}
+	return nil, fmt.Errorf("namespace %q not found", name)
+}
+
+func (c *namespaceDiscoveryConnection) Namespaces() ([]corev1.Namespace, error) {
+	return c.namespaces, nil
+}
+
+func (c *namespaceDiscoveryConnection) InventoryConfig() *inventory.Config {
+	return c.asset.Connections[0]
+}
+
+var _ shared.Connection = (*namespaceDiscoveryConnection)(nil)


### PR DESCRIPTION
## What
- Routes staged discovery to namespace stage only when the parsed namespace filter contains exactly one namespace.
- Keeps comma-separated namespace filters in cluster-stage discovery so stage 1 can emit one child asset per namespace.
- Reuses the namespace filter parser for include/exclude options and trims empty/whitespace entries.

## Reproduction
Added `TestDiscoverStagedDiscoveryWithCommaSeparatedNamespacesStartsClusterStage`, which covers `options.namespaces="team-a,team-b"`.

Before the fix it failed with:

```text
failed to get namespace "team-a,team-b": namespace "team-a,team-b" not found
```

That proves the staged discovery router treated the comma-separated filter as one literal namespace name.

## Test plan
- `env GOCACHE=/tmp/mql-go-cache go test ./resources -run TestDiscoverStagedDiscoveryWithCommaSeparatedNamespacesStartsClusterStage -count=1`
- `env GOCACHE=/tmp/mql-go-cache go test -timeout=2m ./resources ./provider ./connection/api ./connection/admission ./connection/shared ./connection/shared/resources`

Note: `env GOCACHE=/tmp/mql-go-cache go test -timeout=2m ./resources ./provider ./connection/...` passes the same packages above but fails in `connection/manifest` at `TestManifest_InvalidManifests` in this environment because it attempts to fetch `https://releases.mondoo.com/providers/latest.json` and DNS/network access for that host is unavailable.
