### PR TITLE
⭐ azure: expose creation timestamps on more resources

### DIFF
--- a/providers/azure/resources/appconfiguration.go
+++ b/providers/azure/resources/appconfiguration.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -96,8 +97,10 @@ func configurationStoreToMql(runtime *plugin.Runtime, store *armappconfiguration
 	var endpoint, provisioningState, createMode string
 	var disableLocalAuth, enablePurgeProtection bool
 	var softDeleteRetentionInDays, defaultKeyValueRevisionRetentionPeriodInSeconds int64
+	var creationTime *time.Time
 
 	if p := store.Properties; p != nil {
+		creationTime = p.CreationDate
 		if p.PublicNetworkAccess != nil {
 			publicNetworkAccess = string(*p.PublicNetworkAccess)
 		}
@@ -149,6 +152,7 @@ func configurationStoreToMql(runtime *plugin.Runtime, store *armappconfiguration
 		"provisioningState":         llx.StringData(provisioningState),
 		"createMode":                llx.StringData(createMode),
 		"defaultKeyValueRevisionRetentionPeriodInSeconds": llx.IntData(defaultKeyValueRevisionRetentionPeriodInSeconds),
+		"creationTime": llx.TimeDataPtr(creationTime),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1339,6 +1339,8 @@ azure.subscription.batchService.account.pool @defaults("id name") {
   proxyAgentEnabled bool
   // Security encryption type for confidential computing (e.g., "DiskWithVMGuestState")
   securityEncryptionType string
+  // When the pool was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -1409,6 +1411,8 @@ azure.subscription.databricksService.workspace @defaults("id name location publi
   managedServicesKeyName string
   // Managed-services CMK key version
   managedServicesKeyVersion string
+  // When the workspace was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -6534,6 +6538,8 @@ private azure.subscription.monitorService.applicationInsight @defaults("name loc
   retentionInDays int
   // Log Analytics workspace resource ID
   workspaceResourceId string
+  // When the Application Insights component was created
+  creationTime time
   // Log Analytics workspace where the diagnostic data is sent
   workspace() azure.subscription.monitorService.workspace
 }
@@ -6862,6 +6868,10 @@ private azure.subscription.cloudDefenderService.assessment @defaults("displayNam
   statusCause string
   // Human-readable description of the assessment result
   statusDescription string
+  // When the assessment was created and first evaluated
+  firstEvaluationDate time
+  // When the assessment status last changed
+  statusChangeDate time
   // Severity of the assessment (Low, Medium, High)
   severity string
   // ARM ID of the resource the assessment was run against
@@ -9343,6 +9353,8 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   queues() []azure.subscription.serviceBusService.namespace.queue
   // Topics in this namespace
   topics() []azure.subscription.serviceBusService.namespace.topic
+  // When the namespace was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -9408,6 +9420,8 @@ private azure.subscription.serviceBusService.namespace.queue @defaults("id name"
   requiresSession bool
   // Whether partitioning is enabled
   enablePartitioning bool
+  // When the queue was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -9432,6 +9446,8 @@ private azure.subscription.serviceBusService.namespace.topic @defaults("id name"
   requiresDuplicateDetection bool
   // Default time-to-live for messages (ISO 8601 duration)
   defaultMessageTimeToLive string
+  // When the topic was created
+  creationTime time
   // Subscriptions on this topic
   subscriptions() []azure.subscription.serviceBusService.namespace.topic.subscription
   // Creation and last-modification provenance recorded by Azure Resource Manager
@@ -9458,6 +9474,8 @@ private azure.subscription.serviceBusService.namespace.topic.subscription @defau
   defaultMessageTimeToLive string
   // Whether sessions are required
   requiresSession bool
+  // When the subscription was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -9523,6 +9541,8 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   networkRules() azure.subscription.eventHubService.namespace.networkRules
   // Event Hubs in this namespace
   eventHubs() []azure.subscription.eventHubService.namespace.eventHub
+  // When the namespace was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -9578,6 +9598,8 @@ private azure.subscription.eventHubService.namespace.eventHub @defaults("id name
   partitionIds []string
   // Consumer groups for this Event Hub
   consumerGroups() []azure.subscription.eventHubService.namespace.eventHub.consumerGroup
+  // When the Event Hub was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -9590,6 +9612,8 @@ private azure.subscription.eventHubService.namespace.eventHub.consumerGroup @def
   name string
   // User-defined metadata
   userMetadata string
+  // When the consumer group was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -11251,6 +11275,8 @@ azure.subscription.appConfigurationService.configurationStore @defaults("id name
   createMode string
   // Default retention period (seconds) for revisions of every key-value, controlling how far back point-in-time queries can read
   defaultKeyValueRevisionRetentionPeriodInSeconds int
+  // When the configuration store was created
+  creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -11326,6 +11352,8 @@ azure.subscription.cognitiveServicesService.account @defaults("id name location 
   provisioningState string
   // Whether stored completions (request/response logging used for fine-tuning and evaluation) are disabled
   storedCompletionsDisabled bool
+  // When the account was created
+  creationTime time
   // Whether Microsoft Defender for AI threat detection is enabled on the account
   defenderForAIEnabled() bool
   // Responsible AI content-filter policies configured on the account
@@ -11621,7 +11649,11 @@ private azure.subscription.cognitiveServicesService.account.raiTopic @defaults("
   // URL of the sample blob used to train the topic
   sampleBlobUrl string
   // When the topic was created
-  createdAt time
+  //
+  // Deprecated in favor of creationTime.
+  createdAt @maturity("deprecated") time
+  // When the topic was created
+  creationTime time
   // When the topic was last modified
   lastModifiedAt time
   // Creation and last-modification provenance recorded by Azure Resource Manager

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3604,6 +3604,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.batchService.account.pool.securityEncryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetSecurityEncryptionType()).ToDataRes(types.String)
 	},
+	"azure.subscription.batchService.account.pool.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.batchService.account.pool.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -3684,6 +3687,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.databricksService.workspace.managedServicesKeyVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetManagedServicesKeyVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.databricksService.workspace.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.databricksService.workspace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -9454,6 +9460,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.applicationInsight.workspaceResourceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).GetWorkspaceResourceId()).ToDataRes(types.String)
 	},
+	"azure.subscription.monitorService.applicationInsight.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.monitorService.applicationInsight.workspace": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).GetWorkspace()).ToDataRes(types.Resource("azure.subscription.monitorService.workspace"))
 	},
@@ -9825,6 +9834,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cloudDefenderService.assessment.statusDescription": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetStatusDescription()).ToDataRes(types.String)
+	},
+	"azure.subscription.cloudDefenderService.assessment.firstEvaluationDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetFirstEvaluationDate()).ToDataRes(types.Time)
+	},
+	"azure.subscription.cloudDefenderService.assessment.statusChangeDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetStatusChangeDate()).ToDataRes(types.Time)
 	},
 	"azure.subscription.cloudDefenderService.assessment.severity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetSeverity()).ToDataRes(types.String)
@@ -12670,6 +12685,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetTopics()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.topic")))
 	},
+	"azure.subscription.serviceBusService.namespace.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.serviceBusService.namespace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -12730,6 +12748,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.queue.enablePartitioning": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).GetEnablePartitioning()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.serviceBusService.namespace.queue.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.serviceBusService.namespace.queue.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -12759,6 +12780,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.defaultMessageTimeToLive": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetDefaultMessageTimeToLive()).ToDataRes(types.String)
+	},
+	"azure.subscription.serviceBusService.namespace.topic.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscriptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetSubscriptions()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.topic.subscription")))
@@ -12792,6 +12816,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.requiresSession": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetRequiresSession()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.serviceBusService.namespace.topic.subscription.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -12859,6 +12886,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.eventHubService.namespace.eventHubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetEventHubs()).ToDataRes(types.Array(types.Resource("azure.subscription.eventHubService.namespace.eventHub")))
 	},
+	"azure.subscription.eventHubService.namespace.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.eventHubService.namespace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -12904,6 +12934,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).GetConsumerGroups()).ToDataRes(types.Array(types.Resource("azure.subscription.eventHubService.namespace.eventHub.consumerGroup")))
 	},
+	"azure.subscription.eventHubService.namespace.eventHub.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.eventHubService.namespace.eventHub.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -12915,6 +12948,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.userMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).GetUserMetadata()).ToDataRes(types.String)
+	},
+	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -14698,6 +14734,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.appConfigurationService.configurationStore.defaultKeyValueRevisionRetentionPeriodInSeconds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetDefaultKeyValueRevisionRetentionPeriodInSeconds()).ToDataRes(types.Int)
 	},
+	"azure.subscription.appConfigurationService.configurationStore.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetCreationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.appConfigurationService.configurationStore.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -14766,6 +14805,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.storedCompletionsDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetStoredCompletionsDisabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.cognitiveServicesService.account.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.cognitiveServicesService.account.defenderForAIEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetDefenderForAIEnabled()).ToDataRes(types.Bool)
@@ -15042,6 +15084,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"azure.subscription.cognitiveServicesService.account.raiTopic.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.lastModifiedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetLastModifiedAt()).ToDataRes(types.Time)
@@ -17803,6 +17848,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionBatchServiceAccountPool).SecurityEncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.batchService.account.pool.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccountPool).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.batchService.account.pool.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccountPool).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -17917,6 +17966,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.databricksService.workspace.managedServicesKeyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).ManagedServicesKeyVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.databricksService.workspace.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.databricksService.workspace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26311,6 +26364,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).WorkspaceResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.applicationInsight.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.applicationInsight.workspace": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceApplicationInsight).Workspace, ok = plugin.RawToTValue[*mqlAzureSubscriptionMonitorServiceWorkspace](v.Value, v.Error)
 		return
@@ -26845,6 +26902,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.assessment.statusDescription": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).StatusDescription, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.assessment.firstEvaluationDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).FirstEvaluationDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.assessment.statusChangeDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).StatusChangeDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.assessment.severity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31023,6 +31088,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).Topics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -31115,6 +31184,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).EnablePartitioning, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.queue.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.queue.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -31157,6 +31230,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.defaultMessageTimeToLive": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).DefaultMessageTimeToLive, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.serviceBusService.namespace.topic.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscriptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31205,6 +31282,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.requiresSession": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).RequiresSession, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.serviceBusService.namespace.topic.subscription.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31303,6 +31384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionEventHubServiceNamespace).EventHubs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.eventHubService.namespace.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespace).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.eventHubService.namespace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -31375,6 +31460,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).ConsumerGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.eventHubService.namespace.eventHub.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.eventHubService.namespace.eventHub.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -31393,6 +31482,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.userMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).UserMetadata, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33967,6 +34060,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).DefaultKeyValueRevisionRetentionPeriodInSeconds, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.appConfigurationService.configurationStore.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.appConfigurationService.configurationStore.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -34065,6 +34162,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.storedCompletionsDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).StoredCompletionsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.defenderForAIEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34465,6 +34566,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.raiTopic.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.lastModifiedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40136,6 +40241,7 @@ type mqlAzureSubscriptionBatchServiceAccountPool struct {
 	HostEndpointProtectionMode    plugin.TValue[string]
 	ProxyAgentEnabled             plugin.TValue[bool]
 	SecurityEncryptionType        plugin.TValue[string]
+	CreationTime                  plugin.TValue[*time.Time]
 	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -40234,6 +40340,10 @@ func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetProxyAgentEnabled() *pl
 
 func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetSecurityEncryptionType() *plugin.TValue[string] {
 	return &c.SecurityEncryptionType
+}
+
+func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -40347,6 +40457,7 @@ type mqlAzureSubscriptionDatabricksServiceWorkspace struct {
 	ManagedServicesKeyVaultUri      plugin.TValue[string]
 	ManagedServicesKeyName          plugin.TValue[string]
 	ManagedServicesKeyVersion       plugin.TValue[string]
+	CreationTime                    plugin.TValue[*time.Time]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -40481,6 +40592,10 @@ func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetManagedServicesKeyNa
 
 func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetManagedServicesKeyVersion() *plugin.TValue[string] {
 	return &c.ManagedServicesKeyVersion
+}
+
+func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -60660,6 +60775,7 @@ type mqlAzureSubscriptionMonitorServiceApplicationInsight struct {
 	PublicNetworkAccessForQuery     plugin.TValue[string]
 	RetentionInDays                 plugin.TValue[int64]
 	WorkspaceResourceId             plugin.TValue[string]
+	CreationTime                    plugin.TValue[*time.Time]
 	Workspace                       plugin.TValue[*mqlAzureSubscriptionMonitorServiceWorkspace]
 }
 
@@ -60746,6 +60862,10 @@ func (c *mqlAzureSubscriptionMonitorServiceApplicationInsight) GetRetentionInDay
 
 func (c *mqlAzureSubscriptionMonitorServiceApplicationInsight) GetWorkspaceResourceId() *plugin.TValue[string] {
 	return &c.WorkspaceResourceId
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceApplicationInsight) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionMonitorServiceApplicationInsight) GetWorkspace() *plugin.TValue[*mqlAzureSubscriptionMonitorServiceWorkspace] {
@@ -62090,6 +62210,8 @@ type mqlAzureSubscriptionCloudDefenderServiceAssessment struct {
 	Status                   plugin.TValue[string]
 	StatusCause              plugin.TValue[string]
 	StatusDescription        plugin.TValue[string]
+	FirstEvaluationDate      plugin.TValue[*time.Time]
+	StatusChangeDate         plugin.TValue[*time.Time]
 	Severity                 plugin.TValue[string]
 	ResourceId               plugin.TValue[string]
 	AdditionalData           plugin.TValue[any]
@@ -62169,6 +62291,14 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetStatusCause() *p
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetStatusDescription() *plugin.TValue[string] {
 	return &c.StatusDescription
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetFirstEvaluationDate() *plugin.TValue[*time.Time] {
+	return &c.FirstEvaluationDate
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetStatusChangeDate() *plugin.TValue[*time.Time] {
+	return &c.StatusChangeDate
 }
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetSeverity() *plugin.TValue[string] {
@@ -72100,6 +72230,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespace struct {
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules]
 	Queues                          plugin.TValue[[]any]
 	Topics                          plugin.TValue[[]any]
+	CreationTime                    plugin.TValue[*time.Time]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -72244,6 +72375,10 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetTopics() *plugin.TVa
 
 		return c.topics()
 	})
+}
+
+func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -72404,6 +72539,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceQueue struct {
 	RequiresDuplicateDetection plugin.TValue[bool]
 	RequiresSession            plugin.TValue[bool]
 	EnablePartitioning         plugin.TValue[bool]
+	CreationTime               plugin.TValue[*time.Time]
 	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -72492,6 +72628,10 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) GetEnablePartition
 	return &c.EnablePartitioning
 }
 
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
+}
+
 func (c *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -72522,6 +72662,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceTopic struct {
 	SupportOrdering            plugin.TValue[bool]
 	RequiresDuplicateDetection plugin.TValue[bool]
 	DefaultMessageTimeToLive   plugin.TValue[string]
+	CreationTime               plugin.TValue[*time.Time]
 	Subscriptions              plugin.TValue[[]any]
 	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
@@ -72599,6 +72740,10 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) GetDefaultMessageT
 	return &c.DefaultMessageTimeToLive
 }
 
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
+}
+
 func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) GetSubscriptions() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Subscriptions, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -72645,6 +72790,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription struct {
 	LockDuration             plugin.TValue[string]
 	DefaultMessageTimeToLive plugin.TValue[string]
 	RequiresSession          plugin.TValue[bool]
+	CreationTime             plugin.TValue[*time.Time]
 	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -72719,6 +72865,10 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetDef
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetRequiresSession() *plugin.TValue[bool] {
 	return &c.RequiresSession
+}
+
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -72827,6 +72977,7 @@ type mqlAzureSubscriptionEventHubServiceNamespace struct {
 	NetworkRuleSet                  plugin.TValue[any]
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules]
 	EventHubs                       plugin.TValue[[]any]
+	CreationTime                    plugin.TValue[*time.Time]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -72967,6 +73118,10 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetEventHubs() *plugin.TV
 
 		return c.eventHubs()
 	})
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -73122,6 +73277,7 @@ type mqlAzureSubscriptionEventHubServiceNamespaceEventHub struct {
 	Status                 plugin.TValue[string]
 	PartitionIds           plugin.TValue[[]any]
 	ConsumerGroups         plugin.TValue[[]any]
+	CreationTime           plugin.TValue[*time.Time]
 	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -73202,6 +73358,10 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) GetConsumerGroups
 	})
 }
 
+func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
+}
+
 func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -73226,6 +73386,7 @@ type mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup struct {
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	UserMetadata   plugin.TValue[string]
+	CreationTime   plugin.TValue[*time.Time]
 	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -73276,6 +73437,10 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetN
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetUserMetadata() *plugin.TValue[string] {
 	return &c.UserMetadata
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -79212,6 +79377,7 @@ type mqlAzureSubscriptionAppConfigurationServiceConfigurationStore struct {
 	ProvisioningState                               plugin.TValue[string]
 	CreateMode                                      plugin.TValue[string]
 	DefaultKeyValueRevisionRetentionPeriodInSeconds plugin.TValue[int64]
+	CreationTime                                    plugin.TValue[*time.Time]
 	SystemMetadata                                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -79314,6 +79480,10 @@ func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetCreat
 
 func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetDefaultKeyValueRevisionRetentionPeriodInSeconds() *plugin.TValue[int64] {
 	return &c.DefaultKeyValueRevisionRetentionPeriodInSeconds
+}
+
+func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -79423,6 +79593,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccount struct {
 	Endpoint                      plugin.TValue[string]
 	ProvisioningState             plugin.TValue[string]
 	StoredCompletionsDisabled     plugin.TValue[bool]
+	CreationTime                  plugin.TValue[*time.Time]
 	DefenderForAIEnabled          plugin.TValue[bool]
 	RaiPolicies                   plugin.TValue[[]any]
 	RaiTopics                     plugin.TValue[[]any]
@@ -79547,6 +79718,10 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetProvisioningSta
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetStoredCompletionsDisabled() *plugin.TValue[bool] {
 	return &c.StoredCompletionsDisabled
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetDefenderForAIEnabled() *plugin.TValue[bool] {
@@ -80439,6 +80614,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic struct {
 	FailedReason   plugin.TValue[string]
 	SampleBlobUrl  plugin.TValue[string]
 	CreatedAt      plugin.TValue[*time.Time]
+	CreationTime   plugin.TValue[*time.Time]
 	LastModifiedAt plugin.TValue[*time.Time]
 	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
@@ -80514,6 +80690,10 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetSampleB
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetLastModifiedAt() *plugin.TValue[*time.Time] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -209,6 +209,7 @@ azure.subscription.appConfigurationService.configurationStore 13.11.3
 azure.subscription.appConfigurationService.configurationStore.cmkIdentityClientId 13.11.3
 azure.subscription.appConfigurationService.configurationStore.cmkKeyIdentifier 13.11.3
 azure.subscription.appConfigurationService.configurationStore.createMode 13.11.3
+azure.subscription.appConfigurationService.configurationStore.creationTime 13.22.1
 azure.subscription.appConfigurationService.configurationStore.defaultKeyValueRevisionRetentionPeriodInSeconds 13.12.2
 azure.subscription.appConfigurationService.configurationStore.disableLocalAuth 13.11.3
 azure.subscription.appConfigurationService.configurationStore.enablePurgeProtection 13.11.3
@@ -344,6 +345,7 @@ azure.subscription.batchService.account.name 11.4.0
 azure.subscription.batchService.account.networkProfile 11.4.0
 azure.subscription.batchService.account.nodeManagementEndpoint 11.4.0
 azure.subscription.batchService.account.pool 11.4.0
+azure.subscription.batchService.account.pool.creationTime 13.22.1
 azure.subscription.batchService.account.pool.deploymentConfiguration 11.4.0
 azure.subscription.batchService.account.pool.diskCustomerManagedKeyEnabled 13.1.8
 azure.subscription.batchService.account.pool.diskEncryptionTargets 13.1.8
@@ -449,6 +451,7 @@ azure.subscription.cloudDefenderService.assessment.assessmentType 13.14.1
 azure.subscription.cloudDefenderService.assessment.categories 13.14.1
 azure.subscription.cloudDefenderService.assessment.description 13.14.1
 azure.subscription.cloudDefenderService.assessment.displayName 13.11.3
+azure.subscription.cloudDefenderService.assessment.firstEvaluationDate 13.22.1
 azure.subscription.cloudDefenderService.assessment.id 13.11.3
 azure.subscription.cloudDefenderService.assessment.implementationEffort 13.14.1
 azure.subscription.cloudDefenderService.assessment.name 13.11.3
@@ -463,6 +466,7 @@ azure.subscription.cloudDefenderService.assessment.riskLevel 13.14.1
 azure.subscription.cloudDefenderService.assessment.severity 13.11.3
 azure.subscription.cloudDefenderService.assessment.status 13.11.3
 azure.subscription.cloudDefenderService.assessment.statusCause 13.11.3
+azure.subscription.cloudDefenderService.assessment.statusChangeDate 13.22.1
 azure.subscription.cloudDefenderService.assessment.statusDescription 13.11.3
 azure.subscription.cloudDefenderService.assessment.tactics 13.14.1
 azure.subscription.cloudDefenderService.assessment.techniques 13.14.1
@@ -733,6 +737,7 @@ azure.subscription.cognitiveServicesService.account.connection.systemMetadata 13
 azure.subscription.cognitiveServicesService.account.connection.target 13.15.2
 azure.subscription.cognitiveServicesService.account.connection.useWorkspaceManagedIdentity 13.15.2
 azure.subscription.cognitiveServicesService.account.connections 13.15.2
+azure.subscription.cognitiveServicesService.account.creationTime 13.22.1
 azure.subscription.cognitiveServicesService.account.customSubDomainName 13.11.3
 azure.subscription.cognitiveServicesService.account.defenderForAIEnabled 13.12.2
 azure.subscription.cognitiveServicesService.account.deployment 13.15.2
@@ -820,6 +825,7 @@ azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.topic 13.
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.topicName 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.createdAt 13.12.2
+azure.subscription.cognitiveServicesService.account.raiTopic.creationTime 13.22.1
 azure.subscription.cognitiveServicesService.account.raiTopic.description 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.failedReason 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.id 13.12.2
@@ -1775,6 +1781,7 @@ azure.subscription.databricks 11.4.28
 azure.subscription.databricksService 11.4.25
 azure.subscription.databricksService.subscriptionId 11.4.25
 azure.subscription.databricksService.workspace 11.4.25
+azure.subscription.databricksService.workspace.creationTime 13.22.1
 azure.subscription.databricksService.workspace.customVirtualNetworkId 13.5.1
 azure.subscription.databricksService.workspace.diskEncryptionSetId 13.5.1
 azure.subscription.databricksService.workspace.enableNoPublicIp 13.5.1
@@ -1940,14 +1947,17 @@ azure.subscription.eventHubService 13.3.3
 azure.subscription.eventHubService.namespace 13.3.3
 azure.subscription.eventHubService.namespace.cmkKeySource 13.5.1
 azure.subscription.eventHubService.namespace.cmkKeys 13.5.1
+azure.subscription.eventHubService.namespace.creationTime 13.22.1
 azure.subscription.eventHubService.namespace.disableLocalAuth 13.3.3
 azure.subscription.eventHubService.namespace.eventHub 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup 13.3.3
+azure.subscription.eventHubService.namespace.eventHub.consumerGroup.creationTime 13.22.1
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.id 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.name 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata 13.22.1
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.userMetadata 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroups 13.3.3
+azure.subscription.eventHubService.namespace.eventHub.creationTime 13.22.1
 azure.subscription.eventHubService.namespace.eventHub.id 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.messageRetentionInDays 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.name 13.3.3
@@ -2560,6 +2570,7 @@ azure.subscription.monitorService.activityLog.entry.status 13.19.2
 azure.subscription.monitorService.activityLog.entry.subStatus 13.19.2
 azure.subscription.monitorService.activityLog.subscriptionId 9.0.1
 azure.subscription.monitorService.applicationInsight 9.0.1
+azure.subscription.monitorService.applicationInsight.creationTime 13.22.1
 azure.subscription.monitorService.applicationInsight.disableIpMasking 11.6.1
 azure.subscription.monitorService.applicationInsight.id 9.0.1
 azure.subscription.monitorService.applicationInsight.kind 9.0.1
@@ -3898,6 +3909,7 @@ azure.subscription.serviceBusService 13.3.3
 azure.subscription.serviceBusService.namespace 13.3.3
 azure.subscription.serviceBusService.namespace.cmkKeySource 13.5.1
 azure.subscription.serviceBusService.namespace.cmkKeys 13.5.1
+azure.subscription.serviceBusService.namespace.creationTime 13.22.1
 azure.subscription.serviceBusService.namespace.disableLocalAuth 13.3.3
 azure.subscription.serviceBusService.namespace.id 13.3.3
 azure.subscription.serviceBusService.namespace.location 13.3.3
@@ -3914,6 +3926,7 @@ azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRule.s
 azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRules 13.12.2
 azure.subscription.serviceBusService.namespace.provisioningState 13.5.1
 azure.subscription.serviceBusService.namespace.queue 13.3.3
+azure.subscription.serviceBusService.namespace.queue.creationTime 13.22.1
 azure.subscription.serviceBusService.namespace.queue.deadLetterMessageCount 13.3.3
 azure.subscription.serviceBusService.namespace.queue.defaultMessageTimeToLive 13.3.3
 azure.subscription.serviceBusService.namespace.queue.enablePartitioning 13.3.3
@@ -3935,6 +3948,7 @@ azure.subscription.serviceBusService.namespace.status 13.3.3
 azure.subscription.serviceBusService.namespace.systemMetadata 13.22.1
 azure.subscription.serviceBusService.namespace.tags 13.3.3
 azure.subscription.serviceBusService.namespace.topic 13.3.3
+azure.subscription.serviceBusService.namespace.topic.creationTime 13.22.1
 azure.subscription.serviceBusService.namespace.topic.defaultMessageTimeToLive 13.3.3
 azure.subscription.serviceBusService.namespace.topic.enablePartitioning 13.3.3
 azure.subscription.serviceBusService.namespace.topic.id 13.3.3
@@ -3943,6 +3957,7 @@ azure.subscription.serviceBusService.namespace.topic.name 13.3.3
 azure.subscription.serviceBusService.namespace.topic.requiresDuplicateDetection 13.3.3
 azure.subscription.serviceBusService.namespace.topic.status 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscription 13.3.3
+azure.subscription.serviceBusService.namespace.topic.subscription.creationTime 13.22.1
 azure.subscription.serviceBusService.namespace.topic.subscription.deadLetterMessageCount 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscription.defaultMessageTimeToLive 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscription.id 13.3.3

--- a/providers/azure/resources/batch.go
+++ b/providers/azure/resources/batch.go
@@ -396,9 +396,13 @@ func createBatchPoolRawData(pool *armbatch.Pool) (map[string]*llx.RawData, error
 		hostEndpointProtectionMode      = llx.NilData
 		proxyAgentEnabled               = llx.NilData
 		securityEncryptionType          = llx.NilData
+		creationTimeData                = llx.NilData
 	)
 
 	if pool.Properties != nil {
+		if pool.Properties.CreationTime != nil {
+			creationTimeData = llx.TimeDataPtr(pool.Properties.CreationTime)
+		}
 		if dict, err := convert.JsonToDict(pool.Properties); err != nil {
 			return nil, err
 		} else if dict != nil {
@@ -487,6 +491,7 @@ func createBatchPoolRawData(pool *armbatch.Pool) (map[string]*llx.RawData, error
 		"hostEndpointProtectionMode":    hostEndpointProtectionMode,
 		"proxyAgentEnabled":             proxyAgentEnabled,
 		"securityEncryptionType":        securityEncryptionType,
+		"creationTime":                  creationTimeData,
 	}, nil
 }
 

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -1432,6 +1432,7 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 		}
 		for _, item := range page.Value {
 			var displayName, status, statusCause, statusDescription string
+			var firstEvaluationDate, statusChangeDate *time.Time
 			additionalData := map[string]any{}
 
 			var riskLevel string
@@ -1454,6 +1455,8 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 					if props.Status.Description != nil {
 						statusDescription = *props.Status.Description
 					}
+					firstEvaluationDate = props.Status.FirstEvaluationDate
+					statusChangeDate = props.Status.StatusChangeDate
 				}
 				for k, v := range props.AdditionalData {
 					if v != nil {
@@ -1493,6 +1496,8 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 					"status":                   llx.StringData(status),
 					"statusCause":              llx.StringData(statusCause),
 					"statusDescription":        llx.StringData(statusDescription),
+					"firstEvaluationDate":      llx.TimeDataPtr(firstEvaluationDate),
+					"statusChangeDate":         llx.TimeDataPtr(statusChangeDate),
 					"severity":                 llx.StringData(meta.severity),
 					"resourceId":               llx.StringData(resourceId),
 					"additionalData":           llx.DictData(additionalData),

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -99,9 +99,12 @@ func cognitiveServicesAccountToMql(runtime *plugin.Runtime, account *armcognitiv
 	var endpoint, provisioningState string
 	var disableLocalAuth, restrictOutboundNetworkAccess, storedCompletionsDisabled bool
 	var networkAclsDefaultAction, networkAclsBypass string
+	var creationTime *time.Time
 	networkAcls := llx.NilData
 
 	if p := account.Properties; p != nil {
+		// DateCreated arrives as an ISO 8601 string; parse it to a timestamp.
+		creationTime = parseAzureTimestamp(p.DateCreated)
 		if p.PublicNetworkAccess != nil {
 			publicNetworkAccess = string(*p.PublicNetworkAccess)
 		}
@@ -172,6 +175,7 @@ func cognitiveServicesAccountToMql(runtime *plugin.Runtime, account *armcognitiv
 		"endpoint":                      llx.StringData(endpoint),
 		"provisioningState":             llx.StringData(provisioningState),
 		"storedCompletionsDisabled":     llx.BoolData(storedCompletionsDisabled),
+		"creationTime":                  llx.TimeDataPtr(creationTime),
 	})
 	if err != nil {
 		return nil, err
@@ -776,6 +780,7 @@ func raiTopicToMql(runtime *plugin.Runtime, t *armcognitiveservices.RaiTopic) (*
 		"failedReason":   llx.StringData(failedReason),
 		"sampleBlobUrl":  llx.StringData(sampleBlobUrl),
 		"createdAt":      llx.TimeDataPtr(createdAt),
+		"creationTime":   llx.TimeDataPtr(createdAt),
 		"lastModifiedAt": llx.TimeDataPtr(lastModifiedAt),
 	})
 	if err != nil {

--- a/providers/azure/resources/databricks.go
+++ b/providers/azure/resources/databricks.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks"
@@ -100,8 +101,10 @@ func databricksWorkspaceToMql(runtime *plugin.Runtime, workspace *armdatabricks.
 	var customVnetId string
 	var managedDiskKeySource, managedDiskKeyVaultUri, managedDiskKeyName, managedDiskKeyVersion string
 	var managedServicesKeySource, managedServicesKeyVaultUri, managedServicesKeyName, managedServicesKeyVersion string
+	var creationTime *time.Time
 
 	if props := workspace.Properties; props != nil {
+		creationTime = props.CreatedDateTime
 		if props.PublicNetworkAccess != nil {
 			publicNetworkAccess = string(*props.PublicNetworkAccess)
 		}
@@ -210,6 +213,7 @@ func databricksWorkspaceToMql(runtime *plugin.Runtime, workspace *armdatabricks.
 		"managedServicesKeyVaultUri":      llx.StringData(managedServicesKeyVaultUri),
 		"managedServicesKeyName":          llx.StringData(managedServicesKeyName),
 		"managedServicesKeyVersion":       llx.StringData(managedServicesKeyVersion),
+		"creationTime":                    llx.TimeDataPtr(creationTime),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
@@ -103,7 +104,9 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 			var maximumThroughputUnits int64
 			var minimumTlsVersion, publicNetworkAccess string
 			var cmkKeys []any
+			var creationTime *time.Time
 			if ns.Properties != nil {
+				creationTime = ns.Properties.CreatedAt
 				if ns.Properties.Status != nil {
 					status = *ns.Properties.Status
 				}
@@ -161,6 +164,7 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 				"cmkKeySource":                    llx.StringData(cmkKeySource),
 				"requireInfrastructureEncryption": llx.BoolDataPtr(requireInfraEnc),
 				"cmkKeys":                         llx.ArrayData(cmkKeys, types.Dict),
+				"creationTime":                    llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err
@@ -213,7 +217,9 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespace) eventHubs() ([]any, error
 			var partitionCount, messageRetentionInDays int64
 			var status string
 			var partitionIds []any
+			var creationTime *time.Time
 			if eh.Properties != nil {
+				creationTime = eh.Properties.CreatedAt
 				if eh.Properties.PartitionCount != nil {
 					partitionCount = *eh.Properties.PartitionCount
 				}
@@ -239,6 +245,7 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespace) eventHubs() ([]any, error
 				"messageRetentionInDays": llx.IntData(messageRetentionInDays),
 				"status":                 llx.StringData(status),
 				"partitionIds":           llx.ArrayData(partitionIds, types.String),
+				"creationTime":           llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err
@@ -294,14 +301,19 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 			}
 
 			var userMetadata string
-			if cg.Properties != nil && cg.Properties.UserMetadata != nil {
-				userMetadata = *cg.Properties.UserMetadata
+			var creationTime *time.Time
+			if cg.Properties != nil {
+				creationTime = cg.Properties.CreatedAt
+				if cg.Properties.UserMetadata != nil {
+					userMetadata = *cg.Properties.UserMetadata
+				}
 			}
 
 			mqlCg, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup", map[string]*llx.RawData{
 				"id":           llx.StringDataPtr(cg.ID),
 				"name":         llx.StringDataPtr(cg.Name),
 				"userMetadata": llx.StringData(userMetadata),
+				"creationTime": llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -184,7 +184,9 @@ func createApplicationInsightResource(runtime *plugin.Runtime, entry *appinsight
 	var publicNetworkAccessForIngestion, publicNetworkAccessForQuery string
 	var retentionInDays int64
 	var workspaceResourceId string
+	var creationTime *time.Time
 	if entry.Properties != nil {
+		creationTime = entry.Properties.CreationDate
 		if entry.Properties.DisableIPMasking != nil {
 			disableIpMasking = *entry.Properties.DisableIPMasking
 		}
@@ -216,6 +218,7 @@ func createApplicationInsightResource(runtime *plugin.Runtime, entry *appinsight
 			"publicNetworkAccessForQuery":     llx.StringData(publicNetworkAccessForQuery),
 			"retentionInDays":                 llx.IntData(retentionInDays),
 			"workspaceResourceId":             llx.StringData(workspaceResourceId),
+			"creationTime":                    llx.TimeDataPtr(creationTime),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/servicebus.go
+++ b/providers/azure/resources/servicebus.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus"
@@ -121,7 +122,9 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 			var disableLocalAuth, zoneRedundant bool
 			var requireInfraEnc *bool
 			var cmkKeys []any
+			var creationTime *time.Time
 			if ns.Properties != nil {
+				creationTime = ns.Properties.CreatedAt
 				if ns.Properties.Status != nil {
 					status = *ns.Properties.Status
 				}
@@ -167,6 +170,7 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 				"cmkKeySource":                    llx.StringData(cmkKeySource),
 				"requireInfrastructureEncryption": llx.BoolDataPtr(requireInfraEnc),
 				"cmkKeys":                         llx.ArrayData(cmkKeys, types.Dict),
+				"creationTime":                    llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err
@@ -221,7 +225,9 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) queues() ([]any, error)
 			var messageCount, deadLetterMessageCount int64
 			var lockDuration, defaultMessageTimeToLive string
 			var requiresDuplicateDetection, requiresSession, enablePartitioning bool
+			var creationTime *time.Time
 			if q.Properties != nil {
+				creationTime = q.Properties.CreatedAt
 				if q.Properties.Status != nil {
 					status = string(*q.Properties.Status)
 				}
@@ -267,6 +273,7 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) queues() ([]any, error)
 				"requiresDuplicateDetection": llx.BoolData(requiresDuplicateDetection),
 				"requiresSession":            llx.BoolData(requiresSession),
 				"enablePartitioning":         llx.BoolData(enablePartitioning),
+				"creationTime":               llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err
@@ -321,7 +328,9 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) topics() ([]any, error)
 			var subscriptionCount int64
 			var enablePartitioning, supportOrdering, requiresDuplicateDetection bool
 			var defaultMessageTimeToLive string
+			var creationTime *time.Time
 			if t.Properties != nil {
+				creationTime = t.Properties.CreatedAt
 				if t.Properties.Status != nil {
 					status = string(*t.Properties.Status)
 				}
@@ -355,6 +364,7 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) topics() ([]any, error)
 				"supportOrdering":            llx.BoolData(supportOrdering),
 				"requiresDuplicateDetection": llx.BoolData(requiresDuplicateDetection),
 				"defaultMessageTimeToLive":   llx.StringData(defaultMessageTimeToLive),
+				"creationTime":               llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err
@@ -414,7 +424,9 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) subscriptions() ([
 			var maxDeliveryCount int64
 			var lockDuration, defaultMessageTimeToLive string
 			var requiresSession bool
+			var creationTime *time.Time
 			if sub.Properties != nil {
+				creationTime = sub.Properties.CreatedAt
 				if sub.Properties.Status != nil {
 					status = string(*sub.Properties.Status)
 				}
@@ -448,6 +460,7 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) subscriptions() ([
 				"lockDuration":             llx.StringData(lockDuration),
 				"defaultMessageTimeToLive": llx.StringData(defaultMessageTimeToLive),
 				"requiresSession":          llx.BoolData(requiresSession),
+				"creationTime":             llx.TimeDataPtr(creationTime),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -5,10 +5,26 @@ package resources
 
 import (
 	"strings"
+	"time"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 )
+
+// parseAzureTimestamp parses an RFC 3339 timestamp string into a *time.Time,
+// returning nil when the input is nil, empty, or not valid RFC 3339. Some Azure
+// SDK models expose creation timestamps as strings rather than typed time
+// values (e.g. the Cognitive Services account DateCreated field).
+func parseAzureTimestamp(s *string) *time.Time {
+	if s == nil || *s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, *s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
 
 type assetIdentifier struct {
 	name string

--- a/providers/azure/resources/shared_test.go
+++ b/providers/azure/resources/shared_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseAzureTimestamp(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	t.Run("nil input", func(t *testing.T) {
+		if got := parseAzureTimestamp(nil); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		if got := parseAzureTimestamp(str("")); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("invalid string", func(t *testing.T) {
+		if got := parseAzureTimestamp(str("not-a-timestamp")); got != nil {
+			t.Fatalf("expected nil for unparseable input, got %v", got)
+		}
+	})
+
+	t.Run("valid RFC 3339", func(t *testing.T) {
+		got := parseAzureTimestamp(str("2023-04-05T12:34:56Z"))
+		if got == nil {
+			t.Fatal("expected a parsed timestamp, got nil")
+		}
+		want := time.Date(2023, 4, 5, 12, 34, 56, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("expected %v, got %v", want, *got)
+		}
+	})
+
+	t.Run("valid RFC 3339 with offset", func(t *testing.T) {
+		got := parseAzureTimestamp(str("2023-04-05T12:34:56+02:00"))
+		if got == nil {
+			t.Fatal("expected a parsed timestamp, got nil")
+		}
+		want := time.Date(2023, 4, 5, 10, 34, 56, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("expected %v (UTC), got %v", want, got.UTC())
+		}
+	})
+}


### PR DESCRIPTION
## What

Surfaces dedicated **creation-time** fields that the Azure SDK already returns but mql did not yet model. Each is a real "when was this created" value, available no other way (not derivable from existing fields).

New generic creation-timestamp fields all use **`creationTime`** — the most-used creation-timestamp field name already in the azure provider (10 existing fields, vs `timeCreated` 9 / `creationDate` 8 / `createdAt` 7):

| Resource | New field |
|---|---|
| `appConfigurationService.configurationStore` | `creationTime` |
| `eventHubService.namespace` | `creationTime` |
| `eventHubService.namespace.eventHub` | `creationTime` |
| `eventHubService.namespace.eventHub.consumerGroup` | `creationTime` |
| `serviceBusService.namespace` | `creationTime` |
| `serviceBusService.namespace.queue` | `creationTime` |
| `serviceBusService.namespace.topic` | `creationTime` |
| `serviceBusService.namespace.topic.subscription` | `creationTime` |
| `databricksService.workspace` | `creationTime` |
| `monitorService.applicationInsight` | `creationTime` |
| `cognitiveServicesService.account` | `creationTime` |
| `batchService.account.pool` | `creationTime` |
| `cloudDefenderService.assessment` | `firstEvaluationDate`, `statusChangeDate` |

## Notes

- All values come straight from the corresponding SDK `*Properties` structs; most are `*time.Time` passthroughs.
- **Cognitive Services**: the SDK exposes its creation time as an ISO 8601 **string** (`DateCreated`), not a typed time. It is parsed into a typed `time` value via a new shared `parseAzureTimestamp` helper (with unit tests) so the field is a proper timestamp.
- **Batch pool `creationTime`** was previously only reachable through the untyped `properties` dict; it is now a first-class typed field.
- **Defender assessment** keeps `firstEvaluationDate` / `statusChangeDate` — these are assessment-lifecycle timestamps (first-evaluated / status-changed), not a generic resource-creation time.
- `.lr.versions` entries assigned `13.22.1` (next patch after the current `13.22.0`).
- `azure.permissions.json` diff is header-only (version/timestamp regeneration); no permission changes.

## Test

- `go test ./resources/ -run TestParseAzureTimestamp` passes.
- `make providers/build/azure` succeeds (codegen + version assignment + compile).