### PR TITLE
✨ aws: add managedBy and cloudformationStack to 26 more resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1383,6 +1383,12 @@ private aws.efs.filesystem @defaults("name id region") {
   availabilityZone string
   // Tags for the file system
   tags map[string]string
+  // CloudFormation stack that manages this file system, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this file system
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the file system is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Creation timestamp
   createdAt time
   // Mount targets for the file system
@@ -1711,6 +1717,12 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   metadata() dict
   // Tags for the KMS key
   tags() map[string]string
+  // CloudFormation stack that manages this key, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this key
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the key is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Aliases for the KMS key
   aliases() []string
   // Current state of the key: Creating, Enabled, Disabled, PendingDeletion, PendingImport, PendingReplicaDeletion, Unavailable, or Updating
@@ -2042,6 +2054,10 @@ private aws.iam.user @defaults("arn name createdAt") {
   passwordLastUsed time
   // Tags for the IAM user
   tags map[string]string
+  // Infrastructure-management system that owns this user
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the user is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // List of inline policies attached to the user
   policies() []string
   // List of managed policies attached to the user
@@ -2507,6 +2523,12 @@ private aws.sagemaker.notebookinstance @defaults("arn name") {
   region string
   // Tags for the notebook instance
   tags() map[string]string
+  // CloudFormation stack that manages this notebook instance, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this notebook instance
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the notebook instance is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Time when the notebook instance was created
   createdAt time
   // Time when the notebook instance was last modified
@@ -2701,6 +2723,12 @@ private aws.sagemaker.trainingjob @defaults("arn name status") {
   trainingEndTime time
   // Tags for the training job
   tags() map[string]string
+  // CloudFormation stack that manages this training job, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this training job
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the training job is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // IAM role for the training job
   iamRole() aws.iam.role
   // Algorithm specification
@@ -2781,6 +2809,12 @@ private aws.sagemaker.processingjob @defaults("arn name status") {
   exitMessage string
   // Tags for the processing job
   tags() map[string]string
+  // CloudFormation stack that manages this processing job, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this processing job
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the processing job is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // IAM role for the processing job
   iamRole() aws.iam.role
   // Whether network isolation is enabled
@@ -4771,6 +4805,12 @@ private aws.es.domain @defaults("arn name") {
   region string
   // Tags for the domain
   tags map[string]string
+  // CloudFormation stack that manages this domain, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this domain
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the domain is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Version of Elasticsearch running
   elasticsearchVersion string
   // Elasticsearch domain ID
@@ -5340,6 +5380,12 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   vpc aws.vpc
   // Tags on the load balancer
   tags() map[string]string
+  // CloudFormation stack that manages this load balancer, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this load balancer
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the load balancer is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // List of target groups for the load balancer
   targetGroups() []aws.elb.targetgroup
   // List of EC2 instances registered with the load balancer (classic ELB only)
@@ -6875,6 +6921,12 @@ aws.secretsmanager.secret @defaults("arn name") {
   rotationRules aws.secretsmanager.secret.rotationRules
   // Tags for the secret
   tags map[string]string
+  // CloudFormation stack that manages this secret, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this secret
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the secret is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Resource-based policy attached to the secret (JSON string, empty if none)
   resourcePolicy() string
   // Parsed statements from the resource-based policy
@@ -7681,6 +7733,12 @@ private aws.emr.cluster @defaults("arn") {
   id string
   // Tags for the cluster
   tags() map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Name of the security configuration applied to the cluster
   securityConfiguration() string
   // Security configuration applied to the cluster
@@ -9072,6 +9130,12 @@ private aws.cloudwatch.loggroup @defaults("arn") {
   retentionInDays int
   // Tags for the log group
   tags() map[string]string
+  // CloudFormation stack that manages this log group, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this log group
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the log group is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Data protection policy status
   //
   // One of ACTIVATED, DELETED, or ARCHIVED. ACTIVATED indicates that the log
@@ -9980,6 +10044,12 @@ private aws.cloudtrail.trail @defaults("name region") {
   stoppedLoggingAt() time
   // Tags associated with the trail
   tags() map[string]string
+  // CloudFormation stack that manages this trail, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this trail
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the trail is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Time of the most recent delivery of log files to the trail's S3 bucket
   latestDeliveredAt() time
   // Time of the most recent delivery of log files to the trail's S3 bucket
@@ -11309,6 +11379,12 @@ private aws.dynamodb.table @defaults("name region") {
   sourceTable() aws.dynamodb.table
   // Tags for the table
   tags() map[string]string
+  // CloudFormation stack that manages this table, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this table
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the table is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Date and time the table was created
   createdAt() time
   // Whether deletion protection is enabled
@@ -11573,6 +11649,12 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   snapshots() []aws.rds.snapshot
   // Tags for the database cluster
   tags map[string]string
+  // CloudFormation stack that manages this database cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this database cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the database cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Whether the cluster is encrypted
   storageEncrypted bool
   // Type of encryption for data at rest: "none", "sse-rds", or "sse-kms"
@@ -11803,6 +11885,12 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   enhancedMonitoringResourceArn string
   // Tags for the database instance
   tags map[string]string
+  // CloudFormation stack that manages this database instance, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this database instance
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the database instance is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Name of the compute and memory capacity class of the database instance
   dbInstanceClass string
   // User-supplied unique key that identifies a database instance
@@ -12127,6 +12215,12 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   replicationGroupId string
   // Resource tags for the cluster
   tags() map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon ElastiCache serverless cache
@@ -13458,6 +13552,12 @@ private aws.ecr.repository @defaults("uri region") {
   architectures() []string
   // AWS resource tags for the repository (private repositories only)
   tags() map[string]string
+  // CloudFormation stack that manages this repository, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this repository
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the repository is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // AWS ECR repository lifecycle policy
@@ -13774,6 +13874,12 @@ private aws.apigateway.restapi @defaults("name id") {
   region string
   // Tags for the REST API
   tags map[string]string
+  // CloudFormation stack that manages this API, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this API
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the API is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Source of the API key for metering requests (HEADER or AUTHORIZER)
   apiKeySource string
   // Whether the default execute-api endpoint is disabled
@@ -14368,6 +14474,12 @@ private aws.lambda.function @defaults("arn") {
   region string
   // Tags for the function
   tags() map[string]string
+  // CloudFormation stack that manages this function, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this function
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the function is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Instruction set architectures supported by the function (x86_64, arm64)
   architectures []string
   // Size of the /tmp directory in MB (512-10240)
@@ -14770,6 +14882,12 @@ private aws.ssm.instance @defaults("instanceId region platformName platformVersi
   arn string
   // Tags for the SSM instance
   tags() map[string]string
+  // CloudFormation stack that manages this instance, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this instance
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the instance is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Version of the SSM Agent running on the instance
   agentVersion string
   // Last time the agent pinged the SSM service
@@ -15635,6 +15753,12 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   completionTime time
   // Tags for the snapshot
   tags map[string]string
+  // CloudFormation stack that manages this snapshot, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this snapshot
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the snapshot is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // State of the snapshot: pending, completed, error, recoverable, or recovering
   state string
   // Size of the volume, in GiB
@@ -15679,6 +15803,12 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   state string
   // A map of tags associated with the EBS volume
   tags map[string]string
+  // CloudFormation stack that manages this volume, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this volume
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the volume is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Availability Zone in which the volume was created
   availabilityZone string
   // EBS volume type: gp2, gp3, io1, io2, st1, sc1, or standard
@@ -16780,6 +16910,12 @@ aws.eks.cluster @defaults("arn version status") {
   region string
   // A map of tags associated with the cluster
   tags() map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Endpoint of Kubernetes API server
   endpoint() string
   // Kubernetes server version
@@ -17621,6 +17757,12 @@ private aws.documentdb.cluster @defaults("arn name status") {
   storageType string
   // Tags for the cluster
   tags() map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Snapshots for this cluster
   snapshots() []aws.documentdb.snapshot
   // List of VPC security groups associated with the DB cluster
@@ -21072,6 +21214,12 @@ private aws.msk.cluster @defaults("name state clusterType region") {
   createdAt time
   // Tags for the cluster
   tags map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Encryption configuration for an MSK cluster
@@ -21625,6 +21773,12 @@ private aws.mq.broker @defaults("name engineType deploymentMode state region") {
   createdAt time
   // Tags for the broker
   tags() map[string]string
+  // CloudFormation stack that manages this broker, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this broker
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the broker is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon MQ broker configuration

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6054,6 +6054,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.filesystem.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.efs.filesystem.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystem).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.efs.filesystem.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystem).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.efs.filesystem.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystem).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -6420,6 +6426,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.kms.key.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.kms.key.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.kms.key.aliases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetAliases()).ToDataRes(types.Array(types.String))
 	},
@@ -6764,6 +6776,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.user.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.iam.user.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.iam.user.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetPolicies()).ToDataRes(types.Array(types.String))
@@ -7302,6 +7317,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sagemaker.notebookinstance.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerNotebookinstance).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.sagemaker.notebookinstance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerNotebookinstance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.sagemaker.notebookinstance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerNotebookinstance).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.sagemaker.notebookinstance.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerNotebookinstance).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -7542,6 +7563,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sagemaker.trainingjob.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerTrainingjob).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.sagemaker.trainingjob.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerTrainingjob).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.sagemaker.trainingjob.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerTrainingjob).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.sagemaker.trainingjob.iamRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerTrainingjob).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
@@ -7640,6 +7667,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.sagemaker.processingjob.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerProcessingjob).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.sagemaker.processingjob.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerProcessingjob).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.sagemaker.processingjob.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerProcessingjob).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.sagemaker.processingjob.iamRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerProcessingjob).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
@@ -10023,6 +10056,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.es.domain.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.es.domain.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.es.domain.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.es.domain.elasticsearchVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetElasticsearchVersion()).ToDataRes(types.String)
 	},
@@ -10754,6 +10793,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.loadbalancer.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.elb.loadbalancer.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.elb.loadbalancer.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.elb.loadbalancer.targetGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetTargetGroups()).ToDataRes(types.Array(types.Resource("aws.elb.targetgroup")))
@@ -12375,6 +12420,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.secretsmanager.secret.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.secretsmanager.secret.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.secretsmanager.secret.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.secretsmanager.secret.resourcePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetResourcePolicy()).ToDataRes(types.String)
 	},
@@ -13292,6 +13343,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.emr.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.emr.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.emr.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.emr.cluster.securityConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetSecurityConfiguration()).ToDataRes(types.String)
@@ -14742,6 +14799,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudwatch.loggroup.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.cloudwatch.loggroup.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroup).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.cloudwatch.loggroup.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroup).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.cloudwatch.loggroup.dataProtectionStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetDataProtectionStatus()).ToDataRes(types.String)
 	},
@@ -15569,6 +15632,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cloudtrail.trail.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.cloudtrail.trail.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.cloudtrail.trail.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.cloudtrail.trail.latestDeliveredAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetLatestDeliveredAt()).ToDataRes(types.Time)
@@ -17004,6 +17073,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.dynamodb.table.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.dynamodb.table.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.dynamodb.table.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.dynamodb.table.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -17276,6 +17351,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbcluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.rds.dbcluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.rds.dbcluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetStorageEncrypted()).ToDataRes(types.Bool)
@@ -17588,6 +17669,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.rds.dbinstance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.rds.dbinstance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.rds.dbinstance.dbInstanceClass": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetDbInstanceClass()).ToDataRes(types.String)
@@ -17975,6 +18062,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.elasticache.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.elasticache.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.elasticache.serverlessCache.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheServerlessCache).GetArn()).ToDataRes(types.String)
@@ -19398,6 +19491,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecr.repository.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.ecr.repository.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.ecr.repository.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.ecr.lifecyclePolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrLifecyclePolicy).GetId()).ToDataRes(types.String)
 	},
@@ -19766,6 +19865,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.apigateway.restapi.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayRestapi).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.apigateway.restapi.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayRestapi).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.apigateway.restapi.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayRestapi).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.apigateway.restapi.apiKeySource": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayRestapi).GetApiKeySource()).ToDataRes(types.String)
@@ -20379,6 +20484,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.lambda.function.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.lambda.function.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.lambda.function.architectures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetArchitectures()).ToDataRes(types.Array(types.String))
 	},
@@ -20855,6 +20966,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ssm.instance.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmInstance).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ssm.instance.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.ssm.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.ssm.instance.agentVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmInstance).GetAgentVersion()).ToDataRes(types.String)
@@ -21906,6 +22023,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.ec2.snapshot.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.ec2.snapshot.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.ec2.snapshot.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetState()).ToDataRes(types.String)
 	},
@@ -21965,6 +22088,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.volume.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ec2.volume.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.ec2.volume.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.ec2.volume.availabilityZone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetAvailabilityZone()).ToDataRes(types.String)
@@ -23244,6 +23373,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.eks.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.eks.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.eks.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.eks.cluster.endpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetEndpoint()).ToDataRes(types.String)
 	},
@@ -24221,6 +24356,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.documentdb.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.documentdb.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.documentdb.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbCluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.documentdb.cluster.snapshots": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetSnapshots()).ToDataRes(types.Array(types.Resource("aws.documentdb.snapshot")))
@@ -28086,6 +28227,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.msk.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMskCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.msk.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMskCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.msk.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMskCluster).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.msk.cluster.encryptionInfo.atRestKmsKeyArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMskClusterEncryptionInfo).GetAtRestKmsKeyArn()).ToDataRes(types.String)
 	},
@@ -28706,6 +28853,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.mq.broker.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMqBroker).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.mq.broker.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMqBroker).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.mq.broker.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMqBroker).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.mq.configuration.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMqConfiguration).GetArn()).ToDataRes(types.String)
@@ -35193,6 +35346,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEfsFilesystem).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.efs.filesystem.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystem).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.efs.filesystem.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystem).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.efs.filesystem.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystem).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -35729,6 +35890,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKmsKey).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.kms.key.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.kms.key.aliases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).Aliases, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -36215,6 +36384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.user.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.iam.user.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36997,6 +37170,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSagemakerNotebookinstance).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.sagemaker.notebookinstance.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerNotebookinstance).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.notebookinstance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerNotebookinstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sagemaker.notebookinstance.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerNotebookinstance).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -37349,6 +37530,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSagemakerTrainingjob).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.sagemaker.trainingjob.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerTrainingjob).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.trainingjob.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerTrainingjob).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sagemaker.trainingjob.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerTrainingjob).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
 		return
@@ -37491,6 +37680,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.sagemaker.processingjob.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerProcessingjob).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.processingjob.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerProcessingjob).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.processingjob.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerProcessingjob).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.sagemaker.processingjob.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -41009,6 +41206,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEsDomain).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.es.domain.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.es.domain.elasticsearchVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEsDomain).ElasticsearchVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -42027,6 +42232,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.loadbalancer.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elb.loadbalancer.targetGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44417,6 +44630,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSecretsmanagerSecret).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.secretsmanager.secret.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.secretsmanager.secret.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.secretsmanager.secret.resourcePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecret).ResourcePolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -45771,6 +45992,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.emr.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.emr.cluster.securityConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47957,6 +48186,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudwatchLoggroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.cloudwatch.loggroup.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroup).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroup).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.cloudwatch.loggroup.dataProtectionStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchLoggroup).DataProtectionStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -49175,6 +49412,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudtrail.trail.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudtrailTrail).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.cloudtrail.trail.latestDeliveredAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51293,6 +51538,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsDynamodbTable).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.dynamodb.table.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.dynamodb.table.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.dynamodb.table.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbTable).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -51683,6 +51936,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbcluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52107,6 +52368,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbinstance.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.dbInstanceClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52651,6 +52920,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.serverlessCache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -54697,6 +54974,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcrRepository).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.ecr.repository.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.ecr.repository.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ecr.lifecyclePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrLifecyclePolicy).__id, ok = v.Value.(string)
 		return
@@ -55239,6 +55524,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apigateway.restapi.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayRestapi).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.restapi.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayRestapi).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.restapi.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayRestapi).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.apigateway.restapi.apiKeySource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56129,6 +56422,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaFunction).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.function.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.function.architectures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).Architectures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -56815,6 +57116,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ssm.instance.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmInstance).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ssm.instance.agentVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58353,6 +58662,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Snapshot).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.snapshot.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -58435,6 +58752,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.volume.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.volume.availabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60305,6 +60630,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEksCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.eks.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.eks.cluster.endpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).Endpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -61683,6 +62016,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.documentdb.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDocumentdbCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.documentdb.cluster.snapshots": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -67277,6 +67618,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsMskCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.msk.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMskCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.msk.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMskCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.msk.cluster.encryptionInfo.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsMskClusterEncryptionInfo).__id, ok = v.Value.(string)
 		return
@@ -68215,6 +68564,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.mq.broker.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsMqBroker).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.mq.broker.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMqBroker).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.mq.broker.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMqBroker).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.mq.configuration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80422,6 +80779,8 @@ type mqlAwsEfsFilesystem struct {
 	Region                   plugin.TValue[string]
 	AvailabilityZone         plugin.TValue[string]
 	Tags                     plugin.TValue[map[string]any]
+	CloudformationStack      plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                plugin.TValue[string]
 	CreatedAt                plugin.TValue[*time.Time]
 	MountTargets             plugin.TValue[[]any]
 	AccessPoints             plugin.TValue[[]any]
@@ -80526,6 +80885,28 @@ func (c *mqlAwsEfsFilesystem) GetAvailabilityZone() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsFilesystem) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsEfsFilesystem) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.filesystem", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEfsFilesystem) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsEfsFilesystem) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -81828,6 +82209,8 @@ type mqlAwsKmsKey struct {
 	KeyRotationEnabled        plugin.TValue[bool]
 	Metadata                  plugin.TValue[any]
 	Tags                      plugin.TValue[map[string]any]
+	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                 plugin.TValue[string]
 	Aliases                   plugin.TValue[[]any]
 	KeyState                  plugin.TValue[string]
 	CreatedAt                 plugin.TValue[*time.Time]
@@ -81924,6 +82307,28 @@ func (c *mqlAwsKmsKey) GetMetadata() *plugin.TValue[any] {
 func (c *mqlAwsKmsKey) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kms.key", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -83060,6 +83465,7 @@ type mqlAwsIamUser struct {
 	CreatedAt           plugin.TValue[*time.Time]
 	PasswordLastUsed    plugin.TValue[*time.Time]
 	Tags                plugin.TValue[map[string]any]
+	ManagedBy           plugin.TValue[string]
 	Policies            plugin.TValue[[]any]
 	AttachedPolicies    plugin.TValue[[]any]
 	Groups              plugin.TValue[[]any]
@@ -83130,6 +83536,12 @@ func (c *mqlAwsIamUser) GetPasswordLastUsed() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsIamUser) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsIamUser) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsIamUser) GetPolicies() *plugin.TValue[[]any] {
@@ -85537,6 +85949,8 @@ type mqlAwsSagemakerNotebookinstance struct {
 	Details                    plugin.TValue[*mqlAwsSagemakerNotebookinstancedetails]
 	Region                     plugin.TValue[string]
 	Tags                       plugin.TValue[map[string]any]
+	CloudformationStack        plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                  plugin.TValue[string]
 	CreatedAt                  plugin.TValue[*time.Time]
 	LastModifiedAt             plugin.TValue[*time.Time]
 	Status                     plugin.TValue[string]
@@ -85615,6 +86029,28 @@ func (c *mqlAwsSagemakerNotebookinstance) GetRegion() *plugin.TValue[string] {
 func (c *mqlAwsSagemakerNotebookinstance) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsSagemakerNotebookinstance) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sagemaker.notebookinstance", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsSagemakerNotebookinstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -86475,6 +86911,8 @@ type mqlAwsSagemakerTrainingjob struct {
 	LastModifiedAt                        plugin.TValue[*time.Time]
 	TrainingEndTime                       plugin.TValue[*time.Time]
 	Tags                                  plugin.TValue[map[string]any]
+	CloudformationStack                   plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                             plugin.TValue[string]
 	IamRole                               plugin.TValue[*mqlAwsIamRole]
 	AlgorithmSpecification                plugin.TValue[any]
 	HyperParameters                       plugin.TValue[map[string]any]
@@ -86561,6 +86999,28 @@ func (c *mqlAwsSagemakerTrainingjob) GetTrainingEndTime() *plugin.TValue[*time.T
 func (c *mqlAwsSagemakerTrainingjob) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsSagemakerTrainingjob) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sagemaker.trainingjob", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsSagemakerTrainingjob) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -86838,6 +87298,8 @@ type mqlAwsSagemakerProcessingjob struct {
 	FailureReason                         plugin.TValue[string]
 	ExitMessage                           plugin.TValue[string]
 	Tags                                  plugin.TValue[map[string]any]
+	CloudformationStack                   plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                             plugin.TValue[string]
 	IamRole                               plugin.TValue[*mqlAwsIamRole]
 	EnableNetworkIsolation                plugin.TValue[bool]
 	EnableInterContainerTrafficEncryption plugin.TValue[bool]
@@ -86923,6 +87385,28 @@ func (c *mqlAwsSagemakerProcessingjob) GetExitMessage() *plugin.TValue[string] {
 func (c *mqlAwsSagemakerProcessingjob) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsSagemakerProcessingjob) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sagemaker.processingjob", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsSagemakerProcessingjob) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -96452,6 +96936,8 @@ type mqlAwsEsDomain struct {
 	Endpoints                          plugin.TValue[map[string]any]
 	Region                             plugin.TValue[string]
 	Tags                               plugin.TValue[map[string]any]
+	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                          plugin.TValue[string]
 	ElasticsearchVersion               plugin.TValue[string]
 	DomainId                           plugin.TValue[string]
 	DomainName                         plugin.TValue[string]
@@ -96600,6 +97086,28 @@ func (c *mqlAwsEsDomain) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsEsDomain) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsEsDomain) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.es.domain", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEsDomain) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsEsDomain) GetElasticsearchVersion() *plugin.TValue[string] {
@@ -98487,6 +98995,8 @@ type mqlAwsElbLoadbalancer struct {
 	IpAddressType        plugin.TValue[string]
 	Vpc                  plugin.TValue[*mqlAwsVpc]
 	Tags                 plugin.TValue[map[string]any]
+	CloudformationStack  plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy            plugin.TValue[string]
 	TargetGroups         plugin.TValue[[]any]
 	Instances            plugin.TValue[[]any]
 	Listeners            plugin.TValue[[]any]
@@ -98611,6 +99121,28 @@ func (c *mqlAwsElbLoadbalancer) GetVpc() *plugin.TValue[*mqlAwsVpc] {
 func (c *mqlAwsElbLoadbalancer) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elb.loadbalancer", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -104648,6 +105180,8 @@ type mqlAwsSecretsmanagerSecret struct {
 	ExternalRotationRole plugin.TValue[*mqlAwsIamRole]
 	RotationRules        plugin.TValue[*mqlAwsSecretsmanagerSecretRotationRules]
 	Tags                 plugin.TValue[map[string]any]
+	CloudformationStack  plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy            plugin.TValue[string]
 	ResourcePolicy       plugin.TValue[string]
 	PolicyStatements     plugin.TValue[[]any]
 	IsPublic             plugin.TValue[bool]
@@ -104780,6 +105314,28 @@ func (c *mqlAwsSecretsmanagerSecret) GetRotationRules() *plugin.TValue[*mqlAwsSe
 
 func (c *mqlAwsSecretsmanagerSecret) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.secretsmanager.secret", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsSecretsmanagerSecret) GetResourcePolicy() *plugin.TValue[string] {
@@ -108290,6 +108846,8 @@ type mqlAwsEmrCluster struct {
 	MasterInstances            plugin.TValue[[]any]
 	Id                         plugin.TValue[string]
 	Tags                       plugin.TValue[map[string]any]
+	CloudformationStack        plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                  plugin.TValue[string]
 	SecurityConfiguration      plugin.TValue[string]
 	SecurityConfig             plugin.TValue[*mqlAwsEmrSecurityConfiguration]
 	EncryptionConfiguration    plugin.TValue[*mqlAwsEmrClusterEncryptionConfiguration]
@@ -108394,6 +108952,28 @@ func (c *mqlAwsEmrCluster) GetId() *plugin.TValue[string] {
 func (c *mqlAwsEmrCluster) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.emr.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -114715,6 +115295,8 @@ type mqlAwsCloudwatchLoggroup struct {
 	CreatedAt                 plugin.TValue[*time.Time]
 	RetentionInDays           plugin.TValue[int64]
 	Tags                      plugin.TValue[map[string]any]
+	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                 plugin.TValue[string]
 	DataProtectionStatus      plugin.TValue[string]
 	DeletionProtectionEnabled plugin.TValue[bool]
 	LogGroupClass             plugin.TValue[string]
@@ -114848,6 +115430,28 @@ func (c *mqlAwsCloudwatchLoggroup) GetRetentionInDays() *plugin.TValue[int64] {
 func (c *mqlAwsCloudwatchLoggroup) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroup) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudwatch.loggroup", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroup) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -117728,6 +118332,8 @@ type mqlAwsCloudtrailTrail struct {
 	StartLoggingAt                       plugin.TValue[*time.Time]
 	StoppedLoggingAt                     plugin.TValue[*time.Time]
 	Tags                                 plugin.TValue[map[string]any]
+	CloudformationStack                  plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                            plugin.TValue[string]
 	LatestDeliveredAt                    plugin.TValue[*time.Time]
 	LatestDeliveryTime                   plugin.TValue[*time.Time]
 	LatestNotifiedAt                     plugin.TValue[*time.Time]
@@ -118001,6 +118607,28 @@ func (c *mqlAwsCloudtrailTrail) GetStoppedLoggingAt() *plugin.TValue[*time.Time]
 func (c *mqlAwsCloudtrailTrail) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsCloudtrailTrail) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudtrail.trail", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsCloudtrailTrail) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -123421,6 +124049,8 @@ type mqlAwsDynamodbTable struct {
 	RestoreDateTime            plugin.TValue[*time.Time]
 	SourceTable                plugin.TValue[*mqlAwsDynamodbTable]
 	Tags                       plugin.TValue[map[string]any]
+	CloudformationStack        plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                  plugin.TValue[string]
 	CreatedAt                  plugin.TValue[*time.Time]
 	DeletionProtectionEnabled  plugin.TValue[bool]
 	GlobalTableVersion         plugin.TValue[string]
@@ -123611,6 +124241,28 @@ func (c *mqlAwsDynamodbTable) GetSourceTable() *plugin.TValue[*mqlAwsDynamodbTab
 func (c *mqlAwsDynamodbTable) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsDynamodbTable) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.dynamodb.table", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsDynamodbTable) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -124536,6 +125188,8 @@ type mqlAwsRdsDbcluster struct {
 	Members                            plugin.TValue[[]any]
 	Snapshots                          plugin.TValue[[]any]
 	Tags                               plugin.TValue[map[string]any]
+	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                          plugin.TValue[string]
 	StorageEncrypted                   plugin.TValue[bool]
 	StorageEncryptionType              plugin.TValue[string]
 	StorageAllocated                   plugin.TValue[int64]
@@ -124667,6 +125321,28 @@ func (c *mqlAwsRdsDbcluster) GetSnapshots() *plugin.TValue[[]any] {
 
 func (c *mqlAwsRdsDbcluster) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsRdsDbcluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbcluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsRdsDbcluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsRdsDbcluster) GetStorageEncrypted() *plugin.TValue[bool] {
@@ -125236,6 +125912,8 @@ type mqlAwsRdsDbinstance struct {
 	MonitoringInterval                 plugin.TValue[int64]
 	EnhancedMonitoringResourceArn      plugin.TValue[string]
 	Tags                               plugin.TValue[map[string]any]
+	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                          plugin.TValue[string]
 	DbInstanceClass                    plugin.TValue[string]
 	DbInstanceIdentifier               plugin.TValue[string]
 	Engine                             plugin.TValue[string]
@@ -125432,6 +126110,28 @@ func (c *mqlAwsRdsDbinstance) GetEnhancedMonitoringResourceArn() *plugin.TValue[
 
 func (c *mqlAwsRdsDbinstance) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsRdsDbinstance) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsRdsDbinstance) GetDbInstanceClass() *plugin.TValue[string] {
@@ -126424,6 +127124,8 @@ type mqlAwsElasticacheCluster struct {
 	ReplicationGroupLogDeliveryEnabled plugin.TValue[bool]
 	ReplicationGroupId                 plugin.TValue[string]
 	Tags                               plugin.TValue[map[string]any]
+	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                          plugin.TValue[string]
 }
 
 // createAwsElasticacheCluster creates a new instance of this resource
@@ -126613,6 +127315,28 @@ func (c *mqlAwsElasticacheCluster) GetReplicationGroupId() *plugin.TValue[string
 func (c *mqlAwsElasticacheCluster) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsElasticacheCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsElasticacheCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -131314,28 +132038,30 @@ type mqlAwsEcrRepository struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEcrRepositoryInternal
-	Arn                plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Uri                plugin.TValue[string]
-	RegistryId         plugin.TValue[string]
-	Public             plugin.TValue[bool]
-	Images             plugin.TValue[[]any]
-	Region             plugin.TValue[string]
-	ImageScanOnPush    plugin.TValue[bool]
-	ImageTagMutability plugin.TValue[string]
-	EncryptionType     plugin.TValue[string]
-	CreatedAt          plugin.TValue[*time.Time]
-	ScanningFrequency  plugin.TValue[string]
-	Policy             plugin.TValue[any]
-	PolicyStatements   plugin.TValue[[]any]
-	IsPublic           plugin.TValue[bool]
-	LifecyclePolicy    plugin.TValue[*mqlAwsEcrLifecyclePolicy]
-	AboutText          plugin.TValue[string]
-	UsageText          plugin.TValue[string]
-	CatalogDescription plugin.TValue[string]
-	OperatingSystems   plugin.TValue[[]any]
-	Architectures      plugin.TValue[[]any]
-	Tags               plugin.TValue[map[string]any]
+	Arn                 plugin.TValue[string]
+	Name                plugin.TValue[string]
+	Uri                 plugin.TValue[string]
+	RegistryId          plugin.TValue[string]
+	Public              plugin.TValue[bool]
+	Images              plugin.TValue[[]any]
+	Region              plugin.TValue[string]
+	ImageScanOnPush     plugin.TValue[bool]
+	ImageTagMutability  plugin.TValue[string]
+	EncryptionType      plugin.TValue[string]
+	CreatedAt           plugin.TValue[*time.Time]
+	ScanningFrequency   plugin.TValue[string]
+	Policy              plugin.TValue[any]
+	PolicyStatements    plugin.TValue[[]any]
+	IsPublic            plugin.TValue[bool]
+	LifecyclePolicy     plugin.TValue[*mqlAwsEcrLifecyclePolicy]
+	AboutText           plugin.TValue[string]
+	UsageText           plugin.TValue[string]
+	CatalogDescription  plugin.TValue[string]
+	OperatingSystems    plugin.TValue[[]any]
+	Architectures       plugin.TValue[[]any]
+	Tags                plugin.TValue[map[string]any]
+	CloudformationStack plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy           plugin.TValue[string]
 }
 
 // createAwsEcrRepository creates a new instance of this resource
@@ -131514,6 +132240,28 @@ func (c *mqlAwsEcrRepository) GetArchitectures() *plugin.TValue[[]any] {
 func (c *mqlAwsEcrRepository) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsEcrRepository) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecr.repository", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEcrRepository) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -132869,6 +133617,8 @@ type mqlAwsApigatewayRestapi struct {
 	RequestValidators         plugin.TValue[[]any]
 	Region                    plugin.TValue[string]
 	Tags                      plugin.TValue[map[string]any]
+	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                 plugin.TValue[string]
 	ApiKeySource              plugin.TValue[string]
 	DisableExecuteApiEndpoint plugin.TValue[bool]
 	EndpointTypes             plugin.TValue[[]any]
@@ -132991,6 +133741,28 @@ func (c *mqlAwsApigatewayRestapi) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsApigatewayRestapi) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsApigatewayRestapi) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.apigateway.restapi", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsApigatewayRestapi) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsApigatewayRestapi) GetApiKeySource() *plugin.TValue[string] {
@@ -134920,6 +135692,8 @@ type mqlAwsLambdaFunction struct {
 	SecurityGroups                plugin.TValue[[]any]
 	Region                        plugin.TValue[string]
 	Tags                          plugin.TValue[map[string]any]
+	CloudformationStack           plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                     plugin.TValue[string]
 	Architectures                 plugin.TValue[[]any]
 	EphemeralStorageSize          plugin.TValue[int64]
 	MemorySize                    plugin.TValue[int64]
@@ -135121,6 +135895,28 @@ func (c *mqlAwsLambdaFunction) GetRegion() *plugin.TValue[string] {
 func (c *mqlAwsLambdaFunction) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -136644,23 +137440,25 @@ type mqlAwsSsmInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsSsmInstanceInternal
-	InstanceId      plugin.TValue[string]
-	PingStatus      plugin.TValue[string]
-	IpAddress       plugin.TValue[string]
-	PlatformName    plugin.TValue[string]
-	PlatformType    plugin.TValue[string]
-	PlatformVersion plugin.TValue[string]
-	Region          plugin.TValue[string]
-	Arn             plugin.TValue[string]
-	Tags            plugin.TValue[map[string]any]
-	AgentVersion    plugin.TValue[string]
-	LastPingedAt    plugin.TValue[*time.Time]
-	ComputerName    plugin.TValue[string]
-	IamRole         plugin.TValue[*mqlAwsIamRole]
-	SourceType      plugin.TValue[string]
-	SourceId        plugin.TValue[string]
-	ActivationId    plugin.TValue[string]
-	ResourceType    plugin.TValue[string]
+	InstanceId          plugin.TValue[string]
+	PingStatus          plugin.TValue[string]
+	IpAddress           plugin.TValue[string]
+	PlatformName        plugin.TValue[string]
+	PlatformType        plugin.TValue[string]
+	PlatformVersion     plugin.TValue[string]
+	Region              plugin.TValue[string]
+	Arn                 plugin.TValue[string]
+	Tags                plugin.TValue[map[string]any]
+	CloudformationStack plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy           plugin.TValue[string]
+	AgentVersion        plugin.TValue[string]
+	LastPingedAt        plugin.TValue[*time.Time]
+	ComputerName        plugin.TValue[string]
+	IamRole             plugin.TValue[*mqlAwsIamRole]
+	SourceType          plugin.TValue[string]
+	SourceId            plugin.TValue[string]
+	ActivationId        plugin.TValue[string]
+	ResourceType        plugin.TValue[string]
 }
 
 // createAwsSsmInstance creates a new instance of this resource
@@ -136735,6 +137533,28 @@ func (c *mqlAwsSsmInstance) GetArn() *plugin.TValue[string] {
 func (c *mqlAwsSsmInstance) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsSsmInstance) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ssm.instance", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsSsmInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -140550,6 +141370,8 @@ type mqlAwsEc2Snapshot struct {
 	StartTime              plugin.TValue[*time.Time]
 	CompletionTime         plugin.TValue[*time.Time]
 	Tags                   plugin.TValue[map[string]any]
+	CloudformationStack    plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy              plugin.TValue[string]
 	State                  plugin.TValue[string]
 	VolumeSize             plugin.TValue[int64]
 	Description            plugin.TValue[string]
@@ -140635,6 +141457,28 @@ func (c *mqlAwsEc2Snapshot) GetCompletionTime() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsEc2Snapshot) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsEc2Snapshot) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.snapshot", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEc2Snapshot) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsEc2Snapshot) GetState() *plugin.TValue[string] {
@@ -140728,25 +141572,27 @@ type mqlAwsEc2Volume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEc2VolumeInternal
-	Arn                plugin.TValue[string]
-	Id                 plugin.TValue[string]
-	Attachments        plugin.TValue[[]any]
-	Encrypted          plugin.TValue[bool]
-	State              plugin.TValue[string]
-	Tags               plugin.TValue[map[string]any]
-	AvailabilityZone   plugin.TValue[string]
-	VolumeType         plugin.TValue[string]
-	CreateTime         plugin.TValue[*time.Time]
-	Region             plugin.TValue[string]
-	MultiAttachEnabled plugin.TValue[bool]
-	Throughput         plugin.TValue[int64]
-	Size               plugin.TValue[int64]
-	Iops               plugin.TValue[int64]
-	KmsKey             plugin.TValue[*mqlAwsKmsKey]
-	SseType            plugin.TValue[string]
-	SnapshotId         plugin.TValue[string]
-	Snapshot           plugin.TValue[*mqlAwsEc2Snapshot]
-	FastRestored       plugin.TValue[bool]
+	Arn                 plugin.TValue[string]
+	Id                  plugin.TValue[string]
+	Attachments         plugin.TValue[[]any]
+	Encrypted           plugin.TValue[bool]
+	State               plugin.TValue[string]
+	Tags                plugin.TValue[map[string]any]
+	CloudformationStack plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy           plugin.TValue[string]
+	AvailabilityZone    plugin.TValue[string]
+	VolumeType          plugin.TValue[string]
+	CreateTime          plugin.TValue[*time.Time]
+	Region              plugin.TValue[string]
+	MultiAttachEnabled  plugin.TValue[bool]
+	Throughput          plugin.TValue[int64]
+	Size                plugin.TValue[int64]
+	Iops                plugin.TValue[int64]
+	KmsKey              plugin.TValue[*mqlAwsKmsKey]
+	SseType             plugin.TValue[string]
+	SnapshotId          plugin.TValue[string]
+	Snapshot            plugin.TValue[*mqlAwsEc2Snapshot]
+	FastRestored        plugin.TValue[bool]
 }
 
 // createAwsEc2Volume creates a new instance of this resource
@@ -140808,6 +141654,28 @@ func (c *mqlAwsEc2Volume) GetState() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Volume) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsEc2Volume) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.volume", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEc2Volume) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsEc2Volume) GetAvailabilityZone() *plugin.TValue[string] {
@@ -145429,6 +146297,8 @@ type mqlAwsEksCluster struct {
 	Arn                     plugin.TValue[string]
 	Region                  plugin.TValue[string]
 	Tags                    plugin.TValue[map[string]any]
+	CloudformationStack     plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy               plugin.TValue[string]
 	Endpoint                plugin.TValue[string]
 	Version                 plugin.TValue[string]
 	PlatformVersion         plugin.TValue[string]
@@ -145521,6 +146391,28 @@ func (c *mqlAwsEksCluster) GetRegion() *plugin.TValue[string] {
 func (c *mqlAwsEksCluster) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsEksCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eks.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsEksCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -148443,6 +149335,8 @@ type mqlAwsDocumentdbCluster struct {
 	StorageEncrypted             plugin.TValue[bool]
 	StorageType                  plugin.TValue[string]
 	Tags                         plugin.TValue[map[string]any]
+	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                    plugin.TValue[string]
 	Snapshots                    plugin.TValue[[]any]
 	SecurityGroups               plugin.TValue[[]any]
 	NetworkType                  plugin.TValue[string]
@@ -148675,6 +149569,28 @@ func (c *mqlAwsDocumentdbCluster) GetStorageType() *plugin.TValue[string] {
 func (c *mqlAwsDocumentdbCluster) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsDocumentdbCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.documentdb.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsDocumentdbCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -162148,6 +163064,8 @@ type mqlAwsMskCluster struct {
 	ServerlessConfig                plugin.TValue[*mqlAwsMskClusterServerlessConfig]
 	CreatedAt                       plugin.TValue[*time.Time]
 	Tags                            plugin.TValue[map[string]any]
+	CloudformationStack             plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                       plugin.TValue[string]
 }
 
 // createAwsMskCluster creates a new instance of this resource
@@ -162608,6 +163526,28 @@ func (c *mqlAwsMskCluster) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsMskCluster) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
+}
+
+func (c *mqlAwsMskCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.msk.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsMskCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlAwsMskClusterEncryptionInfo for the aws.msk.cluster.encryptionInfo resource
@@ -164998,6 +165938,8 @@ type mqlAwsMqBroker struct {
 	Users                         plugin.TValue[[]any]
 	CreatedAt                     plugin.TValue[*time.Time]
 	Tags                          plugin.TValue[map[string]any]
+	CloudformationStack           plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                     plugin.TValue[string]
 }
 
 // createAwsMqBroker creates a new instance of this resource
@@ -165305,6 +166247,28 @@ func (c *mqlAwsMqBroker) GetCreatedAt() *plugin.TValue[*time.Time] {
 func (c *mqlAwsMqBroker) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsMqBroker) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.mq.broker", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsMqBroker) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -94,12 +94,14 @@ aws.apigateway.restapi.apiKeySource 11.15.2
 aws.apigateway.restapi.arn 11.15.2
 aws.apigateway.restapi.authorizers 13.20.1
 aws.apigateway.restapi.binaryMediaTypes 11.15.2
+aws.apigateway.restapi.cloudformationStack 13.39.2
 aws.apigateway.restapi.createdDate 11.15.2
 aws.apigateway.restapi.description 11.15.2
 aws.apigateway.restapi.disableExecuteApiEndpoint 11.15.2
 aws.apigateway.restapi.endpointTypes 13.15.2
 aws.apigateway.restapi.endpointVpcEndpointIds 13.15.2
 aws.apigateway.restapi.id 11.15.2
+aws.apigateway.restapi.managedBy 13.39.2
 aws.apigateway.restapi.minimumCompressionSize 11.15.2
 aws.apigateway.restapi.name 11.15.2
 aws.apigateway.restapi.policy 11.15.2
@@ -1671,6 +1673,7 @@ aws.cloudtrail.trail.capturesAllManagementEvents 13.34.1
 aws.cloudtrail.trail.cloudWatchLogsLogGroupArn 11.15.2
 aws.cloudtrail.trail.cloudWatchLogsRole 13.12.1
 aws.cloudtrail.trail.cloudWatchLogsRoleArn 11.15.2
+aws.cloudtrail.trail.cloudformationStack 13.39.2
 aws.cloudtrail.trail.eventSelector 13.12.1
 aws.cloudtrail.trail.eventSelector.dataResource 13.12.1
 aws.cloudtrail.trail.eventSelector.dataResource.type 13.12.1
@@ -1707,6 +1710,7 @@ aws.cloudtrail.trail.latestNotificationTime 13.12.1
 aws.cloudtrail.trail.latestNotifiedAt 13.12.1
 aws.cloudtrail.trail.logFileValidationEnabled 11.15.2
 aws.cloudtrail.trail.logGroup 11.15.2
+aws.cloudtrail.trail.managedBy 13.39.2
 aws.cloudtrail.trail.name 11.15.2
 aws.cloudtrail.trail.region 11.15.2
 aws.cloudtrail.trail.s3bucket 11.15.2
@@ -1763,6 +1767,7 @@ aws.cloudwatch.logInsightQuery.queryString 13.6.3
 aws.cloudwatch.logInsightQuery.region 13.6.3
 aws.cloudwatch.loggroup 11.15.2
 aws.cloudwatch.loggroup.arn 11.15.2
+aws.cloudwatch.loggroup.cloudformationStack 13.39.2
 aws.cloudwatch.loggroup.createdAt 13.38.2
 aws.cloudwatch.loggroup.dataProtectionPolicy 13.26.3
 aws.cloudwatch.loggroup.dataProtectionStatus 11.15.2
@@ -1779,6 +1784,7 @@ aws.cloudwatch.loggroup.logstream.lastEventTimestamp 13.6.3
 aws.cloudwatch.loggroup.logstream.lastIngestionTime 13.6.3
 aws.cloudwatch.loggroup.logstream.name 13.6.3
 aws.cloudwatch.loggroup.logstream.region 13.6.3
+aws.cloudwatch.loggroup.managedBy 13.39.2
 aws.cloudwatch.loggroup.metricsFilters 11.15.2
 aws.cloudwatch.loggroup.metricsfilter 11.15.2
 aws.cloudwatch.loggroup.metricsfilter.applyOnTransformedLogs 13.26.3
@@ -2410,6 +2416,7 @@ aws.documentdb.cluster.auditLogsEnabled 13.19.1
 aws.documentdb.cluster.availabilityZones 11.16.1
 aws.documentdb.cluster.backupRetentionPeriod 11.16.1
 aws.documentdb.cluster.cloneGroupId 13.19.1
+aws.documentdb.cluster.cloudformationStack 13.39.2
 aws.documentdb.cluster.clusterIdentifier 11.16.1
 aws.documentdb.cluster.clusterParameterGroup 11.16.1
 aws.documentdb.cluster.clusterResourceId 11.16.1
@@ -2426,6 +2433,7 @@ aws.documentdb.cluster.hostedZoneId 13.19.1
 aws.documentdb.cluster.iamRoles 13.19.1
 aws.documentdb.cluster.kmsKey 11.16.1
 aws.documentdb.cluster.latestRestorableTime 13.19.1
+aws.documentdb.cluster.managedBy 13.39.2
 aws.documentdb.cluster.masterUsername 11.16.1
 aws.documentdb.cluster.members 13.19.1
 aws.documentdb.cluster.multiAZ 11.16.1
@@ -2794,6 +2802,7 @@ aws.dynamodb.table.arn 11.15.2
 aws.dynamodb.table.autoScalingEnabled 13.38.2
 aws.dynamodb.table.backups 11.15.2
 aws.dynamodb.table.billingMode 11.16.1
+aws.dynamodb.table.cloudformationStack 13.39.2
 aws.dynamodb.table.continuousBackups 11.15.2
 aws.dynamodb.table.continuousBackupsEnabled 13.39.2
 aws.dynamodb.table.createdAt 11.15.2
@@ -2807,6 +2816,7 @@ aws.dynamodb.table.kmsMasterKeyId 13.29.1
 aws.dynamodb.table.latestRestorableDateTime 13.39.2
 aws.dynamodb.table.latestStreamArn 11.15.2
 aws.dynamodb.table.latestStreamLabel 11.15.2
+aws.dynamodb.table.managedBy 13.39.2
 aws.dynamodb.table.name 11.15.2
 aws.dynamodb.table.pitrRecoveryPeriodInDays 13.39.2
 aws.dynamodb.table.pointInTimeRecoveryEnabled 13.39.2
@@ -3332,6 +3342,7 @@ aws.ec2.securitygroup.vpc 11.15.2
 aws.ec2.serialConsoleAccessEnabled 13.6.3
 aws.ec2.snapshot 11.15.2
 aws.ec2.snapshot.arn 11.15.2
+aws.ec2.snapshot.cloudformationStack 13.39.2
 aws.ec2.snapshot.completionTime 11.15.2
 aws.ec2.snapshot.createVolumePermission 11.15.2
 aws.ec2.snapshot.dataEncryptionKeyId 13.35.2
@@ -3340,6 +3351,7 @@ aws.ec2.snapshot.encrypted 11.15.2
 aws.ec2.snapshot.id 11.15.2
 aws.ec2.snapshot.isPublic 13.2.7
 aws.ec2.snapshot.kmsKey 11.15.2
+aws.ec2.snapshot.managedBy 13.39.2
 aws.ec2.snapshot.outpostArn 13.35.2
 aws.ec2.snapshot.ownerAlias 13.35.2
 aws.ec2.snapshot.ownerId 13.38.2
@@ -3413,12 +3425,14 @@ aws.ec2.volume 11.15.2
 aws.ec2.volume.arn 11.15.2
 aws.ec2.volume.attachments 11.15.2
 aws.ec2.volume.availabilityZone 11.15.2
+aws.ec2.volume.cloudformationStack 13.39.2
 aws.ec2.volume.createTime 11.15.2
 aws.ec2.volume.encrypted 11.15.2
 aws.ec2.volume.fastRestored 13.35.2
 aws.ec2.volume.id 11.15.2
 aws.ec2.volume.iops 11.15.2
 aws.ec2.volume.kmsKey 11.15.2
+aws.ec2.volume.managedBy 13.39.2
 aws.ec2.volume.multiAttachEnabled 11.15.2
 aws.ec2.volume.region 11.15.2
 aws.ec2.volume.size 11.15.2
@@ -3530,6 +3544,7 @@ aws.ecr.repository.aboutText 11.16.1
 aws.ecr.repository.architectures 11.16.1
 aws.ecr.repository.arn 11.15.2
 aws.ecr.repository.catalogDescription 11.16.1
+aws.ecr.repository.cloudformationStack 13.39.2
 aws.ecr.repository.createdAt 11.15.2
 aws.ecr.repository.encryptionType 11.15.2
 aws.ecr.repository.imageScanOnPush 11.15.2
@@ -3537,6 +3552,7 @@ aws.ecr.repository.imageTagMutability 11.15.2
 aws.ecr.repository.images 11.15.2
 aws.ecr.repository.isPublic 13.37.1
 aws.ecr.repository.lifecyclePolicy 11.15.2
+aws.ecr.repository.managedBy 13.39.2
 aws.ecr.repository.name 11.15.2
 aws.ecr.repository.operatingSystems 11.16.1
 aws.ecr.repository.policy 13.5.0
@@ -3857,6 +3873,7 @@ aws.efs.filesystem.accessPoints 11.15.2
 aws.efs.filesystem.arn 11.15.2
 aws.efs.filesystem.availabilityZone 11.15.2
 aws.efs.filesystem.backupPolicy 11.15.2
+aws.efs.filesystem.cloudformationStack 13.39.2
 aws.efs.filesystem.createdAt 11.15.2
 aws.efs.filesystem.encrypted 11.15.2
 aws.efs.filesystem.fileSystemPolicy 11.15.2
@@ -3869,6 +3886,7 @@ aws.efs.filesystem.lifecycleConfiguration.transitionToArchive 13.12.1
 aws.efs.filesystem.lifecycleConfiguration.transitionToIA 13.12.1
 aws.efs.filesystem.lifecycleConfiguration.transitionToPrimaryStorageClass 13.12.1
 aws.efs.filesystem.lifecycleState 13.12.1
+aws.efs.filesystem.managedBy 13.39.2
 aws.efs.filesystem.mountTargets 11.15.2
 aws.efs.filesystem.name 11.15.2
 aws.efs.filesystem.ownerId 13.38.2
@@ -3950,6 +3968,7 @@ aws.eks.cluster.arn 11.15.2
 aws.eks.cluster.authenticationMode 11.15.2
 aws.eks.cluster.availableAddonVersions 13.12.1
 aws.eks.cluster.certificateAuthority 13.12.1
+aws.eks.cluster.cloudformationStack 13.39.2
 aws.eks.cluster.clusterSecurityGroup 13.12.1
 aws.eks.cluster.clusterSecurityGroups 13.12.1
 aws.eks.cluster.clusterSubnets 13.12.1
@@ -3969,6 +3988,7 @@ aws.eks.cluster.iamRole 11.15.2
 aws.eks.cluster.identityProviderConfigs 13.6.3
 aws.eks.cluster.insights 13.12.1
 aws.eks.cluster.logging 11.15.2
+aws.eks.cluster.managedBy 13.39.2
 aws.eks.cluster.name 11.15.2
 aws.eks.cluster.networkConfig 11.15.2
 aws.eks.cluster.nodeGroups 11.15.2
@@ -4084,11 +4104,13 @@ aws.elasticache.cluster.cacheNodes 11.15.2
 aws.elasticache.cluster.cacheSecurityGroups 11.15.2
 aws.elasticache.cluster.cacheSubnetGroupName 11.15.2
 aws.elasticache.cluster.clientDownloadLandingPage 11.15.2
+aws.elasticache.cluster.cloudformationStack 13.39.2
 aws.elasticache.cluster.engine 11.15.2
 aws.elasticache.cluster.engineVersion 11.15.2
 aws.elasticache.cluster.ipDiscovery 11.15.2
 aws.elasticache.cluster.kmsKey 13.3.1
 aws.elasticache.cluster.logDeliveryConfigurations 11.15.2
+aws.elasticache.cluster.managedBy 13.39.2
 aws.elasticache.cluster.networkType 11.15.2
 aws.elasticache.cluster.nodeType 11.15.2
 aws.elasticache.cluster.notificationConfiguration 11.15.2
@@ -4281,6 +4303,7 @@ aws.elb.loadbalancer.attribute.wafFailOpenEnabled 11.15.2
 aws.elb.loadbalancer.attribute.zonalShiftEnabled 11.15.2
 aws.elb.loadbalancer.attributes 11.15.2
 aws.elb.loadbalancer.availabilityZones 11.15.2
+aws.elb.loadbalancer.cloudformationStack 13.39.2
 aws.elb.loadbalancer.createdAt 11.15.2
 aws.elb.loadbalancer.dnsName 11.15.2
 aws.elb.loadbalancer.elbType 11.15.2
@@ -4292,6 +4315,7 @@ aws.elb.loadbalancer.instances 11.15.2
 aws.elb.loadbalancer.ipAddressType 11.15.2
 aws.elb.loadbalancer.listenerDescriptions 11.15.2
 aws.elb.loadbalancer.listeners 11.15.2
+aws.elb.loadbalancer.managedBy 13.39.2
 aws.elb.loadbalancer.name 11.15.2
 aws.elb.loadbalancer.region 11.15.2
 aws.elb.loadbalancer.scheme 11.15.2
@@ -4348,6 +4372,7 @@ aws.emr.cluster.bootstrapAction.args 13.12.1
 aws.emr.cluster.bootstrapAction.name 13.12.1
 aws.emr.cluster.bootstrapAction.scriptPath 13.12.1
 aws.emr.cluster.bootstrapActions 13.12.1
+aws.emr.cluster.cloudformationStack 13.39.2
 aws.emr.cluster.configurations 13.21.4
 aws.emr.cluster.createdAt 13.38.2
 aws.emr.cluster.ebsRootVolumeIops 13.21.4
@@ -4379,6 +4404,7 @@ aws.emr.cluster.instanceGroups 13.12.1
 aws.emr.cluster.kerberosAttributes 13.21.4
 aws.emr.cluster.logEncryptionKmsKey 13.3.1
 aws.emr.cluster.logUri 13.3.0
+aws.emr.cluster.managedBy 13.39.2
 aws.emr.cluster.masterInstances 11.15.2
 aws.emr.cluster.masterPublicDnsName 13.3.1
 aws.emr.cluster.name 11.15.2
@@ -4459,6 +4485,7 @@ aws.es.domain.automatedSnapshotPauseStartTime 13.25.1
 aws.es.domain.automatedSnapshotPauseState 13.25.1
 aws.es.domain.automatedSnapshotStartHour 13.21.4
 aws.es.domain.availabilityZones 13.21.4
+aws.es.domain.cloudformationStack 13.39.2
 aws.es.domain.cognitoEnabled 13.21.4
 aws.es.domain.cognitoIdentityPoolId 13.21.4
 aws.es.domain.cognitoRoleArn 13.21.4
@@ -4492,6 +4519,7 @@ aws.es.domain.instanceType 13.21.4
 aws.es.domain.internalUserDatabaseEnabled 13.21.4
 aws.es.domain.isPublic 13.37.1
 aws.es.domain.kmsKey 13.21.4
+aws.es.domain.managedBy 13.39.2
 aws.es.domain.name 11.15.2
 aws.es.domain.nodeToNodeEncryptionEnabled 11.15.2
 aws.es.domain.policyStatements 13.37.1
@@ -5410,6 +5438,7 @@ aws.iam.user.createdAt 11.15.2
 aws.iam.user.groups 11.15.2
 aws.iam.user.id 11.15.2
 aws.iam.user.loginProfile 11.15.2
+aws.iam.user.managedBy 13.39.2
 aws.iam.user.mfaDevices 13.26.2
 aws.iam.user.name 11.15.2
 aws.iam.user.passwordLastUsed 11.15.2
@@ -5817,6 +5846,7 @@ aws.kms.grants 13.26.3
 aws.kms.key 11.15.2
 aws.kms.key.aliases 11.15.2
 aws.kms.key.arn 11.15.2
+aws.kms.key.cloudformationStack 13.39.2
 aws.kms.key.createdAt 11.15.2
 aws.kms.key.customKeyStore 13.26.3
 aws.kms.key.deletedAt 11.15.2
@@ -5837,6 +5867,7 @@ aws.kms.key.keyState 11.15.2
 aws.kms.key.keyUsage 13.6.3
 aws.kms.key.lastUsageOperation 13.18.1
 aws.kms.key.lastUsedAt 13.18.1
+aws.kms.key.managedBy 13.39.2
 aws.kms.key.metadata 11.15.2
 aws.kms.key.multiRegion 13.6.3
 aws.kms.key.multiRegionConfiguration 13.6.3
@@ -5933,6 +5964,7 @@ aws.lambda.function.aliases 11.15.2
 aws.lambda.function.allowsPublicAccess 13.33.2
 aws.lambda.function.architectures 11.15.2
 aws.lambda.function.arn 11.15.2
+aws.lambda.function.cloudformationStack 13.39.2
 aws.lambda.function.codeSha256 11.15.2
 aws.lambda.function.codeSigningConfig 11.15.2
 aws.lambda.function.codeSize 11.15.2
@@ -5964,6 +5996,7 @@ aws.lambda.function.loggingConfig.applicationLogLevel 11.15.2
 aws.lambda.function.loggingConfig.logFormat 11.15.2
 aws.lambda.function.loggingConfig.logGroup 11.15.2
 aws.lambda.function.loggingConfig.systemLogLevel 11.15.2
+aws.lambda.function.managedBy 13.39.2
 aws.lambda.function.masterArn 13.38.2
 aws.lambda.function.masterFunction 13.38.2
 aws.lambda.function.memorySize 11.15.2
@@ -6418,6 +6451,7 @@ aws.mq.broker.auditLogsEnabled 11.16.1
 aws.mq.broker.authenticationStrategy 11.16.1
 aws.mq.broker.autoMinorVersionUpgrade 11.16.1
 aws.mq.broker.brokerId 11.16.1
+aws.mq.broker.cloudformationStack 13.39.2
 aws.mq.broker.configurations 13.21.4
 aws.mq.broker.createdAt 11.16.1
 aws.mq.broker.dataReplicationMode 13.21.4
@@ -6433,6 +6467,7 @@ aws.mq.broker.ldapServerMetadata 13.21.4
 aws.mq.broker.maintenanceDayOfWeek 13.21.4
 aws.mq.broker.maintenanceTimeOfDay 13.21.4
 aws.mq.broker.maintenanceTimeZone 13.21.4
+aws.mq.broker.managedBy 13.39.2
 aws.mq.broker.name 11.16.1
 aws.mq.broker.pendingAuthenticationStrategy 13.21.4
 aws.mq.broker.pendingDataReplicationMode 13.21.4
@@ -6518,6 +6553,7 @@ aws.msk.cluster.clientVpcConnection.owner 13.14.2
 aws.msk.cluster.clientVpcConnection.state 13.14.2
 aws.msk.cluster.clientVpcConnection.vpcConnectionArn 13.14.2
 aws.msk.cluster.clientVpcConnections 13.14.2
+aws.msk.cluster.cloudformationStack 13.39.2
 aws.msk.cluster.cloudwatchLogsEnabled 11.16.1
 aws.msk.cluster.cloudwatchLogsGroup 11.16.1
 aws.msk.cluster.clusterPolicy 13.14.2
@@ -6561,6 +6597,7 @@ aws.msk.cluster.loggingInfo.s3.bucket 13.14.2
 aws.msk.cluster.loggingInfo.s3.bucketName 13.14.2
 aws.msk.cluster.loggingInfo.s3.enabled 13.14.2
 aws.msk.cluster.loggingInfo.s3.prefix 13.14.2
+aws.msk.cluster.managedBy 13.39.2
 aws.msk.cluster.monitoring 13.14.2
 aws.msk.cluster.monitoring.enhancedMonitoring 13.14.2
 aws.msk.cluster.monitoring.jmxExporterEnabled 13.14.2
@@ -7148,6 +7185,7 @@ aws.rds.dbcluster.backupSettings 11.15.2
 aws.rds.dbcluster.certificateAuthority 11.15.2
 aws.rds.dbcluster.certificateExpiresAt 11.15.2
 aws.rds.dbcluster.cloneGroupId 13.38.2
+aws.rds.dbcluster.cloudformationStack 13.39.2
 aws.rds.dbcluster.clusterDbInstanceClass 11.15.2
 aws.rds.dbcluster.copyTagsToSnapshot 11.16.1
 aws.rds.dbcluster.createdAt 11.15.2
@@ -7172,6 +7210,7 @@ aws.rds.dbcluster.iamDatabaseAuthentication 11.15.2
 aws.rds.dbcluster.id 11.15.2
 aws.rds.dbcluster.kmsKey 11.15.2
 aws.rds.dbcluster.latestRestorableTime 11.15.2
+aws.rds.dbcluster.managedBy 13.39.2
 aws.rds.dbcluster.masterUserSecret 11.16.1
 aws.rds.dbcluster.masterUsername 11.15.2
 aws.rds.dbcluster.members 11.15.2
@@ -7218,6 +7257,7 @@ aws.rds.dbinstance.backupRetentionPeriod 11.15.2
 aws.rds.dbinstance.backupSettings 11.15.2
 aws.rds.dbinstance.certificateAuthority 11.15.2
 aws.rds.dbinstance.certificateExpiresAt 11.15.2
+aws.rds.dbinstance.cloudformationStack 13.39.2
 aws.rds.dbinstance.copyTagsToSnapshot 11.15.2
 aws.rds.dbinstance.createdAt 11.15.2
 aws.rds.dbinstance.customIamInstanceProfile 11.15.2
@@ -7243,6 +7283,7 @@ aws.rds.dbinstance.id 11.15.2
 aws.rds.dbinstance.kmsKey 11.15.2
 aws.rds.dbinstance.latestRestorableTime 11.15.2
 aws.rds.dbinstance.licenseModel 11.15.2
+aws.rds.dbinstance.managedBy 13.39.2
 aws.rds.dbinstance.masterUserSecret 11.16.1
 aws.rds.dbinstance.masterUsername 11.15.2
 aws.rds.dbinstance.maxAllocatedStorage 11.15.2
@@ -8654,12 +8695,14 @@ aws.sagemaker.notebookInstances 11.15.2
 aws.sagemaker.notebookinstance 11.15.2
 aws.sagemaker.notebookinstance.additionalCodeRepositories 13.12.0
 aws.sagemaker.notebookinstance.arn 11.15.2
+aws.sagemaker.notebookinstance.cloudformationStack 13.39.2
 aws.sagemaker.notebookinstance.createdAt 11.16.1
 aws.sagemaker.notebookinstance.defaultCodeRepository 13.12.0
 aws.sagemaker.notebookinstance.details 11.15.2
 aws.sagemaker.notebookinstance.instanceType 13.12.0
 aws.sagemaker.notebookinstance.lastModifiedAt 11.16.1
 aws.sagemaker.notebookinstance.lifecycleConfigName 13.12.0
+aws.sagemaker.notebookinstance.managedBy 13.39.2
 aws.sagemaker.notebookinstance.name 11.15.2
 aws.sagemaker.notebookinstance.region 11.15.2
 aws.sagemaker.notebookinstance.status 11.16.1
@@ -8696,6 +8739,7 @@ aws.sagemaker.pipelines 13.0.2
 aws.sagemaker.processingJobs 13.0.2
 aws.sagemaker.processingjob 13.0.2
 aws.sagemaker.processingjob.arn 13.0.2
+aws.sagemaker.processingjob.cloudformationStack 13.39.2
 aws.sagemaker.processingjob.createdAt 13.0.2
 aws.sagemaker.processingjob.enableInterContainerTrafficEncryption 13.0.2
 aws.sagemaker.processingjob.enableNetworkIsolation 13.0.2
@@ -8704,6 +8748,7 @@ aws.sagemaker.processingjob.exitMessage 13.0.2
 aws.sagemaker.processingjob.failureReason 13.0.2
 aws.sagemaker.processingjob.iamRole 13.0.2
 aws.sagemaker.processingjob.lastModifiedAt 13.0.2
+aws.sagemaker.processingjob.managedBy 13.39.2
 aws.sagemaker.processingjob.name 13.0.2
 aws.sagemaker.processingjob.processingEndTime 13.0.2
 aws.sagemaker.processingjob.processingResources 13.0.2
@@ -8767,6 +8812,7 @@ aws.sagemaker.trainingjob.algorithmSpecification 13.0.2
 aws.sagemaker.trainingjob.arn 13.0.2
 aws.sagemaker.trainingjob.billableTimeInSeconds 13.0.2
 aws.sagemaker.trainingjob.checkpointConfig 13.13.4
+aws.sagemaker.trainingjob.cloudformationStack 13.39.2
 aws.sagemaker.trainingjob.createdAt 13.0.2
 aws.sagemaker.trainingjob.enableInterContainerTrafficEncryption 13.0.2
 aws.sagemaker.trainingjob.enableNetworkIsolation 13.0.2
@@ -8775,6 +8821,7 @@ aws.sagemaker.trainingjob.finalMetrics 13.13.4
 aws.sagemaker.trainingjob.hyperParameters 13.0.2
 aws.sagemaker.trainingjob.iamRole 13.0.2
 aws.sagemaker.trainingjob.lastModifiedAt 13.0.2
+aws.sagemaker.trainingjob.managedBy 13.39.2
 aws.sagemaker.trainingjob.metricData 13.13.4
 aws.sagemaker.trainingjob.metricData.metricName 13.13.4
 aws.sagemaker.trainingjob.metricData.timestamp 13.13.4
@@ -8913,6 +8960,7 @@ aws.sagemaker.workteams 13.13.4
 aws.secretsmanager 11.15.2
 aws.secretsmanager.secret 11.15.2
 aws.secretsmanager.secret.arn 11.15.2
+aws.secretsmanager.secret.cloudformationStack 13.39.2
 aws.secretsmanager.secret.createdAt 11.15.2
 aws.secretsmanager.secret.deletedAt 13.12.1
 aws.secretsmanager.secret.description 11.15.2
@@ -8922,6 +8970,7 @@ aws.secretsmanager.secret.kmsKey 11.15.2
 aws.secretsmanager.secret.lastAccessedDate 11.15.2
 aws.secretsmanager.secret.lastChangedDate 11.15.2
 aws.secretsmanager.secret.lastRotatedDate 11.15.2
+aws.secretsmanager.secret.managedBy 13.39.2
 aws.secretsmanager.secret.name 11.15.2
 aws.secretsmanager.secret.nextRotationDate 11.15.2
 aws.secretsmanager.secret.owningService 11.15.2
@@ -9303,11 +9352,13 @@ aws.ssm.instance 11.15.2
 aws.ssm.instance.activationId 13.38.2
 aws.ssm.instance.agentVersion 11.15.2
 aws.ssm.instance.arn 11.15.2
+aws.ssm.instance.cloudformationStack 13.39.2
 aws.ssm.instance.computerName 11.15.2
 aws.ssm.instance.iamRole 13.38.2
 aws.ssm.instance.instanceId 11.15.2
 aws.ssm.instance.ipAddress 11.15.2
 aws.ssm.instance.lastPingedAt 11.15.2
+aws.ssm.instance.managedBy 13.39.2
 aws.ssm.instance.pingStatus 11.15.2
 aws.ssm.instance.platformName 11.15.2
 aws.ssm.instance.platformType 11.15.2

--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -1,0 +1,245 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromResourceTags returns the infrastructure-management system that
+// owns a resource, inferred from the provenance tags AWS injects on managed
+// resources. It propagates any error from resolving computed tags.
+func managedByFromResourceTags(tags *plugin.TValue[map[string]any]) (string, error) {
+	if tags.Error != nil {
+		return "", tags.Error
+	}
+	return managedByFromTags(tags.Data), nil
+}
+
+// cloudformationStackFromResourceTags resolves the CloudFormation stack that
+// provisioned a resource from its AWS-injected stack-name tag, setting the
+// field to null when the resource carries no such tag.
+func cloudformationStackFromResourceTags(runtime *plugin.Runtime, region string, tags *plugin.TValue[map[string]any], field *plugin.TValue[*mqlAwsCloudformationStack]) (*mqlAwsCloudformationStack, error) {
+	if tags.Error != nil {
+		return nil, tags.Error
+	}
+	stack, err := cloudformationStackForTags(runtime, region, tags.Data)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		field.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return stack, nil
+}
+
+func (a *mqlAwsRdsDbinstance) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsRdsDbinstance) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsRdsDbcluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsRdsDbcluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEc2Volume) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEc2Volume) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEc2Snapshot) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEc2Snapshot) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEfsFilesystem) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEfsFilesystem) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsApigatewayRestapi) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsApigatewayRestapi) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEsDomain) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEsDomain) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsMskCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsMskCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsCloudtrailTrail) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsCloudtrailTrail) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsDynamodbTable) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsDynamodbTable) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsCloudwatchLoggroup) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsCloudwatchLoggroup) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsLambdaFunction) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsLambdaFunction) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsElbLoadbalancer) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsElbLoadbalancer) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsKmsKey) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsKmsKey) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsSagemakerNotebookinstance) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSagemakerNotebookinstance) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsSagemakerProcessingjob) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSagemakerProcessingjob) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsSagemakerTrainingjob) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSagemakerTrainingjob) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsSsmInstance) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSsmInstance) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEcrRepository) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEcrRepository) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsMqBroker) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsMqBroker) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEksCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEksCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsElasticacheCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsElasticacheCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsDocumentdbCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsDocumentdbCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsIamUser) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSecretsmanagerSecret) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsSecretsmanagerSecret) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.GetPrimaryRegion().Data, a.GetTags(), &a.CloudformationStack)
+}
+
+func (a *mqlAwsEmrCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsEmrCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	region := ""
+	if parsed, err := arn.Parse(a.Arn.Data); err == nil {
+		region = parsed.Region
+	}
+	return cloudformationStackFromResourceTags(a.MqlRuntime, region, a.GetTags(), &a.CloudformationStack)
+}


### PR DESCRIPTION
## What

Extends the tag-derived management-provenance accessors — already on `aws.s3.bucket`, `aws.ec2.instance`, `aws.ec2.securitygroup`, `aws.vpc`, and `aws.redshift.cluster` — to **every other requested resource that carries usable resource tags**:

`rds.dbinstance`, `rds.dbcluster`, `ec2.volume`, `ec2.snapshot`, `iam.user`, `efs.filesystem`, `apigateway.restapi`, `es.domain`, `msk.cluster`, `secretsmanager.secret`, `cloudtrail.trail`, `dynamodb.table`, `cloudwatch.loggroup`, `lambda.function`, `elb.loadbalancer`, `kms.key`, `sagemaker.notebookinstance`, `sagemaker.processingjob`, `sagemaker.trainingjob`, `ssm.instance`, `ecr.repository`, `mq.broker`, `eks.cluster`, `elasticache.cluster`, `emr.cluster`, `documentdb.cluster`.

- **`managedBy() string`** — infers the owning system (`cloudformation`, `elasticbeanstalk`, `eks`, `servicecatalog`, `autoscaling`) from the tags AWS injects on managed resources; `""` when unmanaged.
- **`cloudformationStack() aws.cloudformation.stack`** — resolves the typed stack from the `aws:cloudformation:stack-name` tag.

Both reuse the existing shared `managedByFromTags` / `cloudformationStackForTags` helpers and read tags the resource already exposes — **no new API calls**. All accessors live in one new `aws_managed_by.go` behind two shared helpers, so the 26 resources add ~4 lines of hand-written Go each.

## Scope decisions

- **Skipped** (no usable resource tags): `iam.group`, `ecs.container`, `ecs.instance`, `ecs.taskdefinition`, `route53.hostedzone`, `cloudfront.distribution`, `neptune.cluster` have no `tags` field modeled; `ecr.image`'s `tags` are image tags, not resource tags.
- **`iam.user`** is global (no region to resolve a regional stack), so it gets `managedBy` only.
- **`secretsmanager.secret`** uses its `primaryRegion`; **`emr.cluster`** derives the region from its ARN.
- `ec2.securitygroup` already had the pair (in `aws_ec2.go`) and is untouched.

## Verification

Built and installed the provider; ran against live AWS. A Lambda function provisioned by CloudFormation reports `managedBy: "cloudformation"` and resolves `cloudformationStack.name` to the owning stack (`"mondoo"`); unmanaged resources (DynamoDB table, KMS key, CloudTrail trail, IAM user) correctly report `""` / `null`. `mqlr generate` is clean and the package builds. `aws.permissions.json` shows only a version/timestamp metadata bump (no new IAM permissions).