### PR TITLE
🐛 portainer: rename instance platform to portainer-server

### DIFF
--- a/providers/portainer/connection/platform.go
+++ b/providers/portainer/connection/platform.go
@@ -133,11 +133,11 @@ func MembershipRole(r int64) string {
 
 func InstancePlatform() *inventory.Platform {
 	return &inventory.Platform{
-		Name:                  "portainer",
+		Name:                  "portainer-server",
 		Family:                []string{"portainer"},
 		Kind:                  "api",
 		Runtime:               "portainer",
-		Title:                 "Portainer",
+		Title:                 "Portainer Server",
 		TechnologyUrlSegments: []string{"virtualization", "portainer", "instance"},
 	}
 }

--- a/providers/portainer/provider/provider.go
+++ b/providers/portainer/provider/provider.go
@@ -147,12 +147,12 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.PortainerConne
 		return nil
 	}
 
-	// keep a user-provided asset name; otherwise label it "Portainer <hostname>"
-	// (falling back to plain "Portainer" when the hostname is unknown)
+	// keep a user-provided asset name; otherwise label it "Portainer Server <hostname>"
+	// (falling back to plain "Portainer Server" when the hostname is unknown)
 	if asset.Name == "" {
-		asset.Name = "Portainer"
+		asset.Name = "Portainer Server"
 		if h := conn.Hostname(); h != "" {
-			asset.Name = "Portainer " + h
+			asset.Name = "Portainer Server " + h
 		}
 	}
 	asset.Platform = connection.InstancePlatform()


### PR DESCRIPTION
## What

Renames the Portainer provider's connected root asset platform from `portainer` to `portainer-server`:
- platform `Name` → `portainer-server`
- platform `Title` → `Portainer Server`
- default asset label → `Portainer Server <hostname>`

## Why

"Portainer Server" is Portainer's own term for the central install, as distinct from the Agent / Edge Agent that run on each managed environment. `portainer-server` / `portainer-environment` mirrors that Server-vs-environment model.

## Compatibility

The platform ID format (`.../instance/<id>`) and the MQL resource name (`portainer`) are unchanged, so asset identity and existing queries are unaffected.

## Context

This change was originally committed onto #8806's branch but landed after that PR squash-merged, so it never reached main. This PR re-applies it off fresh main.