### PR TITLE
🐛 quiet noisy SBOM/provider logs for embedders

### DIFF
--- a/providers/os/resources/cpe/pkg2cpe.go
+++ b/providers/os/resources/cpe/pkg2cpe.go
@@ -4,7 +4,6 @@
 package cpe
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,11 +39,13 @@ func NewPackage2Cpe(vendor, name, version, release, arch string) ([]string, erro
 		}
 	}
 
-	if name == "" {
-		return cpes, errors.New("name is empty")
-	}
-	if version == "" {
-		return cpes, errors.New("version is empty")
+	// A CPE needs both a product name and a version. When either is missing we
+	// simply cannot build one — that is not an error worth surfacing, since CPEs
+	// are optional vulnerability-matching enrichment. Return no CPEs and no error
+	// so callers don't log spurious warnings for nameless/versionless packages
+	// (common in JS lockfiles).
+	if name == "" || version == "" {
+		return cpes, nil
 	}
 
 	attr := wfn.Attributes{}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -251,15 +251,18 @@ func ListAll() ([]*Provider, error) {
 	CachedProviders = all
 
 	// This really shouldn't happen, but just in case it does...
+	// Logged at debug, not warn: embedders that ship their own builtin providers
+	// (e.g. xgrep) intentionally configure no external provider paths, so this is
+	// an expected condition rather than a misconfiguration to warn about.
 	if SystemPath == "" && HomePath == "" && CustomProviderPath == "" {
-		log.Warn().Msg("can't find any paths for providers, none are configured")
+		log.Debug().Msg("can't find any paths for providers, none are configured")
 		return nil, nil
 	}
 
 	sysOk := config.ProbeDir(SystemPath)
 	homeOk := config.ProbeDir(HomePath)
 	if !sysOk && !homeOk {
-		msg := log.Warn()
+		msg := log.Debug()
 		if SystemPath != "" {
 			msg = msg.Str("system-path", SystemPath)
 		}


### PR DESCRIPTION
## What

Two unactionable warnings spam the output of tools that embed mql for SBOM generation (e.g. xgrep `ci`, which surfaced this). Both are pure noise for any consumer:

### 1. `failed to create cpe` (cpe)
Every language's `NewCpes` calls `cpe.NewPackage2Cpe`, which returned an error (`"name is empty"` / `"version is empty"`) when a package had no name or version — common for entries in JS lockfiles. The callers log that error at `warn`, producing lines like:

```
WRN failed to create cpe error="name is empty" name= version=0.0.0
```

A CPE is optional vulnerability-matching enrichment, so a missing name/version isn't an error — it just means "no CPE". `NewPackage2Cpe` now returns no CPE and `nil` error in that case, so none of the 12 language callers warn.

### 2. `can't find any paths for providers` (providers)
`ListAll` logged this at `warn` when no provider paths are configured. Embedders that ship their own builtin providers (like xgrep) intentionally configure no external provider paths, so this is an expected condition, not a misconfiguration. Downgraded both occurrences to `debug`.

## Testing
- `go build ./providers/...` ✅
- `go test ./providers/os/resources/cpe/` ✅ (no test asserted the empty-name error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)