### PR TITLE
🐛 portainer: virtualization technology URL + rename instance platform to portainer-server

### DIFF
--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -73,7 +73,7 @@ The address and access token can also be supplied through environment variables:
 	},
 	AssetUrlTrees: []*inventory.AssetUrlBranch{
 		{
-			PathSegments: []string{"technology=saas", "provider=portainer"},
+			PathSegments: []string{"technology=virtualization", "provider=portainer"},
 			Key:          "kind",
 			Title:        "Kind",
 			Values: map[string]*inventory.AssetUrlBranch{

--- a/providers/portainer/connection/platform.go
+++ b/providers/portainer/connection/platform.go
@@ -138,7 +138,7 @@ func InstancePlatform() *inventory.Platform {
 		Kind:                  "api",
 		Runtime:               "portainer",
 		Title:                 "Portainer",
-		TechnologyUrlSegments: []string{"saas", "portainer", "instance"},
+		TechnologyUrlSegments: []string{"virtualization", "portainer", "instance"},
 	}
 }
 
@@ -149,7 +149,7 @@ func EnvironmentPlatform(envType int64) *inventory.Platform {
 		Kind:                  "api",
 		Runtime:               "portainer",
 		Title:                 "Portainer Environment (" + EnvironmentType(envType) + ")",
-		TechnologyUrlSegments: []string{"saas", "portainer", "environment"},
+		TechnologyUrlSegments: []string{"virtualization", "portainer", "environment"},
 	}
 }
 


### PR DESCRIPTION
## What

Two related platform-naming changes for the Portainer provider:

1. **Technology classification** — moves the Portainer instance and environment assets from the `saas` technology URL segment to `virtualization`, in both `TechnologyUrlSegments` (`connection/platform.go`) and the `AssetUrlTrees` path segment (`config/config.go`).

2. **Instance platform rename** — renames the connected root asset's platform from `portainer` to `portainer-server`, matching Portainer's own Server-vs-Agent vocabulary and paralleling the `portainer-environment` child assets. This updates the platform `Name` (`portainer-server`), `Title` (`Portainer Server`), and the default asset label.

## Why

- Portainer is a container/Kubernetes environment management plane, so it belongs under `virtualization` rather than `saas`.
- "Portainer Server" is Portainer's actual term for the central install (as opposed to the Agent / Edge Agent that run on each managed environment). `portainer-server` / `portainer-environment` mirrors that model.

## Compatibility

The platform ID format (`.../instance/<id>`) and the MQL resource name (`portainer`) are unchanged, so asset identity and existing queries are unaffected. The generated `dist/portainer.json` is gitignored and regenerated by the dist build.