### PR TITLE
⭐ gcp: expose source, hierarchy, and build provenance

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -215,7 +215,56 @@ type mqlGcpProjectBigqueryServiceDatasetInternal struct {
 }
 
 type mqlGcpProjectBigqueryServiceTableInternal struct {
-	cacheKmsKeyName string
+	cacheKmsKeyName        string
+	cacheSnapshotBaseTable *bigquery.Table
+	cacheCloneBaseTable    *bigquery.Table
+}
+
+// resolveBaseTable builds the typed table that a snapshot or clone derives from.
+// The BigQuery base-table reference carries only project/dataset/table IDs, so
+// the table's location is inherited from the owning table (a base table lives in
+// the same location as its snapshots and clones).
+func (g *mqlGcpProjectBigqueryServiceTable) resolveBaseTable(ref *bigquery.Table) (*mqlGcpProjectBigqueryServiceTable, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	location := ""
+	if g.Location.Error == nil {
+		location = g.Location.Data
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
+		"id":        llx.StringData(ref.TableID),
+		"projectId": llx.StringData(ref.ProjectID),
+		"datasetId": llx.StringData(ref.DatasetID),
+		"name":      llx.StringData(ref.TableID),
+		"location":  llx.StringData(location),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectBigqueryServiceTable), nil
+}
+
+func (g *mqlGcpProjectBigqueryServiceTable) snapshotBaseTable() (*mqlGcpProjectBigqueryServiceTable, error) {
+	t, err := g.resolveBaseTable(g.cacheSnapshotBaseTable)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		g.SnapshotBaseTable.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return t, nil
+}
+
+func (g *mqlGcpProjectBigqueryServiceTable) cloneBaseTable() (*mqlGcpProjectBigqueryServiceTable, error) {
+	t, err := g.resolveBaseTable(g.cacheCloneBaseTable)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		g.CloneBaseTable.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return t, nil
 }
 
 type mqlGcpProjectBigqueryServiceModelInternal struct {
@@ -494,6 +543,11 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 			snapshotTime = &metadata.SnapshotDefinition.SnapshotTime
 		}
 
+		var cloneTime *time.Time
+		if metadata.CloneDefinition != nil {
+			cloneTime = &metadata.CloneDefinition.CloneTime
+		}
+
 		mqlInstance, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
 			"id":                     llx.StringData(table.TableID),
 			"projectId":              llx.StringData(table.ProjectID),
@@ -513,6 +567,7 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 			"expirationTime":         llx.TimeData(metadata.ExpirationTime),
 			"kmsName":                llx.StringData(kmsName),
 			"snapshotTime":           llx.TimeDataPtr(snapshotTime),
+			"cloneTime":              llx.TimeDataPtr(cloneTime),
 			"viewQuery":              llx.StringData(metadata.ViewQuery),
 			"clusteringFields":       llx.DictData(clusteringFields),
 			"externalDataConfig":     llx.DictData(externalDataConfig),
@@ -524,7 +579,14 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		mqlInstance.(*mqlGcpProjectBigqueryServiceTable).cacheKmsKeyName = kmsName
+		mqlTable := mqlInstance.(*mqlGcpProjectBigqueryServiceTable)
+		mqlTable.cacheKmsKeyName = kmsName
+		if metadata.SnapshotDefinition != nil {
+			mqlTable.cacheSnapshotBaseTable = metadata.SnapshotDefinition.BaseTableReference
+		}
+		if metadata.CloneDefinition != nil {
+			mqlTable.cacheCloneBaseTable = metadata.CloneDefinition.BaseTableReference
+		}
 		res = append(res, mqlInstance)
 
 	}

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -174,6 +174,7 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			"timeout":             llx.TimeData(llx.DurationToTime(int64(f.Timeout.Seconds))),
 			"availableMemoryMb":   llx.IntData(int64(f.AvailableMemoryMb)),
 			"serviceAccountEmail": llx.StringData(f.ServiceAccountEmail),
+			"buildServiceAccount": llx.StringData(f.BuildServiceAccount),
 			"updated":             llx.TimeData(f.UpdateTime.AsTime()),
 			"versionId":           llx.IntData(f.VersionId),
 			"labels":              llx.MapData(convert.MapToInterfaceMap(f.Labels), types.String),
@@ -316,6 +317,24 @@ func (g *mqlGcpProjectCloudFunction) serviceAccount() (*mqlGcpProjectIamServiceS
 		return nil, err
 	}
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
+}
+
+func (g *mqlGcpProjectCloudFunction) buildServiceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.BuildServiceAccount.Error != nil {
+		return nil, g.BuildServiceAccount.Error
+	}
+	projectId := ""
+	if g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.BuildServiceAccount.Data, projectId)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.BuildServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
 }
 
 func (g *mqlGcpProjectCloudFunction) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -174,7 +174,6 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			"timeout":             llx.TimeData(llx.DurationToTime(int64(f.Timeout.Seconds))),
 			"availableMemoryMb":   llx.IntData(int64(f.AvailableMemoryMb)),
 			"serviceAccountEmail": llx.StringData(f.ServiceAccountEmail),
-			"buildServiceAccount": llx.StringData(f.BuildServiceAccount),
 			"updated":             llx.TimeData(f.UpdateTime.AsTime()),
 			"versionId":           llx.IntData(f.VersionId),
 			"labels":              llx.MapData(convert.MapToInterfaceMap(f.Labels), types.String),
@@ -200,13 +199,15 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 		}
 		mqlFunc := mqlCloudFuncs.(*mqlGcpProjectCloudFunction)
 		mqlFunc.cacheKmsKeyName = f.KmsKeyName
+		mqlFunc.cacheBuildServiceAccount = f.BuildServiceAccount
 		cloudFunctions = append(cloudFunctions, mqlCloudFuncs)
 	}
 	return cloudFunctions, nil
 }
 
 type mqlGcpProjectCloudFunctionInternal struct {
-	cacheKmsKeyName string
+	cacheKmsKeyName          string
+	cacheBuildServiceAccount string
 }
 
 func (g *mqlGcpProjectCloudFunction) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -319,20 +320,17 @@ func (g *mqlGcpProjectCloudFunction) serviceAccount() (*mqlGcpProjectIamServiceS
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
-func (g *mqlGcpProjectCloudFunction) buildServiceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.BuildServiceAccount.Error != nil {
-		return nil, g.BuildServiceAccount.Error
-	}
+func (g *mqlGcpProjectCloudFunction) buildServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
 	projectId := ""
 	if g.ProjectId.Error == nil {
 		projectId = g.ProjectId.Data
 	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.BuildServiceAccount.Data, projectId)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheBuildServiceAccount, projectId)
 	if err != nil {
 		return nil, err
 	}
 	if sa == nil {
-		g.BuildServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
+		g.BuildServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
 	}
 	return sa, nil
 }

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -211,6 +211,16 @@ func fnV2BuildConfig(runtime *plugin.Runtime, parentName string, cfg *functionsp
 		return nil, err
 	}
 
+	sourceProvenanceDict, err := protoToDict(cfg.GetSourceProvenance())
+	if err != nil {
+		return nil, err
+	}
+
+	var gitUri string
+	if cfg.GetSourceProvenance() != nil {
+		gitUri = cfg.GetSourceProvenance().GetGitUri()
+	}
+
 	var envVars map[string]any
 	if len(cfg.EnvironmentVariables) > 0 {
 		envVars = make(map[string]any, len(cfg.EnvironmentVariables))
@@ -228,6 +238,9 @@ func fnV2BuildConfig(runtime *plugin.Runtime, parentName string, cfg *functionsp
 		"environmentVariables": llx.MapData(envVars, types.String),
 		"dockerRepository":     llx.StringData(cfg.DockerRepository),
 		"serviceAccount":       llx.StringData(cfg.ServiceAccount),
+		"build":                llx.StringData(cfg.Build),
+		"sourceProvenance":     llx.DictData(sourceProvenanceDict),
+		"gitUri":               llx.StringData(gitUri),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -520,6 +520,8 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 					"satisfiesPzs":                  llx.BoolData(s.SatisfiesPzs),
 					"uid":                           llx.StringData(s.Uid),
 					"etag":                          llx.StringData(s.Etag),
+					"client":                        llx.StringData(s.Client),
+					"clientVersion":                 llx.StringData(s.ClientVersion),
 					"binaryAuthorization":           llx.DictData(baDict),
 					"binaryAuthorizationUseDefault": llx.BoolData(baUseDefault),
 					"binaryAuthorizationBreakglassJustification": llx.StringData(baBreakglass),

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -101,6 +101,40 @@ func resolveServiceAccountRef(runtime *plugin.Runtime, raw, fallbackProjectId st
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
+// parentFolderFromId resolves the typed folder for a Cloud Resource Manager
+// parent reference. It returns nil when the parent is not a folder (for example
+// an organization or an empty reference), leaving the caller to mark the field
+// null.
+func parentFolderFromId(parentId string, runtime *plugin.Runtime) (*mqlGcpFolder, error) {
+	const prefix = "folders/"
+	if !strings.HasPrefix(parentId, prefix) {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "gcp.folder", map[string]*llx.RawData{
+		"id": llx.StringData(strings.TrimPrefix(parentId, prefix)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpFolder), nil
+}
+
+// parentOrganizationFromId resolves the typed organization for a Cloud Resource
+// Manager parent reference. It returns nil when the direct parent is not an
+// organization (for example a folder). The organization resource resolves the
+// organization of the active connection, which is the parent org of any project
+// or folder under that org.
+func parentOrganizationFromId(parentId string, runtime *plugin.Runtime) (*mqlGcpOrganization, error) {
+	if !strings.HasPrefix(parentId, "organizations/") {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "gcp.organization", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpOrganization), nil
+}
+
 // protoToDict converts a protobuf message to a map[string]any suitable for use as a dict field.
 // Returns nil for nil input, including typed nil interface values.
 func protoToDict(msg proto.Message) (map[string]any, error) {

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1187,9 +1187,6 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 					"users":                       llx.ArrayData(convert.SliceAnyToInterface(disk.Users), types.String),
 					"accessMode":                  llx.StringData(disk.AccessMode),
 					"provisionedThroughput":       llx.IntData(disk.ProvisionedThroughput),
-					"sourceImageId":               llx.StringData(disk.SourceImageId),
-					"sourceSnapshotId":            llx.StringData(disk.SourceSnapshotId),
-					"sourceDiskId":                llx.StringData(disk.SourceDiskId),
 				})
 				if err != nil {
 					return err
@@ -1436,7 +1433,6 @@ func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 				"enableConfidentialCompute":      llx.BoolData(snapshot.EnableConfidentialCompute),
 				"satisfiesPzi":                   llx.BoolData(snapshot.SatisfiesPzi),
 				"satisfiesPzs":                   llx.BoolData(snapshot.SatisfiesPzs),
-				"sourceDiskId":                   llx.StringData(snapshot.SourceDiskId),
 				"sourceDisk":                     llx.StringData(snapshot.SourceDisk),
 				"sourceSnapshotSchedulePolicy":   llx.StringData(snapshot.SourceSnapshotSchedulePolicy),
 				"sourceSnapshotSchedulePolicyId": llx.StringData(snapshot.SourceSnapshotSchedulePolicyId),
@@ -1671,9 +1667,6 @@ func (g *mqlGcpProjectComputeService) images() ([]any, error) {
 				"storageLocations":             llx.ArrayData(convert.SliceAnyToInterface(image.StorageLocations), types.String),
 				"imageEncryptionKey":           llx.DictData(customerEncryptionKeyToDict(image.ImageEncryptionKey)),
 				"shieldedInstanceInitialState": llx.DictData(shieldedInitialState),
-				"sourceDiskId":                 llx.StringData(image.SourceDiskId),
-				"sourceImageId":                llx.StringData(image.SourceImageId),
-				"sourceSnapshotId":             llx.StringData(image.SourceSnapshotId),
 			})
 			if err != nil {
 				return err

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1437,6 +1437,7 @@ func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 				"satisfiesPzi":                   llx.BoolData(snapshot.SatisfiesPzi),
 				"satisfiesPzs":                   llx.BoolData(snapshot.SatisfiesPzs),
 				"sourceDiskId":                   llx.StringData(snapshot.SourceDiskId),
+				"sourceDisk":                     llx.StringData(snapshot.SourceDisk),
 				"sourceSnapshotSchedulePolicy":   llx.StringData(snapshot.SourceSnapshotSchedulePolicy),
 				"sourceSnapshotSchedulePolicyId": llx.StringData(snapshot.SourceSnapshotSchedulePolicyId),
 				"snapshotEncryptionKey":          llx.DictData(customerEncryptionKeyToDict(snapshot.SnapshotEncryptionKey)),
@@ -1549,9 +1550,9 @@ func (g *mqlGcpProjectComputeServiceSnapshot) kmsKey() (*mqlGcpProjectKmsService
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
-func (g *mqlGcpProjectComputeServiceSnapshot) sourceDisk() (*mqlGcpProjectComputeServiceDisk, error) {
+func (g *mqlGcpProjectComputeServiceSnapshot) sourceDiskRef() (*mqlGcpProjectComputeServiceDisk, error) {
 	if g.cacheSourceDiskUrl == "" {
-		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
+		g.SourceDiskRef.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	return getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1187,6 +1187,9 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 					"users":                       llx.ArrayData(convert.SliceAnyToInterface(disk.Users), types.String),
 					"accessMode":                  llx.StringData(disk.AccessMode),
 					"provisionedThroughput":       llx.IntData(disk.ProvisionedThroughput),
+					"sourceImageId":               llx.StringData(disk.SourceImageId),
+					"sourceSnapshotId":            llx.StringData(disk.SourceSnapshotId),
+					"sourceDiskId":                llx.StringData(disk.SourceDiskId),
 				})
 				if err != nil {
 					return err
@@ -1433,7 +1436,7 @@ func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 				"enableConfidentialCompute":      llx.BoolData(snapshot.EnableConfidentialCompute),
 				"satisfiesPzi":                   llx.BoolData(snapshot.SatisfiesPzi),
 				"satisfiesPzs":                   llx.BoolData(snapshot.SatisfiesPzs),
-				"sourceDisk":                     llx.StringData(snapshot.SourceDisk),
+				"sourceDiskId":                   llx.StringData(snapshot.SourceDiskId),
 				"sourceSnapshotSchedulePolicy":   llx.StringData(snapshot.SourceSnapshotSchedulePolicy),
 				"sourceSnapshotSchedulePolicyId": llx.StringData(snapshot.SourceSnapshotSchedulePolicyId),
 				"snapshotEncryptionKey":          llx.DictData(customerEncryptionKeyToDict(snapshot.SnapshotEncryptionKey)),
@@ -1442,7 +1445,9 @@ func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 				return err
 			}
 
-			mqlSnapshpt.(*mqlGcpProjectComputeServiceSnapshot).cacheKmsKeyName = snapshotKmsKeyName
+			mqlSnap := mqlSnapshpt.(*mqlGcpProjectComputeServiceSnapshot)
+			mqlSnap.cacheKmsKeyName = snapshotKmsKeyName
+			mqlSnap.cacheSourceDiskUrl = snapshot.SourceDisk
 			res = append(res, mqlSnapshpt)
 		}
 		return nil
@@ -1527,7 +1532,8 @@ func (g *mqlGcpProjectComputeServiceImage) kmsKey() (*mqlGcpProjectKmsServiceKey
 }
 
 type mqlGcpProjectComputeServiceSnapshotInternal struct {
-	cacheKmsKeyName string
+	cacheKmsKeyName    string
+	cacheSourceDiskUrl string
 }
 
 func (g *mqlGcpProjectComputeServiceSnapshot) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -1541,6 +1547,14 @@ func (g *mqlGcpProjectComputeServiceSnapshot) kmsKey() (*mqlGcpProjectKmsService
 		return nil, err
 	}
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+}
+
+func (g *mqlGcpProjectComputeServiceSnapshot) sourceDisk() (*mqlGcpProjectComputeServiceDisk, error) {
+	if g.cacheSourceDiskUrl == "" {
+		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
 }
 
 func (g *mqlGcpProjectComputeServiceImage) sourceDisk() (*mqlGcpProjectComputeServiceDisk, error) {
@@ -1656,6 +1670,9 @@ func (g *mqlGcpProjectComputeService) images() ([]any, error) {
 				"storageLocations":             llx.ArrayData(convert.SliceAnyToInterface(image.StorageLocations), types.String),
 				"imageEncryptionKey":           llx.DictData(customerEncryptionKeyToDict(image.ImageEncryptionKey)),
 				"shieldedInstanceInitialState": llx.DictData(shieldedInitialState),
+				"sourceDiskId":                 llx.StringData(image.SourceDiskId),
+				"sourceImageId":                llx.StringData(image.SourceImageId),
+				"sourceSnapshotId":             llx.StringData(image.SourceSnapshotId),
 			})
 			if err != nil {
 				return err

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -148,6 +150,16 @@ func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				templateUrl := igm.InstanceTemplate
+				if templateUrl == "" {
+					for _, v := range igm.Versions {
+						if v.InstanceTemplate != "" {
+							templateUrl = v.InstanceTemplate
+							break
+						}
+					}
+				}
+				mqlIGM.(*mqlGcpProjectComputeServiceInstanceGroupManager).cacheInstanceTemplateUrl = templateUrl
 				res = append(res, mqlIGM)
 			}
 		}
@@ -162,8 +174,48 @@ func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
 	return res, nil
 }
 
+type mqlGcpProjectComputeServiceInstanceGroupManagerInternal struct {
+	cacheInstanceTemplateUrl string
+}
+
 func (g *mqlGcpProjectComputeServiceInstanceGroupManager) id() (string, error) {
 	return "gcloud.compute.instanceGroupManager/" + g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectComputeServiceInstanceGroupManager) instanceTemplate() (*mqlGcpProjectComputeServiceInstanceTemplate, error) {
+	url := g.cacheInstanceTemplateUrl
+	if url == "" {
+		g.InstanceTemplate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	name := url[strings.LastIndex(url, "/")+1:]
+
+	obj, err := CreateResource(g.MqlRuntime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(g.ProjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	svc := obj.(*mqlGcpProjectComputeService)
+	tmpls := svc.GetInstanceTemplates()
+	if tmpls.Error != nil {
+		return nil, tmpls.Error
+	}
+	for _, t := range tmpls.Data {
+		tmpl := t.(*mqlGcpProjectComputeServiceInstanceTemplate)
+		n := tmpl.GetName()
+		if n.Error != nil {
+			return nil, n.Error
+		}
+		if n.Data == name {
+			return tmpl, nil
+		}
+	}
+	g.InstanceTemplate.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 // Network firewall policies

--- a/providers/gcp/resources/compute_instance_templates.go
+++ b/providers/gcp/resources/compute_instance_templates.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"google.golang.org/api/cloudresourcemanager/v3"
@@ -79,4 +81,35 @@ func (g *mqlGcpProjectComputeServiceInstanceTemplate) id() (string, error) {
 	}
 	id := g.Id.Data
 	return fmt.Sprintf("gcp.project.computeService.instanceTemplate/%s", id), nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstanceTemplate) sourceInstanceRef() (*mqlGcpProjectComputeServiceInstance, error) {
+	if g.SourceInstance.Error != nil {
+		return nil, g.SourceInstance.Error
+	}
+	url := g.SourceInstance.Data
+	if url == "" {
+		g.SourceInstanceRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	// URL format: https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}
+	params := strings.TrimPrefix(url, "https://www.googleapis.com/compute/v1/")
+	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
+	parts := strings.Split(params, "/")
+	if len(parts) < 6 || parts[0] != "projects" || parts[2] != "zones" || parts[4] != "instances" {
+		g.SourceInstanceRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	project, zone, name := parts[1], parts[3], parts[5]
+
+	res, err := NewResource(g.MqlRuntime, "gcp.project.computeService.instance", map[string]*llx.RawData{
+		"name":      llx.StringData(name),
+		"region":    llx.StringData(zone),
+		"projectId": llx.StringData(project),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectComputeServiceInstance), nil
 }

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -97,7 +97,38 @@ func initGcpFolder(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 	args["updated"] = llx.TimeDataPtr(parseTime(folder.UpdateTime))
 	args["parentId"] = llx.StringData(folder.Parent)
 	args["state"] = llx.StringData(folder.State)
+	args["managementProject"] = llx.StringData(folder.ManagementProject)
 	return args, nil, nil
+}
+
+func (g *mqlGcpFolder) parentFolder() (*mqlGcpFolder, error) {
+	parentId := g.GetParentId()
+	if parentId.Error != nil {
+		return nil, parentId.Error
+	}
+	f, err := parentFolderFromId(parentId.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		g.ParentFolder.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return f, nil
+}
+
+func (g *mqlGcpFolder) parentOrganization() (*mqlGcpOrganization, error) {
+	parentId := g.GetParentId()
+	if parentId.Error != nil {
+		return nil, parentId.Error
+	}
+	o, err := parentOrganizationFromId(parentId.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if o == nil {
+		g.ParentOrganization.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return o, nil
 }
 
 func (g *mqlGcpFolders) children() ([]any, error) {
@@ -215,13 +246,14 @@ func (g *mqlGcpFolder) projects() (*mqlGcpProjects, error) {
 
 func folderToMql(runtime *plugin.Runtime, f *cloudresourcemanager.Folder) (any, error) {
 	return CreateResource(runtime, "gcp.folder", map[string]*llx.RawData{
-		"id":         llx.StringData(f.Name),
-		"name":       llx.StringData(f.DisplayName),
-		"created":    llx.TimeDataPtr(parseTime(f.CreateTime)),
-		"updated":    llx.TimeDataPtr(parseTime(f.UpdateTime)),
-		"parentId":   llx.StringData(f.Parent),
-		"state":      llx.StringData(f.State),
-		"deleteTime": llx.TimeDataPtr(parseTime(f.DeleteTime)),
+		"id":                llx.StringData(f.Name),
+		"name":              llx.StringData(f.DisplayName),
+		"created":           llx.TimeDataPtr(parseTime(f.CreateTime)),
+		"updated":           llx.TimeDataPtr(parseTime(f.UpdateTime)),
+		"parentId":          llx.StringData(f.Parent),
+		"state":             llx.StringData(f.State),
+		"deleteTime":        llx.TimeDataPtr(parseTime(f.DeleteTime)),
+		"managementProject": llx.StringData(f.ManagementProject),
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1888,8 +1888,10 @@ private gcp.project.computeService.snapshot @defaults("name") {
   satisfiesPzs bool
   // ID of the source disk used to create this snapshot
   sourceDiskId string
+  // URL of the source disk used to create this snapshot
+  sourceDisk string
   // Source disk used to create this snapshot
-  sourceDisk() gcp.project.computeService.disk
+  sourceDiskRef() gcp.project.computeService.disk
   // URL of the snapshot schedule policy that created this snapshot
   sourceSnapshotSchedulePolicy string
   // ID of the snapshot schedule policy

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1785,12 +1785,6 @@ private gcp.project.computeService.disk @defaults("name") {
   satisfiesPzs bool
   // Source disk used to create this disk
   sourceDisk() gcp.project.computeService.disk
-  // ID of the source image used to create the disk
-  sourceImageId string
-  // ID of the source snapshot used to create the disk
-  sourceSnapshotId string
-  // ID of the source disk used to create this disk
-  sourceDiskId string
 }
 
 // Google Cloud (GCP) Compute attached disk
@@ -1886,8 +1880,6 @@ private gcp.project.computeService.snapshot @defaults("name") {
   satisfiesPzi bool
   // Whether the snapshot satisfies Google's Protected Zone Separation requirements
   satisfiesPzs bool
-  // ID of the source disk used to create this snapshot
-  sourceDiskId string
   // URL of the source disk used to create this snapshot
   sourceDisk string
   // Source disk used to create this snapshot
@@ -1954,16 +1946,10 @@ private gcp.project.computeService.image @defaults("id name") {
   storageLocations []string
   // Source disk used to create this image
   sourceDisk() gcp.project.computeService.disk
-  // ID of the source disk used to create this image
-  sourceDiskId string
   // Source image used to create this image
   sourceImage() gcp.project.computeService.image
-  // ID of the source image used to create this image
-  sourceImageId string
   // Source snapshot used to create this image
   sourceSnapshot() gcp.project.computeService.snapshot
-  // ID of the source snapshot used to create this image
-  sourceSnapshotId string
   // Customer-managed KMS key used for image encryption (null when Google-managed or customer-supplied)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Encryption key protecting the image
@@ -5686,10 +5672,8 @@ private gcp.project.cloudFunction @defaults("name") {
   serviceAccountEmail string
   // IAM service account used by the function
   serviceAccount() gcp.project.iamService.serviceAccount
-  // Email of the service account used to build the function's container
-  buildServiceAccount string
   // IAM service account used to build the function's container
-  buildServiceAccountRef() gcp.project.iamService.serviceAccount
+  buildServiceAccount() gcp.project.iamService.serviceAccount
   // Update timestamp
   updated time
   // Version identifier of the cloud function

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -642,6 +642,12 @@ private gcp.folder @defaults("name") {
   updated time
   // Parent ID
   parentId string
+  // Parent folder when this folder is nested under another folder
+  parentFolder() gcp.folder
+  // Parent organization when this folder sits directly under the organization
+  parentOrganization() gcp.organization
+  // Resource name of the management project associated with this folder
+  managementProject string
   // Folder state
   state string
   // Timestamp when deletion was requested
@@ -697,6 +703,10 @@ gcp.project @defaults("name number") {
   name() string
   // Parent ID
   parentId() string
+  // Parent folder when the project sits directly under a folder
+  parentFolder() gcp.folder
+  // Parent organization when the project sits directly under the organization
+  parentOrganization() gcp.organization
   // Project lifecycle state
   state() string
   // Creation time
@@ -1775,6 +1785,12 @@ private gcp.project.computeService.disk @defaults("name") {
   satisfiesPzs bool
   // Source disk used to create this disk
   sourceDisk() gcp.project.computeService.disk
+  // ID of the source image used to create the disk
+  sourceImageId string
+  // ID of the source snapshot used to create the disk
+  sourceSnapshotId string
+  // ID of the source disk used to create this disk
+  sourceDiskId string
 }
 
 // Google Cloud (GCP) Compute attached disk
@@ -1870,8 +1886,10 @@ private gcp.project.computeService.snapshot @defaults("name") {
   satisfiesPzi bool
   // Whether the snapshot satisfies Google's Protected Zone Separation requirements
   satisfiesPzs bool
-  // URL of the source disk used to create this snapshot
-  sourceDisk string
+  // ID of the source disk used to create this snapshot
+  sourceDiskId string
+  // Source disk used to create this snapshot
+  sourceDisk() gcp.project.computeService.disk
   // URL of the snapshot schedule policy that created this snapshot
   sourceSnapshotSchedulePolicy string
   // ID of the snapshot schedule policy
@@ -1934,10 +1952,16 @@ private gcp.project.computeService.image @defaults("id name") {
   storageLocations []string
   // Source disk used to create this image
   sourceDisk() gcp.project.computeService.disk
+  // ID of the source disk used to create this image
+  sourceDiskId string
   // Source image used to create this image
   sourceImage() gcp.project.computeService.image
+  // ID of the source image used to create this image
+  sourceImageId string
   // Source snapshot used to create this image
   sourceSnapshot() gcp.project.computeService.snapshot
+  // ID of the source snapshot used to create this image
+  sourceSnapshotId string
   // Customer-managed KMS key used for image encryption (null when Google-managed or customer-supplied)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Encryption key protecting the image
@@ -2681,6 +2705,8 @@ private gcp.project.sqlService.instance @defaults("name") {
   maintenanceVersion string
   // Name of the instance that acts as primary in the replica
   masterInstanceName string
+  // Primary instance this read replica replicates from
+  master() gcp.project.sqlService.instance
   // Maximum disk size in bytes
   maxDiskSize int
   // Instance name
@@ -2689,6 +2715,8 @@ private gcp.project.sqlService.instance @defaults("name") {
   region string
   // Names of read-replica instances of this primary
   replicaNames []string
+  // Read-replica instances of this primary
+  replicas() []gcp.project.sqlService.instance
   // Detailed Cloud SQL instance configuration (tier, flags, backups, network, IAM)
   settings gcp.project.sqlService.instance.settings
   // Whether the instance is reachable on a public IP — flat hoist of settings.ipConfiguration.ipv4Enabled
@@ -3292,6 +3320,12 @@ private gcp.project.bigqueryService.table @defaults("id") {
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Snapshot creation time
   snapshotTime time
+  // Table this snapshot was taken from
+  snapshotBaseTable() gcp.project.bigqueryService.table
+  // Table this table was cloned from
+  cloneBaseTable() gcp.project.bigqueryService.table
+  // Time the base table was cloned
+  cloneTime time
   // Query to use for a logical view
   viewQuery string
   // Data clustering configuration
@@ -5650,6 +5684,10 @@ private gcp.project.cloudFunction @defaults("name") {
   serviceAccountEmail string
   // IAM service account used by the function
   serviceAccount() gcp.project.iamService.serviceAccount
+  // Email of the service account used to build the function's container
+  buildServiceAccount string
+  // IAM service account used to build the function's container
+  buildServiceAccountRef() gcp.project.iamService.serviceAccount
   // Update timestamp
   updated time
   // Version identifier of the cloud function
@@ -5765,6 +5803,15 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   serviceAccount @maturity("deprecated") string
   // Service account identity used for the build (resolved from serviceAccount)
   serviceAccountRef() gcp.project.iamService.serviceAccount
+  // Cloud Build name of the latest successful deployment of this function
+  build string
+  // Permanent fixed identifier for the resolved source
+  //
+  // Carries the resolved storage source, resolved repo source, and the
+  // git_uri (with commits resolved) captured at build time.
+  sourceProvenance dict
+  // Resolved Git URI of the source, if the function was built from a Git repository
+  gitUri string
 }
 
 // Google Cloud (GCP) Cloud Function v2 service (Cloud Run) configuration
@@ -6517,6 +6564,10 @@ private gcp.project.cloudRunService.service @defaults("name") {
   uid string
   // ETag for optimistic locking
   etag string
+  // Arbitrary identifier for the API client that deployed the service
+  client string
+  // Version of the API client that deployed the service
+  clientVersion string
   // IAM policy bindings for this Cloud Run service
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the service is reachable from the public internet: ingress allows all traffic AND IAM grants invoke to allUsers or allAuthenticatedUsers
@@ -8937,6 +8988,8 @@ private gcp.project.computeService.instanceGroupManager @defaults("name targetSi
   region() gcp.project.computeService.region
   // Instance template URL
   instanceTemplateUrl string
+  // Instance template used to create instances in this managed group
+  instanceTemplate() gcp.project.computeService.instanceTemplate
   // Target number of running instances
   targetSize int
   // Current actions being performed on instances
@@ -10507,6 +10560,8 @@ private gcp.project.computeService.instanceTemplate @defaults("name description"
   selfLink string
   // Source instance URL (if created from an existing instance)
   sourceInstance string
+  // Existing instance this template was created from
+  sourceInstanceRef() gcp.project.computeService.instance
   // Instance properties (machine type, disks, network interfaces, etc.)
   properties dict
   // Creation timestamp

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4186,15 +4186,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.disk.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
-	"gcp.project.computeService.disk.sourceImageId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceImageId()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.disk.sourceSnapshotId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceSnapshotId()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.disk.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceDiskId()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.attachedDisk.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAttachedDisk).GetId()).ToDataRes(types.String)
 	},
@@ -4306,9 +4297,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.satisfiesPzs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSatisfiesPzs()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.snapshot.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDiskId()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDisk()).ToDataRes(types.String)
 	},
@@ -4384,20 +4372,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.image.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
-	"gcp.project.computeService.image.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceDiskId()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.image.sourceImage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceImage()).ToDataRes(types.Resource("gcp.project.computeService.image"))
 	},
-	"gcp.project.computeService.image.sourceImageId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceImageId()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceSnapshot()).ToDataRes(types.Resource("gcp.project.computeService.snapshot"))
-	},
-	"gcp.project.computeService.image.sourceSnapshotId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceSnapshotId()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.image.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -7961,10 +7940,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlGcpProjectCloudFunction).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.cloudFunction.buildServiceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunction).GetBuildServiceAccount()).ToDataRes(types.String)
-	},
-	"gcp.project.cloudFunction.buildServiceAccountRef": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunction).GetBuildServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+		return (r.(*mqlGcpProjectCloudFunction).GetBuildServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetUpdated()).ToDataRes(types.Time)
@@ -19650,18 +19626,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceDisk).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.disk.sourceImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceDisk).SourceImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.disk.sourceSnapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceDisk).SourceSnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.disk.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceDisk).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.attachedDisk.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAttachedDisk).__id, ok = v.Value.(string)
 		return
@@ -19818,10 +19782,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).SatisfiesPzs, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.snapshot.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDisk, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -19926,24 +19886,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceImage).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.image.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceImage).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.image.sourceImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).SourceImage, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceImage](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.image.sourceImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceImage).SourceImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).SourceSnapshot, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSnapshot](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.image.sourceSnapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceImage).SourceSnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.image.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25127,11 +25075,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"gcp.project.cloudFunction.buildServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunction).BuildServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudFunction.buildServiceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunction).BuildServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		r.(*mqlGcpProjectCloudFunction).BuildServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -45185,9 +45129,6 @@ type mqlGcpProjectComputeServiceDisk struct {
 	SatisfiesPzi                plugin.TValue[bool]
 	SatisfiesPzs                plugin.TValue[bool]
 	SourceDisk                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
-	SourceImageId               plugin.TValue[string]
-	SourceSnapshotId            plugin.TValue[string]
-	SourceDiskId                plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceDisk creates a new instance of this resource
@@ -45431,18 +45372,6 @@ func (c *mqlGcpProjectComputeServiceDisk) GetSourceDisk() *plugin.TValue[*mqlGcp
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceDisk) GetSourceImageId() *plugin.TValue[string] {
-	return &c.SourceImageId
-}
-
-func (c *mqlGcpProjectComputeServiceDisk) GetSourceSnapshotId() *plugin.TValue[string] {
-	return &c.SourceSnapshotId
-}
-
-func (c *mqlGcpProjectComputeServiceDisk) GetSourceDiskId() *plugin.TValue[string] {
-	return &c.SourceDiskId
-}
-
 // mqlGcpProjectComputeServiceAttachedDisk for the gcp.project.computeService.attachedDisk resource
 type mqlGcpProjectComputeServiceAttachedDisk struct {
 	MqlRuntime *plugin.Runtime
@@ -45605,7 +45534,6 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	EnableConfidentialCompute      plugin.TValue[bool]
 	SatisfiesPzi                   plugin.TValue[bool]
 	SatisfiesPzs                   plugin.TValue[bool]
-	SourceDiskId                   plugin.TValue[string]
 	SourceDisk                     plugin.TValue[string]
 	SourceDiskRef                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 	SourceSnapshotSchedulePolicy   plugin.TValue[string]
@@ -45737,10 +45665,6 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetSatisfiesPzs() *plugin.TValue[b
 	return &c.SatisfiesPzs
 }
 
-func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDiskId() *plugin.TValue[string] {
-	return &c.SourceDiskId
-}
-
 func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[string] {
 	return &c.SourceDisk
 }
@@ -45833,11 +45757,8 @@ type mqlGcpProjectComputeServiceImage struct {
 	SatisfiesPzs                 plugin.TValue[bool]
 	StorageLocations             plugin.TValue[[]any]
 	SourceDisk                   plugin.TValue[*mqlGcpProjectComputeServiceDisk]
-	SourceDiskId                 plugin.TValue[string]
 	SourceImage                  plugin.TValue[*mqlGcpProjectComputeServiceImage]
-	SourceImageId                plugin.TValue[string]
 	SourceSnapshot               plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
-	SourceSnapshotId             plugin.TValue[string]
 	KmsKey                       plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	ImageEncryptionKey           plugin.TValue[any]
 	ShieldedInstanceInitialState plugin.TValue[any]
@@ -45962,10 +45883,6 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceDisk() *plugin.TValue[*mqlGc
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceImage) GetSourceDiskId() *plugin.TValue[string] {
-	return &c.SourceDiskId
-}
-
 func (c *mqlGcpProjectComputeServiceImage) GetSourceImage() *plugin.TValue[*mqlGcpProjectComputeServiceImage] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceImage](&c.SourceImage, func() (*mqlGcpProjectComputeServiceImage, error) {
 		if c.MqlRuntime.HasRecording {
@@ -45982,10 +45899,6 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceImage() *plugin.TValue[*mqlG
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceImage) GetSourceImageId() *plugin.TValue[string] {
-	return &c.SourceImageId
-}
-
 func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshot() *plugin.TValue[*mqlGcpProjectComputeServiceSnapshot] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSnapshot](&c.SourceSnapshot, func() (*mqlGcpProjectComputeServiceSnapshot, error) {
 		if c.MqlRuntime.HasRecording {
@@ -46000,10 +45913,6 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshot() *plugin.TValue[*m
 
 		return c.sourceSnapshot()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshotId() *plugin.TValue[string] {
-	return &c.SourceSnapshotId
 }
 
 func (c *mqlGcpProjectComputeServiceImage) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -57739,47 +57648,46 @@ type mqlGcpProjectCloudFunction struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectCloudFunctionInternal
-	ProjectId              plugin.TValue[string]
-	Location               plugin.TValue[string]
-	Name                   plugin.TValue[string]
-	Description            plugin.TValue[string]
-	SourceArchiveUrl       plugin.TValue[string]
-	SourceRepository       plugin.TValue[any]
-	SourceUploadUrl        plugin.TValue[string]
-	HttpsTrigger           plugin.TValue[any]
-	EventTrigger           plugin.TValue[any]
-	Status                 plugin.TValue[string]
-	EntryPoint             plugin.TValue[string]
-	Runtime                plugin.TValue[string]
-	Timeout                plugin.TValue[*time.Time]
-	AvailableMemoryMb      plugin.TValue[int64]
-	ServiceAccountEmail    plugin.TValue[string]
-	ServiceAccount         plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	BuildServiceAccount    plugin.TValue[string]
-	BuildServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	Updated                plugin.TValue[*time.Time]
-	VersionId              plugin.TValue[int64]
-	Labels                 plugin.TValue[map[string]any]
-	EnvVars                plugin.TValue[map[string]any]
-	BuildEnvVars           plugin.TValue[map[string]any]
-	Network                plugin.TValue[string]
-	NetworkRef             plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
-	MaxInstances           plugin.TValue[int64]
-	MinInstances           plugin.TValue[int64]
-	VpcConnector           plugin.TValue[string]
-	EgressSettings         plugin.TValue[string]
-	IngressSettings        plugin.TValue[string]
-	KmsKeyName             plugin.TValue[string]
-	KmsKey                 plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	BuildWorkerPool        plugin.TValue[string]
-	BuildId                plugin.TValue[string]
-	BuildName              plugin.TValue[string]
-	SecretEnvVars          plugin.TValue[map[string]any]
-	SecretVolumes          plugin.TValue[[]any]
-	DockerRepository       plugin.TValue[string]
-	DockerRegistry         plugin.TValue[string]
-	IamPolicy              plugin.TValue[[]any]
-	AllowsUnauthenticated  plugin.TValue[bool]
+	ProjectId             plugin.TValue[string]
+	Location              plugin.TValue[string]
+	Name                  plugin.TValue[string]
+	Description           plugin.TValue[string]
+	SourceArchiveUrl      plugin.TValue[string]
+	SourceRepository      plugin.TValue[any]
+	SourceUploadUrl       plugin.TValue[string]
+	HttpsTrigger          plugin.TValue[any]
+	EventTrigger          plugin.TValue[any]
+	Status                plugin.TValue[string]
+	EntryPoint            plugin.TValue[string]
+	Runtime               plugin.TValue[string]
+	Timeout               plugin.TValue[*time.Time]
+	AvailableMemoryMb     plugin.TValue[int64]
+	ServiceAccountEmail   plugin.TValue[string]
+	ServiceAccount        plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	BuildServiceAccount   plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Updated               plugin.TValue[*time.Time]
+	VersionId             plugin.TValue[int64]
+	Labels                plugin.TValue[map[string]any]
+	EnvVars               plugin.TValue[map[string]any]
+	BuildEnvVars          plugin.TValue[map[string]any]
+	Network               plugin.TValue[string]
+	NetworkRef            plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	MaxInstances          plugin.TValue[int64]
+	MinInstances          plugin.TValue[int64]
+	VpcConnector          plugin.TValue[string]
+	EgressSettings        plugin.TValue[string]
+	IngressSettings       plugin.TValue[string]
+	KmsKeyName            plugin.TValue[string]
+	KmsKey                plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	BuildWorkerPool       plugin.TValue[string]
+	BuildId               plugin.TValue[string]
+	BuildName             plugin.TValue[string]
+	SecretEnvVars         plugin.TValue[map[string]any]
+	SecretVolumes         plugin.TValue[[]any]
+	DockerRepository      plugin.TValue[string]
+	DockerRegistry        plugin.TValue[string]
+	IamPolicy             plugin.TValue[[]any]
+	AllowsUnauthenticated plugin.TValue[bool]
 }
 
 // createGcpProjectCloudFunction creates a new instance of this resource
@@ -57895,14 +57803,10 @@ func (c *mqlGcpProjectCloudFunction) GetServiceAccount() *plugin.TValue[*mqlGcpP
 	})
 }
 
-func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccount() *plugin.TValue[string] {
-	return &c.BuildServiceAccount
-}
-
-func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
-	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.BuildServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.BuildServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "buildServiceAccountRef")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "buildServiceAccount")
 			if err != nil {
 				return nil, err
 			}
@@ -57911,7 +57815,7 @@ func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccountRef() *plugin.TValue[
 			}
 		}
 
-		return c.buildServiceAccountRef()
+		return c.buildServiceAccount()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2980,6 +2980,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.folder.parentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpFolder).GetParentId()).ToDataRes(types.String)
 	},
+	"gcp.folder.parentFolder": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpFolder).GetParentFolder()).ToDataRes(types.Resource("gcp.folder"))
+	},
+	"gcp.folder.parentOrganization": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpFolder).GetParentOrganization()).ToDataRes(types.Resource("gcp.organization"))
+	},
+	"gcp.folder.managementProject": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpFolder).GetManagementProject()).ToDataRes(types.String)
+	},
 	"gcp.folder.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpFolder).GetState()).ToDataRes(types.String)
 	},
@@ -3024,6 +3033,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.parentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetParentId()).ToDataRes(types.String)
+	},
+	"gcp.project.parentFolder": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetParentFolder()).ToDataRes(types.Resource("gcp.folder"))
+	},
+	"gcp.project.parentOrganization": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetParentOrganization()).ToDataRes(types.Resource("gcp.organization"))
 	},
 	"gcp.project.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetState()).ToDataRes(types.String)
@@ -4171,6 +4186,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.disk.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
+	"gcp.project.computeService.disk.sourceImageId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceImageId()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.disk.sourceSnapshotId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceSnapshotId()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.disk.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceDiskId()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.attachedDisk.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAttachedDisk).GetId()).ToDataRes(types.String)
 	},
@@ -4282,8 +4306,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.satisfiesPzs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSatisfiesPzs()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.snapshot.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDiskId()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDisk()).ToDataRes(types.String)
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
 	"gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceSnapshotSchedulePolicy()).ToDataRes(types.String)
@@ -4354,11 +4381,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.image.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
+	"gcp.project.computeService.image.sourceDiskId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceDiskId()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.image.sourceImage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceImage()).ToDataRes(types.Resource("gcp.project.computeService.image"))
 	},
+	"gcp.project.computeService.image.sourceImageId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceImageId()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceSnapshot()).ToDataRes(types.Resource("gcp.project.computeService.snapshot"))
+	},
+	"gcp.project.computeService.image.sourceSnapshotId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceSnapshotId()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.image.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -5104,6 +5140,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.masterInstanceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetMasterInstanceName()).ToDataRes(types.String)
 	},
+	"gcp.project.sqlService.instance.master": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetMaster()).ToDataRes(types.Resource("gcp.project.sqlService.instance"))
+	},
 	"gcp.project.sqlService.instance.maxDiskSize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetMaxDiskSize()).ToDataRes(types.Int)
 	},
@@ -5115,6 +5154,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.replicaNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetReplicaNames()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.sqlService.instance.replicas": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetReplicas()).ToDataRes(types.Array(types.Resource("gcp.project.sqlService.instance")))
 	},
 	"gcp.project.sqlService.instance.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetSettings()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings"))
@@ -5766,6 +5808,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigqueryService.table.snapshotTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTable).GetSnapshotTime()).ToDataRes(types.Time)
+	},
+	"gcp.project.bigqueryService.table.snapshotBaseTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceTable).GetSnapshotBaseTable()).ToDataRes(types.Resource("gcp.project.bigqueryService.table"))
+	},
+	"gcp.project.bigqueryService.table.cloneBaseTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceTable).GetCloneBaseTable()).ToDataRes(types.Resource("gcp.project.bigqueryService.table"))
+	},
+	"gcp.project.bigqueryService.table.cloneTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceTable).GetCloneTime()).ToDataRes(types.Time)
 	},
 	"gcp.project.bigqueryService.table.viewQuery": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTable).GetViewQuery()).ToDataRes(types.String)
@@ -7906,6 +7957,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
+	"gcp.project.cloudFunction.buildServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetBuildServiceAccount()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudFunction.buildServiceAccountRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetBuildServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetUpdated()).ToDataRes(types.Time)
 	},
@@ -8049,6 +8106,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.build": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetBuild()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.sourceProvenance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetSourceProvenance()).ToDataRes(types.Dict)
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.gitUri": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetGitUri()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).GetId()).ToDataRes(types.String)
@@ -8826,6 +8892,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.service.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceService).GetEtag()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.service.client": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetClient()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.service.clientVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetClientVersion()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudRunService.service.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceService).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
@@ -11263,6 +11335,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instanceGroupManager.instanceTemplateUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetInstanceTemplateUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.instanceGroupManager.instanceTemplate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetInstanceTemplate()).ToDataRes(types.Resource("gcp.project.computeService.instanceTemplate"))
+	},
 	"gcp.project.computeService.instanceGroupManager.targetSize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetTargetSize()).ToDataRes(types.Int)
 	},
@@ -12849,6 +12924,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instanceTemplate.sourceInstance": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceTemplate).GetSourceInstance()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.instanceTemplate.sourceInstanceRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceTemplate).GetSourceInstanceRef()).ToDataRes(types.Resource("gcp.project.computeService.instance"))
 	},
 	"gcp.project.computeService.instanceTemplate.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceTemplate).GetProperties()).ToDataRes(types.Dict)
@@ -17869,6 +17947,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpFolder).ParentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.folder.parentFolder": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpFolder).ParentFolder, ok = plugin.RawToTValue[*mqlGcpFolder](v.Value, v.Error)
+		return
+	},
+	"gcp.folder.parentOrganization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpFolder).ParentOrganization, ok = plugin.RawToTValue[*mqlGcpOrganization](v.Value, v.Error)
+		return
+	},
+	"gcp.folder.managementProject": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpFolder).ManagementProject, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.folder.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpFolder).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -17935,6 +18025,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.parentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProject).ParentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.parentFolder": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).ParentFolder, ok = plugin.RawToTValue[*mqlGcpFolder](v.Value, v.Error)
+		return
+	},
+	"gcp.project.parentOrganization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).ParentOrganization, ok = plugin.RawToTValue[*mqlGcpOrganization](v.Value, v.Error)
 		return
 	},
 	"gcp.project.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19549,6 +19647,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceDisk).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.disk.sourceImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).SourceImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.sourceSnapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).SourceSnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.attachedDisk.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAttachedDisk).__id, ok = v.Value.(string)
 		return
@@ -19705,8 +19815,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).SatisfiesPzs, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.snapshot.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDisk, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19805,12 +19919,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceImage).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.image.sourceDiskId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).SourceDiskId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.image.sourceImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).SourceImage, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceImage](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.image.sourceImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).SourceImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).SourceSnapshot, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSnapshot](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.image.sourceSnapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).SourceSnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.image.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20865,6 +20991,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).MasterInstanceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.master": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).Master, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstance](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.maxDiskSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).MaxDiskSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -20879,6 +21009,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.replicaNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).ReplicaNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.replicas": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).Replicas, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21815,6 +21949,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigqueryService.table.snapshotTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceTable).SnapshotTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.table.snapshotBaseTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceTable).SnapshotBaseTable, ok = plugin.RawToTValue[*mqlGcpProjectBigqueryServiceTable](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.table.cloneBaseTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceTable).CloneBaseTable, ok = plugin.RawToTValue[*mqlGcpProjectBigqueryServiceTable](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.table.cloneTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceTable).CloneTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigqueryService.table.viewQuery": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24973,6 +25119,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunction.buildServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).BuildServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunction.buildServiceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).BuildServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).Updated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -25171,6 +25325,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.build": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).Build, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.sourceProvenance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).SourceProvenance, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.buildConfig.gitUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GitUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26307,6 +26473,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.service.etag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceService).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.service.client": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).Client, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.service.clientVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).ClientVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.service.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29853,6 +30027,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).InstanceTemplateUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instanceGroupManager.instanceTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).InstanceTemplate, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceTemplate](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instanceGroupManager.targetSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).TargetSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -32171,6 +32349,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instanceTemplate.sourceInstance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceTemplate).SourceInstance, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instanceTemplate.sourceInstanceRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceTemplate).SourceInstanceRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstance](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instanceTemplate.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40439,20 +40621,23 @@ type mqlGcpFolder struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpFolderInternal
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Created           plugin.TValue[*time.Time]
-	Updated           plugin.TValue[*time.Time]
-	ParentId          plugin.TValue[string]
-	State             plugin.TValue[string]
-	DeleteTime        plugin.TValue[*time.Time]
-	Folders           plugin.TValue[*mqlGcpFolders]
-	Projects          plugin.TValue[*mqlGcpProjects]
-	OrgPolicies       plugin.TValue[[]any]
-	IamPolicy         plugin.TValue[[]any]
-	AuditConfig       plugin.TValue[[]any]
-	Logging           plugin.TValue[*mqlGcpFolderLoggingService]
-	EssentialContacts plugin.TValue[[]any]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Created            plugin.TValue[*time.Time]
+	Updated            plugin.TValue[*time.Time]
+	ParentId           plugin.TValue[string]
+	ParentFolder       plugin.TValue[*mqlGcpFolder]
+	ParentOrganization plugin.TValue[*mqlGcpOrganization]
+	ManagementProject  plugin.TValue[string]
+	State              plugin.TValue[string]
+	DeleteTime         plugin.TValue[*time.Time]
+	Folders            plugin.TValue[*mqlGcpFolders]
+	Projects           plugin.TValue[*mqlGcpProjects]
+	OrgPolicies        plugin.TValue[[]any]
+	IamPolicy          plugin.TValue[[]any]
+	AuditConfig        plugin.TValue[[]any]
+	Logging            plugin.TValue[*mqlGcpFolderLoggingService]
+	EssentialContacts  plugin.TValue[[]any]
 }
 
 // createGcpFolder creates a new instance of this resource
@@ -40510,6 +40695,42 @@ func (c *mqlGcpFolder) GetUpdated() *plugin.TValue[*time.Time] {
 
 func (c *mqlGcpFolder) GetParentId() *plugin.TValue[string] {
 	return &c.ParentId
+}
+
+func (c *mqlGcpFolder) GetParentFolder() *plugin.TValue[*mqlGcpFolder] {
+	return plugin.GetOrCompute[*mqlGcpFolder](&c.ParentFolder, func() (*mqlGcpFolder, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.folder", c.__id, "parentFolder")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpFolder), nil
+			}
+		}
+
+		return c.parentFolder()
+	})
+}
+
+func (c *mqlGcpFolder) GetParentOrganization() *plugin.TValue[*mqlGcpOrganization] {
+	return plugin.GetOrCompute[*mqlGcpOrganization](&c.ParentOrganization, func() (*mqlGcpOrganization, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.folder", c.__id, "parentOrganization")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpOrganization), nil
+			}
+		}
+
+		return c.parentOrganization()
+	})
+}
+
+func (c *mqlGcpFolder) GetManagementProject() *plugin.TValue[string] {
+	return &c.ManagementProject
 }
 
 func (c *mqlGcpFolder) GetState() *plugin.TValue[string] {
@@ -40723,6 +40944,8 @@ type mqlGcpProject struct {
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	ParentId                 plugin.TValue[string]
+	ParentFolder             plugin.TValue[*mqlGcpFolder]
+	ParentOrganization       plugin.TValue[*mqlGcpOrganization]
 	State                    plugin.TValue[string]
 	CreateTime               plugin.TValue[*time.Time]
 	Labels                   plugin.TValue[map[string]any]
@@ -40855,6 +41078,38 @@ func (c *mqlGcpProject) GetName() *plugin.TValue[string] {
 func (c *mqlGcpProject) GetParentId() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ParentId, func() (string, error) {
 		return c.parentId()
+	})
+}
+
+func (c *mqlGcpProject) GetParentFolder() *plugin.TValue[*mqlGcpFolder] {
+	return plugin.GetOrCompute[*mqlGcpFolder](&c.ParentFolder, func() (*mqlGcpFolder, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project", c.__id, "parentFolder")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpFolder), nil
+			}
+		}
+
+		return c.parentFolder()
+	})
+}
+
+func (c *mqlGcpProject) GetParentOrganization() *plugin.TValue[*mqlGcpOrganization] {
+	return plugin.GetOrCompute[*mqlGcpOrganization](&c.ParentOrganization, func() (*mqlGcpOrganization, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project", c.__id, "parentOrganization")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpOrganization), nil
+			}
+		}
+
+		return c.parentOrganization()
 	})
 }
 
@@ -44923,6 +45178,9 @@ type mqlGcpProjectComputeServiceDisk struct {
 	SatisfiesPzi                plugin.TValue[bool]
 	SatisfiesPzs                plugin.TValue[bool]
 	SourceDisk                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
+	SourceImageId               plugin.TValue[string]
+	SourceSnapshotId            plugin.TValue[string]
+	SourceDiskId                plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceDisk creates a new instance of this resource
@@ -45166,6 +45424,18 @@ func (c *mqlGcpProjectComputeServiceDisk) GetSourceDisk() *plugin.TValue[*mqlGcp
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceDisk) GetSourceImageId() *plugin.TValue[string] {
+	return &c.SourceImageId
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetSourceSnapshotId() *plugin.TValue[string] {
+	return &c.SourceSnapshotId
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetSourceDiskId() *plugin.TValue[string] {
+	return &c.SourceDiskId
+}
+
 // mqlGcpProjectComputeServiceAttachedDisk for the gcp.project.computeService.attachedDisk resource
 type mqlGcpProjectComputeServiceAttachedDisk struct {
 	MqlRuntime *plugin.Runtime
@@ -45328,7 +45598,8 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	EnableConfidentialCompute      plugin.TValue[bool]
 	SatisfiesPzi                   plugin.TValue[bool]
 	SatisfiesPzs                   plugin.TValue[bool]
-	SourceDisk                     plugin.TValue[string]
+	SourceDiskId                   plugin.TValue[string]
+	SourceDisk                     plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 	SourceSnapshotSchedulePolicy   plugin.TValue[string]
 	SourceSnapshotSchedulePolicyId plugin.TValue[string]
 	KmsKey                         plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
@@ -45458,8 +45729,24 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetSatisfiesPzs() *plugin.TValue[b
 	return &c.SatisfiesPzs
 }
 
-func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[string] {
-	return &c.SourceDisk
+func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDiskId() *plugin.TValue[string] {
+	return &c.SourceDiskId
+}
+
+func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[*mqlGcpProjectComputeServiceDisk] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceDisk](&c.SourceDisk, func() (*mqlGcpProjectComputeServiceDisk, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.snapshot", c.__id, "sourceDisk")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceDisk), nil
+			}
+		}
+
+		return c.sourceDisk()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceSnapshotSchedulePolicy() *plugin.TValue[string] {
@@ -45534,8 +45821,11 @@ type mqlGcpProjectComputeServiceImage struct {
 	SatisfiesPzs                 plugin.TValue[bool]
 	StorageLocations             plugin.TValue[[]any]
 	SourceDisk                   plugin.TValue[*mqlGcpProjectComputeServiceDisk]
+	SourceDiskId                 plugin.TValue[string]
 	SourceImage                  plugin.TValue[*mqlGcpProjectComputeServiceImage]
+	SourceImageId                plugin.TValue[string]
 	SourceSnapshot               plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
+	SourceSnapshotId             plugin.TValue[string]
 	KmsKey                       plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	ImageEncryptionKey           plugin.TValue[any]
 	ShieldedInstanceInitialState plugin.TValue[any]
@@ -45660,6 +45950,10 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceDisk() *plugin.TValue[*mqlGc
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceImage) GetSourceDiskId() *plugin.TValue[string] {
+	return &c.SourceDiskId
+}
+
 func (c *mqlGcpProjectComputeServiceImage) GetSourceImage() *plugin.TValue[*mqlGcpProjectComputeServiceImage] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceImage](&c.SourceImage, func() (*mqlGcpProjectComputeServiceImage, error) {
 		if c.MqlRuntime.HasRecording {
@@ -45676,6 +45970,10 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceImage() *plugin.TValue[*mqlG
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceImage) GetSourceImageId() *plugin.TValue[string] {
+	return &c.SourceImageId
+}
+
 func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshot() *plugin.TValue[*mqlGcpProjectComputeServiceSnapshot] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSnapshot](&c.SourceSnapshot, func() (*mqlGcpProjectComputeServiceSnapshot, error) {
 		if c.MqlRuntime.HasRecording {
@@ -45690,6 +45988,10 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshot() *plugin.TValue[*m
 
 		return c.sourceSnapshot()
 	})
+}
+
+func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshotId() *plugin.TValue[string] {
+	return &c.SourceSnapshotId
 }
 
 func (c *mqlGcpProjectComputeServiceImage) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -47685,10 +47987,12 @@ type mqlGcpProjectSqlServiceInstance struct {
 	IpAddresses                                plugin.TValue[[]any]
 	MaintenanceVersion                         plugin.TValue[string]
 	MasterInstanceName                         plugin.TValue[string]
+	Master                                     plugin.TValue[*mqlGcpProjectSqlServiceInstance]
 	MaxDiskSize                                plugin.TValue[int64]
 	Name                                       plugin.TValue[string]
 	Region                                     plugin.TValue[string]
 	ReplicaNames                               plugin.TValue[[]any]
+	Replicas                                   plugin.TValue[[]any]
 	Settings                                   plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettings]
 	PublicIpEnabled                            plugin.TValue[bool]
 	InternetReachable                          plugin.TValue[bool]
@@ -47853,6 +48157,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetMasterInstanceName() *plugin.TValue
 	return &c.MasterInstanceName
 }
 
+func (c *mqlGcpProjectSqlServiceInstance) GetMaster() *plugin.TValue[*mqlGcpProjectSqlServiceInstance] {
+	return plugin.GetOrCompute[*mqlGcpProjectSqlServiceInstance](&c.Master, func() (*mqlGcpProjectSqlServiceInstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "master")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectSqlServiceInstance), nil
+			}
+		}
+
+		return c.master()
+	})
+}
+
 func (c *mqlGcpProjectSqlServiceInstance) GetMaxDiskSize() *plugin.TValue[int64] {
 	return &c.MaxDiskSize
 }
@@ -47867,6 +48187,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectSqlServiceInstance) GetReplicaNames() *plugin.TValue[[]any] {
 	return &c.ReplicaNames
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetReplicas() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Replicas, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "replicas")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.replicas()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstance) GetSettings() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettings] {
@@ -49735,6 +50071,9 @@ type mqlGcpProjectBigqueryServiceTable struct {
 	KmsName                plugin.TValue[string]
 	KmsKey                 plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	SnapshotTime           plugin.TValue[*time.Time]
+	SnapshotBaseTable      plugin.TValue[*mqlGcpProjectBigqueryServiceTable]
+	CloneBaseTable         plugin.TValue[*mqlGcpProjectBigqueryServiceTable]
+	CloneTime              plugin.TValue[*time.Time]
 	ViewQuery              plugin.TValue[string]
 	ClusteringFields       plugin.TValue[any]
 	ExternalDataConfig     plugin.TValue[any]
@@ -49870,6 +50209,42 @@ func (c *mqlGcpProjectBigqueryServiceTable) GetKmsKey() *plugin.TValue[*mqlGcpPr
 
 func (c *mqlGcpProjectBigqueryServiceTable) GetSnapshotTime() *plugin.TValue[*time.Time] {
 	return &c.SnapshotTime
+}
+
+func (c *mqlGcpProjectBigqueryServiceTable) GetSnapshotBaseTable() *plugin.TValue[*mqlGcpProjectBigqueryServiceTable] {
+	return plugin.GetOrCompute[*mqlGcpProjectBigqueryServiceTable](&c.SnapshotBaseTable, func() (*mqlGcpProjectBigqueryServiceTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigqueryService.table", c.__id, "snapshotBaseTable")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBigqueryServiceTable), nil
+			}
+		}
+
+		return c.snapshotBaseTable()
+	})
+}
+
+func (c *mqlGcpProjectBigqueryServiceTable) GetCloneBaseTable() *plugin.TValue[*mqlGcpProjectBigqueryServiceTable] {
+	return plugin.GetOrCompute[*mqlGcpProjectBigqueryServiceTable](&c.CloneBaseTable, func() (*mqlGcpProjectBigqueryServiceTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigqueryService.table", c.__id, "cloneBaseTable")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBigqueryServiceTable), nil
+			}
+		}
+
+		return c.cloneBaseTable()
+	})
+}
+
+func (c *mqlGcpProjectBigqueryServiceTable) GetCloneTime() *plugin.TValue[*time.Time] {
+	return &c.CloneTime
 }
 
 func (c *mqlGcpProjectBigqueryServiceTable) GetViewQuery() *plugin.TValue[string] {
@@ -57352,45 +57727,47 @@ type mqlGcpProjectCloudFunction struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectCloudFunctionInternal
-	ProjectId             plugin.TValue[string]
-	Location              plugin.TValue[string]
-	Name                  plugin.TValue[string]
-	Description           plugin.TValue[string]
-	SourceArchiveUrl      plugin.TValue[string]
-	SourceRepository      plugin.TValue[any]
-	SourceUploadUrl       plugin.TValue[string]
-	HttpsTrigger          plugin.TValue[any]
-	EventTrigger          plugin.TValue[any]
-	Status                plugin.TValue[string]
-	EntryPoint            plugin.TValue[string]
-	Runtime               plugin.TValue[string]
-	Timeout               plugin.TValue[*time.Time]
-	AvailableMemoryMb     plugin.TValue[int64]
-	ServiceAccountEmail   plugin.TValue[string]
-	ServiceAccount        plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	Updated               plugin.TValue[*time.Time]
-	VersionId             plugin.TValue[int64]
-	Labels                plugin.TValue[map[string]any]
-	EnvVars               plugin.TValue[map[string]any]
-	BuildEnvVars          plugin.TValue[map[string]any]
-	Network               plugin.TValue[string]
-	NetworkRef            plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
-	MaxInstances          plugin.TValue[int64]
-	MinInstances          plugin.TValue[int64]
-	VpcConnector          plugin.TValue[string]
-	EgressSettings        plugin.TValue[string]
-	IngressSettings       plugin.TValue[string]
-	KmsKeyName            plugin.TValue[string]
-	KmsKey                plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	BuildWorkerPool       plugin.TValue[string]
-	BuildId               plugin.TValue[string]
-	BuildName             plugin.TValue[string]
-	SecretEnvVars         plugin.TValue[map[string]any]
-	SecretVolumes         plugin.TValue[[]any]
-	DockerRepository      plugin.TValue[string]
-	DockerRegistry        plugin.TValue[string]
-	IamPolicy             plugin.TValue[[]any]
-	AllowsUnauthenticated plugin.TValue[bool]
+	ProjectId              plugin.TValue[string]
+	Location               plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Description            plugin.TValue[string]
+	SourceArchiveUrl       plugin.TValue[string]
+	SourceRepository       plugin.TValue[any]
+	SourceUploadUrl        plugin.TValue[string]
+	HttpsTrigger           plugin.TValue[any]
+	EventTrigger           plugin.TValue[any]
+	Status                 plugin.TValue[string]
+	EntryPoint             plugin.TValue[string]
+	Runtime                plugin.TValue[string]
+	Timeout                plugin.TValue[*time.Time]
+	AvailableMemoryMb      plugin.TValue[int64]
+	ServiceAccountEmail    plugin.TValue[string]
+	ServiceAccount         plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	BuildServiceAccount    plugin.TValue[string]
+	BuildServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Updated                plugin.TValue[*time.Time]
+	VersionId              plugin.TValue[int64]
+	Labels                 plugin.TValue[map[string]any]
+	EnvVars                plugin.TValue[map[string]any]
+	BuildEnvVars           plugin.TValue[map[string]any]
+	Network                plugin.TValue[string]
+	NetworkRef             plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	MaxInstances           plugin.TValue[int64]
+	MinInstances           plugin.TValue[int64]
+	VpcConnector           plugin.TValue[string]
+	EgressSettings         plugin.TValue[string]
+	IngressSettings        plugin.TValue[string]
+	KmsKeyName             plugin.TValue[string]
+	KmsKey                 plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	BuildWorkerPool        plugin.TValue[string]
+	BuildId                plugin.TValue[string]
+	BuildName              plugin.TValue[string]
+	SecretEnvVars          plugin.TValue[map[string]any]
+	SecretVolumes          plugin.TValue[[]any]
+	DockerRepository       plugin.TValue[string]
+	DockerRegistry         plugin.TValue[string]
+	IamPolicy              plugin.TValue[[]any]
+	AllowsUnauthenticated  plugin.TValue[bool]
 }
 
 // createGcpProjectCloudFunction creates a new instance of this resource
@@ -57503,6 +57880,26 @@ func (c *mqlGcpProjectCloudFunction) GetServiceAccount() *plugin.TValue[*mqlGcpP
 		}
 
 		return c.serviceAccount()
+	})
+}
+
+func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccount() *plugin.TValue[string] {
+	return &c.BuildServiceAccount
+}
+
+func (c *mqlGcpProjectCloudFunction) GetBuildServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.BuildServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "buildServiceAccountRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.buildServiceAccountRef()
 	})
 }
 
@@ -57800,6 +58197,9 @@ type mqlGcpProjectCloudFunctionV2BuildConfig struct {
 	DockerRepository     plugin.TValue[string]
 	ServiceAccount       plugin.TValue[string]
 	ServiceAccountRef    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Build                plugin.TValue[string]
+	SourceProvenance     plugin.TValue[any]
+	GitUri               plugin.TValue[string]
 }
 
 // createGcpProjectCloudFunctionV2BuildConfig creates a new instance of this resource
@@ -57885,6 +58285,18 @@ func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccountRef() *plugin
 
 		return c.serviceAccountRef()
 	})
+}
+
+func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetBuild() *plugin.TValue[string] {
+	return &c.Build
+}
+
+func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetSourceProvenance() *plugin.TValue[any] {
+	return &c.SourceProvenance
+}
+
+func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetGitUri() *plugin.TValue[string] {
+	return &c.GitUri
 }
 
 // mqlGcpProjectCloudFunctionV2ServiceConfig for the gcp.project.cloudFunctionV2.serviceConfig resource
@@ -60331,6 +60743,8 @@ type mqlGcpProjectCloudRunServiceService struct {
 	BinaryAuthorizationBreakglassJustification plugin.TValue[string]
 	Uid                                        plugin.TValue[string]
 	Etag                                       plugin.TValue[string]
+	Client                                     plugin.TValue[string]
+	ClientVersion                              plugin.TValue[string]
 	IamPolicy                                  plugin.TValue[[]any]
 	PublicInvocable                            plugin.TValue[bool]
 }
@@ -60506,6 +60920,14 @@ func (c *mqlGcpProjectCloudRunServiceService) GetUid() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectCloudRunServiceService) GetEtag() *plugin.TValue[string] {
 	return &c.Etag
+}
+
+func (c *mqlGcpProjectCloudRunServiceService) GetClient() *plugin.TValue[string] {
+	return &c.Client
+}
+
+func (c *mqlGcpProjectCloudRunServiceService) GetClientVersion() *plugin.TValue[string] {
+	return &c.ClientVersion
 }
 
 func (c *mqlGcpProjectCloudRunServiceService) GetIamPolicy() *plugin.TValue[[]any] {
@@ -68576,7 +68998,7 @@ func (c *mqlGcpProjectComputeServiceInstanceGroup) GetSelfLink() *plugin.TValue[
 type mqlGcpProjectComputeServiceInstanceGroupManager struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceInstanceGroupManagerInternal it will be used here
+	mqlGcpProjectComputeServiceInstanceGroupManagerInternal
 	Id                  plugin.TValue[string]
 	ProjectId           plugin.TValue[string]
 	Name                plugin.TValue[string]
@@ -68586,6 +69008,7 @@ type mqlGcpProjectComputeServiceInstanceGroupManager struct {
 	RegionUrl           plugin.TValue[string]
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	InstanceTemplateUrl plugin.TValue[string]
+	InstanceTemplate    plugin.TValue[*mqlGcpProjectComputeServiceInstanceTemplate]
 	TargetSize          plugin.TValue[int64]
 	CurrentActions      plugin.TValue[any]
 	StatefulPolicy      plugin.TValue[any]
@@ -68692,6 +69115,22 @@ func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetRegion() *plugin.TV
 
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetInstanceTemplateUrl() *plugin.TValue[string] {
 	return &c.InstanceTemplateUrl
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetInstanceTemplate() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceTemplate] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceInstanceTemplate](&c.InstanceTemplate, func() (*mqlGcpProjectComputeServiceInstanceTemplate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instanceGroupManager", c.__id, "instanceTemplate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceInstanceTemplate), nil
+			}
+		}
+
+		return c.instanceTemplate()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetTargetSize() *plugin.TValue[int64] {
@@ -74110,6 +74549,7 @@ type mqlGcpProjectComputeServiceInstanceTemplate struct {
 	Description       plugin.TValue[string]
 	SelfLink          plugin.TValue[string]
 	SourceInstance    plugin.TValue[string]
+	SourceInstanceRef plugin.TValue[*mqlGcpProjectComputeServiceInstance]
 	Properties        plugin.TValue[any]
 	CreationTimestamp plugin.TValue[*time.Time]
 }
@@ -74169,6 +74609,22 @@ func (c *mqlGcpProjectComputeServiceInstanceTemplate) GetSelfLink() *plugin.TVal
 
 func (c *mqlGcpProjectComputeServiceInstanceTemplate) GetSourceInstance() *plugin.TValue[string] {
 	return &c.SourceInstance
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceTemplate) GetSourceInstanceRef() *plugin.TValue[*mqlGcpProjectComputeServiceInstance] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceInstance](&c.SourceInstanceRef, func() (*mqlGcpProjectComputeServiceInstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instanceTemplate", c.__id, "sourceInstanceRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceInstance), nil
+			}
+		}
+
+		return c.sourceInstanceRef()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceTemplate) GetProperties() *plugin.TValue[any] {

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4310,7 +4310,10 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDiskId()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDisk()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.snapshot.sourceDiskRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceDiskRef()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
 	"gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceSnapshotSchedulePolicy()).ToDataRes(types.String)
@@ -19820,7 +19823,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"gcp.project.computeService.snapshot.sourceDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
+		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDisk, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.snapshot.sourceDiskRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).SourceDiskRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -45599,7 +45606,8 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	SatisfiesPzi                   plugin.TValue[bool]
 	SatisfiesPzs                   plugin.TValue[bool]
 	SourceDiskId                   plugin.TValue[string]
-	SourceDisk                     plugin.TValue[*mqlGcpProjectComputeServiceDisk]
+	SourceDisk                     plugin.TValue[string]
+	SourceDiskRef                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 	SourceSnapshotSchedulePolicy   plugin.TValue[string]
 	SourceSnapshotSchedulePolicyId plugin.TValue[string]
 	KmsKey                         plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
@@ -45733,10 +45741,14 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDiskId() *plugin.TValue[s
 	return &c.SourceDiskId
 }
 
-func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[*mqlGcpProjectComputeServiceDisk] {
-	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceDisk](&c.SourceDisk, func() (*mqlGcpProjectComputeServiceDisk, error) {
+func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[string] {
+	return &c.SourceDisk
+}
+
+func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDiskRef() *plugin.TValue[*mqlGcpProjectComputeServiceDisk] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceDisk](&c.SourceDiskRef, func() (*mqlGcpProjectComputeServiceDisk, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.snapshot", c.__id, "sourceDisk")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.snapshot", c.__id, "sourceDiskRef")
 			if err != nil {
 				return nil, err
 			}
@@ -45745,7 +45757,7 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceDisk() *plugin.TValue[*mq
 			}
 		}
 
-		return c.sourceDisk()
+		return c.sourceDiskRef()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -91,9 +91,12 @@ gcp.folder.loggingService.sink.name 13.16.3
 gcp.folder.loggingService.sink.updated 13.16.3
 gcp.folder.loggingService.sink.writerIdentity 13.16.3
 gcp.folder.loggingService.sinks 13.16.3
+gcp.folder.managementProject 13.25.2
 gcp.folder.name 9.0.0
 gcp.folder.orgPolicies 13.16.3
+gcp.folder.parentFolder 13.25.2
 gcp.folder.parentId 9.0.0
+gcp.folder.parentOrganization 13.25.2
 gcp.folder.projects 9.0.0
 gcp.folder.state 9.0.0
 gcp.folder.updated 9.0.0
@@ -686,6 +689,8 @@ gcp.project.bigqueryService.routine.modified 9.0.0
 gcp.project.bigqueryService.routine.projectId 9.0.0
 gcp.project.bigqueryService.routine.type 9.0.0
 gcp.project.bigqueryService.table 9.0.0
+gcp.project.bigqueryService.table.cloneBaseTable 13.25.2
+gcp.project.bigqueryService.table.cloneTime 13.25.2
 gcp.project.bigqueryService.table.clusteringFields 9.0.0
 gcp.project.bigqueryService.table.created 9.0.0
 gcp.project.bigqueryService.table.datasetId 9.0.0
@@ -710,6 +715,7 @@ gcp.project.bigqueryService.table.public 13.21.2
 gcp.project.bigqueryService.table.rangePartitioning 9.0.0
 gcp.project.bigqueryService.table.requirePartitionFilter 9.0.0
 gcp.project.bigqueryService.table.schema 9.0.0
+gcp.project.bigqueryService.table.snapshotBaseTable 13.25.2
 gcp.project.bigqueryService.table.snapshotTime 9.0.0
 gcp.project.bigqueryService.table.timePartitioning 9.0.0
 gcp.project.bigqueryService.table.type 9.0.0
@@ -1112,6 +1118,8 @@ gcp.project.cloudFunction.availableMemoryMb 9.0.0
 gcp.project.cloudFunction.buildEnvVars 9.0.0
 gcp.project.cloudFunction.buildId 9.0.0
 gcp.project.cloudFunction.buildName 9.0.0
+gcp.project.cloudFunction.buildServiceAccount 13.25.2
+gcp.project.cloudFunction.buildServiceAccountRef 13.25.2
 gcp.project.cloudFunction.buildWorkerPool 9.0.0
 gcp.project.cloudFunction.description 9.0.0
 gcp.project.cloudFunction.dockerRegistry 9.0.0
@@ -1149,15 +1157,18 @@ gcp.project.cloudFunction.vpcConnector 9.0.0
 gcp.project.cloudFunctionV2 13.7.2
 gcp.project.cloudFunctionV2.allowsUnauthenticated 13.19.2
 gcp.project.cloudFunctionV2.buildConfig 13.7.2
+gcp.project.cloudFunctionV2.buildConfig.build 13.25.2
 gcp.project.cloudFunctionV2.buildConfig.buildWorkerPool 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.dockerRepository 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.entryPoint 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.environmentVariables 13.7.2
+gcp.project.cloudFunctionV2.buildConfig.gitUri 13.25.2
 gcp.project.cloudFunctionV2.buildConfig.id 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.runtime 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.serviceAccount 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef 13.21.2
 gcp.project.cloudFunctionV2.buildConfig.source 13.7.2
+gcp.project.cloudFunctionV2.buildConfig.sourceProvenance 13.25.2
 gcp.project.cloudFunctionV2.createTime 13.7.2
 gcp.project.cloudFunctionV2.description 13.7.2
 gcp.project.cloudFunctionV2.environment 13.7.2
@@ -1291,6 +1302,8 @@ gcp.project.cloudRunService.service.annotations 9.0.0
 gcp.project.cloudRunService.service.binaryAuthorization 13.7.2
 gcp.project.cloudRunService.service.binaryAuthorizationBreakglassJustification 13.18.1
 gcp.project.cloudRunService.service.binaryAuthorizationUseDefault 13.18.1
+gcp.project.cloudRunService.service.client 13.25.2
+gcp.project.cloudRunService.service.clientVersion 13.25.2
 gcp.project.cloudRunService.service.conditions 9.0.0
 gcp.project.cloudRunService.service.created 9.0.0
 gcp.project.cloudRunService.service.creator 9.0.0
@@ -1551,10 +1564,13 @@ gcp.project.computeService.disk.satisfiesPzi 13.1.2
 gcp.project.computeService.disk.satisfiesPzs 13.1.2
 gcp.project.computeService.disk.sizeGb 9.0.0
 gcp.project.computeService.disk.sourceDisk 13.1.2
+gcp.project.computeService.disk.sourceDiskId 13.25.2
 gcp.project.computeService.disk.sourceImage 11.6.6
 gcp.project.computeService.disk.sourceImageEncryptionKey 13.16.3
+gcp.project.computeService.disk.sourceImageId 13.25.2
 gcp.project.computeService.disk.sourceSnapshot 11.6.6
 gcp.project.computeService.disk.sourceSnapshotEncryptionKey 13.16.3
+gcp.project.computeService.disk.sourceSnapshotId 13.25.2
 gcp.project.computeService.disk.status 9.0.0
 gcp.project.computeService.disk.storagePool 11.6.6
 gcp.project.computeService.disk.type 11.6.6
@@ -1711,8 +1727,11 @@ gcp.project.computeService.image.satisfiesPzi 11.6.6
 gcp.project.computeService.image.satisfiesPzs 11.6.6
 gcp.project.computeService.image.shieldedInstanceInitialState 13.19.2
 gcp.project.computeService.image.sourceDisk 13.1.2
+gcp.project.computeService.image.sourceDiskId 13.25.2
 gcp.project.computeService.image.sourceImage 13.1.2
+gcp.project.computeService.image.sourceImageId 13.25.2
 gcp.project.computeService.image.sourceSnapshot 13.1.2
+gcp.project.computeService.image.sourceSnapshotId 13.25.2
 gcp.project.computeService.image.status 9.0.0
 gcp.project.computeService.image.storageLocations 13.1.2
 gcp.project.computeService.images 9.0.0
@@ -1846,6 +1865,7 @@ gcp.project.computeService.instanceGroupManager.currentActions 11.6.6
 gcp.project.computeService.instanceGroupManager.description 11.6.6
 gcp.project.computeService.instanceGroupManager.id 11.6.6
 gcp.project.computeService.instanceGroupManager.instanceGroupUrl 11.6.6
+gcp.project.computeService.instanceGroupManager.instanceTemplate 13.25.2
 gcp.project.computeService.instanceGroupManager.instanceTemplateUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.name 11.6.6
 gcp.project.computeService.instanceGroupManager.projectId 11.6.6
@@ -1867,6 +1887,7 @@ gcp.project.computeService.instanceTemplate.name 13.7.2
 gcp.project.computeService.instanceTemplate.properties 13.7.2
 gcp.project.computeService.instanceTemplate.selfLink 13.7.2
 gcp.project.computeService.instanceTemplate.sourceInstance 13.7.2
+gcp.project.computeService.instanceTemplate.sourceInstanceRef 13.25.2
 gcp.project.computeService.instanceTemplates 13.7.2
 gcp.project.computeService.instances 9.0.0
 gcp.project.computeService.interconnect 13.6.1
@@ -2173,6 +2194,7 @@ gcp.project.computeService.snapshot.satisfiesPzs 11.6.6
 gcp.project.computeService.snapshot.snapshotEncryptionKey 13.19.2
 gcp.project.computeService.snapshot.snapshotType 9.0.0
 gcp.project.computeService.snapshot.sourceDisk 11.6.6
+gcp.project.computeService.snapshot.sourceDiskId 13.25.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy 13.1.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicyId 13.1.2
 gcp.project.computeService.snapshot.status 9.0.0
@@ -4002,7 +4024,9 @@ gcp.project.osConfigService.patchDeployment.state 13.15.1
 gcp.project.osConfigService.patchDeployment.updated 13.15.1
 gcp.project.osConfigService.patchDeployments 13.15.1
 gcp.project.osConfigService.projectId 13.15.1
+gcp.project.parentFolder 13.25.2
 gcp.project.parentId 9.0.0
+gcp.project.parentOrganization 13.25.2
 gcp.project.primitiveRoleBindings 13.12.2
 gcp.project.pubsub 9.0.0
 gcp.project.pubsubService 9.0.0
@@ -4463,6 +4487,7 @@ gcp.project.sqlService.instance.ipMapping.type 9.0.0
 gcp.project.sqlService.instance.kmsKey 13.12.2
 gcp.project.sqlService.instance.localRootEnabled 13.12.2
 gcp.project.sqlService.instance.maintenanceVersion 9.0.0
+gcp.project.sqlService.instance.master 13.25.2
 gcp.project.sqlService.instance.masterInstanceName 9.0.0
 gcp.project.sqlService.instance.maxDiskSize 9.0.0
 gcp.project.sqlService.instance.name 9.0.0
@@ -4474,6 +4499,7 @@ gcp.project.sqlService.instance.publicIpEnabled 13.12.2
 gcp.project.sqlService.instance.region 9.0.0
 gcp.project.sqlService.instance.replicaConfiguration 13.7.2
 gcp.project.sqlService.instance.replicaNames 9.0.0
+gcp.project.sqlService.instance.replicas 13.25.2
 gcp.project.sqlService.instance.replicationCluster 13.16.3
 gcp.project.sqlService.instance.satisfiesPzi 11.6.6
 gcp.project.sqlService.instance.satisfiesPzs 11.6.6

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1119,7 +1119,6 @@ gcp.project.cloudFunction.buildEnvVars 9.0.0
 gcp.project.cloudFunction.buildId 9.0.0
 gcp.project.cloudFunction.buildName 9.0.0
 gcp.project.cloudFunction.buildServiceAccount 13.25.2
-gcp.project.cloudFunction.buildServiceAccountRef 13.25.2
 gcp.project.cloudFunction.buildWorkerPool 9.0.0
 gcp.project.cloudFunction.description 9.0.0
 gcp.project.cloudFunction.dockerRegistry 9.0.0
@@ -1564,13 +1563,10 @@ gcp.project.computeService.disk.satisfiesPzi 13.1.2
 gcp.project.computeService.disk.satisfiesPzs 13.1.2
 gcp.project.computeService.disk.sizeGb 9.0.0
 gcp.project.computeService.disk.sourceDisk 13.1.2
-gcp.project.computeService.disk.sourceDiskId 13.25.2
 gcp.project.computeService.disk.sourceImage 11.6.6
 gcp.project.computeService.disk.sourceImageEncryptionKey 13.16.3
-gcp.project.computeService.disk.sourceImageId 13.25.2
 gcp.project.computeService.disk.sourceSnapshot 11.6.6
 gcp.project.computeService.disk.sourceSnapshotEncryptionKey 13.16.3
-gcp.project.computeService.disk.sourceSnapshotId 13.25.2
 gcp.project.computeService.disk.status 9.0.0
 gcp.project.computeService.disk.storagePool 11.6.6
 gcp.project.computeService.disk.type 11.6.6
@@ -1727,11 +1723,8 @@ gcp.project.computeService.image.satisfiesPzi 11.6.6
 gcp.project.computeService.image.satisfiesPzs 11.6.6
 gcp.project.computeService.image.shieldedInstanceInitialState 13.19.2
 gcp.project.computeService.image.sourceDisk 13.1.2
-gcp.project.computeService.image.sourceDiskId 13.25.2
 gcp.project.computeService.image.sourceImage 13.1.2
-gcp.project.computeService.image.sourceImageId 13.25.2
 gcp.project.computeService.image.sourceSnapshot 13.1.2
-gcp.project.computeService.image.sourceSnapshotId 13.25.2
 gcp.project.computeService.image.status 9.0.0
 gcp.project.computeService.image.storageLocations 13.1.2
 gcp.project.computeService.images 9.0.0
@@ -2194,7 +2187,6 @@ gcp.project.computeService.snapshot.satisfiesPzs 11.6.6
 gcp.project.computeService.snapshot.snapshotEncryptionKey 13.19.2
 gcp.project.computeService.snapshot.snapshotType 9.0.0
 gcp.project.computeService.snapshot.sourceDisk 11.6.6
-gcp.project.computeService.snapshot.sourceDiskId 13.25.2
 gcp.project.computeService.snapshot.sourceDiskRef 13.25.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy 13.1.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicyId 13.1.2

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -2195,6 +2195,7 @@ gcp.project.computeService.snapshot.snapshotEncryptionKey 13.19.2
 gcp.project.computeService.snapshot.snapshotType 9.0.0
 gcp.project.computeService.snapshot.sourceDisk 11.6.6
 gcp.project.computeService.snapshot.sourceDiskId 13.25.2
+gcp.project.computeService.snapshot.sourceDiskRef 13.25.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicy 13.1.2
 gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicyId 13.1.2
 gcp.project.computeService.snapshot.status 9.0.0

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -89,6 +89,36 @@ func (g *mqlGcpProject) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProject) parentFolder() (*mqlGcpFolder, error) {
+	parentId := g.GetParentId()
+	if parentId.Error != nil {
+		return nil, parentId.Error
+	}
+	f, err := parentFolderFromId(parentId.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		g.ParentFolder.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return f, nil
+}
+
+func (g *mqlGcpProject) parentOrganization() (*mqlGcpOrganization, error) {
+	parentId := g.GetParentId()
+	if parentId.Error != nil {
+		return nil, parentId.Error
+	}
+	o, err := parentOrganizationFromId(parentId.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if o == nil {
+		g.ParentOrganization.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return o, nil
+}
+
 func (g *mqlGcpProject) name() (string, error) {
 	// placeholder to convince MQL that this is an optional field
 	// should never be called since the data is initialized in init

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -94,6 +95,86 @@ func initGcpProjectSqlServiceInstance(runtime *plugin.Runtime, args map[string]*
 	}
 
 	return nil, nil, errors.New("SQL instance not found")
+}
+
+// getSqlInstanceByName resolves a sibling Cloud SQL instance by its name within
+// the same project. MasterInstanceName / ReplicaNames carry bare instance names
+// (sometimes prefixed with "project:"), so the lookup lists the project's
+// instances and matches by name rather than going through the region-keyed init.
+// Returns nil when no instance with that name exists in the project (for example
+// a cross-project replication pair).
+func getSqlInstanceByName(runtime *plugin.Runtime, projectId, name string) (*mqlGcpProjectSqlServiceInstance, error) {
+	if name == "" {
+		return nil, nil
+	}
+	if i := strings.LastIndex(name, ":"); i >= 0 {
+		name = name[i+1:]
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.sqlService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	sqlSvc := obj.(*mqlGcpProjectSqlService)
+	instances := sqlSvc.GetInstances()
+	if instances.Error != nil {
+		return nil, instances.Error
+	}
+
+	for _, inst := range instances.Data {
+		instance := inst.(*mqlGcpProjectSqlServiceInstance)
+		n := instance.GetName()
+		if n.Error != nil {
+			return nil, n.Error
+		}
+		if n.Data == name {
+			return instance, nil
+		}
+	}
+	return nil, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) master() (*mqlGcpProjectSqlServiceInstance, error) {
+	if g.MasterInstanceName.Error != nil {
+		return nil, g.MasterInstanceName.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	master, err := getSqlInstanceByName(g.MqlRuntime, g.ProjectId.Data, g.MasterInstanceName.Data)
+	if err != nil {
+		return nil, err
+	}
+	if master == nil {
+		g.Master.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return master, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) replicas() ([]any, error) {
+	if g.ReplicaNames.Error != nil {
+		return nil, g.ReplicaNames.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	res := []any{}
+	for _, raw := range g.ReplicaNames.Data {
+		name, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		replica, err := getSqlInstanceByName(g.MqlRuntime, g.ProjectId.Data, name)
+		if err != nil {
+			return nil, err
+		}
+		if replica != nil {
+			res = append(res, replica)
+		}
+	}
+	return res, nil
 }
 
 // sqlIPMappingID returns a cache-stable identifier for a Cloud SQL instance


### PR DESCRIPTION
## What

Exposes **source, hierarchy, and build provenance** across GCP resources — the metadata that answers "where does this resource sit in the org, what was it created from, and how/by whom was it built." Every value that names a modeled resource is a typed accessor (backed by the `cache*`/Internal-struct pattern or `NewResource` lookups); genuinely opaque or scalar values stay plain. All SDK fields were re-verified against the GCP Go SDKs before wiring.

### Hierarchy (resource-manager parentage)
| Resource | Accessor |
|---|---|
| `gcp.folder` | `parentFolder()`, `parentOrganization()`, `managementProject` |
| `gcp.project` | `parentFolder()`, `parentOrganization()` |

`parentFolder()` / `parentOrganization()` resolve the immediate parent depending on where the folder/project sits, letting you walk the org hierarchy directly.

### Source / lineage (what a resource was created from)
| Resource | Accessor |
|---|---|
| `gcp.project.computeService.snapshot` | `sourceDiskRef()` (typed; raw `sourceDisk` URL retained) |
| `gcp.project.computeService.instanceTemplate` | `sourceInstanceRef()` |
| `gcp.project.computeService.instanceGroupManager` | `instanceTemplate()` |
| `gcp.project.sqlService.instance` | `master()`, `replicas()` (replication topology) |
| `gcp.project.bigqueryService.table` | `snapshotBaseTable()`, `cloneBaseTable()`, `cloneTime` |

### Build provenance (how an artifact was built / who deployed it)
| Resource | Field |
|---|---|
| `gcp.project.cloudFunction` | `buildServiceAccount()` |
| `gcp.project.cloudFunctionV2.buildConfig` | `build`, `sourceProvenance`, `gitUri` |
| `gcp.project.cloudRunService.service` | `client`, `clientVersion` |

## Notes
- **Typed-reference gate:** every ID/URL that names a modeled resource is a typed accessor, not a raw string. `managementProject` stays a raw string (folder management projects aren't modeled as a queryable `gcp.project`); the Cloud Functions v2 `sourceProvenance` stays a `dict` (heterogeneous build-source bag with no single typed target).
- **No redundant ID duplicates:** the compute disk/snapshot/image `source*Id` strings were dropped — they duplicated the existing typed source accessors (`sourceDisk`/`sourceImage`/`sourceSnapshot` and `snapshot.sourceDiskRef`). The Cloud Function build SA is a single typed `buildServiceAccount()` rather than a raw email plus a separate `buildServiceAccountRef()`.
- New `.lr.versions` entries auto-assigned at the next patch; no `config.go` version bump.

## Test
`go build ./...` clean; gofmt applied; generated code in sync (`mqlr generate` produces no diff).
