### PR TITLE
🧹 providers: replace stale cnquery references with mql

### DIFF
--- a/providers/TESTING.md
+++ b/providers/TESTING.md
@@ -35,7 +35,7 @@ Copy completed successfully.
 ### Enjoy your device
 
 ```text
-cnquery shell arista DEVICE_PUBLIC_IP --ask-pass
+mql shell arista DEVICE_PUBLIC_IP --ask-pass
 Enter password:
 → loaded configuration from /Users/tsmith/.config/mondoo/mondoo.yml using source default
 → connected to Arista EOS
@@ -45,7 +45,7 @@ Enter password:
  \___|_| |_|\__, |\__,_|\___|_|   \__, |
   mondoo™      |_|                |___/  interactive shell
 
-cnquery> arista.eos.hostname
+mql> arista.eos.hostname
 arista.eos.hostname: "localhost"
 ```
 

--- a/providers/TESTING.md
+++ b/providers/TESTING.md
@@ -39,11 +39,12 @@ mql shell arista DEVICE_PUBLIC_IP --ask-pass
 Enter password:
 → loaded configuration from /Users/tsmith/.config/mondoo/mondoo.yml using source default
 → connected to Arista EOS
-  ___ _ __   __ _ _   _  ___ _ __ _   _
- / __| '_ \ / _` | | | |/ _ \ '__| | | |
-| (__| | | | (_| | |_| |  __/ |  | |_| |
- \___|_| |_|\__, |\__,_|\___|_|   \__, |
-  mondoo™      |_|                |___/  interactive shell
+ _ __ ___   __ _| |
+| '_ ` _ \ / _` | |
+| | | | | | (_| | |
+|_| |_| |_|\__, |_|
+  mondoo™     |_|
+ interactive shell
 
 mql> arista.eos.hostname
 arista.eos.hostname: "localhost"

--- a/providers/ansible/README.md
+++ b/providers/ansible/README.md
@@ -14,11 +14,12 @@ against an inventory; the analysis is entirely static.
 ```shell
 ±> mql shell ansible providers/ansible/play/testdata/play_cert_validation.yaml
 → connected to Ansible Playbook
-  ___ _ __   __ _ _   _  ___ _ __ _   _ 
- / __| '_ \ / _` | | | |/ _ \ '__| | | |
-| (__| | | | (_| | |_| |  __/ |  | |_| |
- \___|_| |_|\__, |\__,_|\___|_|   \__, |
-  mondoo™      |_|                |___/  interactive shell
+ _ __ ___   __ _| |
+| '_ ` _ \ / _` | |
+| | | | | | (_| | |
+|_| |_| |_|\__, |_|
+  mondoo™     |_|
+ interactive shell
 
 mql> ansible.plays
 ansible.plays: [

--- a/providers/ansible/README.md
+++ b/providers/ansible/README.md
@@ -12,7 +12,7 @@ against an inventory; the analysis is entirely static.
 ## Get started
 
 ```shell
-±> cnquery shell ansible providers/ansible/play/testdata/play_cert_validation.yaml
+±> mql shell ansible providers/ansible/play/testdata/play_cert_validation.yaml
 → connected to Ansible Playbook
   ___ _ __   __ _ _   _  ___ _ __ _   _ 
  / __| '_ \ / _` | | | |/ _ \ '__| | | |
@@ -20,7 +20,7 @@ against an inventory; the analysis is entirely static.
  \___|_| |_|\__, |\__,_|\___|_|   \__, |
   mondoo™      |_|                |___/  interactive shell
 
-cnquery> ansible.plays
+mql> ansible.plays
 ansible.plays: [
   0: ansible.play name="Install packages"
 ]
@@ -46,7 +46,7 @@ Connect to a project directory to analyze the whole codebase through the
 `ansible.project` resource:
 
 ```shell
-cnquery shell ansible ./my-ansible-project
+mql shell ansible ./my-ansible-project
 ```
 
 ```javascript
@@ -103,7 +103,7 @@ with [yum](https://docs.ansible.com/projects/ansible/latest/collections/ansible/
 You can easily query all tasks for all plays in the playbook:
 
 ```shell
-cnquery> ansible.plays.map(tasks)
+mql> ansible.plays.map(tasks)
 ansible.plays.map: [
   0: [
     0: {
@@ -116,7 +116,7 @@ ansible.plays.map: [
 You can also query for all tasks that use `ansible.builtin.yum`:
 
 ```shell
-cnquery> ansible.plays { tasks.where (action["ansible.builtin.yum"] != empty) }
+mql> ansible.plays { tasks.where (action["ansible.builtin.yum"] != empty) }
 ansible.plays: [
   0: {
     tasks.where: [

--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -387,7 +387,7 @@ private cloudflare.streams {}
 
 // Cloudflare live input (stream)
 private cloudflare.streams.liveInput @defaults("uid name") {
-	// cnquery resource ID
+	// mql resource ID
 	id string
 
 	// Unique identifier
@@ -402,7 +402,7 @@ private cloudflare.streams.liveInput @defaults("uid name") {
 
 // Cloudflare videos and recordings
 private cloudflare.streams.video @defaults("name id") {
-	// cnquery resource ID
+	// mql resource ID
 	id string
 
 	// Unique identifier

--- a/providers/digitalocean/testdata/terraform/verify.sh
+++ b/providers/digitalocean/testdata/terraform/verify.sh
@@ -2,7 +2,7 @@
 # Verify the mql DigitalOcean provider against live infrastructure.
 # Prerequisites:
 #   - DIGITALOCEAN_TOKEN set
-#   - cnquery installed with digitalocean provider
+#   - cnspec/mql installed with digitalocean provider
 #   - Terraform resources applied (see main.tf)
 #
 # Usage:
@@ -30,7 +30,7 @@ run_query() {
   local query="$2"
   local result
   local exit_code=0
-  result=$(cnquery run digitalocean --token "$DIGITALOCEAN_TOKEN" -c "$query" 2>&1) || exit_code=$?
+  result=$(cnspec run digitalocean --token "$DIGITALOCEAN_TOKEN" -c "$query" 2>&1) || exit_code=$?
 
   # Filter out normal config loading message, check for real errors
   local filtered

--- a/providers/digitalocean/testdata/terraform/verify.sh
+++ b/providers/digitalocean/testdata/terraform/verify.sh
@@ -30,7 +30,7 @@ run_query() {
   local query="$2"
   local result
   local exit_code=0
-  result=$(cnspec run digitalocean --token "$DIGITALOCEAN_TOKEN" -c "$query" 2>&1) || exit_code=$?
+  result=$(mql run digitalocean --token "$DIGITALOCEAN_TOKEN" -c "$query" 2>&1) || exit_code=$?
 
   # Filter out normal config loading message, check for real errors
   local filtered

--- a/providers/github/resources/github_actions_secrets_test.go
+++ b/providers/github/resources/github_actions_secrets_test.go
@@ -24,18 +24,18 @@ func TestActionsSecretID(t *testing.T) {
 		},
 		{
 			name: "repository scope", scope: scopeRepository,
-			owner: "mondoohq", repo: "cnquery", secr: "TOKEN",
-			want: "github.actionsSecret/repo/mondoohq/cnquery/TOKEN",
+			owner: "mondoohq", repo: "mql", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/mql/TOKEN",
 		},
 		{
 			name: "environment scope", scope: scopeEnvironment,
-			owner: "mondoohq", repo: "cnquery", env: "prod", secr: "TOKEN",
-			want: "github.actionsSecret/repo/mondoohq/cnquery/env/prod/TOKEN",
+			owner: "mondoohq", repo: "mql", env: "prod", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/mql/env/prod/TOKEN",
 		},
 		{
 			name: "unknown scope falls back to repo", scope: "weird",
-			owner: "mondoohq", repo: "cnquery", secr: "TOKEN",
-			want: "github.actionsSecret/repo/mondoohq/cnquery/TOKEN",
+			owner: "mondoohq", repo: "mql", secr: "TOKEN",
+			want: "github.actionsSecret/repo/mondoohq/mql/TOKEN",
 		},
 	}
 	for _, tc := range tests {
@@ -58,18 +58,18 @@ func TestActionsVariableID(t *testing.T) {
 		},
 		{
 			name: "repository scope", scope: scopeRepository,
-			owner: "mondoohq", repo: "cnquery", vari: "REGION",
-			want: "github.actionsVariable/repo/mondoohq/cnquery/REGION",
+			owner: "mondoohq", repo: "mql", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/mql/REGION",
 		},
 		{
 			name: "environment scope", scope: scopeEnvironment,
-			owner: "mondoohq", repo: "cnquery", env: "prod", vari: "REGION",
-			want: "github.actionsVariable/repo/mondoohq/cnquery/env/prod/REGION",
+			owner: "mondoohq", repo: "mql", env: "prod", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/mql/env/prod/REGION",
 		},
 		{
 			name: "unknown scope falls back to repo", scope: "weird",
-			owner: "mondoohq", repo: "cnquery", vari: "REGION",
-			want: "github.actionsVariable/repo/mondoohq/cnquery/REGION",
+			owner: "mondoohq", repo: "mql", vari: "REGION",
+			want: "github.actionsVariable/repo/mondoohq/mql/REGION",
 		},
 	}
 	for _, tc := range tests {

--- a/providers/ipinfo/README.md
+++ b/providers/ipinfo/README.md
@@ -1,7 +1,7 @@
 # IPinfo Provider
 
 ```shell
-cnquery shell ipinfo
+mql shell ipinfo
 ```
 
 For authentication, you can use the `IPINFO_TOKEN` environment variable.
@@ -17,7 +17,7 @@ export IPINFO_TOKEN="<token>"
 Query information for a specific IP address.
 
 ```shell
-cnquery> ipinfo(ip("8.8.8.8")) { * }
+mql> ipinfo(ip("8.8.8.8")) { * }
 ipinfo: {
   requested_ip: "8.8.8.8"
   returned_ip: "8.8.8.8"
@@ -31,7 +31,7 @@ ipinfo: {
 Query information for your machine's public IP address.
 
 ```shell
-cnquery> ipinfo() { * }
+mql> ipinfo() { * }
 ipinfo: {
   requested_ip: null
   returned_ip: "<your-public-ip>"
@@ -45,7 +45,7 @@ ipinfo: {
 Query IP information for all IPs from network interfaces.
 
 ```shell
-cnquery run -c "network.interfaces.map(ips.map(_.ip)).flat.map(ipinfo(_){*})"
+mql run -c "network.interfaces.map(ips.map(_.ip)).flat.map(ipinfo(_){*})"
 network.interfaces.map.flat.map: [
   0: {
     returned_ip: 127.0.0.1

--- a/providers/ipmi/main.go
+++ b/providers/ipmi/main.go
@@ -16,7 +16,7 @@ import (
 // docker run -d -p 623:623/udp vaporio/ipmi-simulator
 //
 // Once the simulator is running, you can query it:
-// cnquery shell ipmi ADMIN@0.0.0.0 --password 'ADMIN'
+// mql shell ipmi ADMIN@0.0.0.0 --password 'ADMIN'
 func main() {
 	plugin.Start(os.Args, provider.Init())
 }

--- a/providers/k8s/connection/shared/resources/manifest_file.go
+++ b/providers/k8s/connection/shared/resources/manifest_file.go
@@ -125,7 +125,7 @@ var serverresources embed.FS
 // CachedServerResources mimics the CachedServerResources call from the dynamic client but based on a manifest file
 func CachedServerResources() ([]*metav1.APIResourceList, error) {
 	arl := []*metav1.APIResourceList{}
-	// Running cnquery with DEBUG=1 will create a .cache folder in the working dir which contains these files for the
+	// Running mql with DEBUG=1 will create a .cache folder in the working dir which contains these files for the
 	// different k8s resource types.
 	dir := "serverresources"
 	entries, err := serverresources.ReadDir(dir)

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -26,9 +26,9 @@ var Config = plugin.Provider{
 RouterOS API.
 
 Examples:
-  cnspec shell mikrotik admin@192.168.88.1 --password 'secret'
-  cnspec shell mikrotik admin@192.168.88.1 --tls --ask-pass
-  cnspec shell mikrotik admin@router.example.com --port 8728 --password 'secret'
+  mql shell mikrotik admin@192.168.88.1 --password 'secret'
+  mql shell mikrotik admin@192.168.88.1 --tls --ask-pass
+  mql shell mikrotik admin@router.example.com --port 8728 --password 'secret'
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -26,9 +26,9 @@ var Config = plugin.Provider{
 RouterOS API.
 
 Examples:
-  mql shell mikrotik admin@192.168.88.1 --password 'secret'
-  mql shell mikrotik admin@192.168.88.1 --tls --ask-pass
-  mql shell mikrotik admin@router.example.com --port 8728 --password 'secret'
+  cnspec scan mikrotik admin@192.168.88.1 --password 'secret'
+  cnspec scan mikrotik admin@192.168.88.1 --tls --ask-pass
+  cnspec shell mikrotik admin@router.example.com --port 8728 --password 'secret'
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -26,9 +26,9 @@ var Config = plugin.Provider{
 RouterOS API.
 
 Examples:
-  cnquery shell mikrotik admin@192.168.88.1 --password 'secret'
-  cnquery shell mikrotik admin@192.168.88.1 --tls --ask-pass
-  cnquery shell mikrotik admin@router.example.com --port 8728 --password 'secret'
+  cnspec shell mikrotik admin@192.168.88.1 --password 'secret'
+  cnspec shell mikrotik admin@192.168.88.1 --tls --ask-pass
+  cnspec shell mikrotik admin@router.example.com --port 8728 --password 'secret'
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{

--- a/providers/mondoo/resources/mondoo.lr
+++ b/providers/mondoo/resources/mondoo.lr
@@ -9,7 +9,7 @@ option go_package = "go.mondoo.com/mql/v13/providers/mondoo/resources"
 
 // Mondoo Client
 //
-// Examine the Mondoo Resource Name (MRN) of the client (cnspec / cnquery /
+// Examine the Mondoo Resource Name (MRN) of the client (cnspec / mql /
 // the platform agent) executing the current scan — the identifier audits
 // can use to attribute findings back to a specific Mondoo client.
 mondoo.client @defaults("mrn") {

--- a/providers/ms365/README.md
+++ b/providers/ms365/README.md
@@ -28,7 +28,7 @@ export MS365_TENANT_ID='your-tenant-id'
 export MS365_CERTIFICATE_PATH='certificate.combo.pem'
 ```
 ```shell
-cnquery shell ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID}
+mql shell ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID}
 ```
 
 ## Examples
@@ -44,15 +44,18 @@ microsoft.domains: [
 ```
 
 ### Get Information about the Azure Application Your Using
+
 Get the integration thumbprint
+
 ```shell
-MS365_THUMBPRINT=$(cnquery run local -c "parse.certificates('${MS365_CERTIFICATE_PATH}') { fingerprints.sha1 }" --json | jq -r '.[0]["parse.certificates.list"][0]["fingerprints[sha1]"]')
-```
-Use it to find the Azure Entra Application
-```shell
-cnquery run ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID} -c "microsoft.applications.where(appId=='${MS365_CLIENT_ID}').where(certificates.any(thumbprint == /${MS365_THUMBPRINT}/i)) { name certificates }"
+MS365_THUMBPRINT=$(mql run local -c "parse.certificates('${MS365_CERTIFICATE_PATH}') { fingerprints.sha1 }" --json | jq -r '.[0]["parse.certificates.list"][0]["fingerprints[sha1]"]')
 ```
 
+Use it to find the Azure Entra Application
+
+```shell
+mql run ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID} -c "microsoft.applications.where(appId=='${MS365_CLIENT_ID}').where(certificates.any(thumbprint == /${MS365_THUMBPRINT}/i)) { name certificates }"
+```
 
 ## Troubleshooting
 

--- a/providers/nmap/README.md
+++ b/providers/nmap/README.md
@@ -11,7 +11,7 @@ This provider requires the Nmap tool to be installed on your system. You can dow
 ## Get Started
 
 ```shell
-cnquery shell nmap
+mql shell nmap
 ```
 
 ## Example
@@ -89,13 +89,13 @@ nmap.network.hosts: [
 Discover all exposed hosts on a network.
 
 ```shell
-cnquery shell nmap --networks "192.168.0.0/20" --discover hosts
+mql shell nmap --networks "192.168.0.0/20" --discover hosts
 ```
 
 Connect to a specific IP address and display all open ports.
 
 ```shell
-cnquery shell nmap host 8.8.8.8
+mql shell nmap host 8.8.8.8
 ```
 
 ## Verifying the Installation of nmap
@@ -103,7 +103,7 @@ cnquery shell nmap host 8.8.8.8
 To verify the installation of nmap, run the following command:
 
 ```shell
-cnquery run nmap -c "nmap.version { * }"
+mql run nmap -c "nmap.version { * }"
 nmap.version: {
   compiledWithout: []
   nsockEngines: [

--- a/providers/opcua/main.go
+++ b/providers/opcua/main.go
@@ -16,7 +16,7 @@ import (
 // docker run --rm -it -p 50000:50000 -p 8080:8080 --name opcplc mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --gn=5 --ut --dca
 //
 // Once the simulator is running, you can query it:
-// cnquery shell opcua --endpoint opc.tcp://localhost:50000
+// mql shell opcua --endpoint opc.tcp://localhost:50000
 func main() {
 	plugin.Start(os.Args, provider.Init())
 }

--- a/providers/opcua/resources/README.md
+++ b/providers/opcua/resources/README.md
@@ -15,21 +15,21 @@ opcua.namespaces: [
 ]
 
 # gather root node
-cnquery> opcua.root
+mql> opcua.root
 opcua.root: opcua.node id="i=84" name="Root"
 
 
 # gather all nodes
-cnquery> opcua.nodes { name namespace.name }
+mql> opcua.nodes { name namespace.name }
 
 # gather node with a specific id
-cnquery> opcua.nodes.where (id == "i=2253")
+mql> opcua.nodes.where (id == "i=2253")
 opcua.nodes.where: [
   0: opcua.node id="i=2253" name="Server"
 ]
 
 # gather details about the server
-cnquery> opcua.server { * }
+mql> opcua.server { * }
 opcua.server: {
   buildInfo: {
     BuildDate: "2023-05-21T21:03:43.817369Z"

--- a/providers/os/resources/cpe/platforms.go
+++ b/providers/os/resources/cpe/platforms.go
@@ -23,7 +23,7 @@ var platformCPES = []platformCPEEntry{
 	{
 		Platform: "macos",
 		CPEBuilder: func(platform, version string, workstation bool) (string, error) {
-			// cnquery uses 10.14 instead of 10.14.0, so we need to add the .0
+			// mql uses 10.14 instead of 10.14.0, so we need to add the .0
 			v := version + ".0"
 			return cpeVersionPatternFunc(
 				"cpe:2.3:o:apple:mac_os_x:{{.Version}}:*:*:*:*:*:*:*",

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -547,7 +547,7 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 
 	// TODO: We need to figure out why we have empty displayNames.
 	// this is common in windows but we need to verify it is a windows
-	// issue and not a cnquery issue.
+	// issue and not an mql issue.
 	if displayName == "" {
 		log.Debug().Msg("ignored package since display name is missing")
 		return nil
@@ -680,7 +680,7 @@ func ParseWindowsAppPackages(platform *inventory.Platform, input io.Reader) ([]P
 
 		// TODO: We need to figure out why we have empty displayNames.
 		// this is common in windows but we need to verify it is a windows
-		// issue and not a cnquery issue.
+		// issue and not an mql issue.
 		if entry.DisplayName == "" {
 			continue
 		}

--- a/providers/proxmox/README.md
+++ b/providers/proxmox/README.md
@@ -17,11 +17,11 @@ Query and scan Proxmox VE clusters with cnspec/cnquery.
 
 ```bash
 # Scan a Proxmox VE cluster
-mql scan proxmox --host https://192.168.1.10:8006 \
+cnspec scan proxmox --host https://192.168.1.10:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret'
 
 # Skip TLS verification (self-signed certificates)
-mql scan proxmox --host https://pve.example.com:8006 \
+cnspec scan proxmox --host https://pve.example.com:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret' --insecure
 
 # Interactive shell

--- a/providers/proxmox/README.md
+++ b/providers/proxmox/README.md
@@ -17,15 +17,15 @@ Query and scan Proxmox VE clusters with cnspec/cnquery.
 
 ```bash
 # Scan a Proxmox VE cluster
-cnspec scan proxmox --host https://192.168.1.10:8006 \
+mql scan proxmox --host https://192.168.1.10:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret'
 
 # Skip TLS verification (self-signed certificates)
-cnspec scan proxmox --host https://pve.example.com:8006 \
+mql scan proxmox --host https://pve.example.com:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret' --insecure
 
 # Interactive shell
-cnquery shell proxmox --host https://192.168.1.10:8006 \
+mql shell proxmox --host https://192.168.1.10:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret'
 ```
 

--- a/providers/shodan/README.md
+++ b/providers/shodan/README.md
@@ -1,7 +1,7 @@
 # Shodan Provider
 
 ```shell
-cnquery shell shodan
+mql shell shodan
 ```
 
 For authentication, you can use the `SHODAN_TOKEN` environment variable.
@@ -17,7 +17,7 @@ export SHODAN_TOKEN="<token>"
 Query the base information for a host by IP address.
 
 ```shell
-cnquery> shodan.host("8.8.8.8") { * }
+mql> shodan.host("8.8.8.8") { * }
 shodan.host: {
   tags: []
   hostnames: [
@@ -41,7 +41,7 @@ shodan.host: {
 Query the hostname for a host.
 
 ```shell
-cnquery> shodan.host("8.8.8.8").hostnames
+mql> shodan.host("8.8.8.8").hostnames
 shodan.host.hostnames: [
   0: "dns.google"
 ]
@@ -52,7 +52,7 @@ shodan.host.hostnames: [
 Display all open ports for a host.
 
 ```shell
-cnquery> shodan.host("8.8.8.8").ports
+mql> shodan.host("8.8.8.8").ports
 shodan.host.ports: [
   0: 443
   1: 53
@@ -64,7 +64,7 @@ shodan.host.ports: [
 Query the DNS information for a domain.
 
 ```shell
-cnquery> shodan.domain("example.com") { * }
+mql> shodan.domain("example.com") { * }
 shodan.domain: {
   name: "example.com"
   nsrecords: [
@@ -96,7 +96,7 @@ shodan.domain: {
 Query the DNS NS records for a domain.
 
 ```shell
-cnquery> shodan.domain("example.com").nsrecords.where(type == "NS") { subdomain  type value }
+mql> shodan.domain("example.com").nsrecords.where(type == "NS") { subdomain  type value }
 shodan.domain.nsrecords.where: [
   0: {
     type: "NS"
@@ -116,7 +116,7 @@ shodan.domain.nsrecords.where: [
 Query the DNS AAAA records for  the "www" subdomain.
 
 ```shell
-cnquery> shodan.domain("example.com").nsrecords.where(type == "AAAA").where(subdomain == "www") { subdomain  type value }
+mql> shodan.domain("example.com").nsrecords.where(type == "AAAA").where(subdomain == "www") { subdomain  type value }
 shodan.domain.nsrecords.where.where: [
   0: {
     subdomain: "www"
@@ -131,17 +131,17 @@ shodan.domain.nsrecords.where.where: [
 Discover all exposed hosts on a network.
 
 ```shell
-cnquery shell shodan --networks "192.168.0.0/20" --discover hosts
+mql shell shodan --networks "192.168.0.0/20" --discover hosts
 ```
 
 Connect to a specific IP address and display all open ports.
 
 ```shell
-cnquery shell shodan host 8.8.8.8
+mql shell shodan host 8.8.8.8
 ```
 
 Connect to a domain and display subdomains.
 
 ```shell
-cnquery shell shodan domain example.com
+mql shell shodan domain example.com
 ```

--- a/providers/snowflake/README.md
+++ b/providers/snowflake/README.md
@@ -1,7 +1,7 @@
 # Snowflake Provider
 
 ```shell
-cnquery shell snowflake
+mql shell snowflake
 ```
 
 Required arguments:
@@ -43,7 +43,7 @@ shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS  --role 
 **Retrieve all users**
 
 ```shell
-cnquery> snowflake.account.users
+mql> snowflake.account.users
 snowflake.account.users: [
   0: snowflake.user name="CHRIS"
   1: snowflake.user name="DATAUSER"
@@ -54,7 +54,7 @@ snowflake.account.users: [
 **Retrieve all users that have no MFA**
 
 ```shell
-cnquery> snowflake.account.users.where(extAuthnDuo == false)
+mql> snowflake.account.users.where(extAuthnDuo == false)
 snowflake.account.users.where: [
   0: snowflake.user name="CHRIS"
   1: snowflake.user name="DATAUSER"
@@ -65,7 +65,7 @@ snowflake.account.users.where: [
 **Retrieve all users that have password authentication**
 
 ```shell
-cnquery> snowflake.account.users.where(hasPassword)
+mql> snowflake.account.users.where(hasPassword)
 snowflake.account.users.where: [
   0: snowflake.user name="CHRIS"
   1: snowflake.user name="DATAUSER"
@@ -77,7 +77,7 @@ snowflake.account.users.where: [
 **Retrieve all users that have certificate authentication**
 
 ```shell
-cnquery> snowflake.account.users.where(hasRsaPublicKey)
+mql> snowflake.account.users.where(hasRsaPublicKey)
 snowflake.account.users.where: [
   0: snowflake.user name="CHRIS"
 ]
@@ -86,7 +86,7 @@ snowflake.account.users.where: [
 **Retrieve users that have not logged in for 30 days**
 
 ```shell
-cnquery> snowflake.account.users.where(time.now - lastSuccessLogin > time.day * 30) { lastSuccessLogin }
+mql> snowflake.account.users.where(time.now - lastSuccessLogin > time.day * 30) { lastSuccessLogin }
 snowflake.account.users.where: [
   0: {
     lastSuccessLogin: 366 days 
@@ -97,7 +97,7 @@ snowflake.account.users.where: [
 **Check that SCIM is enabled**
 
 ```shell
-cnquery> snowflake.account.securityIntegrations.where(type == /SCIM/).any(enabled == true)
+mql> snowflake.account.securityIntegrations.where(type == /SCIM/).any(enabled == true)
 [failed] [].any()
   actual:   []
 ```
@@ -105,13 +105,13 @@ cnquery> snowflake.account.securityIntegrations.where(type == /SCIM/).any(enable
 **Check the retention time is greater 90 days**
 
 ```shell
-cnquery> snowflake.account.parameters.one(key == "DATA_RETENTION_TIME_IN_DAYS" && value >= 90)
+mql> snowflake.account.parameters.one(key == "DATA_RETENTION_TIME_IN_DAYS" && value >= 90)
 ```
 
 **Retrieve all databases**
 
 ```shell
-cnquery> snowflake.account.databases
+mql> snowflake.account.databases
 snowflake.account.databases: [
   0: snowflake.database name="CNQUERY"
   1: snowflake.database name="SNOWFLAKE"

--- a/providers/tailscale/README.md
+++ b/providers/tailscale/README.md
@@ -6,13 +6,13 @@ known as a `tailnet`.
 To authenticate using an API access token:
 
 ```
-cnquery shell tailscale --token <access-token>
+mql shell tailscale --token <access-token>
 ```
 
 To authenticate using an OAuth client:
 
 ```
-cnquery shell tailscale --client-id <id> --client-secret <secret>
+mql shell tailscale --client-id <id> --client-secret <secret>
 ```
 
 You can also use the default environment variables `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET`,
@@ -25,13 +25,13 @@ If you are using an API access token instead of an OAuth client, use the `TAILSC
 **List all devices in a tailnet**
 
 ```shell
-cnquery> tailscale.devices()
+mql> tailscale.devices()
 ```
 
 **Get information on a single device**
 
 ```shell
-cnquery> tailscale.device(id: "55161288425123456") {*}
+mql> tailscale.device(id: "55161288425123456") {*}
 tailscale.device: {
   id: "55161288425123456"
   isExternal: false
@@ -61,13 +61,13 @@ tailscale.device: {
 **List all users in a tailnet**
 
 ```shell
-cnquery> tailscale.users()
+mql> tailscale.users()
 ```
 
 **Get information on a single user**
 
 ```shell
-cnquery> tailscale.user(id: "uiR4AD141DAA") {*}
+mql> tailscale.user(id: "uiR4AD141DAA") {*}
 tailscale.user: {
   id: "uiR4AD141DAA"
   type: "member"
@@ -88,5 +88,5 @@ tailscale.user: {
 **Discover all devices (any computer or mobile device) that join the tailnet `example.com`**
 
 ```shell
-cnquery shell tailscale example.com --discover devices
+mql shell tailscale example.com --discover devices
 ```

--- a/providers/vsphere/provider/provider.go
+++ b/providers/vsphere/provider/provider.go
@@ -51,7 +51,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 			target = "scheme://" + target
 		}
 
-		// eg. used to parse users from `cnquery shell vsphere chris@vsphere.local@hostname`
+		// eg. used to parse users from `mql shell vsphere chris@vsphere.local@hostname`
 		x, err := url.Parse(target)
 		if err != nil {
 			return nil, errors.New("incorrect format of target, please use user@host:port")


### PR DESCRIPTION
## Summary

Sweeps the `providers/` tree for stale `cnquery` references and updates them to the current binary name (`mql`, or `cnspec` where the example is a scan/policy flow). No functional code changes.

## What changed

- **Provider READMEs** (ansible, ipinfo, ms365, nmap, opcua, proxmox, shodan, snowflake, tailscale) — shell prompts and example commands now use `mql>` / `mql shell` / `mql run`.
- **`.lr` doc-comments** (cloudflare, mondoo) — comment text references `mql`.
- **Go comments** (ipmi, k8s manifest_file, opcua, os cpe/platforms, os windows_packages, vsphere) — simulator/debug usage notes use `mql`.
- **Config help text** (mikrotik) — example invocations use `cnspec`.
- **Test fixture** (github actions secrets/variables test) — uses `mondoohq/mql` repo name in expected IDs.
- **Verify script** (digitalocean) — uses `cnspec`/`mql`.
- Minor markdown spacing cleanup in the ms365 README.