### PR TITLE
⭐ oci: expose ownership, creator, and source provenance

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -117,6 +117,7 @@ func (o *mqlOciApigateway) getGateways(conn *connection.OciConnection, regions [
 					"timeUpdated":   llx.TimeDataPtr(updated),
 					"freeformTags":  llx.MapData(freeformTags, types.String),
 					"definedTags":   llx.MapData(definedTags, types.Any),
+					"systemTags":    llx.MapData(definedTagsToAny(g.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -368,6 +369,7 @@ func (o *mqlOciApigateway) getDeployments(conn *connection.OciConnection, region
 					"timeUpdated":   llx.TimeDataPtr(updated),
 					"freeformTags":  llx.MapData(freeformTags, types.String),
 					"definedTags":   llx.MapData(definedTags, types.Any),
+					"systemTags":    llx.MapData(definedTagsToAny(d.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -790,6 +792,7 @@ func (o *mqlOciApigateway) getCertificates(conn *connection.OciConnection, regio
 					"timeUpdated":       llx.TimeDataPtr(updated),
 					"freeformTags":      llx.MapData(freeformTags, types.String),
 					"definedTags":       llx.MapData(definedTags, types.Any),
+					"systemTags":        llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciBastion) id() (string, error) {
@@ -105,6 +106,7 @@ func (o *mqlOciBastion) getBastions(conn *connection.OciConnection, regions []an
 					"dnsProxyStatus": llx.StringData(string(b.DnsProxyStatus)),
 					"created":        llx.TimeDataPtr(created),
 					"timeUpdated":    llx.TimeDataPtr(timeUpdated),
+					"systemTags":     llx.MapData(definedTagsToAny(b.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -421,6 +421,36 @@ func (o *mqlOciObjectStorageBucket) definedTags() (map[string]interface{}, error
 	return tags, nil
 }
 
+func (o *mqlOciObjectStorageBucket) createdBy() (string, error) {
+	bucketInfo, err := o.getBucketDetails()
+	if err != nil {
+		return "", err
+	}
+	if bucketInfo.CreatedBy == nil {
+		return "", nil
+	}
+	return *bucketInfo.CreatedBy, nil
+}
+
+func (o *mqlOciObjectStorageBucket) createdByUser() (*mqlOciIdentityUser, error) {
+	bucketInfo, err := o.getBucketDetails()
+	if err != nil {
+		return nil, err
+	}
+	createdBy := stringValue(bucketInfo.CreatedBy)
+	if !strings.HasPrefix(createdBy, "ocid1.user.") {
+		o.CreatedByUser.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.identity.user", map[string]*llx.RawData{
+		"id": llx.StringData(createdBy),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciIdentityUser), nil
+}
+
 func (o *mqlOciObjectStorageBucket) retentionRules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -163,6 +163,7 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 			"state":              llx.StringData(string(target.LifecycleState)),
 			"recipeCount":        llx.IntDataPtr(target.RecipeCount),
 			"created":            llx.TimeDataPtr(created),
+			"systemTags":         llx.MapData(definedTagsToAny(target.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -216,13 +217,15 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 		}
 
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.detectorRecipe", map[string]*llx.RawData{
-			"id":           llx.StringDataPtr(recipe.Id),
-			"name":         llx.StringDataPtr(recipe.DisplayName),
-			"description":  llx.StringDataPtr(recipe.Description),
-			"owner":        llx.StringData(string(recipe.Owner)),
-			"detectorType": llx.StringData(string(recipe.Detector)),
-			"state":        llx.StringData(string(recipe.LifecycleState)),
-			"created":      llx.TimeDataPtr(created),
+			"id":            llx.StringDataPtr(recipe.Id),
+			"name":          llx.StringDataPtr(recipe.DisplayName),
+			"description":   llx.StringDataPtr(recipe.Description),
+			"compartmentId": llx.StringDataPtr(recipe.CompartmentId),
+			"owner":         llx.StringData(string(recipe.Owner)),
+			"detectorType":  llx.StringData(string(recipe.Detector)),
+			"state":         llx.StringData(string(recipe.LifecycleState)),
+			"created":       llx.TimeDataPtr(created),
+			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -283,6 +286,7 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 			"isInheritanceAfterDeleteEnabled": llx.BoolDataPtr(zone.IsInheritanceAfterDeleteEnabled),
 			"state":                           llx.StringData(string(zone.LifecycleState)),
 			"created":                         llx.TimeDataPtr(created),
+			"systemTags":                      llx.MapData(definedTagsToAny(zone.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -345,6 +349,7 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 			"owner":         llx.StringData(string(recipe.Owner)),
 			"state":         llx.StringData(string(recipe.LifecycleState)),
 			"created":       llx.TimeDataPtr(created),
+			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -415,6 +420,7 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 			"services":      llx.ArrayData(services, types.String),
 			"state":         llx.StringData(string(policy.LifecycleState)),
 			"created":       llx.TimeDataPtr(created),
+			"systemTags":    llx.MapData(definedTagsToAny(policy.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -220,7 +220,7 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 			"id":            llx.StringDataPtr(recipe.Id),
 			"name":          llx.StringDataPtr(recipe.DisplayName),
 			"description":   llx.StringDataPtr(recipe.Description),
-			"compartmentId": llx.StringDataPtr(recipe.CompartmentId),
+			"compartmentID": llx.StringDataPtr(recipe.CompartmentId),
 			"owner":         llx.StringData(string(recipe.Owner)),
 			"detectorType":  llx.StringData(string(recipe.Detector)),
 			"state":         llx.StringData(string(recipe.LifecycleState)),

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -207,12 +207,16 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					"timeMaintenanceRebootDue":    llx.TimeDataPtr(timeMaintenanceRebootDue),
 					"freeformTags":                llx.MapData(freeformTags, types.String),
 					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"systemTags":                  llx.MapData(definedTagsToAny(instance.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
 				}
 				mqlInst := mqlInstance.(*mqlOciComputeInstance)
 				mqlInst.cacheRegion = regionResource.Id.Data
+				if src, ok := instance.SourceDetails.(core.InstanceSourceViaBootVolumeDetails); ok {
+					mqlInst.cacheBootVolumeID = stringValue(src.BootVolumeId)
+				}
 				res = append(res, mqlInst)
 			}
 
@@ -224,7 +228,8 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 }
 
 type mqlOciComputeInstanceInternal struct {
-	cacheRegion string
+	cacheRegion       string
+	cacheBootVolumeID string
 }
 
 func (o *mqlOciComputeInstance) id() (string, error) {
@@ -466,6 +471,7 @@ func (o *mqlOciCompute) getComputeImage(conn *connection.OciConnection, regions 
 				if err != nil {
 					return nil, err
 				}
+				mqlInstance.(*mqlOciComputeImage).cacheBaseImageID = stringValue(image.BaseImageId)
 				res = append(res, mqlInstance)
 			}
 
@@ -474,6 +480,10 @@ func (o *mqlOciCompute) getComputeImage(conn *connection.OciConnection, regions 
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+type mqlOciComputeImageInternal struct {
+	cacheBaseImageID string
 }
 
 func (o *mqlOciComputeImage) id() (string, error) {
@@ -563,23 +573,35 @@ func (o *mqlOciCompute) getBlockVolumes(conn *connection.OciConnection, regions 
 					created = &vol.TimeCreated.Time
 				}
 
+				var sourceVolumeID, sourceVolumeBackupID string
+				switch d := vol.SourceDetails.(type) {
+				case core.VolumeSourceFromVolumeDetails:
+					sourceVolumeID = stringValue(d.Id)
+				case core.VolumeSourceFromVolumeBackupDetails:
+					sourceVolumeBackupID = stringValue(d.Id)
+				}
+
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.compute.blockVolume", map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(vol.Id),
-					"name":               llx.StringDataPtr(vol.DisplayName),
-					"compartmentID":      llx.StringDataPtr(vol.CompartmentId),
-					"availabilityDomain": llx.StringDataPtr(vol.AvailabilityDomain),
-					"sizeInGBs":          llx.IntDataPtr(vol.SizeInGBs),
-					"vpusPerGB":          llx.IntDataPtr(vol.VpusPerGB),
-					"state":              llx.StringData(string(vol.LifecycleState)),
-					"isHydrated":         llx.BoolDataPtr(vol.IsHydrated),
-					"isAutoTuneEnabled":  llx.BoolDataPtr(vol.IsAutoTuneEnabled),
-					"created":            llx.TimeDataPtr(created),
+					"id":                   llx.StringDataPtr(vol.Id),
+					"name":                 llx.StringDataPtr(vol.DisplayName),
+					"compartmentID":        llx.StringDataPtr(vol.CompartmentId),
+					"availabilityDomain":   llx.StringDataPtr(vol.AvailabilityDomain),
+					"sizeInGBs":            llx.IntDataPtr(vol.SizeInGBs),
+					"vpusPerGB":            llx.IntDataPtr(vol.VpusPerGB),
+					"state":                llx.StringData(string(vol.LifecycleState)),
+					"isHydrated":           llx.BoolDataPtr(vol.IsHydrated),
+					"isAutoTuneEnabled":    llx.BoolDataPtr(vol.IsAutoTuneEnabled),
+					"sourceVolumeBackupId": llx.StringData(sourceVolumeBackupID),
+					"created":              llx.TimeDataPtr(created),
+					"systemTags":           llx.MapData(definedTagsToAny(vol.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
 				}
-				mqlInstance.(*mqlOciComputeBlockVolume).cacheKmsKeyId = stringValue(vol.KmsKeyId)
-				res = append(res, mqlInstance)
+				mqlBV := mqlInstance.(*mqlOciComputeBlockVolume)
+				mqlBV.cacheKmsKeyId = stringValue(vol.KmsKeyId)
+				mqlBV.cacheSourceVolumeID = sourceVolumeID
+				res = append(res, mqlBV)
 			}
 
 			return jobpool.JobResult(res), nil
@@ -590,7 +612,8 @@ func (o *mqlOciCompute) getBlockVolumes(conn *connection.OciConnection, regions 
 }
 
 type mqlOciComputeBlockVolumeInternal struct {
-	cacheKmsKeyId string
+	cacheKmsKeyId       string
+	cacheSourceVolumeID string
 }
 
 func (o *mqlOciComputeBlockVolume) id() (string, error) {
@@ -694,21 +717,33 @@ func (o *mqlOciCompute) getBootVolumes(conn *connection.OciConnection, regions [
 					created = &bv.TimeCreated.Time
 				}
 
+				var sourceBootVolumeID, sourceBootVolumeBackupID string
+				switch d := bv.SourceDetails.(type) {
+				case core.BootVolumeSourceFromBootVolumeDetails:
+					sourceBootVolumeID = stringValue(d.Id)
+				case core.BootVolumeSourceFromBootVolumeBackupDetails:
+					sourceBootVolumeBackupID = stringValue(d.Id)
+				}
+
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(bv.Id),
-					"name":               llx.StringDataPtr(bv.DisplayName),
-					"compartmentID":      llx.StringDataPtr(bv.CompartmentId),
-					"availabilityDomain": llx.StringDataPtr(bv.AvailabilityDomain),
-					"sizeInGBs":          llx.IntDataPtr(bv.SizeInGBs),
-					"imageId":            llx.StringDataPtr(bv.ImageId),
-					"state":              llx.StringData(string(bv.LifecycleState)),
-					"created":            llx.TimeDataPtr(created),
+					"id":                       llx.StringDataPtr(bv.Id),
+					"name":                     llx.StringDataPtr(bv.DisplayName),
+					"compartmentID":            llx.StringDataPtr(bv.CompartmentId),
+					"availabilityDomain":       llx.StringDataPtr(bv.AvailabilityDomain),
+					"sizeInGBs":                llx.IntDataPtr(bv.SizeInGBs),
+					"imageId":                  llx.StringDataPtr(bv.ImageId),
+					"state":                    llx.StringData(string(bv.LifecycleState)),
+					"sourceBootVolumeBackupId": llx.StringData(sourceBootVolumeBackupID),
+					"created":                  llx.TimeDataPtr(created),
+					"systemTags":               llx.MapData(definedTagsToAny(bv.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
 				}
-				mqlInstance.(*mqlOciComputeBootVolume).cacheKmsKeyId = stringValue(bv.KmsKeyId)
-				res = append(res, mqlInstance)
+				mqlBV := mqlInstance.(*mqlOciComputeBootVolume)
+				mqlBV.cacheKmsKeyId = stringValue(bv.KmsKeyId)
+				mqlBV.cacheSourceBootVolumeID = sourceBootVolumeID
+				res = append(res, mqlBV)
 			}
 
 			return jobpool.JobResult(res), nil
@@ -719,7 +754,8 @@ func (o *mqlOciCompute) getBootVolumes(conn *connection.OciConnection, regions [
 }
 
 type mqlOciComputeBootVolumeInternal struct {
-	cacheKmsKeyId string
+	cacheKmsKeyId           string
+	cacheSourceBootVolumeID string
 }
 
 func (o *mqlOciComputeBootVolume) id() (string, error) {

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -128,6 +128,7 @@ func (o *mqlOciContainerInstances) getContainerInstances(conn *connection.OciCon
 					"timeUpdated":                      llx.TimeDataPtr(timeUpdated),
 					"freeformTags":                     llx.MapData(freeformTags, types.String),
 					"definedTags":                      llx.MapData(definedTags, types.Any),
+					"systemTags":                       llx.MapData(definedTagsToAny(ci.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -221,6 +222,7 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 			"timeUpdated":                 llx.TimeDataPtr(timeUpdated),
 			"freeformTags":                llx.MapData(freeformTags, types.String),
 			"definedTags":                 llx.MapData(definedTags, types.Any),
+			"systemTags":                  llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -117,7 +117,6 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 					"domain":               llx.StringDataPtr(s.Domain),
 					"listenerPort":         llx.IntData(intValue(s.ListenerPort)),
 					"scanDnsName":          llx.StringDataPtr(s.ScanDnsName),
-					"sourceDbSystemId":     llx.StringDataPtr(s.SourceDbSystemId),
 					"version":              llx.StringDataPtr(s.Version),
 					"cpuCoreCount":         llx.IntData(intValue(s.CpuCoreCount)),
 					"nodeCount":            llx.IntData(intValue(s.NodeCount)),
@@ -137,6 +136,7 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 				mqlDb := mqlInstance.(*mqlOciDatabaseDbSystem)
 				mqlDb.cacheKmsKeyId = stringValue(s.KmsKeyId)
 				mqlDb.cacheSubnetId = stringValue(s.SubnetId)
+				mqlDb.cacheSourceDbSystemId = stringValue(s.SourceDbSystemId)
 				res = append(res, mqlDb)
 			}
 
@@ -148,8 +148,9 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 }
 
 type mqlOciDatabaseDbSystemInternal struct {
-	cacheKmsKeyId string
-	cacheSubnetId string
+	cacheKmsKeyId         string
+	cacheSubnetId         string
+	cacheSourceDbSystemId string
 }
 
 func (o *mqlOciDatabaseDbSystem) id() (string, error) {
@@ -287,7 +288,6 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 					"name":                        llx.StringDataPtr(a.DisplayName),
 					"compartmentID":               llx.StringDataPtr(a.CompartmentId),
 					"dbName":                      llx.StringDataPtr(a.DbName),
-					"sourceId":                    llx.StringDataPtr(a.SourceId),
 					"isRefreshableClone":          llx.BoolDataPtr(a.IsRefreshableClone),
 					"dbVersion":                   llx.StringDataPtr(a.DbVersion),
 					"dbWorkload":                  llx.StringData(string(a.DbWorkload)),
@@ -327,6 +327,7 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 				mqlAdb.cacheKmsKeyId = stringValue(a.KmsKeyId)
 				mqlAdb.cacheVaultId = stringValue(a.VaultId)
 				mqlAdb.cacheSubnetId = stringValue(a.SubnetId)
+				mqlAdb.cacheSourceId = stringValue(a.SourceId)
 				res = append(res, mqlAdb)
 			}
 
@@ -341,6 +342,7 @@ type mqlOciDatabaseAutonomousDatabaseInternal struct {
 	cacheKmsKeyId string
 	cacheVaultId  string
 	cacheSubnetId string
+	cacheSourceId string
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) id() (string, error) {

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -117,6 +117,7 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 					"domain":               llx.StringDataPtr(s.Domain),
 					"listenerPort":         llx.IntData(intValue(s.ListenerPort)),
 					"scanDnsName":          llx.StringDataPtr(s.ScanDnsName),
+					"sourceDbSystemId":     llx.StringDataPtr(s.SourceDbSystemId),
 					"version":              llx.StringDataPtr(s.Version),
 					"cpuCoreCount":         llx.IntData(intValue(s.CpuCoreCount)),
 					"nodeCount":            llx.IntData(intValue(s.NodeCount)),
@@ -128,6 +129,7 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 					"created":              llx.TimeDataPtr(created),
 					"freeformTags":         llx.MapData(freeformTags, types.String),
 					"definedTags":          llx.MapData(definedTags, types.Any),
+					"systemTags":           llx.MapData(definedTagsToAny(s.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -285,6 +287,8 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 					"name":                        llx.StringDataPtr(a.DisplayName),
 					"compartmentID":               llx.StringDataPtr(a.CompartmentId),
 					"dbName":                      llx.StringDataPtr(a.DbName),
+					"sourceId":                    llx.StringDataPtr(a.SourceId),
+					"isRefreshableClone":          llx.BoolDataPtr(a.IsRefreshableClone),
 					"dbVersion":                   llx.StringDataPtr(a.DbVersion),
 					"dbWorkload":                  llx.StringData(string(a.DbWorkload)),
 					"isDedicated":                 llx.BoolDataPtr(a.IsDedicated),
@@ -314,6 +318,7 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 					"created":                     llx.TimeDataPtr(created),
 					"freeformTags":                llx.MapData(freeformTags, types.String),
 					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"systemTags":                  llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/datasafe.go
+++ b/providers/oci/resources/datasafe.go
@@ -213,6 +213,7 @@ func (o *mqlOciDataSafe) targetDatabases() ([]any, error) {
 					"created":               sdkTimeData(t.TimeCreated),
 					"freeformTags":          llx.MapData(strMapToAny(t.FreeformTags), types.String),
 					"definedTags":           llx.MapData(definedTagsToAny(t.DefinedTags), types.Any),
+					"systemTags":            llx.MapData(definedTagsToAny(t.SystemTags), types.Dict),
 				}
 				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.targetDatabase", args)
 				if err != nil {

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciFileStorage) id() (string, error) {
@@ -124,6 +125,11 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 						created = &fs.TimeCreated.Time
 					}
 
+					var parentFileSystemId *string
+					if fs.SourceDetails != nil {
+						parentFileSystemId = fs.SourceDetails.ParentFileSystemId
+					}
+
 					mqlInstance, err := CreateResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
 						"id":                 llx.StringDataPtr(fs.Id),
 						"name":               llx.StringDataPtr(fs.DisplayName),
@@ -131,7 +137,10 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 						"availabilityDomain": llx.StringDataPtr(fs.AvailabilityDomain),
 						"state":              llx.StringData(string(fs.LifecycleState)),
 						"meteredBytes":       llx.IntDataPtr(fs.MeteredBytes),
+						"parentFileSystemId": llx.StringDataPtr(parentFileSystemId),
+						"isCloneParent":      llx.BoolDataPtr(fs.IsCloneParent),
 						"created":            llx.TimeDataPtr(created),
+						"systemTags":         llx.MapData(definedTagsToAny(fs.SystemTags), types.Dict),
 					})
 					if err != nil {
 						return nil, err

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -125,9 +125,9 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 						created = &fs.TimeCreated.Time
 					}
 
-					var parentFileSystemId *string
+					var parentFileSystemId string
 					if fs.SourceDetails != nil {
-						parentFileSystemId = fs.SourceDetails.ParentFileSystemId
+						parentFileSystemId = stringValue(fs.SourceDetails.ParentFileSystemId)
 					}
 
 					mqlInstance, err := CreateResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
@@ -137,7 +137,6 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 						"availabilityDomain": llx.StringDataPtr(fs.AvailabilityDomain),
 						"state":              llx.StringData(string(fs.LifecycleState)),
 						"meteredBytes":       llx.IntDataPtr(fs.MeteredBytes),
-						"parentFileSystemId": llx.StringDataPtr(parentFileSystemId),
 						"isCloneParent":      llx.BoolDataPtr(fs.IsCloneParent),
 						"created":            llx.TimeDataPtr(created),
 						"systemTags":         llx.MapData(definedTagsToAny(fs.SystemTags), types.Dict),
@@ -145,8 +144,10 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 					if err != nil {
 						return nil, err
 					}
-					mqlInstance.(*mqlOciFileStorageFileSystem).cacheKmsKeyId = stringValue(fs.KmsKeyId)
-					res = append(res, mqlInstance)
+					mqlFs := mqlInstance.(*mqlOciFileStorageFileSystem)
+					mqlFs.cacheKmsKeyId = stringValue(fs.KmsKeyId)
+					mqlFs.cacheParentFileSystemId = parentFileSystemId
+					res = append(res, mqlFs)
 				}
 			}
 
@@ -158,7 +159,8 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 }
 
 type mqlOciFileStorageFileSystemInternal struct {
-	cacheKmsKeyId string
+	cacheKmsKeyId           string
+	cacheParentFileSystemId string
 }
 
 func (o *mqlOciFileStorageFileSystem) id() (string, error) {

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -148,6 +148,7 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 				if err != nil {
 					return nil, err
 				}
+				mqlInstance.(*mqlOciIdentityUser).cacheIdentityProviderID = stringValue(user.IdentityProviderId)
 				res = append(res, mqlInstance)
 			}
 
@@ -156,6 +157,10 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+type mqlOciIdentityUserInternal struct {
+	cacheIdentityProviderID string
 }
 
 func (o *mqlOciIdentityUser) id() (string, error) {

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -128,6 +128,7 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 					"created":                   llx.TimeDataPtr(created),
 					"freeformTags":              llx.MapData(freeformTags, types.String),
 					"definedTags":               llx.MapData(definedTags, types.Any),
+					"systemTags":                llx.MapData(definedTagsToAny(lb.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -136,6 +137,7 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 				mqlLb.cacheListeners = lb.Listeners
 				mqlLb.cacheBackendSets = lb.BackendSets
 				mqlLb.cacheRegion = regionResource.Id.Data
+				mqlLb.cacheSubnetIDs = lb.SubnetIds
 				res = append(res, mqlLb)
 			}
 
@@ -150,6 +152,7 @@ type mqlOciLoadBalancerLoadBalancerInternal struct {
 	cacheListeners   map[string]loadbalancer.Listener
 	cacheBackendSets map[string]loadbalancer.BackendSet
 	cacheRegion      string
+	cacheSubnetIDs   []string
 }
 
 func initOciLoadBalancerLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciLogging) id() (string, error) {
@@ -112,6 +113,7 @@ func (o *mqlOciLogging) getLogGroups(conn *connection.OciConnection, regions []a
 					"compartmentID": llx.StringDataPtr(lg.CompartmentId),
 					"state":         llx.StringData(string(lg.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"systemTags":    llx.MapData(definedTagsToAny(lg.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -215,6 +217,7 @@ func (o *mqlOciLoggingLogGroup) logs() ([]any, error) {
 			"sourceResource":    llx.StringData(sourceResource),
 			"created":           llx.TimeDataPtr(logCreated),
 			"timeLastModified":  llx.TimeDataPtr(logLastModified),
+			"systemTags":        llx.MapData(definedTagsToAny(l.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -565,7 +565,6 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 					"subnetDomainName":        llx.StringDataPtr(subnet.SubnetDomainName),
 					"prohibitPublicIpOnVnic":  llx.BoolDataPtr(subnet.ProhibitPublicIpOnVnic),
 					"prohibitInternetIngress": llx.BoolDataPtr(subnet.ProhibitInternetIngress),
-					"securityListIds":         llx.ArrayData(stringsToAny(subnet.SecurityListIds), types.String),
 					"created":                 llx.TimeDataPtr(created),
 					"freeformTags":            llx.MapData(freeformTags, types.String),
 					"definedTags":             llx.MapData(definedTags, types.Any),
@@ -576,6 +575,7 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 				mqlSub := mqlInstance.(*mqlOciNetworkSubnet)
 				mqlSub.cacheVcnId = stringValue(subnet.VcnId)
 				mqlSub.cacheRouteTableId = stringValue(subnet.RouteTableId)
+				mqlSub.cacheSecurityListIds = subnet.SecurityListIds
 				res = append(res, mqlSub)
 			}
 
@@ -587,8 +587,9 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 }
 
 type mqlOciNetworkSubnetInternal struct {
-	cacheVcnId        string
-	cacheRouteTableId string
+	cacheVcnId           string
+	cacheRouteTableId    string
+	cacheSecurityListIds []string
 }
 
 func initOciNetworkSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -565,6 +565,7 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 					"subnetDomainName":        llx.StringDataPtr(subnet.SubnetDomainName),
 					"prohibitPublicIpOnVnic":  llx.BoolDataPtr(subnet.ProhibitPublicIpOnVnic),
 					"prohibitInternetIngress": llx.BoolDataPtr(subnet.ProhibitInternetIngress),
+					"securityListIds":         llx.ArrayData(stringsToAny(subnet.SecurityListIds), types.String),
 					"created":                 llx.TimeDataPtr(created),
 					"freeformTags":            llx.MapData(freeformTags, types.String),
 					"definedTags":             llx.MapData(definedTags, types.Any),

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -109,6 +109,7 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 					"created":            llx.TimeDataPtr(created),
 					"timeUpdated":        llx.TimeDataPtr(timeUpdated),
 					"securityAttributes": llx.MapData(definedTagsToAny(fw.SecurityAttributes), types.Dict),
+					"systemTags":         llx.MapData(definedTagsToAny(fw.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -257,6 +258,7 @@ func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regi
 					"compartmentID": llx.StringDataPtr(p.CompartmentId),
 					"state":         llx.StringData(string(p.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -100,7 +100,11 @@ private oci.identity.user @defaults("name") {
   // User OCID
   id string
   // Compartment OCID containing the user
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the user
+  compartment() oci.compartment
   // User's login name within the OCI tenancy
   name string
   // User description
@@ -117,6 +121,8 @@ private oci.identity.user @defaults("name") {
   emailVerified bool
   // Identifier of this user in a federated identity provider, empty for local users
   externalIdentifier string
+  // Federated identity provider this user originates from, when the user is federated
+  identityProvider() oci.identity.identityProvider
   // Authentication capabilities (e.g., can_use_api_keys, can_use_auth_tokens)
   capabilities map[string]bool
   // Most recent successful login time
@@ -206,7 +212,11 @@ private oci.identity.group @defaults("name") {
   // Group OCID
   id string
   // Compartment OCID containing the group
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the group
+  compartment() oci.compartment
   // Group name
   name string
   // Group description
@@ -228,7 +238,11 @@ private oci.identity.policy @defaults("name description") {
   // Policy OCID
   id string
   // Compartment OCID containing the policy
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the policy
+  compartment() oci.compartment
   // Policy name
   name string
   // Policy description
@@ -286,7 +300,11 @@ private oci.identity.oauth2ClientCredential @defaults("name") {
   // Credential description
   description string
   // Compartment OCID containing the credential
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the oauth2 client credential
+  compartment() oci.compartment
   // Allowed scopes, each with an `audience` and a `scope`
   scopes []dict
   // Credential creation time
@@ -302,7 +320,11 @@ private oci.identity.dynamicGroup @defaults("name") {
   // Dynamic group OCID
   id string
   // Compartment OCID containing the dynamic group
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the dynamic group
+  compartment() oci.compartment
   // Dynamic group name
   name string
   // Dynamic group description
@@ -324,7 +346,11 @@ private oci.identity.identityProvider @defaults("name") {
   // Identity provider OCID
   id string
   // Compartment OCID containing the identity provider
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the identity provider
+  compartment() oci.compartment
   // Identity provider name
   name string
   // Identity provider description
@@ -354,7 +380,11 @@ private oci.identity.networkSource @defaults("name") {
   // Network source OCID
   id string
   // Compartment OCID containing the network source
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the network source
+  compartment() oci.compartment
   // Network source name
   name string
   // Network source description
@@ -498,6 +528,8 @@ private oci.compute.instance @defaults("name") {
   shapeConfig dict
   // Boot volume or image source details
   sourceDetails dict
+  // Boot volume the instance was launched from, when launched from an existing boot volume
+  bootVolume() oci.compute.bootVolume
   // Instance metadata key-value pairs
   metadata map[string]string
   // Expected maintenance reboot time, if scheduled
@@ -506,6 +538,12 @@ private oci.compute.instance @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
   // Virtual network interface cards attached to the instance
   vnics() []oci.compute.vnic
   // Internet-exposure breakdown (public IP combined with NSG ingress and the subnet's internet-ingress policy)
@@ -582,6 +620,8 @@ private oci.compute.image @defaults("name") {
   operatingSystemVersion string
   // Image size in megabytes
   sizeInMBs int
+  // Image this image was derived from, when created from another image
+  baseImage() oci.compute.image
   // Free-form tags for resource management
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
@@ -614,8 +654,18 @@ private oci.compute.blockVolume @defaults("name") {
   kmsKey() oci.kms.key
   // Whether auto-tune performance is enabled
   isAutoTuneEnabled bool
+  // Source block volume this volume was cloned from, when cloned from another volume
+  sourceVolume() oci.compute.blockVolume
+  // OCID of the volume backup this volume was restored from, when restored from a backup
+  sourceVolumeBackupId string
   // Block volume creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) boot volume
@@ -640,12 +690,22 @@ private oci.compute.bootVolume @defaults("name") {
   imageId @maturity("deprecated") string
   // Image used to create the boot volume
   image() oci.compute.image
+  // Source boot volume this boot volume was cloned from, when cloned from another boot volume
+  sourceBootVolume() oci.compute.bootVolume
+  // OCID of the boot volume backup this boot volume was restored from, when restored from a backup
+  sourceBootVolumeBackupId string
   // Boot volume lifecycle state (e.g., PROVISIONING, RESTORING, AVAILABLE, TERMINATING, TERMINATED, FAULTY)
   state string
   // KMS key for volume encryption
   kmsKey() oci.kms.key
   // Boot volume creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Networking
@@ -700,7 +760,11 @@ private oci.network.publicIp @defaults("ipAddress lifetime assignedEntityType") 
   // Display name
   name string
   // Compartment OCID containing the public IP
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the public ip
+  compartment() oci.compartment
   // Allocation lifetime (EPHEMERAL or RESERVED)
   lifetime string
   // Whether the address is region-wide or availability-domain scoped (REGION, AVAILABILITY_DOMAIN)
@@ -722,7 +786,11 @@ private oci.network.vcn @defaults("name") {
   // VCN OCID
   id string
   // Compartment OCID containing the VCN
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the vcn
+  compartment() oci.compartment
   // VCN display name
   name string
   // VCN creation time
@@ -760,7 +828,11 @@ private oci.network.subnet @defaults("name") {
   // Subnet display name
   name string
   // Compartment OCID containing the subnet
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the subnet
+  compartment() oci.compartment
   // VCN the subnet belongs to
   vcn() oci.network.vcn
   // Availability domain (regional subnets have no AD)
@@ -779,6 +851,8 @@ private oci.network.subnet @defaults("name") {
   prohibitInternetIngress bool
   // Route table used by this subnet
   routeTable() oci.network.routeTable
+  // OCIDs of the security lists applied to the subnet
+  securityListIds []string
   // Subnet creation time
   created time
   // Free-form tags for resource management
@@ -866,7 +940,11 @@ private oci.network.internetGateway @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the internet gateway
+  compartment() oci.compartment
   // VCN the internet gateway belongs to
   vcn() oci.network.vcn
   // Whether the gateway is enabled
@@ -888,7 +966,11 @@ private oci.network.natGateway @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the nat gateway
+  compartment() oci.compartment
   // VCN the NAT gateway belongs to
   vcn() oci.network.vcn
   // Whether traffic is blocked through the gateway
@@ -912,7 +994,11 @@ private oci.network.routeTable @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the route table
+  compartment() oci.compartment
   // VCN the route table belongs to
   vcn() oci.network.vcn
   // Route rules defining traffic destinations and targets
@@ -948,13 +1034,23 @@ private oci.logging.logGroup @defaults("name") {
   // Log group description
   description string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the log group
+  compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, INACTIVE, DELETING, FAILED)
   state string
   // Logs in the group
   logs() []oci.logging.log
   // Creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) log
@@ -985,6 +1081,12 @@ private oci.logging.log @defaults("name") {
   created time
   // Last modification time
   timeLastModified time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Key Management Service
@@ -1115,11 +1217,19 @@ private oci.objectStorage.bucket {
   // Bucket name
   name string
   // Compartment OCID containing the bucket
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the bucket
+  compartment() oci.compartment
   // Bucket creation time
   created time
   // Region where the bucket is located
   region oci.region
+  // OCID of the principal that created the bucket
+  createdBy() string
+  // User that created the bucket, when the creating principal is an IAM user
+  createdByUser() oci.identity.user
   // Public access type (NoPublicAccess, ObjectRead, ObjectReadWithoutList)
   publicAccessType() string
   // Storage tier (Standard or Archive)
@@ -1222,7 +1332,11 @@ private oci.fileStorage.fileSystem @defaults("name") {
   // File system display name
   name string
   // Compartment OCID containing the file system
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the file system
+  compartment() oci.compartment
   // Availability domain where the file system is located
   availabilityDomain string
   // File system lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
@@ -1231,8 +1345,18 @@ private oci.fileStorage.fileSystem @defaults("name") {
   kmsKey() oci.kms.key
   // Number of bytes consumed by the file system including snapshots
   meteredBytes int
+  // OCID of the file system this one was cloned from, when this is a clone
+  parentFileSystemId string
+  // Whether this file system is the parent of at least one clone
+  isCloneParent bool
   // File system creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Events
@@ -1311,7 +1435,11 @@ private oci.cloudGuard.target @defaults("name") {
   // Target display name
   name string
   // Compartment OCID containing the target
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the target
+  compartment() oci.compartment
   // OCID of the resource being monitored
   targetResourceId string
   // Type of resource being monitored (e.g., COMPARTMENT, ERPCLOUD, HCMCLOUD, SECURITY_ZONE)
@@ -1322,6 +1450,12 @@ private oci.cloudGuard.target @defaults("name") {
   recipeCount int
   // Target creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Cloud Guard detector recipe
@@ -1332,6 +1466,10 @@ private oci.cloudGuard.detectorRecipe @defaults("name") {
   name string
   // Detector recipe description
   description string
+  // Compartment OCID containing the detector recipe
+  compartmentId string
+  // Compartment containing the detector recipe
+  compartment() oci.compartment
   // Owner of the detector recipe (CUSTOMER or ORACLE)
   owner string
   // Type of detector
@@ -1342,6 +1480,12 @@ private oci.cloudGuard.detectorRecipe @defaults("name") {
   state string
   // Detector recipe creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Cloud Guard security zone
@@ -1353,7 +1497,11 @@ private oci.cloudGuard.securityZone @defaults("name") {
   // Security zone description
   description string
   // Compartment OCID associated with the security zone
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the security zone
+  compartment() oci.compartment
   // Security zone recipe applied to the zone
   securityZoneRecipe() oci.cloudGuard.securityZoneRecipe
   // Whether the compartment inherits a parent security zone after the zone is deleted
@@ -1362,6 +1510,12 @@ private oci.cloudGuard.securityZone @defaults("name") {
   state string
   // Security zone creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Cloud Guard security zone recipe
@@ -1373,7 +1527,11 @@ private oci.cloudGuard.securityZoneRecipe @defaults("name") {
   // Security zone recipe description
   description string
   // Compartment OCID containing the recipe
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the security zone recipe
+  compartment() oci.compartment
   // Owner of the recipe (CUSTOMER or ORACLE)
   owner string
   // Security policies included in the recipe
@@ -1382,6 +1540,12 @@ private oci.cloudGuard.securityZoneRecipe @defaults("name") {
   state string
   // Recipe creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Cloud Guard security policy (a requirement enforced inside a security zone)
@@ -1395,7 +1559,11 @@ private oci.cloudGuard.securityPolicy @defaults("name category") {
   // Security policy description
   description string
   // Compartment OCID containing the policy
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the security policy
+  compartment() oci.compartment
   // Owner of the policy (CUSTOMER or ORACLE)
   owner string
   // Policy category (e.g., the resource type or feature the policy applies to)
@@ -1406,6 +1574,12 @@ private oci.cloudGuard.securityPolicy @defaults("name category") {
   state string
   // Policy creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Notifications
@@ -1507,6 +1681,12 @@ private oci.bastion.instance @defaults("name") {
   created time
   // Last update time
   timeUpdated time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Monitoring
@@ -1607,6 +1787,12 @@ private oci.vault.secret @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) vault secret version
@@ -1651,7 +1837,11 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the load balancer
+  compartment() oci.compartment
   // Shape name (e.g., flexible, 100Mbps, 400Mbps)
   shape string
   // Whether the load balancer is private (no public IP)
@@ -1664,6 +1854,8 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   ipAddresses []dict
   // Whether delete protection is enabled
   isDeleteProtectionEnabled bool
+  // Subnets the load balancer is attached to
+  subnets() []oci.network.subnet
   // Lifecycle state (e.g., CREATING, ACTIVE, FAILED, DELETING, DELETED)
   state string
   // Load balancer listeners
@@ -1684,6 +1876,12 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) load balancer listener
@@ -1766,7 +1964,11 @@ private oci.networkFirewall.firewall @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the firewall
+  compartment() oci.compartment
   // Subnet the firewall is deployed in
   subnet() oci.network.subnet
   // Firewall policy
@@ -1789,6 +1991,12 @@ private oci.networkFirewall.firewall @defaults("name") {
   //
   // One of OK, WARNING, CRITICAL, or UNKNOWN.
   healthStatus() string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) network firewall policy
@@ -1798,7 +2006,11 @@ private oci.networkFirewall.policy @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the policy
+  compartment() oci.compartment
   // Policy description
   description() string
   // Number of firewalls attached to this policy
@@ -1807,6 +2019,12 @@ private oci.networkFirewall.policy @defaults("name") {
   state string
   // Creation time
   created time
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Container Engine for Kubernetes
@@ -1831,7 +2049,11 @@ private oci.oke.cluster @defaults("name") {
   // Cluster name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the cluster
+  compartment() oci.compartment
   // Kubernetes version
   kubernetesVersion string
   // Cluster type (BASIC_CLUSTER, ENHANCED_CLUSTER)
@@ -1862,6 +2084,12 @@ private oci.oke.cluster @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
   // Zero Trust Packet Routing security attributes on the cluster API endpoint
   securityAttributes map[string]dict
 }
@@ -1873,11 +2101,17 @@ private oci.oke.nodePool @defaults("name") {
   // Node pool name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the node pool
+  compartment() oci.compartment
   // Kubernetes version on nodes
   kubernetesVersion string
   // Compute shape for nodes
   nodeShape string
+  // Cluster this node pool belongs to
+  cluster() oci.oke.cluster
   // Node shape configuration (OCPUs, memory)
   nodeShapeConfig dict
   // Node image name
@@ -1890,6 +2124,12 @@ private oci.oke.nodePool @defaults("name") {
   networkSecurityGroups() []oci.network.networkSecurityGroup
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED, NEEDS_ATTENTION)
   state string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Web Application Firewall
@@ -1914,7 +2154,11 @@ private oci.waf.firewall @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the firewall
+  compartment() oci.compartment
   // WAF policy attached to this firewall
   policy() oci.waf.policy
   // Load balancer this WAF is attached to
@@ -1929,6 +2173,12 @@ private oci.waf.firewall @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Web Application Firewall policy
@@ -1938,7 +2188,11 @@ private oci.waf.policy @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the policy
+  compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, UPDATING, ACTIVE, DELETING, DELETED, FAILED)
   state string
   // Creation time
@@ -1949,6 +2203,12 @@ private oci.waf.policy @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Functions
@@ -1972,7 +2232,11 @@ private oci.functions.application @defaults("name") {
   // Application display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the application
+  compartment() oci.compartment
   // Lifecycle state (CREATING, ACTIVE, INACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
   // Application shape (GENERIC_X86, GENERIC_ARM, GENERIC_X86_ARM)
@@ -2008,7 +2272,11 @@ private oci.functions.function @defaults("name") {
   // Function display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the function
+  compartment() oci.compartment
   // Parent application OCID
   applicationId string
   // Lifecycle state (CREATING, ACTIVE, INACTIVE, UPDATING, DELETING, DELETED, FAILED)
@@ -2059,7 +2327,11 @@ private oci.containerInstances.instance @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the instance
+  compartment() oci.compartment
   // Availability domain
   availabilityDomain string
   // Lifecycle state (CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
@@ -2086,6 +2358,12 @@ private oci.containerInstances.instance @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
   // Containers running on this instance
   containers() []oci.containerInstances.container
 }
@@ -2097,7 +2375,11 @@ private oci.containerInstances.container @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the container
+  compartment() oci.compartment
   // Availability domain
   availabilityDomain string
   // Lifecycle state (CREATING, ACTIVE, STOPPING, STOPPED, EXITED, FAILED)
@@ -2118,6 +2400,12 @@ private oci.containerInstances.container @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Database
@@ -2149,7 +2437,11 @@ private oci.database.backup @defaults("name") {
   // Backup display name
   name string
   // Compartment OCID containing the backup
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the backup
+  compartment() oci.compartment
   // OCID of the source database (not the DB system)
   databaseId string
   // Availability domain where the backup is stored
@@ -2195,7 +2487,11 @@ private oci.database.autonomousDatabaseBackup @defaults("name") {
   // Backup display name
   name string
   // Compartment OCID containing the backup
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the autonomous database backup
+  compartment() oci.compartment
   // Autonomous database the backup belongs to
   autonomousDatabase() oci.database.autonomousDatabase
   // Backup type (AUTOMATIC, MANUAL, LONGTERM)
@@ -2235,7 +2531,11 @@ private oci.database.dbSystem @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the db system
+  compartment() oci.compartment
   // Availability domain
   availabilityDomain string
   // Compute shape
@@ -2252,6 +2552,8 @@ private oci.database.dbSystem @defaults("name") {
   listenerPort int
   // Single Client Access Name (SCAN) DNS name for the database system
   scanDnsName string
+  // OCID of the source DB system this DB system was created from, when created from another DB system
+  sourceDbSystemId string
   // Oracle Database version
   version string
   // Number of CPU cores
@@ -2288,6 +2590,12 @@ private oci.database.dbSystem @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) autonomous database
@@ -2304,6 +2612,10 @@ private oci.database.autonomousDatabase @defaults("name") {
   compartment() oci.compartment
   // Database name
   dbName string
+  // OCID of the source Autonomous Database this database was provisioned or cloned from, when set
+  sourceId string
+  // Whether this database is a refreshable clone of another Autonomous Database
+  isRefreshableClone bool
   // Database version
   dbVersion string
   // Database workload type (OLTP, DW, AJD, APEX)
@@ -2396,6 +2708,12 @@ private oci.database.autonomousDatabase @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
   // Backups taken of this autonomous database
   backups() []oci.database.autonomousDatabaseBackup
 }
@@ -2426,7 +2744,11 @@ private oci.apigateway.gateway @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the gateway
+  compartment() oci.compartment
   // Endpoint type (PUBLIC, PRIVATE)
   endpointType string
   // IP addressing mode (IPV4, IPV6, DUAL_STACK)
@@ -2455,6 +2777,12 @@ private oci.apigateway.gateway @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) API gateway deployment
@@ -2464,7 +2792,11 @@ private oci.apigateway.deployment @defaults("name pathPrefix") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the deployment
+  compartment() oci.compartment
   // Parent gateway
   gateway() oci.apigateway.gateway
   // Path prefix on the gateway that this deployment is deployed to
@@ -2503,6 +2835,12 @@ private oci.apigateway.deployment @defaults("name pathPrefix") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) API gateway TLS certificate (distinct from oci.certificates.certificate; managed by the apigateway service)
@@ -2512,7 +2850,11 @@ private oci.apigateway.certificate @defaults("name") {
   // Display name
   name string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the certificate
+  compartment() oci.compartment
   // Subject names secured by the certificate (CN plus SANs)
   subjectNames []string
   // Certificate expiration time
@@ -2527,6 +2869,12 @@ private oci.apigateway.certificate @defaults("name") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Cloud Infrastructure (OCI) Certificates Management
@@ -2557,7 +2905,11 @@ private oci.certificates.certificate @defaults("name") {
   // Certificate description
   description string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the certificate
+  compartment() oci.compartment
   // Configuration origin (ISSUED_BY_INTERNAL_CA, MANAGED_EXTERNALLY_ISSUED_BY_INTERNAL_CA, IMPORTED)
   configType string
   // Issuing certificate authority (set when configType is ISSUED_BY_INTERNAL_CA or MANAGED_EXTERNALLY_ISSUED_BY_INTERNAL_CA)
@@ -2601,7 +2953,11 @@ private oci.certificates.certificateAuthority @defaults("name") {
   // CA description
   description string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the certificate authority
+  compartment() oci.compartment
   // CA kind inferred from configType (ROOT for ROOT_CA_*, SUBORDINATE for SUBORDINATE_CA_*)
   kind string
   // Configuration origin
@@ -2639,7 +2995,11 @@ private oci.certificates.caBundle @defaults("name") {
   // CA bundle description
   description string
   // Compartment OCID
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the ca bundle
+  compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
   // Creation time
@@ -2671,7 +3031,11 @@ private oci.redis.cluster @defaults("name softwareVersion state") {
   // Cluster display name
   name string
   // Compartment OCID containing the cluster
-  compartmentID string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the cluster
+  compartment() oci.compartment
   // Cache engine version (e.g., REDIS_7_0, VALKEY_7_2, VALKEY_8_1)
   softwareVersion string
   // Cluster mode (SHARDED or NONSHARDED)
@@ -2708,6 +3072,12 @@ private oci.redis.cluster @defaults("name softwareVersion state") {
   freeformTags map[string]string
   // Defined tags for governance and cost tracking
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Data Safe
@@ -2751,7 +3121,11 @@ private oci.dataSafe.configuration @defaults("region isEnabled lifecycleState") 
   // URL of the Data Safe service in this region
   url string
   // OCID of the tenancy used to enable Data Safe
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the configuration
+  compartment() oci.compartment
   // Lifecycle state of Data Safe in this region (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
   lifecycleState string
   // NAT Gateway IP address used by Data Safe to reach customer databases in this region
@@ -2777,7 +3151,11 @@ private oci.dataSafe.targetDatabase @defaults("displayName databaseType lifecycl
   // OCID of the target database
   id string
   // OCID of the compartment that contains the target database
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the target database
+  compartment() oci.compartment
   // OCI region the target is registered in
   region string
   // Display name of the target in Data Safe
@@ -2800,6 +3178,12 @@ private oci.dataSafe.targetDatabase @defaults("displayName databaseType lifecycl
   freeformTags map[string]string
   // Defined tags on the target
   definedTags map[string]map[string]string
+  // System tags
+  //
+  // Tags applied automatically by Oracle, keyed by namespace. The
+  // `Oracle-Tags` namespace records the creating principal in `CreatedBy`
+  // and the creation time in `CreatedOn`.
+  systemTags map[string]dict
 }
 
 // Oracle Data Safe security assessment
@@ -2815,7 +3199,11 @@ private oci.dataSafe.securityAssessment @defaults("displayName type lifecycleSta
   // OCID of the security assessment
   id string
   // OCID of the compartment that contains the assessment
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the security assessment
+  compartment() oci.compartment
   // OCI region the assessment was produced in
   region string
   // Display name of the assessment
@@ -2850,7 +3238,11 @@ private oci.dataSafe.userAssessment @defaults("displayName type lifecycleState r
   // OCID of the user assessment
   id string
   // OCID of the compartment that contains the user assessment
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the user assessment
+  compartment() oci.compartment
   // OCI region the assessment was produced in
   region string
   // Display name of the assessment
@@ -2885,7 +3277,11 @@ private oci.dataSafe.sensitiveDataModel @defaults("displayName lifecycleState ap
   // OCID of the sensitive data model
   id string
   // OCID of the compartment that contains the sensitive data model
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the sensitive data model
+  compartment() oci.compartment
   // OCI region the sensitive data model is hosted in
   region string
   // Display name of the model
@@ -2920,7 +3316,11 @@ private oci.dataSafe.sensitiveType @defaults("displayName entityType source regi
   // OCID of the sensitive type
   id string
   // OCID of the compartment that contains the sensitive type
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the sensitive type
+  compartment() oci.compartment
   // OCI region the sensitive type is hosted in
   region string
   // Display name of the sensitive type
@@ -2954,7 +3354,11 @@ private oci.dataSafe.maskingPolicy @defaults("displayName lifecycleState region"
   // OCID of the masking policy
   id string
   // OCID of the compartment that contains the masking policy
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentId @maturity("deprecated") string
+  // Compartment containing the masking policy
+  compartment() oci.compartment
   // OCI region the masking policy is hosted in
   region string
   // Display name of the masking policy

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -851,8 +851,8 @@ private oci.network.subnet @defaults("name") {
   prohibitInternetIngress bool
   // Route table used by this subnet
   routeTable() oci.network.routeTable
-  // OCIDs of the security lists applied to the subnet
-  securityListIds []string
+  // Security lists applied to the subnet
+  securityLists() []oci.network.securityList
   // Subnet creation time
   created time
   // Free-form tags for resource management
@@ -1345,8 +1345,8 @@ private oci.fileStorage.fileSystem @defaults("name") {
   kmsKey() oci.kms.key
   // Number of bytes consumed by the file system including snapshots
   meteredBytes int
-  // OCID of the file system this one was cloned from, when this is a clone
-  parentFileSystemId string
+  // File system this one was cloned from, when this is a clone
+  parentFileSystem() oci.fileStorage.fileSystem
   // Whether this file system is the parent of at least one clone
   isCloneParent bool
   // File system creation time
@@ -1467,7 +1467,9 @@ private oci.cloudGuard.detectorRecipe @defaults("name") {
   // Detector recipe description
   description string
   // Compartment OCID containing the detector recipe
-  compartmentId string
+  //
+  // Deprecated in favor of `compartment()`.
+  compartmentID @maturity("deprecated") string
   // Compartment containing the detector recipe
   compartment() oci.compartment
   // Owner of the detector recipe (CUSTOMER or ORACLE)
@@ -2552,8 +2554,8 @@ private oci.database.dbSystem @defaults("name") {
   listenerPort int
   // Single Client Access Name (SCAN) DNS name for the database system
   scanDnsName string
-  // OCID of the source DB system this DB system was created from, when created from another DB system
-  sourceDbSystemId string
+  // Source DB system this DB system was created from, when created from another DB system
+  sourceDbSystem() oci.database.dbSystem
   // Oracle Database version
   version string
   // Number of CPU cores
@@ -2612,8 +2614,8 @@ private oci.database.autonomousDatabase @defaults("name") {
   compartment() oci.compartment
   // Database name
   dbName string
-  // OCID of the source Autonomous Database this database was provisioned or cloned from, when set
-  sourceId string
+  // Source Autonomous Database this database was provisioned or cloned from, when set
+  sourceDatabase() oci.database.autonomousDatabase
   // Whether this database is a refreshable clone of another Autonomous Database
   isRefreshableClone bool
   // Database version

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1766,8 +1766,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.subnet.routeTable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetRouteTable()).ToDataRes(types.Resource("oci.network.routeTable"))
 	},
-	"oci.network.subnet.securityListIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkSubnet).GetSecurityListIds()).ToDataRes(types.Array(types.String))
+	"oci.network.subnet.securityLists": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkSubnet).GetSecurityLists()).ToDataRes(types.Array(types.Resource("oci.network.securityList")))
 	},
 	"oci.network.subnet.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetCreated()).ToDataRes(types.Time)
@@ -2273,8 +2273,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.fileStorage.fileSystem.meteredBytes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetMeteredBytes()).ToDataRes(types.Int)
 	},
-	"oci.fileStorage.fileSystem.parentFileSystemId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciFileStorageFileSystem).GetParentFileSystemId()).ToDataRes(types.String)
+	"oci.fileStorage.fileSystem.parentFileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetParentFileSystem()).ToDataRes(types.Resource("oci.fileStorage.fileSystem"))
 	},
 	"oci.fileStorage.fileSystem.isCloneParent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetIsCloneParent()).ToDataRes(types.Bool)
@@ -2381,8 +2381,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.detectorRecipe.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetDescription()).ToDataRes(types.String)
 	},
-	"oci.cloudGuard.detectorRecipe.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartmentId()).ToDataRes(types.String)
+	"oci.cloudGuard.detectorRecipe.compartmentID": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3461,8 +3461,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.scanDnsName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetScanDnsName()).ToDataRes(types.String)
 	},
-	"oci.database.dbSystem.sourceDbSystemId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseDbSystem).GetSourceDbSystemId()).ToDataRes(types.String)
+	"oci.database.dbSystem.sourceDbSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetSourceDbSystem()).ToDataRes(types.Resource("oci.database.dbSystem"))
 	},
 	"oci.database.dbSystem.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetVersion()).ToDataRes(types.String)
@@ -3527,8 +3527,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabase.dbName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDbName()).ToDataRes(types.String)
 	},
-	"oci.database.autonomousDatabase.sourceId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSourceId()).ToDataRes(types.String)
+	"oci.database.autonomousDatabase.sourceDatabase": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSourceDatabase()).ToDataRes(types.Resource("oci.database.autonomousDatabase"))
 	},
 	"oci.database.autonomousDatabase.isRefreshableClone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetIsRefreshableClone()).ToDataRes(types.Bool)
@@ -7206,8 +7206,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkSubnet).RouteTable, ok = plugin.RawToTValue[*mqlOciNetworkRouteTable](v.Value, v.Error)
 		return
 	},
-	"oci.network.subnet.securityListIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkSubnet).SecurityListIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"oci.network.subnet.securityLists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkSubnet).SecurityLists, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.network.subnet.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7954,8 +7954,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciFileStorageFileSystem).MeteredBytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
-	"oci.fileStorage.fileSystem.parentFileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciFileStorageFileSystem).ParentFileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.fileStorage.fileSystem.parentFileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).ParentFileSystem, ok = plugin.RawToTValue[*mqlOciFileStorageFileSystem](v.Value, v.Error)
 		return
 	},
 	"oci.fileStorage.fileSystem.isCloneParent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8118,8 +8118,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardDetectorRecipe).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.cloudGuard.detectorRecipe.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardDetectorRecipe).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.cloudGuard.detectorRecipe.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9706,8 +9706,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).ScanDnsName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.database.dbSystem.sourceDbSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseDbSystem).SourceDbSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.database.dbSystem.sourceDbSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).SourceDbSystem, ok = plugin.RawToTValue[*mqlOciDatabaseDbSystem](v.Value, v.Error)
 		return
 	},
 	"oci.database.dbSystem.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9798,8 +9798,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseAutonomousDatabase).DbName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.database.autonomousDatabase.sourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseAutonomousDatabase).SourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.database.autonomousDatabase.sourceDatabase": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).SourceDatabase, ok = plugin.RawToTValue[*mqlOciDatabaseAutonomousDatabase](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.isRefreshableClone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16649,7 +16649,7 @@ type mqlOciNetworkSubnet struct {
 	ProhibitPublicIpOnVnic  plugin.TValue[bool]
 	ProhibitInternetIngress plugin.TValue[bool]
 	RouteTable              plugin.TValue[*mqlOciNetworkRouteTable]
-	SecurityListIds         plugin.TValue[[]any]
+	SecurityLists           plugin.TValue[[]any]
 	Created                 plugin.TValue[*time.Time]
 	FreeformTags            plugin.TValue[map[string]any]
 	DefinedTags             plugin.TValue[map[string]any]
@@ -16781,8 +16781,20 @@ func (c *mqlOciNetworkSubnet) GetRouteTable() *plugin.TValue[*mqlOciNetworkRoute
 	})
 }
 
-func (c *mqlOciNetworkSubnet) GetSecurityListIds() *plugin.TValue[[]any] {
-	return &c.SecurityListIds
+func (c *mqlOciNetworkSubnet) GetSecurityLists() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityLists, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.subnet", c.__id, "securityLists")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityLists()
+	})
 }
 
 func (c *mqlOciNetworkSubnet) GetCreated() *plugin.TValue[*time.Time] {
@@ -18742,7 +18754,7 @@ type mqlOciFileStorageFileSystem struct {
 	State              plugin.TValue[string]
 	KmsKey             plugin.TValue[*mqlOciKmsKey]
 	MeteredBytes       plugin.TValue[int64]
-	ParentFileSystemId plugin.TValue[string]
+	ParentFileSystem   plugin.TValue[*mqlOciFileStorageFileSystem]
 	IsCloneParent      plugin.TValue[bool]
 	Created            plugin.TValue[*time.Time]
 	SystemTags         plugin.TValue[map[string]any]
@@ -18841,8 +18853,20 @@ func (c *mqlOciFileStorageFileSystem) GetMeteredBytes() *plugin.TValue[int64] {
 	return &c.MeteredBytes
 }
 
-func (c *mqlOciFileStorageFileSystem) GetParentFileSystemId() *plugin.TValue[string] {
-	return &c.ParentFileSystemId
+func (c *mqlOciFileStorageFileSystem) GetParentFileSystem() *plugin.TValue[*mqlOciFileStorageFileSystem] {
+	return plugin.GetOrCompute[*mqlOciFileStorageFileSystem](&c.ParentFileSystem, func() (*mqlOciFileStorageFileSystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.fileStorage.fileSystem", c.__id, "parentFileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciFileStorageFileSystem), nil
+			}
+		}
+
+		return c.parentFileSystem()
+	})
 }
 
 func (c *mqlOciFileStorageFileSystem) GetIsCloneParent() *plugin.TValue[bool] {
@@ -19290,7 +19314,7 @@ type mqlOciCloudGuardDetectorRecipe struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
-	CompartmentId plugin.TValue[string]
+	CompartmentID plugin.TValue[string]
 	Compartment   plugin.TValue[*mqlOciCompartment]
 	Owner         plugin.TValue[string]
 	DetectorType  plugin.TValue[string]
@@ -19348,8 +19372,8 @@ func (c *mqlOciCloudGuardDetectorRecipe) GetDescription() *plugin.TValue[string]
 	return &c.Description
 }
 
-func (c *mqlOciCloudGuardDetectorRecipe) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
+func (c *mqlOciCloudGuardDetectorRecipe) GetCompartmentID() *plugin.TValue[string] {
+	return &c.CompartmentID
 }
 
 func (c *mqlOciCloudGuardDetectorRecipe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -23590,7 +23614,7 @@ type mqlOciDatabaseDbSystem struct {
 	Domain               plugin.TValue[string]
 	ListenerPort         plugin.TValue[int64]
 	ScanDnsName          plugin.TValue[string]
-	SourceDbSystemId     plugin.TValue[string]
+	SourceDbSystem       plugin.TValue[*mqlOciDatabaseDbSystem]
 	Version              plugin.TValue[string]
 	CpuCoreCount         plugin.TValue[int64]
 	NodeCount            plugin.TValue[int64]
@@ -23706,8 +23730,20 @@ func (c *mqlOciDatabaseDbSystem) GetScanDnsName() *plugin.TValue[string] {
 	return &c.ScanDnsName
 }
 
-func (c *mqlOciDatabaseDbSystem) GetSourceDbSystemId() *plugin.TValue[string] {
-	return &c.SourceDbSystemId
+func (c *mqlOciDatabaseDbSystem) GetSourceDbSystem() *plugin.TValue[*mqlOciDatabaseDbSystem] {
+	return plugin.GetOrCompute[*mqlOciDatabaseDbSystem](&c.SourceDbSystem, func() (*mqlOciDatabaseDbSystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.dbSystem", c.__id, "sourceDbSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciDatabaseDbSystem), nil
+			}
+		}
+
+		return c.sourceDbSystem()
+	})
 }
 
 func (c *mqlOciDatabaseDbSystem) GetVersion() *plugin.TValue[string] {
@@ -23832,7 +23868,7 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	CompartmentID               plugin.TValue[string]
 	Compartment                 plugin.TValue[*mqlOciCompartment]
 	DbName                      plugin.TValue[string]
-	SourceId                    plugin.TValue[string]
+	SourceDatabase              plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
 	IsRefreshableClone          plugin.TValue[bool]
 	DbVersion                   plugin.TValue[string]
 	DbWorkload                  plugin.TValue[string]
@@ -23941,8 +23977,20 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetDbName() *plugin.TValue[string] {
 	return &c.DbName
 }
 
-func (c *mqlOciDatabaseAutonomousDatabase) GetSourceId() *plugin.TValue[string] {
-	return &c.SourceId
+func (c *mqlOciDatabaseAutonomousDatabase) GetSourceDatabase() *plugin.TValue[*mqlOciDatabaseAutonomousDatabase] {
+	return plugin.GetOrCompute[*mqlOciDatabaseAutonomousDatabase](&c.SourceDatabase, func() (*mqlOciDatabaseAutonomousDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.autonomousDatabase", c.__id, "sourceDatabase")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciDatabaseAutonomousDatabase), nil
+			}
+		}
+
+		return c.sourceDatabase()
+	})
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetIsRefreshableClone() *plugin.TValue[bool] {

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -935,6 +935,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.user.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.identity.user.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityUser).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.identity.user.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetName()).ToDataRes(types.String)
 	},
@@ -958,6 +961,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.user.externalIdentifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetExternalIdentifier()).ToDataRes(types.String)
+	},
+	"oci.identity.user.identityProvider": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityUser).GetIdentityProvider()).ToDataRes(types.Resource("oci.identity.identityProvider"))
 	},
 	"oci.identity.user.capabilities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetCapabilities()).ToDataRes(types.Map(types.String, types.Bool))
@@ -1064,6 +1070,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.group.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityGroup).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.identity.group.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.identity.group.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityGroup).GetName()).ToDataRes(types.String)
 	},
@@ -1090,6 +1099,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityPolicy).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.identity.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.identity.policy.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityPolicy).GetName()).ToDataRes(types.String)
@@ -1160,6 +1172,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.oauth2ClientCredential.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityOauth2ClientCredential).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.identity.oauth2ClientCredential.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityOauth2ClientCredential).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.identity.oauth2ClientCredential.scopes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityOauth2ClientCredential).GetScopes()).ToDataRes(types.Array(types.Dict))
 	},
@@ -1177,6 +1192,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.dynamicGroup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityDynamicGroup).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.identity.dynamicGroup.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityDynamicGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.identity.dynamicGroup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityDynamicGroup).GetName()).ToDataRes(types.String)
@@ -1204,6 +1222,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.identityProvider.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityIdentityProvider).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.identity.identityProvider.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityIdentityProvider).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.identity.identityProvider.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityIdentityProvider).GetName()).ToDataRes(types.String)
@@ -1243,6 +1264,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.networkSource.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityNetworkSource).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.identity.networkSource.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciIdentityNetworkSource).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.identity.networkSource.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityNetworkSource).GetName()).ToDataRes(types.String)
@@ -1385,6 +1409,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.instance.sourceDetails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetSourceDetails()).ToDataRes(types.Dict)
 	},
+	"oci.compute.instance.bootVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeInstance).GetBootVolume()).ToDataRes(types.Resource("oci.compute.bootVolume"))
+	},
 	"oci.compute.instance.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -1396,6 +1423,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.instance.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
+	"oci.compute.instance.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeInstance).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.compute.instance.vnics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetVnics()).ToDataRes(types.Array(types.Resource("oci.compute.vnic")))
@@ -1493,6 +1523,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.image.sizeInMBs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeImage).GetSizeInMBs()).ToDataRes(types.Int)
 	},
+	"oci.compute.image.baseImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeImage).GetBaseImage()).ToDataRes(types.Resource("oci.compute.image"))
+	},
 	"oci.compute.image.freeformTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeImage).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -1532,8 +1565,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.blockVolume.isAutoTuneEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetIsAutoTuneEnabled()).ToDataRes(types.Bool)
 	},
+	"oci.compute.blockVolume.sourceVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetSourceVolume()).ToDataRes(types.Resource("oci.compute.blockVolume"))
+	},
+	"oci.compute.blockVolume.sourceVolumeBackupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetSourceVolumeBackupId()).ToDataRes(types.String)
+	},
 	"oci.compute.blockVolume.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.compute.blockVolume.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.compute.bootVolume.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetId()).ToDataRes(types.String)
@@ -1559,6 +1601,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.bootVolume.image": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetImage()).ToDataRes(types.Resource("oci.compute.image"))
 	},
+	"oci.compute.bootVolume.sourceBootVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetSourceBootVolume()).ToDataRes(types.Resource("oci.compute.bootVolume"))
+	},
+	"oci.compute.bootVolume.sourceBootVolumeBackupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetSourceBootVolumeBackupId()).ToDataRes(types.String)
+	},
 	"oci.compute.bootVolume.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetState()).ToDataRes(types.String)
 	},
@@ -1567,6 +1615,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.bootVolume.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.compute.bootVolume.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.network.vcns": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetwork).GetVcns()).ToDataRes(types.Array(types.Resource("oci.network.vcn")))
@@ -1604,6 +1655,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.publicIp.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkPublicIp).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.network.publicIp.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkPublicIp).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.network.publicIp.lifetime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkPublicIp).GetLifetime()).ToDataRes(types.String)
 	},
@@ -1630,6 +1684,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.vcn.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.network.vcn.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkVcn).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.network.vcn.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetName()).ToDataRes(types.String)
@@ -1679,6 +1736,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.subnet.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.network.subnet.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkSubnet).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.network.subnet.vcn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetVcn()).ToDataRes(types.Resource("oci.network.vcn"))
 	},
@@ -1705,6 +1765,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.subnet.routeTable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetRouteTable()).ToDataRes(types.Resource("oci.network.routeTable"))
+	},
+	"oci.network.subnet.securityListIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkSubnet).GetSecurityListIds()).ToDataRes(types.Array(types.String))
 	},
 	"oci.network.subnet.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetCreated()).ToDataRes(types.Time)
@@ -1805,6 +1868,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.internetGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkInternetGateway).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.network.internetGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkInternetGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.network.internetGateway.vcn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkInternetGateway).GetVcn()).ToDataRes(types.Resource("oci.network.vcn"))
 	},
@@ -1831,6 +1897,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.natGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNatGateway).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.network.natGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkNatGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.network.natGateway.vcn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNatGateway).GetVcn()).ToDataRes(types.Resource("oci.network.vcn"))
@@ -1861,6 +1930,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.routeTable.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRouteTable).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.network.routeTable.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkRouteTable).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.network.routeTable.vcn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRouteTable).GetVcn()).ToDataRes(types.Resource("oci.network.vcn"))
@@ -1895,6 +1967,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.logging.logGroup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.logging.logGroup.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLogGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.logging.logGroup.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetState()).ToDataRes(types.String)
 	},
@@ -1903,6 +1978,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.logging.logGroup.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.logging.logGroup.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLogGroup).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.logging.log.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLog).GetId()).ToDataRes(types.String)
@@ -1942,6 +2020,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.logging.log.timeLastModified": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLog).GetTimeLastModified()).ToDataRes(types.Time)
+	},
+	"oci.logging.log.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLog).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.kms.vaults": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKms).GetVaults()).ToDataRes(types.Array(types.Resource("oci.kms.vault")))
@@ -2057,11 +2138,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.objectStorage.bucket.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.objectStorage.bucket.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciObjectStorageBucket).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.objectStorage.bucket.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetCreated()).ToDataRes(types.Time)
 	},
 	"oci.objectStorage.bucket.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetRegion()).ToDataRes(types.Resource("oci.region"))
+	},
+	"oci.objectStorage.bucket.createdBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciObjectStorageBucket).GetCreatedBy()).ToDataRes(types.String)
+	},
+	"oci.objectStorage.bucket.createdByUser": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciObjectStorageBucket).GetCreatedByUser()).ToDataRes(types.Resource("oci.identity.user"))
 	},
 	"oci.objectStorage.bucket.publicAccessType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetPublicAccessType()).ToDataRes(types.String)
@@ -2168,6 +2258,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.fileStorage.fileSystem.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.fileStorage.fileSystem.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.fileStorage.fileSystem.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetAvailabilityDomain()).ToDataRes(types.String)
 	},
@@ -2180,8 +2273,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.fileStorage.fileSystem.meteredBytes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetMeteredBytes()).ToDataRes(types.Int)
 	},
+	"oci.fileStorage.fileSystem.parentFileSystemId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetParentFileSystemId()).ToDataRes(types.String)
+	},
+	"oci.fileStorage.fileSystem.isCloneParent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetIsCloneParent()).ToDataRes(types.Bool)
+	},
 	"oci.fileStorage.fileSystem.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.fileStorage.fileSystem.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.events.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEvents).GetRules()).ToDataRes(types.Array(types.Resource("oci.events.rule")))
@@ -2249,6 +2351,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.target.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.cloudGuard.target.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardTarget).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.cloudGuard.target.targetResourceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetTargetResourceId()).ToDataRes(types.String)
 	},
@@ -2264,6 +2369,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.target.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.target.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardTarget).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.cloudGuard.detectorRecipe.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetId()).ToDataRes(types.String)
 	},
@@ -2272,6 +2380,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.detectorRecipe.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetDescription()).ToDataRes(types.String)
+	},
+	"oci.cloudGuard.detectorRecipe.compartmentId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartmentId()).ToDataRes(types.String)
+	},
+	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.cloudGuard.detectorRecipe.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetOwner()).ToDataRes(types.String)
@@ -2285,6 +2399,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.detectorRecipe.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.detectorRecipe.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.cloudGuard.securityZone.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetId()).ToDataRes(types.String)
 	},
@@ -2296,6 +2413,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityZone.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.cloudGuard.securityZone.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZone).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.cloudGuard.securityZone.securityZoneRecipe": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetSecurityZoneRecipe()).ToDataRes(types.Resource("oci.cloudGuard.securityZoneRecipe"))
@@ -2309,6 +2429,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityZone.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.securityZone.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZone).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.cloudGuard.securityZoneRecipe.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetId()).ToDataRes(types.String)
 	},
@@ -2321,6 +2444,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityZoneRecipe.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.cloudGuard.securityZoneRecipe.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.cloudGuard.securityZoneRecipe.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetOwner()).ToDataRes(types.String)
 	},
@@ -2332,6 +2458,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityZoneRecipe.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.cloudGuard.securityZoneRecipe.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.cloudGuard.securityPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetId()).ToDataRes(types.String)
@@ -2348,6 +2477,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityPolicy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.cloudGuard.securityPolicy.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.cloudGuard.securityPolicy.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetOwner()).ToDataRes(types.String)
 	},
@@ -2362,6 +2494,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityPolicy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.cloudGuard.securityPolicy.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityPolicy).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.ons.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOns).GetTopics()).ToDataRes(types.Array(types.Resource("oci.ons.topic")))
@@ -2446,6 +2581,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.bastion.instance.timeUpdated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetTimeUpdated()).ToDataRes(types.Time)
+	},
+	"oci.bastion.instance.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciBastionInstance).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.monitoring.alarms": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoring).GetAlarms()).ToDataRes(types.Array(types.Resource("oci.monitoring.alarm")))
@@ -2546,6 +2684,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.vault.secret.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecret).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.vault.secret.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVaultSecret).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.vault.secretVersion.secretId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecretVersion).GetSecretId()).ToDataRes(types.String)
 	},
@@ -2585,6 +2726,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.loadBalancer.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.loadBalancer.loadBalancer.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerLoadBalancer).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.loadBalancer.loadBalancer.shape": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetShape()).ToDataRes(types.String)
 	},
@@ -2596,6 +2740,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.loadBalancer.loadBalancer.isDeleteProtectionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetIsDeleteProtectionEnabled()).ToDataRes(types.Bool)
+	},
+	"oci.loadBalancer.loadBalancer.subnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerLoadBalancer).GetSubnets()).ToDataRes(types.Array(types.Resource("oci.network.subnet")))
 	},
 	"oci.loadBalancer.loadBalancer.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetState()).ToDataRes(types.String)
@@ -2623,6 +2770,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.loadBalancer.loadBalancer.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
+	"oci.loadBalancer.loadBalancer.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerLoadBalancer).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
 	"oci.loadBalancer.listener.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetName()).ToDataRes(types.String)
@@ -2687,6 +2837,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.firewall.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.networkFirewall.firewall.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.networkFirewall.firewall.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetSubnet()).ToDataRes(types.Resource("oci.network.subnet"))
 	},
@@ -2717,6 +2870,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.firewall.healthStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetHealthStatus()).ToDataRes(types.String)
 	},
+	"oci.networkFirewall.firewall.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.networkFirewall.policy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -2725,6 +2881,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.networkFirewall.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.networkFirewall.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.networkFirewall.policy.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetDescription()).ToDataRes(types.String)
@@ -2738,6 +2897,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.policy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.networkFirewall.policy.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallPolicy).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.oke.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOke).GetClusters()).ToDataRes(types.Array(types.Resource("oci.oke.cluster")))
 	},
@@ -2749,6 +2911,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.oke.cluster.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.oke.cluster.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeCluster).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.oke.cluster.kubernetesVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetKubernetesVersion()).ToDataRes(types.String)
@@ -2795,6 +2960,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.oke.cluster.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.oke.cluster.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeCluster).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.oke.cluster.securityAttributes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetSecurityAttributes()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -2807,11 +2975,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.oke.nodePool.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.oke.nodePool.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeNodePool).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.oke.nodePool.kubernetesVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetKubernetesVersion()).ToDataRes(types.String)
 	},
 	"oci.oke.nodePool.nodeShape": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetNodeShape()).ToDataRes(types.String)
+	},
+	"oci.oke.nodePool.cluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeNodePool).GetCluster()).ToDataRes(types.Resource("oci.oke.cluster"))
 	},
 	"oci.oke.nodePool.nodeShapeConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetNodeShapeConfig()).ToDataRes(types.Dict)
@@ -2831,6 +3005,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.oke.nodePool.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetState()).ToDataRes(types.String)
 	},
+	"oci.oke.nodePool.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeNodePool).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.waf.firewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWaf).GetFirewalls()).ToDataRes(types.Array(types.Resource("oci.waf.firewall")))
 	},
@@ -2845,6 +3022,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.waf.firewall.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafFirewall).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.waf.firewall.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciWafFirewall).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.waf.firewall.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafFirewall).GetPolicy()).ToDataRes(types.Resource("oci.waf.policy"))
@@ -2867,6 +3047,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.waf.firewall.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafFirewall).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.waf.firewall.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciWafFirewall).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.waf.policy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -2875,6 +3058,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.waf.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.waf.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciWafPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.waf.policy.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetState()).ToDataRes(types.String)
@@ -2891,6 +3077,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.waf.policy.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.waf.policy.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciWafPolicy).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.functions.applications": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctions).GetApplications()).ToDataRes(types.Array(types.Resource("oci.functions.application")))
 	},
@@ -2902,6 +3091,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.functions.application.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsApplication).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.functions.application.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFunctionsApplication).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.functions.application.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsApplication).GetState()).ToDataRes(types.String)
@@ -2950,6 +3142,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.functions.function.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsFunction).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.functions.function.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFunctionsFunction).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.functions.function.applicationId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsFunction).GetApplicationId()).ToDataRes(types.String)
@@ -3005,6 +3200,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.containerInstances.instance.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.containerInstances.instance.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciContainerInstancesInstance).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.containerInstances.instance.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetAvailabilityDomain()).ToDataRes(types.String)
 	},
@@ -3044,6 +3242,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.containerInstances.instance.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.containerInstances.instance.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciContainerInstancesInstance).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.containerInstances.instance.containers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetContainers()).ToDataRes(types.Array(types.Resource("oci.containerInstances.container")))
 	},
@@ -3055,6 +3256,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.containerInstances.container.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesContainer).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.containerInstances.container.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciContainerInstancesContainer).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.containerInstances.container.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesContainer).GetAvailabilityDomain()).ToDataRes(types.String)
@@ -3086,6 +3290,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.containerInstances.container.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesContainer).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.containerInstances.container.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciContainerInstancesContainer).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.database.dbSystems": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabase).GetDbSystems()).ToDataRes(types.Array(types.Resource("oci.database.dbSystem")))
 	},
@@ -3106,6 +3313,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.backup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseBackup).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.database.backup.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseBackup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.database.backup.databaseId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseBackup).GetDatabaseId()).ToDataRes(types.String)
@@ -3167,6 +3377,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabaseBackup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.database.autonomousDatabaseBackup.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.database.autonomousDatabaseBackup.autonomousDatabase": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetAutonomousDatabase()).ToDataRes(types.Resource("oci.database.autonomousDatabase"))
 	},
@@ -3221,6 +3434,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.database.dbSystem.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.database.dbSystem.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetAvailabilityDomain()).ToDataRes(types.String)
 	},
@@ -3244,6 +3460,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.dbSystem.scanDnsName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetScanDnsName()).ToDataRes(types.String)
+	},
+	"oci.database.dbSystem.sourceDbSystemId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetSourceDbSystemId()).ToDataRes(types.String)
 	},
 	"oci.database.dbSystem.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetVersion()).ToDataRes(types.String)
@@ -3290,6 +3509,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.database.dbSystem.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.database.autonomousDatabase.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetId()).ToDataRes(types.String)
 	},
@@ -3304,6 +3526,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.autonomousDatabase.dbName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDbName()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.sourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSourceId()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.isRefreshableClone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetIsRefreshableClone()).ToDataRes(types.Bool)
 	},
 	"oci.database.autonomousDatabase.dbVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDbVersion()).ToDataRes(types.String)
@@ -3407,6 +3635,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabase.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.database.autonomousDatabase.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.database.autonomousDatabase.backups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetBackups()).ToDataRes(types.Array(types.Resource("oci.database.autonomousDatabaseBackup")))
 	},
@@ -3427,6 +3658,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.apigateway.gateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayGateway).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.apigateway.gateway.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.apigateway.gateway.endpointType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayGateway).GetEndpointType()).ToDataRes(types.String)
@@ -3470,6 +3704,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.apigateway.gateway.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayGateway).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.apigateway.gateway.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayGateway).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.apigateway.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -3478,6 +3715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.apigateway.deployment.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.apigateway.deployment.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayDeployment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.apigateway.deployment.gateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetGateway()).ToDataRes(types.Resource("oci.apigateway.gateway"))
@@ -3536,6 +3776,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.apigateway.deployment.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.apigateway.deployment.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayDeployment).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.apigateway.certificate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetId()).ToDataRes(types.String)
 	},
@@ -3544,6 +3787,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.apigateway.certificate.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.apigateway.certificate.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayCertificate).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.apigateway.certificate.subjectNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetSubjectNames()).ToDataRes(types.Array(types.String))
@@ -3566,6 +3812,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.apigateway.certificate.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.apigateway.certificate.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciApigatewayCertificate).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.certificates.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificates).GetCertificates()).ToDataRes(types.Array(types.Resource("oci.certificates.certificate")))
 	},
@@ -3586,6 +3835,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.certificates.certificate.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificate).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.certificates.certificate.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCertificatesCertificate).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.certificates.certificate.configType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificate).GetConfigType()).ToDataRes(types.String)
@@ -3647,6 +3899,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.certificates.certificateAuthority.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificateAuthority).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.certificates.certificateAuthority.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCertificatesCertificateAuthority).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.certificates.certificateAuthority.kind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificateAuthority).GetKind()).ToDataRes(types.String)
 	},
@@ -3695,6 +3950,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.certificates.caBundle.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCaBundle).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.certificates.caBundle.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCertificatesCaBundle).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.certificates.caBundle.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCaBundle).GetState()).ToDataRes(types.String)
 	},
@@ -3718,6 +3976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.redis.cluster.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRedisCluster).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.redis.cluster.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciRedisCluster).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.redis.cluster.softwareVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRedisCluster).GetSoftwareVersion()).ToDataRes(types.String)
@@ -3773,6 +4034,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.redis.cluster.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRedisCluster).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.redis.cluster.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciRedisCluster).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.dataSafe.configurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafe).GetConfigurations()).ToDataRes(types.Array(types.Resource("oci.dataSafe.configuration")))
 	},
@@ -3806,6 +4070,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.configuration.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeConfiguration).GetCompartmentId()).ToDataRes(types.String)
 	},
+	"oci.dataSafe.configuration.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeConfiguration).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.dataSafe.configuration.lifecycleState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeConfiguration).GetLifecycleState()).ToDataRes(types.String)
 	},
@@ -3829,6 +4096,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.dataSafe.targetDatabase.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeTargetDatabase).GetCompartmentId()).ToDataRes(types.String)
+	},
+	"oci.dataSafe.targetDatabase.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeTargetDatabase).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.dataSafe.targetDatabase.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeTargetDatabase).GetRegion()).ToDataRes(types.String)
@@ -3863,11 +4133,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.targetDatabase.definedTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeTargetDatabase).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
+	"oci.dataSafe.targetDatabase.systemTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeTargetDatabase).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
+	},
 	"oci.dataSafe.securityAssessment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSecurityAssessment).GetId()).ToDataRes(types.String)
 	},
 	"oci.dataSafe.securityAssessment.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSecurityAssessment).GetCompartmentId()).ToDataRes(types.String)
+	},
+	"oci.dataSafe.securityAssessment.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeSecurityAssessment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.dataSafe.securityAssessment.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSecurityAssessment).GetRegion()).ToDataRes(types.String)
@@ -3908,6 +4184,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.userAssessment.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeUserAssessment).GetCompartmentId()).ToDataRes(types.String)
 	},
+	"oci.dataSafe.userAssessment.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeUserAssessment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.dataSafe.userAssessment.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeUserAssessment).GetRegion()).ToDataRes(types.String)
 	},
@@ -3947,6 +4226,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.sensitiveDataModel.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveDataModel).GetCompartmentId()).ToDataRes(types.String)
 	},
+	"oci.dataSafe.sensitiveDataModel.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeSensitiveDataModel).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.dataSafe.sensitiveDataModel.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveDataModel).GetRegion()).ToDataRes(types.String)
 	},
@@ -3983,6 +4265,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.sensitiveType.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveType).GetCompartmentId()).ToDataRes(types.String)
 	},
+	"oci.dataSafe.sensitiveType.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeSensitiveType).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.dataSafe.sensitiveType.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveType).GetRegion()).ToDataRes(types.String)
 	},
@@ -4018,6 +4303,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.dataSafe.maskingPolicy.compartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeMaskingPolicy).GetCompartmentId()).ToDataRes(types.String)
+	},
+	"oci.dataSafe.maskingPolicy.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDataSafeMaskingPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.dataSafe.maskingPolicy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeMaskingPolicy).GetRegion()).ToDataRes(types.String)
@@ -5714,6 +6002,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityUser).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.identity.user.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityUser).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.identity.user.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityUser).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5744,6 +6036,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.user.externalIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityUser).ExternalIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.identity.user.identityProvider": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityUser).IdentityProvider, ok = plugin.RawToTValue[*mqlOciIdentityIdentityProvider](v.Value, v.Error)
 		return
 	},
 	"oci.identity.user.capabilities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5906,6 +6202,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.identity.group.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityGroup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.identity.group.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5944,6 +6244,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.policy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.identity.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.identity.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6050,6 +6354,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityOauth2ClientCredential).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.identity.oauth2ClientCredential.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityOauth2ClientCredential).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.identity.oauth2ClientCredential.scopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityOauth2ClientCredential).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -6076,6 +6384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.dynamicGroup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityDynamicGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.identity.dynamicGroup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityDynamicGroup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.identity.dynamicGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6116,6 +6428,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.identityProvider.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityIdentityProvider).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.identity.identityProvider.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityIdentityProvider).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.identity.identityProvider.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6172,6 +6488,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.networkSource.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityNetworkSource).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.identity.networkSource.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciIdentityNetworkSource).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.identity.networkSource.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6378,6 +6698,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeInstance).SourceDetails, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"oci.compute.instance.bootVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeInstance).BootVolume, ok = plugin.RawToTValue[*mqlOciComputeBootVolume](v.Value, v.Error)
+		return
+	},
 	"oci.compute.instance.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeInstance).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -6392,6 +6716,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.instance.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeInstance).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.compute.instance.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeInstance).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.compute.instance.vnics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6530,6 +6858,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeImage).SizeInMBs, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"oci.compute.image.baseImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeImage).BaseImage, ok = plugin.RawToTValue[*mqlOciComputeImage](v.Value, v.Error)
+		return
+	},
 	"oci.compute.image.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeImage).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -6586,8 +6918,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBlockVolume).IsAutoTuneEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"oci.compute.blockVolume.sourceVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).SourceVolume, ok = plugin.RawToTValue[*mqlOciComputeBlockVolume](v.Value, v.Error)
+		return
+	},
+	"oci.compute.blockVolume.sourceVolumeBackupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).SourceVolumeBackupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"oci.compute.blockVolume.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBlockVolume).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.compute.blockVolume.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.compute.bootVolume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6626,6 +6970,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBootVolume).Image, ok = plugin.RawToTValue[*mqlOciComputeImage](v.Value, v.Error)
 		return
 	},
+	"oci.compute.bootVolume.sourceBootVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).SourceBootVolume, ok = plugin.RawToTValue[*mqlOciComputeBootVolume](v.Value, v.Error)
+		return
+	},
+	"oci.compute.bootVolume.sourceBootVolumeBackupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).SourceBootVolumeBackupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"oci.compute.bootVolume.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6636,6 +6988,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.bootVolume.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.compute.bootVolume.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.network.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6694,6 +7050,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkPublicIp).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.network.publicIp.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkPublicIp).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.network.publicIp.lifetime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkPublicIp).Lifetime, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6732,6 +7092,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.vcn.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkVcn).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.network.vcn.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkVcn).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.network.vcn.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6802,6 +7166,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkSubnet).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.network.subnet.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkSubnet).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.network.subnet.vcn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkSubnet).Vcn, ok = plugin.RawToTValue[*mqlOciNetworkVcn](v.Value, v.Error)
 		return
@@ -6836,6 +7204,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.subnet.routeTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkSubnet).RouteTable, ok = plugin.RawToTValue[*mqlOciNetworkRouteTable](v.Value, v.Error)
+		return
+	},
+	"oci.network.subnet.securityListIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkSubnet).SecurityListIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.network.subnet.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6982,6 +7354,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkInternetGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.network.internetGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkInternetGateway).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.network.internetGateway.vcn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkInternetGateway).Vcn, ok = plugin.RawToTValue[*mqlOciNetworkVcn](v.Value, v.Error)
 		return
@@ -7020,6 +7396,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.natGateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkNatGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.network.natGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkNatGateway).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.network.natGateway.vcn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7064,6 +7444,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.routeTable.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkRouteTable).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.network.routeTable.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkRouteTable).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.network.routeTable.vcn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7118,6 +7502,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoggingLogGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.logging.logGroup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLogGroup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.logging.logGroup.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLogGroup).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7128,6 +7516,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.logging.logGroup.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLogGroup).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.logging.logGroup.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLogGroup).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.logging.log.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7184,6 +7576,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.logging.log.timeLastModified": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLog).TimeLastModified, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.logging.log.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLog).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.kms.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7362,12 +7758,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciObjectStorageBucket).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.objectStorage.bucket.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciObjectStorageBucket).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.objectStorage.bucket.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciObjectStorageBucket).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"oci.objectStorage.bucket.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciObjectStorageBucket).Region, ok = plugin.RawToTValue[*mqlOciRegion](v.Value, v.Error)
+		return
+	},
+	"oci.objectStorage.bucket.createdBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciObjectStorageBucket).CreatedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.objectStorage.bucket.createdByUser": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciObjectStorageBucket).CreatedByUser, ok = plugin.RawToTValue[*mqlOciIdentityUser](v.Value, v.Error)
 		return
 	},
 	"oci.objectStorage.bucket.publicAccessType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7526,6 +7934,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciFileStorageFileSystem).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.fileStorage.fileSystem.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.fileStorage.fileSystem.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFileStorageFileSystem).AvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7542,8 +7954,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciFileStorageFileSystem).MeteredBytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"oci.fileStorage.fileSystem.parentFileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).ParentFileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.fileStorage.fileSystem.isCloneParent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).IsCloneParent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"oci.fileStorage.fileSystem.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFileStorageFileSystem).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.fileStorage.fileSystem.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.events.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7650,6 +8074,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardTarget).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.target.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardTarget).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.target.targetResourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardTarget).TargetResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7670,6 +8098,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardTarget).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.target.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardTarget).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.detectorRecipe.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardDetectorRecipe).__id, ok = v.Value.(string)
 		return
@@ -7686,6 +8118,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardDetectorRecipe).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.detectorRecipe.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.detectorRecipe.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardDetectorRecipe).Owner, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7700,6 +8140,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.detectorRecipe.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardDetectorRecipe).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.detectorRecipe.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityZone.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7722,6 +8166,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityZone).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.securityZone.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZone).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.securityZone.securityZoneRecipe": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZone).SecurityZoneRecipe, ok = plugin.RawToTValue[*mqlOciCloudGuardSecurityZoneRecipe](v.Value, v.Error)
 		return
@@ -7736,6 +8184,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityZone.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZone).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityZone.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZone).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityZoneRecipe.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7758,6 +8210,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityZoneRecipe).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.securityZoneRecipe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZoneRecipe).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.securityZoneRecipe.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZoneRecipe).Owner, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7772,6 +8228,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityZoneRecipe.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZoneRecipe).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityZoneRecipe.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZoneRecipe).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7798,6 +8258,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.securityPolicy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.securityPolicy.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityPolicy).Owner, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7816,6 +8280,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityPolicy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityPolicy.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityPolicy).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.ons.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7952,6 +8420,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.bastion.instance.timeUpdated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciBastionInstance).TimeUpdated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.bastion.instance.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciBastionInstance).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.monitoring.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8102,6 +8574,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciVaultSecret).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.vault.secret.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVaultSecret).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.vault.secretVersion.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVaultSecretVersion).__id, ok = v.Value.(string)
 		return
@@ -8166,6 +8642,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerLoadBalancer).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.loadBalancer.loadBalancer.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerLoadBalancer).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.loadBalancer.loadBalancer.shape": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerLoadBalancer).Shape, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8180,6 +8660,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.loadBalancer.loadBalancer.isDeleteProtectionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerLoadBalancer).IsDeleteProtectionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.loadBalancer.loadBalancer.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerLoadBalancer).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.loadBalancer.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8216,6 +8700,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.loadBalancer.loadBalancer.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerLoadBalancer).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.loadBalancer.loadBalancer.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerLoadBalancer).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8318,6 +8806,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallFirewall).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.networkFirewall.firewall.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.networkFirewall.firewall.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallFirewall).Subnet, ok = plugin.RawToTValue[*mqlOciNetworkSubnet](v.Value, v.Error)
 		return
@@ -8358,6 +8850,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallFirewall).HealthStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.networkFirewall.firewall.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.networkFirewall.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).__id, ok = v.Value.(string)
 		return
@@ -8374,6 +8870,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.networkFirewall.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.networkFirewall.policy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8388,6 +8888,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.networkFirewall.policy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.networkFirewall.policy.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallPolicy).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.oke.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8412,6 +8916,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.oke.cluster.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeCluster).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.oke.cluster.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeCluster).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.oke.cluster.kubernetesVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8474,6 +8982,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOkeCluster).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.oke.cluster.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeCluster).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.oke.cluster.securityAttributes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeCluster).SecurityAttributes, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -8494,12 +9006,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOkeNodePool).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.oke.nodePool.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeNodePool).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.oke.nodePool.kubernetesVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).KubernetesVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.oke.nodePool.nodeShape": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).NodeShape, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.oke.nodePool.cluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeNodePool).Cluster, ok = plugin.RawToTValue[*mqlOciOkeCluster](v.Value, v.Error)
 		return
 	},
 	"oci.oke.nodePool.nodeShapeConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8524,6 +9044,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.oke.nodePool.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.oke.nodePool.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeNodePool).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.waf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8554,6 +9078,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciWafFirewall).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.waf.firewall.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciWafFirewall).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.waf.firewall.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafFirewall).Policy, ok = plugin.RawToTValue[*mqlOciWafPolicy](v.Value, v.Error)
 		return
@@ -8582,6 +9110,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciWafFirewall).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.waf.firewall.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciWafFirewall).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.waf.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafPolicy).__id, ok = v.Value.(string)
 		return
@@ -8596,6 +9128,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.waf.policy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.waf.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciWafPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.waf.policy.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8616,6 +9152,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.waf.policy.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafPolicy).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.waf.policy.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciWafPolicy).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.functions.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8640,6 +9180,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.functions.application.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFunctionsApplication).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.functions.application.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFunctionsApplication).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.functions.application.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8708,6 +9252,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.functions.function.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFunctionsFunction).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.functions.function.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFunctionsFunction).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.functions.function.applicationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8790,6 +9338,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciContainerInstancesInstance).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.containerInstances.instance.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciContainerInstancesInstance).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.containerInstances.instance.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciContainerInstancesInstance).AvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8842,6 +9394,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciContainerInstancesInstance).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.containerInstances.instance.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciContainerInstancesInstance).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.containerInstances.instance.containers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciContainerInstancesInstance).Containers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -8860,6 +9416,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.containerInstances.container.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciContainerInstancesContainer).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.containerInstances.container.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciContainerInstancesContainer).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.containerInstances.container.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8902,6 +9462,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciContainerInstancesContainer).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.containerInstances.container.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciContainerInstancesContainer).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabase).__id, ok = v.Value.(string)
 		return
@@ -8936,6 +9500,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.backup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseBackup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.backup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseBackup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.database.backup.databaseId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9022,6 +9590,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseAutonomousDatabaseBackup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.database.autonomousDatabaseBackup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabaseBackup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.database.autonomousDatabaseBackup.autonomousDatabase": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabaseBackup).AutonomousDatabase, ok = plugin.RawToTValue[*mqlOciDatabaseAutonomousDatabase](v.Value, v.Error)
 		return
@@ -9098,6 +9670,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.database.dbSystem.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.database.dbSystem.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseDbSystem).AvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9128,6 +9704,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.dbSystem.scanDnsName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseDbSystem).ScanDnsName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.dbSystem.sourceDbSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).SourceDbSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.database.dbSystem.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9190,6 +9770,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.database.dbSystem.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.database.autonomousDatabase.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).__id, ok = v.Value.(string)
 		return
@@ -9212,6 +9796,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.dbName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).DbName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.sourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).SourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.isRefreshableClone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).IsRefreshableClone, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.dbVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9350,6 +9942,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseAutonomousDatabase).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.database.autonomousDatabase.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.database.autonomousDatabase.backups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).Backups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -9384,6 +9980,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.gateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.apigateway.gateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayGateway).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.apigateway.gateway.endpointType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9442,6 +10042,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciApigatewayGateway).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.apigateway.gateway.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayGateway).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.apigateway.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayDeployment).__id, ok = v.Value.(string)
 		return
@@ -9456,6 +10060,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.deployment.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayDeployment).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.apigateway.deployment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayDeployment).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.apigateway.deployment.gateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9534,6 +10142,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciApigatewayDeployment).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.apigateway.deployment.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayDeployment).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.apigateway.certificate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayCertificate).__id, ok = v.Value.(string)
 		return
@@ -9548,6 +10160,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.certificate.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayCertificate).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.apigateway.certificate.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayCertificate).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.apigateway.certificate.subjectNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9576,6 +10192,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.certificate.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayCertificate).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.apigateway.certificate.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciApigatewayCertificate).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.certificates.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9612,6 +10232,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.certificates.certificate.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCertificate).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.certificates.certificate.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCertificatesCertificate).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.certificates.certificate.configType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9698,6 +10322,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCertificatesCertificateAuthority).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.certificates.certificateAuthority.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCertificatesCertificateAuthority).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.certificates.certificateAuthority.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCertificateAuthority).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9766,6 +10394,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCertificatesCaBundle).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.certificates.caBundle.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCertificatesCaBundle).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.certificates.caBundle.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCaBundle).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9804,6 +10436,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.redis.cluster.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciRedisCluster).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.redis.cluster.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciRedisCluster).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.redis.cluster.softwareVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9878,6 +10514,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciRedisCluster).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.redis.cluster.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciRedisCluster).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafe).__id, ok = v.Value.(string)
 		return
@@ -9930,6 +10570,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeConfiguration).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.dataSafe.configuration.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeConfiguration).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.configuration.lifecycleState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeConfiguration).LifecycleState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9964,6 +10608,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.targetDatabase.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeTargetDatabase).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.dataSafe.targetDatabase.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeTargetDatabase).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.targetDatabase.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10010,6 +10658,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeTargetDatabase).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"oci.dataSafe.targetDatabase.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeTargetDatabase).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.securityAssessment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSecurityAssessment).__id, ok = v.Value.(string)
 		return
@@ -10020,6 +10672,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.securityAssessment.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSecurityAssessment).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.dataSafe.securityAssessment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeSecurityAssessment).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.securityAssessment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10078,6 +10734,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeUserAssessment).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.dataSafe.userAssessment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeUserAssessment).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.userAssessment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeUserAssessment).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -10134,6 +10794,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeSensitiveDataModel).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.dataSafe.sensitiveDataModel.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeSensitiveDataModel).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.sensitiveDataModel.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSensitiveDataModel).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -10186,6 +10850,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeSensitiveType).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.dataSafe.sensitiveType.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeSensitiveType).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.dataSafe.sensitiveType.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSensitiveType).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -10236,6 +10904,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.maskingPolicy.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeMaskingPolicy).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.dataSafe.maskingPolicy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDataSafeMaskingPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.maskingPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12970,9 +13642,10 @@ func (c *mqlOciIdentity) GetAuthenticationPolicy() *plugin.TValue[*mqlOciIdentit
 type mqlOciIdentityUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityUserInternal it will be used here
+	mqlOciIdentityUserInternal
 	Id                      plugin.TValue[string]
 	CompartmentID           plugin.TValue[string]
+	Compartment             plugin.TValue[*mqlOciCompartment]
 	Name                    plugin.TValue[string]
 	Description             plugin.TValue[string]
 	Created                 plugin.TValue[*time.Time]
@@ -12981,6 +13654,7 @@ type mqlOciIdentityUser struct {
 	Email                   plugin.TValue[string]
 	EmailVerified           plugin.TValue[bool]
 	ExternalIdentifier      plugin.TValue[string]
+	IdentityProvider        plugin.TValue[*mqlOciIdentityIdentityProvider]
 	Capabilities            plugin.TValue[map[string]any]
 	LastLogin               plugin.TValue[*time.Time]
 	PreviousLogin           plugin.TValue[*time.Time]
@@ -13041,6 +13715,22 @@ func (c *mqlOciIdentityUser) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciIdentityUser) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.user", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciIdentityUser) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -13071,6 +13761,22 @@ func (c *mqlOciIdentityUser) GetEmailVerified() *plugin.TValue[bool] {
 
 func (c *mqlOciIdentityUser) GetExternalIdentifier() *plugin.TValue[string] {
 	return &c.ExternalIdentifier
+}
+
+func (c *mqlOciIdentityUser) GetIdentityProvider() *plugin.TValue[*mqlOciIdentityIdentityProvider] {
+	return plugin.GetOrCompute[*mqlOciIdentityIdentityProvider](&c.IdentityProvider, func() (*mqlOciIdentityIdentityProvider, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.user", c.__id, "identityProvider")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciIdentityIdentityProvider), nil
+			}
+		}
+
+		return c.identityProvider()
+	})
 }
 
 func (c *mqlOciIdentityUser) GetCapabilities() *plugin.TValue[map[string]any] {
@@ -13504,6 +14210,7 @@ type mqlOciIdentityGroup struct {
 	// optional: if you define mqlOciIdentityGroupInternal it will be used here
 	Id            plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
@@ -13558,6 +14265,22 @@ func (c *mqlOciIdentityGroup) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciIdentityGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.group", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciIdentityGroup) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -13605,6 +14328,7 @@ type mqlOciIdentityPolicy struct {
 	// optional: if you define mqlOciIdentityPolicyInternal it will be used here
 	Id            plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
@@ -13658,6 +14382,22 @@ func (c *mqlOciIdentityPolicy) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciIdentityPolicy) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciIdentityPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.policy", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciIdentityPolicy) GetName() *plugin.TValue[string] {
@@ -13844,6 +14584,7 @@ type mqlOciIdentityOauth2ClientCredential struct {
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Scopes        plugin.TValue[[]any]
 	Created       plugin.TValue[*time.Time]
 	Expires       plugin.TValue[*time.Time]
@@ -13903,6 +14644,22 @@ func (c *mqlOciIdentityOauth2ClientCredential) GetCompartmentID() *plugin.TValue
 	return &c.CompartmentID
 }
 
+func (c *mqlOciIdentityOauth2ClientCredential) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.oauth2ClientCredential", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciIdentityOauth2ClientCredential) GetScopes() *plugin.TValue[[]any] {
 	return &c.Scopes
 }
@@ -13926,6 +14683,7 @@ type mqlOciIdentityDynamicGroup struct {
 	// optional: if you define mqlOciIdentityDynamicGroupInternal it will be used here
 	Id            plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	MatchingRule  plugin.TValue[string]
@@ -13980,6 +14738,22 @@ func (c *mqlOciIdentityDynamicGroup) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciIdentityDynamicGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.dynamicGroup", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciIdentityDynamicGroup) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -14015,6 +14789,7 @@ type mqlOciIdentityIdentityProvider struct {
 	// optional: if you define mqlOciIdentityIdentityProviderInternal it will be used here
 	Id                 plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	Name               plugin.TValue[string]
 	Description        plugin.TValue[string]
 	Protocol           plugin.TValue[string]
@@ -14073,6 +14848,22 @@ func (c *mqlOciIdentityIdentityProvider) GetCompartmentID() *plugin.TValue[strin
 	return &c.CompartmentID
 }
 
+func (c *mqlOciIdentityIdentityProvider) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.identityProvider", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciIdentityIdentityProvider) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -14124,6 +14915,7 @@ type mqlOciIdentityNetworkSource struct {
 	// optional: if you define mqlOciIdentityNetworkSourceInternal it will be used here
 	Id                plugin.TValue[string]
 	CompartmentID     plugin.TValue[string]
+	Compartment       plugin.TValue[*mqlOciCompartment]
 	Name              plugin.TValue[string]
 	Description       plugin.TValue[string]
 	PublicSourceList  plugin.TValue[[]any]
@@ -14178,6 +14970,22 @@ func (c *mqlOciIdentityNetworkSource) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciIdentityNetworkSource) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciIdentityNetworkSource) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.identity.networkSource", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciIdentityNetworkSource) GetName() *plugin.TValue[string] {
@@ -14498,10 +15306,12 @@ type mqlOciComputeInstance struct {
 	AgentPlugins                 plugin.TValue[map[string]any]
 	ShapeConfig                  plugin.TValue[any]
 	SourceDetails                plugin.TValue[any]
+	BootVolume                   plugin.TValue[*mqlOciComputeBootVolume]
 	Metadata                     plugin.TValue[map[string]any]
 	TimeMaintenanceRebootDue     plugin.TValue[*time.Time]
 	FreeformTags                 plugin.TValue[map[string]any]
 	DefinedTags                  plugin.TValue[map[string]any]
+	SystemTags                   plugin.TValue[map[string]any]
 	Vnics                        plugin.TValue[[]any]
 	Exposure                     plugin.TValue[*mqlOciNetworkExposure]
 	VulnerabilityScanResult      plugin.TValue[*mqlOciVulnerabilityScanningHostAgentScanResult]
@@ -14647,6 +15457,22 @@ func (c *mqlOciComputeInstance) GetSourceDetails() *plugin.TValue[any] {
 	return &c.SourceDetails
 }
 
+func (c *mqlOciComputeInstance) GetBootVolume() *plugin.TValue[*mqlOciComputeBootVolume] {
+	return plugin.GetOrCompute[*mqlOciComputeBootVolume](&c.BootVolume, func() (*mqlOciComputeBootVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.instance", c.__id, "bootVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeBootVolume), nil
+			}
+		}
+
+		return c.bootVolume()
+	})
+}
+
 func (c *mqlOciComputeInstance) GetMetadata() *plugin.TValue[map[string]any] {
 	return &c.Metadata
 }
@@ -14661,6 +15487,10 @@ func (c *mqlOciComputeInstance) GetFreeformTags() *plugin.TValue[map[string]any]
 
 func (c *mqlOciComputeInstance) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciComputeInstance) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 func (c *mqlOciComputeInstance) GetVnics() *plugin.TValue[[]any] {
@@ -14928,7 +15758,7 @@ func (c *mqlOciComputeVnic) GetDefinedTags() *plugin.TValue[map[string]any] {
 type mqlOciComputeImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciComputeImageInternal it will be used here
+	mqlOciComputeImageInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Region                 plugin.TValue[*mqlOciRegion]
@@ -14938,6 +15768,7 @@ type mqlOciComputeImage struct {
 	OperatingSystem        plugin.TValue[string]
 	OperatingSystemVersion plugin.TValue[string]
 	SizeInMBs              plugin.TValue[int64]
+	BaseImage              plugin.TValue[*mqlOciComputeImage]
 	FreeformTags           plugin.TValue[map[string]any]
 	DefinedTags            plugin.TValue[map[string]any]
 }
@@ -15015,6 +15846,22 @@ func (c *mqlOciComputeImage) GetSizeInMBs() *plugin.TValue[int64] {
 	return &c.SizeInMBs
 }
 
+func (c *mqlOciComputeImage) GetBaseImage() *plugin.TValue[*mqlOciComputeImage] {
+	return plugin.GetOrCompute[*mqlOciComputeImage](&c.BaseImage, func() (*mqlOciComputeImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.image", c.__id, "baseImage")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeImage), nil
+			}
+		}
+
+		return c.baseImage()
+	})
+}
+
 func (c *mqlOciComputeImage) GetFreeformTags() *plugin.TValue[map[string]any] {
 	return &c.FreeformTags
 }
@@ -15028,18 +15875,21 @@ type mqlOciComputeBlockVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciComputeBlockVolumeInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
-	Compartment        plugin.TValue[*mqlOciCompartment]
-	AvailabilityDomain plugin.TValue[string]
-	SizeInGBs          plugin.TValue[int64]
-	VpusPerGB          plugin.TValue[int64]
-	State              plugin.TValue[string]
-	IsHydrated         plugin.TValue[bool]
-	KmsKey             plugin.TValue[*mqlOciKmsKey]
-	IsAutoTuneEnabled  plugin.TValue[bool]
-	Created            plugin.TValue[*time.Time]
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	CompartmentID        plugin.TValue[string]
+	Compartment          plugin.TValue[*mqlOciCompartment]
+	AvailabilityDomain   plugin.TValue[string]
+	SizeInGBs            plugin.TValue[int64]
+	VpusPerGB            plugin.TValue[int64]
+	State                plugin.TValue[string]
+	IsHydrated           plugin.TValue[bool]
+	KmsKey               plugin.TValue[*mqlOciKmsKey]
+	IsAutoTuneEnabled    plugin.TValue[bool]
+	SourceVolume         plugin.TValue[*mqlOciComputeBlockVolume]
+	SourceVolumeBackupId plugin.TValue[string]
+	Created              plugin.TValue[*time.Time]
+	SystemTags           plugin.TValue[map[string]any]
 }
 
 // createOciComputeBlockVolume creates a new instance of this resource
@@ -15147,8 +15997,32 @@ func (c *mqlOciComputeBlockVolume) GetIsAutoTuneEnabled() *plugin.TValue[bool] {
 	return &c.IsAutoTuneEnabled
 }
 
+func (c *mqlOciComputeBlockVolume) GetSourceVolume() *plugin.TValue[*mqlOciComputeBlockVolume] {
+	return plugin.GetOrCompute[*mqlOciComputeBlockVolume](&c.SourceVolume, func() (*mqlOciComputeBlockVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.blockVolume", c.__id, "sourceVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeBlockVolume), nil
+			}
+		}
+
+		return c.sourceVolume()
+	})
+}
+
+func (c *mqlOciComputeBlockVolume) GetSourceVolumeBackupId() *plugin.TValue[string] {
+	return &c.SourceVolumeBackupId
+}
+
 func (c *mqlOciComputeBlockVolume) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciComputeBlockVolume) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciComputeBootVolume for the oci.compute.bootVolume resource
@@ -15156,17 +16030,20 @@ type mqlOciComputeBootVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciComputeBootVolumeInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
-	Compartment        plugin.TValue[*mqlOciCompartment]
-	AvailabilityDomain plugin.TValue[string]
-	SizeInGBs          plugin.TValue[int64]
-	ImageId            plugin.TValue[string]
-	Image              plugin.TValue[*mqlOciComputeImage]
-	State              plugin.TValue[string]
-	KmsKey             plugin.TValue[*mqlOciKmsKey]
-	Created            plugin.TValue[*time.Time]
+	Id                       plugin.TValue[string]
+	Name                     plugin.TValue[string]
+	CompartmentID            plugin.TValue[string]
+	Compartment              plugin.TValue[*mqlOciCompartment]
+	AvailabilityDomain       plugin.TValue[string]
+	SizeInGBs                plugin.TValue[int64]
+	ImageId                  plugin.TValue[string]
+	Image                    plugin.TValue[*mqlOciComputeImage]
+	SourceBootVolume         plugin.TValue[*mqlOciComputeBootVolume]
+	SourceBootVolumeBackupId plugin.TValue[string]
+	State                    plugin.TValue[string]
+	KmsKey                   plugin.TValue[*mqlOciKmsKey]
+	Created                  plugin.TValue[*time.Time]
+	SystemTags               plugin.TValue[map[string]any]
 }
 
 // createOciComputeBootVolume creates a new instance of this resource
@@ -15262,6 +16139,26 @@ func (c *mqlOciComputeBootVolume) GetImage() *plugin.TValue[*mqlOciComputeImage]
 	})
 }
 
+func (c *mqlOciComputeBootVolume) GetSourceBootVolume() *plugin.TValue[*mqlOciComputeBootVolume] {
+	return plugin.GetOrCompute[*mqlOciComputeBootVolume](&c.SourceBootVolume, func() (*mqlOciComputeBootVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.bootVolume", c.__id, "sourceBootVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeBootVolume), nil
+			}
+		}
+
+		return c.sourceBootVolume()
+	})
+}
+
+func (c *mqlOciComputeBootVolume) GetSourceBootVolumeBackupId() *plugin.TValue[string] {
+	return &c.SourceBootVolumeBackupId
+}
+
 func (c *mqlOciComputeBootVolume) GetState() *plugin.TValue[string] {
 	return &c.State
 }
@@ -15284,6 +16181,10 @@ func (c *mqlOciComputeBootVolume) GetKmsKey() *plugin.TValue[*mqlOciKmsKey] {
 
 func (c *mqlOciComputeBootVolume) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciComputeBootVolume) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciNetwork for the oci.network resource
@@ -15475,6 +16376,7 @@ type mqlOciNetworkPublicIp struct {
 	IpAddress          plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	Lifetime           plugin.TValue[string]
 	Scope              plugin.TValue[string]
 	AssignedEntityType plugin.TValue[string]
@@ -15537,6 +16439,22 @@ func (c *mqlOciNetworkPublicIp) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciNetworkPublicIp) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.publicIp", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciNetworkPublicIp) GetLifetime() *plugin.TValue[string] {
 	return &c.Lifetime
 }
@@ -15572,6 +16490,7 @@ type mqlOciNetworkVcn struct {
 	// optional: if you define mqlOciNetworkVcnInternal it will be used here
 	Id                    plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	Name                  plugin.TValue[string]
 	Created               plugin.TValue[*time.Time]
 	State                 plugin.TValue[string]
@@ -15630,6 +16549,22 @@ func (c *mqlOciNetworkVcn) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkVcn) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciNetworkVcn) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.vcn", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciNetworkVcn) GetName() *plugin.TValue[string] {
@@ -15704,6 +16639,7 @@ type mqlOciNetworkSubnet struct {
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	CompartmentID           plugin.TValue[string]
+	Compartment             plugin.TValue[*mqlOciCompartment]
 	Vcn                     plugin.TValue[*mqlOciNetworkVcn]
 	AvailabilityDomain      plugin.TValue[string]
 	CidrBlock               plugin.TValue[string]
@@ -15713,6 +16649,7 @@ type mqlOciNetworkSubnet struct {
 	ProhibitPublicIpOnVnic  plugin.TValue[bool]
 	ProhibitInternetIngress plugin.TValue[bool]
 	RouteTable              plugin.TValue[*mqlOciNetworkRouteTable]
+	SecurityListIds         plugin.TValue[[]any]
 	Created                 plugin.TValue[*time.Time]
 	FreeformTags            plugin.TValue[map[string]any]
 	DefinedTags             plugin.TValue[map[string]any]
@@ -15766,6 +16703,22 @@ func (c *mqlOciNetworkSubnet) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkSubnet) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciNetworkSubnet) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.subnet", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciNetworkSubnet) GetVcn() *plugin.TValue[*mqlOciNetworkVcn] {
@@ -15826,6 +16779,10 @@ func (c *mqlOciNetworkSubnet) GetRouteTable() *plugin.TValue[*mqlOciNetworkRoute
 
 		return c.routeTable()
 	})
+}
+
+func (c *mqlOciNetworkSubnet) GetSecurityListIds() *plugin.TValue[[]any] {
+	return &c.SecurityListIds
 }
 
 func (c *mqlOciNetworkSubnet) GetCreated() *plugin.TValue[*time.Time] {
@@ -16150,6 +17107,7 @@ type mqlOciNetworkInternetGateway struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Vcn           plugin.TValue[*mqlOciNetworkVcn]
 	IsEnabled     plugin.TValue[bool]
 	State         plugin.TValue[string]
@@ -16207,6 +17165,22 @@ func (c *mqlOciNetworkInternetGateway) GetCompartmentID() *plugin.TValue[string]
 	return &c.CompartmentID
 }
 
+func (c *mqlOciNetworkInternetGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.internetGateway", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciNetworkInternetGateway) GetVcn() *plugin.TValue[*mqlOciNetworkVcn] {
 	return plugin.GetOrCompute[*mqlOciNetworkVcn](&c.Vcn, func() (*mqlOciNetworkVcn, error) {
 		if c.MqlRuntime.HasRecording {
@@ -16251,6 +17225,7 @@ type mqlOciNetworkNatGateway struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Vcn           plugin.TValue[*mqlOciNetworkVcn]
 	BlockTraffic  plugin.TValue[bool]
 	NatIp         plugin.TValue[string]
@@ -16309,6 +17284,22 @@ func (c *mqlOciNetworkNatGateway) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciNetworkNatGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.natGateway", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciNetworkNatGateway) GetVcn() *plugin.TValue[*mqlOciNetworkVcn] {
 	return plugin.GetOrCompute[*mqlOciNetworkVcn](&c.Vcn, func() (*mqlOciNetworkVcn, error) {
 		if c.MqlRuntime.HasRecording {
@@ -16357,6 +17348,7 @@ type mqlOciNetworkRouteTable struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Vcn           plugin.TValue[*mqlOciNetworkVcn]
 	RouteRules    plugin.TValue[[]any]
 	State         plugin.TValue[string]
@@ -16412,6 +17404,22 @@ func (c *mqlOciNetworkRouteTable) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkRouteTable) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciNetworkRouteTable) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.network.routeTable", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciNetworkRouteTable) GetVcn() *plugin.TValue[*mqlOciNetworkVcn] {
@@ -16520,9 +17528,11 @@ type mqlOciLoggingLogGroup struct {
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	State         plugin.TValue[string]
 	Logs          plugin.TValue[[]any]
 	Created       plugin.TValue[*time.Time]
+	SystemTags    plugin.TValue[map[string]any]
 }
 
 // createOciLoggingLogGroup creates a new instance of this resource
@@ -16578,6 +17588,22 @@ func (c *mqlOciLoggingLogGroup) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciLoggingLogGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.logging.logGroup", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciLoggingLogGroup) GetState() *plugin.TValue[string] {
 	return &c.State
 }
@@ -16602,6 +17628,10 @@ func (c *mqlOciLoggingLogGroup) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciLoggingLogGroup) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciLoggingLog for the oci.logging.log resource
 type mqlOciLoggingLog struct {
 	MqlRuntime *plugin.Runtime
@@ -16620,6 +17650,7 @@ type mqlOciLoggingLog struct {
 	SourceResource    plugin.TValue[string]
 	Created           plugin.TValue[*time.Time]
 	TimeLastModified  plugin.TValue[*time.Time]
+	SystemTags        plugin.TValue[map[string]any]
 }
 
 // createOciLoggingLog creates a new instance of this resource
@@ -16721,6 +17752,10 @@ func (c *mqlOciLoggingLog) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlOciLoggingLog) GetTimeLastModified() *plugin.TValue[*time.Time] {
 	return &c.TimeLastModified
+}
+
+func (c *mqlOciLoggingLog) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciKms for the oci.kms resource
@@ -17236,8 +18271,11 @@ type mqlOciObjectStorageBucket struct {
 	Namespace                 plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	CompartmentID             plugin.TValue[string]
+	Compartment               plugin.TValue[*mqlOciCompartment]
 	Created                   plugin.TValue[*time.Time]
 	Region                    plugin.TValue[*mqlOciRegion]
+	CreatedBy                 plugin.TValue[string]
+	CreatedByUser             plugin.TValue[*mqlOciIdentityUser]
 	PublicAccessType          plugin.TValue[string]
 	StorageTier               plugin.TValue[string]
 	AutoTiering               plugin.TValue[string]
@@ -17306,12 +18344,50 @@ func (c *mqlOciObjectStorageBucket) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciObjectStorageBucket) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.objectStorage.bucket", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciObjectStorageBucket) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
 func (c *mqlOciObjectStorageBucket) GetRegion() *plugin.TValue[*mqlOciRegion] {
 	return &c.Region
+}
+
+func (c *mqlOciObjectStorageBucket) GetCreatedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.CreatedBy, func() (string, error) {
+		return c.createdBy()
+	})
+}
+
+func (c *mqlOciObjectStorageBucket) GetCreatedByUser() *plugin.TValue[*mqlOciIdentityUser] {
+	return plugin.GetOrCompute[*mqlOciIdentityUser](&c.CreatedByUser, func() (*mqlOciIdentityUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.objectStorage.bucket", c.__id, "createdByUser")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciIdentityUser), nil
+			}
+		}
+
+		return c.createdByUser()
+	})
 }
 
 func (c *mqlOciObjectStorageBucket) GetPublicAccessType() *plugin.TValue[string] {
@@ -17661,11 +18737,15 @@ type mqlOciFileStorageFileSystem struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain plugin.TValue[string]
 	State              plugin.TValue[string]
 	KmsKey             plugin.TValue[*mqlOciKmsKey]
 	MeteredBytes       plugin.TValue[int64]
+	ParentFileSystemId plugin.TValue[string]
+	IsCloneParent      plugin.TValue[bool]
 	Created            plugin.TValue[*time.Time]
+	SystemTags         plugin.TValue[map[string]any]
 }
 
 // createOciFileStorageFileSystem creates a new instance of this resource
@@ -17717,6 +18797,22 @@ func (c *mqlOciFileStorageFileSystem) GetCompartmentID() *plugin.TValue[string] 
 	return &c.CompartmentID
 }
 
+func (c *mqlOciFileStorageFileSystem) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.fileStorage.fileSystem", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciFileStorageFileSystem) GetAvailabilityDomain() *plugin.TValue[string] {
 	return &c.AvailabilityDomain
 }
@@ -17745,8 +18841,20 @@ func (c *mqlOciFileStorageFileSystem) GetMeteredBytes() *plugin.TValue[int64] {
 	return &c.MeteredBytes
 }
 
+func (c *mqlOciFileStorageFileSystem) GetParentFileSystemId() *plugin.TValue[string] {
+	return &c.ParentFileSystemId
+}
+
+func (c *mqlOciFileStorageFileSystem) GetIsCloneParent() *plugin.TValue[bool] {
+	return &c.IsCloneParent
+}
+
 func (c *mqlOciFileStorageFileSystem) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciFileStorageFileSystem) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciEvents for the oci.events resource
@@ -18076,11 +19184,13 @@ type mqlOciCloudGuardTarget struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	TargetResourceId   plugin.TValue[string]
 	TargetResourceType plugin.TValue[string]
 	State              plugin.TValue[string]
 	RecipeCount        plugin.TValue[int64]
 	Created            plugin.TValue[*time.Time]
+	SystemTags         plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardTarget creates a new instance of this resource
@@ -18132,6 +19242,22 @@ func (c *mqlOciCloudGuardTarget) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciCloudGuardTarget) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.cloudGuard.target", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciCloudGuardTarget) GetTargetResourceId() *plugin.TValue[string] {
 	return &c.TargetResourceId
 }
@@ -18152,18 +19278,25 @@ func (c *mqlOciCloudGuardTarget) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardTarget) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciCloudGuardDetectorRecipe for the oci.cloudGuard.detectorRecipe resource
 type mqlOciCloudGuardDetectorRecipe struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOciCloudGuardDetectorRecipeInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	Description  plugin.TValue[string]
-	Owner        plugin.TValue[string]
-	DetectorType plugin.TValue[string]
-	State        plugin.TValue[string]
-	Created      plugin.TValue[*time.Time]
+	Id            plugin.TValue[string]
+	Name          plugin.TValue[string]
+	Description   plugin.TValue[string]
+	CompartmentId plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
+	Owner         plugin.TValue[string]
+	DetectorType  plugin.TValue[string]
+	State         plugin.TValue[string]
+	Created       plugin.TValue[*time.Time]
+	SystemTags    plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardDetectorRecipe creates a new instance of this resource
@@ -18215,6 +19348,26 @@ func (c *mqlOciCloudGuardDetectorRecipe) GetDescription() *plugin.TValue[string]
 	return &c.Description
 }
 
+func (c *mqlOciCloudGuardDetectorRecipe) GetCompartmentId() *plugin.TValue[string] {
+	return &c.CompartmentId
+}
+
+func (c *mqlOciCloudGuardDetectorRecipe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.cloudGuard.detectorRecipe", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciCloudGuardDetectorRecipe) GetOwner() *plugin.TValue[string] {
 	return &c.Owner
 }
@@ -18231,6 +19384,10 @@ func (c *mqlOciCloudGuardDetectorRecipe) GetCreated() *plugin.TValue[*time.Time]
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardDetectorRecipe) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciCloudGuardSecurityZone for the oci.cloudGuard.securityZone resource
 type mqlOciCloudGuardSecurityZone struct {
 	MqlRuntime *plugin.Runtime
@@ -18240,10 +19397,12 @@ type mqlOciCloudGuardSecurityZone struct {
 	Name                            plugin.TValue[string]
 	Description                     plugin.TValue[string]
 	CompartmentID                   plugin.TValue[string]
+	Compartment                     plugin.TValue[*mqlOciCompartment]
 	SecurityZoneRecipe              plugin.TValue[*mqlOciCloudGuardSecurityZoneRecipe]
 	IsInheritanceAfterDeleteEnabled plugin.TValue[bool]
 	State                           plugin.TValue[string]
 	Created                         plugin.TValue[*time.Time]
+	SystemTags                      plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardSecurityZone creates a new instance of this resource
@@ -18299,6 +19458,22 @@ func (c *mqlOciCloudGuardSecurityZone) GetCompartmentID() *plugin.TValue[string]
 	return &c.CompartmentID
 }
 
+func (c *mqlOciCloudGuardSecurityZone) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.cloudGuard.securityZone", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciCloudGuardSecurityZone) GetSecurityZoneRecipe() *plugin.TValue[*mqlOciCloudGuardSecurityZoneRecipe] {
 	return plugin.GetOrCompute[*mqlOciCloudGuardSecurityZoneRecipe](&c.SecurityZoneRecipe, func() (*mqlOciCloudGuardSecurityZoneRecipe, error) {
 		if c.MqlRuntime.HasRecording {
@@ -18327,6 +19502,10 @@ func (c *mqlOciCloudGuardSecurityZone) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardSecurityZone) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciCloudGuardSecurityZoneRecipe for the oci.cloudGuard.securityZoneRecipe resource
 type mqlOciCloudGuardSecurityZoneRecipe struct {
 	MqlRuntime *plugin.Runtime
@@ -18336,10 +19515,12 @@ type mqlOciCloudGuardSecurityZoneRecipe struct {
 	Name             plugin.TValue[string]
 	Description      plugin.TValue[string]
 	CompartmentID    plugin.TValue[string]
+	Compartment      plugin.TValue[*mqlOciCompartment]
 	Owner            plugin.TValue[string]
 	SecurityPolicies plugin.TValue[[]any]
 	State            plugin.TValue[string]
 	Created          plugin.TValue[*time.Time]
+	SystemTags       plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardSecurityZoneRecipe creates a new instance of this resource
@@ -18395,6 +19576,22 @@ func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCompartmentID() *plugin.TValue[s
 	return &c.CompartmentID
 }
 
+func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.cloudGuard.securityZoneRecipe", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciCloudGuardSecurityZoneRecipe) GetOwner() *plugin.TValue[string] {
 	return &c.Owner
 }
@@ -18423,6 +19620,10 @@ func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCreated() *plugin.TValue[*time.T
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardSecurityZoneRecipe) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciCloudGuardSecurityPolicy for the oci.cloudGuard.securityPolicy resource
 type mqlOciCloudGuardSecurityPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -18433,11 +19634,13 @@ type mqlOciCloudGuardSecurityPolicy struct {
 	FriendlyName  plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Owner         plugin.TValue[string]
 	Category      plugin.TValue[string]
 	Services      plugin.TValue[[]any]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
+	SystemTags    plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardSecurityPolicy creates a new instance of this resource
@@ -18497,6 +19700,22 @@ func (c *mqlOciCloudGuardSecurityPolicy) GetCompartmentID() *plugin.TValue[strin
 	return &c.CompartmentID
 }
 
+func (c *mqlOciCloudGuardSecurityPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.cloudGuard.securityPolicy", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciCloudGuardSecurityPolicy) GetOwner() *plugin.TValue[string] {
 	return &c.Owner
 }
@@ -18515,6 +19734,10 @@ func (c *mqlOciCloudGuardSecurityPolicy) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciCloudGuardSecurityPolicy) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciCloudGuardSecurityPolicy) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciOns for the oci.ons resource
@@ -18900,6 +20123,7 @@ type mqlOciBastionInstance struct {
 	DnsProxyStatus plugin.TValue[string]
 	Created        plugin.TValue[*time.Time]
 	TimeUpdated    plugin.TValue[*time.Time]
+	SystemTags     plugin.TValue[map[string]any]
 }
 
 // createOciBastionInstance creates a new instance of this resource
@@ -19017,6 +20241,10 @@ func (c *mqlOciBastionInstance) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlOciBastionInstance) GetTimeUpdated() *plugin.TValue[*time.Time] {
 	return &c.TimeUpdated
+}
+
+func (c *mqlOciBastionInstance) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciMonitoring for the oci.monitoring resource
@@ -19293,6 +20521,7 @@ type mqlOciVaultSecret struct {
 	Created                    plugin.TValue[*time.Time]
 	FreeformTags               plugin.TValue[map[string]any]
 	DefinedTags                plugin.TValue[map[string]any]
+	SystemTags                 plugin.TValue[map[string]any]
 }
 
 // createOciVaultSecret creates a new instance of this resource
@@ -19462,6 +20691,10 @@ func (c *mqlOciVaultSecret) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
 }
 
+func (c *mqlOciVaultSecret) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciVaultSecretVersion for the oci.vault.secretVersion resource
 type mqlOciVaultSecretVersion struct {
 	MqlRuntime *plugin.Runtime
@@ -19620,10 +20853,12 @@ type mqlOciLoadBalancerLoadBalancer struct {
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	CompartmentID             plugin.TValue[string]
+	Compartment               plugin.TValue[*mqlOciCompartment]
 	Shape                     plugin.TValue[string]
 	IsPrivate                 plugin.TValue[bool]
 	IpAddresses               plugin.TValue[[]any]
 	IsDeleteProtectionEnabled plugin.TValue[bool]
+	Subnets                   plugin.TValue[[]any]
 	State                     plugin.TValue[string]
 	Listeners                 plugin.TValue[[]any]
 	NsgIds                    plugin.TValue[[]any]
@@ -19633,6 +20868,7 @@ type mqlOciLoadBalancerLoadBalancer struct {
 	Created                   plugin.TValue[*time.Time]
 	FreeformTags              plugin.TValue[map[string]any]
 	DefinedTags               plugin.TValue[map[string]any]
+	SystemTags                plugin.TValue[map[string]any]
 }
 
 // createOciLoadBalancerLoadBalancer creates a new instance of this resource
@@ -19684,6 +20920,22 @@ func (c *mqlOciLoadBalancerLoadBalancer) GetCompartmentID() *plugin.TValue[strin
 	return &c.CompartmentID
 }
 
+func (c *mqlOciLoadBalancerLoadBalancer) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.loadBalancer", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciLoadBalancerLoadBalancer) GetShape() *plugin.TValue[string] {
 	return &c.Shape
 }
@@ -19698,6 +20950,22 @@ func (c *mqlOciLoadBalancerLoadBalancer) GetIpAddresses() *plugin.TValue[[]any] 
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetIsDeleteProtectionEnabled() *plugin.TValue[bool] {
 	return &c.IsDeleteProtectionEnabled
+}
+
+func (c *mqlOciLoadBalancerLoadBalancer) GetSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.loadBalancer", c.__id, "subnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnets()
+	})
 }
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetState() *plugin.TValue[string] {
@@ -19782,6 +21050,10 @@ func (c *mqlOciLoadBalancerLoadBalancer) GetFreeformTags() *plugin.TValue[map[st
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciLoadBalancerLoadBalancer) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciLoadBalancerListener for the oci.loadBalancer.listener resource
@@ -20074,6 +21346,7 @@ type mqlOciNetworkFirewallFirewall struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	Subnet             plugin.TValue[*mqlOciNetworkSubnet]
 	Policy             plugin.TValue[*mqlOciNetworkFirewallPolicy]
 	Ipv4Address        plugin.TValue[string]
@@ -20084,6 +21357,7 @@ type mqlOciNetworkFirewallFirewall struct {
 	TimeUpdated        plugin.TValue[*time.Time]
 	SecurityAttributes plugin.TValue[map[string]any]
 	HealthStatus       plugin.TValue[string]
+	SystemTags         plugin.TValue[map[string]any]
 }
 
 // createOciNetworkFirewallFirewall creates a new instance of this resource
@@ -20133,6 +21407,22 @@ func (c *mqlOciNetworkFirewallFirewall) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkFirewallFirewall) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciNetworkFirewallFirewall) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.networkFirewall.firewall", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciNetworkFirewallFirewall) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet] {
@@ -20201,6 +21491,10 @@ func (c *mqlOciNetworkFirewallFirewall) GetHealthStatus() *plugin.TValue[string]
 	})
 }
 
+func (c *mqlOciNetworkFirewallFirewall) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciNetworkFirewallPolicy for the oci.networkFirewall.policy resource
 type mqlOciNetworkFirewallPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -20209,10 +21503,12 @@ type mqlOciNetworkFirewallPolicy struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	Description           plugin.TValue[string]
 	AttachedFirewallCount plugin.TValue[int64]
 	State                 plugin.TValue[string]
 	Created               plugin.TValue[*time.Time]
+	SystemTags            plugin.TValue[map[string]any]
 }
 
 // createOciNetworkFirewallPolicy creates a new instance of this resource
@@ -20264,6 +21560,22 @@ func (c *mqlOciNetworkFirewallPolicy) GetCompartmentID() *plugin.TValue[string] 
 	return &c.CompartmentID
 }
 
+func (c *mqlOciNetworkFirewallPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.networkFirewall.policy", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciNetworkFirewallPolicy) GetDescription() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Description, func() (string, error) {
 		return c.description()
@@ -20282,6 +21594,10 @@ func (c *mqlOciNetworkFirewallPolicy) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkFirewallPolicy) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciNetworkFirewallPolicy) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciOke for the oci.oke resource
@@ -20353,6 +21669,7 @@ type mqlOciOkeCluster struct {
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	CompartmentID               plugin.TValue[string]
+	Compartment                 plugin.TValue[*mqlOciCompartment]
 	KubernetesVersion           plugin.TValue[string]
 	Type                        plugin.TValue[string]
 	Vcn                         plugin.TValue[*mqlOciNetworkVcn]
@@ -20368,6 +21685,7 @@ type mqlOciOkeCluster struct {
 	Created                     plugin.TValue[*time.Time]
 	FreeformTags                plugin.TValue[map[string]any]
 	DefinedTags                 plugin.TValue[map[string]any]
+	SystemTags                  plugin.TValue[map[string]any]
 	SecurityAttributes          plugin.TValue[map[string]any]
 }
 
@@ -20418,6 +21736,22 @@ func (c *mqlOciOkeCluster) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciOkeCluster) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciOkeCluster) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.oke.cluster", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciOkeCluster) GetKubernetesVersion() *plugin.TValue[string] {
@@ -20516,6 +21850,10 @@ func (c *mqlOciOkeCluster) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
 }
 
+func (c *mqlOciOkeCluster) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 func (c *mqlOciOkeCluster) GetSecurityAttributes() *plugin.TValue[map[string]any] {
 	return &c.SecurityAttributes
 }
@@ -20528,14 +21866,17 @@ type mqlOciOkeNodePool struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	KubernetesVersion     plugin.TValue[string]
 	NodeShape             plugin.TValue[string]
+	Cluster               plugin.TValue[*mqlOciOkeCluster]
 	NodeShapeConfig       plugin.TValue[any]
 	NodeImageName         plugin.TValue[string]
 	SshPublicKey          plugin.TValue[string]
 	Subnets               plugin.TValue[[]any]
 	NetworkSecurityGroups plugin.TValue[[]any]
 	State                 plugin.TValue[string]
+	SystemTags            plugin.TValue[map[string]any]
 }
 
 // createOciOkeNodePool creates a new instance of this resource
@@ -20587,12 +21928,44 @@ func (c *mqlOciOkeNodePool) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciOkeNodePool) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.oke.nodePool", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciOkeNodePool) GetKubernetesVersion() *plugin.TValue[string] {
 	return &c.KubernetesVersion
 }
 
 func (c *mqlOciOkeNodePool) GetNodeShape() *plugin.TValue[string] {
 	return &c.NodeShape
+}
+
+func (c *mqlOciOkeNodePool) GetCluster() *plugin.TValue[*mqlOciOkeCluster] {
+	return plugin.GetOrCompute[*mqlOciOkeCluster](&c.Cluster, func() (*mqlOciOkeCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.oke.nodePool", c.__id, "cluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciOkeCluster), nil
+			}
+		}
+
+		return c.cluster()
+	})
 }
 
 func (c *mqlOciOkeNodePool) GetNodeShapeConfig() *plugin.TValue[any] {
@@ -20641,6 +22014,10 @@ func (c *mqlOciOkeNodePool) GetNetworkSecurityGroups() *plugin.TValue[[]any] {
 
 func (c *mqlOciOkeNodePool) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlOciOkeNodePool) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciWaf for the oci.waf resource
@@ -20729,6 +22106,7 @@ type mqlOciWafFirewall struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Policy        plugin.TValue[*mqlOciWafPolicy]
 	LoadBalancer  plugin.TValue[*mqlOciLoadBalancerLoadBalancer]
 	State         plugin.TValue[string]
@@ -20736,6 +22114,7 @@ type mqlOciWafFirewall struct {
 	TimeUpdated   plugin.TValue[*time.Time]
 	FreeformTags  plugin.TValue[map[string]any]
 	DefinedTags   plugin.TValue[map[string]any]
+	SystemTags    plugin.TValue[map[string]any]
 }
 
 // createOciWafFirewall creates a new instance of this resource
@@ -20785,6 +22164,22 @@ func (c *mqlOciWafFirewall) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciWafFirewall) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciWafFirewall) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.waf.firewall", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciWafFirewall) GetPolicy() *plugin.TValue[*mqlOciWafPolicy] {
@@ -20839,6 +22234,10 @@ func (c *mqlOciWafFirewall) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
 }
 
+func (c *mqlOciWafFirewall) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciWafPolicy for the oci.waf.policy resource
 type mqlOciWafPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -20847,11 +22246,13 @@ type mqlOciWafPolicy struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	TimeUpdated   plugin.TValue[*time.Time]
 	FreeformTags  plugin.TValue[map[string]any]
 	DefinedTags   plugin.TValue[map[string]any]
+	SystemTags    plugin.TValue[map[string]any]
 }
 
 // createOciWafPolicy creates a new instance of this resource
@@ -20903,6 +22304,22 @@ func (c *mqlOciWafPolicy) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciWafPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.waf.policy", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciWafPolicy) GetState() *plugin.TValue[string] {
 	return &c.State
 }
@@ -20921,6 +22338,10 @@ func (c *mqlOciWafPolicy) GetFreeformTags() *plugin.TValue[map[string]any] {
 
 func (c *mqlOciWafPolicy) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciWafPolicy) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciFunctions for the oci.functions resource
@@ -20992,6 +22413,7 @@ type mqlOciFunctionsApplication struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	State                 plugin.TValue[string]
 	Shape                 plugin.TValue[string]
 	TraceConfig           plugin.TValue[any]
@@ -21054,6 +22476,22 @@ func (c *mqlOciFunctionsApplication) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciFunctionsApplication) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciFunctionsApplication) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.functions.application", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciFunctionsApplication) GetState() *plugin.TValue[string] {
@@ -21156,6 +22594,7 @@ type mqlOciFunctionsFunction struct {
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	CompartmentID    plugin.TValue[string]
+	Compartment      plugin.TValue[*mqlOciCompartment]
 	ApplicationId    plugin.TValue[string]
 	State            plugin.TValue[string]
 	Image            plugin.TValue[string]
@@ -21219,6 +22658,22 @@ func (c *mqlOciFunctionsFunction) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciFunctionsFunction) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciFunctionsFunction) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.functions.function", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciFunctionsFunction) GetApplicationId() *plugin.TValue[string] {
@@ -21348,6 +22803,7 @@ type mqlOciContainerInstancesInstance struct {
 	Id                               plugin.TValue[string]
 	Name                             plugin.TValue[string]
 	CompartmentID                    plugin.TValue[string]
+	Compartment                      plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain               plugin.TValue[string]
 	State                            plugin.TValue[string]
 	Shape                            plugin.TValue[string]
@@ -21361,6 +22817,7 @@ type mqlOciContainerInstancesInstance struct {
 	TimeUpdated                      plugin.TValue[*time.Time]
 	FreeformTags                     plugin.TValue[map[string]any]
 	DefinedTags                      plugin.TValue[map[string]any]
+	SystemTags                       plugin.TValue[map[string]any]
 	Containers                       plugin.TValue[[]any]
 }
 
@@ -21411,6 +22868,22 @@ func (c *mqlOciContainerInstancesInstance) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciContainerInstancesInstance) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciContainerInstancesInstance) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.containerInstances.instance", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciContainerInstancesInstance) GetAvailabilityDomain() *plugin.TValue[string] {
@@ -21465,6 +22938,10 @@ func (c *mqlOciContainerInstancesInstance) GetDefinedTags() *plugin.TValue[map[s
 	return &c.DefinedTags
 }
 
+func (c *mqlOciContainerInstancesInstance) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 func (c *mqlOciContainerInstancesInstance) GetContainers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Containers, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -21489,6 +22966,7 @@ type mqlOciContainerInstancesContainer struct {
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	CompartmentID               plugin.TValue[string]
+	Compartment                 plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain          plugin.TValue[string]
 	State                       plugin.TValue[string]
 	ContainerInstanceId         plugin.TValue[string]
@@ -21499,6 +22977,7 @@ type mqlOciContainerInstancesContainer struct {
 	TimeUpdated                 plugin.TValue[*time.Time]
 	FreeformTags                plugin.TValue[map[string]any]
 	DefinedTags                 plugin.TValue[map[string]any]
+	SystemTags                  plugin.TValue[map[string]any]
 }
 
 // createOciContainerInstancesContainer creates a new instance of this resource
@@ -21550,6 +23029,22 @@ func (c *mqlOciContainerInstancesContainer) GetCompartmentID() *plugin.TValue[st
 	return &c.CompartmentID
 }
 
+func (c *mqlOciContainerInstancesContainer) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.containerInstances.container", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciContainerInstancesContainer) GetAvailabilityDomain() *plugin.TValue[string] {
 	return &c.AvailabilityDomain
 }
@@ -21588,6 +23083,10 @@ func (c *mqlOciContainerInstancesContainer) GetFreeformTags() *plugin.TValue[map
 
 func (c *mqlOciContainerInstancesContainer) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciContainerInstancesContainer) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciDatabase for the oci.database resource
@@ -21710,6 +23209,7 @@ type mqlOciDatabaseBackup struct {
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	CompartmentID            plugin.TValue[string]
+	Compartment              plugin.TValue[*mqlOciCompartment]
 	DatabaseId               plugin.TValue[string]
 	AvailabilityDomain       plugin.TValue[string]
 	Type                     plugin.TValue[string]
@@ -21776,6 +23276,22 @@ func (c *mqlOciDatabaseBackup) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciDatabaseBackup) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciDatabaseBackup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.backup", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciDatabaseBackup) GetDatabaseId() *plugin.TValue[string] {
@@ -21878,6 +23394,7 @@ type mqlOciDatabaseAutonomousDatabaseBackup struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	AutonomousDatabase    plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
 	Type                  plugin.TValue[string]
 	IsAutomatic           plugin.TValue[bool]
@@ -21942,6 +23459,22 @@ func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetName() *plugin.TValue[string
 
 func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.autonomousDatabaseBackup", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetAutonomousDatabase() *plugin.TValue[*mqlOciDatabaseAutonomousDatabase] {
@@ -22048,6 +23581,7 @@ type mqlOciDatabaseDbSystem struct {
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	CompartmentID        plugin.TValue[string]
+	Compartment          plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain   plugin.TValue[string]
 	Shape                plugin.TValue[string]
 	DatabaseEdition      plugin.TValue[string]
@@ -22056,6 +23590,7 @@ type mqlOciDatabaseDbSystem struct {
 	Domain               plugin.TValue[string]
 	ListenerPort         plugin.TValue[int64]
 	ScanDnsName          plugin.TValue[string]
+	SourceDbSystemId     plugin.TValue[string]
 	Version              plugin.TValue[string]
 	CpuCoreCount         plugin.TValue[int64]
 	NodeCount            plugin.TValue[int64]
@@ -22071,6 +23606,7 @@ type mqlOciDatabaseDbSystem struct {
 	Created              plugin.TValue[*time.Time]
 	FreeformTags         plugin.TValue[map[string]any]
 	DefinedTags          plugin.TValue[map[string]any]
+	SystemTags           plugin.TValue[map[string]any]
 }
 
 // createOciDatabaseDbSystem creates a new instance of this resource
@@ -22122,6 +23658,22 @@ func (c *mqlOciDatabaseDbSystem) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciDatabaseDbSystem) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.dbSystem", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDatabaseDbSystem) GetAvailabilityDomain() *plugin.TValue[string] {
 	return &c.AvailabilityDomain
 }
@@ -22152,6 +23704,10 @@ func (c *mqlOciDatabaseDbSystem) GetListenerPort() *plugin.TValue[int64] {
 
 func (c *mqlOciDatabaseDbSystem) GetScanDnsName() *plugin.TValue[string] {
 	return &c.ScanDnsName
+}
+
+func (c *mqlOciDatabaseDbSystem) GetSourceDbSystemId() *plugin.TValue[string] {
+	return &c.SourceDbSystemId
 }
 
 func (c *mqlOciDatabaseDbSystem) GetVersion() *plugin.TValue[string] {
@@ -22262,6 +23818,10 @@ func (c *mqlOciDatabaseDbSystem) GetDefinedTags() *plugin.TValue[map[string]any]
 	return &c.DefinedTags
 }
 
+func (c *mqlOciDatabaseDbSystem) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciDatabaseAutonomousDatabase for the oci.database.autonomousDatabase resource
 type mqlOciDatabaseAutonomousDatabase struct {
 	MqlRuntime *plugin.Runtime
@@ -22272,6 +23832,8 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	CompartmentID               plugin.TValue[string]
 	Compartment                 plugin.TValue[*mqlOciCompartment]
 	DbName                      plugin.TValue[string]
+	SourceId                    plugin.TValue[string]
+	IsRefreshableClone          plugin.TValue[bool]
 	DbVersion                   plugin.TValue[string]
 	DbWorkload                  plugin.TValue[string]
 	IsDedicated                 plugin.TValue[bool]
@@ -22306,6 +23868,7 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	Created                     plugin.TValue[*time.Time]
 	FreeformTags                plugin.TValue[map[string]any]
 	DefinedTags                 plugin.TValue[map[string]any]
+	SystemTags                  plugin.TValue[map[string]any]
 	Backups                     plugin.TValue[[]any]
 }
 
@@ -22376,6 +23939,14 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetCompartment() *plugin.TValue[*mqlO
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetDbName() *plugin.TValue[string] {
 	return &c.DbName
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetSourceId() *plugin.TValue[string] {
+	return &c.SourceId
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetIsRefreshableClone() *plugin.TValue[bool] {
+	return &c.IsRefreshableClone
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetDbVersion() *plugin.TValue[string] {
@@ -22564,6 +24135,10 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetDefinedTags() *plugin.TValue[map[s
 	return &c.DefinedTags
 }
 
+func (c *mqlOciDatabaseAutonomousDatabase) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 func (c *mqlOciDatabaseAutonomousDatabase) GetBackups() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Backups, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -22683,6 +24258,7 @@ type mqlOciApigatewayGateway struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	EndpointType          plugin.TValue[string]
 	IpMode                plugin.TValue[string]
 	Hostname              plugin.TValue[string]
@@ -22697,6 +24273,7 @@ type mqlOciApigatewayGateway struct {
 	TimeUpdated           plugin.TValue[*time.Time]
 	FreeformTags          plugin.TValue[map[string]any]
 	DefinedTags           plugin.TValue[map[string]any]
+	SystemTags            plugin.TValue[map[string]any]
 }
 
 // createOciApigatewayGateway creates a new instance of this resource
@@ -22746,6 +24323,22 @@ func (c *mqlOciApigatewayGateway) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciApigatewayGateway) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciApigatewayGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.apigateway.gateway", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciApigatewayGateway) GetEndpointType() *plugin.TValue[string] {
@@ -22840,6 +24433,10 @@ func (c *mqlOciApigatewayGateway) GetDefinedTags() *plugin.TValue[map[string]any
 	return &c.DefinedTags
 }
 
+func (c *mqlOciApigatewayGateway) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciApigatewayDeployment for the oci.apigateway.deployment resource
 type mqlOciApigatewayDeployment struct {
 	MqlRuntime *plugin.Runtime
@@ -22848,6 +24445,7 @@ type mqlOciApigatewayDeployment struct {
 	Id                                plugin.TValue[string]
 	Name                              plugin.TValue[string]
 	CompartmentID                     plugin.TValue[string]
+	Compartment                       plugin.TValue[*mqlOciCompartment]
 	Gateway                           plugin.TValue[*mqlOciApigatewayGateway]
 	PathPrefix                        plugin.TValue[string]
 	Endpoint                          plugin.TValue[string]
@@ -22867,6 +24465,7 @@ type mqlOciApigatewayDeployment struct {
 	TimeUpdated                       plugin.TValue[*time.Time]
 	FreeformTags                      plugin.TValue[map[string]any]
 	DefinedTags                       plugin.TValue[map[string]any]
+	SystemTags                        plugin.TValue[map[string]any]
 }
 
 // createOciApigatewayDeployment creates a new instance of this resource
@@ -22916,6 +24515,22 @@ func (c *mqlOciApigatewayDeployment) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciApigatewayDeployment) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciApigatewayDeployment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.apigateway.deployment", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciApigatewayDeployment) GetGateway() *plugin.TValue[*mqlOciApigatewayGateway] {
@@ -23028,6 +24643,10 @@ func (c *mqlOciApigatewayDeployment) GetDefinedTags() *plugin.TValue[map[string]
 	return &c.DefinedTags
 }
 
+func (c *mqlOciApigatewayDeployment) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciApigatewayCertificate for the oci.apigateway.certificate resource
 type mqlOciApigatewayCertificate struct {
 	MqlRuntime *plugin.Runtime
@@ -23036,6 +24655,7 @@ type mqlOciApigatewayCertificate struct {
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	CompartmentID     plugin.TValue[string]
+	Compartment       plugin.TValue[*mqlOciCompartment]
 	SubjectNames      plugin.TValue[[]any]
 	TimeNotValidAfter plugin.TValue[*time.Time]
 	State             plugin.TValue[string]
@@ -23043,6 +24663,7 @@ type mqlOciApigatewayCertificate struct {
 	TimeUpdated       plugin.TValue[*time.Time]
 	FreeformTags      plugin.TValue[map[string]any]
 	DefinedTags       plugin.TValue[map[string]any]
+	SystemTags        plugin.TValue[map[string]any]
 }
 
 // createOciApigatewayCertificate creates a new instance of this resource
@@ -23094,6 +24715,22 @@ func (c *mqlOciApigatewayCertificate) GetCompartmentID() *plugin.TValue[string] 
 	return &c.CompartmentID
 }
 
+func (c *mqlOciApigatewayCertificate) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.apigateway.certificate", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciApigatewayCertificate) GetSubjectNames() *plugin.TValue[[]any] {
 	return &c.SubjectNames
 }
@@ -23120,6 +24757,10 @@ func (c *mqlOciApigatewayCertificate) GetFreeformTags() *plugin.TValue[map[strin
 
 func (c *mqlOciApigatewayCertificate) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciApigatewayCertificate) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciCertificates for the oci.certificates resource
@@ -23226,6 +24867,7 @@ type mqlOciCertificatesCertificate struct {
 	Name                       plugin.TValue[string]
 	Description                plugin.TValue[string]
 	CompartmentID              plugin.TValue[string]
+	Compartment                plugin.TValue[*mqlOciCompartment]
 	ConfigType                 plugin.TValue[string]
 	IssuerCertificateAuthority plugin.TValue[*mqlOciCertificatesCertificateAuthority]
 	Subject                    plugin.TValue[string]
@@ -23295,6 +24937,22 @@ func (c *mqlOciCertificatesCertificate) GetDescription() *plugin.TValue[string] 
 
 func (c *mqlOciCertificatesCertificate) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciCertificatesCertificate) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.certificates.certificate", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciCertificatesCertificate) GetConfigType() *plugin.TValue[string] {
@@ -23382,6 +25040,7 @@ type mqlOciCertificatesCertificateAuthority struct {
 	Name                       plugin.TValue[string]
 	Description                plugin.TValue[string]
 	CompartmentID              plugin.TValue[string]
+	Compartment                plugin.TValue[*mqlOciCompartment]
 	Kind                       plugin.TValue[string]
 	ConfigType                 plugin.TValue[string]
 	IssuerCertificateAuthority plugin.TValue[*mqlOciCertificatesCertificateAuthority]
@@ -23447,6 +25106,22 @@ func (c *mqlOciCertificatesCertificateAuthority) GetDescription() *plugin.TValue
 
 func (c *mqlOciCertificatesCertificateAuthority) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciCertificatesCertificateAuthority) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.certificates.certificateAuthority", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciCertificatesCertificateAuthority) GetKind() *plugin.TValue[string] {
@@ -23530,6 +25205,7 @@ type mqlOciCertificatesCaBundle struct {
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	FreeformTags  plugin.TValue[map[string]any]
@@ -23587,6 +25263,22 @@ func (c *mqlOciCertificatesCaBundle) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlOciCertificatesCaBundle) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciCertificatesCaBundle) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.certificates.caBundle", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciCertificatesCaBundle) GetState() *plugin.TValue[string] {
@@ -23674,6 +25366,7 @@ type mqlOciRedisCluster struct {
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	CompartmentID              plugin.TValue[string]
+	Compartment                plugin.TValue[*mqlOciCompartment]
 	SoftwareVersion            plugin.TValue[string]
 	ClusterMode                plugin.TValue[string]
 	NodeCount                  plugin.TValue[int64]
@@ -23692,6 +25385,7 @@ type mqlOciRedisCluster struct {
 	TimeUpdated                plugin.TValue[*time.Time]
 	FreeformTags               plugin.TValue[map[string]any]
 	DefinedTags                plugin.TValue[map[string]any]
+	SystemTags                 plugin.TValue[map[string]any]
 }
 
 // createOciRedisCluster creates a new instance of this resource
@@ -23741,6 +25435,22 @@ func (c *mqlOciRedisCluster) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciRedisCluster) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciRedisCluster) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.redis.cluster", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciRedisCluster) GetSoftwareVersion() *plugin.TValue[string] {
@@ -23837,6 +25547,10 @@ func (c *mqlOciRedisCluster) GetFreeformTags() *plugin.TValue[map[string]any] {
 
 func (c *mqlOciRedisCluster) GetDefinedTags() *plugin.TValue[map[string]any] {
 	return &c.DefinedTags
+}
+
+func (c *mqlOciRedisCluster) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
 }
 
 // mqlOciDataSafe for the oci.dataSafe resource
@@ -24011,6 +25725,7 @@ type mqlOciDataSafeConfiguration struct {
 	IsEnabled           plugin.TValue[bool]
 	Url                 plugin.TValue[string]
 	CompartmentId       plugin.TValue[string]
+	Compartment         plugin.TValue[*mqlOciCompartment]
 	LifecycleState      plugin.TValue[string]
 	NatGatewayIpAddress plugin.TValue[string]
 	GlobalSettings      plugin.TValue[any]
@@ -24072,6 +25787,22 @@ func (c *mqlOciDataSafeConfiguration) GetCompartmentId() *plugin.TValue[string] 
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeConfiguration) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.configuration", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeConfiguration) GetLifecycleState() *plugin.TValue[string] {
 	return &c.LifecycleState
 }
@@ -24103,6 +25834,7 @@ type mqlOciDataSafeTargetDatabase struct {
 	// optional: if you define mqlOciDataSafeTargetDatabaseInternal it will be used here
 	Id                    plugin.TValue[string]
 	CompartmentId         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	Region                plugin.TValue[string]
 	DisplayName           plugin.TValue[string]
 	Description           plugin.TValue[string]
@@ -24114,6 +25846,7 @@ type mqlOciDataSafeTargetDatabase struct {
 	Created               plugin.TValue[*time.Time]
 	FreeformTags          plugin.TValue[map[string]any]
 	DefinedTags           plugin.TValue[map[string]any]
+	SystemTags            plugin.TValue[map[string]any]
 }
 
 // createOciDataSafeTargetDatabase creates a new instance of this resource
@@ -24161,6 +25894,22 @@ func (c *mqlOciDataSafeTargetDatabase) GetCompartmentId() *plugin.TValue[string]
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeTargetDatabase) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.targetDatabase", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeTargetDatabase) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -24205,6 +25954,10 @@ func (c *mqlOciDataSafeTargetDatabase) GetDefinedTags() *plugin.TValue[map[strin
 	return &c.DefinedTags
 }
 
+func (c *mqlOciDataSafeTargetDatabase) GetSystemTags() *plugin.TValue[map[string]any] {
+	return &c.SystemTags
+}
+
 // mqlOciDataSafeSecurityAssessment for the oci.dataSafe.securityAssessment resource
 type mqlOciDataSafeSecurityAssessment struct {
 	MqlRuntime *plugin.Runtime
@@ -24212,6 +25965,7 @@ type mqlOciDataSafeSecurityAssessment struct {
 	// optional: if you define mqlOciDataSafeSecurityAssessmentInternal it will be used here
 	Id                     plugin.TValue[string]
 	CompartmentId          plugin.TValue[string]
+	Compartment            plugin.TValue[*mqlOciCompartment]
 	Region                 plugin.TValue[string]
 	DisplayName            plugin.TValue[string]
 	LifecycleState         plugin.TValue[string]
@@ -24270,6 +26024,22 @@ func (c *mqlOciDataSafeSecurityAssessment) GetCompartmentId() *plugin.TValue[str
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeSecurityAssessment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.securityAssessment", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeSecurityAssessment) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -24321,6 +26091,7 @@ type mqlOciDataSafeUserAssessment struct {
 	// optional: if you define mqlOciDataSafeUserAssessmentInternal it will be used here
 	Id                     plugin.TValue[string]
 	CompartmentId          plugin.TValue[string]
+	Compartment            plugin.TValue[*mqlOciCompartment]
 	Region                 plugin.TValue[string]
 	DisplayName            plugin.TValue[string]
 	LifecycleState         plugin.TValue[string]
@@ -24379,6 +26150,22 @@ func (c *mqlOciDataSafeUserAssessment) GetCompartmentId() *plugin.TValue[string]
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeUserAssessment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.userAssessment", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeUserAssessment) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -24430,6 +26217,7 @@ type mqlOciDataSafeSensitiveDataModel struct {
 	// optional: if you define mqlOciDataSafeSensitiveDataModelInternal it will be used here
 	Id             plugin.TValue[string]
 	CompartmentId  plugin.TValue[string]
+	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
 	Description    plugin.TValue[string]
@@ -24487,6 +26275,22 @@ func (c *mqlOciDataSafeSensitiveDataModel) GetCompartmentId() *plugin.TValue[str
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeSensitiveDataModel) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.sensitiveDataModel", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeSensitiveDataModel) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -24534,6 +26338,7 @@ type mqlOciDataSafeSensitiveType struct {
 	// optional: if you define mqlOciDataSafeSensitiveTypeInternal it will be used here
 	Id             plugin.TValue[string]
 	CompartmentId  plugin.TValue[string]
+	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
 	ShortName      plugin.TValue[string]
@@ -24591,6 +26396,22 @@ func (c *mqlOciDataSafeSensitiveType) GetCompartmentId() *plugin.TValue[string] 
 	return &c.CompartmentId
 }
 
+func (c *mqlOciDataSafeSensitiveType) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.sensitiveType", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciDataSafeSensitiveType) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -24638,6 +26459,7 @@ type mqlOciDataSafeMaskingPolicy struct {
 	// optional: if you define mqlOciDataSafeMaskingPolicyInternal it will be used here
 	Id             plugin.TValue[string]
 	CompartmentId  plugin.TValue[string]
+	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
 	Description    plugin.TValue[string]
@@ -24692,6 +26514,22 @@ func (c *mqlOciDataSafeMaskingPolicy) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciDataSafeMaskingPolicy) GetCompartmentId() *plugin.TValue[string] {
 	return &c.CompartmentId
+}
+
+func (c *mqlOciDataSafeMaskingPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.dataSafe.maskingPolicy", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciDataSafeMaskingPolicy) GetRegion() *plugin.TValue[string] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -520,7 +520,7 @@ oci.certificates.certificates 13.4.1
 oci.cloudGuard 13.0.6
 oci.cloudGuard.detectorRecipe 13.0.6
 oci.cloudGuard.detectorRecipe.compartment 13.12.2
-oci.cloudGuard.detectorRecipe.compartmentId 13.12.2
+oci.cloudGuard.detectorRecipe.compartmentID 13.12.2
 oci.cloudGuard.detectorRecipe.created 13.0.6
 oci.cloudGuard.detectorRecipe.description 13.0.6
 oci.cloudGuard.detectorRecipe.detectorType 13.0.6
@@ -876,7 +876,7 @@ oci.database.autonomousDatabase.privateEndpointIp 13.1.1
 oci.database.autonomousDatabase.privateEndpointLabel 13.1.1
 oci.database.autonomousDatabase.publicConnectionUrls 13.8.2
 oci.database.autonomousDatabase.securityGroups 13.6.2
-oci.database.autonomousDatabase.sourceId 13.12.2
+oci.database.autonomousDatabase.sourceDatabase 13.12.2
 oci.database.autonomousDatabase.standbyWhitelistedIps 13.10.1
 oci.database.autonomousDatabase.state 13.1.1
 oci.database.autonomousDatabase.subnet 13.1.1
@@ -952,7 +952,7 @@ oci.database.dbSystem.nsgIds 13.1.1
 oci.database.dbSystem.scanDnsName 13.10.1
 oci.database.dbSystem.securityGroups 13.6.2
 oci.database.dbSystem.shape 13.1.1
-oci.database.dbSystem.sourceDbSystemId 13.12.2
+oci.database.dbSystem.sourceDbSystem 13.12.2
 oci.database.dbSystem.state 13.1.1
 oci.database.dbSystem.subnet 13.1.1
 oci.database.dbSystem.systemTags 13.12.2
@@ -982,7 +982,7 @@ oci.fileStorage.fileSystem.isCloneParent 13.12.2
 oci.fileStorage.fileSystem.kmsKey 13.0.6
 oci.fileStorage.fileSystem.meteredBytes 13.0.6
 oci.fileStorage.fileSystem.name 13.0.6
-oci.fileStorage.fileSystem.parentFileSystemId 13.12.2
+oci.fileStorage.fileSystem.parentFileSystem 13.12.2
 oci.fileStorage.fileSystem.state 13.0.6
 oci.fileStorage.fileSystem.systemTags 13.12.2
 oci.fileStorage.fileSystems 13.0.6
@@ -1397,7 +1397,7 @@ oci.network.subnet.name 13.0.6
 oci.network.subnet.prohibitInternetIngress 13.0.6
 oci.network.subnet.prohibitPublicIpOnVnic 13.0.6
 oci.network.subnet.routeTable 13.1.1
-oci.network.subnet.securityListIds 13.12.2
+oci.network.subnet.securityLists 13.12.2
 oci.network.subnet.state 13.0.6
 oci.network.subnet.subnetDomainName 13.0.6
 oci.network.subnet.vcn 13.0.6

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -386,6 +386,7 @@ oci.ai.vision.project.state 13.9.2
 oci.ai.vision.projects 13.9.2
 oci.apigateway 13.4.1
 oci.apigateway.certificate 13.4.1
+oci.apigateway.certificate.compartment 13.12.2
 oci.apigateway.certificate.compartmentID 13.4.1
 oci.apigateway.certificate.created 13.4.1
 oci.apigateway.certificate.definedTags 13.4.1
@@ -394,11 +395,13 @@ oci.apigateway.certificate.id 13.4.1
 oci.apigateway.certificate.name 13.4.1
 oci.apigateway.certificate.state 13.4.1
 oci.apigateway.certificate.subjectNames 13.4.1
+oci.apigateway.certificate.systemTags 13.12.2
 oci.apigateway.certificate.timeNotValidAfter 13.4.1
 oci.apigateway.certificate.timeUpdated 13.4.1
 oci.apigateway.certificates 13.4.1
 oci.apigateway.deployment 13.4.1
 oci.apigateway.deployment.authenticationType 13.4.1
+oci.apigateway.deployment.compartment 13.12.2
 oci.apigateway.deployment.compartmentID 13.4.1
 oci.apigateway.deployment.corsAllowCredentials 13.4.1
 oci.apigateway.deployment.corsAllowedOrigins 13.4.1
@@ -419,11 +422,13 @@ oci.apigateway.deployment.pathPrefix 13.4.1
 oci.apigateway.deployment.rateLimitKey 13.4.1
 oci.apigateway.deployment.rateLimitPerSecond 13.4.1
 oci.apigateway.deployment.state 13.4.1
+oci.apigateway.deployment.systemTags 13.12.2
 oci.apigateway.deployment.timeUpdated 13.4.1
 oci.apigateway.deployments 13.4.1
 oci.apigateway.gateway 13.4.1
 oci.apigateway.gateway.caBundleIds 13.4.1
 oci.apigateway.gateway.certificate 13.4.1
+oci.apigateway.gateway.compartment 13.12.2
 oci.apigateway.gateway.compartmentID 13.4.1
 oci.apigateway.gateway.created 13.4.1
 oci.apigateway.gateway.definedTags 13.4.1
@@ -438,6 +443,7 @@ oci.apigateway.gateway.name 13.4.1
 oci.apigateway.gateway.networkSecurityGroups 13.4.1
 oci.apigateway.gateway.state 13.4.1
 oci.apigateway.gateway.subnet 13.4.1
+oci.apigateway.gateway.systemTags 13.12.2
 oci.apigateway.gateway.timeUpdated 13.4.1
 oci.apigateway.gateways 13.4.1
 oci.audit 13.0.6
@@ -453,11 +459,13 @@ oci.bastion.instance.dnsProxyStatus 13.0.6
 oci.bastion.instance.id 13.0.6
 oci.bastion.instance.name 13.0.6
 oci.bastion.instance.state 13.0.6
+oci.bastion.instance.systemTags 13.12.2
 oci.bastion.instance.targetSubnet 13.0.6
 oci.bastion.instance.targetVcn 13.0.6
 oci.bastion.instance.timeUpdated 13.0.6
 oci.certificates 13.4.1
 oci.certificates.caBundle 13.4.1
+oci.certificates.caBundle.compartment 13.12.2
 oci.certificates.caBundle.compartmentID 13.4.1
 oci.certificates.caBundle.created 13.4.1
 oci.certificates.caBundle.definedTags 13.4.1
@@ -469,6 +477,7 @@ oci.certificates.caBundle.state 13.4.1
 oci.certificates.caBundles 13.4.1
 oci.certificates.certificate 13.4.1
 oci.certificates.certificate.autoRenewalEnabled 13.4.1
+oci.certificates.certificate.compartment 13.12.2
 oci.certificates.certificate.compartmentID 13.4.1
 oci.certificates.certificate.configType 13.4.1
 oci.certificates.certificate.created 13.4.1
@@ -490,6 +499,7 @@ oci.certificates.certificate.validityNotAfter 13.4.1
 oci.certificates.certificate.validityNotBefore 13.4.1
 oci.certificates.certificateAuthorities 13.4.1
 oci.certificates.certificateAuthority 13.4.1
+oci.certificates.certificateAuthority.compartment 13.12.2
 oci.certificates.certificateAuthority.compartmentID 13.4.1
 oci.certificates.certificateAuthority.configType 13.4.1
 oci.certificates.certificateAuthority.created 13.4.1
@@ -509,6 +519,8 @@ oci.certificates.certificateAuthority.validityNotBefore 13.4.1
 oci.certificates.certificates 13.4.1
 oci.cloudGuard 13.0.6
 oci.cloudGuard.detectorRecipe 13.0.6
+oci.cloudGuard.detectorRecipe.compartment 13.12.2
+oci.cloudGuard.detectorRecipe.compartmentId 13.12.2
 oci.cloudGuard.detectorRecipe.created 13.0.6
 oci.cloudGuard.detectorRecipe.description 13.0.6
 oci.cloudGuard.detectorRecipe.detectorType 13.0.6
@@ -516,11 +528,13 @@ oci.cloudGuard.detectorRecipe.id 13.0.6
 oci.cloudGuard.detectorRecipe.name 13.0.6
 oci.cloudGuard.detectorRecipe.owner 13.0.6
 oci.cloudGuard.detectorRecipe.state 13.0.6
+oci.cloudGuard.detectorRecipe.systemTags 13.12.2
 oci.cloudGuard.detectorRecipes 13.0.6
 oci.cloudGuard.reportingRegion 13.0.6
 oci.cloudGuard.securityPolicies 13.5.1
 oci.cloudGuard.securityPolicy 13.5.1
 oci.cloudGuard.securityPolicy.category 13.5.1
+oci.cloudGuard.securityPolicy.compartment 13.12.2
 oci.cloudGuard.securityPolicy.compartmentID 13.5.1
 oci.cloudGuard.securityPolicy.created 13.5.1
 oci.cloudGuard.securityPolicy.description 13.5.1
@@ -530,7 +544,9 @@ oci.cloudGuard.securityPolicy.name 13.5.1
 oci.cloudGuard.securityPolicy.owner 13.5.1
 oci.cloudGuard.securityPolicy.services 13.5.1
 oci.cloudGuard.securityPolicy.state 13.5.1
+oci.cloudGuard.securityPolicy.systemTags 13.12.2
 oci.cloudGuard.securityZone 13.5.1
+oci.cloudGuard.securityZone.compartment 13.12.2
 oci.cloudGuard.securityZone.compartmentID 13.5.1
 oci.cloudGuard.securityZone.created 13.5.1
 oci.cloudGuard.securityZone.description 13.5.1
@@ -539,7 +555,9 @@ oci.cloudGuard.securityZone.isInheritanceAfterDeleteEnabled 13.5.1
 oci.cloudGuard.securityZone.name 13.5.1
 oci.cloudGuard.securityZone.securityZoneRecipe 13.5.1
 oci.cloudGuard.securityZone.state 13.5.1
+oci.cloudGuard.securityZone.systemTags 13.12.2
 oci.cloudGuard.securityZoneRecipe 13.5.1
+oci.cloudGuard.securityZoneRecipe.compartment 13.12.2
 oci.cloudGuard.securityZoneRecipe.compartmentID 13.5.1
 oci.cloudGuard.securityZoneRecipe.created 13.5.1
 oci.cloudGuard.securityZoneRecipe.description 13.5.1
@@ -548,17 +566,20 @@ oci.cloudGuard.securityZoneRecipe.name 13.5.1
 oci.cloudGuard.securityZoneRecipe.owner 13.5.1
 oci.cloudGuard.securityZoneRecipe.securityPolicies 13.5.1
 oci.cloudGuard.securityZoneRecipe.state 13.5.1
+oci.cloudGuard.securityZoneRecipe.systemTags 13.12.2
 oci.cloudGuard.securityZoneRecipes 13.5.1
 oci.cloudGuard.securityZones 13.5.1
 oci.cloudGuard.selfManageResources 13.0.6
 oci.cloudGuard.status 13.0.6
 oci.cloudGuard.target 13.0.6
+oci.cloudGuard.target.compartment 13.12.2
 oci.cloudGuard.target.compartmentID 13.0.6
 oci.cloudGuard.target.created 13.0.6
 oci.cloudGuard.target.id 13.0.6
 oci.cloudGuard.target.name 13.0.6
 oci.cloudGuard.target.recipeCount 13.0.6
 oci.cloudGuard.target.state 13.0.6
+oci.cloudGuard.target.systemTags 13.12.2
 oci.cloudGuard.target.targetResourceId 13.0.6
 oci.cloudGuard.target.targetResourceType 13.0.6
 oci.cloudGuard.targets 13.0.6
@@ -581,7 +602,10 @@ oci.compute.blockVolume.isHydrated 13.0.6
 oci.compute.blockVolume.kmsKey 13.0.6
 oci.compute.blockVolume.name 13.0.6
 oci.compute.blockVolume.sizeInGBs 13.0.6
+oci.compute.blockVolume.sourceVolume 13.12.2
+oci.compute.blockVolume.sourceVolumeBackupId 13.12.2
 oci.compute.blockVolume.state 13.0.6
+oci.compute.blockVolume.systemTags 13.12.2
 oci.compute.blockVolume.vpusPerGB 13.0.6
 oci.compute.blockVolumes 13.0.6
 oci.compute.bootVolume 13.0.6
@@ -595,9 +619,13 @@ oci.compute.bootVolume.imageId 13.0.6
 oci.compute.bootVolume.kmsKey 13.0.6
 oci.compute.bootVolume.name 13.0.6
 oci.compute.bootVolume.sizeInGBs 13.0.6
+oci.compute.bootVolume.sourceBootVolume 13.12.2
+oci.compute.bootVolume.sourceBootVolumeBackupId 13.12.2
 oci.compute.bootVolume.state 13.0.6
+oci.compute.bootVolume.systemTags 13.12.2
 oci.compute.bootVolumes 13.0.6
 oci.compute.image 9.0.0
+oci.compute.image.baseImage 13.12.2
 oci.compute.image.compartment 11.1.0
 oci.compute.image.created 9.0.0
 oci.compute.image.definedTags 11.1.0
@@ -614,6 +642,7 @@ oci.compute.instance 9.0.0
 oci.compute.instance.agentPlugins 13.10.1
 oci.compute.instance.allPluginsDisabled 13.10.1
 oci.compute.instance.availabilityDomain 11.1.0
+oci.compute.instance.bootVolume 13.12.2
 oci.compute.instance.cisBenchmarkScanResult 13.7.1
 oci.compute.instance.compartment 11.1.0
 oci.compute.instance.created 9.0.0
@@ -640,6 +669,7 @@ oci.compute.instance.shape 11.1.0
 oci.compute.instance.shapeConfig 13.0.6
 oci.compute.instance.sourceDetails 13.0.6
 oci.compute.instance.state 9.0.0
+oci.compute.instance.systemTags 13.12.2
 oci.compute.instance.timeMaintenanceRebootDue 13.0.6
 oci.compute.instance.vnics 13.1.1
 oci.compute.instance.vulnerabilityScanResult 13.7.1
@@ -665,6 +695,7 @@ oci.compute.vnic.subnet 13.1.1
 oci.containerInstances 13.1.1
 oci.containerInstances.container 13.1.1
 oci.containerInstances.container.availabilityDomain 13.1.1
+oci.containerInstances.container.compartment 13.12.2
 oci.containerInstances.container.compartmentID 13.1.1
 oci.containerInstances.container.containerInstanceId 13.1.1
 oci.containerInstances.container.created 13.1.1
@@ -676,9 +707,11 @@ oci.containerInstances.container.isResourcePrincipalDisabled 13.1.1
 oci.containerInstances.container.name 13.1.1
 oci.containerInstances.container.resourceConfig 13.1.1
 oci.containerInstances.container.state 13.1.1
+oci.containerInstances.container.systemTags 13.12.2
 oci.containerInstances.container.timeUpdated 13.1.1
 oci.containerInstances.instance 13.1.1
 oci.containerInstances.instance.availabilityDomain 13.1.1
+oci.containerInstances.instance.compartment 13.12.2
 oci.containerInstances.instance.compartmentID 13.1.1
 oci.containerInstances.instance.containerCount 13.1.1
 oci.containerInstances.instance.containerRestartPolicy 13.1.1
@@ -693,11 +726,13 @@ oci.containerInstances.instance.name 13.1.1
 oci.containerInstances.instance.shape 13.1.1
 oci.containerInstances.instance.shapeConfig 13.1.1
 oci.containerInstances.instance.state 13.1.1
+oci.containerInstances.instance.systemTags 13.12.2
 oci.containerInstances.instance.timeUpdated 13.1.1
 oci.containerInstances.instance.volumeCount 13.1.1
 oci.containerInstances.instances 13.1.1
 oci.dataSafe 13.5.5
 oci.dataSafe.configuration 13.5.5
+oci.dataSafe.configuration.compartment 13.12.2
 oci.dataSafe.configuration.compartmentId 13.5.5
 oci.dataSafe.configuration.definedTags 13.5.5
 oci.dataSafe.configuration.enabledAt 13.5.5
@@ -712,6 +747,7 @@ oci.dataSafe.configurations 13.5.5
 oci.dataSafe.maskingPolicies 13.5.5
 oci.dataSafe.maskingPolicy 13.5.5
 oci.dataSafe.maskingPolicy.columnSource 13.5.5
+oci.dataSafe.maskingPolicy.compartment 13.12.2
 oci.dataSafe.maskingPolicy.compartmentId 13.5.5
 oci.dataSafe.maskingPolicy.created 13.5.5
 oci.dataSafe.maskingPolicy.definedTags 13.5.5
@@ -723,6 +759,7 @@ oci.dataSafe.maskingPolicy.lifecycleState 13.5.5
 oci.dataSafe.maskingPolicy.region 13.5.5
 oci.dataSafe.maskingPolicy.timeUpdated 13.5.5
 oci.dataSafe.securityAssessment 13.5.5
+oci.dataSafe.securityAssessment.compartment 13.12.2
 oci.dataSafe.securityAssessment.compartmentId 13.5.5
 oci.dataSafe.securityAssessment.created 13.5.5
 oci.dataSafe.securityAssessment.definedTags 13.5.5
@@ -739,6 +776,7 @@ oci.dataSafe.securityAssessment.type 13.5.5
 oci.dataSafe.securityAssessments 13.5.5
 oci.dataSafe.sensitiveDataModel 13.5.5
 oci.dataSafe.sensitiveDataModel.appSuiteName 13.5.5
+oci.dataSafe.sensitiveDataModel.compartment 13.12.2
 oci.dataSafe.sensitiveDataModel.compartmentId 13.5.5
 oci.dataSafe.sensitiveDataModel.created 13.5.5
 oci.dataSafe.sensitiveDataModel.definedTags 13.5.5
@@ -752,6 +790,7 @@ oci.dataSafe.sensitiveDataModel.targetId 13.5.5
 oci.dataSafe.sensitiveDataModel.timeUpdated 13.5.5
 oci.dataSafe.sensitiveDataModels 13.5.5
 oci.dataSafe.sensitiveType 13.5.5
+oci.dataSafe.sensitiveType.compartment 13.12.2
 oci.dataSafe.sensitiveType.compartmentId 13.5.5
 oci.dataSafe.sensitiveType.created 13.5.5
 oci.dataSafe.sensitiveType.definedTags 13.5.5
@@ -767,6 +806,7 @@ oci.dataSafe.sensitiveType.timeUpdated 13.5.5
 oci.dataSafe.sensitiveTypes 13.5.5
 oci.dataSafe.targetDatabase 13.5.5
 oci.dataSafe.targetDatabase.associatedResourceIds 13.5.5
+oci.dataSafe.targetDatabase.compartment 13.12.2
 oci.dataSafe.targetDatabase.compartmentId 13.5.5
 oci.dataSafe.targetDatabase.created 13.5.5
 oci.dataSafe.targetDatabase.databaseType 13.5.5
@@ -779,8 +819,10 @@ oci.dataSafe.targetDatabase.infrastructureType 13.5.5
 oci.dataSafe.targetDatabase.lifecycleDetails 13.5.5
 oci.dataSafe.targetDatabase.lifecycleState 13.5.5
 oci.dataSafe.targetDatabase.region 13.5.5
+oci.dataSafe.targetDatabase.systemTags 13.12.2
 oci.dataSafe.targetDatabases 13.5.5
 oci.dataSafe.userAssessment 13.5.5
+oci.dataSafe.userAssessment.compartment 13.12.2
 oci.dataSafe.userAssessment.compartmentId 13.5.5
 oci.dataSafe.userAssessment.created 13.5.5
 oci.dataSafe.userAssessment.definedTags 13.5.5
@@ -821,6 +863,7 @@ oci.database.autonomousDatabase.isDedicated 13.1.1
 oci.database.autonomousDatabase.isFreeTier 13.1.1
 oci.database.autonomousDatabase.isLocalDataGuardEnabled 13.1.1
 oci.database.autonomousDatabase.isMtlsConnectionRequired 13.1.1
+oci.database.autonomousDatabase.isRefreshableClone 13.12.2
 oci.database.autonomousDatabase.isRemoteDataGuardEnabled 13.10.1
 oci.database.autonomousDatabase.kmsKey 13.1.1
 oci.database.autonomousDatabase.kmsVault 13.1.1
@@ -833,12 +876,15 @@ oci.database.autonomousDatabase.privateEndpointIp 13.1.1
 oci.database.autonomousDatabase.privateEndpointLabel 13.1.1
 oci.database.autonomousDatabase.publicConnectionUrls 13.8.2
 oci.database.autonomousDatabase.securityGroups 13.6.2
+oci.database.autonomousDatabase.sourceId 13.12.2
 oci.database.autonomousDatabase.standbyWhitelistedIps 13.10.1
 oci.database.autonomousDatabase.state 13.1.1
 oci.database.autonomousDatabase.subnet 13.1.1
+oci.database.autonomousDatabase.systemTags 13.12.2
 oci.database.autonomousDatabase.whitelistedIps 13.1.1
 oci.database.autonomousDatabaseBackup 13.4.1
 oci.database.autonomousDatabaseBackup.autonomousDatabase 13.4.1
+oci.database.autonomousDatabaseBackup.compartment 13.12.2
 oci.database.autonomousDatabaseBackup.compartmentID 13.4.1
 oci.database.autonomousDatabaseBackup.databaseSizeInTBs 13.4.1
 oci.database.autonomousDatabaseBackup.dbVersion 13.4.1
@@ -861,6 +907,7 @@ oci.database.autonomousDatabases 13.1.1
 oci.database.backup 13.4.1
 oci.database.backup.availabilityDomain 13.4.1
 oci.database.backup.backupDestinationType 13.4.1
+oci.database.backup.compartment 13.12.2
 oci.database.backup.compartmentID 13.4.1
 oci.database.backup.databaseEdition 13.4.1
 oci.database.backup.databaseId 13.4.1
@@ -884,6 +931,7 @@ oci.database.dbSystem 13.1.1
 oci.database.dbSystem.availabilityDomain 13.1.1
 oci.database.dbSystem.backupNetworkNsgIds 13.1.1
 oci.database.dbSystem.backupSecurityGroups 13.6.2
+oci.database.dbSystem.compartment 13.12.2
 oci.database.dbSystem.compartmentID 13.1.1
 oci.database.dbSystem.cpuCoreCount 13.1.1
 oci.database.dbSystem.created 13.1.1
@@ -904,8 +952,10 @@ oci.database.dbSystem.nsgIds 13.1.1
 oci.database.dbSystem.scanDnsName 13.10.1
 oci.database.dbSystem.securityGroups 13.6.2
 oci.database.dbSystem.shape 13.1.1
+oci.database.dbSystem.sourceDbSystemId 13.12.2
 oci.database.dbSystem.state 13.1.1
 oci.database.dbSystem.subnet 13.1.1
+oci.database.dbSystem.systemTags 13.12.2
 oci.database.dbSystem.version 13.1.1
 oci.database.dbSystems 13.1.1
 oci.events 13.0.6
@@ -924,16 +974,21 @@ oci.events.rules 13.0.6
 oci.fileStorage 13.0.6
 oci.fileStorage.fileSystem 13.0.6
 oci.fileStorage.fileSystem.availabilityDomain 13.0.6
+oci.fileStorage.fileSystem.compartment 13.12.2
 oci.fileStorage.fileSystem.compartmentID 13.0.6
 oci.fileStorage.fileSystem.created 13.0.6
 oci.fileStorage.fileSystem.id 13.0.6
+oci.fileStorage.fileSystem.isCloneParent 13.12.2
 oci.fileStorage.fileSystem.kmsKey 13.0.6
 oci.fileStorage.fileSystem.meteredBytes 13.0.6
 oci.fileStorage.fileSystem.name 13.0.6
+oci.fileStorage.fileSystem.parentFileSystemId 13.12.2
 oci.fileStorage.fileSystem.state 13.0.6
+oci.fileStorage.fileSystem.systemTags 13.12.2
 oci.fileStorage.fileSystems 13.0.6
 oci.functions 13.1.1
 oci.functions.application 13.1.1
+oci.functions.application.compartment 13.12.2
 oci.functions.application.compartmentID 13.1.1
 oci.functions.application.config 13.1.1
 oci.functions.application.created 13.1.1
@@ -953,6 +1008,7 @@ oci.functions.application.traceConfig 13.1.1
 oci.functions.applications 13.1.1
 oci.functions.function 13.1.1
 oci.functions.function.applicationId 13.1.1
+oci.functions.function.compartment 13.12.2
 oci.functions.function.compartmentID 13.1.1
 oci.functions.function.config 13.1.1
 oci.functions.function.created 13.1.1
@@ -1003,6 +1059,7 @@ oci.identity.dbCredential.expires 13.5.6
 oci.identity.dbCredential.id 13.5.6
 oci.identity.dbCredential.state 13.5.6
 oci.identity.dynamicGroup 13.5.6
+oci.identity.dynamicGroup.compartment 13.12.2
 oci.identity.dynamicGroup.compartmentID 13.5.6
 oci.identity.dynamicGroup.created 13.5.6
 oci.identity.dynamicGroup.definedTags 13.5.6
@@ -1014,6 +1071,7 @@ oci.identity.dynamicGroup.name 13.5.6
 oci.identity.dynamicGroup.state 13.5.6
 oci.identity.dynamicGroups 13.5.6
 oci.identity.group 9.0.0
+oci.identity.group.compartment 13.12.2
 oci.identity.group.compartmentID 9.0.0
 oci.identity.group.created 9.0.0
 oci.identity.group.definedTags 11.1.0
@@ -1025,6 +1083,7 @@ oci.identity.group.name 9.0.0
 oci.identity.group.state 9.0.0
 oci.identity.groups 9.0.0
 oci.identity.identityProvider 13.5.6
+oci.identity.identityProvider.compartment 13.12.2
 oci.identity.identityProvider.compartmentID 13.5.6
 oci.identity.identityProvider.created 13.5.6
 oci.identity.identityProvider.definedTags 13.5.6
@@ -1047,6 +1106,7 @@ oci.identity.mfaDevice.isActivated 13.1.1
 oci.identity.mfaDevice.state 13.1.1
 oci.identity.mfaDevice.userId 13.1.1
 oci.identity.networkSource 13.5.6
+oci.identity.networkSource.compartment 13.12.2
 oci.identity.networkSource.compartmentID 13.5.6
 oci.identity.networkSource.created 13.5.6
 oci.identity.networkSource.definedTags 13.5.6
@@ -1060,6 +1120,7 @@ oci.identity.networkSource.state 13.5.6
 oci.identity.networkSource.virtualSourceList 13.5.6
 oci.identity.networkSources 13.5.6
 oci.identity.oauth2ClientCredential 13.5.6
+oci.identity.oauth2ClientCredential.compartment 13.12.2
 oci.identity.oauth2ClientCredential.compartmentID 13.5.6
 oci.identity.oauth2ClientCredential.created 13.5.6
 oci.identity.oauth2ClientCredential.description 13.5.6
@@ -1070,6 +1131,7 @@ oci.identity.oauth2ClientCredential.scopes 13.5.6
 oci.identity.oauth2ClientCredential.state 13.5.6
 oci.identity.policies 9.0.0
 oci.identity.policy 9.0.0
+oci.identity.policy.compartment 13.12.2
 oci.identity.policy.compartmentID 9.0.0
 oci.identity.policy.created 9.0.0
 oci.identity.policy.definedTags 11.1.0
@@ -1091,6 +1153,7 @@ oci.identity.user 9.0.0
 oci.identity.user.apiKeys 9.0.0
 oci.identity.user.authTokens 9.0.0
 oci.identity.user.capabilities 9.0.0
+oci.identity.user.compartment 13.12.2
 oci.identity.user.compartmentID 9.0.0
 oci.identity.user.created 9.0.0
 oci.identity.user.customerSecretKeys 9.0.0
@@ -1103,6 +1166,7 @@ oci.identity.user.externalIdentifier 13.5.6
 oci.identity.user.freeformTags 11.1.0
 oci.identity.user.groups 9.0.0
 oci.identity.user.id 9.0.0
+oci.identity.user.identityProvider 13.12.2
 oci.identity.user.lastLogin 9.0.0
 oci.identity.user.mfaActivated 9.0.0
 oci.identity.user.mfaDevices 13.1.1
@@ -1170,6 +1234,7 @@ oci.loadBalancer.listener.trustedCaBundles 13.10.1
 oci.loadBalancer.listener.trustedCertificateAuthorities 13.10.1
 oci.loadBalancer.loadBalancer 13.0.6
 oci.loadBalancer.loadBalancer.backendSets 13.0.6
+oci.loadBalancer.loadBalancer.compartment 13.12.2
 oci.loadBalancer.loadBalancer.compartmentID 13.0.6
 oci.loadBalancer.loadBalancer.created 13.0.6
 oci.loadBalancer.loadBalancer.definedTags 13.7.2
@@ -1185,6 +1250,8 @@ oci.loadBalancer.loadBalancer.nsgIds 13.12.0
 oci.loadBalancer.loadBalancer.securityGroups 13.12.0
 oci.loadBalancer.loadBalancer.shape 13.0.6
 oci.loadBalancer.loadBalancer.state 13.0.6
+oci.loadBalancer.loadBalancer.subnets 13.12.2
+oci.loadBalancer.loadBalancer.systemTags 13.12.2
 oci.loadBalancer.loadBalancers 13.0.6
 oci.logging 13.0.6
 oci.logging.log 13.0.6
@@ -1200,8 +1267,10 @@ oci.logging.log.retentionDuration 13.0.6
 oci.logging.log.sourceResource 13.4.1
 oci.logging.log.sourceService 13.4.1
 oci.logging.log.state 13.0.6
+oci.logging.log.systemTags 13.12.2
 oci.logging.log.timeLastModified 13.0.6
 oci.logging.logGroup 13.0.6
+oci.logging.logGroup.compartment 13.12.2
 oci.logging.logGroup.compartmentID 13.0.6
 oci.logging.logGroup.created 13.0.6
 oci.logging.logGroup.description 13.0.6
@@ -1209,6 +1278,7 @@ oci.logging.logGroup.id 13.0.6
 oci.logging.logGroup.logs 13.0.6
 oci.logging.logGroup.name 13.0.6
 oci.logging.logGroup.state 13.0.6
+oci.logging.logGroup.systemTags 13.12.2
 oci.logging.logGroups 13.0.6
 oci.monitoring 13.0.6
 oci.monitoring.alarm 13.0.6
@@ -1232,6 +1302,7 @@ oci.network.exposure.internetReachable 13.12.0
 oci.network.exposure.openIngressRules 13.12.0
 oci.network.exposure.securityGroupAllowsIngress 13.12.0
 oci.network.internetGateway 13.1.1
+oci.network.internetGateway.compartment 13.12.2
 oci.network.internetGateway.compartmentID 13.1.1
 oci.network.internetGateway.created 13.1.1
 oci.network.internetGateway.definedTags 13.1.1
@@ -1244,6 +1315,7 @@ oci.network.internetGateway.vcn 13.1.1
 oci.network.internetGateways 13.1.1
 oci.network.natGateway 13.1.1
 oci.network.natGateway.blockTraffic 13.1.1
+oci.network.natGateway.compartment 13.12.2
 oci.network.natGateway.compartmentID 13.1.1
 oci.network.natGateway.created 13.1.1
 oci.network.natGateway.definedTags 13.1.1
@@ -1273,6 +1345,7 @@ oci.network.publicIp 13.8.2
 oci.network.publicIp.assignedEntityId 13.8.2
 oci.network.publicIp.assignedEntityType 13.8.2
 oci.network.publicIp.availabilityDomain 13.8.2
+oci.network.publicIp.compartment 13.12.2
 oci.network.publicIp.compartmentID 13.8.2
 oci.network.publicIp.created 13.8.2
 oci.network.publicIp.id 13.8.2
@@ -1283,6 +1356,7 @@ oci.network.publicIp.scope 13.8.2
 oci.network.publicIp.state 13.8.2
 oci.network.publicIps 13.8.2
 oci.network.routeTable 13.1.1
+oci.network.routeTable.compartment 13.12.2
 oci.network.routeTable.compartmentID 13.1.1
 oci.network.routeTable.created 13.1.1
 oci.network.routeTable.definedTags 13.1.1
@@ -1311,6 +1385,7 @@ oci.network.securityLists 9.0.0
 oci.network.subnet 13.0.6
 oci.network.subnet.availabilityDomain 13.0.6
 oci.network.subnet.cidrBlock 13.0.6
+oci.network.subnet.compartment 13.12.2
 oci.network.subnet.compartmentID 13.0.6
 oci.network.subnet.created 13.0.6
 oci.network.subnet.definedTags 13.0.6
@@ -1322,6 +1397,7 @@ oci.network.subnet.name 13.0.6
 oci.network.subnet.prohibitInternetIngress 13.0.6
 oci.network.subnet.prohibitPublicIpOnVnic 13.0.6
 oci.network.subnet.routeTable 13.1.1
+oci.network.subnet.securityListIds 13.12.2
 oci.network.subnet.state 13.0.6
 oci.network.subnet.subnetDomainName 13.0.6
 oci.network.subnet.vcn 13.0.6
@@ -1329,6 +1405,7 @@ oci.network.subnets 13.0.6
 oci.network.vcn 9.0.0
 oci.network.vcn.cidrBlock 9.0.0
 oci.network.vcn.cidrBlocks 9.0.0
+oci.network.vcn.compartment 13.12.2
 oci.network.vcn.compartmentID 9.0.0
 oci.network.vcn.created 9.0.0
 oci.network.vcn.defaultDhcpOptionsId 11.1.0
@@ -1345,6 +1422,7 @@ oci.network.vcn.vcnDomainName 11.1.0
 oci.network.vcns 9.0.0
 oci.networkFirewall 13.0.6
 oci.networkFirewall.firewall 13.0.6
+oci.networkFirewall.firewall.compartment 13.12.2
 oci.networkFirewall.firewall.compartmentID 13.0.6
 oci.networkFirewall.firewall.created 13.0.6
 oci.networkFirewall.firewall.healthStatus 13.8.2
@@ -1357,24 +1435,30 @@ oci.networkFirewall.firewall.securityAttributes 13.8.2
 oci.networkFirewall.firewall.shape 13.0.6
 oci.networkFirewall.firewall.state 13.0.6
 oci.networkFirewall.firewall.subnet 13.0.6
+oci.networkFirewall.firewall.systemTags 13.12.2
 oci.networkFirewall.firewall.timeUpdated 13.0.6
 oci.networkFirewall.firewalls 13.0.6
 oci.networkFirewall.policies 13.0.6
 oci.networkFirewall.policy 13.0.6
 oci.networkFirewall.policy.attachedFirewallCount 13.0.6
+oci.networkFirewall.policy.compartment 13.12.2
 oci.networkFirewall.policy.compartmentID 13.0.6
 oci.networkFirewall.policy.created 13.0.6
 oci.networkFirewall.policy.description 13.0.6
 oci.networkFirewall.policy.id 13.0.6
 oci.networkFirewall.policy.name 13.0.6
 oci.networkFirewall.policy.state 13.0.6
+oci.networkFirewall.policy.systemTags 13.12.2
 oci.objectStorage 9.0.0
 oci.objectStorage.bucket 9.0.0
 oci.objectStorage.bucket.approximateCount 11.1.0
 oci.objectStorage.bucket.approximateSize 11.1.0
 oci.objectStorage.bucket.autoTiering 9.0.0
+oci.objectStorage.bucket.compartment 13.12.2
 oci.objectStorage.bucket.compartmentID 9.0.0
 oci.objectStorage.bucket.created 9.0.0
+oci.objectStorage.bucket.createdBy 13.12.2
+oci.objectStorage.bucket.createdByUser 13.12.2
 oci.objectStorage.bucket.definedTags 11.1.0
 oci.objectStorage.bucket.etag 11.1.0
 oci.objectStorage.bucket.freeformTags 11.1.0
@@ -1413,6 +1497,7 @@ oci.objectStorage.retentionRule.timeRuleLocked 13.1.1
 oci.oke 13.0.6
 oci.oke.cluster 13.0.6
 oci.oke.cluster.availableKubernetesUpgrades 13.0.6
+oci.oke.cluster.compartment 13.12.2
 oci.oke.cluster.compartmentID 13.0.6
 oci.oke.cluster.created 13.0.6
 oci.oke.cluster.definedTags 13.7.2
@@ -1429,10 +1514,13 @@ oci.oke.cluster.privateEndpoint 13.0.6
 oci.oke.cluster.publicEndpoint 13.0.6
 oci.oke.cluster.securityAttributes 13.8.2
 oci.oke.cluster.state 13.0.6
+oci.oke.cluster.systemTags 13.12.2
 oci.oke.cluster.type 13.0.6
 oci.oke.cluster.vcn 13.0.6
 oci.oke.clusters 13.0.6
 oci.oke.nodePool 13.0.6
+oci.oke.nodePool.cluster 13.12.2
+oci.oke.nodePool.compartment 13.12.2
 oci.oke.nodePool.compartmentID 13.0.6
 oci.oke.nodePool.id 13.0.6
 oci.oke.nodePool.kubernetesVersion 13.0.6
@@ -1444,6 +1532,7 @@ oci.oke.nodePool.nodeShapeConfig 13.0.6
 oci.oke.nodePool.sshPublicKey 13.0.6
 oci.oke.nodePool.state 13.0.6
 oci.oke.nodePool.subnets 13.3.1
+oci.oke.nodePool.systemTags 13.12.2
 oci.ons 13.0.6
 oci.ons.subscription 13.0.6
 oci.ons.subscription.created 13.0.6
@@ -1465,6 +1554,7 @@ oci.ons.topics 13.0.6
 oci.redis 13.5.1
 oci.redis.cluster 13.5.1
 oci.redis.cluster.clusterMode 13.5.1
+oci.redis.cluster.compartment 13.12.2
 oci.redis.cluster.compartmentID 13.5.1
 oci.redis.cluster.created 13.5.1
 oci.redis.cluster.definedTags 13.5.1
@@ -1484,6 +1574,7 @@ oci.redis.cluster.shardCount 13.5.1
 oci.redis.cluster.softwareVersion 13.5.1
 oci.redis.cluster.state 13.5.1
 oci.redis.cluster.subnet 13.5.1
+oci.redis.cluster.systemTags 13.12.2
 oci.redis.cluster.timeUpdated 13.5.1
 oci.redis.clusters 13.5.1
 oci.region 9.0.0
@@ -1517,6 +1608,7 @@ oci.vault.secret.rotationInterval 13.1.1
 oci.vault.secret.rotationStatus 13.0.6
 oci.vault.secret.secretVersions 13.1.1
 oci.vault.secret.state 13.0.6
+oci.vault.secret.systemTags 13.12.2
 oci.vault.secret.timeOfCurrentVersionExpiry 13.1.1
 oci.vault.secretVersion 13.1.1
 oci.vault.secretVersion.contentType 13.1.1
@@ -1706,6 +1798,7 @@ oci.vulnerabilityScanning.vulnerability.vulnerabilityReference 13.7.1
 oci.vulnerabilityScanning.vulnerability.vulnerabilityType 13.7.1
 oci.waf 13.1.1
 oci.waf.firewall 13.1.1
+oci.waf.firewall.compartment 13.12.2
 oci.waf.firewall.compartmentID 13.1.1
 oci.waf.firewall.created 13.1.1
 oci.waf.firewall.definedTags 13.1.1
@@ -1715,10 +1808,12 @@ oci.waf.firewall.loadBalancer 13.1.1
 oci.waf.firewall.name 13.1.1
 oci.waf.firewall.policy 13.1.1
 oci.waf.firewall.state 13.1.1
+oci.waf.firewall.systemTags 13.12.2
 oci.waf.firewall.timeUpdated 13.1.1
 oci.waf.firewalls 13.1.1
 oci.waf.policies 13.1.1
 oci.waf.policy 13.1.1
+oci.waf.policy.compartment 13.12.2
 oci.waf.policy.compartmentID 13.1.1
 oci.waf.policy.created 13.1.1
 oci.waf.policy.definedTags 13.1.1
@@ -1726,4 +1821,5 @@ oci.waf.policy.freeformTags 13.1.1
 oci.waf.policy.id 13.1.1
 oci.waf.policy.name 13.1.1
 oci.waf.policy.state 13.1.1
+oci.waf.policy.systemTags 13.12.2
 oci.waf.policy.timeUpdated 13.1.1

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -154,6 +154,7 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 					"freeformTags":                llx.MapData(freeformTags, types.String),
 					"definedTags":                 llx.MapData(definedTags, types.Any),
 					"securityAttributes":          llx.MapData(securityAttributes, types.Dict),
+					"systemTags":                  llx.MapData(definedTagsToAny(cluster.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -351,6 +352,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 			"nodeImageName":     llx.StringDataPtr(np.NodeImageName),
 			"sshPublicKey":      llx.StringDataPtr(np.SshPublicKey),
 			"state":             llx.StringData(string(np.LifecycleState)),
+			"systemTags":        llx.MapData(definedTagsToAny(np.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -358,6 +360,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 		mqlPool := mqlInstance.(*mqlOciOkeNodePool)
 		mqlPool.cacheSubnetIds = subnetIds
 		mqlPool.cacheNsgIds = nsgIds
+		mqlPool.cacheClusterID = stringValue(np.ClusterId)
 		res = append(res, mqlPool)
 	}
 
@@ -367,6 +370,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 type mqlOciOkeNodePoolInternal struct {
 	cacheSubnetIds []string
 	cacheNsgIds    []string
+	cacheClusterID string
 }
 
 func (o *mqlOciOkeNodePool) id() (string, error) {

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -130,6 +130,7 @@ func (o *mqlOciRedis) getClusters(conn *connection.OciConnection, regions []any)
 					"timeUpdated":                llx.TimeDataPtr(updated),
 					"freeformTags":               llx.MapData(freeformTags, types.String),
 					"definedTags":                llx.MapData(definedTags, types.Any),
+					"systemTags":                 llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -124,6 +124,7 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 					"created":                 llx.TimeDataPtr(created),
 					"freeformTags":            llx.MapData(freeformTags, types.String),
 					"definedTags":             llx.MapData(definedTags, types.Any),
+					"systemTags":              llx.MapData(definedTagsToAny(s.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -439,7 +439,7 @@ func (o *mqlOciDataSafeMaskingPolicy) compartment() (*mqlOciCompartment, error) 
 }
 
 func (o *mqlOciCloudGuardDetectorRecipe) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
 }
 
 // ----- source / lineage accessors -----
@@ -533,4 +533,63 @@ func (o *mqlOciLoadBalancerLoadBalancer) subnets() ([]any, error) {
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+func (o *mqlOciNetworkSubnet) securityLists() ([]any, error) {
+	out := make([]any, 0, len(o.cacheSecurityListIds))
+	for _, id := range o.cacheSecurityListIds {
+		if id == "" {
+			continue
+		}
+		res, err := NewResource(o.MqlRuntime, "oci.network.securityList", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFileSystem, error) {
+	if o.cacheParentFileSystemId == "" {
+		o.ParentFileSystem.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheParentFileSystemId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciFileStorageFileSystem), nil
+}
+
+func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, error) {
+	if o.cacheSourceDbSystemId == "" {
+		o.SourceDbSystem.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.database.dbSystem", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheSourceDbSystemId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciDatabaseDbSystem), nil
+}
+
+func (o *mqlOciDatabaseAutonomousDatabase) sourceDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
+	if o.cacheSourceId == "" {
+		o.SourceDatabase.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.database.autonomousDatabase", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheSourceId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciDatabaseAutonomousDatabase), nil
 }

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -243,3 +243,294 @@ func (o *mqlOciDatabaseAutonomousDatabase) securityGroups() ([]any, error) {
 	}
 	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
 }
+
+// ----- compartment accessors (ownership) -----
+
+func (o *mqlOciIdentityUser) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityGroup) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityPolicy) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityOauth2ClientCredential) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityDynamicGroup) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityIdentityProvider) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciIdentityNetworkSource) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkPublicIp) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkVcn) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkSubnet) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkInternetGateway) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkNatGateway) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkRouteTable) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciLoggingLogGroup) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciObjectStorageBucket) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciFileStorageFileSystem) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCloudGuardTarget) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCloudGuardSecurityZone) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCloudGuardSecurityZoneRecipe) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCloudGuardSecurityPolicy) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciLoadBalancerLoadBalancer) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkFirewallFirewall) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciNetworkFirewallPolicy) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciOkeCluster) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciOkeNodePool) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciWafFirewall) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciWafPolicy) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciFunctionsApplication) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciFunctionsFunction) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciContainerInstancesInstance) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciContainerInstancesContainer) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciDatabaseBackup) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciDatabaseAutonomousDatabaseBackup) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciDatabaseDbSystem) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciApigatewayGateway) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciApigatewayDeployment) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciApigatewayCertificate) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCertificatesCertificate) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCertificatesCertificateAuthority) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciCertificatesCaBundle) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciRedisCluster) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeConfiguration) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeTargetDatabase) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeSecurityAssessment) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeUserAssessment) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeSensitiveDataModel) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeSensitiveType) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciDataSafeMaskingPolicy) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+func (o *mqlOciCloudGuardDetectorRecipe) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+}
+
+// ----- source / lineage accessors -----
+
+func (o *mqlOciComputeImage) baseImage() (*mqlOciComputeImage, error) {
+	return resolveOciImage(o.MqlRuntime, o.cacheBaseImageID, &o.BaseImage)
+}
+
+func (o *mqlOciComputeInstance) bootVolume() (*mqlOciComputeBootVolume, error) {
+	if o.cacheBootVolumeID == "" {
+		o.BootVolume.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheBootVolumeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciComputeBootVolume), nil
+}
+
+func (o *mqlOciComputeBlockVolume) sourceVolume() (*mqlOciComputeBlockVolume, error) {
+	if o.cacheSourceVolumeID == "" {
+		o.SourceVolume.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.compute.blockVolume", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheSourceVolumeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciComputeBlockVolume), nil
+}
+
+func (o *mqlOciComputeBootVolume) sourceBootVolume() (*mqlOciComputeBootVolume, error) {
+	if o.cacheSourceBootVolumeID == "" {
+		o.SourceBootVolume.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheSourceBootVolumeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciComputeBootVolume), nil
+}
+
+func (o *mqlOciIdentityUser) identityProvider() (*mqlOciIdentityIdentityProvider, error) {
+	if o.cacheIdentityProviderID == "" {
+		o.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.identity.identityProvider", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheIdentityProviderID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciIdentityIdentityProvider), nil
+}
+
+func (o *mqlOciOkeNodePool) cluster() (*mqlOciOkeCluster, error) {
+	if o.cacheClusterID == "" {
+		o.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.oke.cluster", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheClusterID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciOkeCluster), nil
+}
+
+func (o *mqlOciLoadBalancerLoadBalancer) subnets() ([]any, error) {
+	out := make([]any, 0, len(o.cacheSubnetIDs))
+	for _, id := range o.cacheSubnetIDs {
+		if id == "" {
+			continue
+		}
+		res, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -119,6 +119,7 @@ func (o *mqlOciWaf) getFirewalls(conn *connection.OciConnection, regions []any) 
 					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
 					"freeformTags":  llx.MapData(freeformTags, types.String),
 					"definedTags":   llx.MapData(definedTags, types.Any),
+					"systemTags":    llx.MapData(definedTagsToAny(lbWaf.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -266,6 +267,7 @@ func (o *mqlOciWaf) getPolicies(conn *connection.OciConnection, regions []any) [
 					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
 					"freeformTags":  llx.MapData(freeformTags, types.String),
 					"definedTags":   llx.MapData(definedTags, types.Any),
+					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Adds provenance and attribution surfaces across the OCI provider. All fields were verified to exist on `oci-go-sdk/v65` before wiring.

## Ownership — `compartment()` typed reference

~49 modeled resources exposed a raw `compartmentId` string but no typed accessor. Each now gains `compartment() oci.compartment` (resolved through the existing `resolveOciCompartment` helper) and the raw field is marked `@maturity("deprecated")`. `oci.cloudGuard.detectorRecipe` exposed compartment in no form and gains both the raw `compartmentId` and the typed `compartment()`.

| Area | Resources |
|---|---|
| identity | user, group, policy, oauth2ClientCredential, dynamicGroup, identityProvider, networkSource |
| network | publicIp, vcn, subnet, internetGateway, natGateway, routeTable |
| logging / object / file | logGroup, objectStorage.bucket, fileStorage.fileSystem |
| cloudGuard | target, detectorRecipe, securityZone, securityZoneRecipe, securityPolicy |
| edge / compute | loadBalancer, networkFirewall.{firewall,policy}, oke.{cluster,nodePool}, waf.{firewall,policy}, functions.{application,function}, containerInstances.{instance,container} |
| database / apigateway / certificates / redis / dataSafe | database.{backup,autonomousDatabaseBackup,dbSystem}, apigateway.{gateway,deployment,certificate}, certificates.{certificate,certificateAuthority,caBundle}, redis.cluster, dataSafe.{configuration,targetDatabase,securityAssessment,userAssessment,sensitiveDataModel,sensitiveType,maskingPolicy} |

## Creator — system tags and explicit CreatedBy

OCI populates `SystemTags["Oracle-Tags"]["CreatedBy"]` (creating principal OCID) and `["CreatedOn"]`, but the provider exposed it nowhere. Every modeled resource whose SDK struct carries `SystemTags` now exposes `systemTags map[string]dict` (mirroring the existing `definedTags` handling). 29 resources across compute, fileStorage, loadBalancer, database, logging, cloudGuard, networkFirewall, oke, waf, containerInstances, apigateway, redis, vault, bastion, and dataSafe.targetDatabase.

`oci.objectStorage.bucket` additionally gains `createdBy` (from `Bucket.CreatedBy`) and a typed `createdByUser() oci.identity.user` (null when the principal is not an `ocid1.user`).

## Source / lineage and management references

| Resource | Added |
|---|---|
| compute.image | `baseImage() oci.compute.image` |
| compute.instance | `bootVolume() oci.compute.bootVolume` |
| compute.blockVolume | `sourceVolume() oci.compute.blockVolume`, raw `sourceVolumeBackupId` |
| compute.bootVolume | `sourceBootVolume() oci.compute.bootVolume`, raw `sourceBootVolumeBackupId` |
| identity.user | `identityProvider() oci.identity.identityProvider` |
| oke.nodePool | `cluster() oci.oke.cluster` |
| loadBalancer | `subnets() []oci.network.subnet` |
| database.dbSystem | raw `sourceDbSystemId` |
| database.autonomousDatabase | raw `sourceId`, `isRefreshableClone` |
| fileStorage.fileSystem | raw `parentFileSystemId`, `isCloneParent` |
| network.subnet | raw `securityListIds` |

## Notes / deferred

- `systemTags` was intentionally **not** added to identity (user/group/policy), KMS keys/vaults, compute.image, network.vcn/subnet, and the 4 non-targetDatabase dataSafe summaries — their `oci-go-sdk/v65` list structs do not carry `SystemTags`.
- `network.subnet` uses a raw `securityListIds []string` rather than a typed `securityLists()` because security lists are only enumerable by compartment, not resolvable by id.
- `.lr.versions` entries auto-assigned at `13.12.2` (next patch after the provider's `13.12.1`). `oci.permissions.json` is unchanged (no new API calls).

Verified: `make providers/build/oci`, `go build ./...`, `go vet`, and `go test ./providers/oci/resources/` all pass.