### PR TITLE
🧹 Update mondoo.com/docs URLs to their current canonical targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mql shell aws
 > aws.ec2.instances{*}
 ```
 
-[:books: To learn more, read the MQL docs.](https://mondoo.com/docs/mql/home/)
+[:books: To learn more, read the MQL docs.](https://mondoo.com/docs/mql)
 
 ## Installation
 
@@ -91,7 +91,7 @@ To more easily explore your infrastructure, sign up for a Mondoo Platform accoun
 
 To get started, [contact us](https://mondoo.com/contact).
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.com/docs/platform/home/) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.com/docs) or visit [mondoo.com](https://mondoo.com).
 
 ## Supported targets
 
@@ -181,9 +181,9 @@ There are so many things MQL can do! Gather information about your infrastructur
 
 Explore:
 
-- [MQL docs](https://mondoo.com/docs/mql/home/)
+- [MQL docs](https://mondoo.com/docs/mql)
 - [MQL introduction](https://mondoohq.github.io/mql-intro/index.html)
-- [MQL language reference](https://mondoo.com/docs/mql/resources/)
+- [MQL language reference](https://mondoo.com/docs/mql/resources)
 - [cnspec](https://github.com/mondoohq/cnspec), our open source, cloud-native security scanner
 
 ## Join the community!

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -265,7 +265,7 @@ func (s Status) RenderCliStatus(ctx context.Context) {
 		log.Info().Msg(theme.DefaultTheme.Success("client authenticated successfully"))
 	} else if s.Client.PingPongError != nil {
 		log.Error().Err(s.Client.PingPongError).
-			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/.",
+			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/install/registration.",
 				viper.ConfigFileUsed())
 	}
 

--- a/apps/mql/cmd/vault.go
+++ b/apps/mql/cmd/vault.go
@@ -51,7 +51,7 @@ var vaultListCmd = &cobra.Command{
 		_ = viper.BindPFlag("show-options", cmd.Flags().Lookup("show-options"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/platform/infra/opsys/automation/vault/ for how to use vault environments")
+		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/infra/opsys/automation/vault for how to use vault environments")
 	},
 }
 
@@ -127,7 +127,7 @@ var vaultRemoveCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/platform/infra/opsys/automation/vault/ for how to use vault environments")
+		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/infra/opsys/automation/vault for how to use vault environments")
 	},
 }
 
@@ -138,7 +138,7 @@ var vaultResetCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(0),
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/platform/infra/opsys/automation/vault/ for how to use vault environments")
+		log.Fatal().Msg("sub-command is not supported anymore, see https://mondoo.com/docs/infra/opsys/automation/vault for how to use vault environments")
 	},
 }
 

--- a/providers-sdk/v1/resources/resources.go
+++ b/providers-sdk/v1/resources/resources.go
@@ -26,5 +26,5 @@ type MissingUpstreamError struct{}
 func (m MissingUpstreamError) Error() string {
 	return `To use this resource, you must authenticate with Mondoo Platform.
 To learn how, read:
-https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/`
+https://mondoo.com/docs/cnspec/install/registration`
 }

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -51,7 +51,7 @@ Examples:
 
 Notes:
   If you set the AWS_PROFILE environment variable, you can omit the profile flag.
-	To learn about setting up your AWS credentials, read https://mondoo.com/docs/cnspec/cloud/aws/.
+	To learn about setting up your AWS credentials, read https://mondoo.com/docs/cnspec/cloud/aws.
 `,
 			MinArgs: 0,
 			MaxArgs: 4,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -32,7 +32,7 @@ Examples without logging into and configuring GCP:
   cnspec scan gcp project <PROJECT-ID> --credentials-path <PATH-TO-YOUR-SERVICE-ACCT>
 
 Note:
-  If you log into GCP and configure the project you want to query or scan, you can omit credentials. To learn how, read https://mondoo.com/docs/cnspec/cloud/gcp/.
+  If you log into GCP and configure the project you want to query or scan, you can omit credentials. To learn how, read https://mondoo.com/docs/cnspec/cloud/gcp.
 
 Examples with the GCP project configured:
   cnspec scan gcp folder <FOLDER-ID>

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -33,9 +33,9 @@ Examples:
   cnspec shell github org <YOUR-GITHUB-ORG> --app-id <YOUR-GITHUB-APP-ID> --app-installation-id <YOUR-GITHUB-APP-INSTALL-ID> --app-private-key <PATH-TO-PEM-FILE>
 
 Notes:
-  Mondoo needs a personal access token to scan a GitHub organization, public repo, or private repo. The token's level of access determines how much information Mondoo can retrieve. Supply your personal access token to Mondoo by setting the GITHUB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/github/.
+  Mondoo needs a personal access token to scan a GitHub organization, public repo, or private repo. The token's level of access determines how much information Mondoo can retrieve. Supply your personal access token to Mondoo by setting the GITHUB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/github.
 
-	If you have very large GitHub organizations, consider giving Mondoo access using custom GitHub app credentials. To learn how, read https://mondoo.com/docs/cnspec/saas/gh-app/. Provide the app's private key as a file path with --app-private-key, as inline PEM content with --app-private-key-content, or by setting the GITHUB_APP_PRIVATE_KEY environment variable.
+	If you have very large GitHub organizations, consider giving Mondoo access using custom GitHub app credentials. To learn how, read https://mondoo.com/docs/cnspec/saas/gh-app. Provide the app's private key as a file path with --app-private-key, as inline PEM content with --app-private-key-content, or by setting the GITHUB_APP_PRIVATE_KEY environment variable.
 
 	If you have a GitHub Enterprise Server account, you must provide the URL for the account using the --enterprise-url flag.
 `,

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -40,7 +40,7 @@ Examples:
   cnspec shell gitlab --group <GROUP_NAME> --project <PROJECT_NAME> --token <YOUR_TOKEN>
 
 Notes:
-  Mondoo needs a personal access token to scan a GitLab group or project. The token's level of access determines how much information Mondoo can retrieve. Instead of providing a token with every command, you can supply your personal access token to Mondoo by setting the GITLAB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/gitlab/.
+  Mondoo needs a personal access token to scan a GitLab group or project. The token's level of access determines how much information Mondoo can retrieve. Instead of providing a token with every command, you can supply your personal access token to Mondoo by setting the GITLAB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/gitlab.
 `,
 			Discovery: []string{
 				provider.DiscoveryGroup,

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -21,7 +21,7 @@ var Config = plugin.Provider{
 			Short: "Mondoo Platform",
 			Long: `Use the mondoo provider to query resources in Mondoo Platform.
 
-To query Mondoo Platform from a workstation, the workstation must be registered with Mondoo Platform. To learn how to register a workstation, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/. 
+To query Mondoo Platform from a workstation, the workstation must be registered with Mondoo Platform. To learn how to register a workstation, read https://mondoo.com/docs/cnspec/install/registration. 
 
 Examples:
   cnspec shell mondoo

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -29,7 +29,7 @@ Examples:
   cnspec scan ms365 --certificate-path <PATH-TO-YOUR-PEM> --tenant-id <YOUR-TENANT-ID> --client-id <YOUR-CLIENT-ID>
 
 Notes:
-  If you give cnspec access through the Microsoft 365 API, you can omit the certificate-path, tenant-id, and client-id flags. To learn how, read https://mondoo.com/docs/cnspec/saas/ms365/#give-cnspec-access-through-the-microsoft-365-api.
+  If you give cnspec access through the Microsoft 365 API, you can omit the certificate-path, tenant-id, and client-id flags. To learn how, read https://mondoo.com/docs/cnspec/saas/m365#give-cnspec-access.
 `,
 			MinArgs:   0,
 			MaxArgs:   5,

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -23,7 +23,7 @@ var Config = plugin.Provider{
 			Short: "an Okta organization",
 			Long: `Use the okta provider to query resources in an Okta organization.
 
-To query an Okta organization, you need the organization's domain and an API token to access that domain. To learn how, read https://mondoo.com/docs/cnspec/saas/okta/.
+To query an Okta organization, you need the organization's domain and an API token to access that domain. To learn how, read https://mondoo.com/docs/cnspec/identity/okta.
 
 Examples:
   cnspec shell okta -organization <okta-domain> -token <api-token>

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -35,7 +35,7 @@ Examples:
 					Long:    "token",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "Slack API token (To learn more, read https://mondoo.com/docs/cnspec/saas/slack/)",
+					Desc:    "Slack API token (To learn more, read https://mondoo.com/docs/cnspec/saas/slack)",
 				},
 				{
 					Long:    "team-id",


### PR DESCRIPTION
## What

Swept the repo for `mondoo.com/docs` references, followed redirects on each, and updated those that no longer resolve directly. References already pointing at canonical 200-OK pages were left untouched.

### Page moves (path changed)

| Old | New |
|---|---|
| `…/cnspec/cnspec-adv-install/registration/` | `…/cnspec/install/registration` |
| `…/cnspec/saas/ms365/#give-cnspec-access-through-the-microsoft-365-api` | `…/cnspec/saas/m365#give-cnspec-access` |
| `…/cnspec/saas/okta/` | `…/cnspec/identity/okta` |
| `…/platform/home/` | `…/docs` |
| `…/mql/home/` | `…/mql` |
| `…/platform/infra/opsys/automation/vault/` | `…/infra/opsys/automation/vault` |

### Trailing-slash canonicalization

The site 301s these to the no-slash form: `…/cnspec/cloud/aws/`, `…/cnspec/cloud/gcp/`, `…/cnspec/saas/{github,gh-app,gitlab,slack}/`, `…/mql/resources/`.

## Notes

- **`ms365` → `m365`:** the old `saas/ms365` page now 404s. The current page is `saas/m365`, and its anchor was renamed from `#give-cnspec-access-through-the-microsoft-365-api` to `#give-cnspec-access` — both updated together.
- Changes are confined to CLI help text and one `log.Fatal` message (string literals only); no logic touched. Every new URL was re-verified to return a direct `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)