### PR TITLE
🛑 cloudflare: drop synthetic stream id fields in favor of __id

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -387,9 +387,6 @@ private cloudflare.streams {}
 
 // Cloudflare live input (stream)
 private cloudflare.streams.liveInput @defaults("uid name") {
-	// mql resource ID
-	id string
-
 	// Unique identifier
 	uid string
 
@@ -401,10 +398,7 @@ private cloudflare.streams.liveInput @defaults("uid name") {
 }
 
 // Cloudflare videos and recordings
-private cloudflare.streams.video @defaults("name id") {
-	// mql resource ID
-	id string
-
+private cloudflare.streams.video @defaults("name uid") {
 	// Unique identifier
 	uid string
 

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -780,9 +780,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudflare.account.settings.enforceTwoFactor": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareAccountSettings).GetEnforceTwoFactor()).ToDataRes(types.Bool)
 	},
-	"cloudflare.streams.liveInput.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareStreamsLiveInput).GetId()).ToDataRes(types.String)
-	},
 	"cloudflare.streams.liveInput.uid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareStreamsLiveInput).GetUid()).ToDataRes(types.String)
 	},
@@ -791,9 +788,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cloudflare.streams.liveInput.deleteRecordingAfterDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareStreamsLiveInput).GetDeleteRecordingAfterDays()).ToDataRes(types.Int)
-	},
-	"cloudflare.streams.video.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareStreamsVideo).GetId()).ToDataRes(types.String)
 	},
 	"cloudflare.streams.video.uid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareStreamsVideo).GetUid()).ToDataRes(types.String)
@@ -2595,10 +2589,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudflareStreamsLiveInput).__id, ok = v.Value.(string)
 		return
 	},
-	"cloudflare.streams.liveInput.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareStreamsLiveInput).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"cloudflare.streams.liveInput.uid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareStreamsLiveInput).Uid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2613,10 +2603,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudflare.streams.video.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareStreamsVideo).__id, ok = v.Value.(string)
-		return
-	},
-	"cloudflare.streams.video.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareStreamsVideo).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"cloudflare.streams.video.uid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6101,7 +6087,6 @@ type mqlCloudflareStreamsLiveInput struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudflareStreamsLiveInputInternal it will be used here
-	Id                       plugin.TValue[string]
 	Uid                      plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	DeleteRecordingAfterDays plugin.TValue[int64]
@@ -6144,10 +6129,6 @@ func (c *mqlCloudflareStreamsLiveInput) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlCloudflareStreamsLiveInput) GetId() *plugin.TValue[string] {
-	return &c.Id
-}
-
 func (c *mqlCloudflareStreamsLiveInput) GetUid() *plugin.TValue[string] {
 	return &c.Uid
 }
@@ -6165,7 +6146,6 @@ type mqlCloudflareStreamsVideo struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudflareStreamsVideoInternal it will be used here
-	Id                    plugin.TValue[string]
 	Uid                   plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	Creator               plugin.TValue[string]
@@ -6220,10 +6200,6 @@ func (c *mqlCloudflareStreamsVideo) MqlName() string {
 
 func (c *mqlCloudflareStreamsVideo) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlCloudflareStreamsVideo) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlCloudflareStreamsVideo) GetUid() *plugin.TValue[string] {

--- a/providers/cloudflare/resources/cloudflare.lr.versions
+++ b/providers/cloudflare/resources/cloudflare.lr.versions
@@ -284,7 +284,6 @@ cloudflare.r2.buckets 11.0.0
 cloudflare.streams 11.0.0
 cloudflare.streams.liveInput 11.0.0
 cloudflare.streams.liveInput.deleteRecordingAfterDays 11.0.0
-cloudflare.streams.liveInput.id 11.0.0
 cloudflare.streams.liveInput.name 11.0.0
 cloudflare.streams.liveInput.uid 11.0.0
 cloudflare.streams.video 11.0.0
@@ -293,7 +292,6 @@ cloudflare.streams.video.dash 11.0.0
 cloudflare.streams.video.duration 11.0.0
 cloudflare.streams.video.height 11.0.0
 cloudflare.streams.video.hls 11.0.0
-cloudflare.streams.video.id 11.0.0
 cloudflare.streams.video.liveInput 11.0.0
 cloudflare.streams.video.name 11.0.0
 cloudflare.streams.video.preview 11.0.0

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -40,17 +40,11 @@ type streamVideo struct {
 }
 
 func (c *mqlCloudflareStreamsLiveInput) id() (string, error) {
-	if c.Id.Error != nil {
-		return "", c.Id.Error
-	}
-	return c.Id.Data, nil
+	return c.GetUid().Data, nil
 }
 
 func (c *mqlCloudflareStreamsVideo) id() (string, error) {
-	if c.Id.Error != nil {
-		return "", c.Id.Error
-	}
-	return c.Id.Data, nil
+	return c.GetUid().Data, nil
 }
 
 func (c *mqlCloudflareZone) liveInputs() ([]any, error) {
@@ -85,7 +79,7 @@ func fetchLiveInputs(runtime *plugin.Runtime, accountID string) ([]any, error) {
 		name, _ := result.Meta["name"].(string)
 
 		input, err := NewResource(runtime, "cloudflare.streams.liveInput", map[string]*llx.RawData{
-			"id":                       llx.StringData(result.UID),
+			"__id":                     llx.StringData(result.UID),
 			"uid":                      llx.StringData(result.UID),
 			"deleteRecordingAfterDays": llx.IntData(result.DeleteRecordingAfterDays),
 			"name":                     llx.StringData(name),
@@ -130,7 +124,7 @@ func fetchVideos(runtime *plugin.Runtime, accountID string) ([]any, error) {
 		name, _ := video.Meta["name"].(string)
 
 		res, err := NewResource(runtime, "cloudflare.streams.video", map[string]*llx.RawData{
-			"id":                    llx.StringData(video.UID),
+			"__id":                  llx.StringData(video.UID),
 			"uid":                   llx.StringData(video.UID),
 			"name":                  llx.StringData(name),
 			"creator":               llx.StringData(video.Creator),

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -40,11 +40,19 @@ type streamVideo struct {
 }
 
 func (c *mqlCloudflareStreamsLiveInput) id() (string, error) {
-	return c.GetUid().Data, nil
+	v := c.GetUid()
+	if v.Error != nil {
+		return "", v.Error
+	}
+	return v.Data, nil
 }
 
 func (c *mqlCloudflareStreamsVideo) id() (string, error) {
-	return c.GetUid().Data, nil
+	v := c.GetUid()
+	if v.Error != nil {
+		return "", v.Error
+	}
+	return v.Data, nil
 }
 
 func (c *mqlCloudflareZone) liveInputs() ([]any, error) {


### PR DESCRIPTION
## Summary

`cloudflare.streams.liveInput` and `cloudflare.streams.video` each exposed a public `id string` field whose value was a verbatim copy of `uid` (the genuine Cloudflare Stream identifier). The field was even doc-commented `// mql resource ID` — it carried no information distinct from `uid` and existed only to seed the resource cache key, which is exactly what `__id` is for.

This is the synthetic-`id` anti-pattern called out in `CLAUDE.md` ("Hide synthetic `__id` values; don't expose them as `id` fields"). A public `id` should only exist when its value is user-meaningful (something you'd write `.where(id == "...")` against); here `id == uid`, so it added no query power.

## Changes

- **`cloudflare.lr`**: remove the `id string` field from both `cloudflare.streams.liveInput` and `cloudflare.streams.video`; update `video`'s `@defaults("name id")` → `@defaults("name uid")`.
- **`stream.go`**: pass the UID as an explicit `"__id"` to `NewResource` instead of as `"id"`. The cache key value is unchanged (still the UID), so only the redundant public field goes away. Kept lightweight `id()` fallback methods (returning `uid`) to satisfy the generator's `if res.__id == "" { res.id() }` contract, matching the existing `workers.secret` / `r2.bucket` pattern.
- Regenerated `cloudflare.lr.go` and `.lr.versions`.

## Breaking change

This removes the public `id` field on these two resources. Anyone querying `.id` on `cloudflare.streams.liveInput` / `cloudflare.streams.video` should use `uid` instead (which always held the same value). The `__id` cache key is unchanged.

## Verification

- `go build ./resources/...` — clean
- `go test ./resources/` — `ok`
- `gofmt` applied, generated code in sync