### PR TITLE
⭐ vsphere: add createDate to vsphere.vswitch.dvs

### DIFF
--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -495,10 +495,16 @@ func (v *mqlVsphereDatacenter) distributedSwitches() ([]any, error) {
 			return nil, err
 		}
 
+		var createDate time.Time
+		if config.Config != nil {
+			createDate = config.Config.GetDVSConfigInfo().CreateTime
+		}
+
 		mqlVswitch, err := CreateResource(v.MqlRuntime, "vsphere.vswitch.dvs", map[string]*llx.RawData{
 			"moid":       llx.StringData(s.Reference().Encode()),
 			"name":       llx.StringData(s.Name()),
 			"properties": llx.DictData(configMap),
+			"createDate": llx.TimeData(createDate),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -495,16 +495,17 @@ func (v *mqlVsphereDatacenter) distributedSwitches() ([]any, error) {
 			return nil, err
 		}
 
-		var createDate time.Time
+		var createDate *time.Time
 		if config.Config != nil {
-			createDate = config.Config.GetDVSConfigInfo().CreateTime
+			t := config.Config.GetDVSConfigInfo().CreateTime
+			createDate = &t
 		}
 
 		mqlVswitch, err := CreateResource(v.MqlRuntime, "vsphere.vswitch.dvs", map[string]*llx.RawData{
 			"moid":       llx.StringData(s.Reference().Encode()),
 			"name":       llx.StringData(s.Name()),
 			"properties": llx.DictData(configMap),
-			"createDate": llx.TimeData(createDate),
+			"createDate": llx.TimeDataPtr(createDate),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -273,6 +273,7 @@ func (v *mqlVsphereHost) distributedSwitch() ([]any, error) {
 			"__id":       llx.StringData(esxiClient.InventoryPath + "/" + name),
 			"name":       llx.StringData(name),
 			"properties": llx.DictData(s),
+			"createDate": llx.TimeData(time.Time{}),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -273,7 +273,8 @@ func (v *mqlVsphereHost) distributedSwitch() ([]any, error) {
 			"__id":       llx.StringData(esxiClient.InventoryPath + "/" + name),
 			"name":       llx.StringData(name),
 			"properties": llx.DictData(s),
-			"createDate": llx.TimeData(time.Time{}),
+			// esxcli vswitch output carries no creation time; null marks it unknown.
+			"createDate": llx.TimeDataPtr(nil),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -1324,7 +1324,7 @@ private vsphere.vswitch.dvs @defaults("name") {
   properties dict
   // When the distributed virtual switch was created
   //
-  // Reported by vCenter for switches iterated from `vsphere.datacenter.distributedSwitches`; the zero time (0001-01-01) when the switch is observed directly from a host or vCenter does not report it.
+  // Reported by vCenter for switches iterated from `vsphere.datacenter.distributedSwitches`; null when the switch is observed directly from a host or vCenter does not report it.
   createDate time
   // Physical NICs the host (or all member hosts) contribute as uplinks to this DVS
   uplinks() []vsphere.vmnic

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -1322,6 +1322,10 @@ private vsphere.vswitch.dvs @defaults("name") {
   name string
   // Raw output of `esxcli network vswitch dvs vmware list` for this DVS, as a dict
   properties dict
+  // When the distributed virtual switch was created
+  //
+  // Reported by vCenter for switches iterated from `vsphere.datacenter.distributedSwitches`; the zero time (0001-01-01) when the switch is observed directly from a host or vCenter does not report it.
+  createDate time
   // Physical NICs the host (or all member hosts) contribute as uplinks to this DVS
   uplinks() []vsphere.vmnic
   // Port-mirroring (SPAN) sessions configured on the switch

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -1671,6 +1671,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.vswitch.dvs.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVswitchDvs).GetProperties()).ToDataRes(types.Dict)
 	},
+	"vsphere.vswitch.dvs.createDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVswitchDvs).GetCreateDate()).ToDataRes(types.Time)
+	},
 	"vsphere.vswitch.dvs.uplinks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVswitchDvs).GetUplinks()).ToDataRes(types.Array(types.Resource("vsphere.vmnic")))
 	},
@@ -3910,6 +3913,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.vswitch.dvs.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereVswitchDvs).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"vsphere.vswitch.dvs.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVswitchDvs).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"vsphere.vswitch.dvs.uplinks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9466,6 +9473,7 @@ type mqlVsphereVswitchDvs struct {
 	Moid          plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Properties    plugin.TValue[any]
+	CreateDate    plugin.TValue[*time.Time]
 	Uplinks       plugin.TValue[[]any]
 	VspanSessions plugin.TValue[[]any]
 }
@@ -9517,6 +9525,10 @@ func (c *mqlVsphereVswitchDvs) GetName() *plugin.TValue[string] {
 
 func (c *mqlVsphereVswitchDvs) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlVsphereVswitchDvs) GetCreateDate() *plugin.TValue[*time.Time] {
+	return &c.CreateDate
 }
 
 func (c *mqlVsphereVswitchDvs) GetUplinks() *plugin.TValue[[]any] {

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -501,6 +501,7 @@ vsphere.vmnic.pauseParams 9.0.0
 vsphere.vmnic.properties 9.0.0
 vsphere.vmnic.wakeOnLanSupported 13.1.1
 vsphere.vswitch.dvs 9.0.0
+vsphere.vswitch.dvs.createDate 13.6.1
 vsphere.vswitch.dvs.moid 11.0.39
 vsphere.vswitch.dvs.name 9.0.0
 vsphere.vswitch.dvs.properties 9.0.0


### PR DESCRIPTION
## What

Adds a typed top-level `createDate` (`time`) field to the `vsphere.vswitch.dvs` (distributed virtual switch) resource.

| Resource | New field | Source |
|---|---|---|
| `vsphere.vswitch.dvs` | `createDate time` | govmomi `DVSConfigInfo.CreateTime` via `mo.DistributedVirtualSwitch.Config` |

## Why

The DVS creation time was already fetched into the resource (it sits inside the raw `properties` dict) but had no typed accessor. This follows the existing vSphere convention where `vsphere.vm` and `vsphere.vm.snapshot` both expose their creation time as `createDate`.

## Details

The datacenter-level creator already calls `GetDistributedVirtualSwitchConfig`, so the value is available with no extra API call. `CreateTime` lives on the base `DVSConfigInfo` and is reached through `config.Config.GetDVSConfigInfo().CreateTime`, guarded for a nil `Config`.

The host-level (esxcli) discovery path does not report a creation time, so switches observed directly from a host carry the zero time (`0001-01-01`), consistent with how `vsphere.vm.createDate` handles an unknown value.

`.lr.versions` auto-assigned `13.6.1` (next patch after the provider's current `13.6.0`).