### PR TITLE
🎉 gcp-13.27.0, portainer-13.1.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.26.1",
+	Version: "13.27.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
-	Version:         "13.0.1",
+	Version:         "13.1.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the **gcp** and **portainer** providers.

## gcp — 13.26.1 → 13.27.0

Promotes the feature work already merged in the `13.26.x` line to a proper minor release:

- ⭐ gcp: expose source, hierarchy, and build provenance (#8772)
- ⭐ gcp: add creation timestamps where the SDK exposes them (#8761)
- 🧹 gcp: storage tag support (#8800)
- 🧹 Use root provider directory for GCP to infer permissions (#8801)

## portainer — 13.0.1 → 13.1.0

Changes since the last release:

- 🐛 portainer: rename instance platform to portainer-server (#8808)
- 🧹 portainer: mark provider as experimental (#8807)
- 🐛 portainer: classify under virtualization technology URL (#8806)
