### PR TITLE
⭐ azure: expose ARM systemMetadata provenance on more resources

### DIFF
--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -23,6 +23,7 @@ import (
 
 type mqlAzureSubscriptionApiManagementServiceServiceInternal struct {
 	cachePublicIpAddressId string
+	cacheSystemData        any
 }
 
 func (a *mqlAzureSubscriptionApiManagementService) id() (string, error) {
@@ -31,6 +32,10 @@ func (a *mqlAzureSubscriptionApiManagementService) id() (string, error) {
 
 func (a *mqlAzureSubscriptionApiManagementServiceService) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionApiManagementServiceService) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func initAzureSubscriptionApiManagementService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -240,7 +245,13 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlSvc.(*mqlAzureSubscriptionApiManagementServiceService).cachePublicIpAddressId = publicIpAddressId
+			svcRes := mqlSvc.(*mqlAzureSubscriptionApiManagementServiceService)
+			svcRes.cachePublicIpAddressId = publicIpAddressId
+			sysData, err := convert.JsonToDict(svc.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			svcRes.cacheSystemData = sysData
 			res = append(res, mqlSvc)
 		}
 	}

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -23,7 +23,8 @@ import (
 )
 
 type mqlAzureSubscriptionContainerAppServiceContainerAppInternal struct {
-	cacheRGAndName struct {
+	cacheSystemData any
+	cacheRGAndName  struct {
 		resourceGroup string
 		name          string
 	}
@@ -36,7 +37,8 @@ type mqlAzureSubscriptionContainerAppServiceContainerAppInternal struct {
 }
 
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentInternal struct {
-	cacheRGAndName struct {
+	cacheSystemData any
+	cacheRGAndName  struct {
 		resourceGroup string
 		name          string
 	}
@@ -55,6 +57,78 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentInternal struct {
 	maintenanceLock     sync.Mutex
 	maintenanceFetched  atomic.Bool
 	maintenanceCache    []any
+}
+
+type mqlAzureSubscriptionContainerAppServiceJobInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponentInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificateInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceContainerAppRevisionInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfigInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnectionInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfigInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfigurationInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceJob) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceContainerAppRevision) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionContainerAppService) id() (string, error) {
@@ -352,6 +426,11 @@ func acaManagedEnvironmentToMQL(runtime *plugin.Runtime, entry *apps.ManagedEnvi
 	rg, name := resourceGroupAndName(envRes.Id.Data, "managedEnvironments")
 	envRes.cacheRGAndName.resourceGroup = rg
 	envRes.cacheRGAndName.name = name
+	sysData, err := convert.JsonToDict(entry.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	envRes.cacheSystemData = sysData
 	return envRes, nil
 }
 
@@ -435,6 +514,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) daprComponen
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlComp.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).cacheSystemData = sysData
 			res = append(res, mqlComp)
 		}
 	}
@@ -534,6 +618,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) certificates
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCert.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).cacheSystemData = sysData
 			res = append(res, mqlCert)
 		}
 	}
@@ -775,6 +864,11 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 	rg, name := resourceGroupAndName(appRes.Id.Data, "containerApps")
 	appRes.cacheRGAndName.resourceGroup = rg
 	appRes.cacheRGAndName.name = name
+	appSysData, err := convert.JsonToDict(entry.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	appRes.cacheSystemData = appSysData
 
 	containers, err := acaContainersToMQL(runtime, appRes.Id.Data, containerSpecs, "containers")
 	if err != nil {
@@ -955,6 +1049,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) revisions() ([]any
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRev.(*mqlAzureSubscriptionContainerAppServiceContainerAppRevision).cacheSystemData = sysData
 			res = append(res, mqlRev)
 		}
 	}
@@ -1073,6 +1172,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) authConfigs() ([]a
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAuth.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).cacheSystemData = sysData
 			res = append(res, mqlAuth)
 		}
 	}
@@ -1200,6 +1304,11 @@ func (a *mqlAzureSubscriptionContainerAppService) jobs() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlJob.(*mqlAzureSubscriptionContainerAppServiceJob).cacheSystemData = sysData
 			res = append(res, mqlJob)
 		}
 	}
@@ -1283,6 +1392,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) privateEndpo
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPE.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).cacheSystemData = sysData
 			res = append(res, mqlPE)
 		}
 	}
@@ -1372,6 +1486,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) httpRouteCon
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRoute.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).cacheSystemData = sysData
 			res = append(res, mqlRoute)
 		}
 	}
@@ -1431,6 +1550,11 @@ func (a *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) maintenanceC
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlMaint.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).cacheSystemData = sysData
 			res = append(res, mqlMaint)
 		}
 	}

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -118,11 +118,12 @@ func getServerVulnAssessmentSettings(ctx context.Context, conn armSecurityConn) 
 
 // https://learn.microsoft.com/en-us/azure/templates/microsoft.authorization/policyassignments?pivots=deployment-language-bicep#property-values
 type PolicyAssignment struct {
-	ID       string `json:"id"`
-	Type     string `json:"type"`
-	Name     string `json:"name"`
-	Location string `json:"location,omitempty"`
-	Identity struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Name       string `json:"name"`
+	Location   string `json:"location,omitempty"`
+	SystemData any    `json:"systemData,omitempty"`
+	Identity   struct {
 		Type        string `json:"type"`
 		PrincipalID string `json:"principalId"`
 		TenantID    string `json:"tenantId"`

--- a/providers/azure/resources/automation.go
+++ b/providers/azure/resources/automation.go
@@ -151,7 +151,45 @@ func automationAccountToMql(runtime *plugin.Runtime, acct *armautomation.Account
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionAutomationServiceAccount), nil
+	mqlAccount := res.(*mqlAzureSubscriptionAutomationServiceAccount)
+	sysData, err := convert.JsonToDict(acct.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlAccount.cacheSystemData = sysData
+	return mqlAccount, nil
+}
+
+type mqlAzureSubscriptionAutomationServiceAccountInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionAutomationServiceAccountVariableInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionAutomationServiceAccountCredentialInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionAutomationServiceAccountCertificateInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionAutomationServiceAccount) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionAutomationServiceAccountVariable) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionAutomationServiceAccountCredential) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionAutomationServiceAccountCertificate) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // accountScope parses the resource group and account name out of the
@@ -214,6 +252,11 @@ func (a *mqlAzureSubscriptionAutomationServiceAccount) variables() ([]any, error
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(v.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlVar.(*mqlAzureSubscriptionAutomationServiceAccountVariable).cacheSystemData = sysData
 			res = append(res, mqlVar)
 		}
 	}
@@ -265,6 +308,11 @@ func (a *mqlAzureSubscriptionAutomationServiceAccount) credentials() ([]any, err
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(c.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCred.(*mqlAzureSubscriptionAutomationServiceAccountCredential).cacheSystemData = sysData
 			res = append(res, mqlCred)
 		}
 	}
@@ -319,6 +367,11 @@ func (a *mqlAzureSubscriptionAutomationServiceAccount) certificates() ([]any, er
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(c.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCert.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).cacheSystemData = sysData
 			res = append(res, mqlCert)
 		}
 	}

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -724,6 +724,8 @@ azure.subscription.computeService.diskEncryptionSet @defaults("name location enc
   provisioningState string
   // Identity configuration
   identity dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure disk access resource
@@ -752,6 +754,8 @@ azure.subscription.computeService.diskAccess @defaults("name location") {
   timeCreated time
   // Private endpoint connections
   privateEndpointConnections() []azure.subscription.privateEndpointConnection
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure managed disk snapshot
@@ -947,6 +951,8 @@ azure.subscription.computeService.vmScaleSet.instance @defaults("name instanceId
   properties dict
   // Instance SKU (name, tier, capacity)
   sku dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Dedicated Host Group
@@ -981,6 +987,8 @@ azure.subscription.computeService.dedicatedHostGroup @defaults("name location pl
   instanceView dict
   // Dedicated hosts in this group
   hosts() []azure.subscription.computeService.dedicatedHost
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Dedicated Host
@@ -1021,6 +1029,8 @@ azure.subscription.computeService.dedicatedHost @defaults("name sku.name provisi
   timeCreated time
   // Instance view (host availability + assets)
   instanceView dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Proximity Placement Group
@@ -1286,6 +1296,8 @@ azure.subscription.batchService.account @defaults("id name location") {
   pools() []azure.subscription.batchService.account.pool
   // Batch account diagnostic settings
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Batch pool
@@ -1327,6 +1339,8 @@ azure.subscription.batchService.account.pool @defaults("id name") {
   proxyAgentEnabled bool
   // Security encryption type for confidential computing (e.g., "DiskWithVMGuestState")
   securityEncryptionType string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Databricks
@@ -1395,6 +1409,8 @@ azure.subscription.databricksService.workspace @defaults("id name location publi
   managedServicesKeyName string
   // Managed-services CMK key version
   managedServicesKeyVersion string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure network
@@ -4432,6 +4448,8 @@ private azure.subscription.webService.appslot @defaults("id name location") {
   ftp() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
   // SCM publishing method policies for the slot
   scm() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure AppSite basic publishing credentials policies
@@ -4720,6 +4738,8 @@ private azure.subscription.webService.staticSite @defaults("name defaultHostname
   linkedBackendCount int
   // Number of database connections bound to the static site
   databaseConnectionCount int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure App Service Hostname Binding
@@ -5447,6 +5467,8 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Database for PostgreSQL server
@@ -5774,6 +5796,8 @@ private azure.subscription.mySqlService.flexibleServer @defaults("name location 
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cosmos DB
@@ -5932,6 +5956,8 @@ private azure.subscription.cosmosDbService.mongoCluster @defaults("computeTier s
   replicationSourceId string
   // Key Vault key used for customer-managed encryption (null if platform-managed)
   encryptionKey() azure.subscription.keyVaultService.key
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cosmos DB for PostgreSQL cluster
@@ -5999,6 +6025,8 @@ private azure.subscription.cosmosDbService.postgresqlCluster @defaults("postgres
   maintenanceWindow dict
   // Server names in the cluster
   serverNames []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cosmos DB SQL data-plane role definition (data-plane RBAC, separate from Azure ARM roles)
@@ -6181,6 +6209,8 @@ azure.subscription.keyVaultService.managedHsm @defaults("name location") {
   regions []dict
   // Private endpoint connections
   privateEndpointConnections() []azure.subscription.privateEndpointConnection
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Key Vault vault
@@ -6528,6 +6558,8 @@ private azure.subscription.monitorService.activityLog.alert @defaults("name type
   actions []dict
   // List of resource IDs that must be present to trigger the alert
   scopes []string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Monitor activity log event
@@ -6603,6 +6635,8 @@ private azure.subscription.monitorService.logprofile @defaults("id name location
   storageAccountId string
   // Log profile storage account
   storageAccount() azure.subscription.storageService.account
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Monitor diagnostic setting
@@ -7453,6 +7487,8 @@ private azure.subscription.managedIdentity @defaults("name") {
   // `audiences`. A broad or unexpected issuer/subject is a privilege-
   // escalation path worth auditing.
   federatedIdentityCredentials() []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Kubernetes Service
@@ -7863,6 +7899,8 @@ private azure.subscription.policy.assignment @defaults("name enforcementMode") {
   enforcementMode string
   // Policy parameters
   parameters dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Policy definition
@@ -7887,6 +7925,8 @@ private azure.subscription.policy.definition @defaults("name displayName policyT
   metadata dict
   // Definition version in #.#.# format
   version string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Policy initiative
@@ -7909,6 +7949,8 @@ private azure.subscription.policy.setDefinition @defaults("name displayName poli
   metadata dict
   // Initiative version in #.#.# format
   version string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Policy exemption
@@ -8007,6 +8049,8 @@ private azure.subscription.iotService.iotHub @defaults("id name location") {
   networkRuleSet dict
   // Diagnostic settings configured on the IoT hub (forwarding logs and metrics to Log Analytics, storage, or Event Hub)
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cache for Redis
@@ -8733,6 +8777,8 @@ azure.subscription.monitorService.workspace @defaults("id name location skuName"
   tables() []azure.subscription.monitorService.workspace.table
   // Network Security Perimeter configurations
   networkSecurityPerimeterConfigurations() []azure.subscription.monitorService.workspace.nspConfiguration
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Daily data volume capping for a Log Analytics workspace
@@ -8861,6 +8907,8 @@ private azure.subscription.monitorService.workspace.table @defaults("name plan r
   searchResults dict
   // Search job execution statistics
   resultStatistics dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Network Security Perimeter configuration for a Log Analytics workspace
@@ -8936,6 +8984,8 @@ azure.subscription.monitorService.queryPack @defaults("id name location queryPac
   timeModified time
   // Saved KQL queries in this QueryPack
   queries() []azure.subscription.monitorService.queryPack.query
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Saved KQL query in a Log Analytics QueryPack
@@ -8960,6 +9010,8 @@ private azure.subscription.monitorService.queryPack.query @defaults("id name dis
   timeModified time
   // Tags associated with the query
   tags dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Recovery Services
@@ -9023,6 +9075,8 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   backupPolicies() []azure.subscription.recoveryServicesService.vault.backupPolicy
   // Protected (backed-up) items
   protectedItems() []azure.subscription.recoveryServicesService.vault.protectedItem
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Security settings for a Recovery Services vault
@@ -9183,6 +9237,8 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   //
   // Each entry has shape {name, type, hasKeyVaultReference, slotSetting}. Connection-string values are not returned.
   connectionStrings() []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Function App application setting
@@ -9226,6 +9282,8 @@ private azure.subscription.functionsService.functionApp.function @defaults("id n
   language string
   // Whether the function is disabled
   isDisabled bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // ===== Azure Service Bus Service =====
@@ -9285,6 +9343,8 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   queues() []azure.subscription.serviceBusService.namespace.queue
   // Topics in this namespace
   topics() []azure.subscription.serviceBusService.namespace.topic
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Service Bus namespace network rule set
@@ -9348,6 +9408,8 @@ private azure.subscription.serviceBusService.namespace.queue @defaults("id name"
   requiresSession bool
   // Whether partitioning is enabled
   enablePartitioning bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Service Bus topic
@@ -9372,6 +9434,8 @@ private azure.subscription.serviceBusService.namespace.topic @defaults("id name"
   defaultMessageTimeToLive string
   // Subscriptions on this topic
   subscriptions() []azure.subscription.serviceBusService.namespace.topic.subscription
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Service Bus topic subscription
@@ -9394,6 +9458,8 @@ private azure.subscription.serviceBusService.namespace.topic.subscription @defau
   defaultMessageTimeToLive string
   // Whether sessions are required
   requiresSession bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // ===== Azure Event Hubs Service =====
@@ -9524,6 +9590,8 @@ private azure.subscription.eventHubService.namespace.eventHub.consumerGroup @def
   name string
   // User-defined metadata
   userMetadata string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // ===== Azure Event Grid Service =====
@@ -9580,6 +9648,8 @@ azure.subscription.eventGridService.topic @defaults("name location publicNetwork
   identityType string
   // Number of private endpoint connections to the topic
   privateEndpointConnectionCount int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Event Grid system topic
@@ -9609,6 +9679,8 @@ azure.subscription.eventGridService.systemTopic @defaults("name location topicTy
   metricResourceId string
   // Identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned")
   identityType string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Event Grid domain
@@ -9656,6 +9728,8 @@ azure.subscription.eventGridService.domain @defaults("name location publicNetwor
   identityType string
   // Number of private endpoint connections to the domain
   privateEndpointConnectionCount int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // ===== Azure DNS Service =====
@@ -9804,6 +9878,8 @@ azure.subscription.frontDoorService.profile @defaults("id name location") {
   originGroups() []azure.subscription.frontDoorService.profile.originGroup
   // Security policies (Web Application Firewall associations) attached to this profile
   securityPolicies() []azure.subscription.frontDoorService.profile.securityPolicy
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door security policy associating a WAF policy with domains
@@ -9820,6 +9896,8 @@ private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id
   associations []dict
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door / CDN endpoint
@@ -9838,6 +9916,8 @@ private azure.subscription.frontDoorService.profile.endpoint @defaults("id name 
   provisioningState string
   // Routes attached to this endpoint
   routes() []azure.subscription.frontDoorService.profile.endpoint.route
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door / CDN route attached to an endpoint
@@ -9866,6 +9946,8 @@ private azure.subscription.frontDoorService.profile.endpoint.route @defaults("id
   originGroupId string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door / CDN custom domain
@@ -9884,6 +9966,8 @@ private azure.subscription.frontDoorService.profile.customDomain @defaults("id n
   tlsMinimumVersion string
   // Certificate source ("CustomerCertificate", "ManagedCertificate", or "AzureFirstPartyManagedCertificate")
   tlsCertificateType string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door / CDN origin group
@@ -9900,6 +9984,8 @@ private azure.subscription.frontDoorService.profile.originGroup @defaults("id na
   loadBalancingSettings dict
   // Origins in this origin group
   origins() []azure.subscription.frontDoorService.profile.originGroup.origin
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Front Door / CDN origin
@@ -9924,6 +10010,8 @@ private azure.subscription.frontDoorService.profile.originGroup.origin @defaults
   enabledState string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Container Apps
@@ -10000,6 +10088,8 @@ azure.subscription.containerAppService.managedEnvironment @defaults("name locati
   httpRouteConfigs() []azure.subscription.containerAppService.managedEnvironment.httpRouteConfig
   // Env-scoped maintenance window configurations
   maintenanceConfigurations() []azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Private endpoint connection on a Container Apps managed environment
@@ -10020,6 +10110,8 @@ private azure.subscription.containerAppService.managedEnvironment.privateEndpoin
   groupIds []string
   // ARM resource ID of the private endpoint on the consumer side
   privateEndpointId string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // HTTP route config attached to a Container Apps managed environment
@@ -10042,6 +10134,8 @@ private azure.subscription.containerAppService.managedEnvironment.httpRouteConfi
   rules []dict
   // Errors encountered while reconciling routes
   provisioningErrors []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Maintenance configuration on a Container Apps managed environment
@@ -10057,6 +10151,8 @@ private azure.subscription.containerAppService.managedEnvironment.maintenanceCon
   name string
   // Scheduled maintenance windows — each entry has `weekDay`, `startHourUtc`, `durationHours`
   scheduledEntries []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Dapr component configured at the managed environment scope
@@ -10081,6 +10177,8 @@ private azure.subscription.containerAppService.managedEnvironment.daprComponent 
   provisioningState string
   // Free-form error string set by ARM when deployment or validation failed
   deploymentErrors string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Certificate uploaded to a Container Apps managed environment
@@ -10109,6 +10207,8 @@ private azure.subscription.containerAppService.managedEnvironment.certificate @d
   publicKeyHash string
   // Subject alternative names declared on the cert
   subjectAlternativeNames []string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Container App
@@ -10198,6 +10298,8 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   authConfigs() []azure.subscription.containerAppService.containerApp.authConfig
   // Revision history
   revisions() []azure.subscription.containerAppService.containerApp.revision
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Container definition inside a Container App
@@ -10250,6 +10352,8 @@ private azure.subscription.containerAppService.containerApp.revision @defaults("
   createdTime time
   // Last active time
   lastActiveTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Container App Easy Auth (authConfig) configuration
@@ -10268,6 +10372,8 @@ private azure.subscription.containerAppService.containerApp.authConfig @defaults
   login dict
   // HTTP settings (requireHttps, route configuration, forward proxy)
   httpSettings dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Container Apps Job
@@ -10317,6 +10423,8 @@ azure.subscription.containerAppService.job @defaults("name location triggerType 
   registryAuthUsesIdentity bool
   // Names of declared secrets (values are not returned by ARM on read)
   secretNames []string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Container Instances
@@ -10639,6 +10747,8 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   publicIpAddress() azure.subscription.networkService.ipAddress
   // Service creation time
   createdAt time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Purview
@@ -10769,6 +10879,8 @@ azure.subscription.searchService.service @defaults("id name location publicNetwo
   status string
   // Network rule set: IP firewall rules and the bypass setting governing public access
   networkRuleSet dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Machine Learning
@@ -10922,6 +11034,8 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint @defaults("na
   provisioningState string
   // Model deployments behind the endpoint
   deployments() []azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Model deployment behind an online endpoint
@@ -10963,6 +11077,8 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment @d
   egressPublicNetworkAccess string
   // Provisioning state of the deployment
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Serverless (Models-as-a-Service) endpoint in an Azure Machine Learning workspace
@@ -10999,6 +11115,8 @@ azure.subscription.machineLearningService.workspace.serverlessEndpoint @defaults
   contentSafetyStatus string
   // Provisioning state of the endpoint
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Compute target in an Azure Machine Learning workspace
@@ -11042,6 +11160,8 @@ azure.subscription.machineLearningService.workspace.compute @defaults("name comp
   createdOn time
   // When the compute was last modified
   modifiedOn time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Registered model in an Azure Machine Learning workspace
@@ -11068,6 +11188,8 @@ azure.subscription.machineLearningService.workspace.model @defaults("name latest
   tags map[string]string
   // Provisioning state of the model container
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // App Configuration
@@ -11274,6 +11396,8 @@ azure.subscription.cognitiveServicesService.account.deployment @defaults("name m
   raiPolicyName string
   // Responsible AI content-filter policy applied to the deployment (null when none is attached)
   raiPolicy() azure.subscription.cognitiveServicesService.account.raiPolicy
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure AI Foundry project
@@ -11308,6 +11432,8 @@ azure.subscription.cognitiveServicesService.account.project @defaults("name disp
   endpoints map[string]string
   // Project-scoped connections to external resources, model providers, data sources, and tool servers
   connections() []azure.subscription.cognitiveServicesService.account.project.connection
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Connection on an Azure AI Foundry project
@@ -11354,6 +11480,8 @@ private azure.subscription.cognitiveServicesService.account.project.connection @
   error string
   // When the connection's credentials expire (null when they do not expire)
   expiryTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Connection on an Azure AI Services account
@@ -11400,6 +11528,8 @@ private azure.subscription.cognitiveServicesService.account.connection @defaults
   error string
   // When the connection's credentials expire (null when they do not expire)
   expiryTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Responsible AI content-filter policy on a Cognitive Services account
@@ -11426,6 +11556,8 @@ private azure.subscription.cognitiveServicesService.account.raiPolicy @defaults(
   customBlocklists []dict
   // Custom RAI topic references attached to the policy
   customTopics []azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Content filter on a Responsible AI policy
@@ -11492,6 +11624,8 @@ private azure.subscription.cognitiveServicesService.account.raiTopic @defaults("
   createdAt time
   // When the topic was last modified
   lastModifiedAt time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Sentinel
@@ -11564,6 +11698,8 @@ private azure.subscription.sentinelService.alertRule @defaults("name kind enable
   description string
   // Kind-specific properties (e.g., for Scheduled rules: query, queryFrequency, queryPeriod, triggerThreshold)
   properties dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SignalR Service
@@ -11620,6 +11756,8 @@ azure.subscription.signalRService.signalR @defaults("id name location publicNetw
   networkAclsDefaultAction string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Web PubSub Service
@@ -11677,6 +11815,8 @@ azure.subscription.webPubSubService.webPubSub @defaults("id name location public
   networkAclsDefaultAction string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer (Kusto)
@@ -11903,6 +12043,8 @@ private azure.subscription.kustoService.cluster.privateEndpointConnection @defau
   privateEndpoint() azure.subscription.networkService.privateEndpoint
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer cluster managed private endpoint
@@ -11927,6 +12069,8 @@ private azure.subscription.kustoService.cluster.managedPrivateEndpoint @defaults
   requestMessage string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer database data connection
@@ -12019,6 +12163,8 @@ azure.subscription.automationService.account @defaults("id name location publicN
   credentials() []azure.subscription.automationService.account.credential
   // Certificates stored in the account
   certificates() []azure.subscription.automationService.account.certificate
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Automation account variable
@@ -12035,6 +12181,8 @@ private azure.subscription.automationService.account.variable @defaults("name is
   creationTime time
   // When the variable was last modified
   lastModifiedTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Automation account credential
@@ -12051,6 +12199,8 @@ private azure.subscription.automationService.account.credential @defaults("name 
   creationTime time
   // When the credential was last modified
   lastModifiedTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Automation account certificate
@@ -12069,6 +12219,8 @@ private azure.subscription.automationService.account.certificate @defaults("name
   description string
   // When the certificate was created
   creationTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Virtual Desktop
@@ -12128,4 +12280,6 @@ azure.subscription.desktopVirtualizationService.hostPool @defaults("id name loca
   ssoSecretType string
   // Number of approved private endpoint connections to the host pool
   privateEndpointConnectionCount int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2923,6 +2923,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.diskEncryptionSet.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet).GetIdentity()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.computeService.diskEncryptionSet.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.computeService.diskAccess.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDiskAccess).GetId()).ToDataRes(types.String)
 	},
@@ -2946,6 +2949,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.diskAccess.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDiskAccess).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
+	"azure.subscription.computeService.diskAccess.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceDiskAccess).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.computeService.snapshot.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetId()).ToDataRes(types.String)
@@ -3169,6 +3175,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vmScaleSet.instance.sku": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).GetSku()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.computeService.vmScaleSet.instance.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.computeService.dedicatedHostGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).GetId()).ToDataRes(types.String)
 	},
@@ -3204,6 +3213,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.dedicatedHostGroup.hosts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).GetHosts()).ToDataRes(types.Array(types.Resource("azure.subscription.computeService.dedicatedHost")))
+	},
+	"azure.subscription.computeService.dedicatedHostGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.computeService.dedicatedHost.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHost).GetId()).ToDataRes(types.String)
@@ -3249,6 +3261,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.dedicatedHost.instanceView": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHost).GetInstanceView()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.computeService.dedicatedHost.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceDedicatedHost).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.computeService.proximityPlacementGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).GetId()).ToDataRes(types.String)
@@ -3541,6 +3556,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.batchService.account.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
 	},
+	"azure.subscription.batchService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.batchService.account.pool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetId()).ToDataRes(types.String)
 	},
@@ -3585,6 +3603,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.batchService.account.pool.securityEncryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetSecurityEncryptionType()).ToDataRes(types.String)
+	},
+	"azure.subscription.batchService.account.pool.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccountPool).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.databricksService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksService).GetSubscriptionId()).ToDataRes(types.String)
@@ -3663,6 +3684,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.databricksService.workspace.managedServicesKeyVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetManagedServicesKeyVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.databricksService.workspace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.networkService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkService).GetSubscriptionId()).ToDataRes(types.String)
@@ -6970,6 +6994,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appslot.scm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetScm()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
 	},
+	"azure.subscription.webService.appslot.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetId()).ToDataRes(types.String)
 	},
@@ -7323,6 +7350,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.staticSite.databaseConnectionCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceStaticSite).GetDatabaseConnectionCount()).ToDataRes(types.Int)
+	},
+	"azure.subscription.webService.staticSite.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceStaticSite).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.webService.appsite.hostNameBinding.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).GetId()).ToDataRes(types.String)
@@ -8194,6 +8224,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.postgreSqlService.flexibleServer.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).GetInternetReachable()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.postgreSqlService.flexibleServer.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.postgreSqlService.server.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPostgreSqlServiceServer).GetId()).ToDataRes(types.String)
 	},
@@ -8581,6 +8614,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.mySqlService.flexibleServer.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).GetInternetReachable()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.mySqlService.flexibleServer.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cosmosDbService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -8764,6 +8800,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cosmosDbService.mongoCluster.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServiceMongoCluster).GetEncryptionKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
 	},
+	"azure.subscription.cosmosDbService.mongoCluster.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServiceMongoCluster).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cosmosDbService.postgresqlCluster.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).GetId()).ToDataRes(types.String)
 	},
@@ -8844,6 +8883,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cosmosDbService.postgresqlCluster.serverNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).GetServerNames()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.cosmosDbService.postgresqlCluster.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cosmosDbService.account.sqlRoleDefinition.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbServiceAccountSqlRoleDefinition).GetId()).ToDataRes(types.String)
@@ -9024,6 +9066,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.keyVaultService.managedHsm.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKeyVaultServiceManagedHsm).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
+	"azure.subscription.keyVaultService.managedHsm.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKeyVaultServiceManagedHsm).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.keyVaultService.vault.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKeyVaultServiceVault).GetId()).ToDataRes(types.String)
@@ -9439,6 +9484,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.activityLog.alert.scopes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceActivityLogAlert).GetScopes()).ToDataRes(types.Array(types.String))
 	},
+	"azure.subscription.monitorService.activityLog.alert.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceActivityLogAlert).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.monitorService.activityLog.entry.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceActivityLogEntry).GetId()).ToDataRes(types.String)
 	},
@@ -9519,6 +9567,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.monitorService.logprofile.storageAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceLogprofile).GetStorageAccount()).ToDataRes(types.Resource("azure.subscription.storageService.account"))
+	},
+	"azure.subscription.monitorService.logprofile.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceLogprofile).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.monitorService.diagnosticsetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceDiagnosticsetting).GetId()).ToDataRes(types.String)
@@ -10534,6 +10585,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.managedIdentity.federatedIdentityCredentials": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionManagedIdentity).GetFederatedIdentityCredentials()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.managedIdentity.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionManagedIdentity).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.aksService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -11020,6 +11074,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.policy.assignment.parameters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicyAssignment).GetParameters()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.policy.assignment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPolicyAssignment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.policy.definition.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicyDefinition).GetId()).ToDataRes(types.String)
 	},
@@ -11050,6 +11107,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.policy.definition.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicyDefinition).GetVersion()).ToDataRes(types.String)
 	},
+	"azure.subscription.policy.definition.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPolicyDefinition).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.policy.setDefinition.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicySetDefinition).GetId()).ToDataRes(types.String)
 	},
@@ -11076,6 +11136,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.policy.setDefinition.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicySetDefinition).GetVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.policy.setDefinition.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPolicySetDefinition).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.policy.exemption.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicyExemption).GetId()).ToDataRes(types.String)
@@ -11196,6 +11259,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
+	},
+	"azure.subscription.iotService.iotHub.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cacheService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12007,6 +12073,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.workspace.networkSecurityPerimeterConfigurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspace).GetNetworkSecurityPerimeterConfigurations()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.workspace.nspConfiguration")))
 	},
+	"azure.subscription.monitorService.workspace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.monitorService.workspace.capping.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceCapping).GetId()).ToDataRes(types.String)
 	},
@@ -12157,6 +12226,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.workspace.table.resultStatistics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceTable).GetResultStatistics()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.monitorService.workspace.table.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceTable).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.monitorService.workspace.nspConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -12232,6 +12304,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.queryPack.queries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPack).GetQueries()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.queryPack.query")))
 	},
+	"azure.subscription.monitorService.queryPack.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPack).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.monitorService.queryPack.query.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).GetId()).ToDataRes(types.String)
 	},
@@ -12261,6 +12336,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.monitorService.queryPack.query.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).GetTags()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.monitorService.queryPack.query.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.recoveryServicesService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12330,6 +12408,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItems": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetProtectedItems()).ToDataRes(types.Array(types.Resource("azure.subscription.recoveryServicesService.vault.protectedItem")))
+	},
+	"azure.subscription.recoveryServicesService.vault.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings).GetId()).ToDataRes(types.String)
@@ -12493,6 +12574,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.functionsService.functionApp.connectionStrings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetConnectionStrings()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.functionsService.functionApp.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.functionsService.functionApp.appSetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetId()).ToDataRes(types.String)
 	},
@@ -12525,6 +12609,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.functionsService.functionApp.function.isDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).GetIsDisabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.functionsService.functionApp.function.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.serviceBusService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12583,6 +12670,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetTopics()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.topic")))
 	},
+	"azure.subscription.serviceBusService.namespace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.serviceBusService.namespace.networkRules.defaultAction": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules).GetDefaultAction()).ToDataRes(types.String)
 	},
@@ -12640,6 +12730,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.queue.enablePartitioning": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).GetEnablePartitioning()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.serviceBusService.namespace.queue.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.serviceBusService.namespace.topic.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetId()).ToDataRes(types.String)
 	},
@@ -12670,6 +12763,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.topic.subscriptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetSubscriptions()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.topic.subscription")))
 	},
+	"azure.subscription.serviceBusService.namespace.topic.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetId()).ToDataRes(types.String)
 	},
@@ -12696,6 +12792,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.requiresSession": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetRequiresSession()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.serviceBusService.namespace.topic.subscription.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.eventHubService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12817,6 +12916,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.userMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).GetUserMetadata()).ToDataRes(types.String)
 	},
+	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.eventGridService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -12874,6 +12976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.eventGridService.topic.privateEndpointConnectionCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridServiceTopic).GetPrivateEndpointConnectionCount()).ToDataRes(types.Int)
 	},
+	"azure.subscription.eventGridService.topic.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventGridServiceTopic).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.eventGridService.systemTopic.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).GetId()).ToDataRes(types.String)
 	},
@@ -12900,6 +13005,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventGridService.systemTopic.identityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).GetIdentityType()).ToDataRes(types.String)
+	},
+	"azure.subscription.eventGridService.systemTopic.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.eventGridService.domain.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridServiceDomain).GetId()).ToDataRes(types.String)
@@ -12951,6 +13059,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventGridService.domain.privateEndpointConnectionCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventGridServiceDomain).GetPrivateEndpointConnectionCount()).ToDataRes(types.Int)
+	},
+	"azure.subscription.eventGridService.domain.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventGridServiceDomain).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.dnsService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDnsService).GetSubscriptionId()).ToDataRes(types.String)
@@ -13090,6 +13201,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.frontDoorService.profile.securityPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfile).GetSecurityPolicies()).ToDataRes(types.Array(types.Resource("azure.subscription.frontDoorService.profile.securityPolicy")))
 	},
+	"azure.subscription.frontDoorService.profile.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfile).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.frontDoorService.profile.securityPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -13107,6 +13221,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.securityPolicy.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetId()).ToDataRes(types.String)
@@ -13128,6 +13245,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.routes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetRoutes()).ToDataRes(types.Array(types.Resource("azure.subscription.frontDoorService.profile.endpoint.route")))
+	},
+	"azure.subscription.frontDoorService.profile.endpoint.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.route.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).GetId()).ToDataRes(types.String)
@@ -13165,6 +13285,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.frontDoorService.profile.endpoint.route.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.frontDoorService.profile.endpoint.route.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.frontDoorService.profile.customDomain.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).GetId()).ToDataRes(types.String)
 	},
@@ -13186,6 +13309,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.frontDoorService.profile.customDomain.tlsCertificateType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).GetTlsCertificateType()).ToDataRes(types.String)
 	},
+	"azure.subscription.frontDoorService.profile.customDomain.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.frontDoorService.profile.originGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).GetId()).ToDataRes(types.String)
 	},
@@ -13203,6 +13329,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origins": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).GetOrigins()).ToDataRes(types.Array(types.Resource("azure.subscription.frontDoorService.profile.originGroup.origin")))
+	},
+	"azure.subscription.frontDoorService.profile.originGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origin.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).GetId()).ToDataRes(types.String)
@@ -13233,6 +13362,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origin.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.originGroup.origin.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerAppService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppService).GetSubscriptionId()).ToDataRes(types.String)
@@ -13321,6 +13453,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfigurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment).GetMaintenanceConfigurations()).ToDataRes(types.Array(types.Resource("azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration")))
 	},
+	"azure.subscription.containerAppService.managedEnvironment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).GetId()).ToDataRes(types.String)
 	},
@@ -13345,6 +13480,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.privateEndpointId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).GetPrivateEndpointId()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).GetId()).ToDataRes(types.String)
 	},
@@ -13366,6 +13504,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.provisioningErrors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).GetProvisioningErrors()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -13374,6 +13515,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.scheduledEntries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).GetScheduledEntries()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerAppService.managedEnvironment.daprComponent.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).GetId()).ToDataRes(types.String)
@@ -13404,6 +13548,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.daprComponent.deploymentErrors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).GetDeploymentErrors()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerAppService.managedEnvironment.daprComponent.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerAppService.managedEnvironment.certificate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).GetId()).ToDataRes(types.String)
@@ -13440,6 +13587,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.certificate.subjectAlternativeNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).GetSubjectAlternativeNames()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.containerAppService.managedEnvironment.certificate.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerAppService.containerApp.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetId()).ToDataRes(types.String)
@@ -13546,6 +13696,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.containerApp.revisions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetRevisions()).ToDataRes(types.Array(types.Resource("azure.subscription.containerAppService.containerApp.revision")))
 	},
+	"azure.subscription.containerAppService.containerApp.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerAppService.containerApp.container.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppContainer).GetId()).ToDataRes(types.String)
 	},
@@ -13612,6 +13765,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.containerApp.revision.lastActiveTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppRevision).GetLastActiveTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.containerAppService.containerApp.revision.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppRevision).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerAppService.containerApp.authConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).GetId()).ToDataRes(types.String)
 	},
@@ -13632,6 +13788,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.containerApp.authConfig.httpSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).GetHttpSettings()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.containerAppService.containerApp.authConfig.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerAppService.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceJob).GetId()).ToDataRes(types.String)
@@ -13686,6 +13845,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.job.secretNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceJob).GetSecretNames()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.containerAppService.job.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceJob).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerInstanceService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerInstanceService).GetSubscriptionId()).ToDataRes(types.String)
@@ -14038,6 +14200,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.apiManagementService.service.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"azure.subscription.apiManagementService.service.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.purviewService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPurviewService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -14157,6 +14322,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.searchService.service.networkRuleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSearchServiceService).GetNetworkRuleSet()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.searchService.service.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSearchServiceService).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.machineLearningService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningService).GetSubscriptionId()).ToDataRes(types.String)
@@ -14317,6 +14485,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint).GetDeployments()).ToDataRes(types.Array(types.Resource("azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment")))
 	},
+	"azure.subscription.machineLearningService.workspace.onlineEndpoint.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -14359,6 +14530,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).GetId()).ToDataRes(types.String)
 	},
@@ -14394,6 +14568,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.machineLearningService.workspace.compute.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).GetId()).ToDataRes(types.String)
@@ -14437,6 +14614,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.machineLearningService.workspace.compute.modifiedOn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).GetModifiedOn()).ToDataRes(types.Time)
 	},
+	"azure.subscription.machineLearningService.workspace.compute.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.machineLearningService.workspace.model.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).GetId()).ToDataRes(types.String)
 	},
@@ -14460,6 +14640,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.machineLearningService.workspace.model.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.machineLearningService.workspace.model.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.appConfigurationService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAppConfigurationService).GetSubscriptionId()).ToDataRes(types.String)
@@ -14656,6 +14839,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cognitiveServicesService.account.deployment.raiPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment).GetRaiPolicy()).ToDataRes(types.Resource("azure.subscription.cognitiveServicesService.account.raiPolicy"))
 	},
+	"azure.subscription.cognitiveServicesService.account.deployment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cognitiveServicesService.account.project.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).GetId()).ToDataRes(types.String)
 	},
@@ -14688,6 +14874,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.project.connections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).GetConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.cognitiveServicesService.account.project.connection")))
+	},
+	"azure.subscription.cognitiveServicesService.account.project.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cognitiveServicesService.account.project.connection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection).GetId()).ToDataRes(types.String)
@@ -14728,6 +14917,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cognitiveServicesService.account.project.connection.expiryTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection).GetExpiryTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.cognitiveServicesService.account.project.connection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cognitiveServicesService.account.connection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).GetId()).ToDataRes(types.String)
 	},
@@ -14767,6 +14959,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cognitiveServicesService.account.connection.expiryTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).GetExpiryTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.cognitiveServicesService.account.connection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -14790,6 +14985,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.customTopics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).GetCustomTopics()).ToDataRes(types.Array(types.Resource("azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef")))
+	},
+	"azure.subscription.cognitiveServicesService.account.raiPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.contentFilter.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyContentFilter).GetName()).ToDataRes(types.String)
@@ -14848,6 +15046,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cognitiveServicesService.account.raiTopic.lastModifiedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetLastModifiedAt()).ToDataRes(types.Time)
 	},
+	"azure.subscription.cognitiveServicesService.account.raiTopic.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.sentinelService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSentinelService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -14901,6 +15102,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.sentinelService.alertRule.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSentinelServiceAlertRule).GetProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.sentinelService.alertRule.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSentinelServiceAlertRule).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.signalRService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSignalRService).GetSubscriptionId()).ToDataRes(types.String)
@@ -14956,6 +15160,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.signalRService.signalR.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSignalRServiceSignalR).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.signalRService.signalR.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSignalRServiceSignalR).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webPubSubService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebPubSubService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -15009,6 +15216,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webPubSubService.webPubSub.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.webPubSubService.webPubSub.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.kustoService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoService).GetSubscriptionId()).ToDataRes(types.String)
@@ -15229,6 +15439,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.kustoService.cluster.privateEndpointConnection.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.kustoService.cluster.privateEndpointConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).GetId()).ToDataRes(types.String)
 	},
@@ -15249,6 +15462,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.kustoService.cluster.database.dataConnection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).GetId()).ToDataRes(types.String)
@@ -15343,6 +15559,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.automationService.account.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccount).GetCertificates()).ToDataRes(types.Array(types.Resource("azure.subscription.automationService.account.certificate")))
 	},
+	"azure.subscription.automationService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAutomationServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.automationService.account.variable.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).GetId()).ToDataRes(types.String)
 	},
@@ -15361,6 +15580,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.automationService.account.variable.lastModifiedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).GetLastModifiedTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.automationService.account.variable.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.automationService.account.credential.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).GetId()).ToDataRes(types.String)
 	},
@@ -15378,6 +15600,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.automationService.account.credential.lastModifiedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).GetLastModifiedTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.automationService.account.credential.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.automationService.account.certificate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).GetId()).ToDataRes(types.String)
@@ -15399,6 +15624,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.automationService.account.certificate.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).GetCreationTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.automationService.account.certificate.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.desktopVirtualizationService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDesktopVirtualizationService).GetSubscriptionId()).ToDataRes(types.String)
@@ -15459,6 +15687,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.desktopVirtualizationService.hostPool.privateEndpointConnectionCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool).GetPrivateEndpointConnectionCount()).ToDataRes(types.Int)
+	},
+	"azure.subscription.desktopVirtualizationService.hostPool.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 }
 
@@ -16608,6 +16839,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.diskEncryptionSet.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.diskAccess.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDiskAccess).__id, ok = v.Value.(string)
 		return
@@ -16642,6 +16877,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.diskAccess.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDiskAccess).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.diskAccess.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceDiskAccess).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16952,6 +17191,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).Sku, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vmScaleSet.instance.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.dedicatedHostGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).__id, ok = v.Value.(string)
 		return
@@ -17002,6 +17245,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.dedicatedHostGroup.hosts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).Hosts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.dedicatedHostGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.dedicatedHost.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17066,6 +17313,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.dedicatedHost.instanceView": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDedicatedHost).InstanceView, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.dedicatedHost.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceDedicatedHost).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.proximityPlacementGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17484,6 +17735,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionBatchServiceAccount).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.batchService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.batchService.account.pool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccountPool).__id, ok = v.Value.(string)
 		return
@@ -17546,6 +17801,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.batchService.account.pool.securityEncryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccountPool).SecurityEncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.batchService.account.pool.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccountPool).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.databricksService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17658,6 +17917,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.databricksService.workspace.managedServicesKeyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).ManagedServicesKeyVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.databricksService.workspace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22464,6 +22727,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppslot).Scm, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appslot.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).__id, ok = v.Value.(string)
 		return
@@ -22970,6 +23237,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.staticSite.databaseConnectionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceStaticSite).DatabaseConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.staticSite.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceStaticSite).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsite.hostNameBinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24252,6 +24523,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.postgreSqlService.flexibleServer.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPostgreSqlServiceFlexibleServer).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.postgreSqlService.server.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPostgreSqlServiceServer).__id, ok = v.Value.(string)
 		return
@@ -24812,6 +25087,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.mySqlService.flexibleServer.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServer).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cosmosDbService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCosmosDbService).__id, ok = v.Value.(string)
 		return
@@ -25072,6 +25351,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCosmosDbServiceMongoCluster).EncryptionKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cosmosDbService.mongoCluster.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServiceMongoCluster).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cosmosDbService.postgresqlCluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).__id, ok = v.Value.(string)
 		return
@@ -25182,6 +25465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cosmosDbService.postgresqlCluster.serverNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).ServerNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cosmosDbService.postgresqlCluster.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cosmosDbService.account.sqlRoleDefinition.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25446,6 +25733,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.keyVaultService.managedHsm.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKeyVaultServiceManagedHsm).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.keyVaultService.managedHsm.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKeyVaultServiceManagedHsm).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.keyVaultService.vault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26064,6 +26355,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceActivityLogAlert).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.activityLog.alert.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceActivityLogAlert).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.activityLog.entry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceActivityLogEntry).__id, ok = v.Value.(string)
 		return
@@ -26178,6 +26473,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.monitorService.logprofile.storageAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceLogprofile).StorageAccount, ok = plugin.RawToTValue[*mqlAzureSubscriptionStorageServiceAccount](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.logprofile.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceLogprofile).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.diagnosticsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27656,6 +27955,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionManagedIdentity).FederatedIdentityCredentials, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.managedIdentity.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionManagedIdentity).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.aksService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksService).__id, ok = v.Value.(string)
 		return
@@ -28360,6 +28663,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionPolicyAssignment).Parameters, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.policy.assignment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPolicyAssignment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.policy.definition.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPolicyDefinition).__id, ok = v.Value.(string)
 		return
@@ -28404,6 +28711,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionPolicyDefinition).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.policy.definition.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPolicyDefinition).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.policy.setDefinition.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPolicySetDefinition).__id, ok = v.Value.(string)
 		return
@@ -28442,6 +28753,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.policy.setDefinition.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPolicySetDefinition).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.policy.setDefinition.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPolicySetDefinition).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.policy.exemption.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28618,6 +28933,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionIotServiceIotHub).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.iotService.iotHub.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cacheService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29808,6 +30127,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceWorkspace).NetworkSecurityPerimeterConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.workspace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceWorkspace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.workspace.capping.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceCapping).__id, ok = v.Value.(string)
 		return
@@ -30036,6 +30359,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceTable).ResultStatistics, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.workspace.table.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceTable).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.workspace.nspConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).__id, ok = v.Value.(string)
 		return
@@ -30144,6 +30471,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceQueryPack).Queries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.queryPack.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceQueryPack).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.queryPack.query.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).__id, ok = v.Value.(string)
 		return
@@ -30186,6 +30517,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.monitorService.queryPack.query.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).Tags, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.queryPack.query.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30286,6 +30621,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItems": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).ProtectedItems, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30540,6 +30879,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).ConnectionStrings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.functionsService.functionApp.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.functionsService.functionApp.appSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).__id, ok = v.Value.(string)
 		return
@@ -30590,6 +30933,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.functionsService.functionApp.function.isDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).IsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.function.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.serviceBusService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30674,6 +31021,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.serviceBusService.namespace.topics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).Topics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.serviceBusService.namespace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.serviceBusService.namespace.networkRules.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30764,6 +31115,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).EnablePartitioning, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.queue.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.topic.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).__id, ok = v.Value.(string)
 		return
@@ -30808,6 +31163,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).Subscriptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.topic.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).__id, ok = v.Value.(string)
 		return
@@ -30846,6 +31205,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.serviceBusService.namespace.topic.subscription.requiresSession": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).RequiresSession, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.serviceBusService.namespace.topic.subscription.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventHubService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31032,6 +31395,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).UserMetadata, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.eventGridService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventGridService).__id, ok = v.Value.(string)
 		return
@@ -31116,6 +31483,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionEventGridServiceTopic).PrivateEndpointConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.eventGridService.topic.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventGridServiceTopic).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.eventGridService.systemTopic.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).__id, ok = v.Value.(string)
 		return
@@ -31154,6 +31525,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventGridService.systemTopic.identityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventGridService.systemTopic.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventGridServiceSystemTopic).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventGridService.domain.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31226,6 +31601,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventGridService.domain.privateEndpointConnectionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventGridServiceDomain).PrivateEndpointConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventGridService.domain.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventGridServiceDomain).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dnsService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31440,6 +31819,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfile).SecurityPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.frontDoorService.profile.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfile).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.frontDoorService.profile.securityPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).__id, ok = v.Value.(string)
 		return
@@ -31466,6 +31849,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.securityPolicy.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.securityPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31498,6 +31885,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.routes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).Routes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.endpoint.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.route.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31552,6 +31943,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.frontDoorService.profile.endpoint.route.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.frontDoorService.profile.customDomain.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).__id, ok = v.Value.(string)
 		return
@@ -31584,6 +31979,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).TlsCertificateType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.frontDoorService.profile.customDomain.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.frontDoorService.profile.originGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).__id, ok = v.Value.(string)
 		return
@@ -31610,6 +32009,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origins": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).Origins, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.originGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origin.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31654,6 +32057,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.originGroup.origin.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.originGroup.origin.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31780,6 +32187,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment).MaintenanceConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.managedEnvironment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).__id, ok = v.Value.(string)
 		return
@@ -31816,6 +32227,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).PrivateEndpointId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).__id, ok = v.Value.(string)
 		return
@@ -31848,6 +32263,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).ProvisioningErrors, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).__id, ok = v.Value.(string)
 		return
@@ -31862,6 +32281,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.scheduledEntries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).ScheduledEntries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.managedEnvironment.daprComponent.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31906,6 +32329,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.daprComponent.deploymentErrors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).DeploymentErrors, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.managedEnvironment.daprComponent.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.managedEnvironment.certificate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31958,6 +32385,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.managedEnvironment.certificate.subjectAlternativeNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).SubjectAlternativeNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.managedEnvironment.certificate.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.containerApp.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32104,6 +32535,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).Revisions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.containerApp.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.containerApp.container.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppContainer).__id, ok = v.Value.(string)
 		return
@@ -32200,6 +32635,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppRevision).LastActiveTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.containerApp.revision.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppRevision).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.containerApp.authConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).__id, ok = v.Value.(string)
 		return
@@ -32230,6 +32669,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.containerApp.authConfig.httpSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).HttpSettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.containerApp.authConfig.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.job.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32306,6 +32749,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.job.secretNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceJob).SecretNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.job.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceJob).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerInstanceService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32804,6 +33251,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionApiManagementServiceService).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.apiManagementService.service.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.purviewService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPurviewService).__id, ok = v.Value.(string)
 		return
@@ -32978,6 +33429,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.searchService.service.networkRuleSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSearchServiceService).NetworkRuleSet, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.searchService.service.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSearchServiceService).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.machineLearningService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33204,6 +33659,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.machineLearningService.workspace.onlineEndpoint.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).__id, ok = v.Value.(string)
 		return
@@ -33264,6 +33723,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).__id, ok = v.Value.(string)
 		return
@@ -33314,6 +33777,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.machineLearningService.workspace.serverlessEndpoint.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.machineLearningService.workspace.compute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33376,6 +33843,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).ModifiedOn, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.machineLearningService.workspace.compute.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.machineLearningService.workspace.model.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).__id, ok = v.Value.(string)
 		return
@@ -33410,6 +33881,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.machineLearningService.workspace.model.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.machineLearningService.workspace.model.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.appConfigurationService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33692,6 +34167,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment).RaiPolicy, ok = plugin.RawToTValue[*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cognitiveServicesService.account.deployment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cognitiveServicesService.account.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).__id, ok = v.Value.(string)
 		return
@@ -33738,6 +34217,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.project.connections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).Connections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.project.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.project.connection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33796,6 +34279,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection).ExpiryTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cognitiveServicesService.account.project.connection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cognitiveServicesService.account.connection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).__id, ok = v.Value.(string)
 		return
@@ -33852,6 +34339,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).ExpiryTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cognitiveServicesService.account.connection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).__id, ok = v.Value.(string)
 		return
@@ -33886,6 +34377,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.customTopics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).CustomTopics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.raiPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.raiPolicy.contentFilter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33976,6 +34471,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).LastModifiedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cognitiveServicesService.account.raiTopic.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sentinelService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSentinelService).__id, ok = v.Value.(string)
 		return
@@ -34060,6 +34559,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSentinelServiceAlertRule).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sentinelService.alertRule.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSentinelServiceAlertRule).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.signalRService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSignalRService).__id, ok = v.Value.(string)
 		return
@@ -34140,6 +34643,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSignalRServiceSignalR).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.signalRService.signalR.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSignalRServiceSignalR).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webPubSubService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebPubSubService).__id, ok = v.Value.(string)
 		return
@@ -34218,6 +34725,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webPubSubService.webPubSub.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webPubSubService.webPubSub.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.kustoService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34540,6 +35051,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.kustoService.cluster.privateEndpointConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).__id, ok = v.Value.(string)
 		return
@@ -34570,6 +35085,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.kustoService.cluster.managedPrivateEndpoint.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.kustoService.cluster.database.dataConnection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34708,6 +35227,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAutomationServiceAccount).Certificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.automationService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAutomationServiceAccount).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.automationService.account.variable.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).__id, ok = v.Value.(string)
 		return
@@ -34736,6 +35259,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).LastModifiedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.automationService.account.variable.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAutomationServiceAccountVariable).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.automationService.account.credential.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).__id, ok = v.Value.(string)
 		return
@@ -34762,6 +35289,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.automationService.account.credential.lastModifiedTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).LastModifiedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.automationService.account.credential.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAutomationServiceAccountCredential).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.automationService.account.certificate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34794,6 +35325,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.automationService.account.certificate.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.automationService.account.certificate.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAutomationServiceAccountCertificate).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.desktopVirtualizationService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34882,6 +35417,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.desktopVirtualizationService.hostPool.privateEndpointConnectionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool).PrivateEndpointConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.desktopVirtualizationService.hostPool.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 }
@@ -37627,7 +38166,7 @@ func (c *mqlAzureSubscriptionComputeServiceDisk) GetSystemMetadata() *plugin.TVa
 type mqlAzureSubscriptionComputeServiceDiskEncryptionSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceDiskEncryptionSetInternal it will be used here
+	mqlAzureSubscriptionComputeServiceDiskEncryptionSetInternal
 	Id                                plugin.TValue[string]
 	Name                              plugin.TValue[string]
 	Location                          plugin.TValue[string]
@@ -37640,6 +38179,7 @@ type mqlAzureSubscriptionComputeServiceDiskEncryptionSet struct {
 	LastKeyRotationTimestamp          plugin.TValue[*time.Time]
 	ProvisioningState                 plugin.TValue[string]
 	Identity                          plugin.TValue[any]
+	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceDiskEncryptionSet creates a new instance of this resource
@@ -37727,6 +38267,22 @@ func (c *mqlAzureSubscriptionComputeServiceDiskEncryptionSet) GetIdentity() *plu
 	return &c.Identity
 }
 
+func (c *mqlAzureSubscriptionComputeServiceDiskEncryptionSet) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.diskEncryptionSet", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceDiskAccess for the azure.subscription.computeService.diskAccess resource
 type mqlAzureSubscriptionComputeServiceDiskAccess struct {
 	MqlRuntime *plugin.Runtime
@@ -37740,6 +38296,7 @@ type mqlAzureSubscriptionComputeServiceDiskAccess struct {
 	ProvisioningState          plugin.TValue[string]
 	TimeCreated                plugin.TValue[*time.Time]
 	PrivateEndpointConnections plugin.TValue[[]any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceDiskAccess creates a new instance of this resource
@@ -37820,6 +38377,22 @@ func (c *mqlAzureSubscriptionComputeServiceDiskAccess) GetPrivateEndpointConnect
 		}
 
 		return c.privateEndpointConnections()
+	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceDiskAccess) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.diskAccess", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -38282,7 +38855,7 @@ func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetExtensions() *plugin.T
 type mqlAzureSubscriptionComputeServiceVmScaleSetInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceVmScaleSetInstanceInternal it will be used here
+	mqlAzureSubscriptionComputeServiceVmScaleSetInstanceInternal
 	Id                     plugin.TValue[string]
 	InstanceId             plugin.TValue[string]
 	Name                   plugin.TValue[string]
@@ -38296,6 +38869,7 @@ type mqlAzureSubscriptionComputeServiceVmScaleSetInstance struct {
 	TimeCreated            plugin.TValue[*time.Time]
 	Properties             plugin.TValue[any]
 	Sku                    plugin.TValue[any]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceVmScaleSetInstance creates a new instance of this resource
@@ -38387,11 +38961,27 @@ func (c *mqlAzureSubscriptionComputeServiceVmScaleSetInstance) GetSku() *plugin.
 	return &c.Sku
 }
 
+func (c *mqlAzureSubscriptionComputeServiceVmScaleSetInstance) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vmScaleSet.instance", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceDedicatedHostGroup for the azure.subscription.computeService.dedicatedHostGroup resource
 type mqlAzureSubscriptionComputeServiceDedicatedHostGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceDedicatedHostGroupInternal it will be used here
+	mqlAzureSubscriptionComputeServiceDedicatedHostGroupInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Location                  plugin.TValue[string]
@@ -38404,6 +38994,7 @@ type mqlAzureSubscriptionComputeServiceDedicatedHostGroup struct {
 	AdditionalCapabilities    plugin.TValue[any]
 	InstanceView              plugin.TValue[any]
 	Hosts                     plugin.TValue[[]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceDedicatedHostGroup creates a new instance of this resource
@@ -38503,11 +39094,27 @@ func (c *mqlAzureSubscriptionComputeServiceDedicatedHostGroup) GetHosts() *plugi
 	})
 }
 
+func (c *mqlAzureSubscriptionComputeServiceDedicatedHostGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.dedicatedHostGroup", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceDedicatedHost for the azure.subscription.computeService.dedicatedHost resource
 type mqlAzureSubscriptionComputeServiceDedicatedHost struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceDedicatedHostInternal it will be used here
+	mqlAzureSubscriptionComputeServiceDedicatedHostInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	Location             plugin.TValue[string]
@@ -38523,6 +39130,7 @@ type mqlAzureSubscriptionComputeServiceDedicatedHost struct {
 	ProvisioningState    plugin.TValue[string]
 	TimeCreated          plugin.TValue[*time.Time]
 	InstanceView         plugin.TValue[any]
+	SystemMetadata       plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceDedicatedHost creates a new instance of this resource
@@ -38620,6 +39228,22 @@ func (c *mqlAzureSubscriptionComputeServiceDedicatedHost) GetTimeCreated() *plug
 
 func (c *mqlAzureSubscriptionComputeServiceDedicatedHost) GetInstanceView() *plugin.TValue[any] {
 	return &c.InstanceView
+}
+
+func (c *mqlAzureSubscriptionComputeServiceDedicatedHost) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.dedicatedHost", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionComputeServiceProximityPlacementGroup for the azure.subscription.computeService.proximityPlacementGroup resource
@@ -39281,7 +39905,7 @@ func (c *mqlAzureSubscriptionBatchService) GetAccounts() *plugin.TValue[[]any] {
 type mqlAzureSubscriptionBatchServiceAccount struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionBatchServiceAccountInternal it will be used here
+	mqlAzureSubscriptionBatchServiceAccountInternal
 	Id                                    plugin.TValue[string]
 	Name                                  plugin.TValue[string]
 	Location                              plugin.TValue[string]
@@ -39308,6 +39932,7 @@ type mqlAzureSubscriptionBatchServiceAccount struct {
 	PrivateEndpointConnections            plugin.TValue[[]any]
 	Pools                                 plugin.TValue[[]any]
 	DiagnosticSettings                    plugin.TValue[[]any]
+	SystemMetadata                        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionBatchServiceAccount creates a new instance of this resource
@@ -39475,11 +40100,27 @@ func (c *mqlAzureSubscriptionBatchServiceAccount) GetDiagnosticSettings() *plugi
 	})
 }
 
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionBatchServiceAccountPool for the azure.subscription.batchService.account.pool resource
 type mqlAzureSubscriptionBatchServiceAccountPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionBatchServiceAccountPoolInternal it will be used here
+	mqlAzureSubscriptionBatchServiceAccountPoolInternal
 	Id                            plugin.TValue[string]
 	Name                          plugin.TValue[string]
 	Type                          plugin.TValue[string]
@@ -39495,6 +40136,7 @@ type mqlAzureSubscriptionBatchServiceAccountPool struct {
 	HostEndpointProtectionMode    plugin.TValue[string]
 	ProxyAgentEnabled             plugin.TValue[bool]
 	SecurityEncryptionType        plugin.TValue[string]
+	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionBatchServiceAccountPool creates a new instance of this resource
@@ -39594,6 +40236,22 @@ func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetSecurityEncryptionType(
 	return &c.SecurityEncryptionType
 }
 
+func (c *mqlAzureSubscriptionBatchServiceAccountPool) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account.pool", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionDatabricksService for the azure.subscription.databricksService resource
 type mqlAzureSubscriptionDatabricksService struct {
 	MqlRuntime *plugin.Runtime
@@ -39664,7 +40322,7 @@ func (c *mqlAzureSubscriptionDatabricksService) GetWorkspaces() *plugin.TValue[[
 type mqlAzureSubscriptionDatabricksServiceWorkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDatabricksServiceWorkspaceInternal it will be used here
+	mqlAzureSubscriptionDatabricksServiceWorkspaceInternal
 	Id                              plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Location                        plugin.TValue[string]
@@ -39689,6 +40347,7 @@ type mqlAzureSubscriptionDatabricksServiceWorkspace struct {
 	ManagedServicesKeyVaultUri      plugin.TValue[string]
 	ManagedServicesKeyName          plugin.TValue[string]
 	ManagedServicesKeyVersion       plugin.TValue[string]
+	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDatabricksServiceWorkspace creates a new instance of this resource
@@ -39822,6 +40481,22 @@ func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetManagedServicesKeyNa
 
 func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetManagedServicesKeyVersion() *plugin.TValue[string] {
 	return &c.ManagedServicesKeyVersion
+}
+
+func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.databricksService.workspace", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionNetworkService for the azure.subscription.networkService resource
@@ -51090,7 +51765,7 @@ func (c *mqlAzureSubscriptionPrivateEndpointConnectionConnectionState) GetStatus
 type mqlAzureSubscriptionWebServiceAppslot struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceAppslotInternal it will be used here
+	mqlAzureSubscriptionWebServiceAppslotInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Kind                   plugin.TValue[string]
@@ -51110,6 +51785,7 @@ type mqlAzureSubscriptionWebServiceAppslot struct {
 	Functions              plugin.TValue[[]any]
 	Ftp                    plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
 	Scm                    plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppslot creates a new instance of this resource
@@ -51314,6 +51990,22 @@ func (c *mqlAzureSubscriptionWebServiceAppslot) GetScm() *plugin.TValue[*mqlAzur
 		}
 
 		return c.scm()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -52159,7 +52851,7 @@ func (c *mqlAzureSubscriptionWebServiceCertificate) GetValid() *plugin.TValue[bo
 type mqlAzureSubscriptionWebServiceStaticSite struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceStaticSiteInternal it will be used here
+	mqlAzureSubscriptionWebServiceStaticSiteInternal
 	Id                             plugin.TValue[string]
 	Name                           plugin.TValue[string]
 	Location                       plugin.TValue[string]
@@ -52183,6 +52875,7 @@ type mqlAzureSubscriptionWebServiceStaticSite struct {
 	UserProvidedFunctionAppCount   plugin.TValue[int64]
 	LinkedBackendCount             plugin.TValue[int64]
 	DatabaseConnectionCount        plugin.TValue[int64]
+	SystemMetadata                 plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceStaticSite creates a new instance of this resource
@@ -52312,6 +53005,22 @@ func (c *mqlAzureSubscriptionWebServiceStaticSite) GetLinkedBackendCount() *plug
 
 func (c *mqlAzureSubscriptionWebServiceStaticSite) GetDatabaseConnectionCount() *plugin.TValue[int64] {
 	return &c.DatabaseConnectionCount
+}
+
+func (c *mqlAzureSubscriptionWebServiceStaticSite) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.staticSite", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionWebServiceAppsiteHostNameBinding for the azure.subscription.webService.appsite.hostNameBinding resource
@@ -55376,6 +56085,7 @@ type mqlAzureSubscriptionPostgreSqlServiceFlexibleServer struct {
 	ThreatProtectionState        plugin.TValue[string]
 	PrivateEndpointConnections   plugin.TValue[[]any]
 	InternetReachable            plugin.TValue[bool]
+	SystemMetadata               plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionPostgreSqlServiceFlexibleServer creates a new instance of this resource
@@ -55580,6 +56290,22 @@ func (c *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) GetPrivateEndpoint
 func (c *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) GetInternetReachable() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
 		return c.internetReachable()
+	})
+}
+
+func (c *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.postgreSqlService.flexibleServer", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -56736,6 +57462,7 @@ type mqlAzureSubscriptionMySqlServiceFlexibleServer struct {
 	HighAvailabilityMode   plugin.TValue[string]
 	HighAvailabilityState  plugin.TValue[string]
 	InternetReachable      plugin.TValue[bool]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMySqlServiceFlexibleServer creates a new instance of this resource
@@ -56916,6 +57643,22 @@ func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetHighAvailabilityStat
 func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetInternetReachable() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
 		return c.internetReachable()
+	})
+}
+
+func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.mySqlService.flexibleServer", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -57383,6 +58126,7 @@ type mqlAzureSubscriptionCosmosDbServiceMongoCluster struct {
 	ReplicationState      plugin.TValue[string]
 	ReplicationSourceId   plugin.TValue[string]
 	EncryptionKey         plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCosmosDbServiceMongoCluster creates a new instance of this resource
@@ -57517,11 +58261,27 @@ func (c *mqlAzureSubscriptionCosmosDbServiceMongoCluster) GetEncryptionKey() *pl
 	})
 }
 
+func (c *mqlAzureSubscriptionCosmosDbServiceMongoCluster) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cosmosDbService.mongoCluster", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCosmosDbServicePostgresqlCluster for the azure.subscription.cosmosDbService.postgresqlCluster resource
 type mqlAzureSubscriptionCosmosDbServicePostgresqlCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCosmosDbServicePostgresqlClusterInternal it will be used here
+	mqlAzureSubscriptionCosmosDbServicePostgresqlClusterInternal
 	Id                              plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Location                        plugin.TValue[string]
@@ -57549,6 +58309,7 @@ type mqlAzureSubscriptionCosmosDbServicePostgresqlCluster struct {
 	ReadReplicas                    plugin.TValue[[]any]
 	MaintenanceWindow               plugin.TValue[any]
 	ServerNames                     plugin.TValue[[]any]
+	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCosmosDbServicePostgresqlCluster creates a new instance of this resource
@@ -57689,6 +58450,22 @@ func (c *mqlAzureSubscriptionCosmosDbServicePostgresqlCluster) GetMaintenanceWin
 
 func (c *mqlAzureSubscriptionCosmosDbServicePostgresqlCluster) GetServerNames() *plugin.TValue[[]any] {
 	return &c.ServerNames
+}
+
+func (c *mqlAzureSubscriptionCosmosDbServicePostgresqlCluster) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cosmosDbService.postgresqlCluster", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionCosmosDbServiceAccountSqlRoleDefinition for the azure.subscription.cosmosDbService.account.sqlRoleDefinition resource
@@ -58186,6 +58963,7 @@ type mqlAzureSubscriptionKeyVaultServiceManagedHsm struct {
 	ScheduledPurgeDate         plugin.TValue[*time.Time]
 	Regions                    plugin.TValue[[]any]
 	PrivateEndpointConnections plugin.TValue[[]any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKeyVaultServiceManagedHsm creates a new instance of this resource
@@ -58306,6 +59084,22 @@ func (c *mqlAzureSubscriptionKeyVaultServiceManagedHsm) GetPrivateEndpointConnec
 		}
 
 		return c.privateEndpointConnections()
+	})
+}
+
+func (c *mqlAzureSubscriptionKeyVaultServiceManagedHsm) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.keyVaultService.managedHsm", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -59974,16 +60768,17 @@ func (c *mqlAzureSubscriptionMonitorServiceApplicationInsight) GetWorkspace() *p
 type mqlAzureSubscriptionMonitorServiceActivityLogAlert struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceActivityLogAlertInternal it will be used here
-	Id          plugin.TValue[string]
-	Type        plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Description plugin.TValue[string]
-	Conditions  plugin.TValue[[]any]
-	Location    plugin.TValue[string]
-	Tags        plugin.TValue[map[string]any]
-	Actions     plugin.TValue[[]any]
-	Scopes      plugin.TValue[[]any]
+	mqlAzureSubscriptionMonitorServiceActivityLogAlertInternal
+	Id             plugin.TValue[string]
+	Type           plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Description    plugin.TValue[string]
+	Conditions     plugin.TValue[[]any]
+	Location       plugin.TValue[string]
+	Tags           plugin.TValue[map[string]any]
+	Actions        plugin.TValue[[]any]
+	Scopes         plugin.TValue[[]any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceActivityLogAlert creates a new instance of this resource
@@ -60057,6 +60852,22 @@ func (c *mqlAzureSubscriptionMonitorServiceActivityLogAlert) GetActions() *plugi
 
 func (c *mqlAzureSubscriptionMonitorServiceActivityLogAlert) GetScopes() *plugin.TValue[[]any] {
 	return &c.Scopes
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceActivityLogAlert) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.activityLog.alert", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionMonitorServiceActivityLogEntry for the azure.subscription.monitorService.activityLog.entry resource
@@ -60202,7 +61013,7 @@ func (c *mqlAzureSubscriptionMonitorServiceActivityLogEntry) GetProperties() *pl
 type mqlAzureSubscriptionMonitorServiceLogprofile struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceLogprofileInternal it will be used here
+	mqlAzureSubscriptionMonitorServiceLogprofileInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Location         plugin.TValue[string]
@@ -60211,6 +61022,7 @@ type mqlAzureSubscriptionMonitorServiceLogprofile struct {
 	Properties       plugin.TValue[any]
 	StorageAccountId plugin.TValue[string]
 	StorageAccount   plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceLogprofile creates a new instance of this resource
@@ -60291,6 +61103,22 @@ func (c *mqlAzureSubscriptionMonitorServiceLogprofile) GetStorageAccount() *plug
 		}
 
 		return c.storageAccount()
+	})
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceLogprofile) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.logprofile", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -63676,6 +64504,7 @@ type mqlAzureSubscriptionManagedIdentity struct {
 	TenantId                     plugin.TValue[string]
 	RoleAssignments              plugin.TValue[[]any]
 	FederatedIdentityCredentials plugin.TValue[[]any]
+	SystemMetadata               plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionManagedIdentity creates a new instance of this resource
@@ -63745,6 +64574,22 @@ func (c *mqlAzureSubscriptionManagedIdentity) GetRoleAssignments() *plugin.TValu
 func (c *mqlAzureSubscriptionManagedIdentity) GetFederatedIdentityCredentials() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.FederatedIdentityCredentials, func() ([]any, error) {
 		return c.federatedIdentityCredentials()
+	})
+}
+
+func (c *mqlAzureSubscriptionManagedIdentity) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.managedIdentity", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -65275,7 +66120,7 @@ func (c *mqlAzureSubscriptionPolicy) GetComplianceSummary() *plugin.TValue[*mqlA
 type mqlAzureSubscriptionPolicyAssignment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionPolicyAssignmentInternal it will be used here
+	mqlAzureSubscriptionPolicyAssignmentInternal
 	Id              plugin.TValue[string]
 	AssignmentId    plugin.TValue[string]
 	Name            plugin.TValue[string]
@@ -65283,6 +66128,7 @@ type mqlAzureSubscriptionPolicyAssignment struct {
 	Description     plugin.TValue[string]
 	EnforcementMode plugin.TValue[string]
 	Parameters      plugin.TValue[any]
+	SystemMetadata  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionPolicyAssignment creates a new instance of this resource
@@ -65350,21 +66196,38 @@ func (c *mqlAzureSubscriptionPolicyAssignment) GetParameters() *plugin.TValue[an
 	return &c.Parameters
 }
 
+func (c *mqlAzureSubscriptionPolicyAssignment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.policy.assignment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionPolicyDefinition for the azure.subscription.policy.definition resource
 type mqlAzureSubscriptionPolicyDefinition struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionPolicyDefinitionInternal it will be used here
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	DisplayName plugin.TValue[string]
-	Description plugin.TValue[string]
-	PolicyType  plugin.TValue[string]
-	Mode        plugin.TValue[string]
-	PolicyRule  plugin.TValue[any]
-	Parameters  plugin.TValue[any]
-	Metadata    plugin.TValue[any]
-	Version     plugin.TValue[string]
+	mqlAzureSubscriptionPolicyDefinitionInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	DisplayName    plugin.TValue[string]
+	Description    plugin.TValue[string]
+	PolicyType     plugin.TValue[string]
+	Mode           plugin.TValue[string]
+	PolicyRule     plugin.TValue[any]
+	Parameters     plugin.TValue[any]
+	Metadata       plugin.TValue[any]
+	Version        plugin.TValue[string]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionPolicyDefinition creates a new instance of this resource
@@ -65439,11 +66302,27 @@ func (c *mqlAzureSubscriptionPolicyDefinition) GetVersion() *plugin.TValue[strin
 	return &c.Version
 }
 
+func (c *mqlAzureSubscriptionPolicyDefinition) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.policy.definition", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionPolicySetDefinition for the azure.subscription.policy.setDefinition resource
 type mqlAzureSubscriptionPolicySetDefinition struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionPolicySetDefinitionInternal it will be used here
+	mqlAzureSubscriptionPolicySetDefinitionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	DisplayName       plugin.TValue[string]
@@ -65453,6 +66332,7 @@ type mqlAzureSubscriptionPolicySetDefinition struct {
 	Parameters        plugin.TValue[any]
 	Metadata          plugin.TValue[any]
 	Version           plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionPolicySetDefinition creates a new instance of this resource
@@ -65521,6 +66401,22 @@ func (c *mqlAzureSubscriptionPolicySetDefinition) GetMetadata() *plugin.TValue[a
 
 func (c *mqlAzureSubscriptionPolicySetDefinition) GetVersion() *plugin.TValue[string] {
 	return &c.Version
+}
+
+func (c *mqlAzureSubscriptionPolicySetDefinition) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.policy.setDefinition", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionPolicyExemption for the azure.subscription.policy.exemption resource
@@ -65790,7 +66686,7 @@ func (c *mqlAzureSubscriptionIotService) GetIotHubs() *plugin.TValue[[]any] {
 type mqlAzureSubscriptionIotServiceIotHub struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionIotServiceIotHubInternal it will be used here
+	mqlAzureSubscriptionIotServiceIotHubInternal
 	Id                            plugin.TValue[string]
 	Name                          plugin.TValue[string]
 	Type                          plugin.TValue[string]
@@ -65810,6 +66706,7 @@ type mqlAzureSubscriptionIotServiceIotHub struct {
 	EnableDataResidency           plugin.TValue[bool]
 	NetworkRuleSet                plugin.TValue[any]
 	DiagnosticSettings            plugin.TValue[[]any]
+	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionIotServiceIotHub creates a new instance of this resource
@@ -65934,6 +66831,22 @@ func (c *mqlAzureSubscriptionIotServiceIotHub) GetDiagnosticSettings() *plugin.T
 		}
 
 		return c.diagnosticSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.iotService.iotHub", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -68680,6 +69593,7 @@ type mqlAzureSubscriptionMonitorServiceWorkspace struct {
 	PrivateLinkScopedResources             plugin.TValue[[]any]
 	Tables                                 plugin.TValue[[]any]
 	NetworkSecurityPerimeterConfigurations plugin.TValue[[]any]
+	SystemMetadata                         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceWorkspace creates a new instance of this resource
@@ -68918,6 +69832,22 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspace) GetNetworkSecurityPerimete
 		}
 
 		return c.networkSecurityPerimeterConfigurations()
+	})
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceWorkspace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.workspace", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -69364,7 +70294,7 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspaceFailover) GetLastModifiedDat
 type mqlAzureSubscriptionMonitorServiceWorkspaceTable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceWorkspaceTableInternal it will be used here
+	mqlAzureSubscriptionMonitorServiceWorkspaceTableInternal
 	Id                            plugin.TValue[string]
 	Name                          plugin.TValue[string]
 	Type                          plugin.TValue[string]
@@ -69380,6 +70310,7 @@ type mqlAzureSubscriptionMonitorServiceWorkspaceTable struct {
 	RestoredLogs                  plugin.TValue[any]
 	SearchResults                 plugin.TValue[any]
 	ResultStatistics              plugin.TValue[any]
+	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceWorkspaceTable creates a new instance of this resource
@@ -69477,6 +70408,22 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspaceTable) GetSearchResults() *p
 
 func (c *mqlAzureSubscriptionMonitorServiceWorkspaceTable) GetResultStatistics() *plugin.TValue[any] {
 	return &c.ResultStatistics
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceWorkspaceTable) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.workspace.table", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration for the azure.subscription.monitorService.workspace.nspConfiguration resource
@@ -69602,7 +70549,7 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) GetProvisi
 type mqlAzureSubscriptionMonitorServiceQueryPack struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceQueryPackInternal it will be used here
+	mqlAzureSubscriptionMonitorServiceQueryPackInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -69613,6 +70560,7 @@ type mqlAzureSubscriptionMonitorServiceQueryPack struct {
 	TimeCreated       plugin.TValue[*time.Time]
 	TimeModified      plugin.TValue[*time.Time]
 	Queries           plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceQueryPack creates a new instance of this resource
@@ -69704,21 +70652,38 @@ func (c *mqlAzureSubscriptionMonitorServiceQueryPack) GetQueries() *plugin.TValu
 	})
 }
 
+func (c *mqlAzureSubscriptionMonitorServiceQueryPack) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.queryPack", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionMonitorServiceQueryPackQuery for the azure.subscription.monitorService.queryPack.query resource
 type mqlAzureSubscriptionMonitorServiceQueryPackQuery struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceQueryPackQueryInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	Type         plugin.TValue[string]
-	DisplayName  plugin.TValue[string]
-	Description  plugin.TValue[string]
-	Body         plugin.TValue[string]
-	Author       plugin.TValue[string]
-	TimeCreated  plugin.TValue[*time.Time]
-	TimeModified plugin.TValue[*time.Time]
-	Tags         plugin.TValue[any]
+	mqlAzureSubscriptionMonitorServiceQueryPackQueryInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Type           plugin.TValue[string]
+	DisplayName    plugin.TValue[string]
+	Description    plugin.TValue[string]
+	Body           plugin.TValue[string]
+	Author         plugin.TValue[string]
+	TimeCreated    plugin.TValue[*time.Time]
+	TimeModified   plugin.TValue[*time.Time]
+	Tags           plugin.TValue[any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceQueryPackQuery creates a new instance of this resource
@@ -69796,6 +70761,22 @@ func (c *mqlAzureSubscriptionMonitorServiceQueryPackQuery) GetTimeModified() *pl
 
 func (c *mqlAzureSubscriptionMonitorServiceQueryPackQuery) GetTags() *plugin.TValue[any] {
 	return &c.Tags
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceQueryPackQuery) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.queryPack.query", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionRecoveryServicesService for the azure.subscription.recoveryServicesService resource
@@ -69890,6 +70871,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	PrivateEndpointConnections          plugin.TValue[[]any]
 	BackupPolicies                      plugin.TValue[[]any]
 	ProtectedItems                      plugin.TValue[[]any]
+	SystemMetadata                      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionRecoveryServicesServiceVault creates a new instance of this resource
@@ -70106,6 +71088,22 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetProtectedItems() *
 		}
 
 		return c.protectedItems()
+	})
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.recoveryServicesService.vault", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -70669,7 +71667,7 @@ func (c *mqlAzureSubscriptionFunctionsService) GetFunctionApps() *plugin.TValue[
 type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFunctionsServiceFunctionAppInternal it will be used here
+	mqlAzureSubscriptionFunctionsServiceFunctionAppInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Location                  plugin.TValue[string]
@@ -70688,6 +71686,7 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	Functions                 plugin.TValue[[]any]
 	AppSettings               plugin.TValue[[]any]
 	ConnectionStrings         plugin.TValue[[]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFunctionsServiceFunctionApp creates a new instance of this resource
@@ -70837,6 +71836,22 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetConnectionStrings()
 	})
 }
 
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting for the azure.subscription.functionsService.functionApp.appSetting resource
 type mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting struct {
 	MqlRuntime *plugin.Runtime
@@ -70915,12 +71930,13 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetHasValue(
 type mqlAzureSubscriptionFunctionsServiceFunctionAppFunction struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFunctionsServiceFunctionAppFunctionInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Config     plugin.TValue[any]
-	Language   plugin.TValue[string]
-	IsDisabled plugin.TValue[bool]
+	mqlAzureSubscriptionFunctionsServiceFunctionAppFunctionInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Config         plugin.TValue[any]
+	Language       plugin.TValue[string]
+	IsDisabled     plugin.TValue[bool]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFunctionsServiceFunctionAppFunction creates a new instance of this resource
@@ -70978,6 +71994,22 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) GetLanguage() 
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) GetIsDisabled() *plugin.TValue[bool] {
 	return &c.IsDisabled
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp.function", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionServiceBusService for the azure.subscription.serviceBusService resource
@@ -71068,6 +72100,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespace struct {
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules]
 	Queues                          plugin.TValue[[]any]
 	Topics                          plugin.TValue[[]any]
+	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionServiceBusServiceNamespace creates a new instance of this resource
@@ -71213,6 +72246,22 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetTopics() *plugin.TVa
 	})
 }
 
+func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.serviceBusService.namespace", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules for the azure.subscription.serviceBusService.namespace.networkRules resource
 type mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules struct {
 	MqlRuntime *plugin.Runtime
@@ -71342,7 +72391,7 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRulesVirtualNetwor
 type mqlAzureSubscriptionServiceBusServiceNamespaceQueue struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionServiceBusServiceNamespaceQueueInternal it will be used here
+	mqlAzureSubscriptionServiceBusServiceNamespaceQueueInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Status                     plugin.TValue[string]
@@ -71355,6 +72404,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceQueue struct {
 	RequiresDuplicateDetection plugin.TValue[bool]
 	RequiresSession            plugin.TValue[bool]
 	EnablePartitioning         plugin.TValue[bool]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionServiceBusServiceNamespaceQueue creates a new instance of this resource
@@ -71442,11 +72492,27 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) GetEnablePartition
 	return &c.EnablePartitioning
 }
 
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.serviceBusService.namespace.queue", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionServiceBusServiceNamespaceTopic for the azure.subscription.serviceBusService.namespace.topic resource
 type mqlAzureSubscriptionServiceBusServiceNamespaceTopic struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionServiceBusServiceNamespaceTopicInternal it will be used here
+	mqlAzureSubscriptionServiceBusServiceNamespaceTopicInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Status                     plugin.TValue[string]
@@ -71457,6 +72523,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceTopic struct {
 	RequiresDuplicateDetection plugin.TValue[bool]
 	DefaultMessageTimeToLive   plugin.TValue[string]
 	Subscriptions              plugin.TValue[[]any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionServiceBusServiceNamespaceTopic creates a new instance of this resource
@@ -71548,11 +72615,27 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) GetSubscriptions()
 	})
 }
 
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.serviceBusService.namespace.topic", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription for the azure.subscription.serviceBusService.namespace.topic.subscription resource
 type mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscriptionInternal it will be used here
+	mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscriptionInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Status                   plugin.TValue[string]
@@ -71562,6 +72645,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription struct {
 	LockDuration             plugin.TValue[string]
 	DefaultMessageTimeToLive plugin.TValue[string]
 	RequiresSession          plugin.TValue[bool]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionServiceBusServiceNamespaceTopicSubscription creates a new instance of this resource
@@ -71635,6 +72719,22 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetDef
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetRequiresSession() *plugin.TValue[bool] {
 	return &c.RequiresSession
+}
+
+func (c *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.serviceBusService.namespace.topic.subscription", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionEventHubService for the azure.subscription.eventHubService resource
@@ -72122,10 +73222,11 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) GetSystemMetadata
 type mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroupInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	UserMetadata plugin.TValue[string]
+	mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroupInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	UserMetadata   plugin.TValue[string]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup creates a new instance of this resource
@@ -72175,6 +73276,22 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetN
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetUserMetadata() *plugin.TValue[string] {
 	return &c.UserMetadata
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.eventHubService.namespace.eventHub.consumerGroup", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionEventGridService for the azure.subscription.eventGridService resource
@@ -72281,7 +73398,7 @@ func (c *mqlAzureSubscriptionEventGridService) GetDomains() *plugin.TValue[[]any
 type mqlAzureSubscriptionEventGridServiceTopic struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionEventGridServiceTopicInternal it will be used here
+	mqlAzureSubscriptionEventGridServiceTopicInternal
 	Id                             plugin.TValue[string]
 	Name                           plugin.TValue[string]
 	Location                       plugin.TValue[string]
@@ -72297,6 +73414,7 @@ type mqlAzureSubscriptionEventGridServiceTopic struct {
 	InboundIpRules                 plugin.TValue[[]any]
 	IdentityType                   plugin.TValue[string]
 	PrivateEndpointConnectionCount plugin.TValue[int64]
+	SystemMetadata                 plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionEventGridServiceTopic creates a new instance of this resource
@@ -72396,11 +73514,27 @@ func (c *mqlAzureSubscriptionEventGridServiceTopic) GetPrivateEndpointConnection
 	return &c.PrivateEndpointConnectionCount
 }
 
+func (c *mqlAzureSubscriptionEventGridServiceTopic) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.eventGridService.topic", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionEventGridServiceSystemTopic for the azure.subscription.eventGridService.systemTopic resource
 type mqlAzureSubscriptionEventGridServiceSystemTopic struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionEventGridServiceSystemTopicInternal it will be used here
+	mqlAzureSubscriptionEventGridServiceSystemTopicInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -72410,6 +73544,7 @@ type mqlAzureSubscriptionEventGridServiceSystemTopic struct {
 	TopicType         plugin.TValue[string]
 	MetricResourceId  plugin.TValue[string]
 	IdentityType      plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionEventGridServiceSystemTopic creates a new instance of this resource
@@ -72485,11 +73620,27 @@ func (c *mqlAzureSubscriptionEventGridServiceSystemTopic) GetIdentityType() *plu
 	return &c.IdentityType
 }
 
+func (c *mqlAzureSubscriptionEventGridServiceSystemTopic) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.eventGridService.systemTopic", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionEventGridServiceDomain for the azure.subscription.eventGridService.domain resource
 type mqlAzureSubscriptionEventGridServiceDomain struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionEventGridServiceDomainInternal it will be used here
+	mqlAzureSubscriptionEventGridServiceDomainInternal
 	Id                                   plugin.TValue[string]
 	Name                                 plugin.TValue[string]
 	Location                             plugin.TValue[string]
@@ -72507,6 +73658,7 @@ type mqlAzureSubscriptionEventGridServiceDomain struct {
 	InboundIpRules                       plugin.TValue[[]any]
 	IdentityType                         plugin.TValue[string]
 	PrivateEndpointConnectionCount       plugin.TValue[int64]
+	SystemMetadata                       plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionEventGridServiceDomain creates a new instance of this resource
@@ -72612,6 +73764,22 @@ func (c *mqlAzureSubscriptionEventGridServiceDomain) GetIdentityType() *plugin.T
 
 func (c *mqlAzureSubscriptionEventGridServiceDomain) GetPrivateEndpointConnectionCount() *plugin.TValue[int64] {
 	return &c.PrivateEndpointConnectionCount
+}
+
+func (c *mqlAzureSubscriptionEventGridServiceDomain) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.eventGridService.domain", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionDnsService for the azure.subscription.dnsService resource
@@ -73107,7 +74275,7 @@ func (c *mqlAzureSubscriptionFrontDoorService) GetProfiles() *plugin.TValue[[]an
 type mqlAzureSubscriptionFrontDoorServiceProfile struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -73121,6 +74289,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfile struct {
 	CustomDomains     plugin.TValue[[]any]
 	OriginGroups      plugin.TValue[[]any]
 	SecurityPolicies  plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfile creates a new instance of this resource
@@ -73260,17 +74429,34 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfile) GetSecurityPolicies() *plu
 	})
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfile) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy for the azure.subscription.frontDoorService.profile.securityPolicy resource
 type mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicyInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicyInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	PolicyType        plugin.TValue[string]
 	WafPolicyId       plugin.TValue[string]
 	Associations      plugin.TValue[[]any]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileSecurityPolicy creates a new instance of this resource
@@ -73334,11 +74520,27 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetProvision
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.securityPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileEndpoint for the azure.subscription.frontDoorService.profile.endpoint resource
 type mqlAzureSubscriptionFrontDoorServiceProfileEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileEndpointInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileEndpointInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -73346,6 +74548,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfileEndpoint struct {
 	EnabledState      plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
 	Routes            plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileEndpoint creates a new instance of this resource
@@ -73425,11 +74628,27 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetRoutes() *plugi
 	})
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.endpoint", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute for the azure.subscription.frontDoorService.profile.endpoint.route resource
 type mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileEndpointRouteInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileEndpointRouteInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Type                plugin.TValue[string]
@@ -73442,6 +74661,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute struct {
 	OriginPath          plugin.TValue[string]
 	OriginGroupId       plugin.TValue[string]
 	ProvisioningState   plugin.TValue[string]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileEndpointRoute creates a new instance of this resource
@@ -73529,11 +74749,27 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute) GetProvisioni
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.endpoint.route", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain for the azure.subscription.frontDoorService.profile.customDomain resource
 type mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileCustomDomainInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileCustomDomainInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	HostName           plugin.TValue[string]
@@ -73541,6 +74777,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain struct {
 	ProvisioningState  plugin.TValue[string]
 	TlsMinimumVersion  plugin.TValue[string]
 	TlsCertificateType plugin.TValue[string]
+	SystemMetadata     plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileCustomDomain creates a new instance of this resource
@@ -73608,17 +74845,34 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain) GetTlsCertific
 	return &c.TlsCertificateType
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.customDomain", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup for the azure.subscription.frontDoorService.profile.originGroup resource
 type mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	ProvisioningState     plugin.TValue[string]
 	HealthProbeSettings   plugin.TValue[any]
 	LoadBalancingSettings plugin.TValue[any]
 	Origins               plugin.TValue[[]any]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileOriginGroup creates a new instance of this resource
@@ -73694,11 +74948,27 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup) GetOrigins() *p
 	})
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.originGroup", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin for the azure.subscription.frontDoorService.profile.originGroup.origin resource
 type mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOriginInternal it will be used here
+	mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOriginInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	HostName          plugin.TValue[string]
@@ -73709,6 +74979,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin struct {
 	Weight            plugin.TValue[int64]
 	EnabledState      plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin creates a new instance of this resource
@@ -73786,6 +75057,22 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin) GetEnable
 
 func (c *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.frontDoorService.profile.originGroup.origin", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionContainerAppService for the azure.subscription.containerAppService resource
@@ -73918,6 +75205,7 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironment struct {
 	PrivateEndpointConnections  plugin.TValue[[]any]
 	HttpRouteConfigs            plugin.TValue[[]any]
 	MaintenanceConfigurations   plugin.TValue[[]any]
+	SystemMetadata              plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironment creates a new instance of this resource
@@ -74117,11 +75405,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) GetMaintenan
 	})
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection for the azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection resource
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnectionInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnectionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Status            plugin.TValue[string]
@@ -74130,6 +75434,7 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointCon
 	ProvisioningState plugin.TValue[string]
 	GroupIds          plugin.TValue[[]any]
 	PrivateEndpointId plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection creates a new instance of this resource
@@ -74201,11 +75506,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpoin
 	return &c.PrivateEndpointId
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentPrivateEndpointConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig for the azure.subscription.containerAppService.managedEnvironment.httpRouteConfig resource
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfigInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfigInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	Fqdn               plugin.TValue[string]
@@ -74213,6 +75534,7 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig st
 	CustomDomains      plugin.TValue[[]any]
 	Rules              plugin.TValue[[]any]
 	ProvisioningErrors plugin.TValue[[]any]
+	SystemMetadata     plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig creates a new instance of this resource
@@ -74280,14 +75602,31 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfi
 	return &c.ProvisioningErrors
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentHttpRouteConfig) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment.httpRouteConfig", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration for the azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration resource
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfigurationInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfigurationInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	ScheduledEntries plugin.TValue[[]any]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration creates a new instance of this resource
@@ -74339,11 +75678,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceCon
 	return &c.ScheduledEntries
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentMaintenanceConfiguration) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent for the azure.subscription.containerAppService.managedEnvironment.daprComponent resource
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponentInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponentInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	ComponentType     plugin.TValue[string]
@@ -74354,6 +75709,7 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent stru
 	IgnoreErrors      plugin.TValue[bool]
 	ProvisioningState plugin.TValue[string]
 	DeploymentErrors  plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent creates a new instance of this resource
@@ -74433,11 +75789,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent)
 	return &c.DeploymentErrors
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentDaprComponent) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment.daprComponent", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate for the azure.subscription.containerAppService.managedEnvironment.certificate resource
 type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificateInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificateInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	SubjectName             plugin.TValue[string]
@@ -74450,6 +75822,7 @@ type mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate struct
 	Issuer                  plugin.TValue[string]
 	PublicKeyHash           plugin.TValue[string]
 	SubjectAlternativeNames plugin.TValue[[]any]
+	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate creates a new instance of this resource
@@ -74537,6 +75910,22 @@ func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate) G
 	return &c.SubjectAlternativeNames
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.managedEnvironment.certificate", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceContainerApp for the azure.subscription.containerAppService.containerApp resource
 type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	MqlRuntime *plugin.Runtime
@@ -74577,6 +75966,7 @@ type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	Volumes                  plugin.TValue[[]any]
 	AuthConfigs              plugin.TValue[[]any]
 	Revisions                plugin.TValue[[]any]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceContainerApp creates a new instance of this resource
@@ -74804,6 +76194,22 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetRevisions() *pl
 	})
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceContainerAppContainer for the azure.subscription.containerAppService.containerApp.container resource
 type mqlAzureSubscriptionContainerAppServiceContainerAppContainer struct {
 	MqlRuntime *plugin.Runtime
@@ -74907,7 +76313,7 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerAppContainer) GetVolume
 type mqlAzureSubscriptionContainerAppServiceContainerAppRevision struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceContainerAppRevisionInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceContainerAppRevisionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Active            plugin.TValue[bool]
@@ -74919,6 +76325,7 @@ type mqlAzureSubscriptionContainerAppServiceContainerAppRevision struct {
 	ProvisioningError plugin.TValue[string]
 	CreatedTime       plugin.TValue[*time.Time]
 	LastActiveTime    plugin.TValue[*time.Time]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceContainerAppRevision creates a new instance of this resource
@@ -75002,11 +76409,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerAppRevision) GetLastAct
 	return &c.LastActiveTime
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceContainerAppRevision) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp.revision", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig for the azure.subscription.containerAppService.containerApp.authConfig resource
 type mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfigInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfigInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	Enabled                     plugin.TValue[bool]
@@ -75014,6 +76437,7 @@ type mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig struct {
 	IdentityProviders           plugin.TValue[[]any]
 	Login                       plugin.TValue[any]
 	HttpSettings                plugin.TValue[any]
+	SystemMetadata              plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceContainerAppAuthConfig creates a new instance of this resource
@@ -75081,11 +76505,27 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig) GetHttpS
 	return &c.HttpSettings
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceContainerAppAuthConfig) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp.authConfig", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerAppServiceJob for the azure.subscription.containerAppService.job resource
 type mqlAzureSubscriptionContainerAppServiceJob struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerAppServiceJobInternal it will be used here
+	mqlAzureSubscriptionContainerAppServiceJobInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Location                 plugin.TValue[string]
@@ -75104,6 +76544,7 @@ type mqlAzureSubscriptionContainerAppServiceJob struct {
 	Registries               plugin.TValue[[]any]
 	RegistryAuthUsesIdentity plugin.TValue[bool]
 	SecretNames              plugin.TValue[[]any]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerAppServiceJob creates a new instance of this resource
@@ -75213,6 +76654,22 @@ func (c *mqlAzureSubscriptionContainerAppServiceJob) GetRegistryAuthUsesIdentity
 
 func (c *mqlAzureSubscriptionContainerAppServiceJob) GetSecretNames() *plugin.TValue[[]any] {
 	return &c.SecretNames
+}
+
+func (c *mqlAzureSubscriptionContainerAppServiceJob) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.job", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionContainerInstanceService for the azure.subscription.containerInstanceService resource
@@ -75993,6 +77450,7 @@ type mqlAzureSubscriptionApiManagementServiceService struct {
 	Zones                          plugin.TValue[[]any]
 	PublicIpAddress                plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
 	CreatedAt                      plugin.TValue[*time.Time]
+	SystemMetadata                 plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionApiManagementServiceService creates a new instance of this resource
@@ -76178,6 +77636,22 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetPublicIpAddress() *
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.apiManagementService.service", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionPurviewService for the azure.subscription.purviewService resource
@@ -76455,7 +77929,7 @@ func (c *mqlAzureSubscriptionSearchService) GetServices() *plugin.TValue[[]any] 
 type mqlAzureSubscriptionSearchServiceService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSearchServiceServiceInternal it will be used here
+	mqlAzureSubscriptionSearchServiceServiceInternal
 	Id                            plugin.TValue[string]
 	Name                          plugin.TValue[string]
 	Location                      plugin.TValue[string]
@@ -76473,6 +77947,7 @@ type mqlAzureSubscriptionSearchServiceService struct {
 	ProvisioningState             plugin.TValue[string]
 	Status                        plugin.TValue[string]
 	NetworkRuleSet                plugin.TValue[any]
+	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSearchServiceService creates a new instance of this resource
@@ -76578,6 +78053,22 @@ func (c *mqlAzureSubscriptionSearchServiceService) GetStatus() *plugin.TValue[st
 
 func (c *mqlAzureSubscriptionSearchServiceService) GetNetworkRuleSet() *plugin.TValue[any] {
 	return &c.NetworkRuleSet
+}
+
+func (c *mqlAzureSubscriptionSearchServiceService) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.searchService.service", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionMachineLearningService for the azure.subscription.machineLearningService resource
@@ -77006,6 +78497,7 @@ type mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint struct {
 	Compute             plugin.TValue[*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute]
 	ProvisioningState   plugin.TValue[string]
 	Deployments         plugin.TValue[[]any]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint creates a new instance of this resource
@@ -77133,11 +78625,27 @@ func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint) GetD
 	})
 }
 
+func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.machineLearningService.workspace.onlineEndpoint", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment for the azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment resource
 type mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeploymentInternal it will be used here
+	mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeploymentInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Location                  plugin.TValue[string]
@@ -77152,6 +78660,7 @@ type mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment
 	AppInsightsEnabled        plugin.TValue[bool]
 	EgressPublicNetworkAccess plugin.TValue[string]
 	ProvisioningState         plugin.TValue[string]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment creates a new instance of this resource
@@ -77247,11 +78756,27 @@ func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeploy
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint for the azure.subscription.machineLearningService.workspace.serverlessEndpoint resource
 type mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpointInternal it will be used here
+	mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpointInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Location                  plugin.TValue[string]
@@ -77264,6 +78789,7 @@ type mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint struc
 	MarketplaceSubscriptionId plugin.TValue[string]
 	ContentSafetyStatus       plugin.TValue[string]
 	ProvisioningState         plugin.TValue[string]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint creates a new instance of this resource
@@ -77351,11 +78877,27 @@ func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint) 
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.machineLearningService.workspace.serverlessEndpoint", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute for the azure.subscription.machineLearningService.workspace.compute resource
 type mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMachineLearningServiceWorkspaceComputeInternal it will be used here
+	mqlAzureSubscriptionMachineLearningServiceWorkspaceComputeInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -77370,6 +78912,7 @@ type mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute struct {
 	ProvisioningState plugin.TValue[string]
 	CreatedOn         plugin.TValue[*time.Time]
 	ModifiedOn        plugin.TValue[*time.Time]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMachineLearningServiceWorkspaceCompute creates a new instance of this resource
@@ -77465,11 +79008,27 @@ func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute) GetModified
 	return &c.ModifiedOn
 }
 
+func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.machineLearningService.workspace.compute", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionMachineLearningServiceWorkspaceModel for the azure.subscription.machineLearningService.workspace.model resource
 type mqlAzureSubscriptionMachineLearningServiceWorkspaceModel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMachineLearningServiceWorkspaceModelInternal it will be used here
+	mqlAzureSubscriptionMachineLearningServiceWorkspaceModelInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Description       plugin.TValue[string]
@@ -77478,6 +79037,7 @@ type mqlAzureSubscriptionMachineLearningServiceWorkspaceModel struct {
 	IsArchived        plugin.TValue[bool]
 	Tags              plugin.TValue[map[string]any]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMachineLearningServiceWorkspaceModel creates a new instance of this resource
@@ -77547,6 +79107,22 @@ func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceModel) GetTags() *pl
 
 func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceModel) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionMachineLearningServiceWorkspaceModel) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.machineLearningService.workspace.model", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionAppConfigurationService for the azure.subscription.appConfigurationService resource
@@ -78097,6 +79673,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment struct {
 	Capabilities             plugin.TValue[map[string]any]
 	RaiPolicyName            plugin.TValue[string]
 	RaiPolicy                plugin.TValue[*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountDeployment creates a new instance of this resource
@@ -78216,11 +79793,27 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment) GetRaiPo
 	})
 }
 
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.deployment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCognitiveServicesServiceAccountProject for the azure.subscription.cognitiveServicesService.account.project resource
 type mqlAzureSubscriptionCognitiveServicesServiceAccountProject struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCognitiveServicesServiceAccountProjectInternal it will be used here
+	mqlAzureSubscriptionCognitiveServicesServiceAccountProjectInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -78232,6 +79825,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountProject struct {
 	ProvisioningState plugin.TValue[string]
 	Endpoints         plugin.TValue[map[string]any]
 	Connections       plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountProject creates a new instance of this resource
@@ -78327,11 +79921,27 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountProject) GetConnecti
 	})
 }
 
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountProject) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.project", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection for the azure.subscription.cognitiveServicesService.account.project.connection resource
 type mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnectionInternal it will be used here
+	mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnectionInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	Category                    plugin.TValue[string]
@@ -78345,6 +79955,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection struct
 	Metadata                    plugin.TValue[map[string]any]
 	Error                       plugin.TValue[string]
 	ExpiryTime                  plugin.TValue[*time.Time]
+	SystemMetadata              plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountProjectConnection creates a new instance of this resource
@@ -78436,11 +80047,27 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection) G
 	return &c.ExpiryTime
 }
 
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.project.connection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCognitiveServicesServiceAccountConnection for the azure.subscription.cognitiveServicesService.account.connection resource
 type mqlAzureSubscriptionCognitiveServicesServiceAccountConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCognitiveServicesServiceAccountConnectionInternal it will be used here
+	mqlAzureSubscriptionCognitiveServicesServiceAccountConnectionInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	Category                    plugin.TValue[string]
@@ -78454,6 +80081,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountConnection struct {
 	Metadata                    plugin.TValue[map[string]any]
 	Error                       plugin.TValue[string]
 	ExpiryTime                  plugin.TValue[*time.Time]
+	SystemMetadata              plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountConnection creates a new instance of this resource
@@ -78545,11 +80173,27 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountConnection) GetExpir
 	return &c.ExpiryTime
 }
 
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.connection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy for the azure.subscription.cognitiveServicesService.account.raiPolicy resource
 type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyInternal it will be used here
+	mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Mode             plugin.TValue[string]
@@ -78558,6 +80202,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy struct {
 	ContentFilters   plugin.TValue[[]any]
 	CustomBlocklists plugin.TValue[[]any]
 	CustomTopics     plugin.TValue[[]any]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy creates a new instance of this resource
@@ -78627,6 +80272,22 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy) GetCustom
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy) GetCustomTopics() *plugin.TValue[[]any] {
 	return &c.CustomTopics
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.raiPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyContentFilter for the azure.subscription.cognitiveServicesService.account.raiPolicy.contentFilter resource
@@ -78768,7 +80429,7 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyTopicRef) G
 type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopicInternal it will be used here
+	mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopicInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	TopicName      plugin.TValue[string]
@@ -78779,6 +80440,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic struct {
 	SampleBlobUrl  plugin.TValue[string]
 	CreatedAt      plugin.TValue[*time.Time]
 	LastModifiedAt plugin.TValue[*time.Time]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCognitiveServicesServiceAccountRaiTopic creates a new instance of this resource
@@ -78856,6 +80518,22 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetCreated
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetLastModifiedAt() *plugin.TValue[*time.Time] {
 	return &c.LastModifiedAt
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account.raiTopic", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSentinelService for the azure.subscription.sentinelService resource
@@ -79033,16 +80711,17 @@ func (c *mqlAzureSubscriptionSentinelServiceWorkspace) GetDataConnectors() *plug
 type mqlAzureSubscriptionSentinelServiceAlertRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSentinelServiceAlertRuleInternal it will be used here
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Kind        plugin.TValue[string]
-	Enabled     plugin.TValue[bool]
-	DisplayName plugin.TValue[string]
-	Severity    plugin.TValue[string]
-	Tactics     plugin.TValue[[]any]
-	Description plugin.TValue[string]
-	Properties  plugin.TValue[any]
+	mqlAzureSubscriptionSentinelServiceAlertRuleInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Kind           plugin.TValue[string]
+	Enabled        plugin.TValue[bool]
+	DisplayName    plugin.TValue[string]
+	Severity       plugin.TValue[string]
+	Tactics        plugin.TValue[[]any]
+	Description    plugin.TValue[string]
+	Properties     plugin.TValue[any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSentinelServiceAlertRule creates a new instance of this resource
@@ -79118,6 +80797,22 @@ func (c *mqlAzureSubscriptionSentinelServiceAlertRule) GetProperties() *plugin.T
 	return &c.Properties
 }
 
+func (c *mqlAzureSubscriptionSentinelServiceAlertRule) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sentinelService.alertRule", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionSignalRService for the azure.subscription.signalRService resource
 type mqlAzureSubscriptionSignalRService struct {
 	MqlRuntime *plugin.Runtime
@@ -79188,7 +80883,7 @@ func (c *mqlAzureSubscriptionSignalRService) GetInstances() *plugin.TValue[[]any
 type mqlAzureSubscriptionSignalRServiceSignalR struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSignalRServiceSignalRInternal it will be used here
+	mqlAzureSubscriptionSignalRServiceSignalRInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Location                 plugin.TValue[string]
@@ -79205,6 +80900,7 @@ type mqlAzureSubscriptionSignalRServiceSignalR struct {
 	ClientCertEnabled        plugin.TValue[bool]
 	NetworkAclsDefaultAction plugin.TValue[string]
 	ProvisioningState        plugin.TValue[string]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSignalRServiceSignalR creates a new instance of this resource
@@ -79308,6 +81004,22 @@ func (c *mqlAzureSubscriptionSignalRServiceSignalR) GetProvisioningState() *plug
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionSignalRServiceSignalR) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.signalRService.signalR", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionWebPubSubService for the azure.subscription.webPubSubService resource
 type mqlAzureSubscriptionWebPubSubService struct {
 	MqlRuntime *plugin.Runtime
@@ -79378,7 +81090,7 @@ func (c *mqlAzureSubscriptionWebPubSubService) GetInstances() *plugin.TValue[[]a
 type mqlAzureSubscriptionWebPubSubServiceWebPubSub struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebPubSubServiceWebPubSubInternal it will be used here
+	mqlAzureSubscriptionWebPubSubServiceWebPubSubInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Location                 plugin.TValue[string]
@@ -79395,6 +81107,7 @@ type mqlAzureSubscriptionWebPubSubServiceWebPubSub struct {
 	ClientCertEnabled        plugin.TValue[bool]
 	NetworkAclsDefaultAction plugin.TValue[string]
 	ProvisioningState        plugin.TValue[string]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebPubSubServiceWebPubSub creates a new instance of this resource
@@ -79496,6 +81209,22 @@ func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetNetworkAclsDefaultAct
 
 func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webPubSubService.webPubSub", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionKustoService for the azure.subscription.kustoService resource
@@ -80219,6 +81948,7 @@ type mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection struct {
 	StatusDescription plugin.TValue[string]
 	PrivateEndpoint   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterPrivateEndpointConnection creates a new instance of this resource
@@ -80298,11 +82028,27 @@ func (c *mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection) GetPr
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.privateEndpointConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint for the azure.subscription.kustoService.cluster.managedPrivateEndpoint resource
 type mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpointInternal it will be used here
+	mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpointInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	GroupId                   plugin.TValue[string]
@@ -80310,6 +82056,7 @@ type mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint struct {
 	PrivateLinkResourceRegion plugin.TValue[string]
 	RequestMessage            plugin.TValue[string]
 	ProvisioningState         plugin.TValue[string]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint creates a new instance of this resource
@@ -80375,6 +82122,22 @@ func (c *mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint) GetReque
 
 func (c *mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.managedPrivateEndpoint", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection for the azure.subscription.kustoService.cluster.database.dataConnection resource
@@ -80563,7 +82326,7 @@ func (c *mqlAzureSubscriptionAutomationService) GetAccounts() *plugin.TValue[[]a
 type mqlAzureSubscriptionAutomationServiceAccount struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAutomationServiceAccountInternal it will be used here
+	mqlAzureSubscriptionAutomationServiceAccountInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Location            plugin.TValue[string]
@@ -80581,6 +82344,7 @@ type mqlAzureSubscriptionAutomationServiceAccount struct {
 	Variables           plugin.TValue[[]any]
 	Credentials         plugin.TValue[[]any]
 	Certificates        plugin.TValue[[]any]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionAutomationServiceAccount creates a new instance of this resource
@@ -80724,17 +82488,34 @@ func (c *mqlAzureSubscriptionAutomationServiceAccount) GetCertificates() *plugin
 	})
 }
 
+func (c *mqlAzureSubscriptionAutomationServiceAccount) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.automationService.account", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionAutomationServiceAccountVariable for the azure.subscription.automationService.account.variable resource
 type mqlAzureSubscriptionAutomationServiceAccountVariable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAutomationServiceAccountVariableInternal it will be used here
+	mqlAzureSubscriptionAutomationServiceAccountVariableInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	IsEncrypted      plugin.TValue[bool]
 	Description      plugin.TValue[string]
 	CreationTime     plugin.TValue[*time.Time]
 	LastModifiedTime plugin.TValue[*time.Time]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionAutomationServiceAccountVariable creates a new instance of this resource
@@ -80798,17 +82579,34 @@ func (c *mqlAzureSubscriptionAutomationServiceAccountVariable) GetLastModifiedTi
 	return &c.LastModifiedTime
 }
 
+func (c *mqlAzureSubscriptionAutomationServiceAccountVariable) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.automationService.account.variable", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionAutomationServiceAccountCredential for the azure.subscription.automationService.account.credential resource
 type mqlAzureSubscriptionAutomationServiceAccountCredential struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAutomationServiceAccountCredentialInternal it will be used here
+	mqlAzureSubscriptionAutomationServiceAccountCredentialInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	UserName         plugin.TValue[string]
 	Description      plugin.TValue[string]
 	CreationTime     plugin.TValue[*time.Time]
 	LastModifiedTime plugin.TValue[*time.Time]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionAutomationServiceAccountCredential creates a new instance of this resource
@@ -80872,18 +82670,35 @@ func (c *mqlAzureSubscriptionAutomationServiceAccountCredential) GetLastModified
 	return &c.LastModifiedTime
 }
 
+func (c *mqlAzureSubscriptionAutomationServiceAccountCredential) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.automationService.account.credential", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionAutomationServiceAccountCertificate for the azure.subscription.automationService.account.certificate resource
 type mqlAzureSubscriptionAutomationServiceAccountCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAutomationServiceAccountCertificateInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	Thumbprint   plugin.TValue[string]
-	ExpiryTime   plugin.TValue[*time.Time]
-	IsExportable plugin.TValue[bool]
-	Description  plugin.TValue[string]
-	CreationTime plugin.TValue[*time.Time]
+	mqlAzureSubscriptionAutomationServiceAccountCertificateInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Thumbprint     plugin.TValue[string]
+	ExpiryTime     plugin.TValue[*time.Time]
+	IsExportable   plugin.TValue[bool]
+	Description    plugin.TValue[string]
+	CreationTime   plugin.TValue[*time.Time]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionAutomationServiceAccountCertificate creates a new instance of this resource
@@ -80949,6 +82764,22 @@ func (c *mqlAzureSubscriptionAutomationServiceAccountCertificate) GetDescription
 
 func (c *mqlAzureSubscriptionAutomationServiceAccountCertificate) GetCreationTime() *plugin.TValue[*time.Time] {
 	return &c.CreationTime
+}
+
+func (c *mqlAzureSubscriptionAutomationServiceAccountCertificate) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.automationService.account.certificate", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionDesktopVirtualizationService for the azure.subscription.desktopVirtualizationService resource
@@ -81021,7 +82852,7 @@ func (c *mqlAzureSubscriptionDesktopVirtualizationService) GetHostPools() *plugi
 type mqlAzureSubscriptionDesktopVirtualizationServiceHostPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDesktopVirtualizationServiceHostPoolInternal it will be used here
+	mqlAzureSubscriptionDesktopVirtualizationServiceHostPoolInternal
 	Id                             plugin.TValue[string]
 	Name                           plugin.TValue[string]
 	Location                       plugin.TValue[string]
@@ -81040,6 +82871,7 @@ type mqlAzureSubscriptionDesktopVirtualizationServiceHostPool struct {
 	PublicNetworkAccess            plugin.TValue[string]
 	SsoSecretType                  plugin.TValue[string]
 	PrivateEndpointConnectionCount plugin.TValue[int64]
+	SystemMetadata                 plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDesktopVirtualizationServiceHostPool creates a new instance of this resource
@@ -81149,4 +82981,20 @@ func (c *mqlAzureSubscriptionDesktopVirtualizationServiceHostPool) GetSsoSecretT
 
 func (c *mqlAzureSubscriptionDesktopVirtualizationServiceHostPool) GetPrivateEndpointConnectionCount() *plugin.TValue[int64] {
 	return &c.PrivateEndpointConnectionCount
+}
+
+func (c *mqlAzureSubscriptionDesktopVirtualizationServiceHostPool) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.desktopVirtualizationService.hostPool", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -196,6 +196,7 @@ azure.subscription.apiManagementService.service.publisherName 13.10.2
 azure.subscription.apiManagementService.service.scmUrl 13.10.2
 azure.subscription.apiManagementService.service.skuCapacity 13.10.2
 azure.subscription.apiManagementService.service.skuName 13.10.2
+azure.subscription.apiManagementService.service.systemMetadata 13.22.1
 azure.subscription.apiManagementService.service.tags 13.10.2
 azure.subscription.apiManagementService.service.targetProvisioningState 13.10.2
 azure.subscription.apiManagementService.service.virtualNetworkType 13.10.2
@@ -284,6 +285,7 @@ azure.subscription.automationService.account.certificate.expiryTime 13.16.2
 azure.subscription.automationService.account.certificate.id 13.16.2
 azure.subscription.automationService.account.certificate.isExportable 13.16.2
 azure.subscription.automationService.account.certificate.name 13.16.2
+azure.subscription.automationService.account.certificate.systemMetadata 13.22.1
 azure.subscription.automationService.account.certificate.thumbprint 13.16.2
 azure.subscription.automationService.account.certificates 13.16.2
 azure.subscription.automationService.account.cmkKeyName 13.16.2
@@ -296,6 +298,7 @@ azure.subscription.automationService.account.credential.description 13.16.2
 azure.subscription.automationService.account.credential.id 13.16.2
 azure.subscription.automationService.account.credential.lastModifiedTime 13.16.2
 azure.subscription.automationService.account.credential.name 13.16.2
+azure.subscription.automationService.account.credential.systemMetadata 13.22.1
 azure.subscription.automationService.account.credential.userName 13.16.2
 azure.subscription.automationService.account.credentials 13.16.2
 azure.subscription.automationService.account.disableLocalAuth 13.16.2
@@ -307,6 +310,7 @@ azure.subscription.automationService.account.name 13.16.2
 azure.subscription.automationService.account.publicNetworkAccess 13.16.2
 azure.subscription.automationService.account.sku 13.16.2
 azure.subscription.automationService.account.state 13.16.2
+azure.subscription.automationService.account.systemMetadata 13.22.1
 azure.subscription.automationService.account.tags 13.16.2
 azure.subscription.automationService.account.variable 13.16.2
 azure.subscription.automationService.account.variable.creationTime 13.16.2
@@ -315,6 +319,7 @@ azure.subscription.automationService.account.variable.id 13.16.2
 azure.subscription.automationService.account.variable.isEncrypted 13.16.2
 azure.subscription.automationService.account.variable.lastModifiedTime 13.16.2
 azure.subscription.automationService.account.variable.name 13.16.2
+azure.subscription.automationService.account.variable.systemMetadata 13.22.1
 azure.subscription.automationService.account.variables 13.16.2
 azure.subscription.automationService.accounts 13.16.2
 azure.subscription.automationService.subscriptionId 13.16.2
@@ -351,6 +356,7 @@ azure.subscription.batchService.account.pool.properties 11.4.0
 azure.subscription.batchService.account.pool.provisioningState 11.4.0
 azure.subscription.batchService.account.pool.proxyAgentEnabled 13.1.8
 azure.subscription.batchService.account.pool.securityEncryptionType 13.1.8
+azure.subscription.batchService.account.pool.systemMetadata 13.22.1
 azure.subscription.batchService.account.pool.type 11.4.0
 azure.subscription.batchService.account.pool.virtualMachineConfiguration 11.4.0
 azure.subscription.batchService.account.pool.vmSize 11.4.0
@@ -361,6 +367,7 @@ azure.subscription.batchService.account.privateEndpointConnections 11.4.0
 azure.subscription.batchService.account.properties 11.4.0
 azure.subscription.batchService.account.provisioningState 11.4.0
 azure.subscription.batchService.account.publicNetworkAccess 11.4.0
+azure.subscription.batchService.account.systemMetadata 13.22.1
 azure.subscription.batchService.account.tags 11.4.0
 azure.subscription.batchService.account.type 11.4.0
 azure.subscription.batchService.accounts 11.4.0
@@ -722,6 +729,7 @@ azure.subscription.cognitiveServicesService.account.connection.metadata 13.15.2
 azure.subscription.cognitiveServicesService.account.connection.name 13.15.2
 azure.subscription.cognitiveServicesService.account.connection.peRequirement 13.15.2
 azure.subscription.cognitiveServicesService.account.connection.peStatus 13.15.2
+azure.subscription.cognitiveServicesService.account.connection.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.connection.target 13.15.2
 azure.subscription.cognitiveServicesService.account.connection.useWorkspaceManagedIdentity 13.15.2
 azure.subscription.cognitiveServicesService.account.connections 13.15.2
@@ -743,6 +751,7 @@ azure.subscription.cognitiveServicesService.account.deployment.raiPolicy 13.15.2
 azure.subscription.cognitiveServicesService.account.deployment.raiPolicyName 13.15.2
 azure.subscription.cognitiveServicesService.account.deployment.skuCapacity 13.15.2
 azure.subscription.cognitiveServicesService.account.deployment.skuName 13.15.2
+azure.subscription.cognitiveServicesService.account.deployment.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.deployment.tags 13.15.2
 azure.subscription.cognitiveServicesService.account.deployment.versionUpgradeOption 13.15.2
 azure.subscription.cognitiveServicesService.account.deployments 13.15.2
@@ -769,6 +778,7 @@ azure.subscription.cognitiveServicesService.account.project.connection.metadata 
 azure.subscription.cognitiveServicesService.account.project.connection.name 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connection.peRequirement 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connection.peStatus 13.15.2
+azure.subscription.cognitiveServicesService.account.project.connection.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.project.connection.target 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connection.useWorkspaceManagedIdentity 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connections 13.15.2
@@ -781,6 +791,7 @@ azure.subscription.cognitiveServicesService.account.project.isDefault 13.15.2
 azure.subscription.cognitiveServicesService.account.project.location 13.15.2
 azure.subscription.cognitiveServicesService.account.project.name 13.15.2
 azure.subscription.cognitiveServicesService.account.project.provisioningState 13.15.2
+azure.subscription.cognitiveServicesService.account.project.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.project.tags 13.15.2
 azure.subscription.cognitiveServicesService.account.projects 13.15.2
 azure.subscription.cognitiveServicesService.account.provisioningState 13.11.3
@@ -801,6 +812,7 @@ azure.subscription.cognitiveServicesService.account.raiPolicy.id 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.mode 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.name 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.policyType 13.12.2
+azure.subscription.cognitiveServicesService.account.raiPolicy.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.blocking 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.source 13.12.2
@@ -815,6 +827,7 @@ azure.subscription.cognitiveServicesService.account.raiTopic.lastModifiedAt 13.1
 azure.subscription.cognitiveServicesService.account.raiTopic.name 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.sampleBlobUrl 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.status 13.12.2
+azure.subscription.cognitiveServicesService.account.raiTopic.systemMetadata 13.22.1
 azure.subscription.cognitiveServicesService.account.raiTopic.topicId 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.topicName 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopics 13.12.2
@@ -840,6 +853,7 @@ azure.subscription.computeService.dedicatedHost.properties 13.7.1
 azure.subscription.computeService.dedicatedHost.provisioningState 13.7.1
 azure.subscription.computeService.dedicatedHost.provisioningTime 13.7.1
 azure.subscription.computeService.dedicatedHost.sku 13.7.1
+azure.subscription.computeService.dedicatedHost.systemMetadata 13.22.1
 azure.subscription.computeService.dedicatedHost.tags 13.7.1
 azure.subscription.computeService.dedicatedHost.timeCreated 13.7.1
 azure.subscription.computeService.dedicatedHost.type 13.7.1
@@ -853,6 +867,7 @@ azure.subscription.computeService.dedicatedHostGroup.name 13.7.1
 azure.subscription.computeService.dedicatedHostGroup.platformFaultDomainCount 13.7.1
 azure.subscription.computeService.dedicatedHostGroup.properties 13.7.1
 azure.subscription.computeService.dedicatedHostGroup.supportAutomaticPlacement 13.7.1
+azure.subscription.computeService.dedicatedHostGroup.systemMetadata 13.22.1
 azure.subscription.computeService.dedicatedHostGroup.tags 13.7.1
 azure.subscription.computeService.dedicatedHostGroup.type 13.7.1
 azure.subscription.computeService.dedicatedHostGroup.zones 13.7.1
@@ -899,6 +914,7 @@ azure.subscription.computeService.diskAccess.location 13.3.3
 azure.subscription.computeService.diskAccess.name 13.3.3
 azure.subscription.computeService.diskAccess.privateEndpointConnections 13.3.3
 azure.subscription.computeService.diskAccess.provisioningState 13.3.3
+azure.subscription.computeService.diskAccess.systemMetadata 13.22.1
 azure.subscription.computeService.diskAccess.tags 13.3.3
 azure.subscription.computeService.diskAccess.timeCreated 13.3.3
 azure.subscription.computeService.diskAccess.type 13.3.3
@@ -914,6 +930,7 @@ azure.subscription.computeService.diskEncryptionSet.location 13.3.3
 azure.subscription.computeService.diskEncryptionSet.name 13.3.3
 azure.subscription.computeService.diskEncryptionSet.provisioningState 13.3.3
 azure.subscription.computeService.diskEncryptionSet.rotationToLatestKeyVersionEnabled 13.3.3
+azure.subscription.computeService.diskEncryptionSet.systemMetadata 13.22.1
 azure.subscription.computeService.diskEncryptionSet.tags 13.3.3
 azure.subscription.computeService.diskEncryptionSet.type 13.3.3
 azure.subscription.computeService.diskEncryptionSets 13.3.3
@@ -1150,6 +1167,7 @@ azure.subscription.computeService.vmScaleSet.instance.name 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.properties 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.provisioningState 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.sku 13.7.1
+azure.subscription.computeService.vmScaleSet.instance.systemMetadata 13.22.1
 azure.subscription.computeService.vmScaleSet.instance.tags 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.timeCreated 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.vmId 13.7.1
@@ -1194,6 +1212,7 @@ azure.subscription.containerAppService.containerApp.authConfig.id 13.10.2
 azure.subscription.containerAppService.containerApp.authConfig.identityProviders 13.10.2
 azure.subscription.containerAppService.containerApp.authConfig.login 13.10.2
 azure.subscription.containerAppService.containerApp.authConfig.name 13.10.2
+azure.subscription.containerAppService.containerApp.authConfig.systemMetadata 13.22.1
 azure.subscription.containerAppService.containerApp.authConfig.unauthenticatedClientAction 13.10.2
 azure.subscription.containerAppService.containerApp.authConfigs 13.10.2
 azure.subscription.containerAppService.containerApp.clientCertificateMode 13.10.2
@@ -1242,6 +1261,7 @@ azure.subscription.containerAppService.containerApp.revision.provisioningError 1
 azure.subscription.containerAppService.containerApp.revision.provisioningState 13.10.2
 azure.subscription.containerAppService.containerApp.revision.replicas 13.10.2
 azure.subscription.containerAppService.containerApp.revision.runningState 13.11.3
+azure.subscription.containerAppService.containerApp.revision.systemMetadata 13.22.1
 azure.subscription.containerAppService.containerApp.revision.trafficWeight 13.10.2
 azure.subscription.containerAppService.containerApp.revisionMode 13.10.2
 azure.subscription.containerAppService.containerApp.revisions 13.10.2
@@ -1249,6 +1269,7 @@ azure.subscription.containerAppService.containerApp.runningStatus 13.11.3
 azure.subscription.containerAppService.containerApp.scaleRules 13.10.2
 azure.subscription.containerAppService.containerApp.secretNames 13.10.2
 azure.subscription.containerAppService.containerApp.stickySessions 13.10.2
+azure.subscription.containerAppService.containerApp.systemMetadata 13.22.1
 azure.subscription.containerAppService.containerApp.tags 13.10.2
 azure.subscription.containerAppService.containerApp.targetPort 13.10.2
 azure.subscription.containerAppService.containerApp.transport 13.10.2
@@ -1271,6 +1292,7 @@ azure.subscription.containerAppService.job.registryAuthUsesIdentity 13.10.2
 azure.subscription.containerAppService.job.replicaRetryLimit 13.10.2
 azure.subscription.containerAppService.job.replicaTimeoutSeconds 13.10.2
 azure.subscription.containerAppService.job.secretNames 13.10.2
+azure.subscription.containerAppService.job.systemMetadata 13.22.1
 azure.subscription.containerAppService.job.tags 13.10.2
 azure.subscription.containerAppService.job.triggerType 13.10.2
 azure.subscription.containerAppService.job.workloadProfileName 13.10.2
@@ -1287,6 +1309,7 @@ azure.subscription.containerAppService.managedEnvironment.certificate.provisioni
 azure.subscription.containerAppService.managedEnvironment.certificate.publicKeyHash 13.11.3
 azure.subscription.containerAppService.managedEnvironment.certificate.subjectAlternativeNames 13.11.3
 azure.subscription.containerAppService.managedEnvironment.certificate.subjectName 13.10.2
+azure.subscription.containerAppService.managedEnvironment.certificate.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.certificate.thumbprint 13.10.2
 azure.subscription.containerAppService.managedEnvironment.certificate.valid 13.10.2
 azure.subscription.containerAppService.managedEnvironment.certificates 13.10.2
@@ -1301,6 +1324,7 @@ azure.subscription.containerAppService.managedEnvironment.daprComponent.provisio
 azure.subscription.containerAppService.managedEnvironment.daprComponent.scopes 13.10.2
 azure.subscription.containerAppService.managedEnvironment.daprComponent.secretNames 13.10.2
 azure.subscription.containerAppService.managedEnvironment.daprComponent.secretsConfigured 13.10.2
+azure.subscription.containerAppService.managedEnvironment.daprComponent.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.daprComponent.version 13.10.2
 azure.subscription.containerAppService.managedEnvironment.daprComponents 13.10.2
 azure.subscription.containerAppService.managedEnvironment.defaultDomain 13.10.2
@@ -1313,6 +1337,7 @@ azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.name 1
 azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.provisioningErrors 13.11.3
 azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.provisioningState 13.11.3
 azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.rules 13.11.3
+azure.subscription.containerAppService.managedEnvironment.httpRouteConfig.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.httpRouteConfigs 13.11.3
 azure.subscription.containerAppService.managedEnvironment.id 13.10.2
 azure.subscription.containerAppService.managedEnvironment.ingressConfiguration 13.11.3
@@ -1325,6 +1350,7 @@ azure.subscription.containerAppService.managedEnvironment.maintenanceConfigurati
 azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.id 13.11.3
 azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.name 13.11.3
 azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.scheduledEntries 13.11.3
+azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.maintenanceConfigurations 13.11.3
 azure.subscription.containerAppService.managedEnvironment.name 13.10.2
 azure.subscription.containerAppService.managedEnvironment.peerAuthentication 13.10.2
@@ -1338,10 +1364,12 @@ azure.subscription.containerAppService.managedEnvironment.privateEndpointConnect
 azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.privateEndpointId 13.11.3
 azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.provisioningState 13.11.3
 azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.status 13.11.3
+azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.privateEndpointConnections 13.11.3
 azure.subscription.containerAppService.managedEnvironment.provisioningState 13.10.2
 azure.subscription.containerAppService.managedEnvironment.publicNetworkAccess 13.11.3
 azure.subscription.containerAppService.managedEnvironment.staticIp 13.10.2
+azure.subscription.containerAppService.managedEnvironment.systemMetadata 13.22.1
 azure.subscription.containerAppService.managedEnvironment.tags 13.10.2
 azure.subscription.containerAppService.managedEnvironment.vnetConfiguration 13.10.2
 azure.subscription.containerAppService.managedEnvironment.workloadProfiles 13.10.2
@@ -1647,6 +1675,7 @@ azure.subscription.cosmosDbService.mongoCluster.serverVersion 13.12.1
 azure.subscription.cosmosDbService.mongoCluster.shardCount 13.12.1
 azure.subscription.cosmosDbService.mongoCluster.storageSizeGb 13.12.1
 azure.subscription.cosmosDbService.mongoCluster.storageType 13.12.1
+azure.subscription.cosmosDbService.mongoCluster.systemMetadata 13.22.1
 azure.subscription.cosmosDbService.mongoCluster.tags 13.12.1
 azure.subscription.cosmosDbService.mongoClusters 13.12.1
 azure.subscription.cosmosDbService.postgresqlCluster 13.12.1
@@ -1676,6 +1705,7 @@ azure.subscription.cosmosDbService.postgresqlCluster.serverNames 13.12.1
 azure.subscription.cosmosDbService.postgresqlCluster.sourceLocation 13.12.1
 azure.subscription.cosmosDbService.postgresqlCluster.sourceResourceId 13.12.1
 azure.subscription.cosmosDbService.postgresqlCluster.state 13.12.1
+azure.subscription.cosmosDbService.postgresqlCluster.systemMetadata 13.22.1
 azure.subscription.cosmosDbService.postgresqlCluster.tags 13.12.1
 azure.subscription.cosmosDbService.postgresqlClusters 13.12.1
 azure.subscription.cosmosDbService.subscriptionId 9.0.1
@@ -1766,6 +1796,7 @@ azure.subscription.databricksService.workspace.publicNetworkAccess 13.5.1
 azure.subscription.databricksService.workspace.requireInfrastructureEncryption 13.5.1
 azure.subscription.databricksService.workspace.requiredNsgRules 13.5.1
 azure.subscription.databricksService.workspace.sku 11.4.25
+azure.subscription.databricksService.workspace.systemMetadata 13.22.1
 azure.subscription.databricksService.workspace.tags 11.4.25
 azure.subscription.databricksService.workspace.type 11.4.25
 azure.subscription.databricksService.workspace.workspaceId 13.5.1
@@ -1809,6 +1840,7 @@ azure.subscription.desktopVirtualizationService.hostPool.ring 13.16.2
 azure.subscription.desktopVirtualizationService.hostPool.ssoSecretType 13.16.2
 azure.subscription.desktopVirtualizationService.hostPool.ssoadfsAuthority 13.16.2
 azure.subscription.desktopVirtualizationService.hostPool.startVMOnConnect 13.16.2
+azure.subscription.desktopVirtualizationService.hostPool.systemMetadata 13.22.1
 azure.subscription.desktopVirtualizationService.hostPool.tags 13.16.2
 azure.subscription.desktopVirtualizationService.hostPool.validationEnvironment 13.16.2
 azure.subscription.desktopVirtualizationService.hostPools 13.16.2
@@ -1869,6 +1901,7 @@ azure.subscription.eventGridService.domain.name 13.10.2
 azure.subscription.eventGridService.domain.privateEndpointConnectionCount 13.10.2
 azure.subscription.eventGridService.domain.provisioningState 13.10.2
 azure.subscription.eventGridService.domain.publicNetworkAccess 13.10.2
+azure.subscription.eventGridService.domain.systemMetadata 13.22.1
 azure.subscription.eventGridService.domain.tags 13.10.2
 azure.subscription.eventGridService.domains 13.10.2
 azure.subscription.eventGridService.subscriptionId 13.10.2
@@ -1880,6 +1913,7 @@ azure.subscription.eventGridService.systemTopic.metricResourceId 13.10.2
 azure.subscription.eventGridService.systemTopic.name 13.10.2
 azure.subscription.eventGridService.systemTopic.provisioningState 13.10.2
 azure.subscription.eventGridService.systemTopic.source 13.10.2
+azure.subscription.eventGridService.systemTopic.systemMetadata 13.22.1
 azure.subscription.eventGridService.systemTopic.tags 13.10.2
 azure.subscription.eventGridService.systemTopic.topicType 13.10.2
 azure.subscription.eventGridService.systemTopics 13.10.2
@@ -1898,6 +1932,7 @@ azure.subscription.eventGridService.topic.name 13.10.2
 azure.subscription.eventGridService.topic.privateEndpointConnectionCount 13.10.2
 azure.subscription.eventGridService.topic.provisioningState 13.10.2
 azure.subscription.eventGridService.topic.publicNetworkAccess 13.10.2
+azure.subscription.eventGridService.topic.systemMetadata 13.22.1
 azure.subscription.eventGridService.topic.tags 13.10.2
 azure.subscription.eventGridService.topics 13.10.2
 azure.subscription.eventHub 13.3.3
@@ -1910,6 +1945,7 @@ azure.subscription.eventHubService.namespace.eventHub 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.id 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.name 13.3.3
+azure.subscription.eventHubService.namespace.eventHub.consumerGroup.systemMetadata 13.22.1
 azure.subscription.eventHubService.namespace.eventHub.consumerGroup.userMetadata 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.consumerGroups 13.3.3
 azure.subscription.eventHubService.namespace.eventHub.id 13.3.3
@@ -1954,6 +1990,7 @@ azure.subscription.frontDoorService.profile.customDomain.hostName 13.3.3
 azure.subscription.frontDoorService.profile.customDomain.id 13.3.3
 azure.subscription.frontDoorService.profile.customDomain.name 13.3.3
 azure.subscription.frontDoorService.profile.customDomain.provisioningState 13.3.3
+azure.subscription.frontDoorService.profile.customDomain.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.customDomain.tlsCertificateType 13.5.1
 azure.subscription.frontDoorService.profile.customDomain.tlsMinimumVersion 13.5.1
 azure.subscription.frontDoorService.profile.customDomain.validationState 13.3.3
@@ -1977,8 +2014,10 @@ azure.subscription.frontDoorService.profile.endpoint.route.originPath 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.route.patternsToMatch 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.route.provisioningState 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.route.supportedProtocols 13.5.1
+azure.subscription.frontDoorService.profile.endpoint.route.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.endpoint.route.type 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.routes 13.5.1
+azure.subscription.frontDoorService.profile.endpoint.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.endpoints 13.3.3
 azure.subscription.frontDoorService.profile.frontDoorId 13.3.3
 azure.subscription.frontDoorService.profile.id 13.3.3
@@ -2000,9 +2039,11 @@ azure.subscription.frontDoorService.profile.originGroup.origin.name 13.3.3
 azure.subscription.frontDoorService.profile.originGroup.origin.originHostHeader 13.3.3
 azure.subscription.frontDoorService.profile.originGroup.origin.priority 13.3.3
 azure.subscription.frontDoorService.profile.originGroup.origin.provisioningState 13.3.3
+azure.subscription.frontDoorService.profile.originGroup.origin.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.originGroup.origin.weight 13.3.3
 azure.subscription.frontDoorService.profile.originGroup.origins 13.3.3
 azure.subscription.frontDoorService.profile.originGroup.provisioningState 13.3.3
+azure.subscription.frontDoorService.profile.originGroup.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.originGroups 13.3.3
 azure.subscription.frontDoorService.profile.provisioningState 13.3.3
 azure.subscription.frontDoorService.profile.resourceState 13.3.3
@@ -2013,8 +2054,10 @@ azure.subscription.frontDoorService.profile.securityPolicy.id 13.16.2
 azure.subscription.frontDoorService.profile.securityPolicy.name 13.16.2
 azure.subscription.frontDoorService.profile.securityPolicy.policyType 13.16.2
 azure.subscription.frontDoorService.profile.securityPolicy.provisioningState 13.16.2
+azure.subscription.frontDoorService.profile.securityPolicy.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId 13.16.2
 azure.subscription.frontDoorService.profile.sku 13.3.3
+azure.subscription.frontDoorService.profile.systemMetadata 13.22.1
 azure.subscription.frontDoorService.profile.tags 13.3.3
 azure.subscription.frontDoorService.profiles 13.3.3
 azure.subscription.frontDoorService.subscriptionId 13.3.3
@@ -2040,6 +2083,7 @@ azure.subscription.functionsService.functionApp.function.id 13.3.3
 azure.subscription.functionsService.functionApp.function.isDisabled 13.3.3
 azure.subscription.functionsService.functionApp.function.language 13.3.3
 azure.subscription.functionsService.functionApp.function.name 13.3.3
+azure.subscription.functionsService.functionApp.function.systemMetadata 13.22.1
 azure.subscription.functionsService.functionApp.functions 13.3.3
 azure.subscription.functionsService.functionApp.httpsOnly 13.3.3
 azure.subscription.functionsService.functionApp.id 13.3.3
@@ -2051,6 +2095,7 @@ azure.subscription.functionsService.functionApp.name 13.3.3
 azure.subscription.functionsService.functionApp.properties 13.3.3
 azure.subscription.functionsService.functionApp.publicNetworkAccess 13.18.1
 azure.subscription.functionsService.functionApp.state 13.3.3
+azure.subscription.functionsService.functionApp.systemMetadata 13.22.1
 azure.subscription.functionsService.functionApp.tags 13.3.3
 azure.subscription.functionsService.functionApps 13.3.3
 azure.subscription.functionsService.subscriptionId 13.3.3
@@ -2077,6 +2122,7 @@ azure.subscription.iotService.iotHub.publicNetworkAccess 13.5.1
 azure.subscription.iotService.iotHub.restrictOutboundNetworkAccess 13.5.1
 azure.subscription.iotService.iotHub.sku 13.5.1
 azure.subscription.iotService.iotHub.state 13.5.1
+azure.subscription.iotService.iotHub.systemMetadata 13.22.1
 azure.subscription.iotService.iotHub.tags 13.5.1
 azure.subscription.iotService.iotHub.type 13.5.1
 azure.subscription.iotService.iotHubs 13.5.1
@@ -2158,6 +2204,7 @@ azure.subscription.keyVaultService.managedHsm.regions 13.3.3
 azure.subscription.keyVaultService.managedHsm.scheduledPurgeDate 13.3.3
 azure.subscription.keyVaultService.managedHsm.skuName 13.3.3
 azure.subscription.keyVaultService.managedHsm.softDeleteRetentionInDays 13.3.3
+azure.subscription.keyVaultService.managedHsm.systemMetadata 13.22.1
 azure.subscription.keyVaultService.managedHsm.tags 13.3.3
 azure.subscription.keyVaultService.managedHsm.tenantId 13.3.3
 azure.subscription.keyVaultService.managedHsm.type 13.3.3
@@ -2287,6 +2334,7 @@ azure.subscription.kustoService.cluster.managedPrivateEndpoint.privateLinkResour
 azure.subscription.kustoService.cluster.managedPrivateEndpoint.privateLinkResourceRegion 13.17.1
 azure.subscription.kustoService.cluster.managedPrivateEndpoint.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.managedPrivateEndpoint.requestMessage 13.17.1
+azure.subscription.kustoService.cluster.managedPrivateEndpoint.systemMetadata 13.22.1
 azure.subscription.kustoService.cluster.managedPrivateEndpoints 13.17.1
 azure.subscription.kustoService.cluster.name 13.16.2
 azure.subscription.kustoService.cluster.principalAssignment 13.17.1
@@ -2307,6 +2355,7 @@ azure.subscription.kustoService.cluster.privateEndpointConnection.privateEndpoin
 azure.subscription.kustoService.cluster.privateEndpointConnection.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.privateEndpointConnection.status 13.17.1
 azure.subscription.kustoService.cluster.privateEndpointConnection.statusDescription 13.17.1
+azure.subscription.kustoService.cluster.privateEndpointConnection.systemMetadata 13.22.1
 azure.subscription.kustoService.cluster.privateEndpointConnections 13.17.1
 azure.subscription.kustoService.cluster.provisioningState 13.16.2
 azure.subscription.kustoService.cluster.publicIpType 13.16.2
@@ -2371,6 +2420,7 @@ azure.subscription.machineLearningService.workspace.compute.modifiedOn 13.15.2
 azure.subscription.machineLearningService.workspace.compute.name 13.15.2
 azure.subscription.machineLearningService.workspace.compute.provisioningState 13.15.2
 azure.subscription.machineLearningService.workspace.compute.resourceId 13.15.2
+azure.subscription.machineLearningService.workspace.compute.systemMetadata 13.22.1
 azure.subscription.machineLearningService.workspace.compute.tags 13.15.2
 azure.subscription.machineLearningService.workspace.computes 13.15.2
 azure.subscription.machineLearningService.workspace.containerRegistry 13.14.1
@@ -2398,6 +2448,7 @@ azure.subscription.machineLearningService.workspace.model.latestVersion 13.15.2
 azure.subscription.machineLearningService.workspace.model.name 13.15.2
 azure.subscription.machineLearningService.workspace.model.nextVersion 13.15.2
 azure.subscription.machineLearningService.workspace.model.provisioningState 13.15.2
+azure.subscription.machineLearningService.workspace.model.systemMetadata 13.22.1
 azure.subscription.machineLearningService.workspace.model.tags 13.15.2
 azure.subscription.machineLearningService.workspace.models 13.15.2
 azure.subscription.machineLearningService.workspace.name 13.14.1
@@ -2418,6 +2469,7 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.na
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.provisioningState 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.skuCapacity 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.skuName 13.15.2
+azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.systemMetadata 13.22.1
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment.tags 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployments 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.description 13.15.2
@@ -2431,6 +2483,7 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint.provisioningS
 azure.subscription.machineLearningService.workspace.onlineEndpoint.publicNetworkAccess 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.scoringUri 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.swaggerUri 13.15.2
+azure.subscription.machineLearningService.workspace.onlineEndpoint.systemMetadata 13.22.1
 azure.subscription.machineLearningService.workspace.onlineEndpoint.tags 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoint.traffic 13.15.2
 azure.subscription.machineLearningService.workspace.onlineEndpoints 13.15.2
@@ -2449,6 +2502,7 @@ azure.subscription.machineLearningService.workspace.serverlessEndpoint.marketpla
 azure.subscription.machineLearningService.workspace.serverlessEndpoint.modelId 13.15.2
 azure.subscription.machineLearningService.workspace.serverlessEndpoint.name 13.15.2
 azure.subscription.machineLearningService.workspace.serverlessEndpoint.provisioningState 13.15.2
+azure.subscription.machineLearningService.workspace.serverlessEndpoint.systemMetadata 13.22.1
 azure.subscription.machineLearningService.workspace.serverlessEndpoint.tags 13.15.2
 azure.subscription.machineLearningService.workspace.serverlessEndpoints 13.15.2
 azure.subscription.machineLearningService.workspace.sku 13.14.1
@@ -2466,6 +2520,7 @@ azure.subscription.managedIdentity.federatedIdentityCredentials 13.16.2
 azure.subscription.managedIdentity.name 11.2.1
 azure.subscription.managedIdentity.principalId 11.2.1
 azure.subscription.managedIdentity.roleAssignments 11.2.1
+azure.subscription.managedIdentity.systemMetadata 13.22.1
 azure.subscription.managedIdentity.tenantId 11.2.1
 azure.subscription.monitor 9.0.0
 azure.subscription.monitorService 9.0.1
@@ -2478,6 +2533,7 @@ azure.subscription.monitorService.activityLog.alert.id 9.0.1
 azure.subscription.monitorService.activityLog.alert.location 9.0.1
 azure.subscription.monitorService.activityLog.alert.name 9.0.1
 azure.subscription.monitorService.activityLog.alert.scopes 9.0.1
+azure.subscription.monitorService.activityLog.alert.systemMetadata 13.22.1
 azure.subscription.monitorService.activityLog.alert.tags 9.0.1
 azure.subscription.monitorService.activityLog.alert.type 9.0.1
 azure.subscription.monitorService.activityLog.alerts 9.0.1
@@ -2542,6 +2598,7 @@ azure.subscription.monitorService.logprofile.name 9.0.1
 azure.subscription.monitorService.logprofile.properties 9.0.1
 azure.subscription.monitorService.logprofile.storageAccount 9.0.1
 azure.subscription.monitorService.logprofile.storageAccountId 9.0.1
+azure.subscription.monitorService.logprofile.systemMetadata 13.22.1
 azure.subscription.monitorService.logprofile.tags 9.0.1
 azure.subscription.monitorService.logprofile.type 9.0.1
 azure.subscription.monitorService.queryPack 13.5.1
@@ -2557,11 +2614,13 @@ azure.subscription.monitorService.queryPack.query.description 13.5.1
 azure.subscription.monitorService.queryPack.query.displayName 13.5.1
 azure.subscription.monitorService.queryPack.query.id 13.5.1
 azure.subscription.monitorService.queryPack.query.name 13.5.1
+azure.subscription.monitorService.queryPack.query.systemMetadata 13.22.1
 azure.subscription.monitorService.queryPack.query.tags 13.5.1
 azure.subscription.monitorService.queryPack.query.timeCreated 13.5.1
 azure.subscription.monitorService.queryPack.query.timeModified 13.5.1
 azure.subscription.monitorService.queryPack.query.type 13.5.1
 azure.subscription.monitorService.queryPack.queryPackId 13.5.1
+azure.subscription.monitorService.queryPack.systemMetadata 13.22.1
 azure.subscription.monitorService.queryPack.tags 13.5.1
 azure.subscription.monitorService.queryPack.timeCreated 13.5.1
 azure.subscription.monitorService.queryPack.timeModified 13.5.1
@@ -2645,6 +2704,7 @@ azure.subscription.monitorService.workspace.replication.provisioningState 13.5.1
 azure.subscription.monitorService.workspace.retentionInDays 13.3.3
 azure.subscription.monitorService.workspace.skuCapacityReservationLevel 13.3.3
 azure.subscription.monitorService.workspace.skuName 13.3.3
+azure.subscription.monitorService.workspace.systemMetadata 13.22.1
 azure.subscription.monitorService.workspace.table 13.5.1
 azure.subscription.monitorService.workspace.table.archiveRetentionInDays 13.5.1
 azure.subscription.monitorService.workspace.table.id 13.5.1
@@ -2658,6 +2718,7 @@ azure.subscription.monitorService.workspace.table.retentionInDays 13.5.1
 azure.subscription.monitorService.workspace.table.retentionInDaysAsDefault 13.5.1
 azure.subscription.monitorService.workspace.table.schema 13.5.1
 azure.subscription.monitorService.workspace.table.searchResults 13.5.1
+azure.subscription.monitorService.workspace.table.systemMetadata 13.22.1
 azure.subscription.monitorService.workspace.table.totalRetentionInDays 13.5.1
 azure.subscription.monitorService.workspace.table.totalRetentionInDaysAsDefault 13.5.1
 azure.subscription.monitorService.workspace.table.type 13.5.1
@@ -2691,6 +2752,7 @@ azure.subscription.mySqlService.flexibleServer.name 9.0.1
 azure.subscription.mySqlService.flexibleServer.properties 9.0.1
 azure.subscription.mySqlService.flexibleServer.publicNetworkAccess 11.6.1
 azure.subscription.mySqlService.flexibleServer.sslEnforcement 11.6.1
+azure.subscription.mySqlService.flexibleServer.systemMetadata 13.22.1
 azure.subscription.mySqlService.flexibleServer.tags 9.0.1
 azure.subscription.mySqlService.flexibleServer.type 9.0.1
 azure.subscription.mySqlService.flexibleServer.version 11.4.28
@@ -3555,6 +3617,7 @@ azure.subscription.policy.assignment.id 11.2.0
 azure.subscription.policy.assignment.name 11.2.0
 azure.subscription.policy.assignment.parameters 11.2.0
 azure.subscription.policy.assignment.scope 11.2.0
+azure.subscription.policy.assignment.systemMetadata 13.22.1
 azure.subscription.policy.assignments 11.2.0
 azure.subscription.policy.complianceSummary 13.12.1
 azure.subscription.policy.complianceSummary.assignments 13.12.1
@@ -3573,6 +3636,7 @@ azure.subscription.policy.definition.name 13.12.1
 azure.subscription.policy.definition.parameters 13.12.1
 azure.subscription.policy.definition.policyRule 13.12.1
 azure.subscription.policy.definition.policyType 13.12.1
+azure.subscription.policy.definition.systemMetadata 13.22.1
 azure.subscription.policy.definition.version 13.12.1
 azure.subscription.policy.definitions 13.12.1
 azure.subscription.policy.exemption 13.12.1
@@ -3598,6 +3662,7 @@ azure.subscription.policy.setDefinition.name 13.12.1
 azure.subscription.policy.setDefinition.parameters 13.12.1
 azure.subscription.policy.setDefinition.policyDefinitions 13.12.1
 azure.subscription.policy.setDefinition.policyType 13.12.1
+azure.subscription.policy.setDefinition.systemMetadata 13.22.1
 azure.subscription.policy.setDefinition.version 13.12.1
 azure.subscription.policy.setDefinitions 13.12.1
 azure.subscription.policy.subscriptionId 11.2.0
@@ -3629,6 +3694,7 @@ azure.subscription.postgreSqlService.flexibleServer.primaryEncryptionKeyStatus 1
 azure.subscription.postgreSqlService.flexibleServer.privateEndpointConnections 13.8.2
 azure.subscription.postgreSqlService.flexibleServer.properties 11.0.9
 azure.subscription.postgreSqlService.flexibleServer.publicNetworkAccess 11.4.28
+azure.subscription.postgreSqlService.flexibleServer.systemMetadata 13.22.1
 azure.subscription.postgreSqlService.flexibleServer.tags 11.0.9
 azure.subscription.postgreSqlService.flexibleServer.threatProtectionState 13.5.1
 azure.subscription.postgreSqlService.flexibleServer.type 11.0.9
@@ -3751,6 +3817,7 @@ azure.subscription.recoveryServicesService.vault.securitySettings.softDeleteRete
 azure.subscription.recoveryServicesService.vault.securitySettings.softDeleteState 13.3.3
 azure.subscription.recoveryServicesService.vault.securitySettings.sourceScanConfigurationState 13.5.1
 azure.subscription.recoveryServicesService.vault.skuName 13.3.3
+azure.subscription.recoveryServicesService.vault.systemMetadata 13.22.1
 azure.subscription.recoveryServicesService.vault.tags 13.3.3
 azure.subscription.recoveryServicesService.vault.type 13.3.3
 azure.subscription.recoveryServicesService.vaults 13.3.3
@@ -3799,6 +3866,7 @@ azure.subscription.searchService.service.publicNetworkAccess 13.11.3
 azure.subscription.searchService.service.replicaCount 13.11.3
 azure.subscription.searchService.service.sku 13.11.3
 azure.subscription.searchService.service.status 13.11.3
+azure.subscription.searchService.service.systemMetadata 13.22.1
 azure.subscription.searchService.service.tags 13.11.3
 azure.subscription.searchService.services 13.11.3
 azure.subscription.searchService.subscriptionId 13.11.3
@@ -3813,6 +3881,7 @@ azure.subscription.sentinelService.alertRule.kind 13.12.2
 azure.subscription.sentinelService.alertRule.name 13.12.2
 azure.subscription.sentinelService.alertRule.properties 13.12.2
 azure.subscription.sentinelService.alertRule.severity 13.12.2
+azure.subscription.sentinelService.alertRule.systemMetadata 13.22.1
 azure.subscription.sentinelService.alertRule.tactics 13.12.2
 azure.subscription.sentinelService.subscriptionId 13.12.2
 azure.subscription.sentinelService.workspace 13.12.2
@@ -3857,11 +3926,13 @@ azure.subscription.serviceBusService.namespace.queue.name 13.3.3
 azure.subscription.serviceBusService.namespace.queue.requiresDuplicateDetection 13.3.3
 azure.subscription.serviceBusService.namespace.queue.requiresSession 13.3.3
 azure.subscription.serviceBusService.namespace.queue.status 13.3.3
+azure.subscription.serviceBusService.namespace.queue.systemMetadata 13.22.1
 azure.subscription.serviceBusService.namespace.queues 13.3.3
 azure.subscription.serviceBusService.namespace.requireInfrastructureEncryption 13.5.1
 azure.subscription.serviceBusService.namespace.serviceBusEndpoint 13.3.3
 azure.subscription.serviceBusService.namespace.sku 13.3.3
 azure.subscription.serviceBusService.namespace.status 13.3.3
+azure.subscription.serviceBusService.namespace.systemMetadata 13.22.1
 azure.subscription.serviceBusService.namespace.tags 13.3.3
 azure.subscription.serviceBusService.namespace.topic 13.3.3
 azure.subscription.serviceBusService.namespace.topic.defaultMessageTimeToLive 13.3.3
@@ -3881,9 +3952,11 @@ azure.subscription.serviceBusService.namespace.topic.subscription.messageCount 1
 azure.subscription.serviceBusService.namespace.topic.subscription.name 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscription.requiresSession 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscription.status 13.3.3
+azure.subscription.serviceBusService.namespace.topic.subscription.systemMetadata 13.22.1
 azure.subscription.serviceBusService.namespace.topic.subscriptionCount 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscriptions 13.3.3
 azure.subscription.serviceBusService.namespace.topic.supportOrdering 13.3.3
+azure.subscription.serviceBusService.namespace.topic.systemMetadata 13.22.1
 azure.subscription.serviceBusService.namespace.topics 13.3.3
 azure.subscription.serviceBusService.namespace.zoneRedundant 13.4.3
 azure.subscription.serviceBusService.namespaces 13.3.3
@@ -3906,6 +3979,7 @@ azure.subscription.signalRService.signalR.networkAclsDefaultAction 13.16.2
 azure.subscription.signalRService.signalR.provisioningState 13.16.2
 azure.subscription.signalRService.signalR.publicNetworkAccess 13.16.2
 azure.subscription.signalRService.signalR.sku 13.16.2
+azure.subscription.signalRService.signalR.systemMetadata 13.22.1
 azure.subscription.signalRService.signalR.tags 13.16.2
 azure.subscription.signalRService.signalR.version 13.16.2
 azure.subscription.signalRService.subscriptionId 13.16.2
@@ -4565,6 +4639,7 @@ azure.subscription.webPubSubService.webPubSub.networkAclsDefaultAction 13.16.2
 azure.subscription.webPubSubService.webPubSub.provisioningState 13.16.2
 azure.subscription.webPubSubService.webPubSub.publicNetworkAccess 13.16.2
 azure.subscription.webPubSubService.webPubSub.sku 13.16.2
+azure.subscription.webPubSubService.webPubSub.systemMetadata 13.22.1
 azure.subscription.webPubSubService.webPubSub.tags 13.16.2
 azure.subscription.webPubSubService.webPubSub.version 13.16.2
 azure.subscription.webService 9.0.1
@@ -4719,6 +4794,7 @@ azure.subscription.webService.appslot.parent 11.3.85
 azure.subscription.webService.appslot.properties 11.3.85
 azure.subscription.webService.appslot.scm 11.3.85
 azure.subscription.webService.appslot.stack 11.3.85
+azure.subscription.webService.appslot.systemMetadata 13.22.1
 azure.subscription.webService.appslot.tags 11.3.85
 azure.subscription.webService.appslot.type 11.3.85
 azure.subscription.webService.availableRuntimes 9.0.1
@@ -4793,6 +4869,7 @@ azure.subscription.webService.staticSite.repositoryUrl 13.10.2
 azure.subscription.webService.staticSite.skuName 13.10.2
 azure.subscription.webService.staticSite.skuTier 13.10.2
 azure.subscription.webService.staticSite.stagingEnvironmentPolicy 13.10.2
+azure.subscription.webService.staticSite.systemMetadata 13.22.1
 azure.subscription.webService.staticSite.tags 13.10.2
 azure.subscription.webService.staticSite.userProvidedFunctionAppCount 13.10.2
 azure.subscription.webService.staticSites 13.10.2

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.21.1",
-  "generated_at": "2026-06-25T11:58:23-07:00",
+  "version": "13.22.0",
+  "generated_at": "2026-06-26T21:25:53-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/azure/resources/batch.go
+++ b/providers/azure/resources/batch.go
@@ -300,7 +300,21 @@ func batchAccountToMql(runtime *plugin.Runtime, account *armbatch.Account) (*mql
 		return nil, err
 	}
 
+	sysData, err := convert.JsonToDict(account.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionBatchServiceAccount).cacheSystemData = sysData
+
 	return res.(*mqlAzureSubscriptionBatchServiceAccount), nil
+}
+
+type mqlAzureSubscriptionBatchServiceAccountInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccount) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionBatchServiceAccount) pools() ([]any, error) {
@@ -487,5 +501,19 @@ func batchPoolToMql(runtime *plugin.Runtime, pool *armbatch.Pool) (*mqlAzureSubs
 		return nil, err
 	}
 
+	sysData, err := convert.JsonToDict(pool.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	resource.(*mqlAzureSubscriptionBatchServiceAccountPool).cacheSystemData = sysData
+
 	return resource.(*mqlAzureSubscriptionBatchServiceAccountPool), nil
+}
+
+type mqlAzureSubscriptionBatchServiceAccountPoolInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccountPool) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -399,7 +399,21 @@ func raiPolicyToMql(runtime *plugin.Runtime, pol *armcognitiveservices.RaiPolicy
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy), nil
+	mqlPolicy := res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy)
+	sysData, err := convert.JsonToDict(pol.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlPolicy.cacheSystemData = sysData
+	return mqlPolicy, nil
+}
+
+type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func raiContentFilterToMql(runtime *plugin.Runtime, pol *armcognitiveservices.RaiPolicy, idx int, f *armcognitiveservices.RaiPolicyContentFilter) (*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicyContentFilter, error) {
@@ -673,11 +687,21 @@ func cognitiveServicesDeploymentToMql(runtime *plugin.Runtime, dep *armcognitive
 				parsed.SubscriptionID, parsed.ResourceGroup, parsed.Path["accounts"])
 		}
 	}
+	sysData, err := convert.JsonToDict(dep.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlDep.cacheSystemData = sysData
 	return mqlDep, nil
 }
 
 type mqlAzureSubscriptionCognitiveServicesServiceAccountDeploymentInternal struct {
-	cacheAccountId string
+	cacheAccountId  string
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountDeployment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // raiPolicy resolves the deployment's content-filter policy by matching raiPolicyName
@@ -757,7 +781,21 @@ func raiTopicToMql(runtime *plugin.Runtime, t *armcognitiveservices.RaiTopic) (*
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic), nil
+	mqlTopic := res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic)
+	sysData, err := convert.JsonToDict(t.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlTopic.cacheSystemData = sysData
+	return mqlTopic, nil
+}
+
+type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopicInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountProject) id() (string, error) {
@@ -862,7 +900,21 @@ func cognitiveServicesProjectToMql(runtime *plugin.Runtime, proj *armcognitivese
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject), nil
+	mqlProject := res.(*mqlAzureSubscriptionCognitiveServicesServiceAccountProject)
+	sysData, err := convert.JsonToDict(proj.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlProject.cacheSystemData = sysData
+	return mqlProject, nil
+}
+
+type mqlAzureSubscriptionCognitiveServicesServiceAccountProjectInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountProject) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) connections() ([]any, error) {
@@ -1023,5 +1075,31 @@ func cognitiveServicesConnectionToMql(runtime *plugin.Runtime, resourceType stri
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(c.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	switch r := res.(type) {
+	case *mqlAzureSubscriptionCognitiveServicesServiceAccountConnection:
+		r.cacheSystemData = sysData
+	case *mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection:
+		r.cacheSystemData = sysData
+	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionCognitiveServicesServiceAccountConnectionInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnectionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountProjectConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -1107,11 +1107,29 @@ func diskEncryptionSetToMql(runtime *plugin.Runtime, des compute.DiskEncryptionS
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(des.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet), nil
+}
+
+type mqlAzureSubscriptionComputeServiceDiskEncryptionSetInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceDiskEncryptionSet) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 type mqlAzureSubscriptionComputeServiceDiskAccessInternal struct {
 	cachePrivateEndpointConnections []*compute.PrivateEndpointConnection
+	cacheSystemData                 any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceDiskAccess) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeService) diskAccesses() ([]any, error) {
@@ -1173,6 +1191,12 @@ func (a *mqlAzureSubscriptionComputeService) diskAccesses() ([]any, error) {
 			// Cache private endpoint connections for lazy loading
 			mqlDaTyped := mqlDa.(*mqlAzureSubscriptionComputeServiceDiskAccess)
 			mqlDaTyped.cachePrivateEndpointConnections = privateEndpointConns
+
+			sysData, err := convert.JsonToDict(da.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlDaTyped.cacheSystemData = sysData
 
 			res = append(res, mqlDa)
 		}

--- a/providers/azure/resources/compute_extras.go
+++ b/providers/azure/resources/compute_extras.go
@@ -118,7 +118,20 @@ func dedicatedHostGroupToMql(runtime *plugin.Runtime, hg compute.DedicatedHostGr
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(hg.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceDedicatedHostGroup), nil
+}
+
+type mqlAzureSubscriptionComputeServiceDedicatedHostGroupInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceDedicatedHostGroup) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceDedicatedHostGroup) hosts() ([]any, error) {
@@ -212,7 +225,20 @@ func dedicatedHostToMql(runtime *plugin.Runtime, host compute.DedicatedHost) (*m
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(host.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceDedicatedHost).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceDedicatedHost), nil
+}
+
+type mqlAzureSubscriptionComputeServiceDedicatedHostInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceDedicatedHost) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // ----- Proximity Placement Groups -----

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -301,7 +301,20 @@ func vmScaleSetInstanceToMql(runtime *plugin.Runtime, inst compute.VirtualMachin
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(inst.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance), nil
+}
+
+type mqlAzureSubscriptionComputeServiceVmScaleSetInstanceInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceVmScaleSetInstance) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) extensions() ([]any, error) {

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -427,6 +427,11 @@ func newMongoClusterResource(runtime *plugin.Runtime, cluster *armmongocluster.M
 	}
 	mqlCluster := resource.(*mqlAzureSubscriptionCosmosDbServiceMongoCluster)
 	mqlCluster.cacheKeyVaultKeyUri = keyVaultKeyUri
+	sysData, err := convert.JsonToDict(cluster.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlCluster.cacheSystemData = sysData
 	return mqlCluster, nil
 }
 
@@ -552,7 +557,25 @@ func newPostgresClusterResource(runtime *plugin.Runtime, cluster *armcosmosforpo
 	if err != nil {
 		return nil, err
 	}
-	return resource.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster), nil
+	mqlCluster := resource.(*mqlAzureSubscriptionCosmosDbServicePostgresqlCluster)
+	sysData, err := convert.JsonToDict(cluster.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlCluster.cacheSystemData = sysData
+	return mqlCluster, nil
+}
+
+type mqlAzureSubscriptionCosmosDbServicePostgresqlClusterInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCosmosDbServiceMongoCluster) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionCosmosDbServicePostgresqlCluster) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionCosmosDbServiceAccount) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
@@ -565,6 +588,7 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccount) encryptionKey() (*mqlAzureS
 
 type mqlAzureSubscriptionCosmosDbServiceMongoClusterInternal struct {
 	cacheKeyVaultKeyUri string
+	cacheSystemData     any
 }
 
 func (a *mqlAzureSubscriptionCosmosDbServiceMongoCluster) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {

--- a/providers/azure/resources/databricks.go
+++ b/providers/azure/resources/databricks.go
@@ -215,5 +215,20 @@ func databricksWorkspaceToMql(runtime *plugin.Runtime, workspace *armdatabricks.
 		return nil, err
 	}
 
-	return res.(*mqlAzureSubscriptionDatabricksServiceWorkspace), nil
+	mqlWorkspace := res.(*mqlAzureSubscriptionDatabricksServiceWorkspace)
+	sysData, err := convert.JsonToDict(workspace.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlWorkspace.cacheSystemData = sysData
+
+	return mqlWorkspace, nil
+}
+
+type mqlAzureSubscriptionDatabricksServiceWorkspaceInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionDatabricksServiceWorkspace) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/desktopvirtualization.go
+++ b/providers/azure/resources/desktopvirtualization.go
@@ -136,5 +136,19 @@ func hostPoolToMql(runtime *plugin.Runtime, hp *armdesktopvirtualization.HostPoo
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool), nil
+	mqlHostPool := res.(*mqlAzureSubscriptionDesktopVirtualizationServiceHostPool)
+	sysData, err := convert.JsonToDict(hp.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlHostPool.cacheSystemData = sysData
+	return mqlHostPool, nil
+}
+
+type mqlAzureSubscriptionDesktopVirtualizationServiceHostPoolInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionDesktopVirtualizationServiceHostPool) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/eventgrid.go
+++ b/providers/azure/resources/eventgrid.go
@@ -20,8 +20,32 @@ func (a *mqlAzureSubscriptionEventGridService) id() (string, error) {
 	return "azure.subscription.eventGrid/" + a.SubscriptionId.Data, nil
 }
 
+type mqlAzureSubscriptionEventGridServiceTopicInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionEventGridServiceSystemTopicInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionEventGridServiceDomainInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionEventGridServiceTopic) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionEventGridServiceTopic) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionEventGridServiceSystemTopic) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionEventGridServiceDomain) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionEventGridServiceSystemTopic) id() (string, error) {
@@ -151,6 +175,11 @@ func (a *mqlAzureSubscriptionEventGridService) topics() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(t.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlTopic.(*mqlAzureSubscriptionEventGridServiceTopic).cacheSystemData = sysData
 			res = append(res, mqlTopic)
 		}
 	}
@@ -207,6 +236,11 @@ func (a *mqlAzureSubscriptionEventGridService) systemTopics() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(st.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSt.(*mqlAzureSubscriptionEventGridServiceSystemTopic).cacheSystemData = sysData
 			res = append(res, mqlSt)
 		}
 	}
@@ -305,6 +339,11 @@ func (a *mqlAzureSubscriptionEventGridService) domains() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(d.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlDomain.(*mqlAzureSubscriptionEventGridServiceDomain).cacheSystemData = sysData
 			res = append(res, mqlDomain)
 		}
 	}

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -30,6 +30,14 @@ type mqlAzureSubscriptionEventHubServiceNamespaceEventHubInternal struct {
 	cacheSystemData any
 }
 
+type mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroupInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionEventHubService) id() (string, error) {
 	return "azure.subscription.eventHub/" + a.SubscriptionId.Data, nil
 }
@@ -298,6 +306,11 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(cg.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCg.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).cacheSystemData = sysData
 			res = append(res, mqlCg)
 		}
 	}

--- a/providers/azure/resources/frontdoor.go
+++ b/providers/azure/resources/frontdoor.go
@@ -129,6 +129,11 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) securityPolicies() ([]any,
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(sp.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSp.(*mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy).cacheSystemData = sysData
 			res = append(res, mqlSp)
 		}
 	}
@@ -194,6 +199,11 @@ func (a *mqlAzureSubscriptionFrontDoorService) profiles() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(profile.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlProfile.(*mqlAzureSubscriptionFrontDoorServiceProfile).cacheSystemData = sysData
 			res = append(res, mqlProfile)
 		}
 	}
@@ -258,6 +268,11 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) endpoints() ([]any, error)
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ep.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlEp.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).cacheSystemData = sysData
 			res = append(res, mqlEp)
 		}
 	}
@@ -331,6 +346,11 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) customDomains() ([]any, er
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(cd.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCd.(*mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain).cacheSystemData = sysData
 			res = append(res, mqlCd)
 		}
 	}
@@ -398,6 +418,11 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) originGroups() ([]any, err
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(og.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlOg.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup).cacheSystemData = sysData
 			res = append(res, mqlOg)
 		}
 	}
@@ -487,6 +512,11 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup) origins() ([]an
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(origin.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlOrigin.(*mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin).cacheSystemData = sysData
 			res = append(res, mqlOrigin)
 		}
 	}
@@ -586,8 +616,69 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) routes() ([]any, e
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(rt.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRt.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute).cacheSystemData = sysData
 			res = append(res, mqlRt)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfile) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileEndpointInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileCustomDomainInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileCustomDomain) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroup) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOriginInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileOriginGroupOrigin) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileEndpointRouteInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileEndpointRoute) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFrontDoorServiceProfileSecurityPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -189,7 +189,7 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		managedServiceIdentityId = *site.Identity.PrincipalID
 	}
 
-	return CreateResource(runtime, "azure.subscription.functionsService.functionApp", map[string]*llx.RawData{
+	res, err := CreateResource(runtime, "azure.subscription.functionsService.functionApp", map[string]*llx.RawData{
 		"id":                        llx.StringDataPtr(site.ID),
 		"name":                      llx.StringDataPtr(site.Name),
 		"location":                  llx.StringDataPtr(site.Location),
@@ -205,6 +205,31 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		"publicNetworkAccess":       llx.StringData(publicNetworkAccess),
 		"properties":                llx.DictData(properties),
 	})
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(site.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).cacheSystemData = sysData
+	return res, nil
+}
+
+type mqlAzureSubscriptionFunctionsServiceFunctionAppInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionFunctionsServiceFunctionAppFunctionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) functions() ([]any, error) {
@@ -266,6 +291,11 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) functions() ([]any, er
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(fn.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlFn.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).cacheSystemData = sysData
 			res = append(res, mqlFn)
 		}
 	}

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -379,6 +379,7 @@ func initAzureSubscriptionManagedIdentity(runtime *plugin.Runtime, args map[stri
 
 type mqlAzureSubscriptionManagedIdentityInternal struct {
 	cacheResourceID string
+	cacheSystemData any
 }
 
 func newMqlManagedIdentity(runtime *plugin.Runtime, managedIdentity *armmsi.Identity) (*mqlAzureSubscriptionManagedIdentity, error) {
@@ -404,7 +405,18 @@ func newMqlManagedIdentity(runtime *plugin.Runtime, managedIdentity *armmsi.Iden
 
 	mqlManagedIdentity := r.(*mqlAzureSubscriptionManagedIdentity)
 	mqlManagedIdentity.cacheResourceID = convert.ToValue(managedIdentity.ID)
+
+	sysData, err := convert.JsonToDict(managedIdentity.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlManagedIdentity.cacheSystemData = sysData
+
 	return mqlManagedIdentity, nil
+}
+
+func (a *mqlAzureSubscriptionManagedIdentity) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.__id, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionManagedIdentity) roleAssignments() ([]any, error) {

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -16,8 +16,16 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+type mqlAzureSubscriptionIotServiceIotHubInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionIotServiceIotHub) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionIotServiceIotHub) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionIotServiceIotHub) diagnosticSettings() ([]any, error) {
@@ -166,6 +174,11 @@ func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(hub.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlHub.(*mqlAzureSubscriptionIotServiceIotHub).cacheSystemData = sysData
 			res = append(res, mqlHub)
 		}
 	}

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -1593,6 +1593,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) id() (string, error) {
 
 type mqlAzureSubscriptionKeyVaultServiceManagedHsmInternal struct {
 	cachePrivateEndpointConnections []*keyvault.MHSMPrivateEndpointConnectionItem
+	cacheSystemData                 any
+}
+
+func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionKeyVaultService) managedHsms() ([]any, error) {
@@ -1694,6 +1699,12 @@ func (a *mqlAzureSubscriptionKeyVaultService) managedHsms() ([]any, error) {
 			// Cache private endpoint connections for lazy loading
 			mqlHsmTyped := mqlHsm.(*mqlAzureSubscriptionKeyVaultServiceManagedHsm)
 			mqlHsmTyped.cachePrivateEndpointConnections = privateEndpointConns
+
+			sysData, err := convert.JsonToDict(hsm.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlHsmTyped.cacheSystemData = sysData
 
 			res = append(res, mqlHsm)
 		}

--- a/providers/azure/resources/kusto.go
+++ b/providers/azure/resources/kusto.go
@@ -220,6 +220,19 @@ func (a *mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection) id() (st
 
 type mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnectionInternal struct {
 	cachePrivateEndpointID string
+	cacheSystemData        any
+}
+
+type mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpointInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 type mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnectionInternal struct {
@@ -562,6 +575,11 @@ func (a *mqlAzureSubscriptionKustoServiceCluster) privateEndpointConnections() (
 				return nil, err
 			}
 			mqlPec.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).cachePrivateEndpointID = privateEndpointID
+			sysData, err := convert.JsonToDict(pec.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPec.(*mqlAzureSubscriptionKustoServiceClusterPrivateEndpointConnection).cacheSystemData = sysData
 			res = append(res, mqlPec)
 		}
 	}
@@ -620,6 +638,11 @@ func (a *mqlAzureSubscriptionKustoServiceCluster) managedPrivateEndpoints() ([]a
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(mpe.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlMpe.(*mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint).cacheSystemData = sysData
 			res = append(res, mqlMpe)
 		}
 	}

--- a/providers/azure/resources/loganalytics.go
+++ b/providers/azure/resources/loganalytics.go
@@ -28,6 +28,11 @@ type mqlAzureSubscriptionMonitorServiceWorkspaceInternal struct {
 	cachePrivateLinkScopedResources []*armoperationalinsights.PrivateLinkScopedResource
 	cacheReplication                *armoperationalinsights.WorkspaceReplicationProperties
 	cacheFailover                   *armoperationalinsights.WorkspaceFailoverProperties
+	cacheSystemData                 any
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceWorkspace) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 type mqlAzureSubscriptionMonitorServiceApplicationInsightInternal struct {
@@ -160,6 +165,11 @@ func createWorkspaceResource(runtime *plugin.Runtime, ws *armoperationalinsights
 	mqlWs.cachePrivateLinkScopedResources = props.PrivateLinkScopedResources
 	mqlWs.cacheReplication = props.Replication
 	mqlWs.cacheFailover = props.Failover
+	sysData, err := convert.JsonToDict(ws.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlWs.cacheSystemData = sysData
 
 	return mqlWs, nil
 }
@@ -633,6 +643,11 @@ func (a *mqlAzureSubscriptionMonitorServiceWorkspace) tables() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(t.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlT.(*mqlAzureSubscriptionMonitorServiceWorkspaceTable).cacheSystemData = sysData
 			res = append(res, mqlT)
 		}
 	}
@@ -641,6 +656,14 @@ func (a *mqlAzureSubscriptionMonitorServiceWorkspace) tables() ([]any, error) {
 
 func (a *mqlAzureSubscriptionMonitorServiceWorkspaceTable) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionMonitorServiceWorkspaceTableInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceWorkspaceTable) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // flattenNspProperties lifts the nested "properties" object of a Network
@@ -885,10 +908,31 @@ func (a *mqlAzureSubscriptionMonitorService) queryPacks() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(qp.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlQp.(*mqlAzureSubscriptionMonitorServiceQueryPack).cacheSystemData = sysData
 			res = append(res, mqlQp)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionMonitorServiceQueryPackInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionMonitorServiceQueryPackQueryInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceQueryPack) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceQueryPackQuery) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionMonitorServiceQueryPack) id() (string, error) {
@@ -981,6 +1025,11 @@ func (a *mqlAzureSubscriptionMonitorServiceQueryPack) queries() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(q.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlQ.(*mqlAzureSubscriptionMonitorServiceQueryPackQuery).cacheSystemData = sysData
 			res = append(res, mqlQ)
 		}
 	}

--- a/providers/azure/resources/machinelearning.go
+++ b/providers/azure/resources/machinelearning.go
@@ -350,6 +350,11 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspace) onlineEndpoints() 
 			}
 			mqlEp := mqlRes.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint)
 			mqlEp.cacheComputeId = computeId
+			sysData, err := convert.JsonToDict(ep.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlEp.cacheSystemData = sysData
 			res = append(res, mqlEp)
 		}
 	}
@@ -357,7 +362,12 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspace) onlineEndpoints() 
 }
 
 type mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointInternal struct {
-	cacheComputeId string
+	cacheComputeId  string
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // compute resolves the endpoint's serving compute by matching the cached ARM resource ID
@@ -494,6 +504,11 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpoint) depl
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(dep.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlDep.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment).cacheSystemData = sysData
 			res = append(res, mqlDep)
 		}
 	}
@@ -580,6 +595,11 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspace) serverlessEndpoint
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ep.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlEp.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint).cacheSystemData = sysData
 			res = append(res, mqlEp)
 		}
 	}
@@ -674,6 +694,11 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspace) computes() ([]any,
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(c.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCompute.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute).cacheSystemData = sysData
 			res = append(res, mqlCompute)
 		}
 	}
@@ -749,8 +774,45 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspace) models() ([]any, e
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(m.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlModel.(*mqlAzureSubscriptionMachineLearningServiceWorkspaceModel).cacheSystemData = sysData
 			res = append(res, mqlModel)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeploymentInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpointInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionMachineLearningServiceWorkspaceComputeInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionMachineLearningServiceWorkspaceModelInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceOnlineEndpointDeployment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceServerlessEndpoint) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceCompute) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceModel) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -126,6 +126,11 @@ func (a *mqlAzureSubscriptionMonitorService) logProfiles() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAzure.(*mqlAzureSubscriptionMonitorServiceLogprofile).cacheSystemData = sysData
 			res = append(res, mqlAzure)
 		}
 	}
@@ -376,10 +381,31 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]any, error) 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			alert.(*mqlAzureSubscriptionMonitorServiceActivityLogAlert).cacheSystemData = sysData
 			res = append(res, alert)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionMonitorServiceLogprofileInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionMonitorServiceActivityLogAlertInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceLogprofile) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceActivityLogAlert) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionMonitorServiceActivityLogEntry) id() (string, error) {

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -222,6 +222,11 @@ func (a *mqlAzureSubscriptionMySqlService) flexibleServers() ([]any, error) {
 					mqlServer.cacheGeoBackupKeyURI = *dbServer.Properties.DataEncryption.GeoBackupKeyURI
 				}
 			}
+			sysData, err := convert.JsonToDict(dbServer.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlServer.cacheSystemData = sysData
 			res = append(res, mqlAzureDbServer)
 		}
 	}
@@ -553,6 +558,11 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) configuration() ([]any,
 type mqlAzureSubscriptionMySqlServiceFlexibleServerInternal struct {
 	cacheDataEncryptionKeyURI string
 	cacheGeoBackupKeyURI      string
+	cacheSystemData           any
+}
+
+func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) dataEncryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -124,9 +124,24 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		sysData, err := convert.JsonToDict(assignment.SystemData)
+		if err != nil {
+			return nil, err
+		}
+		mqlAssignment.(*mqlAzureSubscriptionPolicyAssignment).cacheSystemData = sysData
+
 		res = append(res, mqlAssignment)
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionPolicyAssignmentInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionPolicyAssignment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // policyAssignmentArgs maps a single policy assignment to the resource fields.
@@ -201,7 +216,7 @@ func newMqlPolicyDefinition(runtime *plugin.Runtime, def *armpolicy.Definition) 
 		return nil, err
 	}
 
-	return CreateResource(runtime, "azure.subscription.policy.definition", map[string]*llx.RawData{
+	res, err := CreateResource(runtime, "azure.subscription.policy.definition", map[string]*llx.RawData{
 		"__id":        llx.StringDataPtr(def.ID),
 		"id":          llx.StringDataPtr(def.ID),
 		"name":        llx.StringDataPtr(def.Name),
@@ -214,6 +229,25 @@ func newMqlPolicyDefinition(runtime *plugin.Runtime, def *armpolicy.Definition) 
 		"metadata":    llx.DictData(metadata),
 		"version":     llx.StringDataPtr(props.Version),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	sysData, err := convert.JsonToDict(def.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionPolicyDefinition).cacheSystemData = sysData
+
+	return res, nil
+}
+
+type mqlAzureSubscriptionPolicyDefinitionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionPolicyDefinition) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionPolicy) setDefinitions() ([]any, error) {
@@ -266,10 +300,25 @@ func (a *mqlAzureSubscriptionPolicy) setDefinitions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			sysData, err := convert.JsonToDict(setDef.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSetDef.(*mqlAzureSubscriptionPolicySetDefinition).cacheSystemData = sysData
+
 			res = append(res, mqlSetDef)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionPolicySetDefinitionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionPolicySetDefinition) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // azurePolicyExemption mirrors the Microsoft.Authorization/policyExemptions REST

--- a/providers/azure/resources/postgresql.go
+++ b/providers/azure/resources/postgresql.go
@@ -141,6 +141,11 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) id() (string, erro
 type mqlAzureSubscriptionPostgreSqlServiceFlexibleServerInternal struct {
 	cachePrimaryKeyURI   string
 	cacheGeoBackupKeyURI string
+	cacheSystemData      any
+}
+
+func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionPostgreSqlService) flexibleServers() ([]any, error) {
@@ -239,6 +244,11 @@ func (a *mqlAzureSubscriptionPostgreSqlService) flexibleServers() ([]any, error)
 					mqlServer.cacheGeoBackupKeyURI = *dbServer.Properties.DataEncryption.GeoBackupKeyURI
 				}
 			}
+			sysData, err := convert.JsonToDict(dbServer.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlServer.cacheSystemData = sysData
 			res = append(res, mqlAzurePostgresServer)
 		}
 	}

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -26,6 +26,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVaultInternal struct {
 	cacheMonitoringSettings  *armrecoveryservices.MonitoringSettings
 	cacheRedundancySettings  *armrecoveryservices.VaultPropertiesRedundancySettings
 	cachePrivateEndpointConn []*armrecoveryservices.PrivateEndpointConnectionVaultProperties
+	cacheSystemData          any
 }
 
 func (a *mqlAzureSubscriptionRecoveryServicesService) id() (string, error) {
@@ -210,7 +211,17 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 	mqlVault.cacheRedundancySettings = props.RedundancySettings
 	mqlVault.cachePrivateEndpointConn = props.PrivateEndpointConnections
 
+	sysData, err := convert.JsonToDict(vault.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlVault.cacheSystemData = sysData
+
 	return mqlVault, nil
+}
+
+func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // securitySettings builds the security settings sub-resource from cached data.

--- a/providers/azure/resources/search.go
+++ b/providers/azure/resources/search.go
@@ -164,5 +164,19 @@ func searchServiceToMql(runtime *plugin.Runtime, svc *armsearch.Service) (*mqlAz
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionSearchServiceService), nil
+	mqlService := res.(*mqlAzureSubscriptionSearchServiceService)
+	sysData, err := convert.JsonToDict(svc.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlService.cacheSystemData = sysData
+	return mqlService, nil
+}
+
+type mqlAzureSubscriptionSearchServiceServiceInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSearchServiceService) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/sentinel.go
+++ b/providers/azure/resources/sentinel.go
@@ -292,7 +292,22 @@ func sentinelAlertRuleToMql(runtime *plugin.Runtime, raw armsecurityinsights.Ale
 	if err != nil {
 		return nil, err
 	}
+
+	sysData, err := convert.JsonToDict(base.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSentinelServiceAlertRule).cacheSystemData = sysData
+
 	return res.(*mqlAzureSubscriptionSentinelServiceAlertRule), nil
+}
+
+type mqlAzureSubscriptionSentinelServiceAlertRuleInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSentinelServiceAlertRule) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionSentinelServiceWorkspace) dataConnectors() ([]any, error) {

--- a/providers/azure/resources/servicebus.go
+++ b/providers/azure/resources/servicebus.go
@@ -23,6 +23,35 @@ type mqlAzureSubscriptionServiceBusServiceNamespaceInternal struct {
 	networkRuleSetFetched bool
 	networkRuleSetProps   *armservicebus.NetworkRuleSetProperties
 	networkRuleSetLock    sync.Mutex
+	cacheSystemData       any
+}
+
+type mqlAzureSubscriptionServiceBusServiceNamespaceQueueInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionServiceBusServiceNamespaceTopicInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscriptionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionServiceBusServiceNamespace) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionServiceBusServiceNamespaceQueue) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionServiceBusService) id() (string, error) {
@@ -142,6 +171,11 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ns.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlNs.(*mqlAzureSubscriptionServiceBusServiceNamespace).cacheSystemData = sysData
 			res = append(res, mqlNs)
 		}
 	}
@@ -237,6 +271,11 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) queues() ([]any, error)
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(q.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlQueue.(*mqlAzureSubscriptionServiceBusServiceNamespaceQueue).cacheSystemData = sysData
 			res = append(res, mqlQueue)
 		}
 	}
@@ -320,6 +359,11 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespace) topics() ([]any, error)
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(t.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlTopic.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopic).cacheSystemData = sysData
 			res = append(res, mqlTopic)
 		}
 	}
@@ -408,6 +452,11 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) subscriptions() ([
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(sub.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSub.(*mqlAzureSubscriptionServiceBusServiceNamespaceTopicSubscription).cacheSystemData = sysData
 			res = append(res, mqlSub)
 		}
 	}

--- a/providers/azure/resources/signalr.go
+++ b/providers/azure/resources/signalr.go
@@ -130,7 +130,21 @@ func signalRToMql(runtime *plugin.Runtime, sr *armsignalr.ResourceInfo) (*mqlAzu
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionSignalRServiceSignalR), nil
+	sysData, err := convert.JsonToDict(sr.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlSr := res.(*mqlAzureSubscriptionSignalRServiceSignalR)
+	mqlSr.cacheSystemData = sysData
+	return mqlSr, nil
+}
+
+type mqlAzureSubscriptionSignalRServiceSignalRInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSignalRServiceSignalR) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func initAzureSubscriptionWebPubSubService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -242,5 +256,19 @@ func webPubSubToMql(runtime *plugin.Runtime, wps *armwebpubsub.ResourceInfo) (*m
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub), nil
+	sysData, err := convert.JsonToDict(wps.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlWps := res.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub)
+	mqlWps.cacheSystemData = sysData
+	return mqlWps, nil
+}
+
+type mqlAzureSubscriptionWebPubSubServiceWebPubSubInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebPubSubServiceWebPubSub) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -150,18 +150,29 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 	if err != nil {
 		return nil, err
 	}
-	if resourceType == ResourceAzureSubscriptionWebServiceAppsite {
-		sysData, err := convert.JsonToDict(site.SystemData)
-		if err != nil {
-			return nil, err
-		}
+	sysData, err := convert.JsonToDict(site.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	switch resourceType {
+	case ResourceAzureSubscriptionWebServiceAppsite:
 		res.(*mqlAzureSubscriptionWebServiceAppsite).cacheSystemData = sysData
+	case ResourceAzureSubscriptionWebServiceAppslot:
+		res.(*mqlAzureSubscriptionWebServiceAppslot).cacheSystemData = sysData
 	}
 	return res, nil
 }
 
 type mqlAzureSubscriptionWebServiceAppsiteInternal struct {
 	cacheSystemData any
+}
+
+type mqlAzureSubscriptionWebServiceAppslotInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 type runtimeStackDescriptor struct {

--- a/providers/azure/resources/web_staticsites.go
+++ b/providers/azure/resources/web_staticsites.go
@@ -14,8 +14,16 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+type mqlAzureSubscriptionWebServiceStaticSiteInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionWebServiceStaticSite) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceStaticSite) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionWebService) staticSites() ([]any, error) {
@@ -140,6 +148,11 @@ func (a *mqlAzureSubscriptionWebService) staticSites() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(site.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSite.(*mqlAzureSubscriptionWebServiceStaticSite).cacheSystemData = sysData
 			res = append(res, mqlSite)
 		}
 	}


### PR DESCRIPTION
## What

Adds the typed `systemMetadata() azure.subscription.systemData` accessor — ARM provenance: `createdAt`, `createdBy`, `createdByType`, `lastModifiedAt`, `lastModifiedBy`, `lastModifiedByType` — to **77 resources** whose Azure SDK objects already return `SystemData` but where we did not yet surface it.

This is the "creation date" companion to #8762: where #8762 added dedicated property-level creation timestamps, this surfaces the ARM-envelope provenance (which includes `createdAt`) uniformly across resources that already had the data in hand.

## Pattern

Follows the established #8355 convention exactly:
- `cacheSystemData any` on each resource's `Internal` struct
- populated from `convert.JsonToDict(obj.SystemData)` right after `CreateResource`
- read back through the shared `systemMetadataFromRaw` helper in `systemdata.go`

No new API calls — `SystemData` is already part of every one of these list/get responses. `azure.permissions.json` diff is header-only.

## Coverage (77 resources)

- **Compute**: diskAccess, diskEncryptionSet, dedicatedHost, dedicatedHostGroup, vmScaleSet.instance
- **Batch**: account, account.pool
- **Data**: cosmos mongoCluster & postgresqlCluster, MySQL & PostgreSQL flexibleServer
- **Network**: signalR, webPubSub, Front Door profile + endpoint, customDomain, originGroup, origin, route, securityPolicy
- **Identity/Policy/Security**: managedIdentity, policy assignment/definition/setDefinition, keyVault managedHsm, recoveryServices vault, sentinel alertRule
- **App/Integration**: webService appslot & staticSite, functionApp & .function, Container Apps (managedEnvironment, containerApp, job, daprComponent, certificate, revision, authConfig, privateEndpointConnection, httpRouteConfig, maintenanceConfiguration), apiManagement service, eventGrid topic/systemTopic/domain, eventHub consumerGroup, serviceBus namespace/queue/topic/subscription, iotHub
- **Analytics/ML**: databricks workspace, monitor activityLog.alert & logprofile, Log Analytics workspace/table/queryPack/query, automation account/variable/credential/certificate, ML onlineEndpoint/deployment/serverlessEndpoint/compute/model, kusto privateEndpointConnection/managedPrivateEndpoint, cognitive deployment/project/raiPolicy/raiTopic/connection/project.connection, search service, AVD hostPool

## Notes

- **policy.assignment** uses a hand-rolled REST struct; added a `SystemData` field to it to capture the envelope. The `init` path (resolution via `policy.exemption.policyAssignment`) does not build the resource itself, so an assignment materialized that way reports `systemMetadata` as null — the list path is fully populated.
- **managedIdentity** has no public `id` field, so its accessor keys off `__id` (the ARM resource ID).
- **Defender `securityContact` / `settings`** were evaluated and **skipped**: their SDK types (`armsecurity.Contact`, `Setting`/`DataExportSettings`/`AlertSyncSettings`) do not expose `SystemData`.
- `.lr.versions` entries assigned `13.22.1` (next patch after current `13.22.0`).

## Test

- `make providers/build/azure` succeeds (codegen + version assignment + compile).
- `go test ./resources/` passes.