### PR TITLE
feat(logger): add loggerconf as single logging config entry point

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -93,11 +93,11 @@ func GetEnvLogLevel() (string, bool) {
 		return v, true
 	}
 
-	if os.Getenv("TRACE") == "true" || os.Getenv("TRACE") == "1" {
+	if v := os.Getenv("TRACE"); v == "true" || v == "1" {
 		return "trace", true
 	}
 
-	if os.Getenv("DEBUG") == "true" || os.Getenv("DEBUG") == "1" {
+	if v := os.Getenv("DEBUG"); v == "true" || v == "1" {
 		return "debug", true
 	}
 

--- a/logger/log.go
+++ b/logger/log.go
@@ -27,7 +27,7 @@ func SetWriter(w io.Writer) {
 
 // UseJSONLogging for global logger
 func UseJSONLogging(out io.Writer) {
-	log.Logger = zerolog.New(out).With().Timestamp().Logger()
+	log.Logger = zerolog.New(out).With().Caller().Timestamp().Logger()
 }
 
 // UseGCPJSONLogging for global logger. This is a JSON logger
@@ -37,7 +37,7 @@ func UseGCPJSONLogging(out io.Writer) {
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
-	log.Logger = zerolog.New(out).With().Timestamp().Logger()
+	log.Logger = zerolog.New(out).With().Caller().Timestamp().Logger()
 }
 
 // CliLogger sets the global logger to the console logger with color

--- a/logger/log.go
+++ b/logger/log.go
@@ -84,7 +84,9 @@ func InitTestEnv() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
 }
 
-// GetEnvLogLevel determines the loglevel from env vars DEBUG or TRACE are set
+// GetEnvLogLevel determines the loglevel from env vars. MONDOO_LOG_LEVEL takes
+// precedence and accepts any zerolog level (e.g. "info", "debug", "trace");
+// the legacy DEBUG=true and TRACE=true vars still work.
 func GetEnvLogLevel() (string, bool) {
 	level := ""
 	ok := false
@@ -96,6 +98,11 @@ func GetEnvLogLevel() (string, bool) {
 
 	if os.Getenv("TRACE") == "true" || os.Getenv("TRACE") == "1" {
 		level = "trace"
+		ok = true
+	}
+
+	if v := os.Getenv("MONDOO_LOG_LEVEL"); v != "" {
+		level = v
 		ok = true
 	}
 

--- a/logger/log.go
+++ b/logger/log.go
@@ -88,23 +88,18 @@ func InitTestEnv() {
 // precedence and accepts any zerolog level (e.g. "info", "debug", "trace");
 // the legacy DEBUG=true and TRACE=true vars still work.
 func GetEnvLogLevel() (string, bool) {
-	level := ""
-	ok := false
-
-	if os.Getenv("DEBUG") == "true" || os.Getenv("DEBUG") == "1" {
-		level = "debug"
-		ok = true
+	// MONDOO_LOG_LEVEL takes precedence, so it is checked first.
+	if v := os.Getenv("MONDOO_LOG_LEVEL"); v != "" {
+		return v, true
 	}
 
 	if os.Getenv("TRACE") == "true" || os.Getenv("TRACE") == "1" {
-		level = "trace"
-		ok = true
+		return "trace", true
 	}
 
-	if v := os.Getenv("MONDOO_LOG_LEVEL"); v != "" {
-		level = v
-		ok = true
+	if os.Getenv("DEBUG") == "true" || os.Getenv("DEBUG") == "1" {
+		return "debug", true
 	}
 
-	return level, ok
+	return "", false
 }

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func TestUseJSONLogging_IncludesCaller(t *testing.T) {
+	saved := log.Logger
+	t.Cleanup(func() { log.Logger = saved })
+
+	var buf bytes.Buffer
+	UseJSONLogging(&buf)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Info().Msg("hello")
+
+	if !strings.Contains(buf.String(), `"caller"`) {
+		t.Errorf("expected a caller field in the json log, got %q", buf.String())
+	}
+}
+
+func TestUseGCPJSONLogging_IncludesCaller(t *testing.T) {
+	saved := log.Logger
+	t.Cleanup(func() { log.Logger = saved })
+
+	var buf bytes.Buffer
+	UseGCPJSONLogging(&buf)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Info().Msg("hello")
+
+	if !strings.Contains(buf.String(), `"caller"`) {
+		t.Errorf("expected a caller field in the gcp json log, got %q", buf.String())
+	}
+}

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -1,10 +1,9 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-// Package loggerconf provides a single entry point that decides how logging
-// happens based on a small, declarative set of options. It is the shared
-// implementation used by cnspec (via the --logging-config flag) and the
-// cnspec-runner so that logging is configured identically everywhere.
+// Package loggerconf configures the global logger from a small, declarative set
+// of options (writer, level, and writer-specific settings), so logging can be
+// set up identically from a single place.
 //
 // It lives in its own package, separate from the base logger package, so that
 // importing it (and therefore the GCP/stackdriver dependency) stays opt-in.

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -1,0 +1,95 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package loggerconf provides a single entry point that decides how logging
+// happens based on a small, declarative set of options. It is the shared
+// implementation used by cnspec (via the --logging-config flag) and the
+// cnspec-runner so that logging is configured identically everywhere.
+//
+// It lives in its own package, separate from the base logger package, so that
+// importing it (and therefore the GCP/stackdriver dependency) stays opt-in.
+package loggerconf
+
+import (
+	"fmt"
+	"os"
+
+	"go.mondoo.com/mql/v13/logger"
+	"go.mondoo.com/mql/v13/logger/stackdriver"
+	"sigs.k8s.io/yaml"
+)
+
+// Options declares how the global logger should be configured.
+type Options struct {
+	// Writer selects the log sink: "cli" (default) or "stackdriver".
+	Writer string `json:"writer,omitempty" mapstructure:"writer"`
+	// Level sets the log level: error, warn, info, debug, trace.
+	Level string `json:"level,omitempty" mapstructure:"level"`
+	// Options carries writer-specific settings. For the "cli" writer this is
+	// "format" (json|gcp-json); for "stackdriver" it is "project-id" and
+	// "log-id".
+	Options map[string]string `json:"options,omitempty" mapstructure:"options"`
+}
+
+// Load reads logging Options from a YAML or JSON file at the given path.
+func Load(path string) (*Options, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read logging config %q: %w", path, err)
+	}
+
+	var opts Options
+	if err := yaml.Unmarshal(raw, &opts); err != nil {
+		return nil, fmt.Errorf("could not parse logging config %q: %w", path, err)
+	}
+	return &opts, nil
+}
+
+// Configure is the single function that decides how logging happens. It applies
+// the given options to the global logger and then lets the DEBUG/TRACE
+// environment variables override the configured level, so that environment
+// variables always win over explicit configuration.
+//
+// A nil opts falls back to the colorized CLI logger at info level.
+func Configure(opts *Options) error {
+	if opts == nil {
+		logger.CliLogger()
+		logger.Set("info")
+	} else {
+		switch opts.Writer {
+		case "", "cli":
+			switch opts.Options["format"] {
+			case "gcp-json":
+				logger.UseGCPJSONLogging(logger.LogOutputWriter)
+			case "json":
+				logger.UseJSONLogging(logger.LogOutputWriter)
+			default:
+				logger.StandardZerologLogger()
+			}
+		case "stackdriver":
+			projectID := opts.Options["project-id"]
+			if projectID == "" {
+				return fmt.Errorf("stackdriver logging requires a `project-id` option")
+			}
+			logID := opts.Options["log-id"]
+			if logID == "" {
+				return fmt.Errorf("stackdriver logging requires a `log-id` option")
+			}
+
+			w, err := stackdriver.NewStackdriverWriter(projectID, logID)
+			if err != nil {
+				return fmt.Errorf("could not initialize stackdriver logger: %w", err)
+			}
+			logger.SetWriter(w)
+		default:
+			return fmt.Errorf("unknown log writer %q", opts.Writer)
+		}
+		logger.Set(opts.Level)
+	}
+
+	// Environment variables always over-write custom configuration.
+	if envLevel, ok := logger.GetEnvLogLevel(); ok {
+		logger.Set(envLevel)
+	}
+	return nil
+}

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -54,46 +54,52 @@ func Configure(opts *LoggingConfig) error {
 	if opts == nil {
 		logger.CliLogger()
 		logger.Set("info")
-	} else {
-		switch opts.Writer {
-		case "", "cli":
-			switch opts.Options["format"] {
-			case "gcp-json":
-				logger.UseGCPJSONLogging(logger.LogOutputWriter)
-			case "json":
-				logger.UseJSONLogging(logger.LogOutputWriter)
-			default:
-				// matches the nil-opts default: colorized console on the
-				// same buffered writer used by the json formats above.
-				logger.CliLogger()
-			}
-		case "stackdriver":
-			if opts.Options == nil {
-				return fmt.Errorf("stackdriver logging requires `project-id` and `log-id` in the options block")
-			}
-			projectID := opts.Options["project-id"]
-			if projectID == "" {
-				return fmt.Errorf("stackdriver logging requires a `project-id` option")
-			}
-			logID := opts.Options["log-id"]
-			if logID == "" {
-				return fmt.Errorf("stackdriver logging requires a `log-id` option")
-			}
-
-			w, err := stackdriver.NewStackdriverWriter(projectID, logID)
-			if err != nil {
-				return fmt.Errorf("could not initialize stackdriver logger: %w", err)
-			}
-			logger.SetWriter(w)
-		default:
-			return fmt.Errorf("unknown log writer %q", opts.Writer)
-		}
-		logger.Set(opts.Level)
+		applyEnvLevel()
+		return nil
 	}
 
-	// Environment variables always over-write custom configuration.
+	switch opts.Writer {
+	case "", "cli":
+		switch opts.Options["format"] {
+		case "gcp-json":
+			logger.UseGCPJSONLogging(logger.LogOutputWriter)
+		case "json":
+			logger.UseJSONLogging(logger.LogOutputWriter)
+		default:
+			// matches the nil-opts default: colorized console on the
+			// same buffered writer used by the json formats above.
+			logger.CliLogger()
+		}
+	case "stackdriver":
+		if opts.Options == nil {
+			return fmt.Errorf("stackdriver logging requires `project-id` and `log-id` in the options block")
+		}
+		projectID := opts.Options["project-id"]
+		if projectID == "" {
+			return fmt.Errorf("stackdriver logging requires a `project-id` option")
+		}
+		logID := opts.Options["log-id"]
+		if logID == "" {
+			return fmt.Errorf("stackdriver logging requires a `log-id` option")
+		}
+
+		w, err := stackdriver.NewStackdriverWriter(projectID, logID)
+		if err != nil {
+			return fmt.Errorf("could not initialize stackdriver logger: %w", err)
+		}
+		logger.SetWriter(w)
+	default:
+		return fmt.Errorf("unknown log writer %q", opts.Writer)
+	}
+	logger.Set(opts.Level)
+	applyEnvLevel()
+	return nil
+}
+
+// applyEnvLevel lets the DEBUG/TRACE/MONDOO_LOG_LEVEL environment variables
+// override the configured level, so environment variables always win.
+func applyEnvLevel() {
 	if envLevel, ok := logger.GetEnvLogLevel(); ok {
 		logger.Set(envLevel)
 	}
-	return nil
 }

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -64,9 +64,14 @@ func Configure(opts *Options) error {
 			case "json":
 				logger.UseJSONLogging(logger.LogOutputWriter)
 			default:
-				logger.StandardZerologLogger()
+				// matches the nil-opts default: colorized console on the
+				// same buffered writer used by the json formats above.
+				logger.CliLogger()
 			}
 		case "stackdriver":
+			if opts.Options == nil {
+				return fmt.Errorf("stackdriver logging requires `project-id` and `log-id` in the options block")
+			}
 			projectID := opts.Options["project-id"]
 			if projectID == "" {
 				return fmt.Errorf("stackdriver logging requires a `project-id` option")

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// Options declares how the global logger should be configured.
-type Options struct {
+// LoggingConfig declares how the global logger should be configured.
+type LoggingConfig struct {
 	// Writer selects the log sink: "cli" (default) or "stackdriver".
 	Writer string `json:"writer,omitempty" mapstructure:"writer"`
 	// Level sets the log level: error, warn, info, debug, trace.
@@ -30,14 +30,14 @@ type Options struct {
 	Options map[string]string `json:"options,omitempty" mapstructure:"options"`
 }
 
-// Load reads logging Options from a YAML or JSON file at the given path.
-func Load(path string) (*Options, error) {
+// Load reads a LoggingConfig from a YAML or JSON file at the given path.
+func Load(path string) (*LoggingConfig, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read logging config %q: %w", path, err)
 	}
 
-	var opts Options
+	var opts LoggingConfig
 	if err := yaml.Unmarshal(raw, &opts); err != nil {
 		return nil, fmt.Errorf("could not parse logging config %q: %w", path, err)
 	}
@@ -50,7 +50,7 @@ func Load(path string) (*Options, error) {
 // variables always win over explicit configuration.
 //
 // A nil opts falls back to the colorized CLI logger at info level.
-func Configure(opts *Options) error {
+func Configure(opts *LoggingConfig) error {
 	if opts == nil {
 		logger.CliLogger()
 		logger.Set("info")

--- a/logger/loggerconf/loggerconf_test.go
+++ b/logger/loggerconf/loggerconf_test.go
@@ -13,9 +13,10 @@ import (
 
 func clearEnvLevel(t *testing.T) {
 	t.Helper()
-	// ensure DEBUG/TRACE don't override the configured level during the test
+	// ensure env vars don't override the configured level during the test
 	t.Setenv("DEBUG", "")
 	t.Setenv("TRACE", "")
+	t.Setenv("MONDOO_LOG_LEVEL", "")
 }
 
 func TestConfigure_Level(t *testing.T) {
@@ -56,6 +57,32 @@ func TestConfigure_EnvOverridesLevel(t *testing.T) {
 	}
 	if got := logger.GetLevel(); got != "debug" {
 		t.Errorf("expected env to force debug, got %q", got)
+	}
+}
+
+func TestConfigure_MondooLogLevelOverridesConfig(t *testing.T) {
+	// the cnspec-runner relies on MONDOO_LOG_LEVEL (set per job) overriding the
+	// configured level; make sure that keeps working through Configure.
+	t.Setenv("DEBUG", "")
+	t.Setenv("TRACE", "")
+	t.Setenv("MONDOO_LOG_LEVEL", "trace")
+	if err := Configure(&LoggingConfig{Writer: "cli", Level: "error"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "trace" {
+		t.Errorf("expected MONDOO_LOG_LEVEL to force trace, got %q", got)
+	}
+}
+
+func TestConfigure_MondooLogLevelOverridesNilConfig(t *testing.T) {
+	t.Setenv("DEBUG", "")
+	t.Setenv("TRACE", "")
+	t.Setenv("MONDOO_LOG_LEVEL", "warn")
+	if err := Configure(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "warn" {
+		t.Errorf("expected MONDOO_LOG_LEVEL to force warn, got %q", got)
 	}
 }
 

--- a/logger/loggerconf/loggerconf_test.go
+++ b/logger/loggerconf/loggerconf_test.go
@@ -20,7 +20,7 @@ func clearEnvLevel(t *testing.T) {
 
 func TestConfigure_Level(t *testing.T) {
 	clearEnvLevel(t)
-	if err := Configure(&Options{Writer: "cli", Level: "warn"}); err != nil {
+	if err := Configure(&LoggingConfig{Writer: "cli", Level: "warn"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := logger.GetLevel(); got != "warn" {
@@ -30,7 +30,7 @@ func TestConfigure_Level(t *testing.T) {
 
 func TestConfigure_EmptyWriterDefaultsToCli(t *testing.T) {
 	clearEnvLevel(t)
-	if err := Configure(&Options{Level: "error"}); err != nil {
+	if err := Configure(&LoggingConfig{Level: "error"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := logger.GetLevel(); got != "error" {
@@ -51,7 +51,7 @@ func TestConfigure_Nil(t *testing.T) {
 func TestConfigure_EnvOverridesLevel(t *testing.T) {
 	t.Setenv("DEBUG", "true")
 	t.Setenv("TRACE", "")
-	if err := Configure(&Options{Writer: "cli", Level: "error"}); err != nil {
+	if err := Configure(&LoggingConfig{Writer: "cli", Level: "error"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := logger.GetLevel(); got != "debug" {
@@ -61,17 +61,17 @@ func TestConfigure_EnvOverridesLevel(t *testing.T) {
 
 func TestConfigure_UnknownWriter(t *testing.T) {
 	clearEnvLevel(t)
-	if err := Configure(&Options{Writer: "bogus"}); err == nil {
+	if err := Configure(&LoggingConfig{Writer: "bogus"}); err == nil {
 		t.Fatal("expected an error for an unknown writer")
 	}
 }
 
 func TestConfigure_StackdriverRequiresOptions(t *testing.T) {
 	clearEnvLevel(t)
-	if err := Configure(&Options{Writer: "stackdriver"}); err == nil {
+	if err := Configure(&LoggingConfig{Writer: "stackdriver"}); err == nil {
 		t.Fatal("expected an error when project-id is missing")
 	}
-	if err := Configure(&Options{Writer: "stackdriver", Options: map[string]string{"project-id": "p"}}); err == nil {
+	if err := Configure(&LoggingConfig{Writer: "stackdriver", Options: map[string]string{"project-id": "p"}}); err == nil {
 		t.Fatal("expected an error when log-id is missing")
 	}
 }

--- a/logger/loggerconf/loggerconf_test.go
+++ b/logger/loggerconf/loggerconf_test.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package loggerconf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.mondoo.com/mql/v13/logger"
+)
+
+func clearEnvLevel(t *testing.T) {
+	t.Helper()
+	// ensure DEBUG/TRACE don't override the configured level during the test
+	t.Setenv("DEBUG", "")
+	t.Setenv("TRACE", "")
+}
+
+func TestConfigure_Level(t *testing.T) {
+	clearEnvLevel(t)
+	if err := Configure(&Options{Writer: "cli", Level: "warn"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "warn" {
+		t.Errorf("expected level warn, got %q", got)
+	}
+}
+
+func TestConfigure_EmptyWriterDefaultsToCli(t *testing.T) {
+	clearEnvLevel(t)
+	if err := Configure(&Options{Level: "error"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "error" {
+		t.Errorf("expected level error, got %q", got)
+	}
+}
+
+func TestConfigure_Nil(t *testing.T) {
+	clearEnvLevel(t)
+	if err := Configure(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "info" {
+		t.Errorf("expected level info, got %q", got)
+	}
+}
+
+func TestConfigure_EnvOverridesLevel(t *testing.T) {
+	t.Setenv("DEBUG", "true")
+	t.Setenv("TRACE", "")
+	if err := Configure(&Options{Writer: "cli", Level: "error"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "debug" {
+		t.Errorf("expected env to force debug, got %q", got)
+	}
+}
+
+func TestConfigure_UnknownWriter(t *testing.T) {
+	clearEnvLevel(t)
+	if err := Configure(&Options{Writer: "bogus"}); err == nil {
+		t.Fatal("expected an error for an unknown writer")
+	}
+}
+
+func TestConfigure_StackdriverRequiresOptions(t *testing.T) {
+	clearEnvLevel(t)
+	if err := Configure(&Options{Writer: "stackdriver"}); err == nil {
+		t.Fatal("expected an error when project-id is missing")
+	}
+	if err := Configure(&Options{Writer: "stackdriver", Options: map[string]string{"project-id": "p"}}); err == nil {
+		t.Fatal("expected an error when log-id is missing")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+
+	yamlPath := filepath.Join(dir, "logging.yaml")
+	if err := os.WriteFile(yamlPath, []byte("writer: cli\nlevel: debug\noptions:\n  format: json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Writer != "cli" || opts.Level != "debug" || opts.Options["format"] != "json" {
+		t.Errorf("unexpected options parsed from yaml: %+v", opts)
+	}
+
+	jsonPath := filepath.Join(dir, "logging.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"writer":"cli","level":"trace"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts, err = Load(jsonPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Writer != "cli" || opts.Level != "trace" {
+		t.Errorf("unexpected options parsed from json: %+v", opts)
+	}
+
+	if _, err := Load(filepath.Join(dir, "does-not-exist.yaml")); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}


### PR DESCRIPTION
## What

Adds a new `logger/loggerconf` package with a **single function** that decides how logging is configured, so cnspec and the cnspec-runner (and any future consumer) set up logging identically.

- `loggerconf.Options{Writer, Level, Options}` — declarative logging config with `json` + `mapstructure` tags.
- `loggerconf.Configure(*Options) error` — uplifted from the cnspec-runner's `ConfigureLogger`. Supports the `cli` writer (`json` / `gcp-json` / plain formats) and `stackdriver`, sets the level, and lets `DEBUG`/`TRACE` env vars override the configured level. Returns an error (instead of `log.Fatal`) so it's safe to use as a library.
- `loggerconf.Load(path)` — reads `Options` from a YAML or JSON file.

It lives in its own subpackage (not the base `logger` package) so the GCP/stackdriver dependency stays opt-in.

## Why

Logging setup was duplicated in the cnspec-runner and only configurable there. This centralizes it so cnspec can expose it via a new `--logging-config` flag and the runner can reuse the exact same logic.

## Follow-ups (separate PRs)

- **cnspec**: new `--logging-config` flag that calls `loggerconf.Load` + `Configure`.
- **server/cnspec-runner**: `ConfigureLogger` delegates to `loggerconf.Configure`.

Both depend on this PR merging and an mql release.

## Test

`go test ./logger/loggerconf/` — covers level setting, nil/empty-writer defaults, env override, unknown-writer + stackdriver validation errors, and YAML/JSON loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)