### PR TITLE
🎉 openstack-13.7.0, oci-13.13.0, azure-13.23.0, gcp-13.26.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.22.0",
+	Version:   "13.23.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.25.1",
+	Version: "13.26.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.12.1",
+	Version:         "13.13.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.6.0",
+	Version:         "13.7.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the openstack, oci, azure, and gcp providers.

| Provider | Old | New |
|---|---|---|
| openstack | 13.6.0 | 13.7.0 |
| oci | 13.12.1 | 13.13.0 |
| azure | 13.22.0 | 13.23.0 |
| gcp | 13.25.1 | 13.26.0 |

## Changes since last release

### openstack (13.6.0 → 13.7.0)
- ⭐ openstack: add creation-date fields to db.instance and objectstorage.container (#8766)
- 🧹 Provide static platform support information across all providers (#8722)

### oci (13.12.1 → 13.13.0)
- ⭐ oci: expose creation timestamps on vulnerability scanning resources (#8763)
- 🧹 Provide static platform support information across all providers (#8722)

### azure (13.22.0 → 13.23.0)
- ⭐ azure: expose creation timestamps on more resources (#8762)
- ⭐ azure: expose ARM systemMetadata provenance on more resources (#8765)
- 🎫 azure: keyless auth via federated token file (workload identity) (#8757)
- 🧹 Provide static platform support information across all providers (#8722)

### gcp (13.25.1 → 13.26.0)
- ⭐ gcp: add creation timestamps where the SDK exposes them (#8761)
- 🧹 Provide static platform support information across all providers (#8722)