### PR TITLE
🐛 aws: resolve S3 buckets referenced by name to their home region

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.38.1",
-  "generated_at": "2026-06-25T20:43:02-07:00",
+  "generated_at": "2026-06-26T13:29:39-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -691,6 +691,7 @@
     "s3:GetBucketObjectLockConfiguration",
     "s3:GetBucketOwnershipControls",
     "s3:GetBucketPolicy",
+    "s3:GetBucketPolicyStatus",
     "s3:GetBucketPublicAccessBlock",
     "s3:GetBucketRequestPayment",
     "s3:GetBucketTagging",
@@ -5201,6 +5202,12 @@
       "permission": "s3:GetBucketPolicy",
       "service": "s3",
       "action": "GetBucketPolicy",
+      "source_file": "aws_s3.go"
+    },
+    {
+      "permission": "s3:GetBucketPolicyStatus",
+      "service": "s3",
+      "action": "GetBucketPolicyStatus",
       "source_file": "aws_s3.go"
     },
     {

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -337,6 +337,12 @@ func (a *mqlAwsCloudtrailTrail) eventSelectors() ([]any, error) {
 		TrailName: &arnValue,
 	})
 	if err != nil {
+		// An organization trail's event selectors are only readable from the
+		// management account that owns it; a member-account scan gets access
+		// denied, so report no selectors instead of failing the query.
+		if Is400AccessDeniedError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -378,23 +378,24 @@ func (a *mqlAwsS3BucketAccessPoint) policy() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) policy() (*mqlAwsS3BucketPolicy, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
 	bucketname := a.Name.Data
-	location := a.Location.Data
-	svc := conn.S3(location)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	policy, err := svc.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: &bucketname,
 	})
 	if err != nil {
-		if isNotFoundForS3(err) {
+		if isS3BucketInaccessible(err) {
 			a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
 			return nil, nil
 		}
@@ -497,16 +498,13 @@ func isFalseConditionValue(v any) bool {
 }
 
 func (a *mqlAwsS3Bucket) tags() (map[string]any, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
-		return nil, nil
+	region, ok, err := a.bucketRegion()
+	if err != nil || !ok {
+		return nil, err
 	}
-	bucketname := a.Name.Data
-	location := a.Location.Data
-
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.S3(location)
+	bucketname := a.Name.Data
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	tags, err := svc.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
@@ -518,6 +516,9 @@ func (a *mqlAwsS3Bucket) tags() (map[string]any, error) {
 			if apiErr.ErrorCode() == "NoSuchTagSet" {
 				return nil, nil
 			}
+		}
+		if isS3BucketInaccessible(err) {
+			return nil, nil
 		}
 
 		return nil, err
@@ -548,6 +549,9 @@ func (a *mqlAwsS3Bucket) location() (string, error) {
 		Bucket: &bucketname,
 	})
 	if err != nil {
+		if isS3BucketInaccessible(err) {
+			return "", nil
+		}
 		return "", err
 	}
 
@@ -558,6 +562,32 @@ func (a *mqlAwsS3Bucket) location() (string, error) {
 		region = "us-east-1"
 	}
 	return region, nil
+}
+
+// bucketRegion resolves the bucket's home region for per-bucket data calls
+// (logging, ACL, policy, ...). Those must target the bucket's own region; a
+// client pointed at the wrong region answers with an HTTP 301 redirect. Buckets
+// discovered through the listing path carry their region, but a bucket reached by
+// name (e.g. aws.cloudtrail.trail.s3bucket) resolves it lazily here.
+//
+// ok is false — and the caller returns the field's empty value — when the bucket
+// can't be reached from the account being scanned: it's a placeholder for a
+// deleted bucket, or its region can't be determined because it lives in another
+// account we have no permission to read. A CloudTrail organization trail delivers
+// logs to a bucket owned by the management account, so a member-account scan
+// can't read it.
+func (a *mqlAwsS3Bucket) bucketRegion() (string, bool, error) {
+	if !a.Exists.Data {
+		return "", false, nil
+	}
+	loc := a.GetLocation()
+	if loc.Error != nil {
+		return "", false, loc.Error
+	}
+	if loc.Data == "" {
+		return "", false, nil
+	}
+	return loc.Data, true, nil
 }
 
 func (a *mqlAwsS3Bucket) cloudformationStack() (*mqlAwsCloudformationStack, error) {
@@ -594,15 +624,32 @@ func (a *mqlAwsS3Bucket) gatherAcl() (*s3.GetBucketAclOutput, error) {
 		return nil, nil
 	}
 	a.aclOnce.Do(func() {
-		bucketname := a.Name.Data
-		location := a.Location.Data
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.aclErr = err
+			return
+		}
+		if !ok {
+			// A cross-account or deleted bucket yields no ACL rather than an
+			// error; callers treat a nil result as "no grants".
+			return
+		}
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-		svc := conn.S3(location)
+		bucketname := a.Name.Data
+		svc := conn.S3(region)
 		ctx := context.Background()
 
-		a.aclOutput, a.aclErr = svc.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+		out, err := svc.GetBucketAcl(ctx, &s3.GetBucketAclInput{
 			Bucket: &bucketname,
 		})
+		if err != nil {
+			if isS3BucketInaccessible(err) {
+				return
+			}
+			a.aclErr = err
+			return
+		}
+		a.aclOutput = out
 	})
 	return a.aclOutput, a.aclErr
 }
@@ -613,6 +660,9 @@ func (a *mqlAwsS3Bucket) acl() ([]any, error) {
 	acl, err := a.gatherAcl()
 	if err != nil {
 		return nil, err
+	}
+	if acl == nil {
+		return []any{}, nil
 	}
 
 	res := []any{}
@@ -654,22 +704,25 @@ func (a *mqlAwsS3Bucket) acl() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) fetchPublicAccessBlock() (*s3types.PublicAccessBlockConfiguration, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
-		return nil, nil
-	}
 	a.publicAccessOnce.Do(func() {
-		bucketname := a.Name.Data
-		location := a.Location.Data
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.publicAccessErr = err
+			return
+		}
+		if !ok {
+			return
+		}
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-		svc := conn.S3(location)
+		bucketname := a.Name.Data
+		svc := conn.S3(region)
 		ctx := context.Background()
 
 		resp, err := svc.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{
 			Bucket: &bucketname,
 		})
 		if err != nil {
-			if isNotFoundForS3(err) {
+			if isS3BucketInaccessible(err) {
 				return
 			}
 			a.publicAccessErr = err
@@ -726,6 +779,9 @@ func (a *mqlAwsS3Bucket) owner() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if acl == nil {
+		return nil, nil
+	}
 
 	if acl.Owner == nil {
 		return nil, errors.New("could not gather aws s3 bucket's owner information")
@@ -745,17 +801,14 @@ const (
 )
 
 func (a *mqlAwsS3Bucket) public() (bool, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
-		return false, nil
+	region, ok, err := a.bucketRegion()
+	if err != nil || !ok {
+		return false, err
 	}
-	var (
-		bucketname = a.Name.Data
-		location   = a.Location.Data
-		conn       = a.MqlRuntime.Connection.(*connection.AwsConnection)
-		svc        = conn.S3(location)
-		ctx        = context.Background()
-	)
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	bucketname := a.Name.Data
+	svc := conn.S3(region)
+	ctx := context.Background()
 
 	// Check Public Access Block settings first (reuses cached result)
 	accessBlock, err := a.fetchPublicAccessBlock()
@@ -786,7 +839,7 @@ func (a *mqlAwsS3Bucket) public() (bool, error) {
 	statusOutput, err := svc.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{
 		Bucket: &bucketname,
 	})
-	if err != nil && !isNotFoundForS3(err) {
+	if err != nil && !isS3BucketInaccessible(err) {
 		return false, err
 	}
 	if statusOutput != nil &&
@@ -820,6 +873,9 @@ func (a *mqlAwsS3Bucket) public() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if acl == nil {
+		return false, nil
+	}
 
 	for i := range acl.Grants {
 		grant := acl.Grants[i]
@@ -834,23 +890,20 @@ func (a *mqlAwsS3Bucket) public() (bool, error) {
 }
 
 func (a *mqlAwsS3Bucket) cors() ([]any, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
-		return nil, nil
+	region, ok, err := a.bucketRegion()
+	if err != nil || !ok {
+		return nil, err
 	}
-	bucketname := a.Name.Data
-	location := a.Location.Data
-
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.S3(location)
+	bucketname := a.Name.Data
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	cors, err := svc.GetBucketCors(ctx, &s3.GetBucketCorsInput{
 		Bucket: &bucketname,
 	})
 	if err != nil {
-		if isNotFoundForS3(err) {
+		if isS3BucketInaccessible(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -878,22 +931,22 @@ func (a *mqlAwsS3Bucket) cors() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) logging() (map[string]any, error) {
-	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
-		return nil, nil
+	region, ok, err := a.bucketRegion()
+	if err != nil || !ok {
+		return nil, err
 	}
-	bucketname := a.Name.Data
-	bucketlocation := a.Location.Data
-
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.S3(bucketlocation)
+	bucketname := a.Name.Data
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	logging, err := svc.GetBucketLogging(ctx, &s3.GetBucketLoggingInput{
 		Bucket: &bucketname,
 	})
 	if err != nil {
+		if isS3BucketInaccessible(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -1889,5 +1942,28 @@ func isNotFoundForS3(err error) bool {
 		}
 	}
 
+	return false
+}
+
+// isS3BucketInaccessible reports whether err from an S3 bucket data call means
+// the bucket's data is unavailable from the account being scanned, rather than a
+// genuine failure worth surfacing. Two cases qualify: the bucket no longer
+// exists (404), or it lives in another account we have no permission to read
+// (403). A CloudTrail organization trail delivers logs to a bucket owned by the
+// management account, so a member-account scan hits a 403 on that bucket and
+// must treat it as "no data" instead of failing the query.
+func isS3BucketInaccessible(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isNotFoundForS3(err) || Is400AccessDeniedError(err) {
+		return true
+	}
+	// A forbidden response from a HEAD request carries no AccessDenied body, so
+	// fall back to the raw status code.
+	var respErr *http.ResponseError
+	if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 403 {
+		return true
+	}
 	return false
 }

--- a/providers/aws/resources/aws_s3_test.go
+++ b/providers/aws/resources/aws_s3_test.go
@@ -4,9 +4,14 @@
 package resources
 
 import (
+	"errors"
+	nethttp "net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +34,41 @@ func TestS3BucketArnValidation(t *testing.T) {
 			parsed, err := arn.Parse(tt.arnStr)
 			isValidS3 := err == nil && parsed.Service == "s3"
 			assert.Equal(t, tt.valid, isValidS3)
+		})
+	}
+}
+
+// s3HTTPError builds an S3-style error carrying an HTTP status code, mirroring
+// what the SDK surfaces for GetBucketLogging / GetBucketPolicyStatus etc.
+func s3HTTPError(code int, apiErr error) error {
+	return &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &nethttp.Response{StatusCode: code}},
+		Err:      apiErr,
+	}
+}
+
+// TestIsS3BucketInaccessible guards the cross-account regression: a CloudTrail
+// organization trail references a log bucket owned by the management account, so
+// a member-account scan must treat the resulting 403 (and a deleted-bucket 404)
+// as "no data" rather than failing the check, while genuine errors still surface.
+func TestIsS3BucketInaccessible(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"cross-account 403 AccessDenied", s3HTTPError(403, &smithy.GenericAPIError{Code: "AccessDenied", Message: "Access Denied"}), true},
+		{"bare 403 forbidden", s3HTTPError(403, &smithy.GenericAPIError{Code: "Forbidden"}), true},
+		{"deleted bucket 404", s3HTTPError(404, &smithy.GenericAPIError{Code: "NoSuchBucket"}), true},
+		{"typed NotFound", &s3types.NotFound{}, true},
+		{"transient 500", s3HTTPError(500, &smithy.GenericAPIError{Code: "InternalError"}), false},
+		{"unrelated error", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isS3BucketInaccessible(tt.err))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Scanning an AWS account that owns (or is a member of) a CloudTrail **organization trail** produced hard errors on the CloudTrail S3-bucket checks:

- `Ensure CloudTrail S3 bucket has access logging enabled` → **Error**
- `Ensure CloudTrail trail has S3 data event logging enabled` → **Error**
- `Ensure CloudTrail S3 bucket is not publicly accessible` → **Error**

## Root cause

Buckets reached **by name** — `aws.cloudtrail.trail.s3bucket`, or any bucket scanned as its own `aws-s3-bucket` asset — are initialized via `initAwsS3Bucket` and never get their `location` populated. Only the bucket-*listing* path sets it. The per-bucket data accessors (`logging`, `public`, `policy`, …) read the empty `location` and issued requests against the default region. A bucket in a different region then answered with **HTTP 301 PermanentRedirect**, which surfaced as a scan error.

An organization trail's log bucket is owned by the **management account** and lives in a **non-default region**, so a member-account scan hit both conditions at once: `GetBucketLocation` returns 403 cross-account (region can't be learned), and the data calls 301.

## Fix

- New `bucketRegion()` helper resolves a by-name bucket's home region lazily and short-circuits to the field's empty value when the bucket can't be reached from the scanned account (placeholder for a deleted bucket, or a cross-account bucket whose region can't be determined).
- Routed `logging`, `public`, `policy`, `tags`, `cors`, `gatherAcl`, `fetchPublicAccessBlock` through it — keeping `conn.S3(region)` **inline** so the permissions extractor still attributes each call.
- New `isS3BucketInaccessible()` treats a 404/403 from a per-bucket call as "no data"; same access-denied handling added to CloudTrail `eventSelectors()`.
- For in-account buckets in other regions this now fetches the **real** data (it previously 301'd); for genuinely cross-account buckets it returns the field's empty value instead of erroring.

## Permissions

`aws.permissions.json` gains `s3:GetBucketPolicyStatus` — the `public()` accessor has always called it, but the permission went undetected because its client was built inside a `var()` block the extractor doesn't trace. Moving it to an inline `conn.S3(region)` fixed the detection.

## Tests

- New `TestIsS3BucketInaccessible` (table-driven: 403/404/500/typed-NotFound/nil) guards the classification against future regressions.
- Verified live against the org-trail asset: the three checks now return clean results (`logging: {}`, `public: false`, `eventSelectors.length: 1`) with no 301/error. Two full `cnspec scan aws` runs confirm the CloudTrail errors are gone.