### PR TITLE
🐛 status: only report config file when one was actually loaded

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -80,6 +80,19 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 	},
 }
 
+// reportedConfigFile returns the config file path to surface in `status`
+// output. viper.ConfigFileUsed() returns the autodetected default path even
+// when no file exists on disk, so a config file must have actually been loaded
+// for the path to be meaningful. When nothing was loaded we report an empty
+// string, keeping the output consistent with the "no configuration file
+// provided" message emitted by config.DisplayUsedConfig.
+func reportedConfigFile(loaded bool, configFileUsed string) string {
+	if !loaded {
+		return ""
+	}
+	return configFileUsed
+}
+
 func checkStatus(ctx context.Context) (Status, error) {
 	s := Status{
 		Client: ClientStatus{
@@ -94,8 +107,8 @@ func checkStatus(ctx context.Context) (Status, error) {
 		return s, cli_errors.NewCommandError(errors.Wrap(optsErr, "could not load configuration"), 1)
 	}
 
-	// record which config file the credentials were loaded from
-	s.Client.ConfigFile = viper.ConfigFileUsed()
+	// record which config file the credentials were loaded from, if any
+	s.Client.ConfigFile = reportedConfigFile(config.LoadedConfig, viper.ConfigFileUsed())
 
 	httpClient, err := opts.GetHttpClient()
 	if err != nil {

--- a/apps/mql/cmd/status_test.go
+++ b/apps/mql/cmd/status_test.go
@@ -49,3 +49,43 @@ func TestClientStatus_ConfigFileSerialization(t *testing.T) {
 		})
 	}
 }
+
+func TestReportedConfigFile(t *testing.T) {
+	const path = "/home/user/.config/mondoo/mondoo.yml"
+
+	tests := []struct {
+		name           string
+		loaded         bool
+		configFileUsed string
+		expected       string
+	}{
+		{
+			name:           "config file loaded",
+			loaded:         true,
+			configFileUsed: path,
+			expected:       path,
+		},
+		{
+			// regression: viper.ConfigFileUsed() returns the autodetected
+			// default path even when no file exists, so a path with loaded=false
+			// must not be reported — otherwise the "Config File" line contradicts
+			// the "no configuration file provided" message.
+			name:           "default path present but nothing loaded",
+			loaded:         false,
+			configFileUsed: path,
+			expected:       "",
+		},
+		{
+			name:           "loaded without a file path (e.g. base64 config)",
+			loaded:         true,
+			configFileUsed: "",
+			expected:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, reportedConfigFile(tt.loaded, tt.configFileUsed))
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes a contradiction in `status` output and adds a regression test.

After #8795, `status` prints the config file path, but it does so even when **no config file was actually loaded**:

```
→ no Mondoo configuration file provided, using defaults
...
→ Config File:        /Users/tsmith/.config/mondoo/mondoo.yml   ← contradicts the line above
x client is not registered
```

`viper.ConfigFileUsed()` returns the **autodetected default path** even when that file doesn't exist on disk (`viper.SetConfigFile` is called unconditionally before the existence check in `cli/config/config.go`). So the path is a *candidate*, not proof a file was read.

## Fix

Gate the reported path on `config.LoadedConfig` — the same signal `config.DisplayUsedConfig()` uses for its top-line message — through a small pure helper:

```go
func reportedConfigFile(loaded bool, configFileUsed string) string {
	if !loaded {
		return ""
	}
	return configFileUsed
}
```

`checkStatus` now calls `reportedConfigFile(config.LoadedConfig, viper.ConfigFileUsed())`. When nothing was loaded the field stays empty and the render guard omits the line, so the output is consistent.

## Why a helper

The decision is a pure function of two inputs, but it was inlined inside `checkStatus()`, which does live network I/O (health check, version fetch, ping) and can't be unit-tested. Extracting the helper creates a seam that is both the implementation and the regression guard — the test exercises the real code path.

## Test

`TestReportedConfigFile` covers:
- config file loaded → path reported
- **default path present but nothing loaded → empty** (the regression)
- loaded without a path (e.g. base64 config) → empty

```
$ go test ./apps/mql/cmd/ -run 'TestReportedConfigFile|TestClientStatus' -v
PASS
```

Verified end to end with `go run apps/mql/mql.go status`: the "no configuration file provided" case no longer prints a `Config File:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)