### PR TITLE
🟢 gcp: map EffectiveTagBindingCollections.Get to a real IAM permission

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1316,6 +1316,12 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// Tag bindings are listed via the resourceTagBindings permission, not a
 		// "resourcemanager.tagBindings.list" form (which is not a real permission).
 		"TagBindings.List": "resourcemanager.resourceTagBindings.list",
+		// Reading effective tag binding collections on a resource is governed by
+		// that resource's listEffectiveTags permission (we only call it for
+		// storage buckets in storage.go), not the auto-derived
+		// "resourcemanager.effectiveTagBindingCollections.get" (not a real
+		// permission).
+		"EffectiveTagBindingCollections.Get": "storage.buckets.listEffectiveTags",
 	},
 }
 

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.26.0",
-  "generated_at": "2026-06-29T23:43:33-07:00",
+  "version": "13.27.0",
+  "generated_at": "2026-06-30T09:47:52-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -234,7 +234,6 @@
     "redis.backups.list",
     "redis.clusters.list",
     "redis.instances.list",
-    "resourcemanager.effectiveTagBindingCollections.get",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.resourceTagBindings.list",
@@ -262,6 +261,7 @@
     "storage.buckets.get",
     "storage.buckets.getIamPolicy",
     "storage.buckets.list",
+    "storage.buckets.listEffectiveTags",
     "workflows.workflows.list"
   ],
   "details": [
@@ -1707,12 +1707,6 @@
       "source_file": "redis.go"
     },
     {
-      "permission": "resourcemanager.effectiveTagBindingCollections.get",
-      "service": "resourcemanager",
-      "action": "EffectiveTagBindingCollections.Get",
-      "source_file": "storage.go"
-    },
-    {
       "permission": "resourcemanager.folders.get",
       "service": "resourcemanager",
       "action": "Folders.Get",
@@ -1934,6 +1928,12 @@
       "permission": "storage.buckets.list",
       "service": "storage",
       "action": "Buckets.List",
+      "source_file": "storage.go"
+    },
+    {
+      "permission": "storage.buckets.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTagBindingCollections.Get",
       "source_file": "storage.go"
     },
     {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -300,6 +300,7 @@ var validatedGCPPermissions = []string{
 	"storage.buckets.get",
 	"storage.buckets.getIamPolicy",
 	"storage.buckets.list",
+	"storage.buckets.listEffectiveTags",
 	"workflows.workflows.list",
 }
 


### PR DESCRIPTION
## Problem

`main` CI is red. The **Code Test → go-test** job fails on `TestGCPPermissionsMatchValidatedList`:

```
unexpected permissions in manifest (not in validated list):
  - resourcemanager.effectiveTagBindingCollections.get
```

## Root cause

PR #8800 added an `EffectiveTagBindingCollections.Get` call in `storage.go` to read bucket tags and regenerated `gcp.permissions.json`. The permission scanner derives IAM permission strings heuristically from SDK method paths, so it emitted `resourcemanager.effectiveTagBindingCollections.get` from the `cloudresourcemanager` REST method path.

That string is **not a real GCP IAM permission** — confirmed absent from `gcloud iam list-testable-permissions` (there are zero `resourcemanager.*tag*` permissions). GCP enforces effective-tag reads with the **target resource's own** `listEffectiveTags` permission, i.e. `storage.buckets.listEffectiveTags` (verified present in the testable list).

Because the derived name was bogus, it was never added to the human-validated list, and the test — which compares the committed manifest against that list — broke.

## Fix

- Add a `gcpPermissionOverrides` entry mapping `resourcemanager` / `EffectiveTagBindingCollections.Get` → `storage.buckets.listEffectiveTags`.
- Regenerate `gcp.permissions.json` (also picks up the now-current `13.27.0` provider version, which the release commit had left stale at `13.26.0`).
- Add `storage.buckets.listEffectiveTags` to `validatedGCPPermissions`.

## Verification

```
$ go test -run TestGCPPermissionsMatchValidatedList ./providers/gcp/resources/...
ok  	go.mondoo.com/mql/v13/providers/gcp/resources	1.106s
```

Permission verified against the live IAM API on a real project, per the test's documented validation workflow.