### PR TITLE
⭐ azure: expose managed identity and image source provenance

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -20,9 +21,10 @@ import (
 )
 
 type mqlAzureSubscriptionAksServiceClusterInternal struct {
-	cacheKmsKeyId   string
-	cacheProperties *clusters.ManagedClusterProperties
-	cacheSystemData any
+	cacheKmsKeyId          string
+	cacheKubeletIdentityId string
+	cacheProperties        *clusters.ManagedClusterProperties
+	cacheSystemData        any
 }
 
 type mqlAzureSubscriptionAksServiceClusterIdentityBindingInternal struct {
@@ -268,6 +270,31 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 				controlPlaneMetricsEnabled = amp.Metrics.ControlPlane.Enabled
 			}
 
+			identityDict, err := convert.JsonToDict(entry.Identity)
+			if err != nil {
+				return nil, err
+			}
+			var principalId *string
+			if entry.Identity != nil {
+				principalId = entry.Identity.PrincipalID
+			}
+
+			servicePrincipalClientId := ""
+			kubeletIdentityId := ""
+			if entry.Properties != nil {
+				// Service-principal clusters report the SP client ID here;
+				// managed-identity clusters report the sentinel "msi" instead,
+				// which carries no provenance value.
+				if spp := entry.Properties.ServicePrincipalProfile; spp != nil && spp.ClientID != nil && !strings.EqualFold(*spp.ClientID, "msi") {
+					servicePrincipalClientId = *spp.ClientID
+				}
+				for k, v := range entry.Properties.IdentityProfile {
+					if strings.EqualFold(k, "kubeletidentity") && v != nil {
+						kubeletIdentityId = convert.ToValue(v.ResourceID)
+					}
+				}
+			}
+
 			mqlAksCluster, err := CreateResource(a.MqlRuntime, "azure.subscription.aksService.cluster",
 				map[string]*llx.RawData{
 					"id":                                llx.StringDataPtr(entry.ID),
@@ -315,12 +342,16 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 					"serviceMeshMode":                   llx.StringDataPtr(serviceMeshMode),
 					"supportPlan":                       llx.StringDataPtr((*string)(entry.Properties.SupportPlan)),
 					"controlPlaneMetricsEnabled":        llx.BoolDataPtr(controlPlaneMetricsEnabled),
+					"identity":                          llx.DictData(identityDict),
+					"principalId":                       llx.StringDataPtr(principalId),
+					"servicePrincipalClientId":          llx.StringData(servicePrincipalClientId),
 				})
 			if err != nil {
 				return nil, err
 			}
 			mqlCluster := mqlAksCluster.(*mqlAzureSubscriptionAksServiceCluster)
 			mqlCluster.cacheKmsKeyId = azureKeyVaultKmsKeyId
+			mqlCluster.cacheKubeletIdentityId = kubeletIdentityId
 			mqlCluster.cacheProperties = entry.Properties
 			sysData, err := convert.JsonToDict(entry.SystemData)
 			if err != nil {
@@ -599,6 +630,19 @@ func (a *mqlAzureSubscriptionAksServiceClusterIdentityBinding) managedIdentity()
 	}
 	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
 		map[string]*llx.RawData{"__id": llx.StringData(a.cacheManagedIdentityId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionManagedIdentity), nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceCluster) kubeletIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	if a.cacheKubeletIdentityId == "" {
+		a.KubeletIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{"__id": llx.StringData(a.cacheKubeletIdentityId)})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -445,6 +445,12 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   patchMode string
   // Virtual Machine Scale Set that manages this VM, if any (resolved from managedBy)
   vmScaleSet() azure.subscription.computeService.vmScaleSet
+  // Managed identity configuration (type, system- and user-assigned identities)
+  identity dict
+  // Principal ID of the VM's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the VM
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Internet-exposure summary combining public IPs and NSG ingress rules
   //
   // Reports whether the VM is reachable from the public internet by checking for
@@ -912,6 +918,12 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
   instances() []azure.subscription.computeService.vmScaleSet.instance
   // Extensions installed on the scale set (each dict describes one extension)
   extensions() []dict
+  // Managed identity configuration (type, system- and user-assigned identities)
+  identity dict
+  // Principal ID of the scale set's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the scale set
+  userAssignedIdentities() []azure.subscription.managedIdentity
 }
 
 // Azure scale set VM instance
@@ -1091,6 +1103,8 @@ azure.subscription.computeService.image @defaults("name location hyperVGeneratio
   properties dict
   // Source VM ARM ID this image was captured from
   sourceVirtualMachineId string
+  // Virtual machine this image was generalized and captured from
+  sourceVirtualMachine() azure.subscription.computeService.vm
   // Storage profile (OS disk + data disks)
   storageProfile dict
   // Provisioning state
@@ -7627,6 +7641,14 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   controlPlaneMetricsEnabled bool
   // Workload identity bindings attached to the cluster
   identityBindings() []azure.subscription.aksService.cluster.identityBinding
+  // Control-plane managed identity configuration (type, system- and user-assigned identities)
+  identity dict
+  // Principal ID of the cluster's system-assigned control-plane managed identity; empty when a user-assigned identity is used
+  principalId string
+  // Managed identity used by the kubelet to pull images from Azure Container Registry
+  kubeletIdentity() azure.subscription.managedIdentity
+  // Client ID of the legacy service principal used by the cluster; empty when the cluster uses a managed identity
+  servicePrincipalClientId string
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // Whether the AKS API server is reachable from the public internet

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2617,6 +2617,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.vmScaleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetVmScaleSet()).ToDataRes(types.Resource("azure.subscription.computeService.vmScaleSet"))
 	},
+	"azure.subscription.computeService.vm.identity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.computeService.vm.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetExposure()).ToDataRes(types.Resource("azure.subscription.networkService.exposure"))
 	},
@@ -3136,6 +3145,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vmScaleSet.extensions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetExtensions()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.computeService.vmScaleSet.identity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.computeService.vmScaleSet.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vmScaleSet.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.computeService.vmScaleSet.instance.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).GetId()).ToDataRes(types.String)
 	},
@@ -3321,6 +3339,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.image.sourceVirtualMachineId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetSourceVirtualMachineId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.image.sourceVirtualMachine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetSourceVirtualMachine()).ToDataRes(types.Resource("azure.subscription.computeService.vm"))
 	},
 	"azure.subscription.computeService.image.storageProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetStorageProfile()).ToDataRes(types.Dict)
@@ -10762,6 +10783,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.identityBindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetIdentityBindings()).ToDataRes(types.Array(types.Resource("azure.subscription.aksService.cluster.identityBinding")))
 	},
+	"azure.subscription.aksService.cluster.identity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.aksService.cluster.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.aksService.cluster.kubeletIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetKubeletIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
+	"azure.subscription.aksService.cluster.servicePrincipalClientId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetServicePrincipalClientId()).ToDataRes(types.String)
+	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -16456,6 +16489,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).VmScaleSet, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceVmScaleSet](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vm.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vm.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).Exposure, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceExposure](v.Value, v.Error)
 		return
@@ -17180,6 +17225,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vmScaleSet.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vmScaleSet.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vmScaleSet.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vmScaleSet.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVmScaleSetInstance).__id, ok = v.Value.(string)
 		return
@@ -17446,6 +17503,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.image.sourceVirtualMachineId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceImage).SourceVirtualMachineId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.image.sourceVirtualMachine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceImage).SourceVirtualMachine, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceVm](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.image.storageProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28244,6 +28305,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAksServiceCluster).IdentityBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.aksService.cluster.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.kubeletIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).KubeletIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.servicePrincipalClientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).ServicePrincipalClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -37251,6 +37328,9 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	EnableAutomaticUpdates        plugin.TValue[bool]
 	PatchMode                     plugin.TValue[string]
 	VmScaleSet                    plugin.TValue[*mqlAzureSubscriptionComputeServiceVmScaleSet]
+	Identity                      plugin.TValue[any]
+	PrincipalId                   plugin.TValue[string]
+	UserAssignedIdentities        plugin.TValue[[]any]
 	Exposure                      plugin.TValue[*mqlAzureSubscriptionNetworkServiceExposure]
 }
 
@@ -37572,6 +37652,30 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetVmScaleSet() *plugin.TValue[*m
 		}
 
 		return c.vmScaleSet()
+	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetIdentity() *plugin.TValue[any] {
+	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vm", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
 	})
 }
 
@@ -38730,7 +38834,7 @@ func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetDiskEncryptionSet() *plu
 type mqlAzureSubscriptionComputeServiceVmScaleSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceVmScaleSetInternal it will be used here
+	mqlAzureSubscriptionComputeServiceVmScaleSetInternal
 	Id                                plugin.TValue[string]
 	Name                              plugin.TValue[string]
 	Location                          plugin.TValue[string]
@@ -38763,6 +38867,9 @@ type mqlAzureSubscriptionComputeServiceVmScaleSet struct {
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
 	Instances                         plugin.TValue[[]any]
 	Extensions                        plugin.TValue[[]any]
+	Identity                          plugin.TValue[any]
+	PrincipalId                       plugin.TValue[string]
+	UserAssignedIdentities            plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionComputeServiceVmScaleSet creates a new instance of this resource
@@ -38953,6 +39060,30 @@ func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetInstances() *plugin.TV
 func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetExtensions() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Extensions, func() ([]any, error) {
 		return c.extensions()
+	})
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetIdentity() *plugin.TValue[any] {
+	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vmScaleSet", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
 	})
 }
 
@@ -39467,6 +39598,7 @@ type mqlAzureSubscriptionComputeServiceImage struct {
 	Type                   plugin.TValue[string]
 	Properties             plugin.TValue[any]
 	SourceVirtualMachineId plugin.TValue[string]
+	SourceVirtualMachine   plugin.TValue[*mqlAzureSubscriptionComputeServiceVm]
 	StorageProfile         plugin.TValue[any]
 	ProvisioningState      plugin.TValue[string]
 	HyperVGeneration       plugin.TValue[string]
@@ -39535,6 +39667,22 @@ func (c *mqlAzureSubscriptionComputeServiceImage) GetProperties() *plugin.TValue
 
 func (c *mqlAzureSubscriptionComputeServiceImage) GetSourceVirtualMachineId() *plugin.TValue[string] {
 	return &c.SourceVirtualMachineId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceImage) GetSourceVirtualMachine() *plugin.TValue[*mqlAzureSubscriptionComputeServiceVm] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionComputeServiceVm](&c.SourceVirtualMachine, func() (*mqlAzureSubscriptionComputeServiceVm, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.image", c.__id, "sourceVirtualMachine")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionComputeServiceVm), nil
+			}
+		}
+
+		return c.sourceVirtualMachine()
+	})
 }
 
 func (c *mqlAzureSubscriptionComputeServiceImage) GetStorageProfile() *plugin.TValue[any] {
@@ -64845,6 +64993,10 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	AutoUpgradeProfile                plugin.TValue[*mqlAzureSubscriptionAksServiceClusterAutoUpgradeProfile]
 	ControlPlaneMetricsEnabled        plugin.TValue[bool]
 	IdentityBindings                  plugin.TValue[[]any]
+	Identity                          plugin.TValue[any]
+	PrincipalId                       plugin.TValue[string]
+	KubeletIdentity                   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+	ServicePrincipalClientId          plugin.TValue[string]
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
 	InternetReachable                 plugin.TValue[bool]
 }
@@ -65148,6 +65300,34 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetIdentityBindings() *plugin.TV
 
 		return c.identityBindings()
 	})
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetIdentity() *plugin.TValue[any] {
+	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetKubeletIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.KubeletIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "kubeletIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.kubeletIdentity()
+	})
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetServicePrincipalClientId() *plugin.TValue[string] {
+	return &c.ServicePrincipalClientId
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -77,6 +77,7 @@ azure.subscription.aksService.cluster.fqdn 9.0.1
 azure.subscription.aksService.cluster.fqdnSubdomain 13.1.8
 azure.subscription.aksService.cluster.httpProxyConfig 9.0.1
 azure.subscription.aksService.cluster.id 9.0.1
+azure.subscription.aksService.cluster.identity 13.22.1
 azure.subscription.aksService.cluster.identityBinding 13.15.2
 azure.subscription.aksService.cluster.identityBinding.id 13.15.2
 azure.subscription.aksService.cluster.identityBinding.managedIdentity 13.15.2
@@ -90,6 +91,7 @@ azure.subscription.aksService.cluster.identityBindings 13.15.2
 azure.subscription.aksService.cluster.imageCleanerEnabled 11.4.28
 azure.subscription.aksService.cluster.imageCleanerIntervalHours 11.4.28
 azure.subscription.aksService.cluster.internetReachable 13.20.1
+azure.subscription.aksService.cluster.kubeletIdentity 13.22.1
 azure.subscription.aksService.cluster.kubernetesVersion 9.0.1
 azure.subscription.aksService.cluster.location 9.0.1
 azure.subscription.aksService.cluster.name 9.0.1
@@ -147,6 +149,7 @@ azure.subscription.aksService.cluster.nodeResourceGroupRestrictionLevel 13.1.8
 azure.subscription.aksService.cluster.oidcIssuerEnabled 13.1.8
 azure.subscription.aksService.cluster.podIdentityProfile 9.0.1
 azure.subscription.aksService.cluster.powerState 9.0.1
+azure.subscription.aksService.cluster.principalId 13.22.1
 azure.subscription.aksService.cluster.privateDnsZone 11.4.28
 azure.subscription.aksService.cluster.privateFqdn 13.1.8
 azure.subscription.aksService.cluster.provisioningState 9.0.1
@@ -154,6 +157,7 @@ azure.subscription.aksService.cluster.publicNetworkAccess 11.4.28
 azure.subscription.aksService.cluster.rbacEnabled 9.0.1
 azure.subscription.aksService.cluster.securityProfile 9.0.1
 azure.subscription.aksService.cluster.serviceMeshMode 13.1.8
+azure.subscription.aksService.cluster.servicePrincipalClientId 13.22.1
 azure.subscription.aksService.cluster.skuTier 13.1.8
 azure.subscription.aksService.cluster.storageProfile 9.0.1
 azure.subscription.aksService.cluster.supportPlan 13.1.8
@@ -1048,6 +1052,7 @@ azure.subscription.computeService.image.location 13.7.1
 azure.subscription.computeService.image.name 13.7.1
 azure.subscription.computeService.image.properties 13.7.1
 azure.subscription.computeService.image.provisioningState 13.7.1
+azure.subscription.computeService.image.sourceVirtualMachine 13.22.1
 azure.subscription.computeService.image.sourceVirtualMachineId 13.7.1
 azure.subscription.computeService.image.storageProfile 13.7.1
 azure.subscription.computeService.image.tags 13.7.1
@@ -1115,6 +1120,7 @@ azure.subscription.computeService.vm.exposure 13.20.1
 azure.subscription.computeService.vm.extensions 9.0.1
 azure.subscription.computeService.vm.fipsEncryptionEnabled 13.8.2
 azure.subscription.computeService.vm.id 9.0.1
+azure.subscription.computeService.vm.identity 13.22.1
 azure.subscription.computeService.vm.imageReference 13.12.2
 azure.subscription.computeService.vm.imageReference.communityGalleryImageId 13.12.2
 azure.subscription.computeService.vm.imageReference.exactVersion 13.12.2
@@ -1135,6 +1141,7 @@ azure.subscription.computeService.vm.omsInstalled 13.12.2
 azure.subscription.computeService.vm.osDisk 9.0.1
 azure.subscription.computeService.vm.osType 13.18.1
 azure.subscription.computeService.vm.patchMode 13.5.1
+azure.subscription.computeService.vm.principalId 13.22.1
 azure.subscription.computeService.vm.properties 9.0.1
 azure.subscription.computeService.vm.provisionVMAgent 13.5.1
 azure.subscription.computeService.vm.provisioningState 11.6.2
@@ -1153,6 +1160,7 @@ azure.subscription.computeService.vm.systemMetadata 13.19.2
 azure.subscription.computeService.vm.tags 9.0.1
 azure.subscription.computeService.vm.timeCreated 11.6.2
 azure.subscription.computeService.vm.type 9.0.1
+azure.subscription.computeService.vm.userAssignedIdentities 13.22.1
 azure.subscription.computeService.vm.userData 13.12.2
 azure.subscription.computeService.vm.vmId 11.6.2
 azure.subscription.computeService.vm.vmScaleSet 13.7.1
@@ -1163,6 +1171,7 @@ azure.subscription.computeService.vmScaleSet.automaticRepairsPolicy 13.7.1
 azure.subscription.computeService.vmScaleSet.encryptionAtHost 13.16.2
 azure.subscription.computeService.vmScaleSet.extensions 13.7.1
 azure.subscription.computeService.vmScaleSet.id 13.7.1
+azure.subscription.computeService.vmScaleSet.identity 13.22.1
 azure.subscription.computeService.vmScaleSet.instance 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.id 13.7.1
 azure.subscription.computeService.vmScaleSet.instance.instanceId 13.7.1
@@ -1184,6 +1193,7 @@ azure.subscription.computeService.vmScaleSet.name 13.7.1
 azure.subscription.computeService.vmScaleSet.orchestrationMode 13.7.1
 azure.subscription.computeService.vmScaleSet.overprovision 13.7.1
 azure.subscription.computeService.vmScaleSet.platformFaultDomainCount 13.7.1
+azure.subscription.computeService.vmScaleSet.principalId 13.22.1
 azure.subscription.computeService.vmScaleSet.priorityMixPolicy 13.8.2
 azure.subscription.computeService.vmScaleSet.properties 13.7.1
 azure.subscription.computeService.vmScaleSet.provisioningState 13.7.1
@@ -1203,6 +1213,7 @@ azure.subscription.computeService.vmScaleSet.timeCreated 13.7.1
 azure.subscription.computeService.vmScaleSet.type 13.7.1
 azure.subscription.computeService.vmScaleSet.uniqueId 13.7.1
 azure.subscription.computeService.vmScaleSet.upgradePolicy 13.7.1
+azure.subscription.computeService.vmScaleSet.userAssignedIdentities 13.22.1
 azure.subscription.computeService.vmScaleSet.vtpmEnabled 13.16.2
 azure.subscription.computeService.vmScaleSet.zonalPlatformFaultDomainAlignMode 13.8.2
 azure.subscription.computeService.vmScaleSet.zones 13.7.1

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -231,6 +231,17 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 		}
 	}
 
+	identityDict, err := convert.JsonToDict(vm.Identity)
+	if err != nil {
+		return nil, err
+	}
+	var principalId *string
+	var userAssignedIdentityIds []string
+	if vm.Identity != nil {
+		principalId = vm.Identity.PrincipalID
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(vm.Identity.UserAssignedIdentities)
+	}
+
 	vmIDStr := ""
 	if vm.ID != nil {
 		vmIDStr = *vm.ID
@@ -280,11 +291,19 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 			"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
 			"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
 			"userData":                      llx.StringData(userData),
+			"identity":                      llx.DictData(identityDict),
+			"principalId":                   llx.StringDataPtr(principalId),
 		})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionComputeServiceVm), nil
+	mqlVm := res.(*mqlAzureSubscriptionComputeServiceVm)
+	mqlVm.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+	return mqlVm, nil
+}
+
+func (a *mqlAzureSubscriptionComputeServiceVm) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {
@@ -330,9 +349,10 @@ func (a *mqlAzureSubscriptionComputeServiceVm) isRunning() (bool, error) {
 }
 
 type mqlAzureSubscriptionComputeServiceVmInternal struct {
-	extensionsOnce  sync.Once
-	extensionsList  []*compute.VirtualMachineExtension
-	extensionsError error
+	extensionsOnce               sync.Once
+	extensionsList               []*compute.VirtualMachineExtension
+	extensionsError              error
+	cacheUserAssignedIdentityIds []string
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) fetchExtensions() ([]*compute.VirtualMachineExtension, error) {

--- a/providers/azure/resources/compute_extras.go
+++ b/providers/azure/resources/compute_extras.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -432,6 +433,21 @@ func imageToMql(runtime *plugin.Runtime, img compute.Image) (*mqlAzureSubscripti
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionComputeServiceImage), nil
+}
+
+func (a *mqlAzureSubscriptionComputeServiceImage) sourceVirtualMachine() (*mqlAzureSubscriptionComputeServiceVm, error) {
+	id := a.SourceVirtualMachineId.Data
+	if id == "" {
+		a.SourceVirtualMachine.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.computeService.vm", map[string]*llx.RawData{
+		"id": llx.StringData(strings.ToLower(id)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionComputeServiceVm), nil
 }
 
 // ----- Compute Galleries (Shared Image Gallery) -----

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -130,16 +130,29 @@ func vmScaleSetToMql(runtime *plugin.Runtime, vmss compute.VirtualMachineScaleSe
 		return nil, err
 	}
 
+	identityDict, err := convert.JsonToDict(vmss.Identity)
+	if err != nil {
+		return nil, err
+	}
+	var principalId *string
+	var userAssignedIdentityIds []string
+	if vmss.Identity != nil {
+		principalId = vmss.Identity.PrincipalID
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(vmss.Identity.UserAssignedIdentities)
+	}
+
 	args := map[string]*llx.RawData{
-		"id":         llx.StringDataPtr(vmss.ID),
-		"name":       llx.StringDataPtr(vmss.Name),
-		"location":   llx.StringDataPtr(vmss.Location),
-		"tags":       llx.MapData(convert.PtrMapStrToInterface(vmss.Tags), types.String),
-		"type":       llx.StringDataPtr(vmss.Type),
-		"zones":      llx.ArrayData(convert.SliceStrPtrToInterface(vmss.Zones), types.String),
-		"sku":        llx.DictData(sku),
-		"properties": llx.DictData(properties),
-		"systemData": llx.DictData(systemData),
+		"id":          llx.StringDataPtr(vmss.ID),
+		"name":        llx.StringDataPtr(vmss.Name),
+		"location":    llx.StringDataPtr(vmss.Location),
+		"tags":        llx.MapData(convert.PtrMapStrToInterface(vmss.Tags), types.String),
+		"type":        llx.StringDataPtr(vmss.Type),
+		"zones":       llx.ArrayData(convert.SliceStrPtrToInterface(vmss.Zones), types.String),
+		"sku":         llx.DictData(sku),
+		"properties":  llx.DictData(properties),
+		"systemData":  llx.DictData(systemData),
+		"identity":    llx.DictData(identityDict),
+		"principalId": llx.StringDataPtr(principalId),
 	}
 
 	if vmss.Properties != nil {
@@ -215,7 +228,17 @@ func vmScaleSetToMql(runtime *plugin.Runtime, vmss compute.VirtualMachineScaleSe
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionComputeServiceVmScaleSet), nil
+	mqlVmss := res.(*mqlAzureSubscriptionComputeServiceVmScaleSet)
+	mqlVmss.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+	return mqlVmss, nil
+}
+
+type mqlAzureSubscriptionComputeServiceVmScaleSetInternal struct {
+	cacheUserAssignedIdentityIds []string
+}
+
+func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) instances() ([]any, error) {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -18,6 +19,42 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// sortedUserAssignedIdentityIDs returns the keys of a UserAssignedIdentities
+// map (the ARM resource IDs of the assigned managed identities) in stable
+// sorted order. Returns nil when the map is empty.
+func sortedUserAssignedIdentityIDs[V any](m map[string]*V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// resolveUserAssignedIdentities resolves a set of user-assigned managed
+// identity ARM resource IDs into typed managedIdentity resources. The IDs are
+// the keys of an SDK UserAssignedIdentities map. The runtime cache short-
+// circuits identities already listed by managedIdentities(); others are
+// fetched on demand by their init. Returns an empty slice when none are set.
+func resolveUserAssignedIdentities(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	res := make([]any, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		mqlIdentity, err := NewResource(runtime, "azure.subscription.managedIdentity",
+			map[string]*llx.RawData{"__id": llx.StringData(id)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlIdentity)
+	}
+	return res, nil
+}
 
 func (a *mqlAzureSubscription) iam() (*mqlAzureSubscriptionAuthorizationService, error) {
 	svc, err := NewResource(a.MqlRuntime, "azure.subscription.authorizationService", map[string]*llx.RawData{


### PR DESCRIPTION
## What

Exposes two provenance areas in the Azure provider — **managed identity** (what a resource runs as) and **image source lineage**.

### Managed identity
| Resource | Added |
|---|---|
| `computeService.vm` | `identity` dict, `principalId`, `userAssignedIdentities() []azure.subscription.managedIdentity` |
| `computeService.vmScaleSet` | `identity` dict, `principalId`, `userAssignedIdentities() []azure.subscription.managedIdentity` |
| `aksService.cluster` | `identity` dict, `principalId`, `kubeletIdentity() azure.subscription.managedIdentity`, `servicePrincipalClientId` |

Previously the compute/AKS resources exposed no managed-identity data at all (every other major resource already has an `identity` dict). The AKS `kubeletIdentity` is the identity nodes use to pull images / reach ACR — a strong supply-chain attribution signal. This also backs the AKS doc-comment that already claimed identity/kubeletIdentity were surfaced.

### Image source lineage
| Resource | Added |
|---|---|
| `computeService.image` | `sourceVirtualMachine() azure.subscription.computeService.vm` |

Typed accessor alongside the existing raw `sourceVirtualMachineId`, mirroring `snapshot.sourceDisk()` — answers "what VM this image was captured from."

## Notes
- All typed refs resolve through `NewResource` by ARM resource ID (the existing `managedIdentity` init Gets by the `userAssignedIdentities` component). Singular accessors set `StateIsSet | StateIsNull` before returning nil.
- SDK fields verified against pinned `armcompute/v8`, `armcontainerservice/v9`, `armmsi`.
- `azure.permissions.json` unchanged; new `.lr.versions` entries auto-assigned at the next patch.
- Build + `go test ./resources/` pass.