### PR TITLE
feat(logger): support GCP log labels in gcp-json and stackdriver

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -30,14 +30,44 @@ func UseJSONLogging(out io.Writer) {
 	log.Logger = zerolog.New(out).With().Caller().Timestamp().Logger()
 }
 
+// GCPLogOption configures UseGCPJSONLogging.
+type GCPLogOption func(*gcpLogOptions)
+
+type gcpLogOptions struct {
+	labels map[string]string
+}
+
+// WithGCPLabels attaches static key/value labels to every log entry under the
+// special "logging.googleapis.com/labels" field. Cloud Logging lifts that field
+// into LogEntry.labels, so the labels can be filtered as `labels.<key>` in the
+// Logs Explorer. Mirrors stackdriver.WithLabels for the stdout JSON path.
+func WithGCPLabels(labels map[string]string) GCPLogOption {
+	return func(o *gcpLogOptions) { o.labels = labels }
+}
+
 // UseGCPJSONLogging for global logger. This is a JSON logger
 // with field names GCP will recognize
-func UseGCPJSONLogging(out io.Writer) {
+func UseGCPJSONLogging(out io.Writer, opts ...GCPLogOption) {
+	o := &gcpLogOptions{}
+	for _, fn := range opts {
+		if fn != nil {
+			fn(o)
+		}
+	}
+
 	zerolog.LevelFieldName = "severity"
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
-	log.Logger = zerolog.New(out).With().Caller().Timestamp().Logger()
+	logCtx := zerolog.New(out).With().Caller().Timestamp()
+	if len(o.labels) > 0 {
+		labels := zerolog.Dict()
+		for k, v := range o.labels {
+			labels = labels.Str(k, v)
+		}
+		logCtx = logCtx.Dict("logging.googleapis.com/labels", labels)
+	}
+	log.Logger = logCtx.Logger()
 }
 
 // CliLogger sets the global logger to the console logger with color

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -5,6 +5,7 @@ package logger
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -37,5 +38,42 @@ func TestUseGCPJSONLogging_IncludesCaller(t *testing.T) {
 
 	if !strings.Contains(buf.String(), `"caller"`) {
 		t.Errorf("expected a caller field in the gcp json log, got %q", buf.String())
+	}
+}
+
+func TestUseGCPJSONLogging_WithLabels(t *testing.T) {
+	saved := log.Logger
+	t.Cleanup(func() { log.Logger = saved })
+
+	var buf bytes.Buffer
+	UseGCPJSONLogging(&buf, WithGCPLabels(map[string]string{"project_id": "scanned-proj", "scan_type": "gcp"}))
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Info().Msg("hello")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("log line is not valid json: %v (%q)", err, buf.String())
+	}
+	// Cloud Logging lifts this special field into LogEntry.labels.
+	labels, ok := entry["logging.googleapis.com/labels"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a logging.googleapis.com/labels object, got %v", entry["logging.googleapis.com/labels"])
+	}
+	if labels["project_id"] != "scanned-proj" || labels["scan_type"] != "gcp" {
+		t.Errorf("unexpected labels: %v", labels)
+	}
+}
+
+func TestUseGCPJSONLogging_NoLabelsByDefault(t *testing.T) {
+	saved := log.Logger
+	t.Cleanup(func() { log.Logger = saved })
+
+	var buf bytes.Buffer
+	UseGCPJSONLogging(&buf)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Info().Msg("hello")
+
+	if strings.Contains(buf.String(), "logging.googleapis.com/labels") {
+		t.Errorf("did not expect a labels field without WithGCPLabels, got %q", buf.String())
 	}
 }

--- a/logger/loggerconf/loggerconf.go
+++ b/logger/loggerconf/loggerconf.go
@@ -28,6 +28,11 @@ type LoggingConfig struct {
 	// "format" (json|gcp-json); for "stackdriver" it is "project-id" and
 	// "log-id".
 	Options map[string]string `json:"options,omitempty" mapstructure:"options"`
+	// Labels are static key/value labels attached to every log entry, surfaced
+	// as Cloud Logging LogEntry.labels (filterable as `labels.<key>`). Applied
+	// by the GCP-aware sinks: the "gcp-json" cli format and the "stackdriver"
+	// writer; ignored by the plain "json" and console formats.
+	Labels map[string]string `json:"labels,omitempty" mapstructure:"labels"`
 }
 
 // Load reads a LoggingConfig from a YAML or JSON file at the given path.
@@ -62,7 +67,11 @@ func Configure(opts *LoggingConfig) error {
 	case "", "cli":
 		switch opts.Options["format"] {
 		case "gcp-json":
-			logger.UseGCPJSONLogging(logger.LogOutputWriter)
+			var gcpOpts []logger.GCPLogOption
+			if len(opts.Labels) > 0 {
+				gcpOpts = append(gcpOpts, logger.WithGCPLabels(opts.Labels))
+			}
+			logger.UseGCPJSONLogging(logger.LogOutputWriter, gcpOpts...)
 		case "json":
 			logger.UseJSONLogging(logger.LogOutputWriter)
 		default:
@@ -83,7 +92,11 @@ func Configure(opts *LoggingConfig) error {
 			return fmt.Errorf("stackdriver logging requires a `log-id` option")
 		}
 
-		w, err := stackdriver.NewStackdriverWriter(projectID, logID)
+		var sdOpts []stackdriver.Option
+		if len(opts.Labels) > 0 {
+			sdOpts = append(sdOpts, stackdriver.WithLabels(opts.Labels))
+		}
+		w, err := stackdriver.NewStackdriverWriter(projectID, logID, sdOpts...)
 		if err != nil {
 			return fmt.Errorf("could not initialize stackdriver logger: %w", err)
 		}

--- a/logger/loggerconf/loggerconf_test.go
+++ b/logger/loggerconf/loggerconf_test.go
@@ -134,3 +134,36 @@ func TestLoad(t *testing.T) {
 		t.Fatal("expected an error for a missing file")
 	}
 }
+
+func TestLoad_Labels(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logging.yaml")
+	yaml := "writer: cli\noptions:\n  format: gcp-json\nlabels:\n  project_id: scanned-proj\n  scan_type: gcp\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Labels["project_id"] != "scanned-proj" || opts.Labels["scan_type"] != "gcp" {
+		t.Errorf("unexpected labels parsed from yaml: %+v", opts.Labels)
+	}
+}
+
+func TestConfigure_GcpJSONWithLabels(t *testing.T) {
+	clearEnvLevel(t)
+	err := Configure(&LoggingConfig{
+		Writer:  "cli",
+		Level:   "info",
+		Options: map[string]string{"format": "gcp-json"},
+		Labels:  map[string]string{"project_id": "scanned-proj"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := logger.GetLevel(); got != "info" {
+		t.Errorf("expected level info, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a `labels` field to `loggerconf.LoggingConfig`, applied by the GCP-aware sinks so log entries carry static labels that surface as Cloud Logging `LogEntry.labels` — filterable as `labels.<key>` in the Logs Explorer:

- **`gcp-json` (cli format)** — attaches them under the special `logging.googleapis.com/labels` field, which Cloud Logging lifts into `LogEntry.labels`.
- **`stackdriver` writer** — forwards them via the existing `stackdriver.WithLabels`.

`UseGCPJSONLogging` gains an option pattern (`WithGCPLabels`), mirroring `stackdriver.WithLabels`; the no-option call site is unchanged (variadic, non-breaking).

## Why

So a serverless scan job (which scans one project per execution) can tag its cnspec logs with e.g. the scanned project id and filter on it — wired through `--logging-config` (cnspec #2957) without any per-line `jsonPayload` substring matching.

Config example:
```yaml
writer: cli
options:
  format: gcp-json
labels:
  project_id: scanned-proj-123
  scan_type: gcp
```

## Tests

- `UseGCPJSONLogging_WithLabels` — asserts the `logging.googleapis.com/labels` object round-trips.
- `UseGCPJSONLogging_NoLabelsByDefault` — no labels field without the option (backward compat).
- `loggerconf` `TestLoad_Labels` + `TestConfigure_GcpJSONWithLabels`.

`go build`/`vet`/`test`/`gofmt` clean for the logger packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)