### PR TITLE
:star: depsdev-13.1.0

### DIFF
--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "depsdev",
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
-	Version:         "13.0.19",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### depsdev (13.1.0)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- ✨ depsdev: expose version licenses, links, registries, SLSA provenance, and related projects (#8740)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)