### PR TITLE
✨ aws: add logging start/stop provenance to aws.cloudtrail.trail

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9930,6 +9930,13 @@ private aws.cloudtrail.trail @defaults("name region") {
   hasCustomEventSelectors bool
   // Whether logging is currently enabled for the trail
   isLogging() bool
+  // Time logging was most recently started for the trail
+  startLoggingAt() time
+  // Time logging was most recently stopped for the trail
+  //
+  // A non-null value on a trail that is currently logging indicates capture was
+  // interrupted at some point, leaving a gap in the recorded event history.
+  stoppedLoggingAt() time
   // Tags associated with the trail
   tags() map[string]string
   // Time of the most recent delivery of log files to the trail's S3 bucket

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -15526,6 +15526,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudtrail.trail.isLogging": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetIsLogging()).ToDataRes(types.Bool)
 	},
+	"aws.cloudtrail.trail.startLoggingAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetStartLoggingAt()).ToDataRes(types.Time)
+	},
+	"aws.cloudtrail.trail.stoppedLoggingAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetStoppedLoggingAt()).ToDataRes(types.Time)
+	},
 	"aws.cloudtrail.trail.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -49024,6 +49030,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudtrail.trail.isLogging": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudtrailTrail).IsLogging, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.startLoggingAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).StartLoggingAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.stoppedLoggingAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).StoppedLoggingAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.cloudtrail.trail.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -117381,6 +117395,8 @@ type mqlAwsCloudtrailTrail struct {
 	InsightSelectorEntries               plugin.TValue[[]any]
 	HasCustomEventSelectors              plugin.TValue[bool]
 	IsLogging                            plugin.TValue[bool]
+	StartLoggingAt                       plugin.TValue[*time.Time]
+	StoppedLoggingAt                     plugin.TValue[*time.Time]
 	Tags                                 plugin.TValue[map[string]any]
 	LatestDeliveredAt                    plugin.TValue[*time.Time]
 	LatestDeliveryTime                   plugin.TValue[*time.Time]
@@ -117637,6 +117653,18 @@ func (c *mqlAwsCloudtrailTrail) GetHasCustomEventSelectors() *plugin.TValue[bool
 func (c *mqlAwsCloudtrailTrail) GetIsLogging() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsLogging, func() (bool, error) {
 		return c.isLogging()
+	})
+}
+
+func (c *mqlAwsCloudtrailTrail) GetStartLoggingAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.StartLoggingAt, func() (*time.Time, error) {
+		return c.startLoggingAt()
+	})
+}
+
+func (c *mqlAwsCloudtrailTrail) GetStoppedLoggingAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.StoppedLoggingAt, func() (*time.Time, error) {
+		return c.stoppedLoggingAt()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1712,7 +1712,9 @@ aws.cloudtrail.trail.region 11.15.2
 aws.cloudtrail.trail.s3bucket 11.15.2
 aws.cloudtrail.trail.snsTopic 13.12.1
 aws.cloudtrail.trail.snsTopicARN 11.15.2
+aws.cloudtrail.trail.startLoggingAt 13.39.2
 aws.cloudtrail.trail.status 11.15.2
+aws.cloudtrail.trail.stoppedLoggingAt 13.39.2
 aws.cloudtrail.trail.tags 13.12.1
 aws.cloudtrail.trails 11.15.2
 aws.cloudwatch 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.38.1",
-  "generated_at": "2026-06-26T19:15:04-07:00",
+  "version": "13.39.1",
+  "generated_at": "2026-06-30T23:48:59+02:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -644,6 +644,22 @@ func (a *mqlAwsCloudtrailTrail) latestNotifiedAt() (*time.Time, error) {
 	return trailstatus.LatestNotificationTime, nil
 }
 
+func (a *mqlAwsCloudtrailTrail) startLoggingAt() (*time.Time, error) {
+	trailstatus, err := a.getTrailStatus()
+	if err != nil {
+		return nil, err
+	}
+	return trailstatus.StartLoggingTime, nil
+}
+
+func (a *mqlAwsCloudtrailTrail) stoppedLoggingAt() (*time.Time, error) {
+	trailstatus, err := a.getTrailStatus()
+	if err != nil {
+		return nil, err
+	}
+	return trailstatus.StopLoggingTime, nil
+}
+
 func (a *mqlAwsCloudtrailTrail) latestCloudWatchLogsDeliveredAt() (*time.Time, error) {
 	trailstatus, err := a.getTrailStatus()
 	if err != nil {


### PR DESCRIPTION
## What

Adds two typed provenance fields to `aws.cloudtrail.trail`:

| Field | Type | Source |
|---|---|---|
| `startLoggingAt` | `time` | `GetTrailStatus.StartLoggingTime` — when the trail began capturing events |
| `stoppedLoggingAt` | `time` | `GetTrailStatus.StopLoggingTime` — when capture was last halted |

## Why

CloudTrail does **not** expose a trail creation date (the `Trail` type has no `CreatedDate`), so the logging lifecycle is the meaningful provenance available. `stoppedLoggingAt` is the audit-relevant one: a non-null value on a trail that is currently `isLogging: true` reveals that capture was interrupted at some point, leaving a gap in the recorded event history.

```mql
// trails whose capture was ever halted
aws.cloudtrail.trails.where(stoppedLoggingAt != null)
```

## Cost

**No new API calls** — both fields read from the `GetTrailStatus` response the trail already fetches (and caches) for `isLogging`, `latestDeliveredAt`, and the other status fields. Purely additive; no deprecation, no breaking change.

## Verification

Built and installed the provider; ran against live AWS. A trail reports `startLoggingAt` and `stoppedLoggingAt` timestamps consistent with its `isLogging` state (a stopped trail shows both a start and a later stop time with `isLogging: false`). `aws.permissions.json` shows only a version/timestamp metadata bump (no new IAM permissions).