### PR TITLE
🧹 portainer: rename "Portainer instance" to "Portainer server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.c
 | OpenAI account                | `openai`                   | `mql shell openai --token TOKEN`                                                                                                                |
 | Oracle Cloud Interface (OCI)  | `oci`                      | `mql shell oci`                                                                                                                                 |
 | OpenStack project             | `openstack`                | `mql shell openstack --cloud CLOUD_NAME` or<br></br>`mql shell openstack --auth-url AUTH_URL --username USER --password PASSWORD --project-name PROJECT` |
-| Portainer instance            | `portainer`                | `mql shell portainer HOST --access-token TOKEN`                                                                                                 |
+| Portainer server              | `portainer`                | `mql shell portainer HOST --access-token TOKEN`                                                                                                 |
 | Proxmox VE                    | `proxmox`                  | `mql shell proxmox --host HOST --token TOKEN`                                                                                                   |
 | Palo Alto Networks PAN-OS     | `panos`                    | `mql shell panos --hostname DEVICE_IP --username admin --password PASSWORD`                                                                     |
 | Running containers            | `docker`                   | `mql shell docker CONTAINER_ID`                                                                                                                 |

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -762,7 +762,7 @@ var DefaultProviders Providers = map[string]*Provider{
 				{
 					Name:  "portainer",
 					Use:   "portainer",
-					Short: "a Portainer instance",
+					Short: "a Portainer server",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Renames the user-facing "Portainer instance" label to "Portainer server", following up on the recent instance → `portainer-server` platform rename (#8808).

## Changes

- `providers/defaults.go` — provider short description: `a Portainer instance` → `a Portainer server`
- `README.md` — connection table row label (column alignment preserved)