### PR TITLE
✨ python: scan Program Files and per-user install paths on Windows

### DIFF
--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -36,6 +36,9 @@ var defaultPythonPaths = []string{
 	"/usr/lib64/python*",
 	// Windows
 	"C:\\Python*\\Lib",
+	"C:\\Program Files\\Python*\\Lib",
+	// per-user installs across all profiles
+	"C:\\Users\\*\\AppData\\Local\\Programs\\Python\\Python*\\Lib",
 	// macOS
 	"/opt/homebrew/lib/python*",
 	"/System/Library/Frameworks/Python.framework/Versions/*/lib/python*",


### PR DESCRIPTION
## What

Extends the default search locations for `python.packages()` / `python.toplevel()` on Windows.

When called without an explicit `path`, the python resource scans the hardcoded globs in `defaultPythonPaths`. On Windows the only default location was `C:\Python*\Lib` (the classic python.org installer layout), which missed two very common install locations:

- **System-wide installs** — `C:\Program Files\Python*\Lib`
- **Per-user installs** (the python.org installer's "Install for me only" default, and Store-adjacent layouts) under each profile's `AppData\Local\Programs\Python\Python*\Lib`

```go
	// Windows
	"C:\\Python*\\Lib",
	"C:\\Program Files\\Python*\\Lib",
	// per-user installs across all profiles
	"C:\\Users\\*\\AppData\\Local\\Programs\\Python\\Python*\\Lib",
```

## Notes

- We use a `C:\Users\*` glob rather than `%LOCALAPPDATA%` — nothing in this code path expands environment variables (`afero.Glob` would treat `%LOCALAPPDATA%` as a literal dir), and the glob covers all profiles.
- No deny filter for system/template profiles (`Default`, `Public`, etc.): they have no Python install, so they self-filter to zero matches — just a few extra non-existent dir walks.
- **Known pre-existing limitation (not addressed here):** `afero.Glob` splits patterns using the provider host's `filepath.Separator`, so these backslash globs only expand when the OS provider runs *on* Windows (local/builtin scan). This already affects the existing `C:\Python*\Lib` entry — not a regression.

## Verification

On a Windows target:

```
mql run local -c "python.packages { name version }"
mql run local -c "python.packages.length"
```

Confirm packages from a per-user `C:\Users\<you>\AppData\Local\Programs\Python\Python3XX\Lib\site-packages` and a system-wide `C:\Program Files\Python3XX` install now appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)