### PR TITLE
⭐ openstack: add creation-date fields to db.instance and objectstorage.container

### DIFF
--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -1506,6 +1506,8 @@ private openstack.objectstorage.container @defaults("name objectCount bytes publ
   objectCount int
   // Total bytes stored in the container
   bytes int
+  // Creation timestamp (derived from the container's X-Timestamp header)
+  created() time
   // Read ACL entries (X-Container-Read; e.g. ".r:*" means publicly readable)
   readACL() []string
   // Write ACL entries (X-Container-Write)
@@ -2450,6 +2452,8 @@ private openstack.db.instance @defaults("id name status datastoreType datastoreV
   datastoreVersion string
   // Size of the attached data volume in gibibytes
   volumeSize int
+  // Creation timestamp
+  created time
   // Network addresses assigned to the instance ([{type, address}]); `type` is for example `public` or `private`
   addresses []dict
   // Flavor (compute size) the instance runs on

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -2318,6 +2318,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.objectstorage.container.bytes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackObjectstorageContainer).GetBytes()).ToDataRes(types.Int)
 	},
+	"openstack.objectstorage.container.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetCreated()).ToDataRes(types.Time)
+	},
 	"openstack.objectstorage.container.readACL": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackObjectstorageContainer).GetReadACL()).ToDataRes(types.Array(types.String))
 	},
@@ -3334,6 +3337,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.db.instance.volumeSize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDbInstance).GetVolumeSize()).ToDataRes(types.Int)
+	},
+	"openstack.db.instance.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackDbInstance).GetCreated()).ToDataRes(types.Time)
 	},
 	"openstack.db.instance.addresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDbInstance).GetAddresses()).ToDataRes(types.Array(types.Dict))
@@ -6224,6 +6230,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackObjectstorageContainer).Bytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"openstack.objectstorage.container.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"openstack.objectstorage.container.readACL": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackObjectstorageContainer).ReadACL, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -7690,6 +7700,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.db.instance.volumeSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackDbInstance).VolumeSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"openstack.db.instance.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackDbInstance).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"openstack.db.instance.addresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15264,6 +15278,7 @@ type mqlOpenstackObjectstorageContainer struct {
 	Name             plugin.TValue[string]
 	ObjectCount      plugin.TValue[int64]
 	Bytes            plugin.TValue[int64]
+	Created          plugin.TValue[*time.Time]
 	ReadACL          plugin.TValue[[]any]
 	WriteACL         plugin.TValue[[]any]
 	StoragePolicy    plugin.TValue[string]
@@ -15321,6 +15336,12 @@ func (c *mqlOpenstackObjectstorageContainer) GetObjectCount() *plugin.TValue[int
 
 func (c *mqlOpenstackObjectstorageContainer) GetBytes() *plugin.TValue[int64] {
 	return &c.Bytes
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetCreated() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.Created, func() (*time.Time, error) {
+		return c.created()
+	})
 }
 
 func (c *mqlOpenstackObjectstorageContainer) GetReadACL() *plugin.TValue[[]any] {
@@ -18877,6 +18898,7 @@ type mqlOpenstackDbInstance struct {
 	DatastoreType    plugin.TValue[string]
 	DatastoreVersion plugin.TValue[string]
 	VolumeSize       plugin.TValue[int64]
+	Created          plugin.TValue[*time.Time]
 	Addresses        plugin.TValue[[]any]
 	Flavor           plugin.TValue[*mqlOpenstackComputeFlavor]
 	Databases        plugin.TValue[[]any]
@@ -18946,6 +18968,10 @@ func (c *mqlOpenstackDbInstance) GetDatastoreVersion() *plugin.TValue[string] {
 
 func (c *mqlOpenstackDbInstance) GetVolumeSize() *plugin.TValue[int64] {
 	return &c.VolumeSize
+}
+
+func (c *mqlOpenstackDbInstance) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
 }
 
 func (c *mqlOpenstackDbInstance) GetAddresses() *plugin.TValue[[]any] {

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -370,6 +370,7 @@ openstack.credentials 13.1.4
 openstack.databaseInstances 13.1.4
 openstack.db.instance 13.1.4
 openstack.db.instance.addresses 13.1.4
+openstack.db.instance.created 13.6.1
 openstack.db.instance.databases 13.1.4
 openstack.db.instance.datastoreType 13.1.4
 openstack.db.instance.datastoreVersion 13.1.4
@@ -663,6 +664,7 @@ openstack.objectstorage.account.quotaBytes 13.0.1
 openstack.objectstorage.account.tempUrlKeySet 13.0.1
 openstack.objectstorage.container 13.0.1
 openstack.objectstorage.container.bytes 13.0.1
+openstack.objectstorage.container.created 13.6.1
 openstack.objectstorage.container.historyLocation 13.0.1
 openstack.objectstorage.container.metadata 13.0.1
 openstack.objectstorage.container.name 13.0.1

--- a/providers/openstack/resources/swift.go
+++ b/providers/openstack/resources/swift.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1/accounts"
@@ -180,6 +181,20 @@ func (r *mqlOpenstackObjectstorageContainer) fetchHeader() (*containers.GetHeade
 	r.header = header
 	r.headerMeta = meta
 	return header, meta, nil
+}
+
+func (r *mqlOpenstackObjectstorageContainer) created() (*time.Time, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return nil, err
+	}
+	// X-Timestamp is a Unix epoch (seconds, with fractional part) recording when
+	// the container was created. Guard the zero/absent value so it surfaces as null.
+	if h.Timestamp == 0 {
+		return nil, nil
+	}
+	t := time.Unix(int64(h.Timestamp), 0).UTC()
+	return &t, nil
 }
 
 func (r *mqlOpenstackObjectstorageContainer) readACL() ([]any, error) {

--- a/providers/openstack/resources/trove.go
+++ b/providers/openstack/resources/trove.go
@@ -84,6 +84,7 @@ func (o *mqlOpenstack) databaseInstances() ([]any, error) {
 			"datastoreType":    llx.StringData(inst.Datastore.Type),
 			"datastoreVersion": llx.StringData(inst.Datastore.Version),
 			"volumeSize":       llx.IntData(int64(inst.Volume.Size)),
+			"created":          llx.TimeDataPtr(timePtr(inst.Created)),
 			"addresses":        dictSliceData(addresses),
 		})
 		if err != nil {


### PR DESCRIPTION
Exposes resource creation timestamps that the gophercloud SDK already returns but mql did not surface. Both fields are named `created` to match the existing `openstack.compute.server.created` convention.

| Resource | New field | SDK source |
|---|---|---|
| `openstack.db.instance` | `created` (time) | `instances.Instance.Created` (`time.Time`) |
| `openstack.objectstorage.container` | `created` (time) | `containers.GetHeader.Timestamp` (`X-Timestamp`) |

Notes:
- The Swift container `X-Timestamp` is a Unix epoch (`float64`) recording container creation time. It is converted via `time.Unix(int64(ts), 0).UTC()`, guarding the zero/absent value so it surfaces as null. The conversion reuses the existing `fetchHeader()` lazy loader.
- The Trove instance value maps directly in the `CreateResource` call, guarded by `timePtr` for zero-time nil semantics.
- `.lr.versions` entries auto-assigned at `13.6.1` by the build.