### PR TITLE
⭐ oci: expose creation timestamps on vulnerability scanning resources

### DIFF
--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -3047,6 +3047,8 @@ private oci.vulnerabilityScanning.hostScanRecipe @defaults("name compartmentId p
   scheduleType string
   // Day of week for weekly schedules (MONDAY..SUNDAY)
   scheduleDayOfWeek string
+  // When the recipe was created
+  created time
   // Free-form tags on the recipe
   freeformTags map[string]string
 }
@@ -3081,6 +3083,8 @@ private oci.vulnerabilityScanning.hostScanTarget @defaults("name compartmentId s
   instances() []oci.compute.instance
   // Lifecycle state (CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
+  // When the target was created
+  created time
   // Free-form tags on the target
   freeformTags map[string]string
 }
@@ -3105,6 +3109,8 @@ private oci.vulnerabilityScanning.containerScanRecipe @defaults("name compartmen
   scanLevel string
   // Number of images covered by recipes referencing this scan recipe
   imageCount int
+  // When the recipe was created
+  created time
   // Free-form tags on the recipe
   freeformTags map[string]string
 }
@@ -3138,6 +3144,8 @@ private oci.vulnerabilityScanning.containerScanTarget @defaults("name compartmen
   registryRepositories []string
   // Lifecycle state
   state string
+  // When the target was created
+  created time
   // Free-form tags on the target
   freeformTags map[string]string
 }

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -4118,6 +4118,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.vulnerabilityScanning.hostScanRecipe.scheduleDayOfWeek": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningHostScanRecipe).GetScheduleDayOfWeek()).ToDataRes(types.String)
 	},
+	"oci.vulnerabilityScanning.hostScanRecipe.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVulnerabilityScanningHostScanRecipe).GetCreated()).ToDataRes(types.Time)
+	},
 	"oci.vulnerabilityScanning.hostScanRecipe.freeformTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningHostScanRecipe).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -4157,6 +4160,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.vulnerabilityScanning.hostScanTarget.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningHostScanTarget).GetState()).ToDataRes(types.String)
 	},
+	"oci.vulnerabilityScanning.hostScanTarget.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVulnerabilityScanningHostScanTarget).GetCreated()).ToDataRes(types.Time)
+	},
 	"oci.vulnerabilityScanning.hostScanTarget.freeformTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningHostScanTarget).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -4180,6 +4186,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.vulnerabilityScanning.containerScanRecipe.imageCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningContainerScanRecipe).GetImageCount()).ToDataRes(types.Int)
+	},
+	"oci.vulnerabilityScanning.containerScanRecipe.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVulnerabilityScanningContainerScanRecipe).GetCreated()).ToDataRes(types.Time)
 	},
 	"oci.vulnerabilityScanning.containerScanRecipe.freeformTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningContainerScanRecipe).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
@@ -4216,6 +4225,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.vulnerabilityScanning.containerScanTarget.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningContainerScanTarget).GetState()).ToDataRes(types.String)
+	},
+	"oci.vulnerabilityScanning.containerScanTarget.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVulnerabilityScanningContainerScanTarget).GetCreated()).ToDataRes(types.Time)
 	},
 	"oci.vulnerabilityScanning.containerScanTarget.freeformTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVulnerabilityScanningContainerScanTarget).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
@@ -10366,6 +10378,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciVulnerabilityScanningHostScanRecipe).ScheduleDayOfWeek, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.vulnerabilityScanning.hostScanRecipe.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVulnerabilityScanningHostScanRecipe).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"oci.vulnerabilityScanning.hostScanRecipe.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVulnerabilityScanningHostScanRecipe).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -10422,6 +10438,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciVulnerabilityScanningHostScanTarget).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.vulnerabilityScanning.hostScanTarget.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVulnerabilityScanningHostScanTarget).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"oci.vulnerabilityScanning.hostScanTarget.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVulnerabilityScanningHostScanTarget).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -10456,6 +10476,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.vulnerabilityScanning.containerScanRecipe.imageCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVulnerabilityScanningContainerScanRecipe).ImageCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"oci.vulnerabilityScanning.containerScanRecipe.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVulnerabilityScanningContainerScanRecipe).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"oci.vulnerabilityScanning.containerScanRecipe.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10508,6 +10532,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.vulnerabilityScanning.containerScanTarget.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVulnerabilityScanningContainerScanTarget).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.vulnerabilityScanning.containerScanTarget.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVulnerabilityScanningContainerScanTarget).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"oci.vulnerabilityScanning.containerScanTarget.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24935,6 +24963,7 @@ type mqlOciVulnerabilityScanningHostScanRecipe struct {
 	ApplicationFoldersToScan    plugin.TValue[[]any]
 	ScheduleType                plugin.TValue[string]
 	ScheduleDayOfWeek           plugin.TValue[string]
+	Created                     plugin.TValue[*time.Time]
 	FreeformTags                plugin.TValue[map[string]any]
 }
 
@@ -25043,6 +25072,10 @@ func (c *mqlOciVulnerabilityScanningHostScanRecipe) GetScheduleDayOfWeek() *plug
 	return &c.ScheduleDayOfWeek
 }
 
+func (c *mqlOciVulnerabilityScanningHostScanRecipe) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
 func (c *mqlOciVulnerabilityScanningHostScanRecipe) GetFreeformTags() *plugin.TValue[map[string]any] {
 	return &c.FreeformTags
 }
@@ -25064,6 +25097,7 @@ type mqlOciVulnerabilityScanningHostScanTarget struct {
 	InstanceIds         plugin.TValue[[]any]
 	Instances           plugin.TValue[[]any]
 	State               plugin.TValue[string]
+	Created             plugin.TValue[*time.Time]
 	FreeformTags        plugin.TValue[map[string]any]
 }
 
@@ -25200,6 +25234,10 @@ func (c *mqlOciVulnerabilityScanningHostScanTarget) GetState() *plugin.TValue[st
 	return &c.State
 }
 
+func (c *mqlOciVulnerabilityScanningHostScanTarget) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
 func (c *mqlOciVulnerabilityScanningHostScanTarget) GetFreeformTags() *plugin.TValue[map[string]any] {
 	return &c.FreeformTags
 }
@@ -25216,6 +25254,7 @@ type mqlOciVulnerabilityScanningContainerScanRecipe struct {
 	State         plugin.TValue[string]
 	ScanLevel     plugin.TValue[string]
 	ImageCount    plugin.TValue[int64]
+	Created       plugin.TValue[*time.Time]
 	FreeformTags  plugin.TValue[map[string]any]
 }
 
@@ -25296,6 +25335,10 @@ func (c *mqlOciVulnerabilityScanningContainerScanRecipe) GetImageCount() *plugin
 	return &c.ImageCount
 }
 
+func (c *mqlOciVulnerabilityScanningContainerScanRecipe) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
 func (c *mqlOciVulnerabilityScanningContainerScanRecipe) GetFreeformTags() *plugin.TValue[map[string]any] {
 	return &c.FreeformTags
 }
@@ -25316,6 +25359,7 @@ type mqlOciVulnerabilityScanningContainerScanTarget struct {
 	RegistryUrl           plugin.TValue[string]
 	RegistryRepositories  plugin.TValue[[]any]
 	State                 plugin.TValue[string]
+	Created               plugin.TValue[*time.Time]
 	FreeformTags          plugin.TValue[map[string]any]
 }
 
@@ -25422,6 +25466,10 @@ func (c *mqlOciVulnerabilityScanningContainerScanTarget) GetRegistryRepositories
 
 func (c *mqlOciVulnerabilityScanningContainerScanTarget) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlOciVulnerabilityScanningContainerScanTarget) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
 }
 
 func (c *mqlOciVulnerabilityScanningContainerScanTarget) GetFreeformTags() *plugin.TValue[map[string]any] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -1533,6 +1533,7 @@ oci.vulnerabilityScanning 13.7.1
 oci.vulnerabilityScanning.containerScanRecipe 13.7.1
 oci.vulnerabilityScanning.containerScanRecipe.compartment 13.7.1
 oci.vulnerabilityScanning.containerScanRecipe.compartmentId 13.7.1
+oci.vulnerabilityScanning.containerScanRecipe.created 13.12.2
 oci.vulnerabilityScanning.containerScanRecipe.freeformTags 13.7.1
 oci.vulnerabilityScanning.containerScanRecipe.id 13.7.1
 oci.vulnerabilityScanning.containerScanRecipe.imageCount 13.7.1
@@ -1566,6 +1567,7 @@ oci.vulnerabilityScanning.containerScanTarget 13.7.1
 oci.vulnerabilityScanning.containerScanTarget.compartment 13.7.1
 oci.vulnerabilityScanning.containerScanTarget.compartmentId 13.7.1
 oci.vulnerabilityScanning.containerScanTarget.containerScanRecipeId 13.7.1
+oci.vulnerabilityScanning.containerScanTarget.created 13.12.2
 oci.vulnerabilityScanning.containerScanTarget.description 13.7.1
 oci.vulnerabilityScanning.containerScanTarget.freeformTags 13.7.1
 oci.vulnerabilityScanning.containerScanTarget.id 13.7.1
@@ -1651,6 +1653,7 @@ oci.vulnerabilityScanning.hostScanRecipe.applicationScanRecurrence 13.7.1
 oci.vulnerabilityScanning.hostScanRecipe.cisBenchmarkScanLevel 13.7.1
 oci.vulnerabilityScanning.hostScanRecipe.compartment 13.7.1
 oci.vulnerabilityScanning.hostScanRecipe.compartmentId 13.7.1
+oci.vulnerabilityScanning.hostScanRecipe.created 13.12.2
 oci.vulnerabilityScanning.hostScanRecipe.endpointProtectionScanLevel 13.7.1
 oci.vulnerabilityScanning.hostScanRecipe.freeformTags 13.7.1
 oci.vulnerabilityScanning.hostScanRecipe.id 13.7.1
@@ -1663,6 +1666,7 @@ oci.vulnerabilityScanning.hostScanRecipes 13.7.1
 oci.vulnerabilityScanning.hostScanTarget 13.7.1
 oci.vulnerabilityScanning.hostScanTarget.compartment 13.7.1
 oci.vulnerabilityScanning.hostScanTarget.compartmentId 13.7.1
+oci.vulnerabilityScanning.hostScanTarget.created 13.12.2
 oci.vulnerabilityScanning.hostScanTarget.description 13.7.1
 oci.vulnerabilityScanning.hostScanTarget.freeformTags 13.7.1
 oci.vulnerabilityScanning.hostScanTarget.hostScanRecipeId 13.7.1

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -206,6 +206,7 @@ func newHostScanRecipe(runtime *plugin.Runtime, r vulnerabilityscanning.HostScan
 		"applicationFoldersToScan":    llx.ArrayData(v.applicationFoldersToScan, types.Dict),
 		"scheduleType":                llx.StringData(v.scheduleType),
 		"scheduleDayOfWeek":           llx.StringData(v.scheduleDayOfWeek),
+		"created":                     sdkTimeData(r.TimeCreated),
 		"freeformTags":                llx.MapData(strMapToAny(r.FreeformTags), types.String),
 	})
 }
@@ -305,6 +306,7 @@ func (o *mqlOciVulnerabilityScanning) fetchHostScanTargets(conn *connection.OciC
 					"hostScanRecipeId":    llx.StringDataPtr(sum.HostScanRecipeId),
 					"instanceIds":         llx.ArrayData(stringsToAny(sum.InstanceIds), types.String),
 					"state":               llx.StringData(string(sum.LifecycleState)),
+					"created":             sdkTimeData(sum.TimeCreated),
 					"freeformTags":        llx.MapData(strMapToAny(sum.FreeformTags), types.String),
 				})
 				if err != nil {
@@ -428,6 +430,7 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanRecipes(conn *connection
 					"state":         llx.StringData(string(recipe.LifecycleState)),
 					"scanLevel":     llx.StringData(scanLevel),
 					"imageCount":    llx.IntData(intValue(recipe.ImageCount)),
+					"created":       sdkTimeData(recipe.TimeCreated),
 					"freeformTags":  llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
 				})
 				if err != nil {
@@ -541,6 +544,7 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanTargets(conn *connection
 					"registryUrl":           llx.StringData(registryView.url),
 					"registryRepositories":  llx.ArrayData(registryView.repositories, types.String),
 					"state":                 llx.StringData(string(sum.LifecycleState)),
+					"created":               sdkTimeData(sum.TimeCreated),
 					"freeformTags":          llx.MapData(strMapToAny(sum.FreeformTags), types.String),
 				})
 				if err != nil {


### PR DESCRIPTION
## What

Surfaces the OCI SDK's `TimeCreated` on the four Vulnerability Scanning (VSS) recipe/target resources that did not yet expose it. Mirrors the recent Azure creation-timestamp effort.

A thorough survey across every OCI service file (identity, compute, network, database, object storage, load balancer, certificates, KMS/vault/secrets, Data Safe, Cloud Guard, AI services, Data Science, GenAI, API Gateway, OKE, Functions, WAF, Network Firewall, containerinstances, redis, ONS, events, bastion, file storage, logging, monitoring) found that the provider **already** maps `created` everywhere the SDK exposes a creation time. These four VSS resources were the only gaps.

## New fields

| Resource | New field | SDK source | Notes |
|---|---|---|---|
| `oci.vulnerabilityScanning.hostScanRecipe` | `created time` | `HostScanRecipe.TimeCreated` | `*common.SDKTime` |
| `oci.vulnerabilityScanning.hostScanTarget` | `created time` | `HostScanTargetSummary.TimeCreated` | `*common.SDKTime` |
| `oci.vulnerabilityScanning.containerScanRecipe` | `created time` | `ContainerScanRecipe.TimeCreated` | `*common.SDKTime` |
| `oci.vulnerabilityScanning.containerScanTarget` | `created time` | `ContainerScanTargetSummary.TimeCreated` | `*common.SDKTime` |

All mapped via the existing `sdkTimeData()` helper (nil-safe). `.lr.versions` entries auto-assigned at `13.12.2`.

## Intentionally skipped

- **`oci.monitoring.alarm`** — the list `AlarmSummary` has no creation time; only the detail `Alarm` struct does, and the resource is built from the summary without a detail fetch. Exposing it would require an added per-alarm Get call, out of scope for this change.
- **VSS scan-result resources, DB backups, OKE node pools, load balancer listeners/backend sets** — their mapped SDK structs genuinely have no creation-time field (only started/finished/updated/expiry times, which are not creation timestamps).