### PR TITLE
🐛 os: fix cloud.instance failing on EC2 hosts with multiple SGs/CIDRs

### DIFF
--- a/providers/os/id/metadata/crawler.go
+++ b/providers/os/id/metadata/crawler.go
@@ -62,12 +62,17 @@ func getMetadataRecursively(r recursive, path string, depth int) (any, error) {
 	// If the data contains sub-paths, fetch them recursively
 	if len(lines) > 1 || strings.HasSuffix(data, "/") {
 		result := make(map[string]any)
+		values := make([]string, 0, len(lines))
+		resolvedChild := false
 
 		for _, line := range lines {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue
 			}
+
+			key := strings.TrimSuffix(line, "/")
+			values = append(values, key)
 
 			subPath := path + line
 
@@ -80,7 +85,18 @@ func getMetadataRecursively(r recursive, path string, depth int) (any, error) {
 				continue
 			}
 
-			result[strings.TrimSuffix(line, "/")] = subData
+			resolvedChild = true
+			result[key] = subData
+		}
+
+		// Some IMDS keys return a newline-separated *list of values* rather than
+		// a directory of navigable sub-paths (e.g. "security-group-ids",
+		// "vpc-ipv4-cidr-blocks", or a multi-valued "local-ipv4s"). For those,
+		// the sub-path lookups above all fail, which previously produced an
+		// empty map and silently dropped the data. Treat that case as a value
+		// list and preserve the values instead.
+		if !resolvedChild {
+			return values, nil
 		}
 
 		return result, nil

--- a/providers/os/id/metadata/crawler_test.go
+++ b/providers/os/id/metadata/crawler_test.go
@@ -54,6 +54,22 @@ func TestCrawl_Mock(t *testing.T) {
 	assert.Equal(t, "line1\nline2\nline3", result)
 }
 
+// TestCrawl_ValueList verifies that a newline-separated *value list* (e.g. an
+// interface's "security-group-ids" with more than one group) is returned as a
+// []string instead of an empty map. IMDS returns the values directly, so the
+// per-value sub-path lookups 404; the crawler must not treat that as an empty
+// directory (which previously dropped the data and broke MacDetails parsing).
+func TestCrawl_ValueList(t *testing.T) {
+	m := new(mockRecursive)
+	m.On("GetMetadataValue", "sgs").Return("sg-aaaaaaaa\nsg-bbbbbbbb", nil)
+	m.On("GetMetadataValue", "sgssg-aaaaaaaa").Return("", errors.New("404"))
+	m.On("GetMetadataValue", "sgssg-bbbbbbbb").Return("", errors.New("404"))
+
+	result, err := subject.Crawl(m, "sgs")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"sg-aaaaaaaa", "sg-bbbbbbbb"}, result)
+}
+
 // Mock is an alternative way to implementation of the recursive interface via map
 type mockRecursiveMap struct {
 	data map[string]string

--- a/providers/os/resources/cloud/aws.go
+++ b/providers/os/resources/cloud/aws.go
@@ -4,8 +4,10 @@
 package cloud
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"sort"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
@@ -94,40 +96,44 @@ func (a *aws) Instance() (*InstanceMetadata, error) {
 	}
 
 	if value, ok := m["network"]; ok {
-		byteData, err := json.Marshal(value)
-		if err != nil {
-			return &instanceMd, err
-		}
+		if byteData, err := json.Marshal(value); err != nil {
+			log.Warn().Err(err).
+				Msg("os.cloud.aws> failed to marshal network metadata, continuing with raw metadata only")
+		} else {
+			var network AWSNetwork
+			if err := json.Unmarshal(byteData, &network); err != nil {
+				// A single unexpected field must not blank out the entire
+				// cloud.instance resource (including public/private IPs and the
+				// raw metadata dict), so log and continue instead of returning
+				// an error here.
+				log.Warn().Err(err).
+					Msg("os.cloud.aws> failed to parse network metadata, continuing with raw metadata only")
+			} else {
+				// all network interfaces
+				instanceMd.PublicIpv4 = make([]Ipv4Address, 0)
+				instanceMd.PrivateIpv4 = make([]Ipv4Address, 0)
+				for mac, details := range network.Interfaces.Macs {
+					ignored := true
 
-		var network AWSNetwork
-		if err := json.Unmarshal(byteData, &network); err != nil {
-			return &instanceMd, err
-		}
+					if ip, ok := details.PublicIP(); ok {
+						instanceMd.PublicIpv4 = append(instanceMd.PublicIpv4, ip)
+						ignored = false
+					}
 
-		// all network interfaces
-		instanceMd.PublicIpv4 = make([]Ipv4Address, 0)
-		instanceMd.PrivateIpv4 = make([]Ipv4Address, 0)
-		for mac, details := range network.Interfaces.Macs {
-			ignored := true
+					if ip, ok := details.PrivateIP(); ok {
+						instanceMd.PrivateIpv4 = append(instanceMd.PrivateIpv4, ip)
+						ignored = false
+					}
 
-			if ip, ok := details.PublicIP(); ok {
-				instanceMd.PublicIpv4 = append(instanceMd.PublicIpv4, ip)
-				ignored = false
+					if ignored {
+						log.Debug().
+							Str("mac", mac).
+							Interface("interface_details", details).
+							Msg("no valid public or private ipaddress, skipping")
+					}
+				}
 			}
-
-			if ip, ok := details.PrivateIP(); ok {
-				instanceMd.PrivateIpv4 = append(instanceMd.PrivateIpv4, ip)
-				ignored = false
-			}
-
-			if ignored {
-				log.Debug().
-					Str("mac", mac).
-					Interface("interface_details", details).
-					Msg("no valid public or private ipaddress, skipping")
-			}
 		}
-
 	}
 
 	return &instanceMd, nil
@@ -144,29 +150,39 @@ type AWSInterfaces struct {
 }
 
 // MacDetails structure
+//
+// Several IMDS fields are lists that the metadata service returns
+// newline-separated (e.g. `security-group-ids`, `vpc-ipv4-cidr-blocks`,
+// `local-ipv4s`). When an interface has more than one value the metadata
+// crawler renders them as a JSON array (or, historically, an object), so those
+// fields use `stringList` rather than a plain string. `owner-id` may be a
+// numeric account id or a string such as `amazon-elb` for service-managed ENIs,
+// so it uses `flexString`. This keeps a multi-valued interface from breaking
+// deserialization of the whole instance metadata.
 type MacDetails struct {
-	DeviceNumber        int64  `json:"device-number"`
-	InterfaceID         string `json:"interface-id"`
-	IPv4Associations    string `json:"ipv4-associations"`
-	LocalHostname       string `json:"local-hostname"`
-	LocalIPv4s          string `json:"local-ipv4s"`
-	Mac                 string `json:"mac"`
-	OwnerID             int64  `json:"owner-id"`
-	PublicHostname      string `json:"public-hostname"`
-	PublicIPv4s         string `json:"public-ipv4s"`
-	SecurityGroupIDs    string `json:"security-group-ids"`
-	SecurityGroups      string `json:"security-groups"`
-	SubnetID            string `json:"subnet-id"`
-	SubnetIPv4CIDRBlock string `json:"subnet-ipv4-cidr-block"`
-	VPCID               string `json:"vpc-id"`
-	VPCIPv4CIDRBlock    string `json:"vpc-ipv4-cidr-block"`
-	VPCIPv4CIDRBlocks   string `json:"vpc-ipv4-cidr-blocks"`
+	DeviceNumber        int64      `json:"device-number"`
+	InterfaceID         string     `json:"interface-id"`
+	IPv4Associations    stringList `json:"ipv4-associations"`
+	LocalHostname       string     `json:"local-hostname"`
+	LocalIPv4s          stringList `json:"local-ipv4s"`
+	Mac                 string     `json:"mac"`
+	OwnerID             flexString `json:"owner-id"`
+	PublicHostname      string     `json:"public-hostname"`
+	PublicIPv4s         stringList `json:"public-ipv4s"`
+	SecurityGroupIDs    stringList `json:"security-group-ids"`
+	SecurityGroups      stringList `json:"security-groups"`
+	SubnetID            string     `json:"subnet-id"`
+	SubnetIPv4CIDRBlock string     `json:"subnet-ipv4-cidr-block"`
+	VPCID               string     `json:"vpc-id"`
+	VPCIPv4CIDRBlock    string     `json:"vpc-ipv4-cidr-block"`
+	VPCIPv4CIDRBlocks   stringList `json:"vpc-ipv4-cidr-blocks"`
 }
 
 // PublicIP detects if the network interface has a public ip address,
 // if so it initializes an Ipv4Address struct and return true.
 func (d MacDetails) PublicIP() (Ipv4Address, bool) {
-	return Ipv4Address{IP: d.PublicIPv4s}, d.PublicIPv4s != ""
+	ip := d.PublicIPv4s.First()
+	return Ipv4Address{IP: ip}, ip != ""
 }
 
 // PrivateIP detects if the network interface has a private ip address,
@@ -176,5 +192,85 @@ func (d MacDetails) PrivateIP() (Ipv4Address, bool) {
 	// Subnet (`SubnetIPv4CIDRBlock`), we use the logical segment since there
 	// are cases where the subnet might have additional configuration like ACLs,
 	// route tables, etc. that we can't detect from within the os
-	return NewIpv4WithSubnet(d.LocalIPv4s, d.SubnetIPv4CIDRBlock), d.LocalIPv4s != ""
+	ip := d.LocalIPv4s.First()
+	return NewIpv4WithSubnet(ip, d.SubnetIPv4CIDRBlock), ip != ""
+}
+
+// stringList normalizes EC2 IMDS metadata fields that may arrive as a single
+// scalar string, a bare scalar (e.g. a number), a JSON array, or—when the
+// field holds multiple newline-separated values—an object produced by the
+// metadata crawler. All shapes are flattened to a []string so a multi-valued
+// interface no longer breaks deserialization of the whole instance metadata.
+type stringList []string
+
+func (s *stringList) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	switch data[0] {
+	case '"':
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		if str != "" {
+			*s = stringList{str}
+		}
+	case '[':
+		var arr []string
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return err
+		}
+		*s = stringList(arr)
+	case '{':
+		// Older metadata crawlers render a newline-separated value list as an
+		// object keyed by the values; recover the values as the list entries.
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return err
+		}
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		*s = stringList(keys)
+	default:
+		// bare scalar (e.g. a number); keep its textual representation
+		*s = stringList{string(data)}
+	}
+	return nil
+}
+
+// First returns the first value of the list, or an empty string if the list is
+// empty. Most consumers expect a single primary value (e.g. the primary IP).
+func (s stringList) First() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}
+
+// flexString accepts a value that AWS IMDS may return either as a JSON number
+// (e.g. an account-owned `owner-id`) or as a string (e.g. `amazon-elb` for
+// service-managed ENIs) and stores it as a string.
+type flexString string
+
+func (f *flexString) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		*f = flexString(str)
+		return nil
+	}
+	*f = flexString(string(data))
+	return nil
 }

--- a/providers/os/resources/cloud/aws_internal_test.go
+++ b/providers/os/resources/cloud/aws_internal_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cloud
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMacDetails_Unmarshal_Shapes verifies that the IMDS list/scalar fields
+// deserialize across every shape the metadata service / crawler can produce,
+// rather than erroring when an interface has more than one security group, more
+// than one VPC CIDR block, or a non-numeric owner-id.
+// Regression test for the cloud.instance failure on multi-valued ENIs.
+func TestMacDetails_Unmarshal_Shapes(t *testing.T) {
+	tests := []struct {
+		name             string
+		json             string
+		wantSecGroupIDs  []string
+		wantVPCCIDRs     []string
+		wantPublicIPv4s  []string
+		wantOwnerID      string
+		wantPublicIPFrom string
+	}{
+		{
+			name: "single value (account-owned, one SG) — the working control case",
+			json: `{
+				"owner-id": 339713021473,
+				"security-group-ids": "sg-0756e626db22be220",
+				"vpc-ipv4-cidr-blocks": "10.0.0.0/16",
+				"public-ipv4s": "3.122.56.61",
+				"local-ipv4s": "10.0.101.220",
+				"subnet-ipv4-cidr-block": "10.0.101.0/24"
+			}`,
+			wantSecGroupIDs:  []string{"sg-0756e626db22be220"},
+			wantVPCCIDRs:     []string{"10.0.0.0/16"},
+			wantPublicIPv4s:  []string{"3.122.56.61"},
+			wantOwnerID:      "339713021473",
+			wantPublicIPFrom: "3.122.56.61",
+		},
+		{
+			name: "multiple security groups + CIDRs as arrays",
+			json: `{
+				"owner-id": 339713021473,
+				"security-group-ids": ["sg-aaaaaaaa", "sg-bbbbbbbb"],
+				"vpc-ipv4-cidr-blocks": ["10.0.0.0/16", "10.1.0.0/16"],
+				"public-ipv4s": "3.122.56.61"
+			}`,
+			wantSecGroupIDs:  []string{"sg-aaaaaaaa", "sg-bbbbbbbb"},
+			wantVPCCIDRs:     []string{"10.0.0.0/16", "10.1.0.0/16"},
+			wantPublicIPv4s:  []string{"3.122.56.61"},
+			wantOwnerID:      "339713021473",
+			wantPublicIPFrom: "3.122.56.61",
+		},
+		{
+			name: "multiple security groups rendered as an object (legacy crawler)",
+			json: `{
+				"security-group-ids": {"sg-aaaaaaaa": {}, "sg-bbbbbbbb": {}}
+			}`,
+			wantSecGroupIDs: []string{"sg-aaaaaaaa", "sg-bbbbbbbb"},
+		},
+		{
+			name: "service-managed ENI with non-numeric owner-id",
+			json: `{
+				"owner-id": "amazon-elb",
+				"security-group-ids": "sg-cccccccc"
+			}`,
+			wantSecGroupIDs: []string{"sg-cccccccc"},
+			wantOwnerID:     "amazon-elb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var md MacDetails
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &md),
+				"MacDetails must deserialize every IMDS shape without error")
+
+			if tt.wantSecGroupIDs != nil {
+				assert.Equal(t, tt.wantSecGroupIDs, []string(md.SecurityGroupIDs))
+			}
+			if tt.wantVPCCIDRs != nil {
+				assert.Equal(t, tt.wantVPCCIDRs, []string(md.VPCIPv4CIDRBlocks))
+			}
+			if tt.wantPublicIPv4s != nil {
+				assert.Equal(t, tt.wantPublicIPv4s, []string(md.PublicIPv4s))
+			}
+			if tt.wantOwnerID != "" {
+				assert.Equal(t, tt.wantOwnerID, string(md.OwnerID))
+			}
+			if tt.wantPublicIPFrom != "" {
+				ip, ok := md.PublicIP()
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantPublicIPFrom, ip.IP)
+			}
+		})
+	}
+}
+
+// TestAWSNetwork_Unmarshal_MultiSG ensures the full network blob (the shape
+// aws.Instance() unmarshals) parses when an interface carries multiple security
+// groups, and that the public/private IPs are still extracted.
+func TestAWSNetwork_Unmarshal_MultiSG(t *testing.T) {
+	const blob = `{
+		"interfaces": {
+			"macs": {
+				"02:90:b6:37:7b:fb": {
+					"owner-id": 339713021473,
+					"security-group-ids": ["sg-aaaaaaaa", "sg-bbbbbbbb"],
+					"public-ipv4s": "3.122.56.61",
+					"local-ipv4s": "10.0.101.220",
+					"subnet-ipv4-cidr-block": "10.0.101.0/24",
+					"vpc-ipv4-cidr-blocks": ["10.0.0.0/16", "10.1.0.0/16"]
+				}
+			}
+		}
+	}`
+
+	var network AWSNetwork
+	require.NoError(t, json.Unmarshal([]byte(blob), &network))
+
+	md, ok := network.Interfaces.Macs["02:90:b6:37:7b:fb"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"sg-aaaaaaaa", "sg-bbbbbbbb"}, []string(md.SecurityGroupIDs))
+
+	pub, ok := md.PublicIP()
+	assert.True(t, ok)
+	assert.Equal(t, "3.122.56.61", pub.IP)
+
+	priv, ok := md.PrivateIP()
+	assert.True(t, ok)
+	assert.Equal(t, "10.0.101.220", priv.IP)
+}


### PR DESCRIPTION
The AWS cloud.instance resource errored on every EC2 host whose ENI had more than one security group or VPC CIDR block, or an AWS-managed ENI whose owner-id is a non-numeric string (e.g. "amazon-elb"). IMDS returns those fields newline-separated, so the metadata crawler rendered them as a (JSON) collection while MacDetails typed them as scalar string/int64 — json.Unmarshal then failed and aws.Instance() returned an error, blanking the entire resource including public/private IP detection and the raw metadata dict.

Fixes:
- MacDetails: list-valued IMDS fields (security-group-ids, security-groups, vpc-ipv4-cidr-blocks, local-ipv4s, public-ipv4s, ipv4-associations) now use a tolerant stringList type that accepts string | array | object; owner-id uses flexString accepting number or string.
- crawler: a newline-separated value list whose entries are not navigable sub-paths is now returned as []string instead of an empty map, preserving the values (e.g. the actual security-group ids).
- aws.Instance(): a network-metadata parse error is logged and skipped instead of failing the whole resource, so raw metadata + parsed IPs survive.
- tests for multi-SG/CIDR, object-shaped lists, non-numeric owner-id, and the crawler value-list path.

Fixes #8785