### PR TITLE
🎉 activedirectory-13.1.3, ansible-13.2.5, arista-13.3.7, atlassian-13.3.7, bicep-13.3.5, claude-13.0.6, cloudformation-13.1.7, datadog-13.0.13, digitalocean-13.10.1, equinix-13.0.20, github-13.6.3, gitlab-13.3.7, google-workspace-13.2.3, grafana-13.1.12, helm-13.3.3, hetzner-13.5.1, huggingface-13.1.6, jamf-13.1.6, ipmi-13.0.19, k8s-13.5.3, kustomize-13.1.6, mikrotik-13.0.2, mistral-13.0.6, mondoo-13.1.8, network-13.2.4, nextdns-13.0.4, nmap-13.0.19, openai-13.0.6, ollama-13.0.7, opcua-13.0.19, vllm-13.0.13

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.1.2",
+	Version:         "13.1.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{

--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.4",
+	Version:         "13.2.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "13.3.6",
+	Version:         "13.3.7",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.3.6",
+	Version:   "13.3.7",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.3.4",
+	Version:         "13.3.5",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "claude",
 	ID:              "go.mondoo.com/mql/providers/claude",
-	Version:         "13.0.5",
+	Version:         "13.0.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.1.6",
+	Version:         "13.1.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "datadog",
 	ID:              "go.mondoo.com/mql/providers/datadog",
-	Version:         "13.0.12",
+	Version:         "13.0.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.10.0",
+	Version:         "13.10.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.19",
+	Version:         "13.0.20",
 	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.6.2",
+	Version:         "13.6.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.3.6",
+	Version: "13.3.7",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.2.2",
+	Version:         "13.2.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.11",
+	Version:         "13.1.12",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.2",
+	Version:         "13.3.3",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.5.0",
+	Version:         "13.5.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "huggingface",
 	ID:              "go.mondoo.com/mql/providers/huggingface",
-	Version:         "13.1.5",
+	Version:         "13.1.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/providers/jamf",
-	Version:         "13.1.5",
+	Version:         "13.1.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.5.2",
+	Version:         "13.5.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.1.5",
+	Version:         "13.1.6",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mikrotik",
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
-	Version:         "13.0.1",
+	Version:         "13.0.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mistral/config/config.go
+++ b/providers/mistral/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mistral",
 	ID:              "go.mondoo.com/mql/providers/mistral",
-	Version:         "13.0.5",
+	Version:         "13.0.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mondoo",
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
-	Version:         "13.1.7",
+	Version:         "13.1.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.2.3",
+	Version:         "13.2.4",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
 	CrossProviderTypes: []string{

--- a/providers/nextdns/config/config.go
+++ b/providers/nextdns/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nextdns",
 	ID:              "go.mondoo.com/mql/providers/nextdns",
-	Version:         "13.0.3",
+	Version:         "13.0.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nmap",
 	ID:              "go.mondoo.com/mql/v13/providers/nmap",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ollama",
 	ID:              "go.mondoo.com/mql/providers/ollama",
-	Version:         "13.0.6",
+	Version:         "13.0.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opcua",
 	ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openai",
 	ID:              "go.mondoo.com/mql/providers/openai",
-	Version:         "13.0.5",
+	Version:         "13.0.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vllm/config/config.go
+++ b/providers/vllm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vllm",
 	ID:              "go.mondoo.com/mql/providers/vllm",
-	Version:         "13.0.12",
+	Version:         "13.0.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Patch release bumping 31 providers. Each provider had unreleased changes since its last version bump (dependency updates, the static platform-support metadata addition, the cnquery→mql reference cleanup, and a few provider-specific changes called out below).

## What's changed per provider

### activedirectory (13.1.2 -> 13.1.3)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### ansible (13.2.4 -> 13.2.5)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### arista (13.3.6 -> 13.3.7)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### atlassian (13.3.6 -> 13.3.7)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### bicep (13.3.4 -> 13.3.5)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### claude (13.0.5 -> 13.0.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)

### cloudformation (13.1.6 -> 13.1.7)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### datadog (13.0.12 -> 13.0.13)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### digitalocean (13.10.0 -> 13.10.1)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)

### equinix (13.0.19 -> 13.0.20)
- 🧹 equinix: mark provider as deprecated (#8783)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### github (13.6.2 -> 13.6.3)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### gitlab (13.3.6 -> 13.3.7)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### google-workspace (13.2.2 -> 13.2.3)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### grafana (13.1.11 -> 13.1.12)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### helm (13.3.2 -> 13.3.3)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### hetzner (13.5.0 -> 13.5.1)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### huggingface (13.1.5 -> 13.1.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### jamf (13.1.5 -> 13.1.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### ipmi (13.0.18 -> 13.0.19)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### k8s (13.5.2 -> 13.5.3)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### kustomize (13.1.5 -> 13.1.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### mikrotik (13.0.1 -> 13.0.2)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### mistral (13.0.5 -> 13.0.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### mondoo (13.1.7 -> 13.1.8)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### network (13.2.3 -> 13.2.4)
- 🧹 Provide static platform support information across all providers (#8722)

### nextdns (13.0.3 -> 13.0.4)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### nmap (13.0.18 -> 13.0.19)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### openai (13.0.5 -> 13.0.6)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### ollama (13.0.6 -> 13.0.7)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)

### opcua (13.0.18 -> 13.0.19)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### vllm (13.0.12 -> 13.0.13)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

