### PR TITLE
🎉 datadog-13.0.12, equinix-13.0.19, shodan-13.2.3, snowflake-13.3.4, stackit-13.2.1

### DIFF
--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "datadog",
 	ID:              "go.mondoo.com/mql/providers/datadog",
-	Version:         "13.0.11",
+	Version:         "13.0.12",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.2.2",
+	Version:         "13.2.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.3.3",
+	Version:         "13.3.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.2.0",
+	Version:         "13.2.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Patch-bumps five providers to release the platform-title cleanup (#8754) and other unreleased changes.

## Changes since last release

### datadog `13.0.11` → `13.0.12`
- 🧹 platform titles: name the scanned object, not the provider (#8754) — title is now "Datadog Organization"
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### equinix `13.0.18` → `13.0.19`
- 🧹 platform titles: name the scanned object, not the provider (#8754) — title is now "Equinix Metal Project"
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### shodan `13.2.2` → `13.2.3`
- 🧹 platform titles: name the scanned object, not the provider (#8754) — `shodan-org` title is now "Shodan Organization"
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### snowflake `13.3.3` → `13.3.4`
- 🧹 platform titles: name the scanned object, not the provider (#8754) — title is now "Snowflake Account"
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### stackit `13.2.0` → `13.2.1`
- 🧹 platform titles: name the scanned object, not the provider (#8754) — `stackit-project` title is now "STACKIT Project"
- 🧹 Provide static platform support information across all providers (#8722)
