### PR TITLE
✨ aws: add copy/restore provenance to ec2 volume and snapshot

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15815,6 +15815,14 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   encrypted bool
   // The storage tier in which the snapshot is stored
   storageTier string
+  // How a snapshot copy was created
+  //
+  // One of standard or time-based, and only set for snapshot copies. Time-based copies complete within a requested duration; standard copies complete on a best-effort basis.
+  transferType string
+  // Time an archived snapshot that was temporarily restored will be automatically re-archived
+  //
+  // Only set for archived snapshots that are currently in a temporary restore.
+  restoreExpiryTime time
   // KMS key used for snapshot encryption
   kmsKey() aws.kms.key
   // Volume the snapshot was created from, when it is still present in this account
@@ -15883,6 +15891,8 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   snapshot() aws.ec2.snapshot
   // Whether the volume was created from a snapshot using fast snapshot restore
   fastRestored bool
+  // Source volume this volume was copied from, when it is still present in this account
+  sourceVolume() aws.ec2.volume
 }
 
 // AWS Signer

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22113,6 +22113,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.storageTier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetStorageTier()).ToDataRes(types.String)
 	},
+	"aws.ec2.snapshot.transferType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetTransferType()).ToDataRes(types.String)
+	},
+	"aws.ec2.snapshot.restoreExpiryTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetRestoreExpiryTime()).ToDataRes(types.Time)
+	},
 	"aws.ec2.snapshot.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
@@ -22202,6 +22208,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.volume.fastRestored": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetFastRestored()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.volume.sourceVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetSourceVolume()).ToDataRes(types.Resource("aws.ec2.volume"))
 	},
 	"aws.signer.signingProfiles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSigner).GetSigningProfiles()).ToDataRes(types.Array(types.Resource("aws.signer.signingProfile")))
@@ -58851,6 +58860,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Snapshot).StorageTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.transferType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).TransferType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.restoreExpiryTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).RestoreExpiryTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.snapshot.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
@@ -58973,6 +58990,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.volume.fastRestored": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).FastRestored, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.sourceVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).SourceVolume, ok = plugin.RawToTValue[*mqlAwsEc2Volume](v.Value, v.Error)
 		return
 	},
 	"aws.signer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -141727,6 +141748,8 @@ type mqlAwsEc2Snapshot struct {
 	Description            plugin.TValue[string]
 	Encrypted              plugin.TValue[bool]
 	StorageTier            plugin.TValue[string]
+	TransferType           plugin.TValue[string]
+	RestoreExpiryTime      plugin.TValue[*time.Time]
 	KmsKey                 plugin.TValue[*mqlAwsKmsKey]
 	SourceVolume           plugin.TValue[*mqlAwsEc2Volume]
 	DataEncryptionKeyId    plugin.TValue[string]
@@ -141851,6 +141874,14 @@ func (c *mqlAwsEc2Snapshot) GetStorageTier() *plugin.TValue[string] {
 	return &c.StorageTier
 }
 
+func (c *mqlAwsEc2Snapshot) GetTransferType() *plugin.TValue[string] {
+	return &c.TransferType
+}
+
+func (c *mqlAwsEc2Snapshot) GetRestoreExpiryTime() *plugin.TValue[*time.Time] {
+	return &c.RestoreExpiryTime
+}
+
 func (c *mqlAwsEc2Snapshot) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
 	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
 		if c.MqlRuntime.HasRecording {
@@ -141943,6 +141974,7 @@ type mqlAwsEc2Volume struct {
 	SnapshotId          plugin.TValue[string]
 	Snapshot            plugin.TValue[*mqlAwsEc2Snapshot]
 	FastRestored        plugin.TValue[bool]
+	SourceVolume        plugin.TValue[*mqlAwsEc2Volume]
 }
 
 // createAwsEc2Volume creates a new instance of this resource
@@ -142102,6 +142134,22 @@ func (c *mqlAwsEc2Volume) GetSnapshot() *plugin.TValue[*mqlAwsEc2Snapshot] {
 
 func (c *mqlAwsEc2Volume) GetFastRestored() *plugin.TValue[bool] {
 	return &c.FastRestored
+}
+
+func (c *mqlAwsEc2Volume) GetSourceVolume() *plugin.TValue[*mqlAwsEc2Volume] {
+	return plugin.GetOrCompute[*mqlAwsEc2Volume](&c.SourceVolume, func() (*mqlAwsEc2Volume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.volume", c.__id, "sourceVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Volume), nil
+			}
+		}
+
+		return c.sourceVolume()
+	})
 }
 
 // mqlAwsSigner for the aws.signer resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3356,6 +3356,7 @@ aws.ec2.snapshot.outpostArn 13.35.2
 aws.ec2.snapshot.ownerAlias 13.35.2
 aws.ec2.snapshot.ownerId 13.38.2
 aws.ec2.snapshot.region 11.15.2
+aws.ec2.snapshot.restoreExpiryTime 13.39.2
 aws.ec2.snapshot.sharedExternally 13.37.1
 aws.ec2.snapshot.sharedWithAccounts 13.37.1
 aws.ec2.snapshot.sourceVolume 13.35.2
@@ -3363,6 +3364,7 @@ aws.ec2.snapshot.startTime 11.15.2
 aws.ec2.snapshot.state 11.15.2
 aws.ec2.snapshot.storageTier 11.15.2
 aws.ec2.snapshot.tags 11.15.2
+aws.ec2.snapshot.transferType 13.39.2
 aws.ec2.snapshot.volumeId 11.15.2
 aws.ec2.snapshot.volumeSize 11.15.2
 aws.ec2.snapshots 11.15.2
@@ -3438,6 +3440,7 @@ aws.ec2.volume.region 11.15.2
 aws.ec2.volume.size 11.15.2
 aws.ec2.volume.snapshot 13.35.2
 aws.ec2.volume.snapshotId 13.35.2
+aws.ec2.volume.sourceVolume 13.39.2
 aws.ec2.volume.sseType 11.16.1
 aws.ec2.volume.state 11.15.2
 aws.ec2.volume.tags 11.15.2

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2511,11 +2511,13 @@ func buildVolumeResource(runtime *plugin.Runtime, region, accountID string, vol 
 	}
 	v := mqlVol.(*mqlAwsEc2Volume)
 	v.cacheKmsKeyId = vol.KmsKeyId
+	v.cacheSourceVolumeId = vol.SourceVolumeId
 	return v, nil
 }
 
 type mqlAwsEc2VolumeInternal struct {
-	cacheKmsKeyId *string
+	cacheKmsKeyId       *string
+	cacheSourceVolumeId *string
 }
 
 // snapshot resolves the source snapshot when it is still present in this
@@ -2534,6 +2536,25 @@ func (a *mqlAwsEc2Volume) snapshot() (*mqlAwsEc2Snapshot, error) {
 		return nil, nil
 	}
 	return mqlSnap.(*mqlAwsEc2Snapshot), nil
+}
+
+// sourceVolume resolves the volume this volume was copied from when it is still
+// present in this account. The source id is only set for volume copies, and the
+// source is frequently since-deleted; in that case the reference is null.
+func (a *mqlAwsEc2Volume) sourceVolume() (*mqlAwsEc2Volume, error) {
+	if a.cacheSourceVolumeId == nil || *a.cacheSourceVolumeId == "" {
+		a.SourceVolume.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	volumeArn := fmt.Sprintf(volumeArnPattern, a.Region.Data, conn.AccountId(), *a.cacheSourceVolumeId)
+	mqlVol, err := NewResource(a.MqlRuntime, ResourceAwsEc2Volume,
+		map[string]*llx.RawData{"arn": llx.StringData(volumeArn)})
+	if err != nil {
+		a.SourceVolume.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return mqlVol.(*mqlAwsEc2Volume), nil
 }
 
 func (a *mqlAwsEc2Volume) kmsKey() (*mqlAwsKmsKey, error) {
@@ -2642,6 +2663,8 @@ func buildSnapshotResource(runtime *plugin.Runtime, region, accountID string, sn
 			"ownerAlias":          llx.StringDataPtr(snapshot.OwnerAlias),
 			"ownerId":             llx.StringDataPtr(snapshot.OwnerId),
 			"outpostArn":          llx.StringDataPtr(snapshot.OutpostArn),
+			"transferType":        llx.StringData(string(snapshot.TransferType)),
+			"restoreExpiryTime":   llx.TimeDataPtr(snapshot.RestoreExpiryTime),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds copy/restore provenance to the EBS resources.

**`aws.ec2.volume`**
- `sourceVolume() aws.ec2.volume` — the volume this one was copied from, when it is still present in the account (only set for volume copies). Mirrors the existing `sourceVolume()` on `aws.ec2.snapshot`. Resolved from a cached source-volume id on the Internal struct, so no redundant raw id field is exposed.

**`aws.ec2.snapshot`**
- `transferType string` — how a snapshot copy was created (`standard` or `time-based`; only set for copies).
- `restoreExpiryTime time` — when a temporarily-restored archived snapshot will be automatically re-archived.

All values come back on the existing `DescribeVolumes` / `DescribeSnapshots` calls, so there are no new API calls or IAM permissions.