### PR TITLE
⭐ aws: add dynamodb.table.autoScalingEnabled and lambda.function.urlConfigAuthType

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11230,6 +11230,12 @@ private aws.dynamodb.table @defaults("name region") {
   streamViewType() string
   // Billing mode: PROVISIONED or PAY_PER_REQUEST
   billingMode() string
+  // Whether Application Auto Scaling is configured for both provisioned read and write capacity
+  //
+  // True when the table has Application Auto Scaling scalable targets for both
+  // the read and write capacity dimensions. Always false for PAY_PER_REQUEST
+  // (on-demand) tables, which scale with demand without auto scaling.
+  autoScalingEnabled() bool
   // Regions where the table is replicated (global tables)
   replicaRegions() []string
   // Time to live (TTL) settings for the table
@@ -14242,6 +14248,12 @@ private aws.lambda.function @defaults("arn") {
   lastModifiedAt time
   // Function URL configuration (null if no URL is configured)
   urlConfig() aws.lambda.function.urlConfig
+  // Authentication type of the function URL, empty if no URL is configured
+  //
+  // One of AWS_IAM or NONE, or an empty string when the function has no URL
+  // configured. NONE means the function URL is publicly invocable without
+  // authentication.
+  urlConfigAuthType() string
   // Current state of the function (Active, Inactive, Pending, Failed, Deactivating, Deactivated, ActiveNonInvocable, Deleting)
   state string
   // Size of the function deployment package in bytes

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -16918,6 +16918,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.dynamodb.table.billingMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetBillingMode()).ToDataRes(types.String)
 	},
+	"aws.dynamodb.table.autoScalingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetAutoScalingEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.dynamodb.table.replicaRegions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetReplicaRegions()).ToDataRes(types.Array(types.String))
 	},
@@ -20235,6 +20238,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.lambda.function.urlConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetUrlConfig()).ToDataRes(types.Resource("aws.lambda.function.urlConfig"))
+	},
+	"aws.lambda.function.urlConfigAuthType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetUrlConfigAuthType()).ToDataRes(types.String)
 	},
 	"aws.lambda.function.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetState()).ToDataRes(types.String)
@@ -50912,6 +50918,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsDynamodbTable).BillingMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.dynamodb.table.autoScalingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).AutoScalingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.dynamodb.table.replicaRegions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbTable).ReplicaRegions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -55670,6 +55680,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.urlConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).UrlConfig, ok = plugin.RawToTValue[*mqlAwsLambdaFunctionUrlConfig](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.urlConfigAuthType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).UrlConfigAuthType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.lambda.function.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -122518,6 +122532,7 @@ type mqlAwsDynamodbTable struct {
 	StreamEnabled             plugin.TValue[bool]
 	StreamViewType            plugin.TValue[string]
 	BillingMode               plugin.TValue[string]
+	AutoScalingEnabled        plugin.TValue[bool]
 	ReplicaRegions            plugin.TValue[[]any]
 	TtlDescription            plugin.TValue[any]
 	GlobalSecondaryIndexes    plugin.TValue[[]any]
@@ -122703,6 +122718,12 @@ func (c *mqlAwsDynamodbTable) GetStreamViewType() *plugin.TValue[string] {
 func (c *mqlAwsDynamodbTable) GetBillingMode() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.BillingMode, func() (string, error) {
 		return c.billingMode()
+	})
+}
+
+func (c *mqlAwsDynamodbTable) GetAutoScalingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AutoScalingEnabled, func() (bool, error) {
+		return c.autoScalingEnabled()
 	})
 }
 
@@ -133772,6 +133793,7 @@ type mqlAwsLambdaFunction struct {
 	Description                   plugin.TValue[string]
 	LastModifiedAt                plugin.TValue[*time.Time]
 	UrlConfig                     plugin.TValue[*mqlAwsLambdaFunctionUrlConfig]
+	UrlConfigAuthType             plugin.TValue[string]
 	State                         plugin.TValue[string]
 	CodeSize                      plugin.TValue[int64]
 	StateReason                   plugin.TValue[string]
@@ -134029,6 +134051,12 @@ func (c *mqlAwsLambdaFunction) GetUrlConfig() *plugin.TValue[*mqlAwsLambdaFuncti
 		}
 
 		return c.urlConfig()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetUrlConfigAuthType() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UrlConfigAuthType, func() (string, error) {
+		return c.urlConfigAuthType()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2783,6 +2783,7 @@ aws.dynamodb.limit.tableMaxWrite 11.15.2
 aws.dynamodb.limits 11.15.2
 aws.dynamodb.table 11.15.2
 aws.dynamodb.table.arn 11.15.2
+aws.dynamodb.table.autoScalingEnabled 13.38.2
 aws.dynamodb.table.backups 11.15.2
 aws.dynamodb.table.billingMode 11.16.1
 aws.dynamodb.table.continuousBackups 11.15.2
@@ -5950,6 +5951,7 @@ aws.lambda.function.urlConfig.corsMaxAge 11.15.2
 aws.lambda.function.urlConfig.createdAt 11.15.2
 aws.lambda.function.urlConfig.functionUrl 11.15.2
 aws.lambda.function.urlConfig.lastModifiedAt 11.15.2
+aws.lambda.function.urlConfigAuthType 13.38.2
 aws.lambda.function.version 13.12.1
 aws.lambda.function.version.arn 13.12.1
 aws.lambda.function.version.codeSha256 13.12.1

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.38.1",
-  "generated_at": "2026-06-26T13:29:39-07:00",
+  "generated_at": "2026-06-26T19:15:04-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -1003,6 +1003,12 @@
       "service": "application-autoscaling",
       "action": "DescribeScalableTargets",
       "source_file": "aws_applicationautoscaling.go"
+    },
+    {
+      "permission": "application-autoscaling:DescribeScalableTargets",
+      "service": "application-autoscaling",
+      "action": "DescribeScalableTargets",
+      "source_file": "aws_dynamodb.go"
     },
     {
       "permission": "application-autoscaling:DescribeScalingPolicies",

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
+	aatypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/cockroachdb/errors"
@@ -763,6 +765,39 @@ func (a *mqlAwsDynamodbTable) billingMode() (string, error) {
 
 func (a *mqlAwsDynamodbTable) replicaRegions() ([]any, error) {
 	return nil, a.fetchDetail()
+}
+
+func (a *mqlAwsDynamodbTable) autoScalingEnabled() (bool, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	tableName := a.Name.Data
+	svc := conn.ApplicationAutoscaling(region)
+	ctx := context.Background()
+
+	// A table "scales with demand" when both its read and write capacity have
+	// Application Auto Scaling scalable targets. On-demand (PAY_PER_REQUEST)
+	// tables have none and are evaluated by their billing mode instead.
+	resp, err := svc.DescribeScalableTargets(ctx, &applicationautoscaling.DescribeScalableTargetsInput{
+		ServiceNamespace: aatypes.ServiceNamespaceDynamodb,
+		ResourceIds:      []string{"table/" + tableName},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	var hasRead, hasWrite bool
+	for i := range resp.ScalableTargets {
+		switch resp.ScalableTargets[i].ScalableDimension {
+		case aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits:
+			hasRead = true
+		case aatypes.ScalableDimensionDynamoDBTableWriteCapacityUnits:
+			hasWrite = true
+		}
+	}
+	return hasRead && hasWrite, nil
 }
 
 func (a *mqlAwsDynamodbTable) globalSecondaryIndexes() ([]any, error) {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -748,6 +748,25 @@ func (a *mqlAwsLambdaFunction) urlConfig() (*mqlAwsLambdaFunctionUrlConfig, erro
 	return res.(*mqlAwsLambdaFunctionUrlConfig), nil
 }
 
+// urlConfigAuthType exposes the function URL's authentication type directly on
+// the function, returning "" when no URL is configured. Reading it avoids
+// dereferencing the nullable urlConfig sub-resource, so a policy can check URL
+// auth without a null-dereference on functions that have no URL.
+func (a *mqlAwsLambdaFunction) urlConfigAuthType() (string, error) {
+	cfg := a.GetUrlConfig()
+	if cfg.Error != nil {
+		return "", cfg.Error
+	}
+	if cfg.Data == nil {
+		return "", nil
+	}
+	authType := cfg.Data.GetAuthType()
+	if authType.Error != nil {
+		return "", authType.Error
+	}
+	return authType.Data, nil
+}
+
 func (a *mqlAwsLambdaFunctionUrlConfig) id() (string, error) {
 	return a.FunctionUrl.Data, nil
 }


### PR DESCRIPTION
## Why

Two AWS security checks error during `cnspec scan aws` because they dereference a **nullable sub-resource**, which the scan surfaces as a hard `! Error` even when the boolean short-circuits:

- **DynamoDB "scales with demand"** queried `aws.dynamodb.globaltable.replicaSettings` — wrong resource for a regular table asset, and it errors outright on accounts with no global tables.
- **Lambda "URL requires auth"** used `aws.lambda.function.urlConfig.authType`, a null dereference on functions with no URL.

Both need a null-safe field that lives **directly on the asset resource** (the same approach that fixed the S3 bucket-policy checks with `enforceSslOnly`/`policyStatements`).

## Fields

- `aws.dynamodb.table.autoScalingEnabled() bool` — whether Application Auto Scaling is configured for **both** the table's provisioned read and write capacity (`DescribeScalableTargets`). Always `false` for `PAY_PER_REQUEST` (on-demand) tables, which scale without auto scaling. A policy expresses the control as `billingMode == "PAY_PER_REQUEST" || autoScalingEnabled`.
- `aws.lambda.function.urlConfigAuthType() string` — the function URL's auth type (`AWS_IAM`/`NONE`), or `""` when no URL is configured. The check becomes `urlConfigAuthType != "NONE"` — one datapoint, on the function, null-safe.

## Notes

- `DescribeScalableTargets` reuses the existing `ApplicationAutoscaling` client; the permissions manifest gains `application-autoscaling:DescribeScalableTargets` for `aws.dynamodb.table`.
- `urlConfigAuthType` reuses the cached `urlConfig` resource (no extra API call).

## Verification

Live against the account that surfaced the errors:

```
aws.dynamodb.tables { name billingMode autoScalingEnabled }
# PROVISIONED tables (no scalable targets) -> autoScalingEnabled: false  (correctly fail)
# PAY_PER_REQUEST tables                   -> pass via billingMode

aws.lambda.functions { name urlConfigAuthType }
# functions with no URL -> urlConfigAuthType: ""   ("" != "NONE" -> pass), no error
```

Consumed by follow-up policy changes in cnspec (Lambda URL check) and cnspec-enterprise-policies (DynamoDB check).