### PR TITLE
🧹 Use root provider directory for GCP and Azure to infer permissions.

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -61,7 +61,6 @@ func main() {
 	}
 
 	providerName := filepath.Base(providerPath)
-	resourcesDir := filepath.Join(providerPath, "resources")
 
 	// Read provider version from config/config.go
 	version := readProviderVersion(filepath.Join(providerPath, "config", "config.go"))
@@ -72,9 +71,9 @@ func main() {
 	case "aws":
 		details = extractAWSPermissions(providerPath)
 	case "gcp":
-		details = extractGCPPermissions(resourcesDir)
+		details = extractGCPPermissions(providerPath)
 	case "azure":
-		details = extractAzurePermissions(resourcesDir)
+		details = extractAzurePermissions(providerPath)
 	default:
 		fmt.Fprintf(os.Stderr, "skipping %s: not a supported cloud provider (aws, gcp, azure)\n", providerName)
 		os.Exit(0)
@@ -742,9 +741,9 @@ func isAWSAPIMethod(name string) bool {
 // GCP Permission Extraction
 // =============================================================================
 
-func extractGCPPermissions(resourcesDir string) []PermissionDetail {
+func extractGCPPermissions(root string) []PermissionDetail {
 	var details []PermissionDetail
-	files := listGoFiles(resourcesDir)
+	files := listGoFiles(root)
 
 	for _, filePath := range files {
 		fileName := filepath.Base(filePath)
@@ -1309,6 +1308,11 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// Projects.Get call in initGcpProject — so skip the generic form here
 		// rather than overwriting that entry's action.
 		"Liens.List": "",
+		// GetAncestry (used by the connection layer to resolve a project's
+		// org/folder ancestry) is governed by resourcemanager.projects.get, not
+		// the auto-derived "resourcemanager.projects.getancestry" (not a real
+		// permission).
+		"Projects.GetAncestry": "resourcemanager.projects.get",
 		// Tag bindings are listed via the resourceTagBindings permission, not a
 		// "resourcemanager.tagBindings.list" form (which is not a real permission).
 		"TagBindings.List": "resourcemanager.resourceTagBindings.list",
@@ -1465,9 +1469,9 @@ func gcpRESTToPermission(service, resource, method string) (string, bool) {
 // Azure Permission Extraction
 // =============================================================================
 
-func extractAzurePermissions(resourcesDir string) []PermissionDetail {
+func extractAzurePermissions(root string) []PermissionDetail {
 	var details []PermissionDetail
-	files := listGoFiles(resourcesDir)
+	files := listGoFiles(root)
 
 	for _, filePath := range files {
 		fileName := filepath.Base(filePath)

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.22.0",
-  "generated_at": "2026-06-26T21:25:53-07:00",
+  "version": "13.23.0",
+  "generated_at": "2026-06-29T23:43:33-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -1315,6 +1315,12 @@
       "service": "Microsoft.Resources",
       "action": "NewListPager",
       "source_file": "resources.go"
+    },
+    {
+      "permission": "Microsoft.Resources/subscriptions/read",
+      "service": "Microsoft.Resources",
+      "action": "NewListPager",
+      "source_file": "client_subscriptions.go"
     },
     {
       "permission": "Microsoft.Resources/subscriptions/read",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.25.1",
-  "generated_at": "2026-06-26T23:07:07-07:00",
+  "version": "13.26.0",
+  "generated_at": "2026-06-29T23:43:33-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -1730,6 +1730,13 @@
       "permission": "resourcemanager.organizations.get",
       "service": "resourcemanager",
       "action": "Organizations.Get",
+      "source_file": "gcp_organization.go",
+      "scope": "org"
+    },
+    {
+      "permission": "resourcemanager.organizations.get",
+      "service": "resourcemanager",
+      "action": "Organizations.Get",
       "source_file": "organization.go",
       "scope": "org"
     },
@@ -1739,6 +1746,12 @@
       "action": "Organizations.GetIamPolicy",
       "source_file": "organization.go",
       "scope": "org"
+    },
+    {
+      "permission": "resourcemanager.projects.get",
+      "service": "resourcemanager",
+      "action": "Projects.Get",
+      "source_file": "gcp_organization.go"
     },
     {
       "permission": "resourcemanager.projects.get",


### PR DESCRIPTION
Aligns the behavior with AWS by using the provider root directory to infer the cloud permissions required to perform every action used by the provider.

In some cases an extra API call can be added e.g. in the providers' `connection.go` file which would be missed if all we're looking at is the `resources/` directory.