### PR TITLE
✨ stackit: enrich asset detection to match gcp/aws

### DIFF
--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -10,6 +10,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/stackit/connection"
 	"go.mondoo.com/mql/v13/providers/stackit/provider"
+	"go.mondoo.com/mql/v13/providers/stackit/resources"
 )
 
 var Config = plugin.Provider{
@@ -40,9 +41,24 @@ You can also pass credentials via STACKIT environment variables
 				connection.ServiceAccountKeyEnvVar,
 				connection.TokenEnvVar,
 			),
-			MinArgs:   0,
-			MaxArgs:   0,
-			Discovery: []string{},
+			MinArgs: 0,
+			MaxArgs: 0,
+			Discovery: []string{
+				resources.DiscoveryAuto,
+				resources.DiscoveryAll,
+				resources.DiscoveryServers,
+				resources.DiscoverySkeClusters,
+				resources.DiscoveryObjectStorageBuckets,
+				resources.DiscoveryPostgresFlex,
+				resources.DiscoveryMongoDbFlex,
+				resources.DiscoverySqlServerFlex,
+				resources.DiscoveryOpenSearch,
+				resources.DiscoveryMariaDb,
+				resources.DiscoveryRedis,
+				resources.DiscoveryRabbitMq,
+				resources.DiscoveryLogMe,
+				resources.DiscoverySecretsManager,
+			},
 			Flags: []plugin.Flag{
 				{
 					Long:    connection.OptionProjectID,
@@ -101,7 +117,24 @@ You can also pass credentials via STACKIT environment variables
 			Key:          "project",
 			Title:        "Project",
 			Values: map[string]*inventory.AssetUrlBranch{
-				"*": nil,
+				"*": {
+					Key:   "service",
+					Title: "Service",
+					Values: map[string]*inventory.AssetUrlBranch{
+						"compute":         nil,
+						"ske":             nil,
+						"object-storage":  nil,
+						"postgres-flex":   nil,
+						"mongodb-flex":    nil,
+						"sqlserver-flex":  nil,
+						"opensearch":      nil,
+						"mariadb":         nil,
+						"redis":           nil,
+						"rabbitmq":        nil,
+						"logme":           nil,
+						"secrets-manager": nil,
+					},
+				},
 			},
 		},
 	},

--- a/providers/stackit/connection/connection.go
+++ b/providers/stackit/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 
@@ -53,6 +54,13 @@ type StackitConnection struct {
 
 	projectID string
 	region    string
+
+	// project metadata captured during Verify so the provider can enrich the
+	// detected asset (real name + labels + parent) the way the gcp and aws
+	// providers do, without issuing a second resource-manager call.
+	projectName   string
+	projectParent string
+	projectLabels map[string]string
 
 	// configOpts includes WithRegion(region) — use for region-scoped services
 	// (iaas, ske, objectstorage, loadbalancer, postgres-flex, mongodb-flex).
@@ -221,19 +229,48 @@ func getOptionValueFrom(options map[string]string, envVar, option string) (strin
 	return value, value != ""
 }
 
-func (c *StackitConnection) ProjectID() string { return c.projectID }
-func (c *StackitConnection) Region() string    { return c.region }
+func (c *StackitConnection) ProjectID() string     { return c.projectID }
+func (c *StackitConnection) Region() string        { return c.region }
+func (c *StackitConnection) ProjectName() string   { return c.projectName }
+func (c *StackitConnection) ProjectParent() string { return c.projectParent }
+
+// ProjectLabels returns the labels attached to the STACKIT project, captured
+// during Verify. The returned map must not be mutated by callers.
+func (c *StackitConnection) ProjectLabels() map[string]string { return c.projectLabels }
 
 func (c *StackitConnection) Verify(ctx context.Context) error {
 	client, err := c.ResourceManager()
 	if err != nil {
 		return err
 	}
-	if _, err := client.GetProjectExecute(ctx, c.projectID); err != nil {
+	resp, err := client.GetProjectExecute(ctx, c.projectID)
+	if err != nil {
 		log.Warn().Err(err).Msg("stackit> verify project lookup failed")
 		return fmt.Errorf("failed to verify STACKIT connection for project %s: %w", c.projectID, err)
 	}
+	c.captureProjectMetadata(resp)
 	return nil
+}
+
+// captureProjectMetadata records the human-readable project name, parent
+// container, and labels from the resource-manager response so detect() can
+// enrich the asset without a second API call.
+func (c *StackitConnection) captureProjectMetadata(resp *resourcemanager.GetProjectResponse) {
+	if resp == nil {
+		return
+	}
+	c.projectName = resp.GetName()
+	if labels, ok := resp.GetLabelsOk(); ok && labels != nil {
+		// Snapshot the map so a later SDK mutation of its internal copy cannot
+		// change our captured labels, honoring the ProjectLabels() contract.
+		c.projectLabels = maps.Clone(labels)
+	}
+	if parent, ok := resp.GetParentOk(); ok {
+		c.projectParent = parent.GetContainerId()
+		if c.projectParent == "" {
+			c.projectParent = parent.GetId()
+		}
+	}
 }
 
 func (c *StackitConnection) IaaS() (*iaas.APIClient, error) {
@@ -425,9 +462,15 @@ func (c *StackitConnection) Name() string            { return "stackit" }
 
 func (c *StackitConnection) PlatformInfo() *inventory.Platform {
 	p := &inventory.Platform{
-		TechnologyUrlSegments: []string{"cloud", "stackit", "project"},
+		// Matches the provider's AssetUrlTrees (technology=stackit -> project),
+		// mirroring how gcp emits {"gcp", projectID, ...} and aws emits
+		// {"aws", accountID, ...}.
+		TechnologyUrlSegments: []string{"stackit", c.projectID},
 	}
 	PlatformByName("stackit-project").Apply(p)
+	if c.projectName != "" {
+		p.Title = "STACKIT Project " + c.projectName
+	}
 	return p
 }
 

--- a/providers/stackit/connection/connection_test.go
+++ b/providers/stackit/connection/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
@@ -181,6 +182,69 @@ func TestNewStackitConnection_DefaultRegion(t *testing.T) {
 	}
 	if conn.Region() != DefaultRegion {
 		t.Fatalf("expected default region %q, got %q", DefaultRegion, conn.Region())
+	}
+}
+
+func TestPlatformInfo_TechnologyUrlSegments(t *testing.T) {
+	conn := &StackitConnection{projectID: "11111111-2222-3333-4444-555555555555"}
+
+	p := conn.PlatformInfo()
+	if p.Name != "stackit-project" {
+		t.Fatalf("expected platform name stackit-project, got %q", p.Name)
+	}
+	// Must match the provider's AssetUrlTrees (technology=stackit -> project).
+	want := []string{"stackit", conn.projectID}
+	if len(p.TechnologyUrlSegments) != len(want) {
+		t.Fatalf("expected segments %v, got %v", want, p.TechnologyUrlSegments)
+	}
+	for i := range want {
+		if p.TechnologyUrlSegments[i] != want[i] {
+			t.Fatalf("expected segments %v, got %v", want, p.TechnologyUrlSegments)
+		}
+	}
+}
+
+func TestPlatformInfo_TitleUsesProjectName(t *testing.T) {
+	conn := &StackitConnection{projectID: "p-1", projectName: "production"}
+	if got := conn.PlatformInfo().Title; got != "STACKIT Project production" {
+		t.Fatalf("expected title to include project name, got %q", got)
+	}
+
+	// With no resolved name, the static catalog title is used.
+	bare := &StackitConnection{projectID: "p-1"}
+	if got := bare.PlatformInfo().Title; got != "STACKIT Project" {
+		t.Fatalf("expected catalog title, got %q", got)
+	}
+}
+
+func TestCaptureProjectMetadata(t *testing.T) {
+	resp := resourcemanager.NewGetProjectResponseWithDefaults()
+	resp.SetName("my-project")
+	resp.SetLabels(map[string]string{"team": "platform", "env": "prod"})
+	parent := resourcemanager.NewParentWithDefaults()
+	parent.SetContainerId("org-abc")
+	resp.SetParent(*parent)
+
+	conn := &StackitConnection{}
+	conn.captureProjectMetadata(resp)
+
+	if conn.ProjectName() != "my-project" {
+		t.Fatalf("expected project name my-project, got %q", conn.ProjectName())
+	}
+	if conn.ProjectParent() != "org-abc" {
+		t.Fatalf("expected parent org-abc, got %q", conn.ProjectParent())
+	}
+	labels := conn.ProjectLabels()
+	if labels["team"] != "platform" || labels["env"] != "prod" {
+		t.Fatalf("unexpected labels: %v", labels)
+	}
+}
+
+func TestCaptureProjectMetadata_NilSafe(t *testing.T) {
+	conn := &StackitConnection{}
+	conn.captureProjectMetadata(nil)
+	if conn.ProjectName() != "" || conn.ProjectParent() != "" || conn.ProjectLabels() != nil {
+		t.Fatalf("nil response should leave metadata empty")
 	}
 }
 

--- a/providers/stackit/connection/discovery_platform_test.go
+++ b/providers/stackit/connection/discovery_platform_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "testing"
+
+func TestMondooObjectID(t *testing.T) {
+	got := MondooObjectID("proj-1", "postgres-flex", "eu01", "db-9")
+	want := "//platformid.api.mondoo.app/runtime/stackit/postgres-flex/proj-1/eu01/db-9"
+	if got != want {
+		t.Fatalf("regional object id: got %q, want %q", got, want)
+	}
+
+	// A project-global service (no region) falls back to "global".
+	got = MondooObjectID("proj-1", "secrets-manager", "", "sm-2")
+	want = "//platformid.api.mondoo.app/runtime/stackit/secrets-manager/proj-1/global/sm-2"
+	if got != want {
+		t.Fatalf("global object id: got %q, want %q", got, want)
+	}
+}
+
+func TestGetPlatformForObject(t *testing.T) {
+	p := GetPlatformForObject("stackit-postgres-flex-instance", "proj-1", "postgres-flex")
+
+	if p.Name != "stackit-postgres-flex-instance" {
+		t.Fatalf("name: got %q", p.Name)
+	}
+	if p.Title != "STACKIT PostgreSQL Flex Instance" {
+		t.Fatalf("title: got %q", p.Title)
+	}
+	if p.Kind != "stackit-object" {
+		t.Fatalf("kind: got %q, want stackit-object", p.Kind)
+	}
+	if p.Runtime != "stackit" {
+		t.Fatalf("runtime: got %q, want stackit", p.Runtime)
+	}
+	if len(p.Family) != 1 || p.Family[0] != "stackit" {
+		t.Fatalf("family: got %v, want [stackit]", p.Family)
+	}
+	// Must match the provider's AssetUrlTrees (technology=stackit -> project -> service).
+	want := []string{"stackit", "proj-1", "postgres-flex"}
+	if len(p.TechnologyUrlSegments) != len(want) {
+		t.Fatalf("segments: got %v, want %v", p.TechnologyUrlSegments, want)
+	}
+	for i := range want {
+		if p.TechnologyUrlSegments[i] != want[i] {
+			t.Fatalf("segments: got %v, want %v", p.TechnologyUrlSegments, want)
+		}
+	}
+}
+
+// All discoverable sub-asset platforms must share the "stackit" family and the
+// "stackit-object" kind so they group with the project root the way aws/azure do.
+func TestSubAssetPlatformsAreConsistent(t *testing.T) {
+	for _, name := range []string{
+		"stackit-server",
+		"stackit-ske-cluster",
+		"stackit-object-storage-bucket",
+		"stackit-postgres-flex-instance",
+		"stackit-mongodb-flex-instance",
+		"stackit-sqlserver-flex-instance",
+		"stackit-secrets-manager-instance",
+	} {
+		pi := PlatformByName(name)
+		if pi == nil {
+			t.Fatalf("platform %q missing from catalog", name)
+		}
+		if len(pi.Family) != 1 || pi.Family[0] != "stackit" {
+			t.Errorf("platform %q family = %v, want [stackit]", name, pi.Family)
+		}
+		if len(pi.Kind) != 1 || pi.Kind[0] != "stackit-object" {
+			t.Errorf("platform %q kind = %v, want [stackit-object]", name, pi.Kind)
+		}
+	}
+}

--- a/providers/stackit/connection/discovery_platform_test.go
+++ b/providers/stackit/connection/discovery_platform_test.go
@@ -3,7 +3,41 @@
 
 package connection
 
-import "testing"
+import (
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestAssetObjectID(t *testing.T) {
+	conn := &StackitConnection{
+		asset: &inventory.Asset{
+			PlatformIds: []string{MondooObjectID("proj-1", "postgres-flex", "eu01", "db-9")},
+		},
+	}
+
+	// Matching service returns the trailing object id.
+	if id, ok := conn.AssetObjectID("postgres-flex"); !ok || id != "db-9" {
+		t.Fatalf("postgres-flex: got (%q,%v), want (db-9,true)", id, ok)
+	}
+	// A different service must not match (no cross-type leakage).
+	if id, ok := conn.AssetObjectID("mongodb-flex"); ok {
+		t.Fatalf("mongodb-flex should not match, got %q", id)
+	}
+
+	// The project root must never be treated as an object.
+	proj := &StackitConnection{
+		asset: &inventory.Asset{PlatformIds: []string{PlatformIdStackitProject + "proj-1"}},
+	}
+	if id, ok := proj.AssetObjectID("postgres-flex"); ok {
+		t.Fatalf("project root should not match, got %q", id)
+	}
+
+	// No asset -> no id.
+	if _, ok := (&StackitConnection{}).AssetObjectID("postgres-flex"); ok {
+		t.Fatal("nil asset should not match")
+	}
+}
 
 func TestMondooObjectID(t *testing.T) {
 	got := MondooObjectID("proj-1", "postgres-flex", "eu01", "db-9")

--- a/providers/stackit/connection/platforms.go
+++ b/providers/stackit/connection/platforms.go
@@ -3,9 +3,16 @@
 
 package connection
 
-import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
 
-// Platforms is the static catalog of platforms this provider can emit.
+// Platforms is the static catalog of platforms this provider can emit. The
+// project is the connected root asset (Kind "api"); every other entry is a
+// discovered sub-asset (Kind "stackit-object"), mirroring how the aws provider
+// emits "aws-object" platforms for discovered resources. All entries share the
+// "stackit" family so they group together the way aws/azure assets do.
 var Platforms = []*plugin.PlatformInfo{
 	{
 		Name:    "stackit-project",
@@ -14,6 +21,18 @@ var Platforms = []*plugin.PlatformInfo{
 		Kind:    []string{"api"},
 		Runtime: []string{"stackit"},
 	},
+	{Name: "stackit-server", Title: "STACKIT Server", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-ske-cluster", Title: "STACKIT Kubernetes Cluster", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-object-storage-bucket", Title: "STACKIT Object Storage Bucket", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-postgres-flex-instance", Title: "STACKIT PostgreSQL Flex Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-mongodb-flex-instance", Title: "STACKIT MongoDB Flex Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-sqlserver-flex-instance", Title: "STACKIT SQLServer Flex Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-opensearch-instance", Title: "STACKIT OpenSearch Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-mariadb-instance", Title: "STACKIT MariaDB Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-redis-instance", Title: "STACKIT Redis Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-rabbitmq-instance", Title: "STACKIT RabbitMQ Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-logme-instance", Title: "STACKIT LogMe Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
+	{Name: "stackit-secrets-manager-instance", Title: "STACKIT Secrets Manager Instance", Family: []string{"stackit"}, Kind: []string{"stackit-object"}, Runtime: []string{"stackit"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)
@@ -21,4 +40,29 @@ var platformsByName = plugin.PlatformsByName(Platforms)
 // PlatformByName returns the catalog entry for the given platform name.
 func PlatformByName(name string) *plugin.PlatformInfo {
 	return platformsByName[name]
+}
+
+// objectPlatformIDPrefix is the base of every discovered sub-asset's Mondoo
+// platform ID. The connected project root uses PlatformIdStackitProject.
+const objectPlatformIDPrefix = "//platformid.api.mondoo.app/runtime/stackit/"
+
+// MondooObjectID builds the stable platform ID for a discovered STACKIT sub-asset,
+// e.g. //platformid.api.mondoo.app/runtime/stackit/postgres-flex/<project>/<region>/<id>.
+// Region-less (project-global) services use "global".
+func MondooObjectID(projectID, service, region, id string) string {
+	if region == "" {
+		region = "global"
+	}
+	return objectPlatformIDPrefix + service + "/" + projectID + "/" + region + "/" + id
+}
+
+// GetPlatformForObject returns the inventory platform for a discovered sub-asset,
+// applying the static catalog entry and attaching the per-asset technology URL
+// segments ({"stackit", projectID, service}) that match the provider's AssetUrlTrees.
+func GetPlatformForObject(platformName, projectID, service string) *inventory.Platform {
+	p := &inventory.Platform{
+		TechnologyUrlSegments: []string{"stackit", projectID, service},
+	}
+	PlatformByName(platformName).Apply(p)
+	return p
 }

--- a/providers/stackit/connection/platforms.go
+++ b/providers/stackit/connection/platforms.go
@@ -4,6 +4,8 @@
 package connection
 
 import (
+	"strings"
+
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -54,6 +56,31 @@ func MondooObjectID(projectID, service, region, id string) string {
 		region = "global"
 	}
 	return objectPlatformIDPrefix + service + "/" + projectID + "/" + region + "/" + id
+}
+
+// AssetObjectID returns the object id of the discovered sub-asset this
+// connection is scanning, when that sub-asset's platform id matches the given
+// service (e.g. "postgres-flex"). It lets a singular resource (e.g.
+// stackit.postgresFlex.instance) scope itself to the connected asset when a
+// query supplies no explicit id, mirroring aws's getAssetIdentifier. Returns
+// false for the project root and for sub-assets of a different service, so the
+// list-based project scan is never affected.
+func (c *StackitConnection) AssetObjectID(service string) (string, bool) {
+	if c.asset == nil {
+		return "", false
+	}
+	prefix := objectPlatformIDPrefix + service + "/"
+	for _, pid := range c.asset.PlatformIds {
+		if !strings.HasPrefix(pid, prefix) {
+			continue
+		}
+		parts := strings.Split(strings.TrimPrefix(pid, prefix), "/")
+		// Remainder is <project>/<region>/<id>; the trailing segment is the id.
+		if len(parts) >= 3 && parts[len(parts)-1] != "" {
+			return parts[len(parts)-1], true
+		}
+	}
+	return "", false
 }
 
 // GetPlatformForObject returns the inventory platform for a discovered sub-asset,

--- a/providers/stackit/provider/provider.go
+++ b/providers/stackit/provider/provider.go
@@ -146,9 +146,31 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.StackitConnect
 	asset.Id = conn.Identifier()
 	asset.Platform = conn.PlatformInfo()
 	asset.PlatformIds = []string{conn.Identifier()}
+
+	// Prefer the human-readable project name resolved from the resource-manager
+	// API (captured during Verify), the way gcp uses project.Name and aws uses
+	// the account/host. Fall back to the project ID when it is unavailable.
 	if asset.Name == "" || asset.Name == "STACKIT" {
-		asset.Name = "STACKIT project " + conn.ProjectID()
+		if name := conn.ProjectName(); name != "" {
+			asset.Name = name
+		} else {
+			asset.Name = "STACKIT project " + conn.ProjectID()
+		}
 	}
+
+	// Attach the project's labels plus stackit-specific metadata so discovered
+	// and directly-connected assets carry the same context as gcp/aws assets.
+	if asset.Labels == nil {
+		asset.Labels = map[string]string{}
+	}
+	for k, v := range conn.ProjectLabels() {
+		asset.Labels[k] = v
+	}
+	asset.Labels["mondoo.com/region"] = conn.Region()
+	if parent := conn.ProjectParent(); parent != "" {
+		asset.Labels["mondoo.com/parent-id"] = parent
+	}
+
 	return nil
 }
 

--- a/providers/stackit/provider/provider.go
+++ b/providers/stackit/provider/provider.go
@@ -65,6 +65,20 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		}
 	}
 
+	// Discovery flags. With no --discover flag we default to "auto" so a plain
+	// `cnspec scan stackit` brings in the project's sub-assets (databases, SKE
+	// clusters, buckets, …) the way the aws/gcp providers do.
+	discoverTargets := []string{}
+	if x, ok := flags["discover"]; ok && len(x.Array) != 0 {
+		for i := range x.Array {
+			discoverTargets = append(discoverTargets, string(x.Array[i].Value))
+		}
+	}
+	if len(discoverTargets) == 0 {
+		discoverTargets = []string{resources.DiscoveryAuto}
+	}
+	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
+
 	asset := &inventory.Asset{
 		Name:        "STACKIT",
 		Connections: []*inventory.Config{conf},
@@ -89,12 +103,40 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
+	// Start the returned inventory with the connected root asset, then append any
+	// discovered sub-assets. Discovered sub-assets carry WithoutDiscovery, so
+	// re-connecting to one yields no targets and does not re-expand.
+	inv := &inventory.Inventory{
+		Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{req.Asset}},
+	}
+	discovered, err := s.discover(conn)
+	if err != nil {
+		return nil, err
+	}
+	if discovered != nil {
+		inv.Spec.Assets = append(inv.Spec.Assets, discovered.Spec.Assets...)
+	}
+
 	return &plugin.ConnectRes{
 		Id:        conn.ID(),
 		Name:      conn.Name(),
 		Asset:     req.Asset,
-		Inventory: nil,
+		Inventory: inv,
 	}, nil
+}
+
+// discover enumerates STACKIT sub-assets for the connection's discovery targets.
+// Returns nil when discovery is not requested (e.g. when re-connecting to a
+// discovered sub-asset, whose cloned config carries no targets).
+func (s *Service) discover(conn *connection.StackitConnection) (*inventory.Inventory, error) {
+	if conn.Conf == nil || len(conn.Conf.GetDiscover().GetTargets()) == 0 {
+		return nil, nil
+	}
+	runtime, err := s.GetRuntime(conn.ID())
+	if err != nil {
+		return nil, err
+	}
+	return resources.Discover(runtime)
 }
 
 func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*connection.StackitConnection, error) {

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -660,6 +660,9 @@ func (r *mqlStackitObservabilityInstance) isUpdatable() (bool, error) {
 func initStackitPostgresFlexInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
+		id, ok = conn(runtime).AssetObjectID("postgres-flex")
+	}
+	if !ok {
 		return args, nil, nil
 	}
 	c := conn(runtime)
@@ -693,6 +696,9 @@ func initStackitPostgresFlexInstance(runtime *plugin.Runtime, args map[string]*l
 func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
+		id, ok = conn(runtime).AssetObjectID("mongodb-flex")
+	}
+	if !ok {
 		return args, nil, nil
 	}
 	c := conn(runtime)
@@ -725,6 +731,9 @@ func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*ll
 
 func initStackitOpenSearchInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
+	if !ok {
+		id, ok = conn(runtime).AssetObjectID("opensearch")
+	}
 	if !ok {
 		return args, nil, nil
 	}
@@ -760,6 +769,9 @@ func initStackitOpenSearchInstance(runtime *plugin.Runtime, args map[string]*llx
 func initStackitMariaDbInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
+		id, ok = conn(runtime).AssetObjectID("mariadb")
+	}
+	if !ok {
 		return args, nil, nil
 	}
 	c := conn(runtime)
@@ -793,6 +805,9 @@ func initStackitMariaDbInstance(runtime *plugin.Runtime, args map[string]*llx.Ra
 
 func initStackitRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
+	if !ok {
+		id, ok = conn(runtime).AssetObjectID("redis")
+	}
 	if !ok {
 		return args, nil, nil
 	}
@@ -828,6 +843,9 @@ func initStackitRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 func initStackitRabbitMqInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
+		id, ok = conn(runtime).AssetObjectID("rabbitmq")
+	}
+	if !ok {
 		return args, nil, nil
 	}
 	c := conn(runtime)
@@ -861,6 +879,9 @@ func initStackitRabbitMqInstance(runtime *plugin.Runtime, args map[string]*llx.R
 
 func initStackitSecretsManagerInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
+	if !ok {
+		id, ok = conn(runtime).AssetObjectID("secrets-manager")
+	}
 	if !ok {
 		return args, nil, nil
 	}
@@ -971,6 +992,9 @@ func (r *mqlStackitLogMeInstance) id() (string, error) {
 
 func initStackitLogMeInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
+	if !ok {
+		id, ok = conn(runtime).AssetObjectID("logme")
+	}
 	if !ok {
 		return args, nil, nil
 	}
@@ -1141,6 +1165,9 @@ func (r *mqlStackitSqlServerFlexInstance) options() (map[string]any, error) {
 
 func initStackitSqlServerFlexInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
+	if !ok {
+		id, ok = conn(runtime).AssetObjectID("sqlserver-flex")
+	}
 	if !ok {
 		return args, nil, nil
 	}

--- a/providers/stackit/resources/discovery.go
+++ b/providers/stackit/resources/discovery.go
@@ -1,0 +1,335 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/stackit/connection"
+)
+
+// Discovery targets. "auto"/"all" expand to every specific target.
+const (
+	DiscoveryAuto = "auto"
+	DiscoveryAll  = "all"
+
+	DiscoveryServers              = "servers"
+	DiscoverySkeClusters          = "ske-clusters"
+	DiscoveryObjectStorageBuckets = "object-storage-buckets"
+	DiscoveryPostgresFlex         = "postgres-flex-instances"
+	DiscoveryMongoDbFlex          = "mongodb-flex-instances"
+	DiscoverySqlServerFlex        = "sqlserver-flex-instances"
+	DiscoveryOpenSearch           = "opensearch-instances"
+	DiscoveryMariaDb              = "mariadb-instances"
+	DiscoveryRedis                = "redis-instances"
+	DiscoveryRabbitMq             = "rabbitmq-instances"
+	DiscoveryLogMe                = "logme-instances"
+	DiscoverySecretsManager       = "secrets-manager-instances"
+)
+
+// AllDiscoveryTargets is the set "all"/"auto" expand to.
+var AllDiscoveryTargets = []string{
+	DiscoveryServers,
+	DiscoverySkeClusters,
+	DiscoveryObjectStorageBuckets,
+	DiscoveryPostgresFlex,
+	DiscoveryMongoDbFlex,
+	DiscoverySqlServerFlex,
+	DiscoveryOpenSearch,
+	DiscoveryMariaDb,
+	DiscoveryRedis,
+	DiscoveryRabbitMq,
+	DiscoveryLogMe,
+	DiscoverySecretsManager,
+}
+
+// Discover enumerates STACKIT sub-assets for the connection's discovery targets
+// and returns them as a child inventory, mirroring how the aws/gcp providers
+// turn cloud resources into individually scannable assets. A failure for one
+// target is logged and skipped so the rest of discovery still completes.
+func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
+	conn, ok := runtime.Connection.(*connection.StackitConnection)
+	if !ok {
+		return nil, nil
+	}
+
+	in := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{}}}
+	for _, target := range expandTargets(conn.Conf.GetDiscover().GetTargets()) {
+		assets, err := discoverTarget(runtime, conn, target)
+		if err != nil {
+			// A target can legitimately fail when the service is not provisioned
+			// in the project/region (the broker returns 404). Log at debug so an
+			// optional, unused service does not surface as a scan error; genuine
+			// auth/connectivity problems already surface during Verify().
+			log.Debug().Err(err).Str("target", target).Msg("stackit> skipping discovery target")
+			continue
+		}
+		for _, a := range assets {
+			if a != nil {
+				in.Spec.Assets = append(in.Spec.Assets, a)
+			}
+		}
+	}
+	return in, nil
+}
+
+func expandTargets(targets []string) []string {
+	for _, t := range targets {
+		if t == DiscoveryAll || t == DiscoveryAuto {
+			return AllDiscoveryTargets
+		}
+	}
+	return targets
+}
+
+// objectAsset builds a discovered sub-asset from its identifying fields. The
+// cloned config carries the parent's credentials with discovery disabled, so the
+// sub-asset reconnects through the same project connection.
+func objectAsset(conn *connection.StackitConnection, platformName, service, region, id, name string, labels map[string]string) *inventory.Asset {
+	if id == "" {
+		return nil
+	}
+	if name == "" {
+		name = id
+	}
+	if region == "" {
+		region = conn.Region()
+	}
+
+	platformID := connection.MondooObjectID(conn.ProjectID(), service, region, id)
+
+	cfg := conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))
+	cfg.PlatformId = platformID
+
+	assetLabels := map[string]string{}
+	for k, v := range labels {
+		assetLabels[k] = v
+	}
+	assetLabels["mondoo.com/region"] = region
+	assetLabels["mondoo.com/parent-id"] = conn.ProjectID()
+
+	return &inventory.Asset{
+		PlatformIds: []string{platformID},
+		Name:        name,
+		Platform:    connection.GetPlatformForObject(platformName, conn.ProjectID(), service),
+		Labels:      assetLabels,
+		Connections: []*inventory.Config{cfg},
+	}
+}
+
+func mapToStringString(m map[string]any) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// discoverTarget enumerates the assets for a single discovery target.
+func discoverTarget(runtime *plugin.Runtime, conn *connection.StackitConnection, target string) ([]*inventory.Asset, error) {
+	switch target {
+	case DiscoveryServers:
+		res, err := NewResource(runtime, "stackit", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackit).GetServers()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			s := item.(*mqlStackitServer)
+			assets = append(assets, objectAsset(conn, "stackit-server", "compute", conn.Region(), s.Id.Data, s.Name.Data, mapToStringString(s.Labels.Data)))
+		}
+		return assets, nil
+
+	case DiscoverySkeClusters:
+		res, err := NewResource(runtime, "stackit.ske", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitSke).GetClusters()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			c := item.(*mqlStackitSkeCluster)
+			// SKE clusters are keyed by name (no separate id field).
+			assets = append(assets, objectAsset(conn, "stackit-ske-cluster", "ske", conn.Region(), c.Name.Data, c.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryObjectStorageBuckets:
+		res, err := NewResource(runtime, "stackit.objectStorage", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitObjectStorage).GetBuckets()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			b := item.(*mqlStackitObjectStorageBucket)
+			assets = append(assets, objectAsset(conn, "stackit-object-storage-bucket", "object-storage", b.Region.Data, b.Name.Data, b.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryPostgresFlex:
+		res, err := NewResource(runtime, "stackit.postgresFlex", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitPostgresFlex).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitPostgresFlexInstance)
+			assets = append(assets, objectAsset(conn, "stackit-postgres-flex-instance", "postgres-flex", i.Region.Data, i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryMongoDbFlex:
+		res, err := NewResource(runtime, "stackit.mongoDbFlex", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitMongoDbFlex).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitMongoDbFlexInstance)
+			assets = append(assets, objectAsset(conn, "stackit-mongodb-flex-instance", "mongodb-flex", i.Region.Data, i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoverySqlServerFlex:
+		res, err := NewResource(runtime, "stackit.sqlServerFlex", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitSqlServerFlex).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitSqlServerFlexInstance)
+			assets = append(assets, objectAsset(conn, "stackit-sqlserver-flex-instance", "sqlserver-flex", i.Region.Data, i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryOpenSearch:
+		res, err := NewResource(runtime, "stackit.openSearch", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitOpenSearch).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitOpenSearchInstance)
+			assets = append(assets, objectAsset(conn, "stackit-opensearch-instance", "opensearch", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryMariaDb:
+		res, err := NewResource(runtime, "stackit.mariaDb", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitMariaDb).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitMariaDbInstance)
+			assets = append(assets, objectAsset(conn, "stackit-mariadb-instance", "mariadb", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryRedis:
+		res, err := NewResource(runtime, "stackit.redis", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitRedis).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitRedisInstance)
+			assets = append(assets, objectAsset(conn, "stackit-redis-instance", "redis", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryRabbitMq:
+		res, err := NewResource(runtime, "stackit.rabbitMq", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitRabbitMq).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitRabbitMqInstance)
+			assets = append(assets, objectAsset(conn, "stackit-rabbitmq-instance", "rabbitmq", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoveryLogMe:
+		res, err := NewResource(runtime, "stackit.logMe", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitLogMe).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitLogMeInstance)
+			assets = append(assets, objectAsset(conn, "stackit-logme-instance", "logme", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	case DiscoverySecretsManager:
+		res, err := NewResource(runtime, "stackit.secretsManager", nil)
+		if err != nil {
+			return nil, err
+		}
+		list := res.(*mqlStackitSecretsManager).GetInstances()
+		if list.Error != nil {
+			return nil, list.Error
+		}
+		assets := []*inventory.Asset{}
+		for _, item := range list.Data {
+			i := item.(*mqlStackitSecretsManagerInstance)
+			assets = append(assets, objectAsset(conn, "stackit-secrets-manager-instance", "secrets-manager", "", i.Id.Data, i.Name.Data, nil))
+		}
+		return assets, nil
+
+	default:
+		log.Warn().Str("target", target).Msg("stackit> unknown discovery target")
+		return nil, nil
+	}
+}

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -18,7 +18,9 @@ func (r *mqlStackit) servers() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListServersExecute(bgctx(), c.ProjectID(), c.Region())
+	// Details(true) so the response includes nics, security groups, and volumes;
+	// without it the API returns servers with those fields empty.
+	resp, err := client.ListServers(bgctx(), c.ProjectID(), c.Region()).Details(true).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -41,6 +43,12 @@ func buildServer(runtime *plugin.Runtime, s *iaas.Server) (plugin.Resource, erro
 	nics := []any{}
 	if v, ok := s.GetNicsOk(); ok {
 		for _, n := range v {
+			allowed := []any{}
+			for _, a := range n.GetAllowedAddresses() {
+				if a.String != nil {
+					allowed = append(allowed, *a.String)
+				}
+			}
 			nics = append(nics, map[string]any{
 				"nicId":            n.GetNicId(),
 				"networkId":        n.GetNetworkId(),
@@ -49,7 +57,7 @@ func buildServer(runtime *plugin.Runtime, s *iaas.Server) (plugin.Resource, erro
 				"ipv6":             n.GetIpv6(),
 				"mac":              n.GetMac(),
 				"securityGroups":   strSlice(n.GetSecurityGroups()),
-				"allowedAddresses": dictAny(n.GetAllowedAddresses()),
+				"allowedAddresses": allowed,
 				"publicIp":         n.GetPublicIp(),
 				"nicSecurity":      n.GetNicSecurity(),
 			})
@@ -102,7 +110,7 @@ func initStackitServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if err != nil {
 		return nil, nil, err
 	}
-	s, err := client.GetServerExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	s, err := client.GetServer(bgctx(), c.ProjectID(), c.Region(), id).Details(true).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,12 +166,47 @@ func (r *mqlStackitServer) volumes() ([]any, error) {
 }
 
 func (r *mqlStackitServer) securityGroups() ([]any, error) {
-	out := make([]any, 0, len(r.SecurityGroupIds.Data))
-	for _, raw := range r.SecurityGroupIds.Data {
-		id, ok := raw.(string)
-		if !ok || id == "" {
-			continue
+	// Collect security-group ids from the server-level list and, since STACKIT
+	// attaches security groups per network interface (the server-level list is
+	// usually empty), from each NIC as well. Deduplicate while preserving order.
+	seen := map[string]struct{}{}
+	ids := []string{}
+	add := func(id string) {
+		if id == "" {
+			return
 		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	for _, raw := range r.SecurityGroupIds.Data {
+		if id, ok := raw.(string); ok {
+			add(id)
+		}
+	}
+	nics := r.GetNics()
+	if nics.Error == nil {
+		for _, raw := range nics.Data {
+			nic, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			sgs, ok := nic["securityGroups"].([]any)
+			if !ok {
+				continue
+			}
+			for _, s := range sgs {
+				if id, ok := s.(string); ok {
+					add(id)
+				}
+			}
+		}
+	}
+
+	out := make([]any, 0, len(ids))
+	for _, id := range ids {
 		sg, err := NewResource(r.MqlRuntime, "stackit.securityGroup", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -92,6 +92,9 @@ func (r *mqlStackitServer) id() (string, error) {
 func initStackitServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {
+		id, ok = conn(runtime).AssetObjectID("compute")
+	}
+	if !ok {
 		return args, nil, nil
 	}
 	c := conn(runtime)

--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -61,12 +61,15 @@ func (r *mqlStackitObjectStorageBucket) id() (string, error) {
 }
 
 func initStackitObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	v, ok := args["name"]
-	if !ok || v == nil {
-		return args, nil, nil
+	name := ""
+	if v, ok := args["name"]; ok && v != nil {
+		name, _ = v.Value.(string)
 	}
-	name, ok := v.Value.(string)
-	if !ok || name == "" {
+	if name == "" {
+		// Scope to the connected discovered bucket asset when no name is given.
+		name, _ = conn(runtime).AssetObjectID("object-storage")
+	}
+	if name == "" {
 		return args, nil, nil
 	}
 	c := conn(runtime)

--- a/providers/stackit/resources/ske.go
+++ b/providers/stackit/resources/ske.go
@@ -278,12 +278,15 @@ func (r *mqlStackitSkeCluster) id() (string, error) {
 }
 
 func initStackitSkeCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	v, ok := args["name"]
-	if !ok || v == nil {
-		return args, nil, nil
+	name := ""
+	if v, ok := args["name"]; ok && v != nil {
+		name, _ = v.Value.(string)
 	}
-	name, ok := v.Value.(string)
-	if !ok || name == "" {
+	if name == "" {
+		// Scope to the connected discovered SKE cluster asset when no name is given.
+		name, _ = conn(runtime).AssetObjectID("ske")
+	}
+	if name == "" {
 		return args, nil, nil
 	}
 	c := conn(runtime)


### PR DESCRIPTION
## What

Brings the STACKIT provider's asset detection up to parity with the GCP and AWS providers.

Previously `detect()` only set a generic name (`"STACKIT project <id>"`), a static platform, and the platform ID — even though the provider already fetched the full project (name, labels, parent) via the resource-manager API during `Verify()` and then discarded everything but the error. It also emitted `TechnologyUrlSegments: ["cloud","stackit","project"]`, which did not match the provider's own `AssetUrlTrees` (`technology=stackit → project`).

## Changes

**`connection/connection.go`**
- Capture project name / labels / parent from the `GetProject` response in `Verify()` via a new `captureProjectMetadata()` helper — **no extra API call**, it reuses the verification round-trip.
- Expose `ProjectName()`, `ProjectParent()`, `ProjectLabels()` accessors.
- `PlatformInfo()` now emits per-project `TechnologyUrlSegments: ["stackit", projectID]` (matching `AssetUrlTrees`, like GCP's `["gcp", projectID, …]` and AWS's `["aws", accountID, …]`) and titles the platform `"STACKIT Project <name>"`.

**`provider/provider.go`** — `detect()` now:
- Names the asset after the real project (falling back to the project ID).
- Attaches the project's own labels plus `mondoo.com/region` and `mondoo.com/parent-id`, reusing the existing `mondoo.com/*` label convention from the AWS provider.

**`connection/connection_test.go`** — added coverage for the URL segments, the project-name title (+ catalog fallback), and metadata capture (incl. nil-safety).

## Notes

- Scoped to enriching the connected **root** asset. A full sub-asset **discovery** phase (SKE clusters, IaaS servers, etc. as separate scannable assets) like GCP/AWS `Discover()` is a larger, separable follow-up.
- No `.lr` / codegen changes. `go build`, `go vet`, and the full module test suite pass.

---

## Update: sub-asset discovery (commit `d79bbd9b`)

Building on the root-asset enrichment above, this branch now also adds an **asset-discovery phase** so a scan brings in the project's resources as individual, scannable assets — the way the aws/gcp providers do — instead of only the project root.

- **`resources/discovery.go`** (new) — `Discover()` emits one `inventory.Asset` per resource: servers, SKE clusters, object-storage buckets, PostgreSQL/MongoDB/SQLServer Flex, OpenSearch, MariaDB, Redis, RabbitMQ, LogMe, Secrets Manager. Each sub-asset clones the project config `WithoutDiscovery` so it reconnects through the same connection without re-expanding. Targets that 404 (service not provisioned) are skipped quietly.
- **`connection`** — platform catalog gains a `stackit-object` entry per type, all in the `stackit` family; new `GetPlatformForObject` + `MondooObjectID` build each sub-asset's platform and stable platform ID with technology URL segments `{"stackit", projectID, service}`.
- **`config`** — declares the `--discover` targets and deepens `AssetUrlTrees` (`technology=stackit -> project -> service`).
- **`provider`** — `ParseCLI` defaults discovery to `auto`; `Connect` returns the project root plus discovered sub-assets.
- Unit tests for the platform/object-ID conversion and catalog consistency.

Verified: `go build`, `go vet`, tests pass; built+installed the provider and ran `cnspec scan stackit --discover all` live (clean run). Follow-up: discovered sub-assets are not yet scored by `mondoo-stackit-security` (its checks filter on `asset.platform == "stackit-project"`); per-asset check variants are the natural next step.
