### PR TITLE
✨ aws: add eventTargets source-to-target lineage to eventbridge rules

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7984,8 +7984,49 @@ private aws.eventbridge.rule @defaults("arn name state") {
   iamRole() aws.iam.role
   // Tags for the rule
   tags() map[string]string
-  // Targets for this rule
-  targets() []dict
+  // Raw target records for this rule
+  //
+  // Deprecated in favor of eventTargets, which exposes each target as a
+  // structured resource with typed references to its destination role and
+  // dead-letter queue.
+  targets() @maturity("deprecated") []dict
+  // Targets that matched events are delivered to
+  eventTargets() []aws.eventbridge.rule.target
+}
+
+// Amazon EventBridge rule target
+//
+// Destination that a rule delivers matched events to, tracing the source
+// rule through to the resource that receives the event. Select by `id`, the
+// target identifier unique within the rule. `arn` is the destination
+// resource (a Lambda function, SNS topic, SQS queue, Kinesis stream, ECS
+// task, Step Functions state machine, and so on); `iamRole` is the role
+// EventBridge assumes to invoke it. `deadLetterQueue` and the retry settings
+// describe delivery reliability, while `input`, `inputPath`, and
+// `inputTransformer` describe how the event payload is shaped before
+// delivery.
+private aws.eventbridge.rule.target @defaults("id arn") {
+  // Target identifier, unique within the rule
+  id string
+  // ARN of the destination resource events are delivered to
+  arn string
+  // IAM role EventBridge assumes to invoke the target
+  iamRole() aws.iam.role
+  // Constant JSON text passed to the target instead of the matched event
+  input string
+  // JSONPath used to extract part of the matched event to pass to the target
+  inputPath string
+  // Input transformer that reshapes the event before it reaches the target
+  //
+  // Holds `inputTemplate` and the `inputPathsMap` of named JSONPath extractions
+  // the template references.
+  inputTransformer dict
+  // Dead-letter queue that receives events that fail delivery to the target
+  deadLetterQueue() aws.sqs.queue
+  // Maximum number of times to retry delivery to the target
+  retryMaxAttempts int
+  // Maximum age of an event, in seconds, that will still be delivered
+  retryMaxEventAgeSeconds int
 }
 
 // Amazon EventBridge connection

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -318,6 +318,7 @@ const (
 	ResourceAwsEventbridge                                                      string = "aws.eventbridge"
 	ResourceAwsEventbridgeEventBus                                              string = "aws.eventbridge.eventBus"
 	ResourceAwsEventbridgeRule                                                  string = "aws.eventbridge.rule"
+	ResourceAwsEventbridgeRuleTarget                                            string = "aws.eventbridge.rule.target"
 	ResourceAwsEventbridgeConnection                                            string = "aws.eventbridge.connection"
 	ResourceAwsEventbridgeApiDestination                                        string = "aws.eventbridge.apiDestination"
 	ResourceAwsEventbridgeArchive                                               string = "aws.eventbridge.archive"
@@ -2131,6 +2132,10 @@ func init() {
 		"aws.eventbridge.rule": {
 			// to override args, implement: initAwsEventbridgeRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsEventbridgeRule,
+		},
+		"aws.eventbridge.rule.target": {
+			// to override args, implement: initAwsEventbridgeRuleTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsEventbridgeRuleTarget,
 		},
 		"aws.eventbridge.connection": {
 			Init:   initAwsEventbridgeConnection,
@@ -13635,6 +13640,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eventbridge.rule.targets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeRule).GetTargets()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.eventbridge.rule.eventTargets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRule).GetEventTargets()).ToDataRes(types.Array(types.Resource("aws.eventbridge.rule.target")))
+	},
+	"aws.eventbridge.rule.target.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetId()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.rule.target.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetArn()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.rule.target.iamRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
+	"aws.eventbridge.rule.target.input": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetInput()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.rule.target.inputPath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetInputPath()).ToDataRes(types.String)
+	},
+	"aws.eventbridge.rule.target.inputTransformer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetInputTransformer()).ToDataRes(types.Dict)
+	},
+	"aws.eventbridge.rule.target.deadLetterQueue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetDeadLetterQueue()).ToDataRes(types.Resource("aws.sqs.queue"))
+	},
+	"aws.eventbridge.rule.target.retryMaxAttempts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetRetryMaxAttempts()).ToDataRes(types.Int)
+	},
+	"aws.eventbridge.rule.target.retryMaxEventAgeSeconds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEventbridgeRuleTarget).GetRetryMaxEventAgeSeconds()).ToDataRes(types.Int)
 	},
 	"aws.eventbridge.connection.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEventbridgeConnection).GetArn()).ToDataRes(types.String)
@@ -46176,6 +46211,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.eventbridge.rule.targets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEventbridgeRule).Targets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.eventTargets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRule).EventTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.eventbridge.rule.target.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.input": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).Input, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.inputPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).InputPath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.inputTransformer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).InputTransformer, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.deadLetterQueue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).DeadLetterQueue, ok = plugin.RawToTValue[*mqlAwsSqsQueue](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.retryMaxAttempts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).RetryMaxAttempts, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.eventbridge.rule.target.retryMaxEventAgeSeconds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEventbridgeRuleTarget).RetryMaxEventAgeSeconds, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.eventbridge.connection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -109399,6 +109478,7 @@ type mqlAwsEventbridgeRule struct {
 	IamRole            plugin.TValue[*mqlAwsIamRole]
 	Tags               plugin.TValue[map[string]any]
 	Targets            plugin.TValue[[]any]
+	EventTargets       plugin.TValue[[]any]
 }
 
 // createAwsEventbridgeRule creates a new instance of this resource
@@ -109495,6 +109575,130 @@ func (c *mqlAwsEventbridgeRule) GetTargets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Targets, func() ([]any, error) {
 		return c.targets()
 	})
+}
+
+func (c *mqlAwsEventbridgeRule) GetEventTargets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EventTargets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eventbridge.rule", c.__id, "eventTargets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.eventTargets()
+	})
+}
+
+// mqlAwsEventbridgeRuleTarget for the aws.eventbridge.rule.target resource
+type mqlAwsEventbridgeRuleTarget struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAwsEventbridgeRuleTargetInternal
+	Id                      plugin.TValue[string]
+	Arn                     plugin.TValue[string]
+	IamRole                 plugin.TValue[*mqlAwsIamRole]
+	Input                   plugin.TValue[string]
+	InputPath               plugin.TValue[string]
+	InputTransformer        plugin.TValue[any]
+	DeadLetterQueue         plugin.TValue[*mqlAwsSqsQueue]
+	RetryMaxAttempts        plugin.TValue[int64]
+	RetryMaxEventAgeSeconds plugin.TValue[int64]
+}
+
+// createAwsEventbridgeRuleTarget creates a new instance of this resource
+func createAwsEventbridgeRuleTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsEventbridgeRuleTarget{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.eventbridge.rule.target", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) MqlName() string {
+	return "aws.eventbridge.rule.target"
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.IamRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eventbridge.rule.target", c.__id, "iamRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.iamRole()
+	})
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetInput() *plugin.TValue[string] {
+	return &c.Input
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetInputPath() *plugin.TValue[string] {
+	return &c.InputPath
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetInputTransformer() *plugin.TValue[any] {
+	return &c.InputTransformer
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetDeadLetterQueue() *plugin.TValue[*mqlAwsSqsQueue] {
+	return plugin.GetOrCompute[*mqlAwsSqsQueue](&c.DeadLetterQueue, func() (*mqlAwsSqsQueue, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eventbridge.rule.target", c.__id, "deadLetterQueue")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsSqsQueue), nil
+			}
+		}
+
+		return c.deadLetterQueue()
+	})
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetRetryMaxAttempts() *plugin.TValue[int64] {
+	return &c.RetryMaxAttempts
+}
+
+func (c *mqlAwsEventbridgeRuleTarget) GetRetryMaxEventAgeSeconds() *plugin.TValue[int64] {
+	return &c.RetryMaxEventAgeSeconds
 }
 
 // mqlAwsEventbridgeConnection for the aws.eventbridge.connection resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4771,6 +4771,7 @@ aws.eventbridge.rule.arn 11.16.1
 aws.eventbridge.rule.description 11.16.1
 aws.eventbridge.rule.eventBusName 11.16.1
 aws.eventbridge.rule.eventPattern 11.16.1
+aws.eventbridge.rule.eventTargets 13.39.2
 aws.eventbridge.rule.iamRole 13.0.2
 aws.eventbridge.rule.name 11.16.1
 aws.eventbridge.rule.region 11.16.1
@@ -4778,6 +4779,16 @@ aws.eventbridge.rule.roleArn 11.16.1
 aws.eventbridge.rule.scheduleExpression 11.16.1
 aws.eventbridge.rule.state 11.16.1
 aws.eventbridge.rule.tags 11.16.1
+aws.eventbridge.rule.target 13.39.2
+aws.eventbridge.rule.target.arn 13.39.2
+aws.eventbridge.rule.target.deadLetterQueue 13.39.2
+aws.eventbridge.rule.target.iamRole 13.39.2
+aws.eventbridge.rule.target.id 13.39.2
+aws.eventbridge.rule.target.input 13.39.2
+aws.eventbridge.rule.target.inputPath 13.39.2
+aws.eventbridge.rule.target.inputTransformer 13.39.2
+aws.eventbridge.rule.target.retryMaxAttempts 13.39.2
+aws.eventbridge.rule.target.retryMaxEventAgeSeconds 13.39.2
 aws.eventbridge.rule.targets 11.16.1
 aws.eventbridge.rules 11.16.1
 aws.eventbridge.schedule 13.1.1

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.38.1",
-  "generated_at": "2026-06-26T19:15:04-07:00",
+  "version": "13.39.1",
+  "generated_at": "2026-06-30T23:48:59+02:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_eventbridge.go
+++ b/providers/aws/resources/aws_eventbridge.go
@@ -5,7 +5,9 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridge_types "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/rs/zerolog/log"
@@ -252,7 +254,9 @@ func (a *mqlAwsEventbridgeRule) tags() (map[string]any, error) {
 	return tags, nil
 }
 
-func (a *mqlAwsEventbridgeRule) targets() ([]any, error) {
+// listTargets fetches every target for the rule, paginating as needed. It
+// backs both the deprecated targets() dict view and the typed eventTargets().
+func (a *mqlAwsEventbridgeRule) listTargets() ([]eventbridge_types.Target, error) {
 	ruleName := a.Name.Data
 	busName := a.EventBusName.Data
 	region := a.Region.Data
@@ -278,10 +282,117 @@ func (a *mqlAwsEventbridgeRule) targets() ([]any, error) {
 		}
 		nextToken = resp.NextToken
 	}
+	return allTargets, nil
+}
 
-	targets, err := convert.JsonToDictSlice(allTargets)
+// Deprecated: use eventTargets(). Retained for backwards compatibility.
+func (a *mqlAwsEventbridgeRule) targets() ([]any, error) {
+	allTargets, err := a.listTargets()
 	if err != nil {
 		return nil, err
 	}
-	return targets, nil
+	return convert.JsonToDictSlice(allTargets)
+}
+
+func (a *mqlAwsEventbridgeRule) eventTargets() ([]any, error) {
+	region := a.Region.Data
+	ruleArn := a.Arn.Data
+
+	allTargets, err := a.listTargets()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]any, 0, len(allTargets))
+	for _, t := range allTargets {
+		var inputTransformer any
+		if t.InputTransformer != nil {
+			d, err := convert.JsonToDict(t.InputTransformer)
+			if err != nil {
+				return nil, err
+			}
+			inputTransformer = d
+		}
+
+		var retryMaxAttempts, retryMaxEventAgeSeconds *int64
+		if t.RetryPolicy != nil {
+			retryMaxAttempts = int32PtrToInt64Ptr(t.RetryPolicy.MaximumRetryAttempts)
+			retryMaxEventAgeSeconds = int32PtrToInt64Ptr(t.RetryPolicy.MaximumEventAgeInSeconds)
+		}
+
+		mqlTarget, err := CreateResource(a.MqlRuntime, "aws.eventbridge.rule.target",
+			map[string]*llx.RawData{
+				// Target.Id is only unique within the rule, so qualify the cache
+				// key with the rule ARN while exposing the plain id as a field.
+				"__id":                    llx.StringData(ruleArn + "/" + convert.ToValue(t.Id)),
+				"id":                      llx.StringDataPtr(t.Id),
+				"arn":                     llx.StringDataPtr(t.Arn),
+				"input":                   llx.StringDataPtr(t.Input),
+				"inputPath":               llx.StringDataPtr(t.InputPath),
+				"inputTransformer":        llx.DictData(inputTransformer),
+				"retryMaxAttempts":        llx.IntDataPtr(retryMaxAttempts),
+				"retryMaxEventAgeSeconds": llx.IntDataPtr(retryMaxEventAgeSeconds),
+			})
+		if err != nil {
+			return nil, err
+		}
+		mqlTargetRes := mqlTarget.(*mqlAwsEventbridgeRuleTarget)
+		mqlTargetRes.region = region
+		mqlTargetRes.cacheRoleArn = t.RoleArn
+		if t.DeadLetterConfig != nil {
+			mqlTargetRes.cacheDeadLetterArn = t.DeadLetterConfig.Arn
+		}
+		res = append(res, mqlTargetRes)
+	}
+	return res, nil
+}
+
+func int32PtrToInt64Ptr(v *int32) *int64 {
+	if v == nil {
+		return nil
+	}
+	i := int64(*v)
+	return &i
+}
+
+type mqlAwsEventbridgeRuleTargetInternal struct {
+	region             string
+	cacheRoleArn       *string
+	cacheDeadLetterArn *string
+}
+
+func (a *mqlAwsEventbridgeRuleTarget) iamRole() (*mqlAwsIamRole, error) {
+	if a.cacheRoleArn == nil || *a.cacheRoleArn == "" {
+		a.IamRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheRoleArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
+}
+
+func (a *mqlAwsEventbridgeRuleTarget) deadLetterQueue() (*mqlAwsSqsQueue, error) {
+	if a.cacheDeadLetterArn == nil || *a.cacheDeadLetterArn == "" {
+		a.DeadLetterQueue.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	parsedArn, err := arn.Parse(*a.cacheDeadLetterArn)
+	if err != nil {
+		return nil, err
+	}
+	// "https://sqs.us-east-1.amazonaws.com/921877552404/my-queue"
+	url := fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", parsedArn.Region, parsedArn.AccountID, parsedArn.Resource)
+	q, err := NewResource(a.MqlRuntime, "aws.sqs.queue",
+		map[string]*llx.RawData{
+			"arn":    llx.StringDataPtr(a.cacheDeadLetterArn),
+			"url":    llx.StringData(url),
+			"region": llx.StringData(parsedArn.Region),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return q.(*mqlAwsSqsQueue), nil
 }


### PR DESCRIPTION
## What

Adds a typed `aws.eventbridge.rule.target` sub-resource so a rule can be traced through to the resources it delivers matched events to. Exposed on the rule as a new **`eventTargets()`** field.

The rule already surfaces the **source** side (`eventPattern`, `scheduleExpression`, `eventBusName`), but its **targets** were only available as a raw `targets() []dict`, so the destination, the invoking role, and the dead-letter queue could not be traversed.

### `aws.eventbridge.rule.target`

| Field | Type | Source |
|---|---|---|
| `id` | `string` | target id, unique within the rule |
| `arn` | `string` | destination resource ARN |
| `iamRole` | `aws.iam.role` | role EventBridge assumes to invoke the target |
| `deadLetterQueue` | `aws.sqs.queue` | DLQ for failed deliveries |
| `retryMaxAttempts` | `int` | retry policy |
| `retryMaxEventAgeSeconds` | `int` | retry policy |
| `input` / `inputPath` / `inputTransformer` | `string` / `string` / `dict` | event payload shaping |

`arn` is kept a raw string deliberately — an EventBridge target can be any of ~20 service types (Lambda, SNS, SQS, Kinesis, ECS, Step Functions, …), so there is no single resource type to point at. `iamRole` and `deadLetterQueue` are always one type each, so those are typed references resolved via `NewResource`.

## Backwards compatibility

The existing `targets() []dict` is **retained** and marked `@maturity("deprecated")` — no consumer breaks. Both `targets()` and `eventTargets()` share a single `ListTargetsByRule` fetch, so there is no extra API cost. The deprecated field keeps its original `.lr.versions` entry (`11.16.1`); only `eventTargets` and the new sub-resource fields are versioned at `13.39.2`.

## Why

`targets()` forced dict digging with no way to follow the edge. Now:

```mql
aws.eventbridge.rules.where(state == "ENABLED").
  all(eventTargets.all(iamRole != null))
```

and a rule traces cleanly to its destination role and dead-letter queue.

## Verification

Built and installed the provider; ran against live AWS. A rule's `eventTargets` resolves the destination `arn` and the invoking IAM role through the typed reference (`iamRole.name`), and the deprecated `targets()` dict output is unchanged. `aws.permissions.json` shows only a version/timestamp metadata bump (no new IAM permissions).