### PR TITLE
Gcp storage tag

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2398,7 +2398,8 @@ private gcp.project.storageService {
 //
 // Examine a Cloud Storage bucket's configuration, access controls, and
 // data-protection settings. Surfaces the `storageClass`, `location` and
-// `locationType`, `labels`, IAM policy (including `public()` which flags
+// `locationType`, `labels`, `tags` (Resource Manager Tags bound to the bucket),
+// IAM policy (including `public()` which flags
 // any `allUsers` / `allAuthenticatedUsers` grant), `iamConfiguration`
 // (uniform bucket-level access, public access prevention), `retentionPolicy`
 // and `retentionPolicyLocked`, object `versioningEnabled`, default CMEK
@@ -2415,6 +2416,8 @@ private gcp.project.storageService.bucket @defaults("id") {
   name string
   // User-defined labels
   labels map[string]string
+  // Resource Manager tags bound to this bucket
+  tags() map[string]string
   // Bucket location
   location string
   // Bucket location type

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4888,6 +4888,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.storageService.bucket.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"gcp.project.storageService.bucket.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"gcp.project.storageService.bucket.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetLocation()).ToDataRes(types.String)
 	},
@@ -20612,6 +20615,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.storageService.bucket.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.storageService.bucket.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47305,6 +47312,7 @@ type mqlGcpProjectStorageServiceBucket struct {
 	ProjectId                       plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Labels                          plugin.TValue[map[string]any]
+	Tags                            plugin.TValue[map[string]any]
 	Location                        plugin.TValue[string]
 	LocationType                    plugin.TValue[string]
 	ProjectNumber                   plugin.TValue[string]
@@ -47401,6 +47409,12 @@ func (c *mqlGcpProjectStorageServiceBucket) GetName() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectStorageServiceBucket) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 func (c *mqlGcpProjectStorageServiceBucket) GetLocation() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4683,6 +4683,7 @@ gcp.project.storageService.bucket.softDeletePolicyEnabled 13.12.2
 gcp.project.storageService.bucket.softDeleteRetentionDuration 13.22.2
 gcp.project.storageService.bucket.softDeleteTime 13.16.3
 gcp.project.storageService.bucket.storageClass 9.0.0
+gcp.project.storageService.bucket.tags 13.26.1
 gcp.project.storageService.bucket.uniformBucketLevelAccess 13.7.2
 gcp.project.storageService.bucket.uniformBucketLevelAccessEnabled 13.12.2
 gcp.project.storageService.bucket.updated 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.25.1",
-  "generated_at": "2026-06-26T23:07:07-07:00",
+  "version": "13.26.0",
+  "generated_at": "2026-06-29T10:27:18+02:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -234,6 +234,7 @@
     "redis.backups.list",
     "redis.clusters.list",
     "redis.instances.list",
+    "resourcemanager.effectiveTagBindingCollections.get",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.resourceTagBindings.list",
@@ -1704,6 +1705,12 @@
       "service": "redis",
       "action": "ListInstances",
       "source_file": "redis.go"
+    },
+    {
+      "permission": "resourcemanager.effectiveTagBindingCollections.get",
+      "service": "resourcemanager",
+      "action": "EffectiveTagBindingCollections.Get",
+      "source_file": "storage.go"
     },
     {
       "permission": "resourcemanager.folders.get",

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -20,6 +20,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	"google.golang.org/api/storage/v1"
@@ -352,6 +353,9 @@ func (g *mqlGcpProjectStorageServiceBucket) tags() (map[string]interface{}, erro
 
 	resp, err := svc.Locations.EffectiveTagBindingCollections.Get(name).Context(ctx).Do()
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && (gerr.Code == 403 || gerr.Code == 404) {
+			return map[string]interface{}{}, nil
+		}
 		return nil, err
 	}
 
@@ -360,7 +364,7 @@ func (g *mqlGcpProjectStorageServiceBucket) tags() (map[string]interface{}, erro
 
 // effectiveTagsToInterface converts the EffectiveTags map from the
 // cloudresourcemanager API (map[string]string) to map[string]interface{}
-// as required by MQL. Exported for unit testing.
+// as required by MQL. Unexported; tested directly in storage_test.go.
 func effectiveTagsToInterface(in map[string]string) map[string]interface{} {
 	out := make(map[string]interface{}, len(in))
 	for k, v := range in {

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -304,6 +306,67 @@ func (g *mqlGcpProjectStorageServiceBucket) defaultKmsKey() (*mqlGcpProjectKmsSe
 
 func (g *mqlGcpProjectStorageServiceBucket) defaultEncryptionEnabled() (bool, error) {
 	return g.cacheDefaultKmsKeyName != "", nil
+}
+
+func (g *mqlGcpProjectStorageServiceBucket) tags() (map[string]interface{}, error) {
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	bucketName := g.Name.Data
+
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+
+	// The bucket location is required to route to the correct regional endpoint.
+	if g.Location.Error != nil {
+		return nil, g.Location.Error
+	}
+	location := strings.ToLower(g.Location.Data)
+
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+
+	// GCS bucket tag bindings require the regional cloudresourcemanager endpoint.
+	// The global endpoint rejects the request with "not a valid One Platform resource name".
+	regionalEndpoint := fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/", location)
+	svc, err := cloudresourcemanager.NewService(ctx,
+		option.WithHTTPClient(client),
+		option.WithEndpoint(regionalEndpoint),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use EffectiveTagBindingCollections to get both directly-attached tags AND
+	// tags inherited from parent resources (project, folder, organization).
+	// Use projects/_ wildcard — the documented format for GCS bucket resource names.
+	fullResource := fmt.Sprintf("//storage.googleapis.com/projects/_/buckets/%s", bucketName)
+	encodedResource := url.PathEscape(fullResource)
+	name := fmt.Sprintf("locations/%s/effectiveTagBindingCollections/%s", location, encodedResource)
+
+	resp, err := svc.Locations.EffectiveTagBindingCollections.Get(name).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return effectiveTagsToInterface(resp.EffectiveTags), nil
+}
+
+// effectiveTagsToInterface converts the EffectiveTags map from the
+// cloudresourcemanager API (map[string]string) to map[string]interface{}
+// as required by MQL. Exported for unit testing.
+func effectiveTagsToInterface(in map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func storageLifecycleRulesToArrayInterface(runtime *plugin.Runtime, bucketId string, lifecycle *storage.BucketLifecycle) (list []any) {

--- a/providers/gcp/resources/storage_test.go
+++ b/providers/gcp/resources/storage_test.go
@@ -121,3 +121,108 @@ func TestBucketRetentionHelpers(t *testing.T) {
 		assert.Equal(t, int64(604800), bucketSoftDeleteRetentionSeconds(&storage.BucketSoftDeletePolicy{RetentionDurationSeconds: 604800}))
 	})
 }
+
+func TestEffectiveTagsToInterface(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]interface{}
+	}{
+		{
+			name: "nil input returns empty map",
+			in:   nil,
+			want: map[string]interface{}{},
+		},
+		{
+			name: "empty input returns empty map",
+			in:   map[string]string{},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "project-scoped tag key",
+			in:   map[string]string{"123456789012/env": "production"},
+			want: map[string]interface{}{"123456789012/env": "production"},
+		},
+		{
+			name: "org-scoped tag key is preserved as-is",
+			in:   map[string]string{"815471563813/glz-resource-optout": "true"},
+			want: map[string]interface{}{"815471563813/glz-resource-optout": "true"},
+		},
+		{
+			name: "multiple tags are all converted",
+			in: map[string]string{
+				"815471563813/glz-resource-optout":   "true",
+				"815471563813/dtit:sec:infosecclass": "internal",
+				"123456789012/env":                   "production",
+			},
+			want: map[string]interface{}{
+				"815471563813/glz-resource-optout":   "true",
+				"815471563813/dtit:sec:infosecclass": "internal",
+				"123456789012/env":                   "production",
+			},
+		},
+		{
+			name: "tag with empty value is preserved",
+			in:   map[string]string{"815471563813/cost-center": ""},
+			want: map[string]interface{}{"815471563813/cost-center": ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveTagsToInterface(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBucketTagKeyMatching(t *testing.T) {
+	// Demonstrates the correct MQL pattern for checking tag existence:
+	// since org-managed keys are namespaced as "orgNumber/keyName",
+	// a suffix match (contains) is needed rather than exact equality.
+	tests := []struct {
+		name       string
+		tags       map[string]interface{}
+		searchKey  string
+		wantExists bool
+	}{
+		{
+			name:       "exact match on namespaced key",
+			tags:       map[string]interface{}{"815471563813/glz-resource-optout": "true"},
+			searchKey:  "815471563813/glz-resource-optout",
+			wantExists: true,
+		},
+		{
+			name:       "suffix match (MQL regex pattern) finds namespaced key",
+			tags:       map[string]interface{}{"815471563813/glz-resource-optout": "true"},
+			searchKey:  "glz-resource-optout",
+			wantExists: true,
+		},
+		{
+			name:       "key not present",
+			tags:       map[string]interface{}{"815471563813/env": "production"},
+			searchKey:  "glz-resource-optout",
+			wantExists: false,
+		},
+		{
+			name:       "empty tags map",
+			tags:       map[string]interface{}{},
+			searchKey:  "glz-resource-optout",
+			wantExists: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate the MQL `tags.keys.any(_ == /suffix/)` pattern.
+			found := false
+			for k := range tc.tags {
+				if k == tc.searchKey || (len(k) > len(tc.searchKey) && k[len(k)-len(tc.searchKey)-1] == '/' && k[len(k)-len(tc.searchKey):] == tc.searchKey) {
+					found = true
+					break
+				}
+			}
+			assert.Equal(t, tc.wantExists, found)
+		})
+	}
+}


### PR DESCRIPTION
**✨ GCP: add `tags()` to storage buckets (Resource Manager Tags)**

## What

Adds a `tags()` field to `gcp.project.storageService.bucket` that returns the GCP Resource Manager Tags bound to a bucket, including tags inherited from parent resources (project, folder, organization).

```mql
gcp.project.storageService.bucket(name: "my-bucket") {
  tags
  tags.keys.any(_ == /glz-resource-optout/)
}
```

## How

GCS buckets require the **regional Cloud Resource Manager endpoint** (`https://{location}-cloudresourcemanager.googleapis.com/`) — the global endpoint rejects bucket resource names. The implementation calls `EffectiveTagBindingCollections.Get` (not `TagBindings.List`) so that tags inherited from parent folders and the organization are included, not just directly-attached bindings.

Resource name format used: `//storage.googleapis.com/projects/_/buckets/{bucketName}` (the `projects/_` wildcard is the documented format for GCS).

**Note on key format:** Org-managed tag keys are namespaced with the org number (e.g. `815471563813/glz-resource-optout`). Use a regex match in MQL to find them without knowing the org number: `tags.keys.any(_ == /glz-resource-optout/)`.

## Files changed

| File | Change |
|---|---|
| `gcp.lr` | Added `tags() map[string]string` field + updated bucket doc comment |
| `gcp.lr.go` | Regenerated |
| `gcp.lr.versions` | New entry `gcp.project.storageService.bucket.tags 13.26.1` |
| `gcp.permissions.json` | Added `resourcemanager.effectiveTagBindingCollections.get` |
| `storage.go` | `tags()` method + `effectiveTagsToInterface()` helper |
| `storage_test.go` | `TestEffectiveTagsToInterface` (6 cases) + `TestBucketTagKeyMatching` (4 cases) |