### PR TITLE
🧹 Ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+*.swo
 /lr
 /mql
 mqlr


### PR DESCRIPTION
Adds `*.swp`/`*.swo` to `.gitignore` so Vim swap files are not accidentally committed.

Follow-up to a swap file that slipped into a commit in mql-enterprise-providers; this brings the rest of the repos in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)