### PR TITLE
⭐ aws: expose ownership, source, and management provenance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -213,6 +213,8 @@ aws.organization @defaults("id masterAccountEmail") {
   featureSet string
   // ID of the organization's master account
   masterAccountId string
+  // ARN of the organization's master account
+  masterAccountArn string
   // Email owner of the organization's master account
   masterAccountEmail string
   // List of accounts that belong to the organization, if available to the caller
@@ -321,6 +323,8 @@ aws.vpc @defaults("id isDefault cidrBlock region") {
   isDefault bool
   // How instance hardware tenancy settings are enforced on instances launched in this VPC
   instanceTenancy string
+  // AWS account ID that owns the VPC
+  ownerId string
   // Region in which the VPC exists
   region string
   // List of endpoints for the VPC
@@ -473,6 +477,8 @@ private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAva
   assignIpv6AddressOnCreation bool
   // State of the subnet: pending, available, unavailable, failed, or failed-insufficient-capacity
   state string
+  // AWS account ID that owns the subnet
+  ownerId string
   // Region in which the VPC subnet exists
   region string
   // The number of available IP addresses in the subnet
@@ -1365,6 +1371,8 @@ private aws.efs.filesystem @defaults("name id region") {
   arn string
   // Whether the file system is encrypted
   encrypted bool
+  // AWS account ID that owns the file system
+  ownerId string
   // KMS key used for encryption of the file system
   kmsKey() aws.kms.key
   // Backup policy for the file system
@@ -2053,6 +2061,8 @@ private aws.iam.user @defaults("arn name createdAt") {
   path string
   // List of MFA devices (virtual and hardware) assigned to the user
   mfaDevices() []dict
+  // Managed policy that sets the permissions boundary for the user, if one is set
+  permissionsBoundary() aws.iam.policy
 }
 
 // IAM user access key
@@ -4670,6 +4680,8 @@ private aws.sns.topic @defaults("arn") {
   tags() map[string]string
   // Signature version used for Amazon SNS message signing (1 or 2)
   signatureVersion() string
+  // AWS account ID of the topic owner
+  owner() string
   // KMS master key used for server-side encryption
   kmsMasterKey() aws.kms.key
   // Access policy for the topic (parsed JSON)
@@ -5561,6 +5573,10 @@ private aws.codebuild.project @defaults("arn name") {
   buildBatchConfig dict
   // Maximum number of concurrent builds allowed for this project
   concurrentBuildLimit int
+  // Default source version (branch, tag, or commit) builds use when none is specified
+  sourceVersion string
+  // IAM role that enables CodeBuild to access resources (such as Amazon EFS) in the customer VPC
+  resourceAccessRole() aws.iam.role
 }
 
 // AWS CodeBuild report group
@@ -6853,6 +6869,8 @@ aws.secretsmanager.secret @defaults("arn name") {
   rotationEnabled bool
   // Lambda function used for automatic rotation
   rotationLambda aws.lambda.function
+  // IAM role Secrets Manager assumes to rotate the secret with a customer-managed rotation Lambda, if configured
+  externalRotationRole() aws.iam.role
   // Rotation schedule configuration
   rotationRules aws.secretsmanager.secret.rotationRules
   // Tags for the secret
@@ -7132,6 +7150,8 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   capacityProviderName string
   // Name of the task group
   group string
+  // Tag or identifier of whatever started the task (a deployment ID, a user, or an ECS service name)
+  startedBy string
   // Whether the execute command functionality is enabled for the task
   enableExecuteCommand bool
   // How the task was stopped
@@ -7252,6 +7272,8 @@ private aws.ecs.taskDefinition @defaults("arn family revision") {
   memory() string
   // When the task definition was registered
   registeredAt() time
+  // ARN of the principal that registered this task definition revision
+  registeredBy() string
   // Launch types the task definition is compatible with (EC2, FARGATE, EXTERNAL)
   requiresCompatibilities() []string
   // CPU architecture the task runs on (X86_64, ARM64)
@@ -7285,7 +7307,11 @@ private aws.ecs.service @defaults("arn name clusterArn status") {
   // Number of running tasks for the service
   runningCount int
   // ARN of the task definition used by the service
-  taskDefinition string
+  //
+  // Deprecated in favor of `taskDefinition()`.
+  taskDefinitionArn @maturity("deprecated") string
+  // Task definition the service runs
+  taskDefinition() aws.ecs.taskDefinition
   // Launch type for the service (EC2, FARGATE, EXTERNAL, MANAGED_INSTANCES)
   launchType string
   // Deployment configuration for the service
@@ -11580,6 +11606,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   dbClusterParameterGroup() aws.rds.clusterParameterGroup
   // Whether the cluster is a clone of a cluster owned by a different account
   crossAccountClone bool
+  // Identifier of the clone group the cluster belongs to, shared across a cluster and its clones
+  cloneGroupId string
   // Identifier of the source DB cluster or DB instance if this cluster is a read replica
   replicationSourceIdentifier string
   // Status of write forwarding for a secondary cluster in an Aurora global cluster
@@ -11632,6 +11660,10 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   timezone string
   // Identifier or ARN of the snapshot this snapshot was copied from
   sourceSnapshot string
+  // Source DB instance the snapshot was taken from, when present in this account
+  sourceDbInstance() aws.rds.dbinstance
+  // Source DB cluster the snapshot was taken from, when present in this account
+  sourceDbCluster() aws.rds.dbcluster
   // Region the source snapshot was copied from (empty unless this is a cross-region copy)
   sourceRegion string
   // Original creation time of the snapshot before any copy (empty unless this snapshot is a copy)
@@ -11767,6 +11799,8 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   dbiResourceId string
   // Cluster identifier if the instance belongs to a DB cluster
   dbClusterIdentifier string
+  // DB cluster the instance belongs to, when present in this account
+  dbCluster() aws.rds.dbcluster
   // Identifier of the source DB instance if this instance is a read replica
   readReplicaSourceInstanceId string
   // Identifier of the source DB cluster if this instance is a read replica
@@ -12001,6 +12035,8 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   preferredMaintenanceWindow string
   // Whether log delivery is enabled for the replication group
   replicationGroupLogDeliveryEnabled bool
+  // Identifier of the replication group the cluster belongs to, when part of one
+  replicationGroupId string
   // Resource tags for the cluster
   tags() map[string]string
 }
@@ -12275,6 +12311,8 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   ipAddressType string
   // KMS key used to encrypt the master password secret in Secrets Manager
   masterPasswordSecretKmsKey() aws.kms.key
+  // Identifier of the snapshot schedule associated with the cluster, if any
+  snapshotScheduleIdentifier string
   // Snapshots for this cluster
   snapshots() []aws.redshift.snapshot
 }
@@ -12287,6 +12325,12 @@ private aws.redshift.snapshot @defaults("arn clusterIdentifier status createdAt"
   id string
   // Cluster identifier
   clusterIdentifier string
+  // Cluster the snapshot was taken from, when present in this account
+  cluster() aws.redshift.cluster
+  // AWS account ID of the snapshot owner
+  ownerAccount string
+  // Accounts authorized to restore the snapshot, each with an account ID and optional alias
+  accountsWithRestoreAccess []dict
   // Region where the snapshot exists
   region string
   // Snapshot type (manual or automated)
@@ -14318,6 +14362,12 @@ private aws.lambda.function @defaults("arn") {
   imageUri() string
   // Resolved digest-pinned container image URI for Image package type functions (empty for Zip package type functions)
   resolvedImageUri() string
+  // ARN of the master function this Lambda was configured from (set for replicated functions such as Lambda@Edge replicas)
+  masterArn string
+  // Master function this Lambda was configured from, when present in this account
+  masterFunction() aws.lambda.function
+  // KMS key used to encrypt the function's deployment package, when configured
+  sourceKmsKey() aws.kms.key
 }
 
 // AWS Lambda function version
@@ -14638,6 +14688,16 @@ private aws.ssm.instance @defaults("instanceId region platformName platformVersi
   lastPingedAt time
   // Fully qualified hostname of the managed node
   computerName string
+  // IAM role assigned to the managed instance for Systems Manager (set for hybrid/on-premises activations)
+  iamRole() aws.iam.role
+  // How the managed node was registered: AWS::EC2::Instance or AWS::SSM::ManagedInstance
+  sourceType string
+  // Identifier of the registration source (instance ID or activation-registered ID)
+  sourceId string
+  // Activation used to register the managed node, for hybrid/on-premises instances
+  activationId string
+  // Type of the managed resource: EC2Instance or ManagedInstance
+  resourceType string
 }
 
 // Amazon Elastic Compute Cloud (EC2)
@@ -15505,6 +15565,8 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   dataEncryptionKeyId string
   // Owner alias of the snapshot (for example, amazon or aws-backup-vault)
   ownerAlias string
+  // AWS account ID of the snapshot owner
+  ownerId string
   // ARN of the Outpost on which the snapshot is stored
   outpostArn string
   // Whether the snapshot is public (shared with all AWS accounts)
@@ -15939,6 +16001,14 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   placement aws.ec2.instance.placement
   // Virtualization type: hvm or paravirtual
   virtualizationType string
+  // Capacity reservation the instance runs in, when targeted to one
+  capacityReservation() aws.ec2.capacityReservation
+  // Auto Scaling group that manages this instance, when launched by one
+  autoScalingGroup() aws.autoscaling.group
+  // Whether the instance is managed by an AWS service provider on your behalf
+  managedByOperator bool
+  // Service provider principal that manages the instance, when operator-managed
+  operatorPrincipal string
 }
 
 // AWS EC2 network interface
@@ -15999,6 +16069,12 @@ private aws.ec2.networkinterface @defaults("id privateIpAddress macAddress") {
   deviceIndex int
   // Whether the network interface is deleted when the instance is terminated
   deleteOnTermination bool
+  // AWS account ID that owns the network interface
+  ownerId string
+  // AWS account ID of the entity that requested the network interface (for service-managed interfaces)
+  requesterId string
+  // AWS account ID that owns the instance the network interface is attached to
+  instanceOwnerId string
 }
 
 // Amazon EC2 key pair
@@ -16150,6 +16226,8 @@ private aws.ec2.image.ebsBlockDevice @defaults("volumeSize volumeType encrypted"
   encrypted bool
   // ID of the snapshot used to create the volume
   snapshotId string
+  // Snapshot the volume is created from, when present in this account
+  snapshot() aws.ec2.snapshot
   // Size of the volume in GiB
   volumeSize int
   // Volume type (gp2, gp3, io1, io2, etc.)
@@ -16247,6 +16325,8 @@ private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   allowsUnrestrictedEgress() bool
   // Region associated with the security group
   region string
+  // AWS account ID that owns the security group
+  ownerId string
   // Whether the security group is attached to Amazon Elastic Compute Cloud
   isAttachedToNetworkInterface() bool
   // Network interfaces this security group is attached to
@@ -16558,6 +16638,10 @@ private aws.eks.nodegroup @defaults("name scalingConfig.DesiredSize diskSize sta
   nodeRepairEnabled() bool
   // Subnets associated with the node group
   nodegroupSubnets() []aws.vpc.subnet
+  // Launch template the node group uses to configure its instances, if any
+  launchTemplate() aws.ec2.launchtemplate
+  // Version of the launch template the node group uses, when a launch template is configured
+  launchTemplateVersion() string
 }
 
 // Amazon EKS add-on
@@ -22361,6 +22445,12 @@ private aws.cloudformation.stack @defaults("name status") {
   updatedAt time
   // Resources the stack provisioned, mapping each template entry to the concrete AWS resource
   resources() []aws.cloudformation.stack.resource
+  // ID of the change set that produced the most recent stack operation, if any
+  changeSetId string
+  // Direct parent stack when this is a nested stack, otherwise null
+  parentStack() aws.cloudformation.stack
+  // Top-level root stack of a nested-stack hierarchy, otherwise null
+  rootStack() aws.cloudformation.stack
 }
 
 // CloudFormation stack resource

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7307,11 +7307,9 @@ private aws.ecs.service @defaults("arn name clusterArn status") {
   // Number of running tasks for the service
   runningCount int
   // ARN of the task definition used by the service
-  //
-  // Deprecated in favor of `taskDefinition()`.
-  taskDefinitionArn @maturity("deprecated") string
+  taskDefinition string
   // Task definition the service runs
-  taskDefinition() aws.ecs.taskDefinition
+  taskDefinitionRef() aws.ecs.taskDefinition
   // Launch type for the service (EC2, FARGATE, EXTERNAL, MANAGED_INSTANCES)
   launchType string
   // Deployment configuration for the service

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12871,11 +12871,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.service.runningCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetRunningCount()).ToDataRes(types.Int)
 	},
-	"aws.ecs.service.taskDefinitionArn": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsEcsService).GetTaskDefinitionArn()).ToDataRes(types.String)
-	},
 	"aws.ecs.service.taskDefinition": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsEcsService).GetTaskDefinition()).ToDataRes(types.Resource("aws.ecs.taskDefinition"))
+		return (r.(*mqlAwsEcsService).GetTaskDefinition()).ToDataRes(types.String)
+	},
+	"aws.ecs.service.taskDefinitionRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsService).GetTaskDefinitionRef()).ToDataRes(types.Resource("aws.ecs.taskDefinition"))
 	},
 	"aws.ecs.service.launchType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetLaunchType()).ToDataRes(types.String)
@@ -45042,12 +45042,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcsService).RunningCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
-	"aws.ecs.service.taskDefinitionArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsEcsService).TaskDefinitionArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.ecs.service.taskDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsService).TaskDefinition, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.ecs.service.taskDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsEcsService).TaskDefinition, ok = plugin.RawToTValue[*mqlAwsEcsTaskDefinition](v.Value, v.Error)
+	"aws.ecs.service.taskDefinitionRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsService).TaskDefinitionRef, ok = plugin.RawToTValue[*mqlAwsEcsTaskDefinition](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.service.launchType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -106246,8 +106246,8 @@ type mqlAwsEcsService struct {
 	Status                        plugin.TValue[string]
 	DesiredCount                  plugin.TValue[int64]
 	RunningCount                  plugin.TValue[int64]
-	TaskDefinitionArn             plugin.TValue[string]
-	TaskDefinition                plugin.TValue[*mqlAwsEcsTaskDefinition]
+	TaskDefinition                plugin.TValue[string]
+	TaskDefinitionRef             plugin.TValue[*mqlAwsEcsTaskDefinition]
 	LaunchType                    plugin.TValue[string]
 	DeploymentConfiguration       plugin.TValue[*mqlAwsEcsServiceDeploymentConfiguration]
 	NetworkConfiguration          plugin.TValue[*mqlAwsEcsServiceNetworkConfiguration]
@@ -106349,14 +106349,14 @@ func (c *mqlAwsEcsService) GetRunningCount() *plugin.TValue[int64] {
 	return &c.RunningCount
 }
 
-func (c *mqlAwsEcsService) GetTaskDefinitionArn() *plugin.TValue[string] {
-	return &c.TaskDefinitionArn
+func (c *mqlAwsEcsService) GetTaskDefinition() *plugin.TValue[string] {
+	return &c.TaskDefinition
 }
 
-func (c *mqlAwsEcsService) GetTaskDefinition() *plugin.TValue[*mqlAwsEcsTaskDefinition] {
-	return plugin.GetOrCompute[*mqlAwsEcsTaskDefinition](&c.TaskDefinition, func() (*mqlAwsEcsTaskDefinition, error) {
+func (c *mqlAwsEcsService) GetTaskDefinitionRef() *plugin.TValue[*mqlAwsEcsTaskDefinition] {
+	return plugin.GetOrCompute[*mqlAwsEcsTaskDefinition](&c.TaskDefinitionRef, func() (*mqlAwsEcsTaskDefinition, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.service", c.__id, "taskDefinition")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.service", c.__id, "taskDefinitionRef")
 			if err != nil {
 				return nil, err
 			}
@@ -106365,7 +106365,7 @@ func (c *mqlAwsEcsService) GetTaskDefinition() *plugin.TValue[*mqlAwsEcsTaskDefi
 			}
 		}
 
-		return c.taskDefinition()
+		return c.taskDefinitionRef()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3153,7 +3153,7 @@ func init() {
 			Create: createAwsEc2PlacementGroup,
 		},
 		"aws.ec2.capacityReservation": {
-			// to override args, implement: initAwsEc2CapacityReservation(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2CapacityReservation,
 			Create: createAwsEc2CapacityReservation,
 		},
 		"aws.ec2.instanceConnectEndpoint": {
@@ -3165,7 +3165,7 @@ func init() {
 			Create: createAwsEc2VpcEndpointServiceConfiguration,
 		},
 		"aws.ec2.launchtemplate": {
-			// to override args, implement: initAwsEc2Launchtemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2Launchtemplate,
 			Create: createAwsEc2Launchtemplate,
 		},
 		"aws.ec2.launchconfiguration": {
@@ -4750,6 +4750,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.organization.masterAccountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetMasterAccountId()).ToDataRes(types.String)
 	},
+	"aws.organization.masterAccountArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetMasterAccountArn()).ToDataRes(types.String)
+	},
 	"aws.organization.masterAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetMasterAccountEmail()).ToDataRes(types.String)
 	},
@@ -4860,6 +4863,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.instanceTenancy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetInstanceTenancy()).ToDataRes(types.String)
+	},
+	"aws.vpc.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetOwnerId()).ToDataRes(types.String)
 	},
 	"aws.vpc.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetRegion()).ToDataRes(types.String)
@@ -5052,6 +5058,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.subnet.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetState()).ToDataRes(types.String)
+	},
+	"aws.vpc.subnet.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetOwnerId()).ToDataRes(types.String)
 	},
 	"aws.vpc.subnet.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetRegion()).ToDataRes(types.String)
@@ -6022,6 +6031,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.filesystem.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetEncrypted()).ToDataRes(types.Bool)
 	},
+	"aws.efs.filesystem.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystem).GetOwnerId()).ToDataRes(types.String)
+	},
 	"aws.efs.filesystem.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
@@ -6771,6 +6783,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.user.mfaDevices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetMfaDevices()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.iam.user.permissionsBoundary": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetPermissionsBoundary()).ToDataRes(types.Resource("aws.iam.policy"))
 	},
 	"aws.iam.user.accessKey.accessKeyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUserAccessKey).GetAccessKeyId()).ToDataRes(types.String)
@@ -9895,6 +9910,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sns.topic.signatureVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetSignatureVersion()).ToDataRes(types.String)
 	},
+	"aws.sns.topic.owner": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSnsTopic).GetOwner()).ToDataRes(types.String)
+	},
 	"aws.sns.topic.kmsMasterKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetKmsMasterKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
@@ -11019,6 +11037,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.codebuild.project.concurrentBuildLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuildProject).GetConcurrentBuildLimit()).ToDataRes(types.Int)
+	},
+	"aws.codebuild.project.sourceVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCodebuildProject).GetSourceVersion()).ToDataRes(types.String)
+	},
+	"aws.codebuild.project.resourceAccessRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCodebuildProject).GetResourceAccessRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
 	"aws.codebuild.reportGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuildReportGroup).GetArn()).ToDataRes(types.String)
@@ -12337,6 +12361,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.secretsmanager.secret.rotationLambda": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetRotationLambda()).ToDataRes(types.Resource("aws.lambda.function"))
 	},
+	"aws.secretsmanager.secret.externalRotationRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetExternalRotationRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
 	"aws.secretsmanager.secret.rotationRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetRotationRules()).ToDataRes(types.Resource("aws.secretsmanager.secret.rotationRules"))
 	},
@@ -12649,6 +12676,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.task.group": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTask).GetGroup()).ToDataRes(types.String)
 	},
+	"aws.ecs.task.startedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTask).GetStartedBy()).ToDataRes(types.String)
+	},
 	"aws.ecs.task.enableExecuteCommand": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTask).GetEnableExecuteCommand()).ToDataRes(types.Bool)
 	},
@@ -12799,6 +12829,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.taskDefinition.registeredAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTaskDefinition).GetRegisteredAt()).ToDataRes(types.Time)
 	},
+	"aws.ecs.taskDefinition.registeredBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTaskDefinition).GetRegisteredBy()).ToDataRes(types.String)
+	},
 	"aws.ecs.taskDefinition.requiresCompatibilities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTaskDefinition).GetRequiresCompatibilities()).ToDataRes(types.Array(types.String))
 	},
@@ -12838,8 +12871,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.service.runningCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetRunningCount()).ToDataRes(types.Int)
 	},
+	"aws.ecs.service.taskDefinitionArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsService).GetTaskDefinitionArn()).ToDataRes(types.String)
+	},
 	"aws.ecs.service.taskDefinition": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsEcsService).GetTaskDefinition()).ToDataRes(types.String)
+		return (r.(*mqlAwsEcsService).GetTaskDefinition()).ToDataRes(types.Resource("aws.ecs.taskDefinition"))
 	},
 	"aws.ecs.service.launchType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetLaunchType()).ToDataRes(types.String)
@@ -17320,6 +17356,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.crossAccountClone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetCrossAccountClone()).ToDataRes(types.Bool)
 	},
+	"aws.rds.dbcluster.cloneGroupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetCloneGroupId()).ToDataRes(types.String)
+	},
 	"aws.rds.dbcluster.replicationSourceIdentifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetReplicationSourceIdentifier()).ToDataRes(types.String)
 	},
@@ -17391,6 +17430,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.snapshot.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetSourceSnapshot()).ToDataRes(types.String)
+	},
+	"aws.rds.snapshot.sourceDbInstance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetSourceDbInstance()).ToDataRes(types.Resource("aws.rds.dbinstance"))
+	},
+	"aws.rds.snapshot.sourceDbCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetSourceDbCluster()).ToDataRes(types.Resource("aws.rds.dbcluster"))
 	},
 	"aws.rds.snapshot.sourceRegion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetSourceRegion()).ToDataRes(types.String)
@@ -17568,6 +17613,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.dbClusterIdentifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetDbClusterIdentifier()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.dbCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetDbCluster()).ToDataRes(types.Resource("aws.rds.dbcluster"))
 	},
 	"aws.rds.dbinstance.readReplicaSourceInstanceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaSourceInstanceId()).ToDataRes(types.String)
@@ -17826,6 +17874,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.cluster.replicationGroupLogDeliveryEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetReplicationGroupLogDeliveryEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.elasticache.cluster.replicationGroupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetReplicationGroupId()).ToDataRes(types.String)
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -18163,6 +18214,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.redshift.cluster.masterPasswordSecretKmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetMasterPasswordSecretKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
+	"aws.redshift.cluster.snapshotScheduleIdentifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftCluster).GetSnapshotScheduleIdentifier()).ToDataRes(types.String)
+	},
 	"aws.redshift.cluster.snapshots": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetSnapshots()).ToDataRes(types.Array(types.Resource("aws.redshift.snapshot")))
 	},
@@ -18174,6 +18228,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.redshift.snapshot.clusterIdentifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftSnapshot).GetClusterIdentifier()).ToDataRes(types.String)
+	},
+	"aws.redshift.snapshot.cluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftSnapshot).GetCluster()).ToDataRes(types.Resource("aws.redshift.cluster"))
+	},
+	"aws.redshift.snapshot.ownerAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftSnapshot).GetOwnerAccount()).ToDataRes(types.String)
+	},
+	"aws.redshift.snapshot.accountsWithRestoreAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftSnapshot).GetAccountsWithRestoreAccess()).ToDataRes(types.Array(types.Dict))
 	},
 	"aws.redshift.snapshot.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftSnapshot).GetRegion()).ToDataRes(types.String)
@@ -20335,6 +20398,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.resolvedImageUri": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetResolvedImageUri()).ToDataRes(types.String)
 	},
+	"aws.lambda.function.masterArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetMasterArn()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.masterFunction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetMasterFunction()).ToDataRes(types.Resource("aws.lambda.function"))
+	},
+	"aws.lambda.function.sourceKmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetSourceKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.lambda.function.version.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunctionVersion).GetArn()).ToDataRes(types.String)
 	},
@@ -20697,6 +20769,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ssm.instance.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmInstance).GetComputerName()).ToDataRes(types.String)
+	},
+	"aws.ssm.instance.iamRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
+	"aws.ssm.instance.sourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetSourceType()).ToDataRes(types.String)
+	},
+	"aws.ssm.instance.sourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetSourceId()).ToDataRes(types.String)
+	},
+	"aws.ssm.instance.activationId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetActivationId()).ToDataRes(types.String)
+	},
+	"aws.ssm.instance.resourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetResourceType()).ToDataRes(types.String)
 	},
 	"aws.ec2.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
@@ -21751,6 +21838,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.ownerAlias": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetOwnerAlias()).ToDataRes(types.String)
 	},
+	"aws.ec2.snapshot.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetOwnerId()).ToDataRes(types.String)
+	},
 	"aws.ec2.snapshot.outpostArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetOutpostArn()).ToDataRes(types.String)
 	},
@@ -22270,6 +22360,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.virtualizationType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetVirtualizationType()).ToDataRes(types.String)
 	},
+	"aws.ec2.instance.capacityReservation": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetCapacityReservation()).ToDataRes(types.Resource("aws.ec2.capacityReservation"))
+	},
+	"aws.ec2.instance.autoScalingGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetAutoScalingGroup()).ToDataRes(types.Resource("aws.autoscaling.group"))
+	},
+	"aws.ec2.instance.managedByOperator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetManagedByOperator()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.instance.operatorPrincipal": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetOperatorPrincipal()).ToDataRes(types.String)
+	},
 	"aws.ec2.networkinterface.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetId()).ToDataRes(types.String)
 	},
@@ -22344,6 +22446,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.networkinterface.deleteOnTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetDeleteOnTermination()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.networkinterface.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkinterface).GetOwnerId()).ToDataRes(types.String)
+	},
+	"aws.ec2.networkinterface.requesterId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkinterface).GetRequesterId()).ToDataRes(types.String)
+	},
+	"aws.ec2.networkinterface.instanceOwnerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkinterface).GetInstanceOwnerId()).ToDataRes(types.String)
 	},
 	"aws.ec2.keypair.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Keypair).GetArn()).ToDataRes(types.String)
@@ -22522,6 +22633,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.image.ebsBlockDevice.snapshotId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ImageEbsBlockDevice).GetSnapshotId()).ToDataRes(types.String)
 	},
+	"aws.ec2.image.ebsBlockDevice.snapshot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2ImageEbsBlockDevice).GetSnapshot()).ToDataRes(types.Resource("aws.ec2.snapshot"))
+	},
 	"aws.ec2.image.ebsBlockDevice.volumeSize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ImageEbsBlockDevice).GetVolumeSize()).ToDataRes(types.Int)
 	},
@@ -22632,6 +22746,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ownerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Securitygroup).GetOwnerId()).ToDataRes(types.String)
 	},
 	"aws.ec2.securitygroup.isAttachedToNetworkInterface": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetIsAttachedToNetworkInterface()).ToDataRes(types.Bool)
@@ -22977,6 +23094,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eks.nodegroup.nodegroupSubnets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksNodegroup).GetNodegroupSubnets()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
+	},
+	"aws.eks.nodegroup.launchTemplate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksNodegroup).GetLaunchTemplate()).ToDataRes(types.Resource("aws.ec2.launchtemplate"))
+	},
+	"aws.eks.nodegroup.launchTemplateVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksNodegroup).GetLaunchTemplateVersion()).ToDataRes(types.String)
 	},
 	"aws.eks.addon.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksAddon).GetName()).ToDataRes(types.String)
@@ -29527,6 +29650,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudformation.stack.resources": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudformationStack).GetResources()).ToDataRes(types.Array(types.Resource("aws.cloudformation.stack.resource")))
 	},
+	"aws.cloudformation.stack.changeSetId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudformationStack).GetChangeSetId()).ToDataRes(types.String)
+	},
+	"aws.cloudformation.stack.parentStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudformationStack).GetParentStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.cloudformation.stack.rootStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudformationStack).GetRootStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
 	"aws.cloudformation.stack.resource.logicalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudformationStackResource).GetLogicalId()).ToDataRes(types.String)
 	},
@@ -33014,6 +33146,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsOrganization).MasterAccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.organization.masterAccountArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).MasterAccountArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.organization.masterAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganization).MasterAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -33180,6 +33316,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.instanceTenancy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).InstanceTenancy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33452,6 +33592,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.subnet.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcSubnet).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.subnet.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34930,6 +35074,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEfsFilesystem).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.efs.filesystem.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystem).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.efs.filesystem.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystem).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
@@ -36004,6 +36152,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.user.mfaDevices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).MfaDevices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.permissionsBoundary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).PermissionsBoundary, ok = plugin.RawToTValue[*mqlAwsIamPolicy](v.Value, v.Error)
 		return
 	},
 	"aws.iam.user.accessKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40606,6 +40758,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSnsTopic).SignatureVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.sns.topic.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSnsTopic).Owner, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sns.topic.kmsMasterKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSnsTopic).KmsMasterKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
@@ -42180,6 +42336,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.codebuild.project.concurrentBuildLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCodebuildProject).ConcurrentBuildLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.codebuild.project.sourceVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCodebuildProject).SourceVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.codebuild.project.resourceAccessRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCodebuildProject).ResourceAccessRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
 		return
 	},
 	"aws.codebuild.reportGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44146,6 +44310,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSecretsmanagerSecret).RotationLambda, ok = plugin.RawToTValue[*mqlAwsLambdaFunction](v.Value, v.Error)
 		return
 	},
+	"aws.secretsmanager.secret.externalRotationRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).ExternalRotationRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
 	"aws.secretsmanager.secret.rotationRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecret).RotationRules, ok = plugin.RawToTValue[*mqlAwsSecretsmanagerSecretRotationRules](v.Value, v.Error)
 		return
@@ -44602,6 +44770,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcsTask).Group, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ecs.task.startedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTask).StartedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ecs.task.enableExecuteCommand": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsTask).EnableExecuteCommand, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -44810,6 +44982,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcsTaskDefinition).RegisteredAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.ecs.taskDefinition.registeredBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTaskDefinition).RegisteredBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ecs.taskDefinition.requiresCompatibilities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsTaskDefinition).RequiresCompatibilities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -44866,8 +45042,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcsService).RunningCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"aws.ecs.service.taskDefinitionArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsService).TaskDefinitionArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ecs.service.taskDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsEcsService).TaskDefinition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlAwsEcsService).TaskDefinition, ok = plugin.RawToTValue[*mqlAwsEcsTaskDefinition](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.service.launchType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51518,6 +51698,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).CrossAccountClone, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.cloneGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).CloneGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbcluster.replicationSourceIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).ReplicationSourceIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -51616,6 +51800,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.snapshot.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).SourceSnapshot, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.sourceDbInstance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).SourceDbInstance, ok = plugin.RawToTValue[*mqlAwsRdsDbinstance](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.sourceDbCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).SourceDbCluster, ok = plugin.RawToTValue[*mqlAwsRdsDbcluster](v.Value, v.Error)
 		return
 	},
 	"aws.rds.snapshot.sourceRegion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51856,6 +52048,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbinstance.dbClusterIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).DbClusterIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.dbCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).DbCluster, ok = plugin.RawToTValue[*mqlAwsRdsDbcluster](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.readReplicaSourceInstanceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52228,6 +52424,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.cluster.replicationGroupLogDeliveryEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).ReplicationGroupLogDeliveryEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.replicationGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).ReplicationGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52710,6 +52910,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRedshiftCluster).MasterPasswordSecretKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
+	"aws.redshift.cluster.snapshotScheduleIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftCluster).SnapshotScheduleIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.redshift.cluster.snapshots": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftCluster).Snapshots, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -52728,6 +52932,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.redshift.snapshot.clusterIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftSnapshot).ClusterIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.snapshot.cluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftSnapshot).Cluster, ok = plugin.RawToTValue[*mqlAwsRedshiftCluster](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.snapshot.ownerAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftSnapshot).OwnerAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.snapshot.accountsWithRestoreAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftSnapshot).AccountsWithRestoreAccess, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.snapshot.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55846,6 +56062,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaFunction).ResolvedImageUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.function.masterArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).MasterArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.masterFunction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).MasterFunction, ok = plugin.RawToTValue[*mqlAwsLambdaFunction](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.sourceKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).SourceKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.function.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunctionVersion).__id, ok = v.Value.(string)
 		return
@@ -56380,6 +56608,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ssm.instance.computerName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmInstance).ComputerName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.sourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).SourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.sourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).SourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.activationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).ActivationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.resourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).ResourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -57922,6 +58170,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Snapshot).OwnerAlias, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.snapshot.outpostArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).OutpostArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -58674,6 +58926,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Instance).VirtualizationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instance.capacityReservation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).CapacityReservation, ok = plugin.RawToTValue[*mqlAwsEc2CapacityReservation](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.autoScalingGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).AutoScalingGroup, ok = plugin.RawToTValue[*mqlAwsAutoscalingGroup](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.managedByOperator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).ManagedByOperator, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.operatorPrincipal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).OperatorPrincipal, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.networkinterface.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Networkinterface).__id, ok = v.Value.(string)
 		return
@@ -58776,6 +59044,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.networkinterface.deleteOnTermination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Networkinterface).DeleteOnTermination, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkinterface.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkinterface).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkinterface.requesterId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkinterface).RequesterId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkinterface.instanceOwnerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkinterface).InstanceOwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.keypair.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59038,6 +59318,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2ImageEbsBlockDevice).SnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.image.ebsBlockDevice.snapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2ImageEbsBlockDevice).Snapshot, ok = plugin.RawToTValue[*mqlAwsEc2Snapshot](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.image.ebsBlockDevice.volumeSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2ImageEbsBlockDevice).VolumeSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -59200,6 +59484,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Securitygroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ownerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Securitygroup).OwnerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.isAttachedToNetworkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59716,6 +60004,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.eks.nodegroup.nodegroupSubnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksNodegroup).NodegroupSubnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.eks.nodegroup.launchTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksNodegroup).LaunchTemplate, ok = plugin.RawToTValue[*mqlAwsEc2Launchtemplate](v.Value, v.Error)
+		return
+	},
+	"aws.eks.nodegroup.launchTemplateVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksNodegroup).LaunchTemplateVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.eks.addon.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -69190,6 +69486,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudformationStack).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.cloudformation.stack.changeSetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudformationStack).ChangeSetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudformation.stack.parentStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudformationStack).ParentStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.cloudformation.stack.rootStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudformationStack).RootStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
 	"aws.cloudformation.stack.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudformationStackResource).__id, ok = v.Value.(string)
 		return
@@ -74573,6 +74881,7 @@ type mqlAwsOrganization struct {
 	Arn                     plugin.TValue[string]
 	FeatureSet              plugin.TValue[string]
 	MasterAccountId         plugin.TValue[string]
+	MasterAccountArn        plugin.TValue[string]
 	MasterAccountEmail      plugin.TValue[string]
 	Accounts                plugin.TValue[[]any]
 	Id                      plugin.TValue[string]
@@ -74623,6 +74932,10 @@ func (c *mqlAwsOrganization) GetFeatureSet() *plugin.TValue[string] {
 
 func (c *mqlAwsOrganization) GetMasterAccountId() *plugin.TValue[string] {
 	return &c.MasterAccountId
+}
+
+func (c *mqlAwsOrganization) GetMasterAccountArn() *plugin.TValue[string] {
+	return &c.MasterAccountArn
 }
 
 func (c *mqlAwsOrganization) GetMasterAccountEmail() *plugin.TValue[string] {
@@ -75050,6 +75363,7 @@ type mqlAwsVpc struct {
 	State                     plugin.TValue[string]
 	IsDefault                 plugin.TValue[bool]
 	InstanceTenancy           plugin.TValue[string]
+	OwnerId                   plugin.TValue[string]
 	Region                    plugin.TValue[string]
 	Endpoints                 plugin.TValue[[]any]
 	FlowLogs                  plugin.TValue[[]any]
@@ -75140,6 +75454,10 @@ func (c *mqlAwsVpc) GetIsDefault() *plugin.TValue[bool] {
 
 func (c *mqlAwsVpc) GetInstanceTenancy() *plugin.TValue[string] {
 	return &c.InstanceTenancy
+}
+
+func (c *mqlAwsVpc) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
 }
 
 func (c *mqlAwsVpc) GetRegion() *plugin.TValue[string] {
@@ -75761,6 +76079,7 @@ type mqlAwsVpcSubnet struct {
 	DefaultForAvailabilityZone  plugin.TValue[bool]
 	AssignIpv6AddressOnCreation plugin.TValue[bool]
 	State                       plugin.TValue[string]
+	OwnerId                     plugin.TValue[string]
 	Region                      plugin.TValue[string]
 	AvailableIpAddressCount     plugin.TValue[int64]
 	InternetGatewayBlockMode    plugin.TValue[string]
@@ -75845,6 +76164,10 @@ func (c *mqlAwsVpcSubnet) GetAssignIpv6AddressOnCreation() *plugin.TValue[bool] 
 
 func (c *mqlAwsVpcSubnet) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlAwsVpcSubnet) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
 }
 
 func (c *mqlAwsVpcSubnet) GetRegion() *plugin.TValue[string] {
@@ -79874,6 +80197,7 @@ type mqlAwsEfsFilesystem struct {
 	Id                       plugin.TValue[string]
 	Arn                      plugin.TValue[string]
 	Encrypted                plugin.TValue[bool]
+	OwnerId                  plugin.TValue[string]
 	KmsKey                   plugin.TValue[*mqlAwsKmsKey]
 	BackupPolicy             plugin.TValue[any]
 	Region                   plugin.TValue[string]
@@ -79945,6 +80269,10 @@ func (c *mqlAwsEfsFilesystem) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsFilesystem) GetEncrypted() *plugin.TValue[bool] {
 	return &c.Encrypted
+}
+
+func (c *mqlAwsEfsFilesystem) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
 }
 
 func (c *mqlAwsEfsFilesystem) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
@@ -82507,20 +82835,21 @@ type mqlAwsIamUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsIamUserInternal
-	Arn              plugin.TValue[string]
-	Id               plugin.TValue[string]
-	Name             plugin.TValue[string]
-	CreatedAt        plugin.TValue[*time.Time]
-	PasswordLastUsed plugin.TValue[*time.Time]
-	Tags             plugin.TValue[map[string]any]
-	Policies         plugin.TValue[[]any]
-	AttachedPolicies plugin.TValue[[]any]
-	Groups           plugin.TValue[[]any]
-	AccessKeys       plugin.TValue[[]any]
-	AccessKeyDetails plugin.TValue[[]any]
-	LoginProfile     plugin.TValue[*mqlAwsIamLoginProfile]
-	Path             plugin.TValue[string]
-	MfaDevices       plugin.TValue[[]any]
+	Arn                 plugin.TValue[string]
+	Id                  plugin.TValue[string]
+	Name                plugin.TValue[string]
+	CreatedAt           plugin.TValue[*time.Time]
+	PasswordLastUsed    plugin.TValue[*time.Time]
+	Tags                plugin.TValue[map[string]any]
+	Policies            plugin.TValue[[]any]
+	AttachedPolicies    plugin.TValue[[]any]
+	Groups              plugin.TValue[[]any]
+	AccessKeys          plugin.TValue[[]any]
+	AccessKeyDetails    plugin.TValue[[]any]
+	LoginProfile        plugin.TValue[*mqlAwsIamLoginProfile]
+	Path                plugin.TValue[string]
+	MfaDevices          plugin.TValue[[]any]
+	PermissionsBoundary plugin.TValue[*mqlAwsIamPolicy]
 }
 
 // createAwsIamUser creates a new instance of this resource
@@ -82657,6 +82986,22 @@ func (c *mqlAwsIamUser) GetPath() *plugin.TValue[string] {
 func (c *mqlAwsIamUser) GetMfaDevices() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.MfaDevices, func() ([]any, error) {
 		return c.mfaDevices()
+	})
+}
+
+func (c *mqlAwsIamUser) GetPermissionsBoundary() *plugin.TValue[*mqlAwsIamPolicy] {
+	return plugin.GetOrCompute[*mqlAwsIamPolicy](&c.PermissionsBoundary, func() (*mqlAwsIamPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.user", c.__id, "permissionsBoundary")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamPolicy), nil
+			}
+		}
+
+		return c.permissionsBoundary()
 	})
 }
 
@@ -95476,6 +95821,7 @@ type mqlAwsSnsTopic struct {
 	Attributes                plugin.TValue[any]
 	Tags                      plugin.TValue[map[string]any]
 	SignatureVersion          plugin.TValue[string]
+	Owner                     plugin.TValue[string]
 	KmsMasterKey              plugin.TValue[*mqlAwsKmsKey]
 	Policy                    plugin.TValue[any]
 	PolicyStatements          plugin.TValue[[]any]
@@ -95565,6 +95911,12 @@ func (c *mqlAwsSnsTopic) GetTags() *plugin.TValue[map[string]any] {
 func (c *mqlAwsSnsTopic) GetSignatureVersion() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.SignatureVersion, func() (string, error) {
 		return c.signatureVersion()
+	})
+}
+
+func (c *mqlAwsSnsTopic) GetOwner() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Owner, func() (string, error) {
+		return c.owner()
 	})
 }
 
@@ -98539,6 +98891,8 @@ type mqlAwsCodebuildProject struct {
 	Webhook                             plugin.TValue[any]
 	BuildBatchConfig                    plugin.TValue[any]
 	ConcurrentBuildLimit                plugin.TValue[int64]
+	SourceVersion                       plugin.TValue[string]
+	ResourceAccessRole                  plugin.TValue[*mqlAwsIamRole]
 }
 
 // createAwsCodebuildProject creates a new instance of this resource
@@ -98888,6 +99242,26 @@ func (c *mqlAwsCodebuildProject) GetBuildBatchConfig() *plugin.TValue[any] {
 
 func (c *mqlAwsCodebuildProject) GetConcurrentBuildLimit() *plugin.TValue[int64] {
 	return &c.ConcurrentBuildLimit
+}
+
+func (c *mqlAwsCodebuildProject) GetSourceVersion() *plugin.TValue[string] {
+	return &c.SourceVersion
+}
+
+func (c *mqlAwsCodebuildProject) GetResourceAccessRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.ResourceAccessRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.codebuild.project", c.__id, "resourceAccessRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.resourceAccessRole()
+	})
 }
 
 // mqlAwsCodebuildReportGroup for the aws.codebuild.reportGroup resource
@@ -104039,28 +104413,29 @@ type mqlAwsSecretsmanagerSecret struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsSecretsmanagerSecretInternal
-	Arn              plugin.TValue[string]
-	CreatedAt        plugin.TValue[*time.Time]
-	Description      plugin.TValue[string]
-	KmsKey           plugin.TValue[*mqlAwsKmsKey]
-	LastAccessedDate plugin.TValue[*time.Time]
-	LastChangedDate  plugin.TValue[*time.Time]
-	LastRotatedDate  plugin.TValue[*time.Time]
-	Name             plugin.TValue[string]
-	NextRotationDate plugin.TValue[*time.Time]
-	OwningService    plugin.TValue[string]
-	PrimaryRegion    plugin.TValue[string]
-	RotationEnabled  plugin.TValue[bool]
-	RotationLambda   plugin.TValue[*mqlAwsLambdaFunction]
-	RotationRules    plugin.TValue[*mqlAwsSecretsmanagerSecretRotationRules]
-	Tags             plugin.TValue[map[string]any]
-	ResourcePolicy   plugin.TValue[string]
-	PolicyStatements plugin.TValue[[]any]
-	IsPublic         plugin.TValue[bool]
-	ReplicaRegions   plugin.TValue[[]any]
-	Type             plugin.TValue[string]
-	Versions         plugin.TValue[[]any]
-	DeletedAt        plugin.TValue[*time.Time]
+	Arn                  plugin.TValue[string]
+	CreatedAt            plugin.TValue[*time.Time]
+	Description          plugin.TValue[string]
+	KmsKey               plugin.TValue[*mqlAwsKmsKey]
+	LastAccessedDate     plugin.TValue[*time.Time]
+	LastChangedDate      plugin.TValue[*time.Time]
+	LastRotatedDate      plugin.TValue[*time.Time]
+	Name                 plugin.TValue[string]
+	NextRotationDate     plugin.TValue[*time.Time]
+	OwningService        plugin.TValue[string]
+	PrimaryRegion        plugin.TValue[string]
+	RotationEnabled      plugin.TValue[bool]
+	RotationLambda       plugin.TValue[*mqlAwsLambdaFunction]
+	ExternalRotationRole plugin.TValue[*mqlAwsIamRole]
+	RotationRules        plugin.TValue[*mqlAwsSecretsmanagerSecretRotationRules]
+	Tags                 plugin.TValue[map[string]any]
+	ResourcePolicy       plugin.TValue[string]
+	PolicyStatements     plugin.TValue[[]any]
+	IsPublic             plugin.TValue[bool]
+	ReplicaRegions       plugin.TValue[[]any]
+	Type                 plugin.TValue[string]
+	Versions             plugin.TValue[[]any]
+	DeletedAt            plugin.TValue[*time.Time]
 }
 
 // createAwsSecretsmanagerSecret creates a new instance of this resource
@@ -104162,6 +104537,22 @@ func (c *mqlAwsSecretsmanagerSecret) GetRotationEnabled() *plugin.TValue[bool] {
 
 func (c *mqlAwsSecretsmanagerSecret) GetRotationLambda() *plugin.TValue[*mqlAwsLambdaFunction] {
 	return &c.RotationLambda
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetExternalRotationRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.ExternalRotationRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.secretsmanager.secret", c.__id, "externalRotationRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.externalRotationRole()
+	})
 }
 
 func (c *mqlAwsSecretsmanagerSecret) GetRotationRules() *plugin.TValue[*mqlAwsSecretsmanagerSecretRotationRules] {
@@ -105196,6 +105587,7 @@ type mqlAwsEcsTask struct {
 	LaunchType                    plugin.TValue[string]
 	CapacityProviderName          plugin.TValue[string]
 	Group                         plugin.TValue[string]
+	StartedBy                     plugin.TValue[string]
 	EnableExecuteCommand          plugin.TValue[bool]
 	StopCode                      plugin.TValue[string]
 	StoppedReason                 plugin.TValue[string]
@@ -105336,6 +105728,10 @@ func (c *mqlAwsEcsTask) GetCapacityProviderName() *plugin.TValue[string] {
 
 func (c *mqlAwsEcsTask) GetGroup() *plugin.TValue[string] {
 	return &c.Group
+}
+
+func (c *mqlAwsEcsTask) GetStartedBy() *plugin.TValue[string] {
+	return &c.StartedBy
 }
 
 func (c *mqlAwsEcsTask) GetEnableExecuteCommand() *plugin.TValue[bool] {
@@ -105590,6 +105986,7 @@ type mqlAwsEcsTaskDefinition struct {
 	Cpu                            plugin.TValue[string]
 	Memory                         plugin.TValue[string]
 	RegisteredAt                   plugin.TValue[*time.Time]
+	RegisteredBy                   plugin.TValue[string]
 	RequiresCompatibilities        plugin.TValue[[]any]
 	RuntimePlatformCpuArchitecture plugin.TValue[string]
 	RuntimePlatformOsFamily        plugin.TValue[string]
@@ -105795,6 +106192,12 @@ func (c *mqlAwsEcsTaskDefinition) GetRegisteredAt() *plugin.TValue[*time.Time] {
 	})
 }
 
+func (c *mqlAwsEcsTaskDefinition) GetRegisteredBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RegisteredBy, func() (string, error) {
+		return c.registeredBy()
+	})
+}
+
 func (c *mqlAwsEcsTaskDefinition) GetRequiresCompatibilities() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.RequiresCompatibilities, func() ([]any, error) {
 		return c.requiresCompatibilities()
@@ -105843,7 +106246,8 @@ type mqlAwsEcsService struct {
 	Status                        plugin.TValue[string]
 	DesiredCount                  plugin.TValue[int64]
 	RunningCount                  plugin.TValue[int64]
-	TaskDefinition                plugin.TValue[string]
+	TaskDefinitionArn             plugin.TValue[string]
+	TaskDefinition                plugin.TValue[*mqlAwsEcsTaskDefinition]
 	LaunchType                    plugin.TValue[string]
 	DeploymentConfiguration       plugin.TValue[*mqlAwsEcsServiceDeploymentConfiguration]
 	NetworkConfiguration          plugin.TValue[*mqlAwsEcsServiceNetworkConfiguration]
@@ -105945,8 +106349,24 @@ func (c *mqlAwsEcsService) GetRunningCount() *plugin.TValue[int64] {
 	return &c.RunningCount
 }
 
-func (c *mqlAwsEcsService) GetTaskDefinition() *plugin.TValue[string] {
-	return &c.TaskDefinition
+func (c *mqlAwsEcsService) GetTaskDefinitionArn() *plugin.TValue[string] {
+	return &c.TaskDefinitionArn
+}
+
+func (c *mqlAwsEcsService) GetTaskDefinition() *plugin.TValue[*mqlAwsEcsTaskDefinition] {
+	return plugin.GetOrCompute[*mqlAwsEcsTaskDefinition](&c.TaskDefinition, func() (*mqlAwsEcsTaskDefinition, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.service", c.__id, "taskDefinition")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEcsTaskDefinition), nil
+			}
+		}
+
+		return c.taskDefinition()
+	})
 }
 
 func (c *mqlAwsEcsService) GetLaunchType() *plugin.TValue[string] {
@@ -123734,6 +124154,7 @@ type mqlAwsRdsDbcluster struct {
 	DatabaseName                       plugin.TValue[string]
 	DbClusterParameterGroup            plugin.TValue[*mqlAwsRdsClusterParameterGroup]
 	CrossAccountClone                  plugin.TValue[bool]
+	CloneGroupId                       plugin.TValue[string]
 	ReplicationSourceIdentifier        plugin.TValue[string]
 	GlobalWriteForwardingStatus        plugin.TValue[string]
 	UpgradeRolloutOrder                plugin.TValue[string]
@@ -124081,6 +124502,10 @@ func (c *mqlAwsRdsDbcluster) GetCrossAccountClone() *plugin.TValue[bool] {
 	return &c.CrossAccountClone
 }
 
+func (c *mqlAwsRdsDbcluster) GetCloneGroupId() *plugin.TValue[string] {
+	return &c.CloneGroupId
+}
+
 func (c *mqlAwsRdsDbcluster) GetReplicationSourceIdentifier() *plugin.TValue[string] {
 	return &c.ReplicationSourceIdentifier
 }
@@ -124134,6 +124559,8 @@ type mqlAwsRdsSnapshot struct {
 	AvailabilityZone      plugin.TValue[string]
 	Timezone              plugin.TValue[string]
 	SourceSnapshot        plugin.TValue[string]
+	SourceDbInstance      plugin.TValue[*mqlAwsRdsDbinstance]
+	SourceDbCluster       plugin.TValue[*mqlAwsRdsDbcluster]
 	SourceRegion          plugin.TValue[string]
 	OriginalCreatedAt     plugin.TValue[*time.Time]
 	KmsKey                plugin.TValue[*mqlAwsKmsKey]
@@ -124259,6 +124686,38 @@ func (c *mqlAwsRdsSnapshot) GetSourceSnapshot() *plugin.TValue[string] {
 	return &c.SourceSnapshot
 }
 
+func (c *mqlAwsRdsSnapshot) GetSourceDbInstance() *plugin.TValue[*mqlAwsRdsDbinstance] {
+	return plugin.GetOrCompute[*mqlAwsRdsDbinstance](&c.SourceDbInstance, func() (*mqlAwsRdsDbinstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.snapshot", c.__id, "sourceDbInstance")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsRdsDbinstance), nil
+			}
+		}
+
+		return c.sourceDbInstance()
+	})
+}
+
+func (c *mqlAwsRdsSnapshot) GetSourceDbCluster() *plugin.TValue[*mqlAwsRdsDbcluster] {
+	return plugin.GetOrCompute[*mqlAwsRdsDbcluster](&c.SourceDbCluster, func() (*mqlAwsRdsDbcluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.snapshot", c.__id, "sourceDbCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsRdsDbcluster), nil
+			}
+		}
+
+		return c.sourceDbCluster()
+	})
+}
+
 func (c *mqlAwsRdsSnapshot) GetSourceRegion() *plugin.TValue[string] {
 	return &c.SourceRegion
 }
@@ -124349,6 +124808,7 @@ type mqlAwsRdsDbinstance struct {
 	DedicatedLogVolume                 plugin.TValue[bool]
 	DbiResourceId                      plugin.TValue[string]
 	DbClusterIdentifier                plugin.TValue[string]
+	DbCluster                          plugin.TValue[*mqlAwsRdsDbcluster]
 	ReadReplicaSourceInstanceId        plugin.TValue[string]
 	ReadReplicaSourceClusterId         plugin.TValue[string]
 	ReadReplicaSourceInstance          plugin.TValue[*mqlAwsRdsDbinstance]
@@ -124716,6 +125176,22 @@ func (c *mqlAwsRdsDbinstance) GetDbiResourceId() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsDbinstance) GetDbClusterIdentifier() *plugin.TValue[string] {
 	return &c.DbClusterIdentifier
+}
+
+func (c *mqlAwsRdsDbinstance) GetDbCluster() *plugin.TValue[*mqlAwsRdsDbcluster] {
+	return plugin.GetOrCompute[*mqlAwsRdsDbcluster](&c.DbCluster, func() (*mqlAwsRdsDbcluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "dbCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsRdsDbcluster), nil
+			}
+		}
+
+		return c.dbCluster()
+	})
 }
 
 func (c *mqlAwsRdsDbinstance) GetReadReplicaSourceInstanceId() *plugin.TValue[string] {
@@ -125434,6 +125910,7 @@ type mqlAwsElasticacheCluster struct {
 	KmsKey                             plugin.TValue[*mqlAwsKmsKey]
 	PreferredMaintenanceWindow         plugin.TValue[string]
 	ReplicationGroupLogDeliveryEnabled plugin.TValue[bool]
+	ReplicationGroupId                 plugin.TValue[string]
 	Tags                               plugin.TValue[map[string]any]
 }
 
@@ -125615,6 +126092,10 @@ func (c *mqlAwsElasticacheCluster) GetPreferredMaintenanceWindow() *plugin.TValu
 
 func (c *mqlAwsElasticacheCluster) GetReplicationGroupLogDeliveryEnabled() *plugin.TValue[bool] {
 	return &c.ReplicationGroupLogDeliveryEnabled
+}
+
+func (c *mqlAwsElasticacheCluster) GetReplicationGroupId() *plugin.TValue[string] {
+	return &c.ReplicationGroupId
 }
 
 func (c *mqlAwsElasticacheCluster) GetTags() *plugin.TValue[map[string]any] {
@@ -126458,6 +126939,7 @@ type mqlAwsRedshiftCluster struct {
 	ManualSnapshotRetentionPeriod    plugin.TValue[int64]
 	IpAddressType                    plugin.TValue[string]
 	MasterPasswordSecretKmsKey       plugin.TValue[*mqlAwsKmsKey]
+	SnapshotScheduleIdentifier       plugin.TValue[string]
 	Snapshots                        plugin.TValue[[]any]
 }
 
@@ -126700,6 +127182,10 @@ func (c *mqlAwsRedshiftCluster) GetMasterPasswordSecretKmsKey() *plugin.TValue[*
 	})
 }
 
+func (c *mqlAwsRedshiftCluster) GetSnapshotScheduleIdentifier() *plugin.TValue[string] {
+	return &c.SnapshotScheduleIdentifier
+}
+
 func (c *mqlAwsRedshiftCluster) GetSnapshots() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Snapshots, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -126724,6 +127210,9 @@ type mqlAwsRedshiftSnapshot struct {
 	Arn                           plugin.TValue[string]
 	Id                            plugin.TValue[string]
 	ClusterIdentifier             plugin.TValue[string]
+	Cluster                       plugin.TValue[*mqlAwsRedshiftCluster]
+	OwnerAccount                  plugin.TValue[string]
+	AccountsWithRestoreAccess     plugin.TValue[[]any]
 	Region                        plugin.TValue[string]
 	SnapshotType                  plugin.TValue[string]
 	SourceRegion                  plugin.TValue[string]
@@ -126794,6 +127283,30 @@ func (c *mqlAwsRedshiftSnapshot) GetId() *plugin.TValue[string] {
 
 func (c *mqlAwsRedshiftSnapshot) GetClusterIdentifier() *plugin.TValue[string] {
 	return &c.ClusterIdentifier
+}
+
+func (c *mqlAwsRedshiftSnapshot) GetCluster() *plugin.TValue[*mqlAwsRedshiftCluster] {
+	return plugin.GetOrCompute[*mqlAwsRedshiftCluster](&c.Cluster, func() (*mqlAwsRedshiftCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.redshift.snapshot", c.__id, "cluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsRedshiftCluster), nil
+			}
+		}
+
+		return c.cluster()
+	})
+}
+
+func (c *mqlAwsRedshiftSnapshot) GetOwnerAccount() *plugin.TValue[string] {
+	return &c.OwnerAccount
+}
+
+func (c *mqlAwsRedshiftSnapshot) GetAccountsWithRestoreAccess() *plugin.TValue[[]any] {
+	return &c.AccountsWithRestoreAccess
 }
 
 func (c *mqlAwsRedshiftSnapshot) GetRegion() *plugin.TValue[string] {
@@ -133933,6 +134446,9 @@ type mqlAwsLambdaFunction struct {
 	Versions                      plugin.TValue[[]any]
 	ImageUri                      plugin.TValue[string]
 	ResolvedImageUri              plugin.TValue[string]
+	MasterArn                     plugin.TValue[string]
+	MasterFunction                plugin.TValue[*mqlAwsLambdaFunction]
+	SourceKmsKey                  plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsLambdaFunction creates a new instance of this resource
@@ -134353,6 +134869,42 @@ func (c *mqlAwsLambdaFunction) GetImageUri() *plugin.TValue[string] {
 func (c *mqlAwsLambdaFunction) GetResolvedImageUri() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ResolvedImageUri, func() (string, error) {
 		return c.resolvedImageUri()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetMasterArn() *plugin.TValue[string] {
+	return &c.MasterArn
+}
+
+func (c *mqlAwsLambdaFunction) GetMasterFunction() *plugin.TValue[*mqlAwsLambdaFunction] {
+	return plugin.GetOrCompute[*mqlAwsLambdaFunction](&c.MasterFunction, func() (*mqlAwsLambdaFunction, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "masterFunction")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsLambdaFunction), nil
+			}
+		}
+
+		return c.masterFunction()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetSourceKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.SourceKmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "sourceKmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.sourceKmsKey()
 	})
 }
 
@@ -135579,7 +136131,7 @@ func (c *mqlAwsSsmParameter) GetPolicies() *plugin.TValue[[]any] {
 type mqlAwsSsmInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsSsmInstanceInternal it will be used here
+	mqlAwsSsmInstanceInternal
 	InstanceId      plugin.TValue[string]
 	PingStatus      plugin.TValue[string]
 	IpAddress       plugin.TValue[string]
@@ -135592,6 +136144,11 @@ type mqlAwsSsmInstance struct {
 	AgentVersion    plugin.TValue[string]
 	LastPingedAt    plugin.TValue[*time.Time]
 	ComputerName    plugin.TValue[string]
+	IamRole         plugin.TValue[*mqlAwsIamRole]
+	SourceType      plugin.TValue[string]
+	SourceId        plugin.TValue[string]
+	ActivationId    plugin.TValue[string]
+	ResourceType    plugin.TValue[string]
 }
 
 // createAwsSsmInstance creates a new instance of this resource
@@ -135679,6 +136236,38 @@ func (c *mqlAwsSsmInstance) GetLastPingedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsSsmInstance) GetComputerName() *plugin.TValue[string] {
 	return &c.ComputerName
+}
+
+func (c *mqlAwsSsmInstance) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.IamRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ssm.instance", c.__id, "iamRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.iamRole()
+	})
+}
+
+func (c *mqlAwsSsmInstance) GetSourceType() *plugin.TValue[string] {
+	return &c.SourceType
+}
+
+func (c *mqlAwsSsmInstance) GetSourceId() *plugin.TValue[string] {
+	return &c.SourceId
+}
+
+func (c *mqlAwsSsmInstance) GetActivationId() *plugin.TValue[string] {
+	return &c.ActivationId
+}
+
+func (c *mqlAwsSsmInstance) GetResourceType() *plugin.TValue[string] {
+	return &c.ResourceType
 }
 
 // mqlAwsEc2 for the aws.ec2 resource
@@ -139458,6 +140047,7 @@ type mqlAwsEc2Snapshot struct {
 	SourceVolume           plugin.TValue[*mqlAwsEc2Volume]
 	DataEncryptionKeyId    plugin.TValue[string]
 	OwnerAlias             plugin.TValue[string]
+	OwnerId                plugin.TValue[string]
 	OutpostArn             plugin.TValue[string]
 	IsPublic               plugin.TValue[bool]
 	SharedWithAccounts     plugin.TValue[[]any]
@@ -139593,6 +140183,10 @@ func (c *mqlAwsEc2Snapshot) GetDataEncryptionKeyId() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Snapshot) GetOwnerAlias() *plugin.TValue[string] {
 	return &c.OwnerAlias
+}
+
+func (c *mqlAwsEc2Snapshot) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
 }
 
 func (c *mqlAwsEc2Snapshot) GetOutpostArn() *plugin.TValue[string] {
@@ -140994,6 +141588,10 @@ type mqlAwsEc2Instance struct {
 	SpotInstanceRequestId   plugin.TValue[string]
 	Placement               plugin.TValue[*mqlAwsEc2InstancePlacement]
 	VirtualizationType      plugin.TValue[string]
+	CapacityReservation     plugin.TValue[*mqlAwsEc2CapacityReservation]
+	AutoScalingGroup        plugin.TValue[*mqlAwsAutoscalingGroup]
+	ManagedByOperator       plugin.TValue[bool]
+	OperatorPrincipal       plugin.TValue[string]
 }
 
 // createAwsEc2Instance creates a new instance of this resource
@@ -141395,6 +141993,46 @@ func (c *mqlAwsEc2Instance) GetVirtualizationType() *plugin.TValue[string] {
 	return &c.VirtualizationType
 }
 
+func (c *mqlAwsEc2Instance) GetCapacityReservation() *plugin.TValue[*mqlAwsEc2CapacityReservation] {
+	return plugin.GetOrCompute[*mqlAwsEc2CapacityReservation](&c.CapacityReservation, func() (*mqlAwsEc2CapacityReservation, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.instance", c.__id, "capacityReservation")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2CapacityReservation), nil
+			}
+		}
+
+		return c.capacityReservation()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetAutoScalingGroup() *plugin.TValue[*mqlAwsAutoscalingGroup] {
+	return plugin.GetOrCompute[*mqlAwsAutoscalingGroup](&c.AutoScalingGroup, func() (*mqlAwsAutoscalingGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.instance", c.__id, "autoScalingGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAutoscalingGroup), nil
+			}
+		}
+
+		return c.autoScalingGroup()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetManagedByOperator() *plugin.TValue[bool] {
+	return &c.ManagedByOperator
+}
+
+func (c *mqlAwsEc2Instance) GetOperatorPrincipal() *plugin.TValue[string] {
+	return &c.OperatorPrincipal
+}
+
 // mqlAwsEc2Networkinterface for the aws.ec2.networkinterface resource
 type mqlAwsEc2Networkinterface struct {
 	MqlRuntime *plugin.Runtime
@@ -141425,6 +142063,9 @@ type mqlAwsEc2Networkinterface struct {
 	NetworkCardIndex    plugin.TValue[int64]
 	DeviceIndex         plugin.TValue[int64]
 	DeleteOnTermination plugin.TValue[bool]
+	OwnerId             plugin.TValue[string]
+	RequesterId         plugin.TValue[string]
+	InstanceOwnerId     plugin.TValue[string]
 }
 
 // createAwsEc2Networkinterface creates a new instance of this resource
@@ -141617,6 +142258,18 @@ func (c *mqlAwsEc2Networkinterface) GetDeviceIndex() *plugin.TValue[int64] {
 
 func (c *mqlAwsEc2Networkinterface) GetDeleteOnTermination() *plugin.TValue[bool] {
 	return &c.DeleteOnTermination
+}
+
+func (c *mqlAwsEc2Networkinterface) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
+}
+
+func (c *mqlAwsEc2Networkinterface) GetRequesterId() *plugin.TValue[string] {
+	return &c.RequesterId
+}
+
+func (c *mqlAwsEc2Networkinterface) GetInstanceOwnerId() *plugin.TValue[string] {
+	return &c.InstanceOwnerId
 }
 
 // mqlAwsEc2Keypair for the aws.ec2.keypair resource
@@ -142156,6 +142809,7 @@ type mqlAwsEc2ImageEbsBlockDevice struct {
 	// optional: if you define mqlAwsEc2ImageEbsBlockDeviceInternal it will be used here
 	Encrypted           plugin.TValue[bool]
 	SnapshotId          plugin.TValue[string]
+	Snapshot            plugin.TValue[*mqlAwsEc2Snapshot]
 	VolumeSize          plugin.TValue[int64]
 	VolumeType          plugin.TValue[string]
 	KmsKeyId            plugin.TValue[string]
@@ -142203,6 +142857,22 @@ func (c *mqlAwsEc2ImageEbsBlockDevice) GetEncrypted() *plugin.TValue[bool] {
 
 func (c *mqlAwsEc2ImageEbsBlockDevice) GetSnapshotId() *plugin.TValue[string] {
 	return &c.SnapshotId
+}
+
+func (c *mqlAwsEc2ImageEbsBlockDevice) GetSnapshot() *plugin.TValue[*mqlAwsEc2Snapshot] {
+	return plugin.GetOrCompute[*mqlAwsEc2Snapshot](&c.Snapshot, func() (*mqlAwsEc2Snapshot, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.image.ebsBlockDevice", c.__id, "snapshot")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Snapshot), nil
+			}
+		}
+
+		return c.snapshot()
+	})
 }
 
 func (c *mqlAwsEc2ImageEbsBlockDevice) GetVolumeSize() *plugin.TValue[int64] {
@@ -142482,6 +143152,7 @@ type mqlAwsEc2Securitygroup struct {
 	IpPermissionsEgress          plugin.TValue[[]any]
 	AllowsUnrestrictedEgress     plugin.TValue[bool]
 	Region                       plugin.TValue[string]
+	OwnerId                      plugin.TValue[string]
 	IsAttachedToNetworkInterface plugin.TValue[bool]
 	NetworkInterfaces            plugin.TValue[[]any]
 	Instances                    plugin.TValue[[]any]
@@ -142602,6 +143273,10 @@ func (c *mqlAwsEc2Securitygroup) GetAllowsUnrestrictedEgress() *plugin.TValue[bo
 
 func (c *mqlAwsEc2Securitygroup) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsEc2Securitygroup) GetOwnerId() *plugin.TValue[string] {
+	return &c.OwnerId
 }
 
 func (c *mqlAwsEc2Securitygroup) GetIsAttachedToNetworkInterface() *plugin.TValue[bool] {
@@ -143857,30 +144532,32 @@ type mqlAwsEksNodegroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEksNodegroupInternal
-	Name              plugin.TValue[string]
-	Arn               plugin.TValue[string]
-	Region            plugin.TValue[string]
-	CreatedAt         plugin.TValue[*time.Time]
-	ModifiedAt        plugin.TValue[*time.Time]
-	Status            plugin.TValue[string]
-	CapacityType      plugin.TValue[string]
-	ScalingConfig     plugin.TValue[any]
-	InstanceTypes     plugin.TValue[[]any]
-	AmiType           plugin.TValue[string]
-	NodeRole          plugin.TValue[*mqlAwsIamRole]
-	DiskSize          plugin.TValue[int64]
-	Labels            plugin.TValue[map[string]any]
-	Tags              plugin.TValue[map[string]any]
-	AutoscalingGroups plugin.TValue[[]any]
-	WarmPoolConfig    plugin.TValue[any]
-	Health            plugin.TValue[any]
-	Taints            plugin.TValue[[]any]
-	ReleaseVersion    plugin.TValue[string]
-	RemoteAccess      plugin.TValue[any]
-	UpdateConfig      plugin.TValue[any]
-	NodeVersion       plugin.TValue[string]
-	NodeRepairEnabled plugin.TValue[bool]
-	NodegroupSubnets  plugin.TValue[[]any]
+	Name                  plugin.TValue[string]
+	Arn                   plugin.TValue[string]
+	Region                plugin.TValue[string]
+	CreatedAt             plugin.TValue[*time.Time]
+	ModifiedAt            plugin.TValue[*time.Time]
+	Status                plugin.TValue[string]
+	CapacityType          plugin.TValue[string]
+	ScalingConfig         plugin.TValue[any]
+	InstanceTypes         plugin.TValue[[]any]
+	AmiType               plugin.TValue[string]
+	NodeRole              plugin.TValue[*mqlAwsIamRole]
+	DiskSize              plugin.TValue[int64]
+	Labels                plugin.TValue[map[string]any]
+	Tags                  plugin.TValue[map[string]any]
+	AutoscalingGroups     plugin.TValue[[]any]
+	WarmPoolConfig        plugin.TValue[any]
+	Health                plugin.TValue[any]
+	Taints                plugin.TValue[[]any]
+	ReleaseVersion        plugin.TValue[string]
+	RemoteAccess          plugin.TValue[any]
+	UpdateConfig          plugin.TValue[any]
+	NodeVersion           plugin.TValue[string]
+	NodeRepairEnabled     plugin.TValue[bool]
+	NodegroupSubnets      plugin.TValue[[]any]
+	LaunchTemplate        plugin.TValue[*mqlAwsEc2Launchtemplate]
+	LaunchTemplateVersion plugin.TValue[string]
 }
 
 // createAwsEksNodegroup creates a new instance of this resource
@@ -144087,6 +144764,28 @@ func (c *mqlAwsEksNodegroup) GetNodegroupSubnets() *plugin.TValue[[]any] {
 		}
 
 		return c.nodegroupSubnets()
+	})
+}
+
+func (c *mqlAwsEksNodegroup) GetLaunchTemplate() *plugin.TValue[*mqlAwsEc2Launchtemplate] {
+	return plugin.GetOrCompute[*mqlAwsEc2Launchtemplate](&c.LaunchTemplate, func() (*mqlAwsEc2Launchtemplate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eks.nodegroup", c.__id, "launchTemplate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Launchtemplate), nil
+			}
+		}
+
+		return c.launchTemplate()
+	})
+}
+
+func (c *mqlAwsEksNodegroup) GetLaunchTemplateVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.LaunchTemplateVersion, func() (string, error) {
+		return c.launchTemplateVersion()
 	})
 }
 
@@ -167488,6 +168187,9 @@ type mqlAwsCloudformationStack struct {
 	CreatedAt                   plugin.TValue[*time.Time]
 	UpdatedAt                   plugin.TValue[*time.Time]
 	Resources                   plugin.TValue[[]any]
+	ChangeSetId                 plugin.TValue[string]
+	ParentStack                 plugin.TValue[*mqlAwsCloudformationStack]
+	RootStack                   plugin.TValue[*mqlAwsCloudformationStack]
 }
 
 // createAwsCloudformationStack creates a new instance of this resource
@@ -167631,6 +168333,42 @@ func (c *mqlAwsCloudformationStack) GetResources() *plugin.TValue[[]any] {
 		}
 
 		return c.resources()
+	})
+}
+
+func (c *mqlAwsCloudformationStack) GetChangeSetId() *plugin.TValue[string] {
+	return &c.ChangeSetId
+}
+
+func (c *mqlAwsCloudformationStack) GetParentStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.ParentStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudformation.stack", c.__id, "parentStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.parentStack()
+	})
+}
+
+func (c *mqlAwsCloudformationStack) GetRootStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.RootStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudformation.stack", c.__id, "rootStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.rootStack()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3680,7 +3680,7 @@ aws.ecs.service.serviceRegistries 13.29.1
 aws.ecs.service.status 11.15.2
 aws.ecs.service.tags 11.15.2
 aws.ecs.service.taskDefinition 11.15.2
-aws.ecs.service.taskDefinitionArn 13.38.2
+aws.ecs.service.taskDefinitionRef 13.38.2
 aws.ecs.service.taskSets 11.15.2
 aws.ecs.task 11.15.2
 aws.ecs.task.arn 11.15.2

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1373,6 +1373,7 @@ aws.billing.monthToDateCost 13.26.2
 aws.cloudformation 13.1.1
 aws.cloudformation.stack 13.1.1
 aws.cloudformation.stack.capabilities 13.1.1
+aws.cloudformation.stack.changeSetId 13.38.2
 aws.cloudformation.stack.createdAt 13.1.1
 aws.cloudformation.stack.description 13.1.1
 aws.cloudformation.stack.driftStatus 13.1.1
@@ -1382,6 +1383,7 @@ aws.cloudformation.stack.name 13.1.1
 aws.cloudformation.stack.notificationTopics 13.1.1
 aws.cloudformation.stack.outputs 13.1.1
 aws.cloudformation.stack.parameters 13.1.1
+aws.cloudformation.stack.parentStack 13.38.2
 aws.cloudformation.stack.region 13.1.1
 aws.cloudformation.stack.resource 13.35.2
 aws.cloudformation.stack.resource.driftStatus 13.35.2
@@ -1393,6 +1395,7 @@ aws.cloudformation.stack.resource.status 13.35.2
 aws.cloudformation.stack.resource.statusReason 13.35.2
 aws.cloudformation.stack.resources 13.35.2
 aws.cloudformation.stack.roleArn 13.26.3
+aws.cloudformation.stack.rootStack 13.38.2
 aws.cloudformation.stack.stackId 13.1.1
 aws.cloudformation.stack.status 13.1.1
 aws.cloudformation.stack.statusReason 13.1.1
@@ -1923,6 +1926,7 @@ aws.codebuild.project.privilegedMode 11.15.2
 aws.codebuild.project.projectVisibility 11.15.2
 aws.codebuild.project.queuedTimeoutInMinutes 11.15.2
 aws.codebuild.project.region 11.15.2
+aws.codebuild.project.resourceAccessRole 13.38.2
 aws.codebuild.project.secondaryArtifacts 13.21.4
 aws.codebuild.project.secondarySources 13.21.4
 aws.codebuild.project.securityGroups 13.21.4
@@ -1936,6 +1940,7 @@ aws.codebuild.project.sourceInsecureSsl 13.21.4
 aws.codebuild.project.sourceLocation 13.21.4
 aws.codebuild.project.sourceReportBuildStatus 13.21.4
 aws.codebuild.project.sourceType 13.21.4
+aws.codebuild.project.sourceVersion 13.38.2
 aws.codebuild.project.subnets 13.21.4
 aws.codebuild.project.tags 11.15.2
 aws.codebuild.project.timeoutInMinutes 11.15.2
@@ -2914,6 +2919,7 @@ aws.ec2.image.ebsBlockDevice.encrypted 11.15.2
 aws.ec2.image.ebsBlockDevice.iops 11.15.2
 aws.ec2.image.ebsBlockDevice.kmsKey 11.16.1
 aws.ec2.image.ebsBlockDevice.kmsKeyId 11.15.2
+aws.ec2.image.ebsBlockDevice.snapshot 13.38.2
 aws.ec2.image.ebsBlockDevice.snapshotId 11.15.2
 aws.ec2.image.ebsBlockDevice.throughput 11.15.2
 aws.ec2.image.ebsBlockDevice.volumeSize 11.15.2
@@ -2963,7 +2969,9 @@ aws.ec2.images 11.15.2
 aws.ec2.instance 11.15.2
 aws.ec2.instance.architecture 11.15.2
 aws.ec2.instance.arn 11.15.2
+aws.ec2.instance.autoScalingGroup 13.38.2
 aws.ec2.instance.bootMode 11.15.2
+aws.ec2.instance.capacityReservation 13.38.2
 aws.ec2.instance.cloudformationStack 13.37.1
 aws.ec2.instance.cpuCoreCount 11.15.3
 aws.ec2.instance.cpuThreadsPerCore 11.15.3
@@ -3006,7 +3014,9 @@ aws.ec2.instance.launchedAt 11.15.2
 aws.ec2.instance.loadBalancers 13.37.1
 aws.ec2.instance.maintenanceAutoRecovery 11.15.3
 aws.ec2.instance.managedBy 13.37.1
+aws.ec2.instance.managedByOperator 13.38.2
 aws.ec2.instance.networkInterfaces 11.15.2
+aws.ec2.instance.operatorPrincipal 13.38.2
 aws.ec2.instance.patchState 11.15.2
 aws.ec2.instance.placement 11.15.3
 aws.ec2.instance.placement.affinity 11.15.3
@@ -3247,15 +3257,18 @@ aws.ec2.networkinterface.deviceIndex 13.15.2
 aws.ec2.networkinterface.elasticIp 13.15.2
 aws.ec2.networkinterface.id 11.15.2
 aws.ec2.networkinterface.instance 13.15.2
+aws.ec2.networkinterface.instanceOwnerId 13.38.2
 aws.ec2.networkinterface.interfaceType 13.15.2
 aws.ec2.networkinterface.ipv6Native 11.15.2
 aws.ec2.networkinterface.macAddress 11.15.2
 aws.ec2.networkinterface.networkCardIndex 13.15.2
+aws.ec2.networkinterface.ownerId 13.38.2
 aws.ec2.networkinterface.privateDnsName 11.15.2
 aws.ec2.networkinterface.privateIpAddress 11.15.2
 aws.ec2.networkinterface.publicDnsName 13.15.2
 aws.ec2.networkinterface.publicIp 13.15.2
 aws.ec2.networkinterface.region 11.16.1
+aws.ec2.networkinterface.requesterId 13.38.2
 aws.ec2.networkinterface.requesterManaged 11.15.2
 aws.ec2.networkinterface.securityGroups 11.15.2
 aws.ec2.networkinterface.sourceDestCheck 11.15.2
@@ -3301,6 +3314,7 @@ aws.ec2.securitygroup.isAttachedToNetworkInterface 11.15.2
 aws.ec2.securitygroup.managedBy 13.37.1
 aws.ec2.securitygroup.name 11.15.2
 aws.ec2.securitygroup.networkInterfaces 13.37.1
+aws.ec2.securitygroup.ownerId 13.38.2
 aws.ec2.securitygroup.region 11.15.2
 aws.ec2.securitygroup.tags 11.15.2
 aws.ec2.securitygroup.vpc 11.15.2
@@ -3317,6 +3331,7 @@ aws.ec2.snapshot.isPublic 13.2.7
 aws.ec2.snapshot.kmsKey 11.15.2
 aws.ec2.snapshot.outpostArn 13.35.2
 aws.ec2.snapshot.ownerAlias 13.35.2
+aws.ec2.snapshot.ownerId 13.38.2
 aws.ec2.snapshot.region 11.15.2
 aws.ec2.snapshot.sharedExternally 13.37.1
 aws.ec2.snapshot.sharedWithAccounts 13.37.1
@@ -3665,6 +3680,7 @@ aws.ecs.service.serviceRegistries 13.29.1
 aws.ecs.service.status 11.15.2
 aws.ecs.service.tags 11.15.2
 aws.ecs.service.taskDefinition 11.15.2
+aws.ecs.service.taskDefinitionArn 13.38.2
 aws.ecs.service.taskSets 11.15.2
 aws.ecs.task 11.15.2
 aws.ecs.task.arn 11.15.2
@@ -3687,6 +3703,7 @@ aws.ecs.task.platformFamily 11.15.2
 aws.ecs.task.platformVersion 11.15.2
 aws.ecs.task.region 11.16.1
 aws.ecs.task.startedAt 13.29.1
+aws.ecs.task.startedBy 13.38.2
 aws.ecs.task.stopCode 13.29.1
 aws.ecs.task.stoppedAt 13.29.1
 aws.ecs.task.stoppedReason 13.29.1
@@ -3754,6 +3771,7 @@ aws.ecs.taskDefinition.placementConstraints 13.29.1
 aws.ecs.taskDefinition.proxyConfiguration 13.29.1
 aws.ecs.taskDefinition.region 11.15.2
 aws.ecs.taskDefinition.registeredAt 11.15.2
+aws.ecs.taskDefinition.registeredBy 13.38.2
 aws.ecs.taskDefinition.requiresCompatibilities 13.29.1
 aws.ecs.taskDefinition.revision 11.15.2
 aws.ecs.taskDefinition.runtimePlatformCpuArchitecture 13.29.1
@@ -3842,6 +3860,7 @@ aws.efs.filesystem.lifecycleConfiguration.transitionToPrimaryStorageClass 13.12.
 aws.efs.filesystem.lifecycleState 13.12.1
 aws.efs.filesystem.mountTargets 11.15.2
 aws.efs.filesystem.name 11.15.2
+aws.efs.filesystem.ownerId 13.38.2
 aws.efs.filesystem.performanceMode 13.12.1
 aws.efs.filesystem.policyStatements 13.32.2
 aws.efs.filesystem.region 11.15.2
@@ -4009,6 +4028,8 @@ aws.eks.nodegroup.diskSize 11.15.2
 aws.eks.nodegroup.health 13.12.1
 aws.eks.nodegroup.instanceTypes 11.15.2
 aws.eks.nodegroup.labels 11.15.2
+aws.eks.nodegroup.launchTemplate 13.38.2
+aws.eks.nodegroup.launchTemplateVersion 13.38.2
 aws.eks.nodegroup.modifiedAt 11.15.2
 aws.eks.nodegroup.name 11.15.2
 aws.eks.nodegroup.nodeRepairEnabled 13.12.1
@@ -4064,6 +4085,7 @@ aws.elasticache.cluster.numCacheNodes 11.15.2
 aws.elasticache.cluster.preferredAvailabilityZone 11.15.2
 aws.elasticache.cluster.preferredMaintenanceWindow 11.15.2
 aws.elasticache.cluster.region 11.15.2
+aws.elasticache.cluster.replicationGroupId 13.38.2
 aws.elasticache.cluster.replicationGroupLogDeliveryEnabled 11.15.2
 aws.elasticache.cluster.securityGroups 11.15.2
 aws.elasticache.cluster.snapshotRetentionLimit 11.15.2
@@ -5370,6 +5392,7 @@ aws.iam.user.mfaDevices 13.26.2
 aws.iam.user.name 11.15.2
 aws.iam.user.passwordLastUsed 11.15.2
 aws.iam.user.path 11.15.2
+aws.iam.user.permissionsBoundary 13.38.2
 aws.iam.user.policies 11.15.2
 aws.iam.user.tags 11.15.2
 aws.iam.usercredentialreportentry 11.15.2
@@ -5919,6 +5942,8 @@ aws.lambda.function.loggingConfig.applicationLogLevel 11.15.2
 aws.lambda.function.loggingConfig.logFormat 11.15.2
 aws.lambda.function.loggingConfig.logGroup 11.15.2
 aws.lambda.function.loggingConfig.systemLogLevel 11.15.2
+aws.lambda.function.masterArn 13.38.2
+aws.lambda.function.masterFunction 13.38.2
 aws.lambda.function.memorySize 11.15.2
 aws.lambda.function.name 11.15.2
 aws.lambda.function.packageType 11.15.2
@@ -5944,6 +5969,7 @@ aws.lambda.function.signingJobArn 11.15.2
 aws.lambda.function.signingProfileVersionArn 11.15.2
 aws.lambda.function.snapStartApplyOn 11.15.2
 aws.lambda.function.snapStartOptimizationStatus 11.15.2
+aws.lambda.function.sourceKmsKey 13.38.2
 aws.lambda.function.state 11.15.2
 aws.lambda.function.stateReason 11.15.2
 aws.lambda.function.subnets 13.2.7
@@ -6940,6 +6966,7 @@ aws.organization.delegatedService.delegationEnabledDate 13.0.2
 aws.organization.delegatedService.servicePrincipal 13.0.2
 aws.organization.featureSet 11.15.2
 aws.organization.id 11.15.2
+aws.organization.masterAccountArn 13.38.2
 aws.organization.masterAccountEmail 11.15.2
 aws.organization.masterAccountId 11.15.2
 aws.organization.organizationalUnit 13.6.3
@@ -7097,6 +7124,7 @@ aws.rds.dbcluster.backupRetentionPeriod 11.15.2
 aws.rds.dbcluster.backupSettings 11.15.2
 aws.rds.dbcluster.certificateAuthority 11.15.2
 aws.rds.dbcluster.certificateExpiresAt 11.15.2
+aws.rds.dbcluster.cloneGroupId 13.38.2
 aws.rds.dbcluster.clusterDbInstanceClass 11.15.2
 aws.rds.dbcluster.copyTagsToSnapshot 11.16.1
 aws.rds.dbcluster.createdAt 11.15.2
@@ -7167,6 +7195,7 @@ aws.rds.dbinstance.copyTagsToSnapshot 11.15.2
 aws.rds.dbinstance.createdAt 11.15.2
 aws.rds.dbinstance.customIamInstanceProfile 11.15.2
 aws.rds.dbinstance.customerOwnedIpEnabled 11.16.1
+aws.rds.dbinstance.dbCluster 13.38.2
 aws.rds.dbinstance.dbClusterIdentifier 11.15.2
 aws.rds.dbinstance.dbInstanceClass 11.15.2
 aws.rds.dbinstance.dbInstanceIdentifier 11.15.2
@@ -7331,6 +7360,8 @@ aws.rds.snapshot.originalCreatedAt 13.35.2
 aws.rds.snapshot.port 11.15.2
 aws.rds.snapshot.preferredBackupWindow 13.14.2
 aws.rds.snapshot.region 11.15.2
+aws.rds.snapshot.sourceDbCluster 13.38.2
+aws.rds.snapshot.sourceDbInstance 13.38.2
 aws.rds.snapshot.sourceRegion 13.35.2
 aws.rds.snapshot.sourceSnapshot 13.35.2
 aws.rds.snapshot.status 11.15.2
@@ -7376,6 +7407,7 @@ aws.redshift.cluster.parameters 11.15.2
 aws.redshift.cluster.preferredMaintenanceWindow 11.15.2
 aws.redshift.cluster.publiclyAccessible 11.15.2
 aws.redshift.cluster.region 11.15.2
+aws.redshift.cluster.snapshotScheduleIdentifier 13.38.2
 aws.redshift.cluster.snapshots 11.15.2
 aws.redshift.cluster.tags 11.15.2
 aws.redshift.cluster.totalStorageCapacityInMegaBytes 11.15.2
@@ -7408,8 +7440,10 @@ aws.redshift.scheduledAction.state 13.12.1
 aws.redshift.scheduledAction.targetAction 13.12.1
 aws.redshift.scheduledActions 13.12.1
 aws.redshift.snapshot 11.15.2
+aws.redshift.snapshot.accountsWithRestoreAccess 13.38.2
 aws.redshift.snapshot.arn 11.15.2
 aws.redshift.snapshot.availabilityZone 11.15.2
+aws.redshift.snapshot.cluster 13.38.2
 aws.redshift.snapshot.clusterCreatedAt 11.15.2
 aws.redshift.snapshot.clusterIdentifier 11.15.2
 aws.redshift.snapshot.clusterVersion 11.15.2
@@ -7425,6 +7459,7 @@ aws.redshift.snapshot.manualSnapshotRetentionPeriod 11.15.2
 aws.redshift.snapshot.masterUsername 11.15.2
 aws.redshift.snapshot.nodeType 11.15.2
 aws.redshift.snapshot.numberOfNodes 11.15.2
+aws.redshift.snapshot.ownerAccount 13.38.2
 aws.redshift.snapshot.port 11.15.2
 aws.redshift.snapshot.region 11.15.2
 aws.redshift.snapshot.snapshotType 11.15.2
@@ -8850,6 +8885,7 @@ aws.secretsmanager.secret.arn 11.15.2
 aws.secretsmanager.secret.createdAt 11.15.2
 aws.secretsmanager.secret.deletedAt 13.12.1
 aws.secretsmanager.secret.description 11.15.2
+aws.secretsmanager.secret.externalRotationRole 13.38.2
 aws.secretsmanager.secret.isPublic 13.37.1
 aws.secretsmanager.secret.kmsKey 11.15.2
 aws.secretsmanager.secret.lastAccessedDate 11.15.2
@@ -9151,6 +9187,7 @@ aws.sns.topic.externalAccessFindings 13.37.1
 aws.sns.topic.fifoTopic 13.12.1
 aws.sns.topic.isPublic 13.37.1
 aws.sns.topic.kmsMasterKey 11.15.2
+aws.sns.topic.owner 13.38.2
 aws.sns.topic.policy 13.6.3
 aws.sns.topic.policyStatements 13.32.2
 aws.sns.topic.region 11.15.2
@@ -9232,9 +9269,11 @@ aws.ssm.document.status 13.6.3
 aws.ssm.document.tags 13.6.3
 aws.ssm.documents 13.6.3
 aws.ssm.instance 11.15.2
+aws.ssm.instance.activationId 13.38.2
 aws.ssm.instance.agentVersion 11.15.2
 aws.ssm.instance.arn 11.15.2
 aws.ssm.instance.computerName 11.15.2
+aws.ssm.instance.iamRole 13.38.2
 aws.ssm.instance.instanceId 11.15.2
 aws.ssm.instance.ipAddress 11.15.2
 aws.ssm.instance.lastPingedAt 11.15.2
@@ -9243,6 +9282,9 @@ aws.ssm.instance.platformName 11.15.2
 aws.ssm.instance.platformType 11.15.2
 aws.ssm.instance.platformVersion 11.15.2
 aws.ssm.instance.region 11.15.2
+aws.ssm.instance.resourceType 13.38.2
+aws.ssm.instance.sourceId 13.38.2
+aws.ssm.instance.sourceType 13.38.2
 aws.ssm.instance.tags 11.15.2
 aws.ssm.instances 11.15.2
 aws.ssm.maintenanceWindow 13.6.3
@@ -9675,6 +9717,7 @@ aws.vpc.natgateway.subnet 11.15.2
 aws.vpc.natgateway.tags 11.15.2
 aws.vpc.natgateway.vpc 11.15.2
 aws.vpc.networkAcls 11.15.2
+aws.vpc.ownerId 13.38.2
 aws.vpc.peeringConnection 11.15.2
 aws.vpc.peeringConnection.accepterAccountId 13.6.3
 aws.vpc.peeringConnection.acceptorVpc 11.15.2
@@ -9763,6 +9806,7 @@ aws.vpc.subnet.name 11.15.2
 aws.vpc.subnet.natGateway 13.6.3
 aws.vpc.subnet.networkAcl 13.6.3
 aws.vpc.subnet.networkInterfaces 13.37.1
+aws.vpc.subnet.ownerId 13.38.2
 aws.vpc.subnet.region 11.15.2
 aws.vpc.subnet.routeTable 11.15.2
 aws.vpc.subnet.state 11.15.2

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -93,6 +93,7 @@ func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
 			"id":                 llx.StringDataPtr(org.Organization.Id),
 			"featureSet":         llx.StringData(string(org.Organization.FeatureSet)),
 			"masterAccountId":    llx.StringDataPtr(org.Organization.MasterAccountId),
+			"masterAccountArn":   llx.StringDataPtr(org.Organization.MasterAccountArn),
 			"masterAccountEmail": llx.StringDataPtr(org.Organization.MasterAccountEmail),
 		})
 	return res.(*mqlAwsOrganization), err

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -173,6 +173,60 @@ type mqlAwsCloudformationStackInternal struct {
 	cacheParameters       []cf_types.Parameter
 	cacheOutputs          []cf_types.Output
 	cacheNotificationArns []string
+	cacheParentId         *string
+	cacheRootId           *string
+}
+
+// resolveStackById issues a targeted DescribeStacks for a single stack id in
+// the given region and builds the resource. Returns (nil, nil) when the stack
+// is empty/missing; callers set the field's null state before returning.
+func resolveStackById(runtime *plugin.Runtime, region string, stackID *string) (*mqlAwsCloudformationStack, error) {
+	if stackID == nil || *stackID == "" {
+		return nil, nil
+	}
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.CloudFormation(region)
+	resp, err := svc.DescribeStacks(context.Background(), &cloudformation.DescribeStacksInput{
+		StackName: stackID,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+			return nil, nil
+		}
+		var oe interface{ ErrorCode() string }
+		if errors.As(err, &oe) && oe.ErrorCode() == "ValidationError" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(resp.Stacks) == 0 {
+		return nil, nil
+	}
+	return buildCloudformationStackResource(runtime, region, resp.Stacks[0])
+}
+
+func (a *mqlAwsCloudformationStack) parentStack() (*mqlAwsCloudformationStack, error) {
+	stack, err := resolveStackById(a.MqlRuntime, a.Region.Data, a.cacheParentId)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		a.ParentStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}
+
+func (a *mqlAwsCloudformationStack) rootStack() (*mqlAwsCloudformationStack, error) {
+	stack, err := resolveStackById(a.MqlRuntime, a.Region.Data, a.cacheRootId)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		a.RootStack.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
 }
 
 func (a *mqlAwsCloudformationStack) iamRole() (*mqlAwsIamRole, error) {
@@ -536,6 +590,7 @@ func buildCloudformationStackResource(runtime *plugin.Runtime, region string, st
 			"tags":                        llx.MapData(cfnTagsToMap(stack.Tags), types.String),
 			"createdAt":                   llx.TimeDataPtr(stack.CreationTime),
 			"updatedAt":                   llx.TimeDataPtr(stack.LastUpdatedTime),
+			"changeSetId":                 llx.StringDataPtr(stack.ChangeSetId),
 		})
 	if err != nil {
 		return nil, err
@@ -545,6 +600,8 @@ func buildCloudformationStackResource(runtime *plugin.Runtime, region string, st
 	mqlStackRes.cacheParameters = stack.Parameters
 	mqlStackRes.cacheOutputs = stack.Outputs
 	mqlStackRes.cacheNotificationArns = stack.NotificationARNs
+	mqlStackRes.cacheParentId = stack.ParentId
+	mqlStackRes.cacheRootId = stack.RootId
 	return mqlStackRes, nil
 }
 

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -165,6 +165,7 @@ func newMqlAwsCodebuildProject(runtime *plugin.Runtime, conn *connection.AwsConn
 		args["privilegedMode"] = llx.BoolData(false)
 	}
 	args["serviceRole"] = llx.StringDataPtr(project.ServiceRole)
+	args["sourceVersion"] = llx.StringDataPtr(project.SourceVersion)
 	args["queuedTimeoutInMinutes"] = llx.IntDataDefault(project.QueuedTimeoutInMinutes, 480)
 
 	if project.ConcurrentBuildLimit != nil {
@@ -353,6 +354,7 @@ func newMqlAwsCodebuildProject(runtime *plugin.Runtime, conn *connection.AwsConn
 	mqlProject := obj.(*mqlAwsCodebuildProject)
 	mqlProject.cacheEncryptionKeyArn = project.EncryptionKey
 	mqlProject.cacheServiceRoleArn = project.ServiceRole
+	mqlProject.cacheResourceAccessRoleArn = project.ResourceAccessRole
 	mqlProject.cacheLogGroupArn = cacheLogGroupArn
 	mqlProject.cacheVpcId = cacheVpcId
 	mqlProject.cacheSubnetIds = subnetIds
@@ -369,13 +371,27 @@ func newMqlAwsCodebuildProject(runtime *plugin.Runtime, conn *connection.AwsConn
 
 type mqlAwsCodebuildProjectInternal struct {
 	securityGroupIdHandler
-	cacheEncryptionKeyArn *string
-	cacheServiceRoleArn   *string
-	cacheLogGroupArn      *string
-	cacheVpcId            *string
-	cacheSubnetIds        []string
-	region                string
-	accountID             string
+	cacheEncryptionKeyArn      *string
+	cacheServiceRoleArn        *string
+	cacheResourceAccessRoleArn *string
+	cacheLogGroupArn           *string
+	cacheVpcId                 *string
+	cacheSubnetIds             []string
+	region                     string
+	accountID                  string
+}
+
+func (a *mqlAwsCodebuildProject) resourceAccessRole() (*mqlAwsIamRole, error) {
+	if a.cacheResourceAccessRoleArn == nil || *a.cacheResourceAccessRoleArn == "" {
+		a.ResourceAccessRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheResourceAccessRoleArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
 }
 
 func (a *mqlAwsCodebuildProject) encryptionKey() (*mqlAwsKmsKey, error) {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1415,6 +1415,15 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 		args["spotInstanceRequestId"] = llx.StringDataPtr(instance.SpotInstanceRequestId)
 		args["virtualizationType"] = llx.StringData(string(instance.VirtualizationType))
 
+		// Operator: whether an AWS service provider manages the instance
+		if instance.Operator != nil {
+			args["managedByOperator"] = llx.BoolDataPtr(instance.Operator.Managed)
+			args["operatorPrincipal"] = llx.StringDataPtr(instance.Operator.Principal)
+		} else {
+			args["managedByOperator"] = llx.BoolData(false)
+			args["operatorPrincipal"] = llx.StringData("")
+		}
+
 		// Placement
 		if instance.Placement != nil {
 			p := instance.Placement
@@ -1593,6 +1602,7 @@ func buildNetworkInterfaceResource(runtime *plugin.Runtime, region string, eni e
 	var deviceIndex, networkCardIndex *int32
 	var deleteOnTermination bool
 	var attachmentInstanceID *string
+	var instanceOwnerID *string
 	if eni.Attachment != nil {
 		attachmentStatus = string(eni.Attachment.Status)
 		attachmentTime = eni.Attachment.AttachTime
@@ -1600,6 +1610,7 @@ func buildNetworkInterfaceResource(runtime *plugin.Runtime, region string, eni e
 		networkCardIndex = eni.Attachment.NetworkCardIndex
 		deleteOnTermination = convert.ToValue(eni.Attachment.DeleteOnTermination)
 		attachmentInstanceID = eni.Attachment.InstanceId
+		instanceOwnerID = eni.Attachment.InstanceOwnerId
 	}
 
 	args := map[string]*llx.RawData{
@@ -1624,6 +1635,9 @@ func buildNetworkInterfaceResource(runtime *plugin.Runtime, region string, eni e
 		"deviceIndex":         llx.IntDataPtr(deviceIndex),
 		"networkCardIndex":    llx.IntDataPtr(networkCardIndex),
 		"deleteOnTermination": llx.BoolData(deleteOnTermination),
+		"ownerId":             llx.StringDataPtr(eni.OwnerId),
+		"requesterId":         llx.StringDataPtr(eni.RequesterId),
+		"instanceOwnerId":     llx.StringDataPtr(instanceOwnerID),
 	}
 	res, err := CreateResource(runtime, ResourceAwsEc2Networkinterface, args)
 	if err != nil {
@@ -1836,6 +1850,21 @@ func (a *mqlAwsEc2ImageEbsBlockDevice) kmsKey() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+func (a *mqlAwsEc2ImageEbsBlockDevice) snapshot() (*mqlAwsEc2Snapshot, error) {
+	if a.SnapshotId.Data == "" {
+		a.Snapshot.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlSnap, err := NewResource(a.MqlRuntime, ResourceAwsEc2Snapshot,
+		map[string]*llx.RawData{
+			"id": llx.StringData(a.SnapshotId.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlSnap.(*mqlAwsEc2Snapshot), nil
+}
+
 // sourceImage resolves the AMI this image was copied from when it is still
 // present in this account. The source may be owned by another account or
 // deregistered; in that case the reference is null and the sourceImageId field
@@ -2031,6 +2060,7 @@ func buildSecurityGroupResource(runtime *plugin.Runtime, region, accountID strin
 		"description": llx.StringDataPtr(group.Description),
 		"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(group.Tags)), types.String),
 		"region":      llx.StringData(region),
+		"ownerId":     llx.StringDataPtr(group.OwnerId),
 	}
 	mqlSG, err := CreateResource(runtime, ResourceAwsEc2Securitygroup, args)
 	if err != nil {
@@ -2610,6 +2640,7 @@ func buildSnapshotResource(runtime *plugin.Runtime, region, accountID string, sn
 			"volumeSize":          llx.IntDataDefault(snapshot.VolumeSize, 0),
 			"dataEncryptionKeyId": llx.StringDataPtr(snapshot.DataEncryptionKeyId),
 			"ownerAlias":          llx.StringDataPtr(snapshot.OwnerAlias),
+			"ownerId":             llx.StringDataPtr(snapshot.OwnerId),
 			"outpostArn":          llx.StringDataPtr(snapshot.OutpostArn),
 		})
 	if err != nil {
@@ -3621,27 +3652,10 @@ func (a *mqlAwsEc2) getLaunchTemplates(conn *connection.AwsConnection) []*jobpoo
 					return nil, err
 				}
 				for _, lt := range page.LaunchTemplates {
-					ltId := convert.ToValue(lt.LaunchTemplateId)
-					ltArn := fmt.Sprintf(launchTemplateArnPattern, region, conn.AccountId(), ltId)
-
-					mqlLt, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Launchtemplate,
-						map[string]*llx.RawData{
-							"id":             llx.StringData(ltId),
-							"arn":            llx.StringData(ltArn),
-							"name":           llx.StringDataPtr(lt.LaunchTemplateName),
-							"region":         llx.StringData(region),
-							"createdAt":      llx.TimeDataPtr(lt.CreateTime),
-							"createdBy":      llx.StringDataPtr(lt.CreatedBy),
-							"defaultVersion": llx.IntData(convert.ToValue(lt.DefaultVersionNumber)),
-							"latestVersion":  llx.IntData(convert.ToValue(lt.LatestVersionNumber)),
-							"tags":           llx.MapData(toInterfaceMap(ec2TagsToMap(lt.Tags)), types.String),
-						})
+					mqlLtRes, err := buildLaunchTemplateResource(a.MqlRuntime, region, conn.AccountId(), lt)
 					if err != nil {
 						return nil, err
 					}
-					mqlLtRes := mqlLt.(*mqlAwsEc2Launchtemplate)
-					mqlLtRes.region = region
-					mqlLtRes.launchTemplateId = ltId
 					res = append(res, mqlLtRes)
 				}
 			}
@@ -3658,6 +3672,66 @@ type mqlAwsEc2LaunchtemplateInternal struct {
 	ltDataOnce       sync.Once
 	ltData           *ec2types.ResponseLaunchTemplateData
 	ltDataErr        error
+}
+
+func buildLaunchTemplateResource(runtime *plugin.Runtime, region, accountID string, lt ec2types.LaunchTemplate) (*mqlAwsEc2Launchtemplate, error) {
+	ltId := convert.ToValue(lt.LaunchTemplateId)
+	ltArn := fmt.Sprintf(launchTemplateArnPattern, region, accountID, ltId)
+
+	mqlLt, err := CreateResource(runtime, ResourceAwsEc2Launchtemplate,
+		map[string]*llx.RawData{
+			"id":             llx.StringData(ltId),
+			"arn":            llx.StringData(ltArn),
+			"name":           llx.StringDataPtr(lt.LaunchTemplateName),
+			"region":         llx.StringData(region),
+			"createdAt":      llx.TimeDataPtr(lt.CreateTime),
+			"createdBy":      llx.StringDataPtr(lt.CreatedBy),
+			"defaultVersion": llx.IntData(convert.ToValue(lt.DefaultVersionNumber)),
+			"latestVersion":  llx.IntData(convert.ToValue(lt.LatestVersionNumber)),
+			"tags":           llx.MapData(toInterfaceMap(ec2TagsToMap(lt.Tags)), types.String),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlLtRes := mqlLt.(*mqlAwsEc2Launchtemplate)
+	mqlLtRes.region = region
+	mqlLtRes.launchTemplateId = ltId
+	return mqlLtRes, nil
+}
+
+func initAwsEc2Launchtemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["region"] == nil || (args["id"] == nil && args["name"] == nil) {
+		return nil, nil, errors.New("region and id or name required to fetch aws ec2 launch template")
+	}
+	region := args["region"].Value.(string)
+
+	input := &ec2.DescribeLaunchTemplatesInput{}
+	if args["id"] != nil {
+		input.LaunchTemplateIds = []string{args["id"].Value.(string)}
+	} else {
+		input.LaunchTemplateNames = []string{args["name"].Value.(string)}
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeLaunchTemplates(context.Background(), input)
+	if err != nil {
+		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.LaunchTemplates) == 0 {
+		return args, nil, nil
+	}
+	mqlLt, err := buildLaunchTemplateResource(runtime, region, conn.AccountId(), resp.LaunchTemplates[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlLt, nil
 }
 
 func (a *mqlAwsEc2Launchtemplate) id() (string, error) {
@@ -4196,6 +4270,41 @@ func (i *mqlAwsEc2Instance) managedBy() (string, error) {
 
 func (a *mqlAwsEc2Securitygroup) managedBy() (string, error) {
 	return managedByFromTags(a.Tags.Data), nil
+}
+
+func (i *mqlAwsEc2Instance) capacityReservation() (*mqlAwsEc2CapacityReservation, error) {
+	crID := convert.ToValue(i.instanceCache.CapacityReservationId)
+	if crID == "" {
+		i.CapacityReservation.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(i.MqlRuntime, "aws.ec2.capacityReservation",
+		map[string]*llx.RawData{
+			"id":     llx.StringData(crID),
+			"region": llx.StringData(i.Region.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2CapacityReservation), nil
+}
+
+func (i *mqlAwsEc2Instance) autoScalingGroup() (*mqlAwsAutoscalingGroup, error) {
+	raw, ok := i.Tags.Data["aws:autoscaling:groupName"]
+	groupName, _ := raw.(string)
+	if !ok || groupName == "" {
+		i.AutoScalingGroup.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(i.MqlRuntime, ResourceAwsAutoscalingGroup,
+		map[string]*llx.RawData{
+			"name":   llx.StringData(groupName),
+			"region": llx.StringData(i.Region.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAutoscalingGroup), nil
 }
 
 func (i *mqlAwsEc2Image) sharedWithAccounts() ([]any, error) {

--- a/providers/aws/resources/aws_ec2_placement.go
+++ b/providers/aws/resources/aws_ec2_placement.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -145,28 +148,7 @@ func (a *mqlAwsEc2) getCapacityReservations(conn *connection.AwsConnection) []*j
 					if conn.Filters.General.MatchesExcludeTags(tags) {
 						continue
 					}
-					arn := fmt.Sprintf("arn:aws:ec2:%s:%s:capacity-reservation/%s", region, conn.AccountId(), convert.ToValue(cr.CapacityReservationId))
-
-					mqlCr, err := CreateResource(a.MqlRuntime, "aws.ec2.capacityReservation",
-						map[string]*llx.RawData{
-							"__id":                   llx.StringData(arn),
-							"id":                     llx.StringDataPtr(cr.CapacityReservationId),
-							"arn":                    llx.StringData(arn),
-							"region":                 llx.StringData(region),
-							"instanceType":           llx.StringDataPtr(cr.InstanceType),
-							"instancePlatform":       llx.StringData(string(cr.InstancePlatform)),
-							"availabilityZone":       llx.StringDataPtr(cr.AvailabilityZone),
-							"totalInstanceCount":     llx.IntDataDefault(cr.TotalInstanceCount, 0),
-							"availableInstanceCount": llx.IntDataDefault(cr.AvailableInstanceCount, 0),
-							"state":                  llx.StringData(string(cr.State)),
-							"instanceMatchCriteria":  llx.StringData(string(cr.InstanceMatchCriteria)),
-							"endDateType":            llx.StringData(string(cr.EndDateType)),
-							"tenancy":                llx.StringData(string(cr.Tenancy)),
-							"ebsOptimized":           llx.BoolData(convert.ToValue(cr.EbsOptimized)),
-							"ephemeralStorage":       llx.BoolData(convert.ToValue(cr.EphemeralStorage)),
-							"createdAt":              llx.TimeDataPtr(cr.CreateDate),
-							"tags":                   llx.MapData(toInterfaceMap(tags), types.String),
-						})
+					mqlCr, err := buildCapacityReservationResource(a.MqlRuntime, region, conn.AccountId(), cr)
 					if err != nil {
 						return nil, err
 					}
@@ -182,6 +164,65 @@ func (a *mqlAwsEc2) getCapacityReservations(conn *connection.AwsConnection) []*j
 
 func (a *mqlAwsEc2CapacityReservation) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func buildCapacityReservationResource(runtime *plugin.Runtime, region, accountID string, cr ec2types.CapacityReservation) (*mqlAwsEc2CapacityReservation, error) {
+	arn := fmt.Sprintf("arn:aws:ec2:%s:%s:capacity-reservation/%s", region, accountID, convert.ToValue(cr.CapacityReservationId))
+	mqlCr, err := CreateResource(runtime, "aws.ec2.capacityReservation",
+		map[string]*llx.RawData{
+			"__id":                   llx.StringData(arn),
+			"id":                     llx.StringDataPtr(cr.CapacityReservationId),
+			"arn":                    llx.StringData(arn),
+			"region":                 llx.StringData(region),
+			"instanceType":           llx.StringDataPtr(cr.InstanceType),
+			"instancePlatform":       llx.StringData(string(cr.InstancePlatform)),
+			"availabilityZone":       llx.StringDataPtr(cr.AvailabilityZone),
+			"totalInstanceCount":     llx.IntDataDefault(cr.TotalInstanceCount, 0),
+			"availableInstanceCount": llx.IntDataDefault(cr.AvailableInstanceCount, 0),
+			"state":                  llx.StringData(string(cr.State)),
+			"instanceMatchCriteria":  llx.StringData(string(cr.InstanceMatchCriteria)),
+			"endDateType":            llx.StringData(string(cr.EndDateType)),
+			"tenancy":                llx.StringData(string(cr.Tenancy)),
+			"ebsOptimized":           llx.BoolData(convert.ToValue(cr.EbsOptimized)),
+			"ephemeralStorage":       llx.BoolData(convert.ToValue(cr.EphemeralStorage)),
+			"createdAt":              llx.TimeDataPtr(cr.CreateDate),
+			"tags":                   llx.MapData(toInterfaceMap(ec2TagsToMap(cr.Tags)), types.String),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlCr.(*mqlAwsEc2CapacityReservation), nil
+}
+
+func initAwsEc2CapacityReservation(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["id"] == nil || args["region"] == nil {
+		return nil, nil, errors.New("id and region required to fetch aws ec2 capacity reservation")
+	}
+	id := args["id"].Value.(string)
+	region := args["region"].Value.(string)
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeCapacityReservations(context.Background(), &ec2.DescribeCapacityReservationsInput{
+		CapacityReservationIds: []string{id},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.CapacityReservations) == 0 {
+		return args, nil, nil
+	}
+	mqlCr, err := buildCapacityReservationResource(runtime, region, conn.AccountId(), resp.CapacityReservations[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlCr, nil
 }
 
 // Instance Connect Endpoints

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -2092,7 +2092,7 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	args["status"] = llx.StringDataPtr(s.Status)
 	args["desiredCount"] = llx.IntData(int64(s.DesiredCount))
 	args["runningCount"] = llx.IntData(int64(s.RunningCount))
-	args["taskDefinitionArn"] = llx.StringData(taskDefinition)
+	args["taskDefinition"] = llx.StringData(taskDefinition)
 	args["launchType"] = llx.StringData(launchType)
 	// Always set deploymentConfiguration - AWS services should always have this, but handle nil case
 	if deploymentConfigResource != nil {
@@ -2446,10 +2446,10 @@ func (a *mqlAwsEcsContainer) task() (*mqlAwsEcsTask, error) {
 	return res.(*mqlAwsEcsTask), nil
 }
 
-func (a *mqlAwsEcsService) taskDefinition() (*mqlAwsEcsTaskDefinition, error) {
-	arnVal := a.TaskDefinitionArn.Data
+func (a *mqlAwsEcsService) taskDefinitionRef() (*mqlAwsEcsTaskDefinition, error) {
+	arnVal := a.TaskDefinition.Data
 	if arnVal == "" {
-		a.TaskDefinition.State = plugin.StateIsNull | plugin.StateIsSet
+		a.TaskDefinitionRef.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	region, err := GetRegionFromArn(arnVal)

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -475,6 +475,7 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	args["launchType"] = llx.StringData(string(t.LaunchType))
 	args["capacityProviderName"] = llx.StringData(convert.ToValue(t.CapacityProviderName))
 	args["group"] = llx.StringData(convert.ToValue(t.Group))
+	args["startedBy"] = llx.StringData(convert.ToValue(t.StartedBy))
 	args["enableExecuteCommand"] = llx.BoolData(t.EnableExecuteCommand)
 	args["stopCode"] = llx.StringData(string(t.StopCode))
 	args["stoppedReason"] = llx.StringData(convert.ToValue(t.StoppedReason))
@@ -1489,9 +1490,17 @@ func (a *mqlAwsEcsTaskDefinition) fetchDetail() error {
 	} else {
 		a.RegisteredAt = plugin.TValue[*time.Time]{Data: &llx.NeverFutureTime, State: plugin.StateIsSet}
 	}
+	a.RegisteredBy = plugin.TValue[string]{Data: convert.ToValue(td.RegisteredBy), State: plugin.StateIsSet}
 
 	a.fetched = true
 	return nil
+}
+
+func (a *mqlAwsEcsTaskDefinition) registeredBy() (string, error) {
+	if err := a.fetchDetail(); err != nil {
+		return "", err
+	}
+	return a.RegisteredBy.Data, nil
 }
 
 func (a *mqlAwsEcsTaskDefinition) family() (string, error) {
@@ -2083,7 +2092,7 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	args["status"] = llx.StringDataPtr(s.Status)
 	args["desiredCount"] = llx.IntData(int64(s.DesiredCount))
 	args["runningCount"] = llx.IntData(int64(s.RunningCount))
-	args["taskDefinition"] = llx.StringData(taskDefinition)
+	args["taskDefinitionArn"] = llx.StringData(taskDefinition)
 	args["launchType"] = llx.StringData(launchType)
 	// Always set deploymentConfiguration - AWS services should always have this, but handle nil case
 	if deploymentConfigResource != nil {
@@ -2435,6 +2444,24 @@ func (a *mqlAwsEcsContainer) task() (*mqlAwsEcsTask, error) {
 		return nil, err
 	}
 	return res.(*mqlAwsEcsTask), nil
+}
+
+func (a *mqlAwsEcsService) taskDefinition() (*mqlAwsEcsTaskDefinition, error) {
+	arnVal := a.TaskDefinitionArn.Data
+	if arnVal == "" {
+		a.TaskDefinition.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	region, err := GetRegionFromArn(arnVal)
+	if err != nil {
+		return nil, err
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.ecs.taskDefinition",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal), "region": llx.StringData(region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEcsTaskDefinition), nil
 }
 
 func (a *mqlAwsEcsService) cluster() (*mqlAwsEcsCluster, error) {

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -110,6 +110,7 @@ func buildEfsFilesystemResource(runtime *plugin.Runtime, region string, fs efsty
 		"arn":              llx.StringDataPtr(fs.FileSystemArn),
 		"name":             llx.StringDataPtr(fs.Name),
 		"encrypted":        llx.BoolData(convert.ToValue(fs.Encrypted)),
+		"ownerId":          llx.StringDataPtr(fs.OwnerId),
 		"region":           llx.StringData(region),
 		"availabilityZone": llx.StringDataPtr(fs.AvailabilityZoneName),
 		"createdAt":        llx.TimeDataPtr(fs.CreationTime),

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -635,6 +635,41 @@ func (a *mqlAwsEksNodegroup) capacityType() (string, error) {
 	return string(ng.CapacityType), nil
 }
 
+func (a *mqlAwsEksNodegroup) launchTemplate() (*mqlAwsEc2Launchtemplate, error) {
+	ng, err := a.fetchDetails()
+	if err != nil {
+		return nil, err
+	}
+	if ng.LaunchTemplate == nil || (ng.LaunchTemplate.Id == nil && ng.LaunchTemplate.Name == nil) {
+		a.LaunchTemplate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	args := map[string]*llx.RawData{"region": llx.StringData(a.region)}
+	if ng.LaunchTemplate.Id != nil && *ng.LaunchTemplate.Id != "" {
+		args["id"] = llx.StringDataPtr(ng.LaunchTemplate.Id)
+	} else {
+		args["name"] = llx.StringDataPtr(ng.LaunchTemplate.Name)
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Launchtemplate, args)
+	if err != nil {
+		a.LaunchTemplate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsEc2Launchtemplate), nil
+}
+
+func (a *mqlAwsEksNodegroup) launchTemplateVersion() (string, error) {
+	ng, err := a.fetchDetails()
+	if err != nil {
+		return "", err
+	}
+	if ng.LaunchTemplate == nil {
+		a.LaunchTemplateVersion.State = plugin.StateIsNull | plugin.StateIsSet
+		return "", nil
+	}
+	return convert.ToValue(ng.LaunchTemplate.Version), nil
+}
+
 func (a *mqlAwsEksNodegroup) status() (string, error) {
 	ng, err := a.fetchDetails()
 	if err != nil {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -207,6 +207,7 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 			"transitEncryptionMode":              llx.StringData(string(cluster.TransitEncryptionMode)),
 			"preferredMaintenanceWindow":         llx.StringDataPtr(cluster.PreferredMaintenanceWindow),
 			"replicationGroupLogDeliveryEnabled": llx.BoolDataPtr(cluster.ReplicationGroupLogDeliveryEnabled),
+			"replicationGroupId":                 llx.StringDataPtr(cluster.ReplicationGroupId),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -424,7 +424,7 @@ func (a *mqlAwsIam) createIamUser(usr *iamtypes.User) (plugin.Resource, error) {
 		return nil, errors.New("no iam user provided")
 	}
 
-	return CreateResource(a.MqlRuntime, ResourceAwsIamUser,
+	res, err := CreateResource(a.MqlRuntime, ResourceAwsIamUser,
 		map[string]*llx.RawData{
 			"arn":              llx.StringDataPtr(usr.Arn),
 			"id":               llx.StringDataPtr(usr.UserId),
@@ -435,6 +435,46 @@ func (a *mqlAwsIam) createIamUser(usr *iamtypes.User) (plugin.Resource, error) {
 			"path":             llx.StringDataPtr(usr.Path),
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	mqlUser := res.(*mqlAwsIamUser)
+	if usr.PermissionsBoundary != nil {
+		mqlUser.permissionsBoundaryArn = convert.ToValue(usr.PermissionsBoundary.PermissionsBoundaryArn)
+		mqlUser.permissionsBoundaryArnSet = true
+	}
+	return res, nil
+}
+
+// permissionsBoundary resolves the managed policy that sets the user's
+// permissions boundary. ListUsers populates the boundary directly; resources
+// built via NewResource without it fall back to a targeted GetUser.
+func (a *mqlAwsIamUser) permissionsBoundary() (*mqlAwsIamPolicy, error) {
+	if !a.permissionsBoundaryArnSet {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		svc := conn.Iam("")
+		userName := a.Name.Data
+		resp, err := svc.GetUser(context.Background(), &iam.GetUserInput{UserName: &userName})
+		if err != nil {
+			return nil, err
+		}
+		if resp.User != nil && resp.User.PermissionsBoundary != nil {
+			a.permissionsBoundaryArn = convert.ToValue(resp.User.PermissionsBoundary.PermissionsBoundaryArn)
+		}
+		a.permissionsBoundaryArnSet = true
+	}
+
+	if a.permissionsBoundaryArn == "" {
+		a.PermissionsBoundary.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	mqlPolicy, err := NewResource(a.MqlRuntime, "aws.iam.policy",
+		map[string]*llx.RawData{"arn": llx.StringData(a.permissionsBoundaryArn)})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPolicy.(*mqlAwsIamPolicy), nil
 }
 
 func (a *mqlAwsIamUser) mfaDevices() ([]any, error) {
@@ -1055,6 +1095,9 @@ type mqlAwsIamUserInternal struct {
 	loginProfileFetched atomic.Bool
 	loginProfileCache   *mqlAwsIamLoginProfile
 	loginProfileLock    sync.Mutex
+
+	permissionsBoundaryArn    string
+	permissionsBoundaryArnSet bool
 }
 
 func (a *mqlAwsIamUser) id() (string, error) {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -284,6 +284,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"signingProfileVersionArn":    llx.StringDataPtr(function.SigningProfileVersionArn),
 		"signingJobArn":               llx.StringDataPtr(function.SigningJobArn),
 		"layers":                      llx.ArrayData(layers, types.Resource("aws.lambda.function.layer")),
+		"masterArn":                   llx.StringDataPtr(function.MasterArn),
 	}
 
 	if loggingConfigResource != nil {
@@ -421,6 +422,7 @@ type mqlAwsLambdaFunctionInternal struct {
 	imageDataLock         sync.Mutex
 	cacheImageUri         *string
 	cacheResolvedImageUri *string
+	cacheSourceKmsKeyArn  *string
 }
 
 // fetchImageData resolves the container image URIs for Image package type
@@ -452,9 +454,46 @@ func (a *mqlAwsLambdaFunction) fetchImageData() error {
 	if resp.Code != nil {
 		a.cacheImageUri = resp.Code.ImageUri
 		a.cacheResolvedImageUri = resp.Code.ResolvedImageUri
+		a.cacheSourceKmsKeyArn = resp.Code.SourceKMSKeyArn
 	}
 	a.imageDataFetched = true
 	return nil
+}
+
+// sourceKmsKey resolves the KMS key used to encrypt the function's deployment
+// package, when one is configured. Backed by the same GetFunction call as the
+// image URIs.
+func (a *mqlAwsLambdaFunction) sourceKmsKey() (*mqlAwsKmsKey, error) {
+	if err := a.fetchImageData(); err != nil {
+		return nil, err
+	}
+	if a.cacheSourceKmsKeyArn == nil || *a.cacheSourceKmsKeyArn == "" {
+		a.SourceKmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheSourceKmsKeyArn)})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
+}
+
+// masterFunction resolves the master function this Lambda was configured from,
+// when present in this account (set for replicated functions such as
+// Lambda@Edge replicas).
+func (a *mqlAwsLambdaFunction) masterFunction() (*mqlAwsLambdaFunction, error) {
+	if !a.MasterArn.IsSet() || a.MasterArn.Data == "" {
+		a.MasterFunction.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.lambda.function",
+		map[string]*llx.RawData{"arn": llx.StringData(a.MasterArn.Data)})
+	if err != nil {
+		a.MasterFunction.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsLambdaFunction), nil
 }
 
 func (a *mqlAwsLambdaFunction) imageUri() (string, error) {

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -773,6 +773,24 @@ func (a *mqlAwsRdsDbinstance) readReplicaSourceCluster() (*mqlAwsRdsDbcluster, e
 	return res.(*mqlAwsRdsDbcluster), nil
 }
 
+// dbCluster resolves the DB cluster this instance belongs to, when it is
+// present in this account. Standalone instances and cross-account members
+// resolve to null; dbClusterIdentifier always carries the identifier.
+func (a *mqlAwsRdsDbinstance) dbCluster() (*mqlAwsRdsDbcluster, error) {
+	if !a.DbClusterIdentifier.IsSet() || a.DbClusterIdentifier.Data == "" {
+		a.DbCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	arnVal := a.rdsSourceArn(a.DbClusterIdentifier.Data, "arn:aws:rds:%s:%s:cluster:%s")
+	res, err := NewResource(a.MqlRuntime, "aws.rds.dbcluster",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.DbCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsRdsDbcluster), nil
+}
+
 func (a *mqlAwsRdsDbinstance) subnets() ([]any, error) {
 	if a.cacheSubnets != nil {
 		res := []any{}
@@ -1116,6 +1134,7 @@ func newMqlAwsRdsCluster(runtime *plugin.Runtime, region string, accountID strin
 			"copyTagsToSnapshot":                 llx.BoolDataPtr(cluster.CopyTagsToSnapshot),
 			"databaseName":                       llx.StringDataPtr(cluster.DatabaseName),
 			"crossAccountClone":                  llx.BoolDataPtr(cluster.CrossAccountClone),
+			"cloneGroupId":                       llx.StringDataPtr(cluster.CloneGroupId),
 			"replicationSourceIdentifier":        llx.StringDataPtr(cluster.ReplicationSourceIdentifier),
 			"globalWriteForwardingStatus":        llx.StringData(string(cluster.GlobalWriteForwardingStatus)),
 			"upgradeRolloutOrder":                llx.StringData(string(cluster.UpgradeRolloutOrder)),
@@ -1261,6 +1280,7 @@ func newMqlAwsRdsClusterSnapshot(runtime *plugin.Runtime, region string, snapsho
 	}
 	mqlSnapshot := res.(*mqlAwsRdsSnapshot)
 	mqlSnapshot.cacheKmsKeyId = snapshot.KmsKeyId
+	mqlSnapshot.cacheSourceDbClusterId = snapshot.DBClusterIdentifier
 	return mqlSnapshot, nil
 }
 
@@ -1296,6 +1316,7 @@ func newMqlAwsRdsDbSnapshot(runtime *plugin.Runtime, region string, snapshot rds
 	}
 	mqlSnapshot := res.(*mqlAwsRdsSnapshot)
 	mqlSnapshot.cacheKmsKeyId = snapshot.KmsKeyId
+	mqlSnapshot.cacheSourceDbInstanceId = snapshot.DBInstanceIdentifier
 	return mqlSnapshot, nil
 }
 
@@ -1304,7 +1325,52 @@ func (a *mqlAwsRdsSnapshot) id() (string, error) {
 }
 
 type mqlAwsRdsSnapshotInternal struct {
-	cacheKmsKeyId *string
+	cacheKmsKeyId           *string
+	cacheSourceDbInstanceId *string
+	cacheSourceDbClusterId  *string
+}
+
+// sourceDbInstance resolves the DB instance this snapshot was taken from, when
+// it is present in this account. Cluster snapshots and instances no longer in
+// the inventory resolve to null.
+func (a *mqlAwsRdsSnapshot) sourceDbInstance() (*mqlAwsRdsDbinstance, error) {
+	if a.cacheSourceDbInstanceId == nil || *a.cacheSourceDbInstanceId == "" {
+		a.SourceDbInstance.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnVal := *a.cacheSourceDbInstanceId
+	if !strings.HasPrefix(arnVal, "arn:") {
+		arnVal = fmt.Sprintf(rdsInstanceArnPattern, a.Region.Data, conn.AccountId(), arnVal)
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.rds.dbinstance",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.SourceDbInstance.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsRdsDbinstance), nil
+}
+
+// sourceDbCluster resolves the DB cluster this snapshot was taken from, when it
+// is present in this account.
+func (a *mqlAwsRdsSnapshot) sourceDbCluster() (*mqlAwsRdsDbcluster, error) {
+	if a.cacheSourceDbClusterId == nil || *a.cacheSourceDbClusterId == "" {
+		a.SourceDbCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnVal := *a.cacheSourceDbClusterId
+	if !strings.HasPrefix(arnVal, "arn:") {
+		arnVal = fmt.Sprintf("arn:aws:rds:%s:%s:cluster:%s", a.Region.Data, conn.AccountId(), arnVal)
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.rds.dbcluster",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.SourceDbCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsRdsDbcluster), nil
 }
 
 func (a *mqlAwsRdsSnapshot) kmsKey() (*mqlAwsKmsKey, error) {

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -138,6 +138,7 @@ func (a *mqlAwsRedshift) getClusters(conn *connection.AwsConnection) []*jobpool.
 							"maintenanceTrackName":             llx.StringDataPtr(cluster.MaintenanceTrackName),
 							"hsmStatus":                        llx.DictData(redshiftHsmStatusToDict(cluster.HsmStatus)),
 							"modifyStatus":                     llx.StringDataPtr(cluster.ModifyStatus),
+							"snapshotScheduleIdentifier":       llx.StringDataPtr(cluster.SnapshotScheduleIdentifier),
 						})
 					if err != nil {
 						return nil, err
@@ -343,6 +344,8 @@ func newMqlAwsRedshiftSnapshot(runtime *plugin.Runtime, region string, snapshot 
 			"arn":                           llx.StringDataPtr(snapshot.SnapshotArn),
 			"id":                            llx.StringDataPtr(snapshot.SnapshotIdentifier),
 			"clusterIdentifier":             llx.StringDataPtr(snapshot.ClusterIdentifier),
+			"ownerAccount":                  llx.StringDataPtr(snapshot.OwnerAccount),
+			"accountsWithRestoreAccess":     llx.ArrayData(redshiftRestoreAccessToDicts(snapshot.AccountsWithRestoreAccess), types.Dict),
 			"region":                        llx.StringData(region),
 			"snapshotType":                  llx.StringDataPtr(snapshot.SnapshotType),
 			"sourceRegion":                  llx.StringDataPtr(snapshot.SourceRegion),
@@ -372,6 +375,38 @@ func newMqlAwsRedshiftSnapshot(runtime *plugin.Runtime, region string, snapshot 
 
 type mqlAwsRedshiftSnapshotInternal struct {
 	cacheKmsKeyId *string
+}
+
+// redshiftRestoreAccessToDicts converts the accounts authorized to restore a
+// snapshot into a slice of dicts, each carrying the account id and optional
+// account alias.
+func redshiftRestoreAccessToDicts(accounts []redshifttypes.AccountWithRestoreAccess) []any {
+	res := make([]any, 0, len(accounts))
+	for _, acc := range accounts {
+		res = append(res, map[string]any{
+			"accountId":    convert.ToValue(acc.AccountId),
+			"accountAlias": convert.ToValue(acc.AccountAlias),
+		})
+	}
+	return res
+}
+
+// cluster resolves the source cluster the snapshot was taken from, when it is
+// still present in this account.
+func (a *mqlAwsRedshiftSnapshot) cluster() (*mqlAwsRedshiftCluster, error) {
+	if !a.ClusterIdentifier.IsSet() || a.ClusterIdentifier.Data == "" {
+		a.Cluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnVal := fmt.Sprintf(redshiftClusterArnPattern, a.Region.Data, conn.AccountId(), a.ClusterIdentifier.Data)
+	res, err := NewResource(a.MqlRuntime, "aws.redshift.cluster",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.Cluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsRedshiftCluster), nil
 }
 
 func (a *mqlAwsRedshiftSnapshot) kmsKey() (*mqlAwsKmsKey, error) {

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -148,6 +148,7 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	mqlSecretRes := mqlSecret.(*mqlAwsSecretsmanagerSecret)
 	mqlSecretRes.cacheRegion = region
 	mqlSecretRes.cacheType = convert.ToValue(resp.Type)
+	mqlSecretRes.cacheExternalRotationRoleArn = resp.ExternalSecretRotationRoleArn
 	mqlSecretRes.DeletedAt = plugin.TValue[*time.Time]{Data: resp.DeletedDate, State: plugin.StateIsSet}
 
 	// We already have the replication status from DescribeSecret; populate
@@ -290,6 +291,7 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 					mqlSecretRes := mqlSecret.(*mqlAwsSecretsmanagerSecret)
 					mqlSecretRes.cacheRegion = region
 					mqlSecretRes.cacheType = convert.ToValue(secret.Type)
+					mqlSecretRes.cacheExternalRotationRoleArn = secret.ExternalSecretRotationRoleArn
 					mqlSecretRes.DeletedAt = plugin.TValue[*time.Time]{Data: secret.DeletedDate, State: plugin.StateIsSet}
 					res = append(res, mqlSecret)
 				}
@@ -338,8 +340,22 @@ func (a *mqlAwsSecretsmanagerSecret) replicaRegions() ([]any, error) {
 }
 
 type mqlAwsSecretsmanagerSecretInternal struct {
-	cacheRegion string
-	cacheType   string
+	cacheRegion                  string
+	cacheType                    string
+	cacheExternalRotationRoleArn *string
+}
+
+func (a *mqlAwsSecretsmanagerSecret) externalRotationRole() (*mqlAwsIamRole, error) {
+	if a.cacheExternalRotationRoleArn == nil || *a.cacheExternalRotationRoleArn == "" {
+		a.ExternalRotationRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheExternalRotationRoleArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
 }
 
 func (a *mqlAwsSecretsmanagerSecret) compute_type() (string, error) {

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -158,6 +158,14 @@ func (a *mqlAwsSnsTopic) signatureVersion() (string, error) {
 	return atts["SignatureVersion"], nil
 }
 
+func (a *mqlAwsSnsTopic) owner() (string, error) {
+	atts, err := a.fetchTopicAttributes()
+	if err != nil {
+		return "", err
+	}
+	return atts["Owner"], nil
+}
+
 func (a *mqlAwsSnsTopic) kmsMasterKey() (*mqlAwsKmsKey, error) {
 	atts, err := a.fetchTopicAttributes()
 	if err != nil {

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -201,10 +201,15 @@ func (a *mqlAwsSsm) getInstances(conn *connection.AwsConnection) []*jobpool.Job 
 						"agentVersion":    llx.StringDataPtr(instance.AgentVersion),
 						"lastPingedAt":    llx.TimeDataPtr(instance.LastPingDateTime),
 						"computerName":    llx.StringDataPtr(instance.ComputerName),
+						"sourceType":      llx.StringData(string(instance.SourceType)),
+						"sourceId":        llx.StringDataPtr(instance.SourceId),
+						"activationId":    llx.StringDataPtr(instance.ActivationId),
+						"resourceType":    llx.StringData(string(instance.ResourceType)),
 					})
 				if err != nil {
 					return nil, err
 				}
+				mqlInstance.(*mqlAwsSsmInstance).iamRoleName = convert.ToValue(instance.IamRole)
 				res = append(res, mqlInstance)
 			}
 			return jobpool.JobResult(res), nil
@@ -224,6 +229,27 @@ func (a *mqlAwsSsmParameter) id() (string, error) {
 
 func (a *mqlAwsSsmInstance) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+type mqlAwsSsmInstanceInternal struct {
+	iamRoleName string
+}
+
+// iamRole resolves the IAM role assigned to the managed instance for Systems
+// Manager. It is set for hybrid and on-premises activations; standard EC2
+// instances report an empty role here (their profile is on the EC2 instance).
+func (a *mqlAwsSsmInstance) iamRole() (*mqlAwsIamRole, error) {
+	if a.iamRoleName == "" {
+		a.IamRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"name": llx.StringData(a.iamRoleName)})
+	if err != nil {
+		a.IamRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsIamRole), nil
 }
 
 const ssmInstanceArnPattern = "arn:aws:ssm:%s:%s:instance/%s"

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -40,6 +40,7 @@ func buildVpcResource(runtime *plugin.Runtime, region, accountID string, vpc vpc
 			"instanceTenancy": llx.StringData(string(vpc.InstanceTenancy)),
 			"isDefault":       llx.BoolData(convert.ToValue(vpc.IsDefault)),
 			"name":            llx.StringData(name),
+			"ownerId":         llx.StringDataPtr(vpc.OwnerId),
 			"region":          llx.StringData(region),
 			"state":           llx.StringData(string(vpc.State)),
 			"tags":            llx.MapData(toInterfaceMap(tagsMap), types.String),
@@ -1023,6 +1024,7 @@ func (a *mqlAwsVpc) subnets() ([]any, error) {
 					"ipv6CidrBlock":               llx.StringData(ipv6CidrBlock),
 					"mapPublicIpOnLaunch":         llx.BoolDataPtr(subnet.MapPublicIpOnLaunch),
 					"name":                        llx.StringData(tagsMap["Name"]),
+					"ownerId":                     llx.StringDataPtr(subnet.OwnerId),
 					"region":                      llx.StringData(a.Region.Data),
 					"state":                       llx.StringData(string(subnet.State)),
 					"tags":                        llx.MapData(toInterfaceMap(tagsMap), types.String),
@@ -1103,6 +1105,7 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		}
 		args["mapPublicIpOnLaunch"] = llx.BoolDataPtr(subnet.MapPublicIpOnLaunch)
 		args["name"] = llx.StringData(tagsMap["Name"])
+		args["ownerId"] = llx.StringDataPtr(subnet.OwnerId)
 		args["region"] = llx.StringData(region)
 		args["state"] = llx.StringData(string(subnet.State))
 		args["tags"] = llx.MapData(toInterfaceMap(tagsMap), types.String)


### PR DESCRIPTION
## What

Exposes **ownership / source / management provenance** across AWS resources — the metadata that answers "who owns this, what was it created from, and what manages it." Every ID/ARN that names a modeled resource is a typed accessor (backed by the `cache*`/Internal-struct pattern); bare account-id strings stay plain strings. All SDK fields were re-verified against aws-sdk-go-v2 before wiring.

### Ownership (raw account-id strings)
| Resource | Field |
|---|---|
| `aws.ec2.snapshot` / `securitygroup` / `networkinterface` | `ownerId` (+ ENI `requesterId`, `instanceOwnerId`) |
| `aws.vpc` / `aws.vpc.subnet` / `aws.efs.filesystem` | `ownerId` |
| `aws.redshift.snapshot` | `ownerAccount`, `accountsWithRestoreAccess` |
| `aws.organization` | `masterAccountArn` |

These identify the owning account of shared/RAM-shared resources, distinct from the scanning account.

### Source / lineage (typed)
| Resource | Accessor |
|---|---|
| `aws.ec2.image.ebsBlockDevice` | `snapshot()` |
| `aws.rds.snapshot` | `sourceDbInstance()`, `sourceDbCluster()` |
| `aws.rds.dbinstance` | `dbCluster()` |
| `aws.rds.dbcluster` | `cloneGroupId` |
| `aws.elasticache.cluster` | `replicationGroupId` |
| `aws.redshift.snapshot` | `cluster()` |
| `aws.lambda.function` | `masterArn` / `masterFunction()`, `sourceKmsKey()` |
| `aws.cloudformation.stack` | `parentStack()`, `rootStack()`, `changeSetId` |
| `aws.eks.nodegroup` | `launchTemplate()`, `launchTemplateVersion` |

### Management / responsibility / creator
| Resource | Field |
|---|---|
| `aws.iam.user` | `permissionsBoundary()` (parity with `aws.iam.role`) |
| `aws.ssm.instance` | `iamRole()` + `sourceType`/`sourceId`/`activationId`/`resourceType` |
| `aws.ecs.task` | `startedBy` |
| `aws.ecs.taskDefinition` | `registeredBy()` |
| `aws.ecs.service` | `taskDefinition()` (raw arn deprecated → `taskDefinitionArn`) |
| `aws.ec2.instance` | `capacityReservation()`, `autoScalingGroup()`, `managedByOperator`, `operatorPrincipal` |
| `aws.redshift.cluster` | `snapshotScheduleIdentifier` |
| `aws.codebuild.project` | `resourceAccessRole()`, `sourceVersion` |
| `aws.secretsmanager.secret` | `externalRotationRole()` |
| `aws.sns.topic` | `owner` |

## Notes
- Added `init` functions for `aws.ec2.capacityReservation` and `aws.ec2.launchtemplate` (neither had one) so the new typed refs resolve to fully-populated resources rather than husks (shared `buildCapacityReservationResource` / `buildLaunchTemplateResource` helpers).
- **One intentional raw-string fallback:** `aws.redshift.cluster.snapshotScheduleIdentifier` stays raw — `aws.redshift.snapshotSchedule` only has a synthetic composite `__id` and no by-id lookup, so a typed accessor would return an empty husk.
- 44 new `.lr.versions` entries auto-assigned at the next patch; no `config.go` version bump.
- `aws.permissions.json` unchanged (the new API calls were already covered).

## Test
`go build ./...` clean; gofmt applied; relevant resource tests pass.