### PR TITLE
⭐ gcp: add creation timestamps where the SDK exposes them

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -70,10 +70,11 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 		}
 
 		mqlPolicy, err := CreateResource(g.MqlRuntime, "gcp.accesscontextmanager.accessPolicy", map[string]*llx.RawData{
-			"name":   llx.StringData(policy.Name),
-			"title":  llx.StringData(policy.Title),
-			"parent": llx.StringData(policy.Parent),
-			"etag":   llx.StringData(policy.Etag),
+			"name":       llx.StringData(policy.Name),
+			"title":      llx.StringData(policy.Title),
+			"parent":     llx.StringData(policy.Parent),
+			"etag":       llx.StringData(policy.Etag),
+			"createTime": llx.TimeDataPtr(timestampAsTimePtr(policy.GetCreateTime())),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -70,11 +70,11 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 		}
 
 		mqlPolicy, err := CreateResource(g.MqlRuntime, "gcp.accesscontextmanager.accessPolicy", map[string]*llx.RawData{
-			"name":       llx.StringData(policy.Name),
-			"title":      llx.StringData(policy.Title),
-			"parent":     llx.StringData(policy.Parent),
-			"etag":       llx.StringData(policy.Etag),
-			"createTime": llx.TimeDataPtr(timestampAsTimePtr(policy.GetCreateTime())),
+			"name":    llx.StringData(policy.Name),
+			"title":   llx.StringData(policy.Title),
+			"parent":  llx.StringData(policy.Parent),
+			"etag":    llx.StringData(policy.Etag),
+			"created": llx.TimeDataPtr(timestampAsTimePtr(policy.GetCreateTime())),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -373,9 +373,10 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 		}
 
 		mqlSit, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.storedInfoType", map[string]*llx.RawData{
-			"name":            llx.StringData(sit.Name),
-			"currentVersion":  llx.DictData(currentVersion),
-			"pendingVersions": llx.ArrayData(pendingVersions, types.Dict),
+			"name":                     llx.StringData(sit.Name),
+			"currentVersion":           llx.DictData(currentVersion),
+			"pendingVersions":          llx.ArrayData(pendingVersions, types.Dict),
+			"currentVersionCreateTime": llx.TimeDataPtr(timestampAsTimePtr(sit.GetCurrentVersion().GetCreateTime())),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -12299,7 +12299,7 @@ private gcp.accesscontextmanager.accessPolicy @defaults("name title") {
   // ETag used for concurrency control on resource updates
   etag string
   // Time the access policy was created
-  createTime time
+  created time
   // Access levels within this policy
   accessLevels() []gcp.accesscontextmanager.accessLevel
   // Service perimeters within this policy

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -6913,6 +6913,8 @@ private gcp.project.monitoringService.notificationChannel @defaults("displayName
   userLabels map[string]string
   // Verification status (UNVERIFIED, VERIFIED)
   verificationStatus string
+  // Time the notification channel was created
+  created time
 }
 
 // Google Cloud (GCP) Cloud Monitoring resource group
@@ -12296,6 +12298,8 @@ private gcp.accesscontextmanager.accessPolicy @defaults("name title") {
   parent string
   // ETag used for concurrency control on resource updates
   etag string
+  // Time the access policy was created
+  createTime time
   // Access levels within this policy
   accessLevels() []gcp.accesscontextmanager.accessLevel
   // Service perimeters within this policy
@@ -13015,6 +13019,8 @@ private gcp.project.dlpService.storedInfoType @defaults("name") {
   currentVersion dict
   // Pending versions (if being updated)
   pendingVersions []dict
+  // Time the current version was created
+  currentVersionCreateTime time
 }
 
 // ============================================================

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -14680,8 +14680,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.accesscontextmanager.accessPolicy.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetEtag()).ToDataRes(types.String)
 	},
-	"gcp.accesscontextmanager.accessPolicy.createTime": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetCreateTime()).ToDataRes(types.Time)
+	"gcp.accesscontextmanager.accessPolicy.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetCreated()).ToDataRes(types.Time)
 	},
 	"gcp.accesscontextmanager.accessPolicy.accessLevels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetAccessLevels()).ToDataRes(types.Array(types.Resource("gcp.accesscontextmanager.accessLevel")))
@@ -34837,8 +34837,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpAccesscontextmanagerAccessPolicy).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.accesscontextmanager.accessPolicy.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpAccesscontextmanagerAccessPolicy).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+	"gcp.accesscontextmanager.accessPolicy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpAccesscontextmanagerAccessPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gcp.accesscontextmanager.accessPolicy.accessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80597,7 +80597,7 @@ type mqlGcpAccesscontextmanagerAccessPolicy struct {
 	Title             plugin.TValue[string]
 	Parent            plugin.TValue[string]
 	Etag              plugin.TValue[string]
-	CreateTime        plugin.TValue[*time.Time]
+	Created           plugin.TValue[*time.Time]
 	AccessLevels      plugin.TValue[[]any]
 	ServicePerimeters plugin.TValue[[]any]
 }
@@ -80655,8 +80655,8 @@ func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetEtag() *plugin.TValue[string
 	return &c.Etag
 }
 
-func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetCreateTime() *plugin.TValue[*time.Time] {
-	return &c.CreateTime
+func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
 }
 
 func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetAccessLevels() *plugin.TValue[[]any] {

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -9250,6 +9250,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.monitoringService.notificationChannel.verificationStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceNotificationChannel).GetVerificationStatus()).ToDataRes(types.String)
 	},
+	"gcp.project.monitoringService.notificationChannel.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectMonitoringServiceNotificationChannel).GetCreated()).ToDataRes(types.Time)
+	},
 	"gcp.project.monitoringService.group.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceGroup).GetName()).ToDataRes(types.String)
 	},
@@ -14677,6 +14680,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.accesscontextmanager.accessPolicy.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetEtag()).ToDataRes(types.String)
 	},
+	"gcp.accesscontextmanager.accessPolicy.createTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetCreateTime()).ToDataRes(types.Time)
+	},
 	"gcp.accesscontextmanager.accessPolicy.accessLevels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerAccessPolicy).GetAccessLevels()).ToDataRes(types.Array(types.Resource("gcp.accesscontextmanager.accessLevel")))
 	},
@@ -15348,6 +15354,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dlpService.storedInfoType.pendingVersions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDlpServiceStoredInfoType).GetPendingVersions()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.project.dlpService.storedInfoType.currentVersionCreateTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDlpServiceStoredInfoType).GetCurrentVersionCreateTime()).ToDataRes(types.Time)
 	},
 	"gcp.project.batchService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBatchService).GetProjectId()).ToDataRes(types.String)
@@ -26916,6 +26925,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectMonitoringServiceNotificationChannel).VerificationStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.monitoringService.notificationChannel.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectMonitoringServiceNotificationChannel).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"gcp.project.monitoringService.group.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectMonitoringServiceGroup).__id, ok = v.Value.(string)
 		return
@@ -34824,6 +34837,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpAccesscontextmanagerAccessPolicy).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.accesscontextmanager.accessPolicy.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpAccesscontextmanagerAccessPolicy).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"gcp.accesscontextmanager.accessPolicy.accessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpAccesscontextmanagerAccessPolicy).AccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -35818,6 +35835,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dlpService.storedInfoType.pendingVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDlpServiceStoredInfoType).PendingVersions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dlpService.storedInfoType.currentVersionCreateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDlpServiceStoredInfoType).CurrentVersionCreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gcp.project.batchService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -61820,6 +61841,7 @@ type mqlGcpProjectMonitoringServiceNotificationChannel struct {
 	Labels             plugin.TValue[map[string]any]
 	UserLabels         plugin.TValue[map[string]any]
 	VerificationStatus plugin.TValue[string]
+	Created            plugin.TValue[*time.Time]
 }
 
 // createGcpProjectMonitoringServiceNotificationChannel creates a new instance of this resource
@@ -61889,6 +61911,10 @@ func (c *mqlGcpProjectMonitoringServiceNotificationChannel) GetUserLabels() *plu
 
 func (c *mqlGcpProjectMonitoringServiceNotificationChannel) GetVerificationStatus() *plugin.TValue[string] {
 	return &c.VerificationStatus
+}
+
+func (c *mqlGcpProjectMonitoringServiceNotificationChannel) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
 }
 
 // mqlGcpProjectMonitoringServiceGroup for the gcp.project.monitoringService.group resource
@@ -80571,6 +80597,7 @@ type mqlGcpAccesscontextmanagerAccessPolicy struct {
 	Title             plugin.TValue[string]
 	Parent            plugin.TValue[string]
 	Etag              plugin.TValue[string]
+	CreateTime        plugin.TValue[*time.Time]
 	AccessLevels      plugin.TValue[[]any]
 	ServicePerimeters plugin.TValue[[]any]
 }
@@ -80626,6 +80653,10 @@ func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetParent() *plugin.TValue[stri
 
 func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetEtag() *plugin.TValue[string] {
 	return &c.Etag
+}
+
+func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetCreateTime() *plugin.TValue[*time.Time] {
+	return &c.CreateTime
 }
 
 func (c *mqlGcpAccesscontextmanagerAccessPolicy) GetAccessLevels() *plugin.TValue[[]any] {
@@ -83116,9 +83147,10 @@ type mqlGcpProjectDlpServiceStoredInfoType struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectDlpServiceStoredInfoTypeInternal it will be used here
-	Name            plugin.TValue[string]
-	CurrentVersion  plugin.TValue[any]
-	PendingVersions plugin.TValue[[]any]
+	Name                     plugin.TValue[string]
+	CurrentVersion           plugin.TValue[any]
+	PendingVersions          plugin.TValue[[]any]
+	CurrentVersionCreateTime plugin.TValue[*time.Time]
 }
 
 // createGcpProjectDlpServiceStoredInfoType creates a new instance of this resource
@@ -83168,6 +83200,10 @@ func (c *mqlGcpProjectDlpServiceStoredInfoType) GetCurrentVersion() *plugin.TVal
 
 func (c *mqlGcpProjectDlpServiceStoredInfoType) GetPendingVersions() *plugin.TValue[[]any] {
 	return &c.PendingVersions
+}
+
+func (c *mqlGcpProjectDlpServiceStoredInfoType) GetCurrentVersionCreateTime() *plugin.TValue[*time.Time] {
+	return &c.CurrentVersionCreateTime
 }
 
 // mqlGcpProjectBatchService for the gcp.project.batchService resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -19,7 +19,7 @@ gcp.accesscontextmanager.accessLevel.title 13.3.4
 gcp.accesscontextmanager.accessLevel.updateTime 13.3.4
 gcp.accesscontextmanager.accessPolicy 13.3.4
 gcp.accesscontextmanager.accessPolicy.accessLevels 13.3.4
-gcp.accesscontextmanager.accessPolicy.createTime 13.25.2
+gcp.accesscontextmanager.accessPolicy.created 13.25.2
 gcp.accesscontextmanager.accessPolicy.etag 13.3.4
 gcp.accesscontextmanager.accessPolicy.name 13.3.4
 gcp.accesscontextmanager.accessPolicy.parent 13.3.4

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -19,6 +19,7 @@ gcp.accesscontextmanager.accessLevel.title 13.3.4
 gcp.accesscontextmanager.accessLevel.updateTime 13.3.4
 gcp.accesscontextmanager.accessPolicy 13.3.4
 gcp.accesscontextmanager.accessPolicy.accessLevels 13.3.4
+gcp.accesscontextmanager.accessPolicy.createTime 13.25.2
 gcp.accesscontextmanager.accessPolicy.etag 13.3.4
 gcp.accesscontextmanager.accessPolicy.name 13.3.4
 gcp.accesscontextmanager.accessPolicy.parent 13.3.4
@@ -2851,6 +2852,7 @@ gcp.project.dlpService.projectDataProfiles 13.14.2
 gcp.project.dlpService.projectId 13.6.1
 gcp.project.dlpService.storedInfoType 13.6.1
 gcp.project.dlpService.storedInfoType.currentVersion 13.6.1
+gcp.project.dlpService.storedInfoType.currentVersionCreateTime 13.25.2
 gcp.project.dlpService.storedInfoType.name 13.6.1
 gcp.project.dlpService.storedInfoType.pendingVersions 13.6.1
 gcp.project.dlpService.storedInfoTypes 13.6.1
@@ -3841,6 +3843,7 @@ gcp.project.monitoringService.group.name 13.6.1
 gcp.project.monitoringService.group.parentName 13.6.1
 gcp.project.monitoringService.groups 13.6.1
 gcp.project.monitoringService.notificationChannel 13.6.1
+gcp.project.monitoringService.notificationChannel.created 13.25.2
 gcp.project.monitoringService.notificationChannel.description 13.6.1
 gcp.project.monitoringService.notificationChannel.displayName 13.6.1
 gcp.project.monitoringService.notificationChannel.enabled 13.6.1

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.25.0",
-  "generated_at": "2026-06-23T15:34:34-06:00",
+  "version": "13.25.1",
+  "generated_at": "2026-06-26T23:07:07-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -415,6 +415,7 @@ func (g *mqlGcpProjectMonitoringService) notificationChannels() ([]any, error) {
 			"labels":             llx.MapData(convert.MapToInterfaceMap(ch.Labels), types.String),
 			"userLabels":         llx.MapData(convert.MapToInterfaceMap(ch.UserLabels), types.String),
 			"verificationStatus": llx.StringData(ch.VerificationStatus.String()),
+			"created":            llx.TimeDataPtr(timestampAsTimePtr(ch.GetCreationRecord().GetMutateTime())),
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

Adds a creation-timestamp field to three GCP resources whose underlying SDK struct carries one that we weren't surfacing:

| Resource | Field | SDK source |
|---|---|---|
| `gcp.accesscontextmanager.accessPolicy` | `createTime` | `AccessPolicy.CreateTime` |
| `gcp.project.monitoringService.notificationChannel` | `created` | `CreationRecord.MutateTime` |
| `gcp.project.dlpService.storedInfoType` | `currentVersionCreateTime` | `CurrentVersion.CreateTime` |

`currentVersionCreateTime` is deliberately named to make clear it reflects the **current version's** build time, not the resource's own creation.

## Context

This came out of an audit of all 449 GCP resource blocks for missing creation-date fields. Findings:

- **Already covered** (no change needed): `pubsubService.schema` and `osConfigService.osPolicyAssignment` already expose `revisionCreateTime` — already named to make the revision scope clear.
- **Genuinely unavailable** from the GCP API (confirmed against the SDK structs): Pub/Sub topics/subscriptions/snapshots, Cloud Function v1 (only `UpdateTime`; v2 already has `createTime`), Dataproc clusters (only `ClusterStatus.StateStartTime`), IAM service accounts, plus ~40 other resources (DNS, Bigtable cluster/table, SQL database/user, healthcare, IAP, org policy, SCC, App Engine, etc.).

## Implementation notes

- Fields are populated with nil-safe proto getters through the existing `timestampAsTimePtr` helper, so a missing timestamp yields MQL null rather than a zero time.
- `.lr.versions` entries added at **13.25.2** (next patch after the provider's current 13.25.1).
- No new IAM permissions (data comes from API responses already fetched), so `gcp.permissions.json` is unchanged.

## Verification

- `./mqlr generate` re-run clean; `make providers/build/gcp` builds successfully (confirms the SDK getter names resolve).
- Not runtime-verified against live resources (the available test project has none of these resource types provisioned).
