### PR TITLE
⭐ stackit: add resource creation-date fields

### DIFF
--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -498,12 +498,14 @@ func (r *mqlStackitSecretsManager) instances() ([]any, error) {
 	for i := range items {
 		inst := items[i]
 		args := map[string]*llx.RawData{
-			"id":            llx.StringData(inst.GetId()),
-			"name":          llx.StringData(inst.GetName()),
-			"state":         llx.StringData(inst.GetState()),
-			"apiUrl":        llx.StringData(inst.GetApiUrl()),
-			"secretsEngine": llx.StringData(inst.GetSecretsEngine()),
-			"secretCount":   llx.IntData(int64(inst.GetSecretCount())),
+			"id":                 llx.StringData(inst.GetId()),
+			"name":               llx.StringData(inst.GetName()),
+			"state":              llx.StringData(inst.GetState()),
+			"apiUrl":             llx.StringData(inst.GetApiUrl()),
+			"secretsEngine":      llx.StringData(inst.GetSecretsEngine()),
+			"secretCount":        llx.IntData(int64(inst.GetSecretCount())),
+			"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(inst.GetCreationStartDate())),
+			"creationFinishedAt": llx.TimeDataPtr(parseDnsTime(inst.GetCreationFinishedDate())),
 		}
 		res, err := CreateResource(r.MqlRuntime, "stackit.secretsManager.instance", args)
 		if err != nil {
@@ -872,12 +874,14 @@ func initStackitSecretsManagerInstance(runtime *plugin.Runtime, args map[string]
 		return nil, nil, err
 	}
 	res, err := CreateResource(runtime, "stackit.secretsManager.instance", map[string]*llx.RawData{
-		"id":            llx.StringData(inst.GetId()),
-		"name":          llx.StringData(inst.GetName()),
-		"state":         llx.StringData(inst.GetState()),
-		"apiUrl":        llx.StringData(inst.GetApiUrl()),
-		"secretsEngine": llx.StringData(inst.GetSecretsEngine()),
-		"secretCount":   llx.IntData(int64(inst.GetSecretCount())),
+		"id":                 llx.StringData(inst.GetId()),
+		"name":               llx.StringData(inst.GetName()),
+		"state":              llx.StringData(inst.GetState()),
+		"apiUrl":             llx.StringData(inst.GetApiUrl()),
+		"secretsEngine":      llx.StringData(inst.GetSecretsEngine()),
+		"secretCount":        llx.IntData(int64(inst.GetSecretCount())),
+		"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(inst.GetCreationStartDate())),
+		"creationFinishedAt": llx.TimeDataPtr(parseDnsTime(inst.GetCreationFinishedDate())),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/providers/stackit/resources/dns.go
+++ b/providers/stackit/resources/dns.go
@@ -64,6 +64,7 @@ func buildDnsZone(runtime *plugin.Runtime, z *dns.Zone) (plugin.Resource, error)
 		"acl":                llx.StringData(z.GetAcl()),
 		"primaries":          strSliceData(z.GetPrimaries()),
 		"isReverseZone":      llx.BoolData(z.GetIsReverseZone()),
+		"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(z.GetCreationStarted())),
 		"creationFinishedAt": llx.TimeDataPtr(created),
 		"labels":             stringMapData(dnsLabels(z.GetLabels())),
 	}
@@ -158,6 +159,7 @@ func (r *mqlStackitDnsZone) recordSets() ([]any, error) {
 				"comment":            llx.StringData(rs.GetComment()),
 				"records":            strSliceData(records),
 				"active":             llx.BoolData(rs.GetActive()),
+				"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(rs.GetCreationStarted())),
 				"creationFinishedAt": llx.TimeDataPtr(parseDnsTime(rs.GetCreationFinished())),
 				"updateFinishedAt":   llx.TimeDataPtr(parseDnsTime(rs.GetUpdateFinished())),
 			}

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -535,10 +535,13 @@ func buildNetwork(runtime *plugin.Runtime, n *iaas.Network) (plugin.Resource, er
 		}
 	}
 
+	createdAt, okCreated := n.GetCreatedAtOk()
+
 	args := map[string]*llx.RawData{
 		"id":              llx.StringData(n.GetId()),
 		"name":            llx.StringData(n.GetName()),
 		"routed":          llx.BoolData(n.GetRouted()),
+		"createdAt":       llx.TimeDataPtr(timeOrNil(createdAt, okCreated)),
 		"ipv4Prefix":      llx.StringData(ipv4PrefixSing),
 		"ipv4Gateway":     llx.StringData(ipv4Gateway),
 		"ipv4Nameservers": strSliceData(ipv4Nameserv),
@@ -751,6 +754,8 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 			protocol = p.GetName()
 		}
 
+		createdAt, okCreated := rule.GetCreatedAtOk()
+
 		args := map[string]*llx.RawData{
 			"id":                    llx.StringData(rule.GetId()),
 			"securityGroupId":       llx.StringData(r.Id.Data),
@@ -764,6 +769,7 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 			"portRangeMax":          llx.IntData(portMax),
 			"ipRange":               llx.StringData(rule.GetIpRange()),
 			"remoteSecurityGroupId": llx.StringData(rule.GetRemoteSecurityGroupId()),
+			"createdAt":             llx.TimeDataPtr(timeOrNil(createdAt, okCreated)),
 		}
 		res, err := CreateResource(r.MqlRuntime, "stackit.securityGroup.rule", args)
 		if err != nil {

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -316,6 +316,8 @@ private stackit.network @defaults("id name routed") {
   ipv6Prefixes []string
   // Network state (CREATING, CREATED, UPDATING, DELETING, FAILED)
   state string
+  // Creation timestamp
+  createdAt time
   // User-defined labels
   labels map[string]string
 }
@@ -393,6 +395,8 @@ private stackit.securityGroup.rule @defaults("id direction protocol") {
   ipRange string
   // Remote security group UUID (empty if remote is a CIDR)
   remoteSecurityGroupId string
+  // Creation timestamp
+  createdAt time
 }
 
 // Server internet-exposure breakdown
@@ -890,6 +894,8 @@ private stackit.dns.zone @defaults("id dnsName type state") {
   primaries []string
   // Whether DNSSEC is enabled for the zone
   isReverseZone bool
+  // When zone creation started
+  creationStartedAt time
   // Creation timestamp
   creationFinishedAt time
   // User-defined labels
@@ -923,6 +929,8 @@ private stackit.dns.recordSet @defaults("name type state") {
   records []string
   // Whether the record set is for active healthcheck failover
   active bool
+  // When record set creation started
+  creationStartedAt time
   // Creation timestamp
   creationFinishedAt time
   // Last update timestamp
@@ -1333,6 +1341,10 @@ private stackit.secretsManager.instance @defaults("id name state") {
   secretsEngine string
   // Number of secrets stored in the instance
   secretCount int
+  // When instance creation started
+  creationStartedAt time
+  // When instance creation finished
+  creationFinishedAt time
   // ACL CIDRs allowed to connect
   acls() []string
 }

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -892,11 +892,11 @@ private stackit.dns.zone @defaults("id dnsName type state") {
   acl string
   // Primary nameservers (for secondary zones)
   primaries []string
-  // Whether DNSSEC is enabled for the zone
+  // Whether this is a reverse DNS zone
   isReverseZone bool
   // When zone creation started
   creationStartedAt time
-  // Creation timestamp
+  // When zone creation finished
   creationFinishedAt time
   // User-defined labels
   labels map[string]string

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -774,6 +774,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.network.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitNetwork).GetState()).ToDataRes(types.String)
 	},
+	"stackit.network.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitNetwork).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"stackit.network.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitNetwork).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -848,6 +851,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.securityGroup.rule.remoteSecurityGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecurityGroupRule).GetRemoteSecurityGroupId()).ToDataRes(types.String)
+	},
+	"stackit.securityGroup.rule.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecurityGroupRule).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"stackit.network.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitNetworkExposure).GetInternetReachable()).ToDataRes(types.Bool)
@@ -1323,6 +1329,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.dns.zone.isReverseZone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsZone).GetIsReverseZone()).ToDataRes(types.Bool)
 	},
+	"stackit.dns.zone.creationStartedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitDnsZone).GetCreationStartedAt()).ToDataRes(types.Time)
+	},
 	"stackit.dns.zone.creationFinishedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsZone).GetCreationFinishedAt()).ToDataRes(types.Time)
 	},
@@ -1358,6 +1367,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.dns.recordSet.active": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsRecordSet).GetActive()).ToDataRes(types.Bool)
+	},
+	"stackit.dns.recordSet.creationStartedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitDnsRecordSet).GetCreationStartedAt()).ToDataRes(types.Time)
 	},
 	"stackit.dns.recordSet.creationFinishedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsRecordSet).GetCreationFinishedAt()).ToDataRes(types.Time)
@@ -1697,6 +1709,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.secretsManager.instance.secretCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecretsManagerInstance).GetSecretCount()).ToDataRes(types.Int)
+	},
+	"stackit.secretsManager.instance.creationStartedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetCreationStartedAt()).ToDataRes(types.Time)
+	},
+	"stackit.secretsManager.instance.creationFinishedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetCreationFinishedAt()).ToDataRes(types.Time)
 	},
 	"stackit.secretsManager.instance.acls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecretsManagerInstance).GetAcls()).ToDataRes(types.Array(types.String))
@@ -2548,6 +2566,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitNetwork).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.network.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitNetwork).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"stackit.network.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitNetwork).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -2658,6 +2680,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.securityGroup.rule.remoteSecurityGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSecurityGroupRule).RemoteSecurityGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.securityGroup.rule.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecurityGroupRule).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"stackit.network.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3364,6 +3390,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitDnsZone).IsReverseZone, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"stackit.dns.zone.creationStartedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitDnsZone).CreationStartedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"stackit.dns.zone.creationFinishedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitDnsZone).CreationFinishedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -3414,6 +3444,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.dns.recordSet.active": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitDnsRecordSet).Active, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.dns.recordSet.creationStartedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitDnsRecordSet).CreationStartedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"stackit.dns.recordSet.creationFinishedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3938,6 +3972,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.secretsManager.instance.secretCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSecretsManagerInstance).SecretCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.creationStartedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).CreationStartedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.creationFinishedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).CreationFinishedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"stackit.secretsManager.instance.acls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5772,6 +5814,7 @@ type mqlStackitNetwork struct {
 	Ipv6Nameservers plugin.TValue[[]any]
 	Ipv6Prefixes    plugin.TValue[[]any]
 	State           plugin.TValue[string]
+	CreatedAt       plugin.TValue[*time.Time]
 	Labels          plugin.TValue[map[string]any]
 }
 
@@ -5858,6 +5901,10 @@ func (c *mqlStackitNetwork) GetIpv6Prefixes() *plugin.TValue[[]any] {
 
 func (c *mqlStackitNetwork) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlStackitNetwork) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlStackitNetwork) GetLabels() *plugin.TValue[map[string]any] {
@@ -6041,6 +6088,7 @@ type mqlStackitSecurityGroupRule struct {
 	PortRangeMax          plugin.TValue[int64]
 	IpRange               plugin.TValue[string]
 	RemoteSecurityGroupId plugin.TValue[string]
+	CreatedAt             plugin.TValue[*time.Time]
 }
 
 // createStackitSecurityGroupRule creates a new instance of this resource
@@ -6126,6 +6174,10 @@ func (c *mqlStackitSecurityGroupRule) GetIpRange() *plugin.TValue[string] {
 
 func (c *mqlStackitSecurityGroupRule) GetRemoteSecurityGroupId() *plugin.TValue[string] {
 	return &c.RemoteSecurityGroupId
+}
+
+func (c *mqlStackitSecurityGroupRule) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlStackitNetworkExposure for the stackit.network.exposure resource
@@ -7770,6 +7822,7 @@ type mqlStackitDnsZone struct {
 	Acl                plugin.TValue[string]
 	Primaries          plugin.TValue[[]any]
 	IsReverseZone      plugin.TValue[bool]
+	CreationStartedAt  plugin.TValue[*time.Time]
 	CreationFinishedAt plugin.TValue[*time.Time]
 	Labels             plugin.TValue[map[string]any]
 	RecordSets         plugin.TValue[[]any]
@@ -7884,6 +7937,10 @@ func (c *mqlStackitDnsZone) GetIsReverseZone() *plugin.TValue[bool] {
 	return &c.IsReverseZone
 }
 
+func (c *mqlStackitDnsZone) GetCreationStartedAt() *plugin.TValue[*time.Time] {
+	return &c.CreationStartedAt
+}
+
 func (c *mqlStackitDnsZone) GetCreationFinishedAt() *plugin.TValue[*time.Time] {
 	return &c.CreationFinishedAt
 }
@@ -7922,6 +7979,7 @@ type mqlStackitDnsRecordSet struct {
 	Comment            plugin.TValue[string]
 	Records            plugin.TValue[[]any]
 	Active             plugin.TValue[bool]
+	CreationStartedAt  plugin.TValue[*time.Time]
 	CreationFinishedAt plugin.TValue[*time.Time]
 	UpdateFinishedAt   plugin.TValue[*time.Time]
 }
@@ -7997,6 +8055,10 @@ func (c *mqlStackitDnsRecordSet) GetRecords() *plugin.TValue[[]any] {
 
 func (c *mqlStackitDnsRecordSet) GetActive() *plugin.TValue[bool] {
 	return &c.Active
+}
+
+func (c *mqlStackitDnsRecordSet) GetCreationStartedAt() *plugin.TValue[*time.Time] {
+	return &c.CreationStartedAt
 }
 
 func (c *mqlStackitDnsRecordSet) GetCreationFinishedAt() *plugin.TValue[*time.Time] {
@@ -9441,13 +9503,15 @@ type mqlStackitSecretsManagerInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlStackitSecretsManagerInstanceInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	State         plugin.TValue[string]
-	ApiUrl        plugin.TValue[string]
-	SecretsEngine plugin.TValue[string]
-	SecretCount   plugin.TValue[int64]
-	Acls          plugin.TValue[[]any]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	State              plugin.TValue[string]
+	ApiUrl             plugin.TValue[string]
+	SecretsEngine      plugin.TValue[string]
+	SecretCount        plugin.TValue[int64]
+	CreationStartedAt  plugin.TValue[*time.Time]
+	CreationFinishedAt plugin.TValue[*time.Time]
+	Acls               plugin.TValue[[]any]
 }
 
 // createStackitSecretsManagerInstance creates a new instance of this resource
@@ -9509,6 +9573,14 @@ func (c *mqlStackitSecretsManagerInstance) GetSecretsEngine() *plugin.TValue[str
 
 func (c *mqlStackitSecretsManagerInstance) GetSecretCount() *plugin.TValue[int64] {
 	return &c.SecretCount
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetCreationStartedAt() *plugin.TValue[*time.Time] {
+	return &c.CreationStartedAt
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetCreationFinishedAt() *plugin.TValue[*time.Time] {
+	return &c.CreationFinishedAt
 }
 
 func (c *mqlStackitSecretsManagerInstance) GetAcls() *plugin.TValue[[]any] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -31,6 +31,7 @@ stackit.dns.recordSet 13.0.0
 stackit.dns.recordSet.active 13.0.0
 stackit.dns.recordSet.comment 13.0.0
 stackit.dns.recordSet.creationFinishedAt 13.0.0
+stackit.dns.recordSet.creationStartedAt 13.2.2
 stackit.dns.recordSet.id 13.0.0
 stackit.dns.recordSet.name 13.0.0
 stackit.dns.recordSet.records 13.0.0
@@ -43,6 +44,7 @@ stackit.dns.zone 13.0.0
 stackit.dns.zone.acl 13.0.0
 stackit.dns.zone.contactEmail 13.0.0
 stackit.dns.zone.creationFinishedAt 13.0.0
+stackit.dns.zone.creationStartedAt 13.2.2
 stackit.dns.zone.defaultTtl 13.0.0
 stackit.dns.zone.description 13.0.0
 stackit.dns.zone.dnsName 13.0.0
@@ -217,6 +219,7 @@ stackit.mongoDbFlex.instance.storage 13.0.0
 stackit.mongoDbFlex.instance.version 13.0.0
 stackit.mongoDbFlex.instances 13.0.0
 stackit.network 13.0.0
+stackit.network.createdAt 13.2.2
 stackit.network.exposure 13.0.6
 stackit.network.exposure.hasPublicIp 13.0.6
 stackit.network.exposure.internetReachable 13.0.6
@@ -336,6 +339,8 @@ stackit.secretsManager 13.0.0
 stackit.secretsManager.instance 13.0.0
 stackit.secretsManager.instance.acls 13.0.0
 stackit.secretsManager.instance.apiUrl 13.0.0
+stackit.secretsManager.instance.creationFinishedAt 13.2.2
+stackit.secretsManager.instance.creationStartedAt 13.2.2
 stackit.secretsManager.instance.id 13.0.0
 stackit.secretsManager.instance.name 13.0.0
 stackit.secretsManager.instance.secretCount 13.0.0
@@ -349,6 +354,7 @@ stackit.securityGroup.id 13.0.0
 stackit.securityGroup.labels 13.0.0
 stackit.securityGroup.name 13.0.0
 stackit.securityGroup.rule 13.0.0
+stackit.securityGroup.rule.createdAt 13.2.2
 stackit.securityGroup.rule.description 13.0.0
 stackit.securityGroup.rule.direction 13.0.0
 stackit.securityGroup.rule.ethertype 13.0.0


### PR DESCRIPTION
Surface resource creation timestamps that the STACKIT SDK already returns but mql did not yet expose.

## New fields

| Resource | New field(s) | SDK source | Notes |
|---|---|---|---|
| `stackit.network` | `createdAt` | `iaas.Network.CreatedAt` | `*time.Time` → `llx.TimeDataPtr` |
| `stackit.securityGroup.rule` | `createdAt` | `iaas.SecurityGroupRule.CreatedAt` | `*time.Time`; matches parent `stackit.securityGroup.createdAt` |
| `stackit.dns.zone` | `creationStartedAt` | `dns.Zone.CreationStarted` | ISO string → `time` via existing `parseDnsTime` (sibling of `creationFinishedAt`) |
| `stackit.dns.recordSet` | `creationStartedAt` | `dns.RecordSet.CreationStarted` | ISO string → `time` via `parseDnsTime` |
| `stackit.secretsManager.instance` | `creationStartedAt`, `creationFinishedAt` | `secretsmanager.Instance.CreationStartDate` / `CreationFinishedDate` | ISO strings → `time` via `parseDnsTime` |

## Implementation notes

- The iaas `*time.Time` fields use the existing `timeOrNil` + `llx.TimeDataPtr` pattern already used for `stackit.securityGroup.createdAt`.
- The dns and secretsManager values are ISO timestamp strings; they are parsed with the existing, already-tested `parseDnsTime` helper (RFC3339, returns nil on empty/malformed input). No new parsing logic was introduced.
- secretsManager.instance is built in two places (list + init lazy-load); both updated.
- Field naming follows the provider's existing conventions (`createdAt` for iaas, `creation{Started,Finished}At` for the string-timestamp services).
- `.lr.versions` entries auto-assigned at `13.2.2` (next patch after the provider's current `13.2.1`); `Version` in `config.go` unchanged.