### PR TITLE
🧹 equinix: mark provider as deprecated

### DIFF
--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers/equinix/connection"
 	"go.mondoo.com/mql/v13/providers/equinix/provider"
 )
@@ -13,6 +14,7 @@ var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
 	Version:         "13.0.19",
+	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
## What

Marks the **equinix** (Equinix Metal) provider as deprecated by setting the provider-level `Maturity` to `deprecated` in `providers/equinix/config/config.go`.

## Why

The codebase models provider lifecycle through a single `Maturity` field (`providers-sdk/v1/plugin/start.go`), the same one used for resources, fields, and connectors — levels are `experimental → preview → stable → deprecated → eol`. There is no separate "deprecated provider" flag; setting `Maturity` is the established mechanism (`bicep`, `helm`, and `kustomize` already use it for `experimental`).

## Effect

The value propagates automatically:
- Serialized into the generated `equinix.json` descriptor via `gen.CLI` at build time (the dist JSON is a build artifact, not committed).
- Read at runtime and rendered as a `[deprecated]` tag in `mql/cnspec providers list` (`apps/mql/cmd/providers.go`).

## Notes

- No `Version` bump — deprecation marking isn't a version change, and version bumps go through the release flow.
- Connector-level help text left unchanged; the provider-level `Maturity` is the single source of truth for lifecycle state.