### PR TITLE
🎉 os-13.30.0, vsphere-13.7.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.29.5",
+	Version: "13.30.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.6.0",
+	Version:         "13.7.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the **os** and **vsphere** providers.

## os: 13.29.5 → 13.30.0

- ✨ python: scan Program Files and per-user install paths on Windows (#8787)
- 🐛 os: fix `cloud.instance` failing on EC2 hosts with multiple SGs/CIDRs (#8786)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ os: detect platform arch from ELF header on command-less fs scans (#8384)
- 🐛 awsebs: fix inverted error check when reading set-hostname (#8662)
- 🐛 awsec2: validate snapshot IDs with the snapshot regex (#8661)
- 🐛 avoid incorrect error-propagation on empty rawdata (#8745)
- 🐛 packages: drop empty-name appx entries instead of leaving holes (#8660)
- 🧹 Provide static platform support information across all providers (#8722)

## vsphere: 13.6.0 → 13.7.0

- 🌟 vsphere: expose tags, content libraries, custom fields, alarms, tasks, events & vCenter certs (#8782)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump (#8779)
- ⭐ vsphere: add createDate to `vsphere.vswitch.dvs` (#8767)
- 🧹 Provide static platform support information across all providers (#8722)