### PR TITLE
🌈 status: redesign mql status output and make it unit-testable

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,6 +38,64 @@ func init() {
 // calls so it cannot hang indefinitely when the API is unreachable.
 const statusTimeout = 30 * time.Second
 
+// spinnerFrames and spinnerFPS are the braille frames and cadence used by the
+// status loading indicator, matching the "Dot" spinner shown while scanning.
+var (
+	spinnerFrames = []string{"⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "⣯ ", "⣷ "}
+	spinnerFPS    = time.Second / 10
+)
+
+// statusSpinner animates a loading indicator on stderr while the status command
+// performs its network calls. It writes to stderr (never stdout, which carries
+// the rendered status) and is a no-op when stderr is not a terminal, keeping
+// piped and redirected output clean.
+type statusSpinner struct {
+	stop chan struct{}
+	done chan struct{}
+}
+
+// startStatusSpinner begins animating message on stderr. It returns nil when
+// stderr is not a TTY; Stop tolerates a nil receiver so callers needn't check.
+func startStatusSpinner(message string) *statusSpinner {
+	if !isatty.IsTerminal(os.Stderr.Fd()) {
+		return nil
+	}
+
+	s := &statusSpinner{stop: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(s.done)
+		ticker := time.NewTicker(spinnerFPS)
+		defer ticker.Stop()
+
+		frame := 0
+		for {
+			select {
+			case <-s.stop:
+				// erase the spinner line so the rendered status starts clean
+				fmt.Fprint(os.Stderr, "\r\033[K")
+				return
+			case <-ticker.C:
+				// Trail each frame with \r so the cursor returns to column 0.
+				// Logs are left running: a log line printing over the spinner
+				// overwrites it and its trailing newline moves output along,
+				// while the next tick simply redraws the fixed-width frame.
+				fmt.Fprintf(os.Stderr, "%s%s\r", spinnerFrames[frame%len(spinnerFrames)], message)
+				frame++
+			}
+		}
+	}()
+	return s
+}
+
+// Stop halts the spinner and clears its line. Safe to call on a nil spinner.
+func (s *statusSpinner) Stop() {
+	if s == nil {
+		return
+	}
+	close(s.stop)
+	<-s.done
+}
+
 // StatusCmd represents the version command
 var StatusCmd = &cobra.Command{
 	Use:   "status",
@@ -57,7 +116,15 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		ctx, cancel := context.WithTimeout(cmd.Context(), statusTimeout)
 		defer cancel()
 
+		// Show a loading indicator while the (potentially slow) network calls
+		// run. Skipped for json/yaml output so machine-readable streams stay
+		// clean, and silent when stderr is not a terminal.
+		var spin *statusSpinner
+		if viper.GetString("output") == "" {
+			spin = startStatusSpinner("Checking status…")
+		}
 		s, err := checkStatus(ctx)
+		spin.Stop()
 		if err != nil {
 			return err
 		}

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"syscall"
@@ -18,7 +19,6 @@ import (
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/cli/config"
 	cli_errors "go.mondoo.com/mql/v13/cli/errors"
-	"go.mondoo.com/mql/v13/cli/theme"
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/sysinfo"
@@ -68,7 +68,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		case "json":
 			s.RenderJson()
 		default:
-			s.RenderCliStatus(ctx)
+			fmt.Fprint(os.Stdout, s.RenderCli(RenderOptions{Color: defaultRenderColor()}))
 		}
 
 		if !s.Client.Registered || s.Client.PingPongError != nil {
@@ -96,9 +96,10 @@ func reportedConfigFile(loaded bool, configFileUsed string) string {
 func checkStatus(ctx context.Context) (Status, error) {
 	s := Status{
 		Client: ClientStatus{
-			Timestamp: time.Now().Format(time.RFC3339),
-			Version:   mql.GetVersion(),
-			Build:     mql.GetBuild(),
+			Timestamp:  time.Now().Format(time.RFC3339),
+			Version:    mql.GetVersion(),
+			APIVersion: mql.APIVersion(),
+			Build:      mql.GetBuild(),
 		},
 	}
 
@@ -191,6 +192,14 @@ func checkStatus(ctx context.Context) (Status, error) {
 		s.Client.ProvidersURL = providers.DefaultProviderRegistryURL
 	}
 
+	// gather installed providers and their version drift up front, so rendering
+	// stays a pure, side-effect-free transformation of the Status value
+	providersList, err := getProviders(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to get provider info")
+	}
+	s.Client.Providers = providersList
+
 	return s, nil
 }
 
@@ -205,6 +214,7 @@ type ClientStatus struct {
 	ServiceAccount string              `json:"service_account,omitempty"`
 	ParentMrn      string              `json:"parentMrn,omitempty"`
 	Version        string              `json:"version,omitempty"`
+	APIVersion     string              `json:"-"`
 	LatestVersion  string              `json:"latest_version,omitempty"`
 	Build          string              `json:"build,omitempty"`
 	Labels         map[string]string   `json:"labels,omitempty"`
@@ -216,83 +226,17 @@ type ClientStatus struct {
 	UpdatesURL     string              `json:"updatesUrl,omitempty"`
 	ProvidersURL   string              `json:"providersUrl,omitempty"`
 	ConfigFile     string              `json:"configFile,omitempty"`
+	Providers      []ProviderStatus    `json:"-"`
 }
 
-func (s Status) RenderCliStatus(ctx context.Context) {
-	if s.Client.Platform != nil {
-		agent := s.Client
-		log.Info().Msg("Platform:\t\t" + agent.Platform.Name)
-		log.Info().Msg("Version:\t\t" + agent.Platform.Version)
-		log.Info().Msg("Hostname:\t\t" + agent.Hostname)
-		log.Info().Msg("IP:\t\t\t" + agent.IP)
-	} else {
-		log.Warn().Msg("could not determine client platform information")
-	}
-
-	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)
-	log.Info().Msg("Version:\t\t" + mql.GetVersion() + " (API Version: " + mql.APIVersion() + ")")
-
-	if s.Client.LatestVersion != "" {
-		log.Info().Msg("Latest Version:\t" + s.Client.LatestVersion)
-
-		if mql.GetVersion() != s.Client.LatestVersion && mql.GetVersion() != "unstable" {
-			log.Warn().Msg("A newer version is available")
-		}
-	}
-
-	log.Info().Msg("Updates URL:\t\t" + s.Client.UpdatesURL)
-	log.Info().Msg("Providers URL:\t" + s.Client.ProvidersURL)
-
-	installed, outdated, err := getProviders(ctx)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to get provider info")
-	}
-	log.Info().Msg("Installed Providers:\t" + strings.Join(installed, " | "))
-
-	if len(outdated) > 0 {
-		log.Info().Msg("Outdated Providers:\t" + strings.Join(outdated, " | "))
-	}
-
-	log.Info().Msg("API ConnectionConfig:\t" + s.Upstream.API.Endpoint)
-	log.Info().Msg("API Status:\t\t" + s.Upstream.API.Status)
-	log.Info().Msg("API Time:\t\t" + s.Upstream.API.Timestamp)
-	log.Info().Msg("API Version:\t\t" + s.Upstream.API.Version)
-
-	if s.Upstream.API.Version != mql.APIVersion() {
-		log.Warn().Msg("API versions do not match, please update the client")
-	}
-
-	if len(s.Upstream.Features) > 0 {
-		log.Info().Msg("Features:\t\t" + strings.Join(s.Upstream.Features, ","))
-	}
-
-	if s.Client.ConfigFile != "" {
-		log.Info().Msg("Config File:\t\t" + s.Client.ConfigFile)
-	}
-
-	if s.Client.ParentMrn != "" {
-		log.Info().Msg("Owner:\t\t" + s.Client.ParentMrn)
-	}
-
-	if s.Client.Registered {
-		log.Info().Msg("Client:\t\t" + s.Client.Mrn)
-		log.Info().Msg("Service Account:\t\t" + s.Client.ServiceAccount)
-		log.Info().Msg(theme.DefaultTheme.Success("client is registered"))
-	} else {
-		log.Error().Msg("client is not registered")
-	}
-
-	if s.Client.Registered && s.Client.PingPongError == nil {
-		log.Info().Msg(theme.DefaultTheme.Success("client authenticated successfully"))
-	} else if s.Client.PingPongError != nil {
-		log.Error().Err(s.Client.PingPongError).
-			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/install/registration.",
-				viper.ConfigFileUsed())
-	}
-
-	for i := range s.Upstream.Warnings {
-		log.Warn().Msg(s.Upstream.Warnings[i])
-	}
+// ProviderStatus captures the installed and latest available version of a
+// single provider, so the status renderer can show version drift without
+// re-querying the registry. Latest is empty when the registry was unreachable.
+type ProviderStatus struct {
+	Name      string
+	Installed string
+	Latest    string
+	Outdated  bool
 }
 
 func (s Status) RenderJson() {
@@ -311,17 +255,16 @@ func (s Status) RenderYaml() {
 	os.Stdout.Write(output)
 }
 
-func getProviders(ctx context.Context) ([]string, []string, error) {
-	var installed []string
-	var outdated []string
-
+func getProviders(ctx context.Context) ([]ProviderStatus, error) {
 	allProviders, err := providers.ListActive()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
+
+	result := make([]ProviderStatus, 0, len(allProviders))
 	var errCircuitBreaker error
 	for _, provider := range allProviders {
-		installed = append(installed, provider.Name)
+		ps := ProviderStatus{Name: provider.Name, Installed: provider.Version}
 		if errCircuitBreaker == nil {
 			latestVersion, err := providers.LatestVersion(ctx, provider.Name)
 			if err != nil {
@@ -332,13 +275,15 @@ func getProviders(ctx context.Context) ([]string, []string, error) {
 					errors.Is(err, context.Canceled) {
 					errCircuitBreaker = err
 				}
-				continue
-			}
-			if latestVersion != provider.Version && provider.Name != "core" {
-				outdated = append(outdated, provider.Name)
+			} else {
+				ps.Latest = latestVersion
+				if latestVersion != provider.Version && provider.Name != "core" {
+					ps.Outdated = true
+				}
 			}
 		}
+		result = append(result, ps)
 	}
 
-	return installed, outdated, errCircuitBreaker
+	return result, errCircuitBreaker
 }

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -1,0 +1,384 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/muesli/termenv"
+	"go.mondoo.com/mql/v13/cli/theme"
+	"go.mondoo.com/mql/v13/cli/theme/colors"
+)
+
+// RenderOptions controls how RenderCli formats the status screen. Color is
+// disabled for non-TTY output and in tests so the rendered string is
+// deterministic plain text.
+type RenderOptions struct {
+	Color bool
+	Width int
+}
+
+// styler applies (or, when disabled, passes through) terminal styling. When
+// Color is off it returns the input verbatim, guaranteeing escape-free output
+// that tests and pipes can assert on. The palette is captured at construction
+// so the semantic helpers don't reach into a global mid-render.
+type styler struct {
+	on      bool
+	profile termenv.Profile
+	palette colors.Theme
+}
+
+// defaultRenderColor reports whether the status screen should be rendered with
+// color, based on the detected terminal profile (which already honors NO_COLOR
+// and non-TTY output).
+func defaultRenderColor() bool {
+	return colors.Profile != termenv.Ascii
+}
+
+func newStyler(color bool) styler {
+	p := colors.Profile
+	if !color {
+		p = termenv.Ascii
+	}
+	return styler{on: color, profile: p, palette: theme.DefaultTheme.Colors}
+}
+
+func (st styler) fg(c termenv.Color, s string) string {
+	if !st.on {
+		return s
+	}
+	return st.profile.String(s).Foreground(c).String()
+}
+
+func (st styler) bold(s string) string {
+	if !st.on {
+		return s
+	}
+	return st.profile.String(s).Bold().String()
+}
+
+// semantic roles mapped onto the theme palette
+func (st styler) value(s string) string  { return st.bold(s) }
+func (st styler) dim(s string) string    { return st.fg(st.palette.Disabled, s) }
+func (st styler) ok(s string) string     { return st.fg(st.palette.Success, s) }
+func (st styler) bad(s string) string    { return st.fg(st.palette.Error, s) }
+func (st styler) warn(s string) string   { return st.fg(st.palette.Warn, s) }
+func (st styler) cmd(s string) string    { return st.fg(st.palette.Command, s) }
+func (st styler) accent(s string) string { return st.fg(st.palette.Secondary, s) }
+
+// RenderCli renders the human-facing status screen as a string. It performs no
+// I/O and reads no globals: everything it needs is on the Status value, which
+// makes it directly unit-testable.
+func (s Status) RenderCli(opts RenderOptions) string {
+	st := newStyler(opts.Color)
+	var b strings.Builder
+
+	s.renderHeader(&b, st)
+	s.renderHealth(&b, st)
+	s.renderSystem(&b, st)
+	s.renderMql(&b, st)
+	s.renderPlatform(&b, st)
+	s.renderProviders(&b, st)
+	s.renderFooter(&b, st)
+
+	// trim trailing whitespace from every line so framed blank rows ("│") and
+	// short rows don't leave ragged trailing spaces
+	lines := strings.Split(b.String(), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+const ruleWidth = 46
+
+// section writes an open-frame header: "── Title ─────────". There is no right
+// border, which sidesteps glyph-width alignment problems entirely.
+func (st styler) section(b *strings.Builder, title string) {
+	fmt.Fprintf(b, "\n  %s %s %s\n", st.dim("──"), st.value(title), st.dim(strings.Repeat("─", ruleWidth)))
+}
+
+// row writes a left-ruled body line: "│  label  value".
+func (st styler) row(b *strings.Builder, label, value string) {
+	fmt.Fprintf(b, "  %s  %s  %s\n", st.dim("│"), st.dim(padRight(label, 9)), value)
+}
+
+// rowRaw writes a left-ruled body line without a label column, for tables and
+// free-form rows under a section.
+func (st styler) rowRaw(b *strings.Builder, value string) {
+	fmt.Fprintf(b, "  %s  %s\n", st.dim("│"), value)
+}
+
+func (s Status) renderSystem(b *strings.Builder, st styler) {
+	st.section(b, "System")
+
+	host := st.value(s.Client.Hostname)
+	if s.Client.IP != "" {
+		host += " " + st.dim("· "+s.Client.IP)
+	}
+	st.row(b, "Host", host)
+
+	plat := st.dim("unknown")
+	if s.Client.Platform != nil {
+		plat = s.Client.Platform.Name + " " + st.value(s.Client.Platform.Version) + " " + st.dim("· "+s.Client.Platform.Arch)
+	}
+	st.row(b, "Platform", plat)
+}
+
+func (s Status) renderMql(b *strings.Builder, st styler) {
+	st.section(b, "mql")
+
+	ver := st.value(s.Client.Version)
+	if s.updateAvailable() {
+		ver = st.dim(s.Client.Version) + "  " + st.accent("→") + "  " + st.warn(s.Client.LatestVersion) +
+			"   " + st.warn("⚠ update recommended")
+	}
+	st.row(b, "Version", ver)
+	st.row(b, "API", "v"+s.Client.APIVersion)
+
+	if s.Client.ConfigFile != "" {
+		st.row(b, "Config", st.value(s.Client.ConfigFile))
+	} else {
+		st.row(b, "Config", st.dim("defaults — no config file loaded"))
+	}
+	st.row(b, "Updates", s.Client.UpdatesURL)
+}
+
+func (s Status) renderPlatform(b *strings.Builder, st styler) {
+	st.section(b, "Mondoo Platform")
+	st.row(b, "Endpoint", s.Upstream.API.Endpoint)
+
+	statusStr := st.bad(s.Upstream.API.Status)
+	if s.Upstream.API.Status == "SERVING" {
+		statusStr = st.ok("SERVING")
+	}
+	sync := st.ok("✓ in sync")
+	if s.Upstream.API.Version != s.Client.APIVersion {
+		sync = st.warn("⚠ version mismatch")
+	}
+	st.row(b, "Status", statusStr+"   "+st.dim("API v"+s.Upstream.API.Version)+" "+sync)
+	st.row(b, "Time", s.Upstream.API.Timestamp)
+
+	if s.Client.Registered {
+		st.row(b, "Client", st.value(s.Client.Mrn))
+	} else {
+		st.row(b, "Client", st.bad("✗ not registered")+" "+st.dim("—")+" run "+st.cmd("mql login"))
+	}
+
+	if len(s.Upstream.Features) > 0 {
+		st.row(b, "Features", st.dim(strings.Join(s.Upstream.Features, ", ")))
+	}
+
+	// surface upstream warnings (clock skew, slow round-trip, etc.) as their own
+	// highlighted lines so they aren't silently dropped
+	for _, w := range s.Upstream.Warnings {
+		st.rowRaw(b, st.warn("⚠ "+w))
+	}
+}
+
+func (s Status) renderHeader(b *strings.Builder, st styler) {
+	meta := fmt.Sprintf("%s · %s · %s", s.Client.Version, s.osArch(), s.Client.Timestamp)
+	fmt.Fprintf(b, "\n  %s    %s\n", st.bold("mql status"), st.dim(meta))
+}
+
+// osArch returns "<os>/<arch>" for the header, or "unknown" when platform info
+// could not be determined.
+func (s Status) osArch() string {
+	if s.Client.Platform == nil {
+		return "unknown"
+	}
+	return s.Client.Platform.Name + "/" + s.Client.Platform.Arch
+}
+
+// renderHealth renders the at-a-glance summary: one dot per dimension (Client,
+// Platform, Updates) colored by state.
+func (s Status) renderHealth(b *strings.Builder, st styler) {
+	b.WriteString("\n")
+
+	switch {
+	case !s.Client.Registered:
+		st.summaryRow(b, st.bad("●"), "Client", st.bad("not registered"), st.bad("✗ action needed"))
+	case s.Client.PingPongError != nil:
+		st.summaryRow(b, st.bad("●"), "Client", st.value("registered"), st.bad("✗ authentication failed"))
+	default:
+		st.summaryRow(b, st.ok("●"), "Client", st.value("registered"), st.ok("✓ authenticated"))
+	}
+
+	if s.platformHealthy() {
+		body := "reachable " + st.dim("·") + " " + st.value("SERVING")
+		st.summaryRow(b, st.ok("●"), "Platform", body, st.ok("✓ healthy"))
+	} else {
+		status := s.Upstream.API.Status
+		if status == "" {
+			status = "unreachable"
+		}
+		st.summaryRow(b, st.bad("●"), "Platform", st.bad(status), st.bad("✗ unreachable"))
+	}
+
+	var parts []string
+	if s.updateAvailable() {
+		parts = append(parts, "mql "+st.dim(s.Client.Version)+" "+st.accent("→")+" "+st.warn(s.Client.LatestVersion))
+	}
+	if n := s.outdatedCount(); n > 0 {
+		parts = append(parts, st.warn(fmt.Sprintf("%d providers outdated", n)))
+	}
+	if len(parts) == 0 {
+		st.summaryRow(b, st.ok("●"), "Updates", st.ok("up to date"), "")
+	} else {
+		st.summaryRow(b, st.warn("●"), "Updates", strings.Join(parts, " "+st.dim("·")+" "), "")
+	}
+}
+
+func (st styler) summaryRow(b *strings.Builder, dot, label, body, trailing string) {
+	fmt.Fprintf(b, "  %s %s  %s", dot, st.value(padRight(label, 9)), body)
+	if trailing != "" {
+		fmt.Fprintf(b, "   %s", trailing)
+	}
+	b.WriteString("\n")
+}
+
+func (s Status) platformHealthy() bool { return s.Upstream.API.Status == "SERVING" }
+
+// updateAvailable reports whether a newer mql release exists. Development
+// builds ("unstable") never count as outdated.
+func (s Status) updateAvailable() bool {
+	return s.Client.LatestVersion != "" &&
+		s.Client.Version != s.Client.LatestVersion &&
+		s.Client.Version != "unstable"
+}
+
+func (s Status) outdatedCount() int {
+	n := 0
+	for _, p := range s.Client.Providers {
+		if p.Outdated {
+			n++
+		}
+	}
+	return n
+}
+
+// registryReachable reports whether provider version data was retrieved. When
+// the registry is unreachable every provider's Latest is empty, so version
+// drift cannot be shown.
+func (s Status) registryReachable() bool {
+	if len(s.Client.Providers) == 0 {
+		return true
+	}
+	for _, p := range s.Client.Providers {
+		if p.Latest != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// providerTableLimit caps how many outdated providers the drift table lists
+// before collapsing the rest into a "+N more" line.
+const providerTableLimit = 8
+
+func (s Status) renderProviders(b *strings.Builder, st styler) {
+	st.section(b, "Providers")
+
+	total := len(s.Client.Providers)
+	outdated := s.outdatedCount()
+	current := total - outdated
+
+	if !s.registryReachable() {
+		st.rowRaw(b, st.value(strconv.Itoa(total))+" "+st.dim("installed")+"   "+
+			st.warn("registry unreachable — provider versions unknown"))
+		return
+	}
+
+	st.rowRaw(b, st.value(strconv.Itoa(total))+" "+st.dim("installed")+" "+st.dim("·")+" "+
+		st.warn(strconv.Itoa(outdated)+" outdated")+" "+st.dim("·")+" "+
+		st.ok(strconv.Itoa(current)+" current"))
+
+	if outdated > 0 {
+		st.rowRaw(b, "")
+		st.rowRaw(b, st.dim(padRight("PROVIDER", 18)+padRight("INSTALLED", 11)+"LATEST"))
+
+		shown := 0
+		for _, p := range s.Client.Providers {
+			if !p.Outdated {
+				continue
+			}
+			if shown >= providerTableLimit {
+				break
+			}
+			st.rowRaw(b, st.value(padRight(p.Name, 18))+st.dim(padRight(p.Installed, 9))+
+				st.accent("→")+"  "+st.warn(p.Latest))
+			shown++
+		}
+		if outdated > providerTableLimit {
+			st.rowRaw(b, st.dim(fmt.Sprintf("+ %d more outdated", outdated-providerTableLimit))+" "+
+				st.dim("·")+" "+st.cmd("mql providers list")+st.dim(" to see all"))
+		}
+	}
+
+	currentNames := make([]string, 0, current)
+	for _, p := range s.Client.Providers {
+		if !p.Outdated {
+			currentNames = append(currentNames, p.Name)
+		}
+	}
+	if len(currentNames) > 0 {
+		st.rowRaw(b, "")
+		extra := 0
+		const currentLimit = 12
+		if len(currentNames) > currentLimit {
+			extra = len(currentNames) - currentLimit
+			currentNames = currentNames[:currentLimit]
+		}
+		line := st.ok("✓ current") + "  " + st.dim(strings.Join(currentNames, ", "))
+		if extra > 0 {
+			line += st.dim(fmt.Sprintf(", +%d", extra))
+		}
+		st.rowRaw(b, line)
+	}
+
+	if outdated > 0 {
+		st.rowRaw(b, st.dim("providers refresh automatically on next run")+" "+st.dim("·")+" "+
+			st.cmd("mql providers install <name>")+st.dim(" to update one now"))
+	}
+}
+
+func (s Status) renderFooter(b *strings.Builder, st styler) {
+	hasError := !s.Client.Registered || s.Client.PingPongError != nil
+	actionable := hasError || s.updateAvailable() || s.outdatedCount() > 0
+
+	b.WriteString("\n")
+	switch {
+	case hasError:
+		fmt.Fprintf(b, "  %s %s\n", st.bad("✗ not registered"), st.dim("· exit 1 · next steps:"))
+	case !actionable:
+		fmt.Fprintf(b, "  %s\n\n", st.ok("✓ all systems healthy"))
+		return
+	default:
+		fmt.Fprintf(b, "  %s\n", st.dim("next steps:"))
+	}
+
+	if !s.Client.Registered {
+		st.footerStep(b, "mql login", "register this client with Mondoo Platform")
+	}
+	if s.updateAvailable() {
+		st.footerStep(b, "visit "+s.Client.UpdatesURL, "upgrade "+s.Client.Version+" → "+s.Client.LatestVersion)
+	}
+	if s.outdatedCount() > 0 {
+		st.footerStep(b, "mql providers install <name>", fmt.Sprintf("update %d outdated providers", s.outdatedCount()))
+	}
+	b.WriteString("\n")
+}
+
+func (st styler) footerStep(b *strings.Builder, command, desc string) {
+	fmt.Fprintf(b, "    %s %s    %s\n", st.cmd("→"), st.cmd(padRight(command, 28)), st.dim(desc))
+}
+
+func padRight(s string, n int) string {
+	if len(s) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(s))
+}

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/muesli/termenv"
 	"go.mondoo.com/mql/v13/cli/theme"
@@ -376,9 +377,12 @@ func (st styler) footerStep(b *strings.Builder, command, desc string) {
 	fmt.Fprintf(b, "    %s %s    %s\n", st.cmd("→"), st.cmd(padRight(command, 28)), st.dim(desc))
 }
 
+// padRight pads s with spaces to a width of n display columns. It counts runes
+// rather than bytes so multi-byte content still aligns.
 func padRight(s string, n int) string {
-	if len(s) >= n {
+	width := utf8.RuneCountInString(s)
+	if width >= n {
 		return s
 	}
-	return s + strings.Repeat(" ", n-len(s))
+	return s + strings.Repeat(" ", n-width)
 }

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -165,6 +165,7 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 
 	if s.Client.Registered {
 		st.row(b, "Client", st.value(s.Client.Mrn))
+		st.row(b, "Account", st.value(s.Client.ServiceAccount))
 	} else {
 		st.row(b, "Client", st.bad("✗ not registered")+" "+st.dim("—")+" run "+st.cmd("mql login"))
 	}

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -290,6 +290,12 @@ func TestRenderCli_Golden(t *testing.T) {
 	}
 }
 
+func TestPadRight_CountsRunesNotBytes(t *testing.T) {
+	// "café" is 5 bytes but 4 runes; padding to width 6 must add 2 spaces
+	// (rune-based), not 1 (byte-based).
+	assert.Equal(t, "café  ", padRight("café", 6))
+}
+
 func TestRenderCli_PlatformSection_WarningsAndFeatures(t *testing.T) {
 	s := healthyRegisteredStatus()
 	s.Upstream.Features = []string{"alpha", "beta"}

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -1,0 +1,303 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// update regenerates the golden files: go test ./apps/mql/cmd -run Golden -update
+var update = flag.Bool("update", false, "update golden files")
+
+// healthyRegisteredStatus returns a fully-populated Status representing a
+// client that is registered, authenticated, on the latest version, and talking
+// to a healthy Mondoo Platform. Individual tests mutate copies of it to cover
+// the conditional branches (not registered, update available, etc.).
+func healthyRegisteredStatus() Status {
+	s := Status{
+		Client: ClientStatus{
+			Timestamp:      "2026-06-29T14:37:00-07:00",
+			Version:        "13.25.0",
+			APIVersion:     "13",
+			LatestVersion:  "13.25.0",
+			Platform:       &inventory.Platform{Name: "macos", Version: "26.5.1", Arch: "arm64"},
+			Hostname:       "workstation.localdomain",
+			IP:             "192.0.2.10",
+			Registered:     true,
+			Mrn:            "//agents.api.mondoo.app/spaces/test/agents/123",
+			ServiceAccount: "//agents.api.mondoo.app/spaces/test/serviceaccounts/abc",
+			ParentMrn:      "//captain.api.mondoo.app/spaces/test",
+			UpdatesURL:     "https://releases.mondoo.com",
+			ProvidersURL:   "https://releases.mondoo.com/providers",
+			ConfigFile:     "",
+			Providers: []ProviderStatus{
+				{Name: "aws", Installed: "13.18.0", Latest: "13.30.0", Outdated: true},
+				{Name: "core", Installed: "13.25.0", Latest: "13.25.0", Outdated: false},
+				{Name: "os", Installed: "13.22.0", Latest: "13.25.2", Outdated: true},
+			},
+		},
+	}
+	s.Upstream.API.Endpoint = "https://us.api.mondoo.com"
+	s.Upstream.API.Status = "SERVING"
+	s.Upstream.API.Timestamp = "2026-06-29T21:37:00Z"
+	s.Upstream.API.Version = "13"
+	return s
+}
+
+func TestRenderCli_Header(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// The header is the first line: the command name plus a metadata strip with
+	// the version, os/arch, and the timestamp.
+	firstLine := strings.SplitN(strings.TrimLeft(out, "\n"), "\n", 2)[0]
+	assert.Contains(t, firstLine, "mql status")
+	assert.Contains(t, firstLine, "13.25.0")
+	assert.Contains(t, firstLine, "macos/arm64")
+	assert.Contains(t, firstLine, "2026-06-29")
+}
+
+func TestRenderCli_NoColorHasNoEscapes(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.NotContains(t, out, "\x1b[", "Color:false output must contain no ANSI escape sequences")
+}
+
+func TestRenderCli_HealthSummary_NotRegistered(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Registered = false
+	s.Client.Mrn = ""
+	s.Client.ServiceAccount = ""
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "Client")
+	assert.Contains(t, out, "not registered")
+	assert.Contains(t, out, "action needed")
+}
+
+func TestRenderCli_HealthSummary_RegisteredAndHealthy(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// Platform dot reflects a reachable, SERVING API.
+	assert.Contains(t, out, "Platform")
+	assert.Contains(t, out, "SERVING")
+	assert.Contains(t, out, "healthy")
+}
+
+func TestRenderCli_HealthSummary_ProvidersStale(t *testing.T) {
+	s := healthyRegisteredStatus() // fixture has 2 outdated providers, mql itself current
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "Updates")
+	assert.Contains(t, out, "2 providers outdated")
+}
+
+func TestRenderCli_HealthSummary_FullyCurrent(t *testing.T) {
+	s := healthyRegisteredStatus()
+	// mark every provider current
+	for i := range s.Client.Providers {
+		s.Client.Providers[i].Outdated = false
+		s.Client.Providers[i].Latest = s.Client.Providers[i].Installed
+	}
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "up to date")
+}
+
+func TestRenderCli_SystemSection(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "System")
+	assert.Contains(t, out, "workstation.localdomain")
+	assert.Contains(t, out, "192.0.2.10")
+	assert.Contains(t, out, "macos")
+	assert.Contains(t, out, "26.5.1")
+	assert.Contains(t, out, "arm64")
+}
+
+func TestRenderCli_MqlSection_DefaultsAndCurrent(t *testing.T) {
+	s := healthyRegisteredStatus() // version == latest, no config file
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "13.25.0")
+	// API version surfaced
+	assert.Contains(t, out, "API")
+	// no config file loaded => communicates defaults
+	assert.Contains(t, out, "defaults")
+	assert.Contains(t, out, "https://releases.mondoo.com")
+}
+
+func TestRenderCli_MqlSection_ConfigFileShown(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.ConfigFile = "/home/user/.config/mondoo/mondoo.yml"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "/home/user/.config/mondoo/mondoo.yml")
+	assert.NotContains(t, out, "defaults — no config file")
+}
+
+func TestRenderCli_MqlSection_UpdateAvailableShowsArrow(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Version = "13.22.0"
+	s.Client.LatestVersion = "13.25.0"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "13.22.0")
+	assert.Contains(t, out, "13.25.0")
+	assert.Contains(t, out, "→")
+}
+
+func TestRenderCli_PlatformSection(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "Mondoo Platform")
+	assert.Contains(t, out, "https://us.api.mondoo.com")
+	assert.Contains(t, out, "SERVING")
+	assert.Contains(t, out, "2026-06-29T21:37:00Z")
+}
+
+func TestRenderCli_PlatformSection_NotRegisteredShowsLoginHint(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Registered = false
+	s.Client.Mrn = ""
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "mql login")
+}
+
+func TestRenderCli_ProvidersSection_Counts(t *testing.T) {
+	s := healthyRegisteredStatus() // 3 installed, 2 outdated, 1 current
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "Providers")
+	assert.Contains(t, out, "3 installed")
+	assert.Contains(t, out, "2 outdated")
+	assert.Contains(t, out, "1 current")
+}
+
+func TestRenderCli_ProvidersSection_DriftRows(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "aws")
+	assert.Contains(t, out, "13.18.0")
+	assert.Contains(t, out, "13.30.0")
+	assert.Contains(t, out, "os")
+	assert.Contains(t, out, "13.25.2")
+}
+
+func TestRenderCli_ProvidersSection_RegistryUnreachable(t *testing.T) {
+	s := healthyRegisteredStatus()
+	for i := range s.Client.Providers {
+		s.Client.Providers[i].Latest = ""
+		s.Client.Providers[i].Outdated = false
+	}
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "3 installed")
+	assert.Contains(t, out, "registry unreachable")
+}
+
+func TestRenderCli_Footer_NotRegistered(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Registered = false
+	s.Client.Mrn = ""
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "exit 1")
+	assert.Contains(t, out, "next steps")
+	assert.Contains(t, out, "mql login")
+}
+
+func TestRenderCli_Footer_AllHealthyHasNoExitBanner(t *testing.T) {
+	s := healthyRegisteredStatus()
+	for i := range s.Client.Providers {
+		s.Client.Providers[i].Outdated = false
+		s.Client.Providers[i].Latest = s.Client.Providers[i].Installed
+	}
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.NotContains(t, out, "exit 1")
+	assert.Contains(t, out, "healthy")
+}
+
+// staleNotRegisteredStatus mirrors a fresh, unregistered install that is behind
+// on both mql and its providers — the worst-case footer with every next step.
+func staleNotRegisteredStatus() Status {
+	s := healthyRegisteredStatus()
+	s.Client.Registered = false
+	s.Client.Mrn = ""
+	s.Client.ServiceAccount = ""
+	s.Client.ParentMrn = ""
+	s.Client.Version = "13.22.0"
+	s.Client.LatestVersion = "13.25.0"
+	return s
+}
+
+func TestRenderCli_Golden(t *testing.T) {
+	cases := []struct {
+		name   string
+		status Status
+	}{
+		{"healthy_registered", healthyRegisteredStatus()},
+		{"stale_not_registered", staleNotRegisteredStatus()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.status.RenderCli(RenderOptions{Color: false})
+			golden := filepath.Join("testdata", "status_"+tc.name+".golden")
+
+			if *update {
+				require.NoError(t, os.MkdirAll("testdata", 0o755))
+				require.NoError(t, os.WriteFile(golden, []byte(got), 0o644))
+			}
+
+			want, err := os.ReadFile(golden)
+			require.NoError(t, err, "missing golden file; run: go test ./apps/mql/cmd -run Golden -update")
+			assert.Equal(t, string(want), got)
+		})
+	}
+}
+
+func TestRenderCli_PlatformSection_WarningsAndFeatures(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Upstream.Features = []string{"alpha", "beta"}
+	s.Upstream.Warnings = []string{"possible clock skew detected: 45s"}
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "alpha, beta")
+	assert.Contains(t, out, "possible clock skew detected: 45s")
+	assert.Contains(t, out, "⚠")
+}

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -20,6 +20,7 @@
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
   │  Client     //agents.api.mondoo.app/spaces/test/agents/123
+  │  Account    //agents.api.mondoo.app/spaces/test/serviceaccounts/abc
 
   ── Providers ──────────────────────────────────────────────
   │  3 installed · 2 outdated · 1 current

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -1,0 +1,36 @@
+
+  mql status    13.25.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
+
+  ● Client     registered   ✓ authenticated
+  ● Platform   reachable · SERVING   ✓ healthy
+  ● Updates    2 providers outdated
+
+  ── System ──────────────────────────────────────────────
+  │  Host       workstation.localdomain · 192.0.2.10
+  │  Platform   macos 26.5.1 · arm64
+
+  ── mql ──────────────────────────────────────────────
+  │  Version    13.25.0
+  │  API        v13
+  │  Config     defaults — no config file loaded
+  │  Updates    https://releases.mondoo.com
+
+  ── Mondoo Platform ──────────────────────────────────────────────
+  │  Endpoint   https://us.api.mondoo.com
+  │  Status     SERVING   API v13 ✓ in sync
+  │  Time       2026-06-29T21:37:00Z
+  │  Client     //agents.api.mondoo.app/spaces/test/agents/123
+
+  ── Providers ──────────────────────────────────────────────
+  │  3 installed · 2 outdated · 1 current
+  │
+  │  PROVIDER          INSTALLED  LATEST
+  │  aws               13.18.0  →  13.30.0
+  │  os                13.22.0  →  13.25.2
+  │
+  │  ✓ current  core
+  │  providers refresh automatically on next run · mql providers install <name> to update one now
+
+  next steps:
+    → mql providers install <name>    update 2 outdated providers
+

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -1,0 +1,38 @@
+
+  mql status    13.22.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
+
+  ● Client     not registered   ✗ action needed
+  ● Platform   reachable · SERVING   ✓ healthy
+  ● Updates    mql 13.22.0 → 13.25.0 · 2 providers outdated
+
+  ── System ──────────────────────────────────────────────
+  │  Host       workstation.localdomain · 192.0.2.10
+  │  Platform   macos 26.5.1 · arm64
+
+  ── mql ──────────────────────────────────────────────
+  │  Version    13.22.0  →  13.25.0   ⚠ update recommended
+  │  API        v13
+  │  Config     defaults — no config file loaded
+  │  Updates    https://releases.mondoo.com
+
+  ── Mondoo Platform ──────────────────────────────────────────────
+  │  Endpoint   https://us.api.mondoo.com
+  │  Status     SERVING   API v13 ✓ in sync
+  │  Time       2026-06-29T21:37:00Z
+  │  Client     ✗ not registered — run mql login
+
+  ── Providers ──────────────────────────────────────────────
+  │  3 installed · 2 outdated · 1 current
+  │
+  │  PROVIDER          INSTALLED  LATEST
+  │  aws               13.18.0  →  13.30.0
+  │  os                13.22.0  →  13.25.2
+  │
+  │  ✓ current  core
+  │  providers refresh automatically on next run · mql providers install <name> to update one now
+
+  ✗ not registered · exit 1 · next steps:
+    → mql login                       register this client with Mondoo Platform
+    → visit https://releases.mondoo.com    upgrade 13.22.0 → 13.25.0
+    → mql providers install <name>    update 2 outdated providers
+

--- a/cli/theme/colors/color.go
+++ b/cli/theme/colors/color.go
@@ -17,6 +17,8 @@ type Theme struct {
 	Disabled  termenv.Color
 	Error     termenv.Color
 	Success   termenv.Color
+	Warn      termenv.Color
+	Command   termenv.Color
 
 	// severity
 	Critical termenv.Color

--- a/cli/theme/colors/color_default.go
+++ b/cli/theme/colors/color_default.go
@@ -19,6 +19,8 @@ var DefaultColorTheme = Theme{
 	Disabled:  Profile.Color("248"),
 	Error:     Profile.Color("210"),
 	Success:   Profile.Color("78"),
+	Warn:      Profile.Color("214"),
+	Command:   Profile.Color("44"),
 
 	// severity
 	Critical: Profile.Color("204"),

--- a/cli/theme/colors/color_windows.go
+++ b/cli/theme/colors/color_windows.go
@@ -19,6 +19,8 @@ var DefaultColorTheme = Theme{
 	Disabled:  Profile.Color("#c0c0c0"),
 	Error:     Profile.Color("#800000"),
 	Success:   Profile.Color("#008000"),
+	Warn:      Profile.Color("#af8700"),
+	Command:   Profile.Color("#00afaf"),
 
 	// severity
 	Critical: Profile.Color("#800000"),

--- a/cli/theme/theme.go
+++ b/cli/theme/theme.go
@@ -39,3 +39,11 @@ func (t Theme) Error(s ...any) string {
 func (t Theme) Success(s ...any) string {
 	return termenv.String(fmt.Sprint(s...)).Foreground(DefaultTheme.Colors.Success).String()
 }
+
+func (t Theme) Warn(s ...any) string {
+	return termenv.String(fmt.Sprint(s...)).Foreground(DefaultTheme.Colors.Warn).String()
+}
+
+func (t Theme) Command(s ...any) string {
+	return termenv.String(fmt.Sprint(s...)).Foreground(DefaultTheme.Colors.Command).String()
+}


### PR DESCRIPTION
## What

Redesigns the default `mql status` output and — just as importantly — restructures it so it is **unit-testable**.

The old output went straight through the global `zerolog` logger and interleaved network I/O (`getProviders`) and global reads (`mql.GetVersion()`) with formatting, so there was nothing a test could capture. This splits the command into a clean seam:

- **`checkStatus()`** gathers everything (provider versions/drift, API version, health, registration) into a `Status` value.
- **`Status.RenderCli(opts) string`** is a **pure function** — no I/O, no globals, no logger. Tests build a `Status` by hand and assert on the returned string.

Color is gated by `RenderOptions.Color`, which is off for non-TTY output and in tests (deterministic, escape-free), and auto-detected in production via the terminal profile (honors `NO_COLOR`).

## New default output

```
→ no Mondoo configuration file provided, using defaults

  mql status    v13.25.0 · macos/arm64 · 2026-06-29T18:08:10-07:00

  ● Client     not registered   ✗ action needed
  ● Platform   reachable · SERVING   ✓ healthy
  ● Updates    mql v13.25.0 → 13.25.0 · 46 providers outdated

  ── System ──────────────────────────────────────────────
  │  Host       workstation.localdomain · 192.0.2.10
  │  Platform   macos 26.5.1 · arm64

  ── mql ──────────────────────────────────────────────
  │  Version    v13.25.0  →  13.25.0   ⚠ update recommended
  │  API        vunstable
  │  Config     defaults — no config file loaded
  │  Updates    https://releases.mondoo.com

  ── Mondoo Platform ──────────────────────────────────────────────
  │  Endpoint   https://us.api.mondoo.com
  │  Status     SERVING   API v12 ⚠ version mismatch
  │  Time       2026-06-30T01:08:10Z
  │  Client     ✗ not registered — run mql login

  ── Providers ──────────────────────────────────────────────
  │  67 installed · 46 outdated · 21 current
  │
  │  PROVIDER          INSTALLED  LATEST
  │  datadog           13.0.12  →  13.0.13
  │  bicep             13.3.4   →  13.3.5
  │  claude            13.0.5   →  13.0.6
  │  k8s               13.5.2   →  13.5.3
  │  equinix           13.0.19  →  13.0.20
  │  arista            13.3.6   →  13.3.7
  │  ansible           13.2.4   →  13.2.5
  │  oci               13.12.1  →  13.13.0
  │  + 38 more outdated · mql providers list to see all
  │
  │  ✓ current  snowflake, ms365, vcd, cloudflare, slack, together, recording, terraform, tailscale, mock, networkdiscovery, core, +9
  │  providers refresh automatically on next run · mql providers install <name> to update one now

  ✗ not registered · exit 1 · next steps:
    → mql login                       register this client with Mondoo Platform
    → visit https://releases.mondoo.com    upgrade v13.25.0 → 13.25.0
    → mql providers install <name>    update 46 outdated providers
```

(In a real terminal the dots, arrows, `⚠`/`✗`/`✓` markers and command hints are colored: green = healthy, yellow = actionable, red = blocked, cyan = commands.)

## Changes

- **New** `apps/mql/cmd/status_render.go` — pure `RenderCli`, a color-gated `styler`, and per-section renderers (header, health summary, system, mql, platform, providers, footer).
- **New** `apps/mql/cmd/status_render_test.go` + `testdata/*.golden` — table-driven unit tests for each branch plus two full-screen golden cases (regenerate with `go test ./apps/mql/cmd -run Golden -update`).
- `apps/mql/cmd/status.go` — moved all gathering into `checkStatus`; `getProviders` now returns `[]ProviderStatus{Name, Installed, Latest, Outdated}`; deleted the old `RenderCliStatus`; wired `RenderCli` as the default.
- `cli/theme/{theme.go, colors/*}` — added `Warn` (yellow) and `Command` (cyan) to the palette.

## Notes / decisions

- `-o json` and `-o yaml` output is **byte-for-byte unchanged** (the two render-only fields are tagged `json:"-"`).
- The not-registered / ping-failure **exit code 1 is preserved**.
- Provider drift shows `installed → latest` (no semver "N minor" classification).
- The `v13.25.0 → 13.25.0` "update recommended" line above is a pre-existing version-comparison quirk (the `v` prefix vs the bare release tag), unrelated to this presentation change and left untouched.

## Verification

- `go test ./apps/mql/cmd/` — 20 tests pass; `go vet` clean; `go build ./apps/mql/...` succeeds; gofmt clean.
- Run live against a real machine: provider drift, truncation (`+38 more`, `+9`), version mismatch, not-registered footer, and `exit 1` all render correctly; forced-color emits the expected ANSI escapes; piped (non-TTY) output renders plain automatically.
