### PR TITLE
🧹 portainer: mark provider as experimental

### DIFF
--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers/portainer/connection"
 	"go.mondoo.com/mql/v13/providers/portainer/provider"
 )
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
 	Version:         "13.0.1",
+	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
## What

Sets `Maturity: resources.MaturityExperimental` on the Portainer provider config.

## Why

The Portainer provider is still early-stage (environment sub-assets are discovered but not yet workload-scanned), so it should carry the experimental maturity flag like the other early providers (`bicep`, `helm`, `kustomize`).