### PR TITLE
✨ aws: add replica/backup/backtrack provenance to rds instances and clusters

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11610,6 +11610,17 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   replicationSourceIdentifier string
   // Status of write forwarding for a secondary cluster in an Aurora global cluster
   globalWriteForwardingStatus string
+  // Identifiers of read replicas that replicate from this cluster
+  readReplicaClusterIds []string
+  // Read replica clusters that replicate from this cluster, when present in this account
+  readReplicas() []aws.rds.dbcluster
+  // Target backtrack window, in seconds, for the cluster
+  //
+  // 0 when backtracking is disabled. Applies to Aurora MySQL clusters, which can
+  // be rewound to any point within this window.
+  backtrackWindow int
+  // Earliest point in time the cluster can be backtracked to
+  earliestBacktrackTime time
   // Order in which engine version updates are rolled out across the cluster
   upgradeRolloutOrder string
   // IAM role used by Enhanced Monitoring to send metrics to CloudWatch Logs
@@ -11807,6 +11818,16 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   readReplicaSourceInstance() aws.rds.dbinstance
   // Source DB cluster this instance replicates from, when it is present in this account
   readReplicaSourceCluster() aws.rds.dbcluster
+  // Identifiers of read replica instances that replicate from this instance
+  readReplicaInstanceIds []string
+  // Read replica instances that replicate from this instance, when present in this account
+  readReplicaInstances() []aws.rds.dbinstance
+  // Identifiers of read replica clusters that replicate from this instance
+  readReplicaClusterIds []string
+  // Read replica clusters that replicate from this instance, when present in this account
+  readReplicaClusters() []aws.rds.dbcluster
+  // ARNs of the replicated automated backups for this instance
+  automatedBackupReplicationArns []string
   // Storage throughput in MiBps for gp3 volumes
   storageThroughput int
   // KMS key used to encrypt the activity stream

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -17365,6 +17365,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.globalWriteForwardingStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetGlobalWriteForwardingStatus()).ToDataRes(types.String)
 	},
+	"aws.rds.dbcluster.readReplicaClusterIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetReadReplicaClusterIds()).ToDataRes(types.Array(types.String))
+	},
+	"aws.rds.dbcluster.readReplicas": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetReadReplicas()).ToDataRes(types.Array(types.Resource("aws.rds.dbcluster")))
+	},
+	"aws.rds.dbcluster.backtrackWindow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetBacktrackWindow()).ToDataRes(types.Int)
+	},
+	"aws.rds.dbcluster.earliestBacktrackTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetEarliestBacktrackTime()).ToDataRes(types.Time)
+	},
 	"aws.rds.dbcluster.upgradeRolloutOrder": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetUpgradeRolloutOrder()).ToDataRes(types.String)
 	},
@@ -17628,6 +17640,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.readReplicaSourceCluster": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaSourceCluster()).ToDataRes(types.Resource("aws.rds.dbcluster"))
+	},
+	"aws.rds.dbinstance.readReplicaInstanceIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaInstanceIds()).ToDataRes(types.Array(types.String))
+	},
+	"aws.rds.dbinstance.readReplicaInstances": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaInstances()).ToDataRes(types.Array(types.Resource("aws.rds.dbinstance")))
+	},
+	"aws.rds.dbinstance.readReplicaClusterIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaClusterIds()).ToDataRes(types.Array(types.String))
+	},
+	"aws.rds.dbinstance.readReplicaClusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetReadReplicaClusters()).ToDataRes(types.Array(types.Resource("aws.rds.dbcluster")))
+	},
+	"aws.rds.dbinstance.automatedBackupReplicationArns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetAutomatedBackupReplicationArns()).ToDataRes(types.Array(types.String))
 	},
 	"aws.rds.dbinstance.storageThroughput": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetStorageThroughput()).ToDataRes(types.Int)
@@ -51710,6 +51737,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).GlobalWriteForwardingStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.readReplicaClusterIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ReadReplicaClusterIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.readReplicas": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ReadReplicas, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.backtrackWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).BacktrackWindow, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.earliestBacktrackTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).EarliestBacktrackTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbcluster.upgradeRolloutOrder": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).UpgradeRolloutOrder, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -52068,6 +52111,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbinstance.readReplicaSourceCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).ReadReplicaSourceCluster, ok = plugin.RawToTValue[*mqlAwsRdsDbcluster](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.readReplicaInstanceIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ReadReplicaInstanceIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.readReplicaInstances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ReadReplicaInstances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.readReplicaClusterIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ReadReplicaClusterIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.readReplicaClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ReadReplicaClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.automatedBackupReplicationArns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).AutomatedBackupReplicationArns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.storageThroughput": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -124157,6 +124220,10 @@ type mqlAwsRdsDbcluster struct {
 	CloneGroupId                       plugin.TValue[string]
 	ReplicationSourceIdentifier        plugin.TValue[string]
 	GlobalWriteForwardingStatus        plugin.TValue[string]
+	ReadReplicaClusterIds              plugin.TValue[[]any]
+	ReadReplicas                       plugin.TValue[[]any]
+	BacktrackWindow                    plugin.TValue[int64]
+	EarliestBacktrackTime              plugin.TValue[*time.Time]
 	UpgradeRolloutOrder                plugin.TValue[string]
 	MonitoringRole                     plugin.TValue[*mqlAwsIamRole]
 }
@@ -124514,6 +124581,34 @@ func (c *mqlAwsRdsDbcluster) GetGlobalWriteForwardingStatus() *plugin.TValue[str
 	return &c.GlobalWriteForwardingStatus
 }
 
+func (c *mqlAwsRdsDbcluster) GetReadReplicaClusterIds() *plugin.TValue[[]any] {
+	return &c.ReadReplicaClusterIds
+}
+
+func (c *mqlAwsRdsDbcluster) GetReadReplicas() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ReadReplicas, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbcluster", c.__id, "readReplicas")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.readReplicas()
+	})
+}
+
+func (c *mqlAwsRdsDbcluster) GetBacktrackWindow() *plugin.TValue[int64] {
+	return &c.BacktrackWindow
+}
+
+func (c *mqlAwsRdsDbcluster) GetEarliestBacktrackTime() *plugin.TValue[*time.Time] {
+	return &c.EarliestBacktrackTime
+}
+
 func (c *mqlAwsRdsDbcluster) GetUpgradeRolloutOrder() *plugin.TValue[string] {
 	return &c.UpgradeRolloutOrder
 }
@@ -124813,6 +124908,11 @@ type mqlAwsRdsDbinstance struct {
 	ReadReplicaSourceClusterId         plugin.TValue[string]
 	ReadReplicaSourceInstance          plugin.TValue[*mqlAwsRdsDbinstance]
 	ReadReplicaSourceCluster           plugin.TValue[*mqlAwsRdsDbcluster]
+	ReadReplicaInstanceIds             plugin.TValue[[]any]
+	ReadReplicaInstances               plugin.TValue[[]any]
+	ReadReplicaClusterIds              plugin.TValue[[]any]
+	ReadReplicaClusters                plugin.TValue[[]any]
+	AutomatedBackupReplicationArns     plugin.TValue[[]any]
 	StorageThroughput                  plugin.TValue[int64]
 	ActivityStreamKmsKey               plugin.TValue[*mqlAwsKmsKey]
 	MasterUserSecret                   plugin.TValue[any]
@@ -125232,6 +125332,50 @@ func (c *mqlAwsRdsDbinstance) GetReadReplicaSourceCluster() *plugin.TValue[*mqlA
 
 		return c.readReplicaSourceCluster()
 	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetReadReplicaInstanceIds() *plugin.TValue[[]any] {
+	return &c.ReadReplicaInstanceIds
+}
+
+func (c *mqlAwsRdsDbinstance) GetReadReplicaInstances() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ReadReplicaInstances, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "readReplicaInstances")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.readReplicaInstances()
+	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetReadReplicaClusterIds() *plugin.TValue[[]any] {
+	return &c.ReadReplicaClusterIds
+}
+
+func (c *mqlAwsRdsDbinstance) GetReadReplicaClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ReadReplicaClusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "readReplicaClusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.readReplicaClusters()
+	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetAutomatedBackupReplicationArns() *plugin.TValue[[]any] {
+	return &c.AutomatedBackupReplicationArns
 }
 
 func (c *mqlAwsRdsDbinstance) GetStorageThroughput() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -7120,6 +7120,7 @@ aws.rds.dbcluster.activityStreamStatus 11.15.2
 aws.rds.dbcluster.arn 11.15.2
 aws.rds.dbcluster.autoMinorVersionUpgrade 11.15.2
 aws.rds.dbcluster.availabilityZones 11.15.2
+aws.rds.dbcluster.backtrackWindow 13.39.2
 aws.rds.dbcluster.backupRetentionPeriod 11.15.2
 aws.rds.dbcluster.backupSettings 11.15.2
 aws.rds.dbcluster.certificateAuthority 11.15.2
@@ -7133,6 +7134,7 @@ aws.rds.dbcluster.databaseInsightsMode 11.15.2
 aws.rds.dbcluster.databaseName 13.14.2
 aws.rds.dbcluster.dbClusterParameterGroup 13.14.2
 aws.rds.dbcluster.deletionProtection 11.15.2
+aws.rds.dbcluster.earliestBacktrackTime 13.39.2
 aws.rds.dbcluster.earliestRestorableTime 11.15.2
 aws.rds.dbcluster.endpoint 11.15.2
 aws.rds.dbcluster.engine 11.15.2
@@ -7162,6 +7164,8 @@ aws.rds.dbcluster.port 11.15.2
 aws.rds.dbcluster.preferredBackupWindow 11.15.2
 aws.rds.dbcluster.preferredMaintenanceWindow 11.15.2
 aws.rds.dbcluster.publiclyAccessible 11.15.2
+aws.rds.dbcluster.readReplicaClusterIds 13.39.2
+aws.rds.dbcluster.readReplicas 13.39.2
 aws.rds.dbcluster.region 11.15.2
 aws.rds.dbcluster.replicationSourceIdentifier 13.14.2
 aws.rds.dbcluster.securityGroups 11.15.2
@@ -7186,6 +7190,7 @@ aws.rds.dbinstance.associatedRole.roleArn 13.14.2
 aws.rds.dbinstance.associatedRole.status 13.14.2
 aws.rds.dbinstance.associatedRoles 13.14.2
 aws.rds.dbinstance.autoMinorVersionUpgrade 11.15.2
+aws.rds.dbinstance.automatedBackupReplicationArns 13.39.2
 aws.rds.dbinstance.availabilityZone 11.15.2
 aws.rds.dbinstance.backupRetentionPeriod 11.15.2
 aws.rds.dbinstance.backupSettings 11.15.2
@@ -7233,6 +7238,10 @@ aws.rds.dbinstance.port 11.15.2
 aws.rds.dbinstance.preferredBackupWindow 11.15.2
 aws.rds.dbinstance.preferredMaintenanceWindow 11.15.2
 aws.rds.dbinstance.publiclyAccessible 11.15.2
+aws.rds.dbinstance.readReplicaClusterIds 13.39.2
+aws.rds.dbinstance.readReplicaClusters 13.39.2
+aws.rds.dbinstance.readReplicaInstanceIds 13.39.2
+aws.rds.dbinstance.readReplicaInstances 13.39.2
 aws.rds.dbinstance.readReplicaSourceCluster 13.35.2
 aws.rds.dbinstance.readReplicaSourceClusterId 13.35.2
 aws.rds.dbinstance.readReplicaSourceInstance 13.35.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.38.1",
-  "generated_at": "2026-06-26T19:15:04-07:00",
+  "version": "13.39.1",
+  "generated_at": "2026-06-30T23:48:59+02:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -584,6 +584,9 @@ func newMqlAwsRdsInstance(runtime *plugin.Runtime, region string, accountID stri
 			"dbClusterIdentifier":                llx.StringDataPtr(dbInstance.DBClusterIdentifier),
 			"readReplicaSourceInstanceId":        llx.StringDataPtr(dbInstance.ReadReplicaSourceDBInstanceIdentifier),
 			"readReplicaSourceClusterId":         llx.StringDataPtr(dbInstance.ReadReplicaSourceDBClusterIdentifier),
+			"readReplicaInstanceIds":             llx.ArrayData(stringSliceToAny(dbInstance.ReadReplicaDBInstanceIdentifiers), types.String),
+			"readReplicaClusterIds":              llx.ArrayData(stringSliceToAny(dbInstance.ReadReplicaDBClusterIdentifiers), types.String),
+			"automatedBackupReplicationArns":     llx.ArrayData(rdsAutomatedBackupReplicationArns(dbInstance.DBInstanceAutomatedBackupsReplications), types.String),
 			"storageThroughput":                  llx.IntDataDefault(dbInstance.StorageThroughput, 0),
 			"masterUserSecret":                   llx.DictData(masterUserSecretToDict(dbInstance.MasterUserSecret)),
 			"customerOwnedIpEnabled":             llx.BoolDataPtr(dbInstance.CustomerOwnedIpEnabled),
@@ -771,6 +774,75 @@ func (a *mqlAwsRdsDbinstance) readReplicaSourceCluster() (*mqlAwsRdsDbcluster, e
 		return nil, nil
 	}
 	return res.(*mqlAwsRdsDbcluster), nil
+}
+
+// rdsAutomatedBackupReplicationArns extracts the ARNs of an instance's
+// cross-region automated backup replications.
+func rdsAutomatedBackupReplicationArns(reps []rds_types.DBInstanceAutomatedBackupsReplication) []any {
+	res := make([]any, 0, len(reps))
+	for _, r := range reps {
+		if r.DBInstanceAutomatedBackupsArn != nil && *r.DBInstanceAutomatedBackupsArn != "" {
+			res = append(res, *r.DBInstanceAutomatedBackupsArn)
+		}
+	}
+	return res
+}
+
+// resolveRdsReplicaRefs resolves read-replica identifiers to typed RDS resources,
+// skipping any that aren't present in this account's inventory (cross-account or
+// cross-region replicas). The raw identifiers remain available on the companion
+// *Ids field so no lineage is lost.
+func (a *mqlAwsRdsDbinstance) resolveRdsReplicaRefs(ids plugin.TValue[[]any], pattern, resourceName string) []any {
+	res := []any{}
+	for _, raw := range ids.Data {
+		id, ok := raw.(string)
+		if !ok || id == "" {
+			continue
+		}
+		r, err := NewResource(a.MqlRuntime, resourceName,
+			map[string]*llx.RawData{"arn": llx.StringData(a.rdsSourceArn(id, pattern))})
+		if err != nil {
+			continue
+		}
+		res = append(res, r)
+	}
+	return res
+}
+
+// readReplicaInstances resolves the DB instances that replicate from this
+// instance. See resolveRdsReplicaRefs for the cross-account/region semantics.
+func (a *mqlAwsRdsDbinstance) readReplicaInstances() ([]any, error) {
+	return a.resolveRdsReplicaRefs(a.ReadReplicaInstanceIds, rdsInstanceArnPattern, "aws.rds.dbinstance"), nil
+}
+
+// readReplicaClusters resolves the DB clusters that replicate from this instance.
+func (a *mqlAwsRdsDbinstance) readReplicaClusters() ([]any, error) {
+	return a.resolveRdsReplicaRefs(a.ReadReplicaClusterIds, "arn:aws:rds:%s:%s:cluster:%s", "aws.rds.dbcluster"), nil
+}
+
+// readReplicas resolves the DB clusters that replicate from this cluster,
+// skipping any not present in this account's inventory. The raw identifiers
+// remain available on readReplicaClusterIds.
+func (a *mqlAwsRdsDbcluster) readReplicas() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	res := []any{}
+	for _, raw := range a.ReadReplicaClusterIds.Data {
+		id, ok := raw.(string)
+		if !ok || id == "" {
+			continue
+		}
+		arnVal := id
+		if !strings.HasPrefix(id, "arn:") {
+			arnVal = fmt.Sprintf("arn:aws:rds:%s:%s:cluster:%s", a.Region.Data, conn.AccountId(), id)
+		}
+		r, err := NewResource(a.MqlRuntime, "aws.rds.dbcluster",
+			map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+		if err != nil {
+			continue
+		}
+		res = append(res, r)
+	}
+	return res, nil
 }
 
 // dbCluster resolves the DB cluster this instance belongs to, when it is
@@ -1138,6 +1210,9 @@ func newMqlAwsRdsCluster(runtime *plugin.Runtime, region string, accountID strin
 			"replicationSourceIdentifier":        llx.StringDataPtr(cluster.ReplicationSourceIdentifier),
 			"globalWriteForwardingStatus":        llx.StringData(string(cluster.GlobalWriteForwardingStatus)),
 			"upgradeRolloutOrder":                llx.StringData(string(cluster.UpgradeRolloutOrder)),
+			"readReplicaClusterIds":              llx.ArrayData(stringSliceToAny(cluster.ReadReplicaIdentifiers), types.String),
+			"backtrackWindow":                    llx.IntDataDefault(cluster.BacktrackWindow, 0),
+			"earliestBacktrackTime":              llx.TimeDataPtr(cluster.EarliestBacktrackTime),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

RDS models replication as a one-directional pointer — each node names the source it replicates *from*, but not the replicas that depend on it. An instance's cross-region automated backups and an Aurora cluster's backtrack window weren't exposed at all. This adds the missing provenance.

### `aws.rds.dbinstance`
| Field | Type | Source |
|---|---|---|
| `readReplicaInstanceIds` | `[]string` | `ReadReplicaDBInstanceIdentifiers` |
| `readReplicaInstances()` | `[]aws.rds.dbinstance` | resolved from the above |
| `readReplicaClusterIds` | `[]string` | `ReadReplicaDBClusterIdentifiers` |
| `readReplicaClusters()` | `[]aws.rds.dbcluster` | resolved from the above |
| `automatedBackupReplicationArns` | `[]string` | `DBInstanceAutomatedBackupsReplications[].DBInstanceAutomatedBackupsArn` |

### `aws.rds.dbcluster`
| Field | Type | Source |
|---|---|---|
| `readReplicaClusterIds` | `[]string` | `ReadReplicaIdentifiers` |
| `readReplicas()` | `[]aws.rds.dbcluster` | resolved from the above |
| `backtrackWindow` | `int` | `BacktrackWindow` (seconds; 0 = disabled) |
| `earliestBacktrackTime` | `time` | `EarliestBacktrackTime` |

## Design

Each replica list is exposed **both** as raw identifiers and typed accessors, matching the existing `readReplicaSource*` convention. The typed accessors resolve in-inventory replicas for traversal (`init` scans inventory and errors on cross-account/region ARNs); the raw `*Ids` retain identifiers the typed refs can't surface, so **no lineage is lost**. `backtrackWindow`/`earliestBacktrackTime` are the Aurora analog of the DynamoDB PITR fields — how far back a cluster can be rewound.

## Cost

**No new API calls** — every field reads from the `DescribeDBInstances` / `DescribeDBClusters` responses already fetched. Purely additive; no deprecations.

## Verification

Built and installed the provider; ran against live AWS. A primary instance (`acg-basic`) with a read replica resolves `readReplicaInstances` to the replica through the typed reference, and `readReplicaInstanceIds` carries the raw identifier. No DB clusters exist in the test account, so the cluster-side fields (`backtrackWindow`, `earliestBacktrackTime`, `readReplicas`) were not exercised live — they are straight SDK-field reads mapped at creation, identical in shape to the verified instance fields, and the package builds and generates cleanly. `aws.permissions.json` shows only a version/timestamp metadata bump (no new IAM permissions).