### PR TITLE
🎉 release: patch bump 15 providers + minor bump stackit & nutanix

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.39.0",
+	Version:         "13.39.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.26.0",
+	Version: "13.26.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.6.3",
+	Version:         "13.6.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.3.7",
+	Version: "13.3.8",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipinfo",
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mondoo",
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
-	Version:         "13.1.8",
+	Version:         "13.1.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.8.2",
+	Version:         "13.8.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.1.3",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.2.3",
+	Version:         "13.2.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "13.1.13",
+	Version:         "13.1.14",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.3.4",
+	Version:         "13.3.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.2.1",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.3.4",
+	Version:         "13.3.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.0",
+	Version:   "13.3.1",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,

--- a/providers/together/config/config.go
+++ b/providers/together/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "together",
 	ID:              "go.mondoo.com/mql/providers/together",
-	Version:         "13.0.5",
+	Version:         "13.0.6",
 	Platforms:       provider.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
-	Version:         "13.0.18",
+	Version:         "13.0.19",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release bumps provider versions for the changes accumulated since each provider's last release.

## Version bumps

| Provider | From | To | Increment |
|---|---|---|---|
| aws | 13.39.0 | 13.39.1 | patch |
| gcp | 13.26.0 | 13.26.1 | patch |
| github | 13.6.3 | 13.6.4 | patch |
| gitlab | 13.3.7 | 13.3.8 | patch |
| ipinfo | 13.0.18 | 13.0.19 | patch |
| mondoo | 13.1.8 | 13.1.9 | patch |
| ms365 | 13.8.2 | 13.8.3 | patch |
| portainer | 13.0.0 | 13.0.1 | patch |
| shodan | 13.2.3 | 13.2.4 | patch |
| slack | 13.1.13 | 13.1.14 | patch |
| snowflake | 13.3.4 | 13.3.5 | patch |
| tailscale | 13.3.4 | 13.3.5 | patch |
| terraform | 13.3.0 | 13.3.1 | patch |
| together | 13.0.5 | 13.0.6 | patch |
| vcd | 13.0.18 | 13.0.19 | patch |
| **stackit** | 13.2.1 | **13.3.0** | **minor** |
| **nutanix** | 13.1.3 | **13.2.0** | **minor** |

## Changes since last release

### aws → 13.39.1
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)

### gcp → 13.26.1
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)

### github → 13.6.4
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)

### gitlab → 13.3.8
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)

### ipinfo → 13.0.19
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)

### mondoo → 13.1.9
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)

### ms365 → 13.8.3
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🐛 ms365: drop stale ms365 entry from static platform catalog (#8739)
- 🧹 Provide static platform support information across all providers (#8722)
- 🐛 ms365: report platform name microsoft365 consistently (#8735)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### portainer → 13.0.1
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### shodan → 13.2.4
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### slack → 13.1.14
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### snowflake → 13.3.5
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### tailscale → 13.3.5
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)

### terraform → 13.3.1
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)

### together → 13.0.6
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### vcd → 13.0.19
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)

### stackit → 13.3.0 (minor)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- ⭐ stackit: add resource creation-date fields (#8768)

### nutanix → 13.2.0 (minor)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- ⭐ nutanix: expose owner, project, and source provenance (#8770)
- 🧹 Provide static platform support information across all providers (#8722)
