### PR TITLE
⭐ aws: expose creation timestamps on more resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1564,6 +1564,8 @@ private aws.fsx.cache @defaults("id lifecycle") {
   arn string
   // Lifecycle status
   lifecycle string
+  // When the cache was created
+  createdAt time
   // Storage capacity in TiB
   storageCapacity int
   // VPC ID where the cache resides
@@ -7102,6 +7104,8 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   connectivity dict
   // Last reported status for the ECS task
   lastStatus string
+  // When the ECS task was created
+  createdAt time
   // Platform Family assigned to the ECS task
   platformFamily string
   // Platform Version assigned to the ECS task
@@ -7645,6 +7649,8 @@ private aws.emr.cluster @defaults("arn") {
   outpostArn string
   // Details about the current status of the cluster
   status dict
+  // When the cluster was created
+  createdAt time
   // List of master instances for the cluster
   masterInstances() []dict
   // EMR cluster ID
@@ -7791,6 +7797,8 @@ private aws.emr.cluster.instanceGroup @defaults("name instanceGroupType instance
   runningInstanceCount int
   // Instance group state
   status string
+  // When the instance group was created
+  createdAt time
   // Spot bid price (if market is SPOT)
   bidPrice string
   // Whether EBS optimization is enabled
@@ -7914,6 +7922,8 @@ private aws.eventbridge.eventBus @defaults("arn name") {
   arn string
   // Name of the event bus
   name string
+  // When the event bus was created
+  creationTime time
   // Region of the event bus
   region string
   // Tags for the event bus
@@ -8991,6 +9001,8 @@ private aws.cloudwatch.loggroup @defaults("arn") {
   kmsKey() aws.kms.key
   // Region where the log group is stored
   region string
+  // When the log group was created
+  createdAt time
   // Number of days to retain the log events in the specified log group
   retentionInDays int
   // Tags for the log group
@@ -15017,6 +15029,8 @@ private aws.ec2.transitgateway.attachment @defaults("id resourceType state") {
   //
   // One of: initiating, initiatingRequest, pendingAcceptance, rollingBack, pending, available, modifying, deleting, deleted, failed, rejected, rejecting, failing.
   state string
+  // When the attachment was created
+  createdAt time
   // Tags on the attachment
   tags map[string]string
   // Region where the attachment exists
@@ -15035,6 +15049,8 @@ private aws.ec2.transitgateway.routeTable @defaults("id state") {
   defaultAssociationRouteTable bool
   // Whether this is the default propagation route table
   defaultPropagationRouteTable bool
+  // When the route table was created
+  createdAt time
   // Tags on the route table
   tags map[string]string
   // Region where the route table exists
@@ -22622,6 +22638,8 @@ private aws.ssm.maintenanceWindow @defaults("id name") {
   endDate time
   // Next scheduled execution time of the window
   nextExecutionTime time
+  // Date the window was created
+  createdDate() time
   // Date the window was last modified
   modifiedDate() time
   // Whether targets that are not associated with the window can be run
@@ -22728,6 +22746,8 @@ private aws.ssm.association @defaults("associationId name") {
   // Includes `date` (when the status changed), `name` (one of `Pending`, `Success`, or `Failed`),
   // `message` (human-readable reason), and `additionalInfo` (free-form user string).
   status() dict
+  // Date the association was created
+  createdDate() time
   // Last execution date
   lastExecutionDate time
   // Last date the association ran successfully
@@ -23863,6 +23883,8 @@ private aws.identitycenter.group @defaults("displayName") {
   groupId string
   // Display name of the group
   displayName string
+  // When the group was created
+  createdAt time
   // Description of the group
   description() string
   // External IDs from the identity provider
@@ -23877,6 +23899,8 @@ private aws.identitycenter.user @defaults("userName displayName") {
   userName string
   // Display name of the user
   displayName string
+  // When the user was created
+  createdAt time
   // Email addresses associated with the user
   emails() []dict
   // External IDs from the identity provider

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7923,7 +7923,7 @@ private aws.eventbridge.eventBus @defaults("arn name") {
   // Name of the event bus
   name string
   // When the event bus was created
-  creationTime time
+  createdAt time
   // Region of the event bus
   region string
   // Tags for the event bus

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -13549,8 +13549,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.eventbridge.eventBus.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeEventBus).GetName()).ToDataRes(types.String)
 	},
-	"aws.eventbridge.eventBus.creationTime": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsEventbridgeEventBus).GetCreationTime()).ToDataRes(types.Time)
+	"aws.eventbridge.eventBus.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeEventBus).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.eventbridge.eventBus.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeEventBus).GetRegion()).ToDataRes(types.String)
@@ -45926,8 +45926,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEventbridgeEventBus).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.eventbridge.eventBus.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsEventbridgeEventBus).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+	"aws.eventbridge.eventBus.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeEventBus).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.eventbridge.eventBus.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -108877,13 +108877,13 @@ type mqlAwsEventbridgeEventBus struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsEventbridgeEventBusInternal it will be used here
-	Arn          plugin.TValue[string]
-	Name         plugin.TValue[string]
-	CreationTime plugin.TValue[*time.Time]
-	Region       plugin.TValue[string]
-	Tags         plugin.TValue[map[string]any]
-	Rules        plugin.TValue[[]any]
-	Policy       plugin.TValue[string]
+	Arn       plugin.TValue[string]
+	Name      plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
+	Region    plugin.TValue[string]
+	Tags      plugin.TValue[map[string]any]
+	Rules     plugin.TValue[[]any]
+	Policy    plugin.TValue[string]
 }
 
 // createAwsEventbridgeEventBus creates a new instance of this resource
@@ -108926,8 +108926,8 @@ func (c *mqlAwsEventbridgeEventBus) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlAwsEventbridgeEventBus) GetCreationTime() *plugin.TValue[*time.Time] {
-	return &c.CreationTime
+func (c *mqlAwsEventbridgeEventBus) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsEventbridgeEventBus) GetRegion() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6241,6 +6241,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.fsx.cache.lifecycle": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxCache).GetLifecycle()).ToDataRes(types.String)
 	},
+	"aws.fsx.cache.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsFsxCache).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.fsx.cache.storageCapacity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxCache).GetStorageCapacity()).ToDataRes(types.Int)
 	},
@@ -12604,6 +12607,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.task.lastStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTask).GetLastStatus()).ToDataRes(types.String)
 	},
+	"aws.ecs.task.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTask).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.ecs.task.platformFamily": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTask).GetPlatformFamily()).ToDataRes(types.String)
 	},
@@ -13234,6 +13240,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.emr.cluster.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetStatus()).ToDataRes(types.Dict)
 	},
+	"aws.emr.cluster.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.emr.cluster.masterInstances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetMasterInstances()).ToDataRes(types.Array(types.Dict))
 	},
@@ -13417,6 +13426,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.emr.cluster.instanceGroup.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrClusterInstanceGroup).GetStatus()).ToDataRes(types.String)
 	},
+	"aws.emr.cluster.instanceGroup.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrClusterInstanceGroup).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.emr.cluster.instanceGroup.bidPrice": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrClusterInstanceGroup).GetBidPrice()).ToDataRes(types.String)
 	},
@@ -13536,6 +13548,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eventbridge.eventBus.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeEventBus).GetName()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.eventBus.creationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeEventBus).GetCreationTime()).ToDataRes(types.Time)
 	},
 	"aws.eventbridge.eventBus.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeEventBus).GetRegion()).ToDataRes(types.String)
@@ -14646,6 +14661,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cloudwatch.loggroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.cloudwatch.loggroup.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroup).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.cloudwatch.loggroup.retentionInDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetRetentionInDays()).ToDataRes(types.Int)
@@ -21136,6 +21154,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.transitgateway.attachment.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetState()).ToDataRes(types.String)
 	},
+	"aws.ec2.transitgateway.attachment.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.ec2.transitgateway.attachment.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -21156,6 +21177,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.transitgateway.routeTable.defaultPropagationRouteTable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetDefaultPropagationRouteTable()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.transitgateway.routeTable.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.ec2.transitgateway.routeTable.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -29839,6 +29863,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ssm.maintenanceWindow.nextExecutionTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmMaintenanceWindow).GetNextExecutionTime()).ToDataRes(types.Time)
 	},
+	"aws.ssm.maintenanceWindow.createdDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmMaintenanceWindow).GetCreatedDate()).ToDataRes(types.Time)
+	},
 	"aws.ssm.maintenanceWindow.modifiedDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmMaintenanceWindow).GetModifiedDate()).ToDataRes(types.Time)
 	},
@@ -29946,6 +29973,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ssm.association.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmAssociation).GetStatus()).ToDataRes(types.Dict)
+	},
+	"aws.ssm.association.createdDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmAssociation).GetCreatedDate()).ToDataRes(types.Time)
 	},
 	"aws.ssm.association.lastExecutionDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmAssociation).GetLastExecutionDate()).ToDataRes(types.Time)
@@ -31171,6 +31201,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.identitycenter.group.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterGroup).GetDisplayName()).ToDataRes(types.String)
 	},
+	"aws.identitycenter.group.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIdentitycenterGroup).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.identitycenter.group.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterGroup).GetDescription()).ToDataRes(types.String)
 	},
@@ -31185,6 +31218,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.identitycenter.user.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterUser).GetDisplayName()).ToDataRes(types.String)
+	},
+	"aws.identitycenter.user.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIdentitycenterUser).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.identitycenter.user.emails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterUser).GetEmails()).ToDataRes(types.Array(types.Dict))
@@ -35216,6 +35252,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.fsx.cache.lifecycle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsFsxCache).Lifecycle, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.fsx.cache.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsFsxCache).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.fsx.cache.storageCapacity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44506,6 +44546,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcsTask).LastStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ecs.task.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTask).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ecs.task.platformFamily": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsTask).PlatformFamily, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -45438,6 +45482,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEmrCluster).Status, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.emr.cluster.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.emr.cluster.masterInstances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrCluster).MasterInstances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -45698,6 +45746,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEmrClusterInstanceGroup).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.emr.cluster.instanceGroup.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrClusterInstanceGroup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.emr.cluster.instanceGroup.bidPrice": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrClusterInstanceGroup).BidPrice, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -45872,6 +45924,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.eventbridge.eventBus.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEventbridgeEventBus).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.eventBus.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeEventBus).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.eventbridge.eventBus.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47568,6 +47624,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudwatch.loggroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchLoggroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.cloudwatch.loggroup.retentionInDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56994,6 +57054,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2TransitgatewayAttachment).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.transitgateway.attachment.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2TransitgatewayAttachment).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.transitgateway.attachment.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2TransitgatewayAttachment).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -57024,6 +57088,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.transitgateway.routeTable.defaultPropagationRouteTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2TransitgatewayRouteTable).DefaultPropagationRouteTable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.transitgateway.routeTable.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2TransitgatewayRouteTable).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.transitgateway.routeTable.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -69610,6 +69678,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSsmMaintenanceWindow).NextExecutionTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.ssm.maintenanceWindow.createdDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmMaintenanceWindow).CreatedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ssm.maintenanceWindow.modifiedDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmMaintenanceWindow).ModifiedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -69764,6 +69836,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ssm.association.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmAssociation).Status, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.association.createdDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmAssociation).CreatedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ssm.association.lastExecutionDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -71550,6 +71626,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIdentitycenterGroup).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.identitycenter.group.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIdentitycenterGroup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.identitycenter.group.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIdentitycenterGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -71572,6 +71652,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.identitycenter.user.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIdentitycenterUser).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.identitycenter.user.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIdentitycenterUser).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.identitycenter.user.emails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80691,6 +80775,7 @@ type mqlAwsFsxCache struct {
 	Id                         plugin.TValue[string]
 	Arn                        plugin.TValue[string]
 	Lifecycle                  plugin.TValue[string]
+	CreatedAt                  plugin.TValue[*time.Time]
 	StorageCapacity            plugin.TValue[int64]
 	VpcId                      plugin.TValue[string]
 	Vpc                        plugin.TValue[*mqlAwsVpc]
@@ -80748,6 +80833,10 @@ func (c *mqlAwsFsxCache) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsFsxCache) GetLifecycle() *plugin.TValue[string] {
 	return &c.Lifecycle
+}
+
+func (c *mqlAwsFsxCache) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsFsxCache) GetStorageCapacity() *plugin.TValue[int64] {
@@ -105093,6 +105182,7 @@ type mqlAwsEcsTask struct {
 	ClusterName                   plugin.TValue[string]
 	Connectivity                  plugin.TValue[any]
 	LastStatus                    plugin.TValue[string]
+	CreatedAt                     plugin.TValue[*time.Time]
 	PlatformFamily                plugin.TValue[string]
 	PlatformVersion               plugin.TValue[string]
 	Tags                          plugin.TValue[map[string]any]
@@ -105166,6 +105256,10 @@ func (c *mqlAwsEcsTask) GetConnectivity() *plugin.TValue[any] {
 
 func (c *mqlAwsEcsTask) GetLastStatus() *plugin.TValue[string] {
 	return &c.LastStatus
+}
+
+func (c *mqlAwsEcsTask) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsEcsTask) GetPlatformFamily() *plugin.TValue[string] {
@@ -107553,6 +107647,7 @@ type mqlAwsEmrCluster struct {
 	NormalizedInstanceHours    plugin.TValue[int64]
 	OutpostArn                 plugin.TValue[string]
 	Status                     plugin.TValue[any]
+	CreatedAt                  plugin.TValue[*time.Time]
 	MasterInstances            plugin.TValue[[]any]
 	Id                         plugin.TValue[string]
 	Tags                       plugin.TValue[map[string]any]
@@ -107641,6 +107736,10 @@ func (c *mqlAwsEmrCluster) GetOutpostArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEmrCluster) GetStatus() *plugin.TValue[any] {
 	return &c.Status
+}
+
+func (c *mqlAwsEmrCluster) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsEmrCluster) GetMasterInstances() *plugin.TValue[[]any] {
@@ -108171,6 +108270,7 @@ type mqlAwsEmrClusterInstanceGroup struct {
 	RequestedInstanceCount plugin.TValue[int64]
 	RunningInstanceCount   plugin.TValue[int64]
 	Status                 plugin.TValue[string]
+	CreatedAt              plugin.TValue[*time.Time]
 	BidPrice               plugin.TValue[string]
 	EbsOptimized           plugin.TValue[bool]
 	CustomAmiId            plugin.TValue[string]
@@ -108245,6 +108345,10 @@ func (c *mqlAwsEmrClusterInstanceGroup) GetRunningInstanceCount() *plugin.TValue
 
 func (c *mqlAwsEmrClusterInstanceGroup) GetStatus() *plugin.TValue[string] {
 	return &c.Status
+}
+
+func (c *mqlAwsEmrClusterInstanceGroup) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsEmrClusterInstanceGroup) GetBidPrice() *plugin.TValue[string] {
@@ -108773,12 +108877,13 @@ type mqlAwsEventbridgeEventBus struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsEventbridgeEventBusInternal it will be used here
-	Arn    plugin.TValue[string]
-	Name   plugin.TValue[string]
-	Region plugin.TValue[string]
-	Tags   plugin.TValue[map[string]any]
-	Rules  plugin.TValue[[]any]
-	Policy plugin.TValue[string]
+	Arn          plugin.TValue[string]
+	Name         plugin.TValue[string]
+	CreationTime plugin.TValue[*time.Time]
+	Region       plugin.TValue[string]
+	Tags         plugin.TValue[map[string]any]
+	Rules        plugin.TValue[[]any]
+	Policy       plugin.TValue[string]
 }
 
 // createAwsEventbridgeEventBus creates a new instance of this resource
@@ -108819,6 +108924,10 @@ func (c *mqlAwsEventbridgeEventBus) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEventbridgeEventBus) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAwsEventbridgeEventBus) GetCreationTime() *plugin.TValue[*time.Time] {
+	return &c.CreationTime
 }
 
 func (c *mqlAwsEventbridgeEventBus) GetRegion() *plugin.TValue[string] {
@@ -113839,6 +113948,7 @@ type mqlAwsCloudwatchLoggroup struct {
 	LogStreams                plugin.TValue[[]any]
 	KmsKey                    plugin.TValue[*mqlAwsKmsKey]
 	Region                    plugin.TValue[string]
+	CreatedAt                 plugin.TValue[*time.Time]
 	RetentionInDays           plugin.TValue[int64]
 	Tags                      plugin.TValue[map[string]any]
 	DataProtectionStatus      plugin.TValue[string]
@@ -113961,6 +114071,10 @@ func (c *mqlAwsCloudwatchLoggroup) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
 
 func (c *mqlAwsCloudwatchLoggroup) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsCloudwatchLoggroup) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsCloudwatchLoggroup) GetRetentionInDays() *plugin.TValue[int64] {
@@ -137457,6 +137571,7 @@ type mqlAwsEc2TransitgatewayAttachment struct {
 	ResourceId       plugin.TValue[string]
 	ResourceType     plugin.TValue[string]
 	State            plugin.TValue[string]
+	CreatedAt        plugin.TValue[*time.Time]
 	Tags             plugin.TValue[map[string]any]
 	Region           plugin.TValue[string]
 }
@@ -137518,6 +137633,10 @@ func (c *mqlAwsEc2TransitgatewayAttachment) GetState() *plugin.TValue[string] {
 	return &c.State
 }
 
+func (c *mqlAwsEc2TransitgatewayAttachment) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
 func (c *mqlAwsEc2TransitgatewayAttachment) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
 }
@@ -137536,6 +137655,7 @@ type mqlAwsEc2TransitgatewayRouteTable struct {
 	State                        plugin.TValue[string]
 	DefaultAssociationRouteTable plugin.TValue[bool]
 	DefaultPropagationRouteTable plugin.TValue[bool]
+	CreatedAt                    plugin.TValue[*time.Time]
 	Tags                         plugin.TValue[map[string]any]
 	Region                       plugin.TValue[string]
 }
@@ -137595,6 +137715,10 @@ func (c *mqlAwsEc2TransitgatewayRouteTable) GetDefaultAssociationRouteTable() *p
 
 func (c *mqlAwsEc2TransitgatewayRouteTable) GetDefaultPropagationRouteTable() *plugin.TValue[bool] {
 	return &c.DefaultPropagationRouteTable
+}
+
+func (c *mqlAwsEc2TransitgatewayRouteTable) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsEc2TransitgatewayRouteTable) GetTags() *plugin.TValue[map[string]any] {
@@ -168567,6 +168691,7 @@ type mqlAwsSsmMaintenanceWindow struct {
 	StartDate                plugin.TValue[*time.Time]
 	EndDate                  plugin.TValue[*time.Time]
 	NextExecutionTime        plugin.TValue[*time.Time]
+	CreatedDate              plugin.TValue[*time.Time]
 	ModifiedDate             plugin.TValue[*time.Time]
 	AllowUnassociatedTargets plugin.TValue[bool]
 	Tasks                    plugin.TValue[[]any]
@@ -168665,6 +168790,12 @@ func (c *mqlAwsSsmMaintenanceWindow) GetEndDate() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsSsmMaintenanceWindow) GetNextExecutionTime() *plugin.TValue[*time.Time] {
 	return &c.NextExecutionTime
+}
+
+func (c *mqlAwsSsmMaintenanceWindow) GetCreatedDate() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CreatedDate, func() (*time.Time, error) {
+		return c.createdDate()
+	})
 }
 
 func (c *mqlAwsSsmMaintenanceWindow) GetModifiedDate() *plugin.TValue[*time.Time] {
@@ -168941,6 +169072,7 @@ type mqlAwsSsmAssociation struct {
 	Targets                     plugin.TValue[[]any]
 	Schedule                    plugin.TValue[string]
 	Status                      plugin.TValue[any]
+	CreatedDate                 plugin.TValue[*time.Time]
 	LastExecutionDate           plugin.TValue[*time.Time]
 	LastSuccessfulExecutionDate plugin.TValue[*time.Time]
 	Overview                    plugin.TValue[any]
@@ -169021,6 +169153,12 @@ func (c *mqlAwsSsmAssociation) GetSchedule() *plugin.TValue[string] {
 func (c *mqlAwsSsmAssociation) GetStatus() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Status, func() (any, error) {
 		return c.status()
+	})
+}
+
+func (c *mqlAwsSsmAssociation) GetCreatedDate() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CreatedDate, func() (*time.Time, error) {
+		return c.createdDate()
 	})
 }
 
@@ -173467,6 +173605,7 @@ type mqlAwsIdentitycenterGroup struct {
 	// optional: if you define mqlAwsIdentitycenterGroupInternal it will be used here
 	GroupId     plugin.TValue[string]
 	DisplayName plugin.TValue[string]
+	CreatedAt   plugin.TValue[*time.Time]
 	Description plugin.TValue[string]
 	ExternalIds plugin.TValue[[]any]
 }
@@ -173516,6 +173655,10 @@ func (c *mqlAwsIdentitycenterGroup) GetDisplayName() *plugin.TValue[string] {
 	return &c.DisplayName
 }
 
+func (c *mqlAwsIdentitycenterGroup) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
 func (c *mqlAwsIdentitycenterGroup) GetDescription() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Description, func() (string, error) {
 		return c.description()
@@ -173536,6 +173679,7 @@ type mqlAwsIdentitycenterUser struct {
 	UserId      plugin.TValue[string]
 	UserName    plugin.TValue[string]
 	DisplayName plugin.TValue[string]
+	CreatedAt   plugin.TValue[*time.Time]
 	Emails      plugin.TValue[[]any]
 	ExternalIds plugin.TValue[[]any]
 }
@@ -173587,6 +173731,10 @@ func (c *mqlAwsIdentitycenterUser) GetUserName() *plugin.TValue[string] {
 
 func (c *mqlAwsIdentitycenterUser) GetDisplayName() *plugin.TValue[string] {
 	return &c.DisplayName
+}
+
+func (c *mqlAwsIdentitycenterUser) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsIdentitycenterUser) GetEmails() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1758,6 +1758,7 @@ aws.cloudwatch.logInsightQuery.queryString 13.6.3
 aws.cloudwatch.logInsightQuery.region 13.6.3
 aws.cloudwatch.loggroup 11.15.2
 aws.cloudwatch.loggroup.arn 11.15.2
+aws.cloudwatch.loggroup.createdAt 13.38.2
 aws.cloudwatch.loggroup.dataProtectionPolicy 13.26.3
 aws.cloudwatch.loggroup.dataProtectionStatus 11.15.2
 aws.cloudwatch.loggroup.deletionProtectionEnabled 11.15.2
@@ -3333,6 +3334,7 @@ aws.ec2.transitgateway.amazonSideAsn 11.15.2
 aws.ec2.transitgateway.arn 11.15.2
 aws.ec2.transitgateway.associationDefaultRouteTableId 11.15.2
 aws.ec2.transitgateway.attachment 13.6.3
+aws.ec2.transitgateway.attachment.createdAt 13.38.2
 aws.ec2.transitgateway.attachment.id 13.6.3
 aws.ec2.transitgateway.attachment.region 13.6.3
 aws.ec2.transitgateway.attachment.resourceId 13.6.3
@@ -3364,6 +3366,7 @@ aws.ec2.transitgateway.peeringAttachments 13.6.3
 aws.ec2.transitgateway.propagationDefaultRouteTableId 11.15.2
 aws.ec2.transitgateway.region 11.15.2
 aws.ec2.transitgateway.routeTable 13.6.3
+aws.ec2.transitgateway.routeTable.createdAt 13.38.2
 aws.ec2.transitgateway.routeTable.defaultAssociationRouteTable 13.6.3
 aws.ec2.transitgateway.routeTable.defaultPropagationRouteTable 13.6.3
 aws.ec2.transitgateway.routeTable.id 13.6.3
@@ -3671,6 +3674,7 @@ aws.ecs.task.connectivity 11.15.2
 aws.ecs.task.containerInstanceArn 13.29.1
 aws.ecs.task.containers 11.15.2
 aws.ecs.task.cpu 13.29.1
+aws.ecs.task.createdAt 13.38.2
 aws.ecs.task.enableExecuteCommand 13.29.1
 aws.ecs.task.ephemeralStorageSizeInGiB 13.29.1
 aws.ecs.task.fargateEphemeralStorageKmsKey 13.29.1
@@ -4312,6 +4316,7 @@ aws.emr.cluster.bootstrapAction.name 13.12.1
 aws.emr.cluster.bootstrapAction.scriptPath 13.12.1
 aws.emr.cluster.bootstrapActions 13.12.1
 aws.emr.cluster.configurations 13.21.4
+aws.emr.cluster.createdAt 13.38.2
 aws.emr.cluster.ebsRootVolumeIops 13.21.4
 aws.emr.cluster.ebsRootVolumeSize 13.21.4
 aws.emr.cluster.ebsRootVolumeThroughput 13.21.4
@@ -4325,6 +4330,7 @@ aws.emr.cluster.instanceCollectionType 13.21.4
 aws.emr.cluster.instanceGroup 13.12.1
 aws.emr.cluster.instanceGroup.bidPrice 13.12.1
 aws.emr.cluster.instanceGroup.configurations 13.21.4
+aws.emr.cluster.instanceGroup.createdAt 13.38.2
 aws.emr.cluster.instanceGroup.customAmiId 13.21.4
 aws.emr.cluster.instanceGroup.ebsBlockDevices 13.21.4
 aws.emr.cluster.instanceGroup.ebsOptimized 13.12.1
@@ -4542,6 +4548,7 @@ aws.eventbridge.endpoint.stateReason 13.26.3
 aws.eventbridge.endpoints 13.26.3
 aws.eventbridge.eventBus 11.16.1
 aws.eventbridge.eventBus.arn 11.16.1
+aws.eventbridge.eventBus.creationTime 13.38.2
 aws.eventbridge.eventBus.name 11.16.1
 aws.eventbridge.eventBus.policy 13.23.2
 aws.eventbridge.eventBus.region 11.16.1
@@ -4896,6 +4903,7 @@ aws.fsx.backup.type 11.15.2
 aws.fsx.backups 11.15.2
 aws.fsx.cache 11.15.2
 aws.fsx.cache.arn 11.15.2
+aws.fsx.cache.createdAt 13.38.2
 aws.fsx.cache.dataRepositoryAssociations 11.15.2
 aws.fsx.cache.id 11.15.2
 aws.fsx.cache.lifecycle 11.15.2
@@ -5421,6 +5429,7 @@ aws.identitycenter.application.portalVisibility 13.20.1
 aws.identitycenter.application.signInOrigin 13.20.1
 aws.identitycenter.application.status 13.20.1
 aws.identitycenter.group 13.12.1
+aws.identitycenter.group.createdAt 13.38.2
 aws.identitycenter.group.description 13.12.1
 aws.identitycenter.group.displayName 13.12.1
 aws.identitycenter.group.externalIds 13.12.1
@@ -5451,6 +5460,7 @@ aws.identitycenter.permissionSet.relayState 13.6.3
 aws.identitycenter.permissionSet.sessionDuration 13.6.3
 aws.identitycenter.permissionSet.tags 13.6.3
 aws.identitycenter.user 13.12.1
+aws.identitycenter.user.createdAt 13.38.2
 aws.identitycenter.user.displayName 13.12.1
 aws.identitycenter.user.emails 13.12.1
 aws.identitycenter.user.externalIds 13.12.1
@@ -9181,6 +9191,7 @@ aws.ssm.association.applyOnlyAtCronInterval 13.26.3
 aws.ssm.association.associationId 13.6.3
 aws.ssm.association.associationName 13.26.3
 aws.ssm.association.complianceSeverity 13.26.3
+aws.ssm.association.createdDate 13.38.2
 aws.ssm.association.documentVersion 13.26.3
 aws.ssm.association.instanceId 13.26.3
 aws.ssm.association.lastExecutionDate 13.6.3
@@ -9237,6 +9248,7 @@ aws.ssm.instances 11.15.2
 aws.ssm.maintenanceWindow 13.6.3
 aws.ssm.maintenanceWindow.allowUnassociatedTargets 13.6.3
 aws.ssm.maintenanceWindow.arn 13.6.3
+aws.ssm.maintenanceWindow.createdDate 13.38.2
 aws.ssm.maintenanceWindow.cutoff 13.6.3
 aws.ssm.maintenanceWindow.description 13.6.3
 aws.ssm.maintenanceWindow.duration 13.6.3

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4548,7 +4548,7 @@ aws.eventbridge.endpoint.stateReason 13.26.3
 aws.eventbridge.endpoints 13.26.3
 aws.eventbridge.eventBus 11.16.1
 aws.eventbridge.eventBus.arn 11.16.1
-aws.eventbridge.eventBus.creationTime 13.38.2
+aws.eventbridge.eventBus.createdAt 13.38.2
 aws.eventbridge.eventBus.name 11.16.1
 aws.eventbridge.eventBus.policy 13.23.2
 aws.eventbridge.eventBus.region 11.16.1

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -629,6 +629,7 @@ func buildLogGroupResource(runtime *plugin.Runtime, region string, loggroup clou
 	args["name"] = llx.StringDataPtr(loggroup.LogGroupName)
 	args["region"] = llx.StringData(region)
 	args["retentionInDays"] = llx.IntDataDefault(loggroup.RetentionInDays, 0)
+	args["createdAt"] = llx.TimeDataPtr(int64MillisToTime(loggroup.CreationTime))
 	args["dataProtectionStatus"] = llx.StringData(string(loggroup.DataProtectionStatus))
 	args["deletionProtectionEnabled"] = llx.BoolDataPtr(loggroup.DeletionProtectionEnabled)
 	args["logGroupClass"] = llx.StringData(string(loggroup.LogGroupClass))

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3130,6 +3130,7 @@ func (a *mqlAwsEc2Transitgateway) attachments() ([]any, error) {
 					"resourceId":       llx.StringData(convert.ToValue(att.ResourceId)),
 					"resourceType":     llx.StringData(string(att.ResourceType)),
 					"state":            llx.StringData(string(att.State)),
+					"createdAt":        llx.TimeDataPtr(att.CreationTime),
 					"tags":             llx.MapData(toInterfaceMap(ec2TagsToMap(att.Tags)), types.String),
 					"region":           llx.StringData(a.region),
 				})
@@ -3172,6 +3173,7 @@ func (a *mqlAwsEc2Transitgateway) routeTables() ([]any, error) {
 					"state":                        llx.StringData(string(rt.State)),
 					"defaultAssociationRouteTable": llx.BoolData(convert.ToValue(rt.DefaultAssociationRouteTable)),
 					"defaultPropagationRouteTable": llx.BoolData(convert.ToValue(rt.DefaultPropagationRouteTable)),
+					"createdAt":                    llx.TimeDataPtr(rt.CreationTime),
 					"tags":                         llx.MapData(toInterfaceMap(ec2TagsToMap(rt.Tags)), types.String),
 					"region":                       llx.StringData(a.region),
 				})

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -478,6 +478,7 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	args["enableExecuteCommand"] = llx.BoolData(t.EnableExecuteCommand)
 	args["stopCode"] = llx.StringData(string(t.StopCode))
 	args["stoppedReason"] = llx.StringData(convert.ToValue(t.StoppedReason))
+	args["createdAt"] = llx.TimeDataPtr(t.CreatedAt)
 	args["startedAt"] = llx.TimeDataPtr(t.StartedAt)
 	args["stoppedAt"] = llx.TimeDataPtr(t.StoppedAt)
 

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/emr"
 	emrtypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
@@ -78,6 +79,10 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 					if err != nil {
 						return nil, err
 					}
+					var createdAt *time.Time
+					if cluster.Status != nil && cluster.Status.Timeline != nil {
+						createdAt = cluster.Status.Timeline.CreationDateTime
+					}
 					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.emr.cluster",
 						map[string]*llx.RawData{
 							"arn":                     llx.StringDataPtr(cluster.ClusterArn),
@@ -85,6 +90,7 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 							"normalizedInstanceHours": llx.IntDataDefault(cluster.NormalizedInstanceHours, 0),
 							"outpostArn":              llx.StringDataPtr(cluster.OutpostArn),
 							"status":                  llx.MapData(jsonStatus, types.String),
+							"createdAt":               llx.TimeDataPtr(createdAt),
 							"id":                      llx.StringDataPtr(cluster.Id),
 						})
 					if err != nil {
@@ -879,8 +885,12 @@ func (a *mqlAwsEmrCluster) instanceGroups() ([]any, error) {
 		}
 		for _, ig := range page.InstanceGroups {
 			var status string
+			var createdAt *time.Time
 			if ig.Status != nil {
 				status = string(ig.Status.State)
+				if ig.Status.Timeline != nil {
+					createdAt = ig.Status.Timeline.CreationDateTime
+				}
 			}
 			var ebsBlockDevices []any
 			if devices, derr := convert.JsonToDictSlice(ig.EbsBlockDevices); derr == nil {
@@ -901,6 +911,7 @@ func (a *mqlAwsEmrCluster) instanceGroups() ([]any, error) {
 					"requestedInstanceCount": llx.IntDataDefault(ig.RequestedInstanceCount, 0),
 					"runningInstanceCount":   llx.IntDataDefault(ig.RunningInstanceCount, 0),
 					"status":                 llx.StringData(status),
+					"createdAt":              llx.TimeDataPtr(createdAt),
 					"bidPrice":               llx.StringDataPtr(ig.BidPrice),
 					"ebsOptimized":           llx.BoolDataPtr(ig.EbsOptimized),
 					"customAmiId":            llx.StringDataPtr(ig.CustomAmiId),

--- a/providers/aws/resources/aws_eventbridge.go
+++ b/providers/aws/resources/aws_eventbridge.go
@@ -69,11 +69,11 @@ func (a *mqlAwsEventbridge) getEventBuses(conn *connection.AwsConnection) []*job
 				for _, bus := range resp.EventBuses {
 					mqlBus, err := CreateResource(a.MqlRuntime, "aws.eventbridge.eventBus",
 						map[string]*llx.RawData{
-							"__id":         llx.StringDataPtr(bus.Arn),
-							"arn":          llx.StringDataPtr(bus.Arn),
-							"name":         llx.StringDataPtr(bus.Name),
-							"creationTime": llx.TimeDataPtr(bus.CreationTime),
-							"region":       llx.StringData(region),
+							"__id":      llx.StringDataPtr(bus.Arn),
+							"arn":       llx.StringDataPtr(bus.Arn),
+							"name":      llx.StringDataPtr(bus.Name),
+							"createdAt": llx.TimeDataPtr(bus.CreationTime),
+							"region":    llx.StringData(region),
 						})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_eventbridge.go
+++ b/providers/aws/resources/aws_eventbridge.go
@@ -69,10 +69,11 @@ func (a *mqlAwsEventbridge) getEventBuses(conn *connection.AwsConnection) []*job
 				for _, bus := range resp.EventBuses {
 					mqlBus, err := CreateResource(a.MqlRuntime, "aws.eventbridge.eventBus",
 						map[string]*llx.RawData{
-							"__id":   llx.StringDataPtr(bus.Arn),
-							"arn":    llx.StringDataPtr(bus.Arn),
-							"name":   llx.StringDataPtr(bus.Name),
-							"region": llx.StringData(region),
+							"__id":         llx.StringDataPtr(bus.Arn),
+							"arn":          llx.StringDataPtr(bus.Arn),
+							"name":         llx.StringDataPtr(bus.Name),
+							"creationTime": llx.TimeDataPtr(bus.CreationTime),
+							"region":       llx.StringData(region),
 						})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -292,6 +292,7 @@ func (a *mqlAwsFsx) getCaches(conn *connection.AwsConnection) []*jobpool.Job {
 						"id":                         llx.StringDataPtr(cache.FileCacheId),
 						"arn":                        llx.StringDataPtr(cache.ResourceARN),
 						"lifecycle":                  llx.StringData(string(cache.Lifecycle)),
+						"createdAt":                  llx.TimeDataPtr(cache.CreationTime),
 						"storageCapacity":            llx.IntDataDefault(cache.StorageCapacity, 0),
 						"vpcId":                      llx.StringDataPtr(cache.VpcId),
 						"subnetIds":                  llx.ArrayData(convert.SliceAnyToInterface(cache.SubnetIds), types.String),

--- a/providers/aws/resources/aws_identitycenter.go
+++ b/providers/aws/resources/aws_identitycenter.go
@@ -479,6 +479,7 @@ func (a *mqlAwsIdentitycenterInstance) groups() ([]any, error) {
 					"__id":        llx.StringData("identitycenter/group/" + convert.ToValue(group.GroupId)),
 					"groupId":     llx.StringDataPtr(group.GroupId),
 					"displayName": llx.StringDataPtr(group.DisplayName),
+					"createdAt":   llx.TimeDataPtr(group.CreatedAt),
 				})
 			if err != nil {
 				return nil, err
@@ -540,6 +541,7 @@ func (a *mqlAwsIdentitycenterInstance) users() ([]any, error) {
 					"userId":      llx.StringDataPtr(user.UserId),
 					"userName":    llx.StringDataPtr(user.UserName),
 					"displayName": llx.StringDataPtr(user.DisplayName),
+					"createdAt":   llx.TimeDataPtr(user.CreatedAt),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/aws/resources/aws_ssm_state.go
+++ b/providers/aws/resources/aws_ssm_state.go
@@ -164,6 +164,14 @@ func (a *mqlAwsSsmMaintenanceWindow) modifiedDate() (*time.Time, error) {
 	return detail.ModifiedDate, nil
 }
 
+func (a *mqlAwsSsmMaintenanceWindow) createdDate() (*time.Time, error) {
+	detail, err := a.fetchDetail()
+	if err != nil {
+		return nil, err
+	}
+	return detail.CreatedDate, nil
+}
+
 func (a *mqlAwsSsmMaintenanceWindow) tasks() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	ssmsvc := conn.Ssm(a.Region.Data)
@@ -329,6 +337,7 @@ func (a *mqlAwsSsmAssociation) fetchDetail() error {
 	}
 
 	a.Status = plugin.TValue[any]{Data: statusDict, State: plugin.StateIsSet}
+	a.CreatedDate = plugin.TValue[*time.Time]{Data: desc.Date, State: plugin.StateIsSet}
 	a.LastSuccessfulExecutionDate = plugin.TValue[*time.Time]{Data: desc.LastSuccessfulExecutionDate, State: plugin.StateIsSet}
 	a.ComplianceSeverity = plugin.TValue[string]{Data: string(desc.ComplianceSeverity), State: plugin.StateIsSet}
 	a.SyncCompliance = plugin.TValue[string]{Data: string(desc.SyncCompliance), State: plugin.StateIsSet}
@@ -340,6 +349,7 @@ func (a *mqlAwsSsmAssociation) fetchDetail() error {
 
 func (a *mqlAwsSsmAssociation) populateEmptyDetail() {
 	a.Status = plugin.TValue[any]{Data: nil, State: plugin.StateIsSet | plugin.StateIsNull}
+	a.CreatedDate = plugin.TValue[*time.Time]{Data: nil, State: plugin.StateIsSet | plugin.StateIsNull}
 	a.LastSuccessfulExecutionDate = plugin.TValue[*time.Time]{Data: nil, State: plugin.StateIsSet | plugin.StateIsNull}
 	a.ComplianceSeverity = plugin.TValue[string]{Data: "", State: plugin.StateIsSet | plugin.StateIsNull}
 	a.SyncCompliance = plugin.TValue[string]{Data: "", State: plugin.StateIsSet | plugin.StateIsNull}
@@ -347,6 +357,10 @@ func (a *mqlAwsSsmAssociation) populateEmptyDetail() {
 }
 
 func (a *mqlAwsSsmAssociation) status() (any, error) {
+	return nil, a.fetchDetail()
+}
+
+func (a *mqlAwsSsmAssociation) createdDate() (*time.Time, error) {
 	return nil, a.fetchDetail()
 }
 


### PR DESCRIPTION
## Summary

Surfaces AWS SDK creation timestamps that several resource creators already fetch from the API but did not map into the schema. Mirrors the recent Azure "expose creation timestamps on more resources" effort.

Each new field follows the existing AWS convention (`createdAt time`, mapped with `llx.TimeDataPtr`). No new API calls were added — the two SSM fields reuse the resources' existing detail-fetch (`GetMaintenanceWindow` / `DescribeAssociation`), so `aws.permissions.json` is unchanged.

## New fields

| Resource | Field | SDK source |
|---|---|---|
| `aws.ec2.transitgateway.attachment` | `createdAt` | `TransitGatewayAttachment.CreationTime` |
| `aws.ec2.transitgateway.routeTable` | `createdAt` | `TransitGatewayRouteTable.CreationTime` |
| `aws.ecs.task` | `createdAt` | `Task.CreatedAt` |
| `aws.fsx.cache` | `createdAt` | `FileCache.CreationTime` |
| `aws.cloudwatch.loggroup` | `createdAt` | `LogGroup.CreationTime` (epoch millis → time via existing `int64MillisToTime`) |
| `aws.eventbridge.eventBus` | `creationTime` | `EventBus.CreationTime` (matches sibling eventbridge resources) |
| `aws.emr.cluster` | `createdAt` | `ClusterSummary.Status.Timeline.CreationDateTime` |
| `aws.emr.cluster.instanceGroup` | `createdAt` | `InstanceGroup.Status.Timeline.CreationDateTime` |
| `aws.identitycenter.group` | `createdAt` | `identitystore.Group.CreatedAt` |
| `aws.identitycenter.user` | `createdAt` | `identitystore.User.CreatedAt` |
| `aws.ssm.maintenanceWindow` | `createdDate()` | `GetMaintenanceWindowOutput.CreatedDate` (existing detail fetch) |
| `aws.ssm.association` | `createdDate()` | `AssociationDescription.Date` (existing detail fetch) |

## Notes

- The CloudWatch log group creation time comes back as `*int64` epoch milliseconds; it is converted with the existing `int64MillisToTime` helper, so no new string-parsing logic was introduced (and thus no new unit test required).
- EMR cluster / instance-group creation time lives on a nested `Status.Timeline` struct; both nil-guard the pointers before deref.
- `identitystore` `ListGroups`/`ListUsers` may return `CreatedAt` null depending on the configured identity source; the schema gap is real but the value can surface null on some tenants.
- `.lr.versions` entries auto-assigned `13.38.2` (next patch after the current provider version).

### Intentionally skipped

- `aws.dynamodb.globaltable` — the only remaining in-scope creation time (`GlobalTableDescription.CreationDateTime`) requires an extra `DescribeGlobalTable` call per legacy global table; low value for a deprecated feature, so left out.