### PR TITLE
feat(azure): keyless auth via federated token file (workload identity)

### DIFF
--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -137,6 +137,17 @@ func (t *retryableManagedIdentityCredential) tryGetToken(ctx context.Context, op
 	return
 }
 
+// GetWorkloadIdentityToken builds a keyless credential that exchanges a
+// Mondoo-issued OIDC token (written to federatedTokenFile) for an Entra access
+// token via the federated identity credential on the app registration.
+func GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile string) (azcore.TokenCredential, error) {
+	return azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+		TenantID:      tenantId,
+		ClientID:      clientId,
+		TokenFilePath: federatedTokenFile,
+	})
+}
+
 func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId string) (azcore.TokenCredential, error) {
 	var azCred azcore.TokenCredential
 	var err error

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -1,0 +1,16 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package azauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWorkloadIdentityToken(t *testing.T) {
+	cred, err := GetWorkloadIdentityToken("tid", "cid", "/tmp/x.jwt")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -107,6 +107,12 @@ Examples run in the Azure CLI:
 					Default: "",
 					Desc:    "Comma-separated list of Azure subscriptions to exclude",
 				},
+				{
+					Long:    "federated-token-file",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Path to a file containing an OIDC token to exchange via Azure workload identity federation",
+				},
 			},
 		},
 	},

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -5,6 +5,7 @@ package connection
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -19,11 +20,12 @@ import (
 )
 
 const (
-	OptionTenantID         = "tenant-id"
-	OptionClientID         = "client-id"
-	OptionDataReport       = "mondoo-ms365-datareport"
-	OptionSubscriptionID   = "subscription-id"
-	OptionPlatformOverride = "platform-override"
+	OptionTenantID           = "tenant-id"
+	OptionClientID           = "client-id"
+	OptionDataReport         = "mondoo-ms365-datareport"
+	OptionSubscriptionID     = "subscription-id"
+	OptionPlatformOverride   = "platform-override"
+	OptionFederatedTokenFile = "azure-federated-token-file"
 )
 
 type AzureConnection struct {
@@ -36,17 +38,35 @@ type AzureConnection struct {
 	clientOptions  policy.ClientOptions
 }
 
-func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {
+// selectAzureCredential chooses the appropriate Azure token credential based on
+// the connection configuration. When a federated token file is provided (via
+// option or env var) and no explicit vault credential is present, it returns a
+// WorkloadIdentityCredential for keyless auth. Otherwise it falls through to
+// the standard cert/secret/default-chain path.
+func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, error) {
 	tenantId := conf.Options[OptionTenantID]
 	clientId := conf.Options[OptionClientID]
-	subId := conf.Options[OptionSubscriptionID]
 
 	var cred *vault.Credential
 	if len(conf.Credentials) != 0 {
 		cred = conf.Credentials[0]
 	}
 
-	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId)
+	federatedTokenFile := conf.Options[OptionFederatedTokenFile]
+	if federatedTokenFile == "" {
+		federatedTokenFile = os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
+	}
+
+	if cred == nil && federatedTokenFile != "" {
+		return azauth.GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile)
+	}
+	return azauth.GetTokenFromCredential(cred, tenantId, clientId)
+}
+
+func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {
+	subId := conf.Options[OptionSubscriptionID]
+
+	token, err := selectAzureCredential(conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for microsoft provider")
 	}

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
 
 func TestSelectAzureCredential_WorkloadIdentity(t *testing.T) {
@@ -33,13 +35,22 @@ func TestSelectAzureCredential_WorkloadIdentity(t *testing.T) {
 
 func TestSelectAzureCredential_WorkloadIdentity_ViaOption(t *testing.T) {
 	// Ensure env var is not set so we test the option path exclusively.
+	// Save and restore to avoid permanently clobbering the env for later tests.
+	prev, ok := os.LookupEnv("AZURE_FEDERATED_TOKEN_FILE")
 	os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+	t.Cleanup(func() {
+		if ok {
+			os.Setenv("AZURE_FEDERATED_TOKEN_FILE", prev)
+		} else {
+			os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+		}
+	})
 
 	conf := &inventory.Config{
 		Options: map[string]string{
-			"tenant-id":                 "tid",
-			"client-id":                 "cid",
-			"subscription-id":           "sub",
+			"tenant-id":                  "tid",
+			"client-id":                  "cid",
+			"subscription-id":            "sub",
 			"azure-federated-token-file": "/tmp/x.jwt",
 		},
 		Credentials: nil,
@@ -48,4 +59,59 @@ func TestSelectAzureCredential_WorkloadIdentity_ViaOption(t *testing.T) {
 	cred, err := selectAzureCredential(conf)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
+}
+
+// TestSelectAzureCredential_VaultCredWins asserts that an explicit vault
+// credential takes precedence over a federated token file env var. Even when
+// AZURE_FEDERATED_TOKEN_FILE is set, the vault credential path must be taken,
+// so the returned credential must not be a WorkloadIdentityCredential.
+func TestSelectAzureCredential_VaultCredWins(t *testing.T) {
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id": "tid",
+			"client-id": "cid",
+		},
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("secret")},
+		},
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	_, isWIF := cred.(*azidentity.WorkloadIdentityCredential)
+	require.False(t, isWIF, "vault credential must win over federated token file env var")
+}
+
+// TestSelectAzureCredential_DefaultChain asserts that when neither a vault
+// credential nor a federated token file is present, selectAzureCredential
+// falls through to the default credential chain — which must not be a
+// WorkloadIdentityCredential.
+func TestSelectAzureCredential_DefaultChain(t *testing.T) {
+	// Unset the env var and restore it after the test.
+	prev, ok := os.LookupEnv("AZURE_FEDERATED_TOKEN_FILE")
+	os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+	t.Cleanup(func() {
+		if ok {
+			os.Setenv("AZURE_FEDERATED_TOKEN_FILE", prev)
+		} else {
+			os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+		}
+	})
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id": "tid",
+			"client-id": "cid",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	_, isWIF := cred.(*azidentity.WorkloadIdentityCredential)
+	require.False(t, isWIF, "no vault cred + no token file must fall through to the default chain, not WorkloadIdentityCredential")
 }

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestSelectAzureCredential_WorkloadIdentity(t *testing.T) {
+	// Set up an env var pointing to a (non-existent) token file.
+	// Construction of WorkloadIdentityCredential does not read the file —
+	// it is read lazily at GetToken time — so the file need not exist.
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":       "tid",
+			"client-id":       "cid",
+			"subscription-id": "sub",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
+func TestSelectAzureCredential_WorkloadIdentity_ViaOption(t *testing.T) {
+	// Ensure env var is not set so we test the option path exclusively.
+	os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":                 "tid",
+			"client-id":                 "cid",
+			"subscription-id":           "sub",
+			"azure-federated-token-file": "/tmp/x.jwt",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -43,6 +43,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	subscriptionsToExclude := flags["subscriptions-exclude"]
 	certificatePath := flags["certificate-path"]
 	certificateSecret := flags["certificate-secret"]
+	federatedTokenFile := flags["federated-token-file"]
 	opts := map[string]string{}
 	creds := []*vault.Credential{}
 
@@ -56,6 +57,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 	if len(subscriptionsToExclude.Value) > 0 {
 		opts["subscriptions-exclude"] = string(subscriptionsToExclude.Value)
+	}
+	if len(federatedTokenFile.Value) > 0 {
+		opts[connection.OptionFederatedTokenFile] = string(federatedTokenFile.Value)
 	}
 	if len(clientSecret.Value) > 0 {
 		creds = append(creds, &vault.Credential{


### PR DESCRIPTION
## Summary

This PR adds Azure Workload Identity Federation (WIF) support to the mql Azure provider. It is part of a three-repo rollout — **this PR must ship together with the dependent PRs** for end-to-end keyless scanning to work.

- Adds `GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile)` helper to `providers-sdk/v1/util/azauth` that wraps `azidentity.NewWorkloadIdentityCredential`.
- Extends `providers/azure/connection` with `OptionFederatedTokenFile = "azure-federated-token-file"` and a `selectAzureCredential` helper that short-circuits to WIF when no vault credential is present and either the `azure-federated-token-file` connection option or the `AZURE_FEDERATED_TOKEN_FILE` env var (set by the job-runner's `azure-client-assertion` strategy) is populated.
- Adds `--federated-token-file` CLI flag so the option can be set for manual E2E testing.
- The existing cert/secret credential path in `GetTokenFromCredential` is **unchanged** — this is purely additive.

## Contract (must match across all three PRs)

| Contract point | Value |
|---|---|
| Env var | `AZURE_FEDERATED_TOKEN_FILE` |
| Connection option key | `azure-federated-token-file` |
| Also reads from env | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` (set by job-runner, read by azidentity internally) |
| Pairs with job-runner strategy | `azure-client-assertion` |

## Test plan

- [x] `providers-sdk/v1/util/azauth`: `TestGetWorkloadIdentityToken` — credential construction succeeds (file not read at construction time)
- [x] `providers/azure/connection`: `TestSelectAzureCredential_WorkloadIdentity` — selects WIF cred when env var set, no vault cred
- [x] `providers/azure/connection`: `TestSelectAzureCredential_WorkloadIdentity_ViaOption` — selects WIF cred when option key set
- [x] Full `go build ./...` and `go test ./...` green in both `providers/azure` and `providers-sdk`
- [ ] Manual E2E: real Azure tenant + Mondoo deployment (operator-run, requires server + job-runner PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)