### PR TITLE
🎉 aws-13.39.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.38.1",
+	Version:         "13.39.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Minor-bumps the AWS provider to release the unreleased changes accumulated since `aws-13.38.1` (#8713).

## Changes since last release (`13.38.1` → `13.39.0`)

- 🐛 aws: fix swapped region/account in EC2 keypair ARN (#8678)
- 🐛 aws: check CreateResource errors for WAF Not/Or statements (#8686)
- 🐛 aws: don't swallow non-404 errors in efs filesystem.backupPolicy() (#8685)
- ⭐ aws: expose ownership, source, and management provenance (#8774)
- ⭐ aws: expose creation timestamps on more resources (#8764)
- ⭐ aws: add dynamodb.table.autoScalingEnabled and lambda.function.urlConfigAuthType (#8760)
- 🐛 aws: resolve S3 buckets referenced by name to their home region (#8759)
- ⚡ aws: targeted single-resource init for filter-in-memory asset types (#8749)
- ⚡ aws: cut redundant IAM API calls when scanning user and group assets (#8748)
- ⚡ aws: cut redundant API calls when scanning security-group assets (#8747)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Broaden permission generation script for AWS (#8726)
- 🧹 Update deps for mql and providers 20260625 (#8733)
