### PR TITLE
✨ aws: add typed destination refs to cloudwatch log subscription filters

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9226,6 +9226,12 @@ private aws.cloudwatch.loggroup.subscriptionfilter @defaults("filterName destina
   filterPattern string
   // ARN of the destination (Kinesis, Lambda, or Firehose)
   destinationArn string
+  // Lambda function this filter streams matching log events to, when the destination is a function
+  lambdaFunction() aws.lambda.function
+  // Kinesis data stream this filter streams matching log events to, when the destination is a stream
+  kinesisStream() aws.kinesis.stream
+  // Firehose delivery stream this filter streams matching log events to, when the destination is a delivery stream
+  firehoseDeliveryStream() aws.kinesis.firehoseDeliveryStream
   // IAM role used to write to the destination
   iamRole() aws.iam.role
   // ARN of the IAM role used to write to the destination

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -14871,6 +14871,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudwatch.loggroup.subscriptionfilter.destinationArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetDestinationArn()).ToDataRes(types.String)
 	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.lambdaFunction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetLambdaFunction()).ToDataRes(types.Resource("aws.lambda.function"))
+	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.kinesisStream": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetKinesisStream()).ToDataRes(types.Resource("aws.kinesis.stream"))
+	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.firehoseDeliveryStream": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetFirehoseDeliveryStream()).ToDataRes(types.Resource("aws.kinesis.firehoseDeliveryStream"))
+	},
 	"aws.cloudwatch.loggroup.subscriptionfilter.iamRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
@@ -48357,6 +48366,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudwatch.loggroup.subscriptionfilter.destinationArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).DestinationArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.lambdaFunction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).LambdaFunction, ok = plugin.RawToTValue[*mqlAwsLambdaFunction](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.kinesisStream": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).KinesisStream, ok = plugin.RawToTValue[*mqlAwsKinesisStream](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.subscriptionfilter.firehoseDeliveryStream": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroupSubscriptionfilter).FirehoseDeliveryStream, ok = plugin.RawToTValue[*mqlAwsKinesisFirehoseDeliveryStream](v.Value, v.Error)
 		return
 	},
 	"aws.cloudwatch.loggroup.subscriptionfilter.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -115772,6 +115793,9 @@ type mqlAwsCloudwatchLoggroupSubscriptionfilter struct {
 	FilterName             plugin.TValue[string]
 	FilterPattern          plugin.TValue[string]
 	DestinationArn         plugin.TValue[string]
+	LambdaFunction         plugin.TValue[*mqlAwsLambdaFunction]
+	KinesisStream          plugin.TValue[*mqlAwsKinesisStream]
+	FirehoseDeliveryStream plugin.TValue[*mqlAwsKinesisFirehoseDeliveryStream]
 	IamRole                plugin.TValue[*mqlAwsIamRole]
 	RoleArn                plugin.TValue[string]
 	Distribution           plugin.TValue[string]
@@ -115831,6 +115855,54 @@ func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetFilterPattern() *plugin.
 
 func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetDestinationArn() *plugin.TValue[string] {
 	return &c.DestinationArn
+}
+
+func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetLambdaFunction() *plugin.TValue[*mqlAwsLambdaFunction] {
+	return plugin.GetOrCompute[*mqlAwsLambdaFunction](&c.LambdaFunction, func() (*mqlAwsLambdaFunction, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudwatch.loggroup.subscriptionfilter", c.__id, "lambdaFunction")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsLambdaFunction), nil
+			}
+		}
+
+		return c.lambdaFunction()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetKinesisStream() *plugin.TValue[*mqlAwsKinesisStream] {
+	return plugin.GetOrCompute[*mqlAwsKinesisStream](&c.KinesisStream, func() (*mqlAwsKinesisStream, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudwatch.loggroup.subscriptionfilter", c.__id, "kinesisStream")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKinesisStream), nil
+			}
+		}
+
+		return c.kinesisStream()
+	})
+}
+
+func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetFirehoseDeliveryStream() *plugin.TValue[*mqlAwsKinesisFirehoseDeliveryStream] {
+	return plugin.GetOrCompute[*mqlAwsKinesisFirehoseDeliveryStream](&c.FirehoseDeliveryStream, func() (*mqlAwsKinesisFirehoseDeliveryStream, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudwatch.loggroup.subscriptionfilter", c.__id, "firehoseDeliveryStream")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKinesisFirehoseDeliveryStream), nil
+			}
+		}
+
+		return c.firehoseDeliveryStream()
+	})
 }
 
 func (c *mqlAwsCloudwatchLoggroupSubscriptionfilter) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1811,8 +1811,11 @@ aws.cloudwatch.loggroup.subscriptionfilter.destinationArn 13.6.3
 aws.cloudwatch.loggroup.subscriptionfilter.distribution 13.6.3
 aws.cloudwatch.loggroup.subscriptionfilter.filterName 13.6.3
 aws.cloudwatch.loggroup.subscriptionfilter.filterPattern 13.6.3
+aws.cloudwatch.loggroup.subscriptionfilter.firehoseDeliveryStream 13.39.2
 aws.cloudwatch.loggroup.subscriptionfilter.iamRole 13.12.1
 aws.cloudwatch.loggroup.subscriptionfilter.id 13.6.3
+aws.cloudwatch.loggroup.subscriptionfilter.kinesisStream 13.39.2
+aws.cloudwatch.loggroup.subscriptionfilter.lambdaFunction 13.39.2
 aws.cloudwatch.loggroup.subscriptionfilter.region 13.6.3
 aws.cloudwatch.loggroup.subscriptionfilter.roleArn 13.6.3
 aws.cloudwatch.loggroup.tags 11.15.2

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -995,13 +995,17 @@ func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) destinationResource(wantSer
 		return nil, false, nil
 	}
 	parsed, err := arn.Parse(arnVal)
-	if err != nil || parsed.Service != wantService {
+	if err != nil {
+		log.Warn().Str("arn", arnVal).Err(err).Msg("could not parse subscription filter destination ARN")
+		return nil, false, nil
+	}
+	if parsed.Service != wantService {
 		return nil, false, nil
 	}
 	res, err := NewResource(a.MqlRuntime, resourceName,
 		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 	return res, true, nil
 }

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -985,6 +985,54 @@ func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) iamRole() (*mqlAwsIamRole, 
 	return res.(*mqlAwsIamRole), nil
 }
 
+// destinationResource resolves the subscription filter's destination ARN to a
+// typed resource, but only when the ARN belongs to wantService. A filter has
+// exactly one destination, so the accessors for the other services resolve to
+// null.
+func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) destinationResource(wantService, resourceName string) (plugin.Resource, bool, error) {
+	arnVal := a.DestinationArn.Data
+	if arnVal == "" {
+		return nil, false, nil
+	}
+	parsed, err := arn.Parse(arnVal)
+	if err != nil || parsed.Service != wantService {
+		return nil, false, nil
+	}
+	res, err := NewResource(a.MqlRuntime, resourceName,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, false, nil
+	}
+	return res, true, nil
+}
+
+func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) lambdaFunction() (*mqlAwsLambdaFunction, error) {
+	res, ok, err := a.destinationResource("lambda", "aws.lambda.function")
+	if err != nil || !ok {
+		a.LambdaFunction.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, err
+	}
+	return res.(*mqlAwsLambdaFunction), nil
+}
+
+func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) kinesisStream() (*mqlAwsKinesisStream, error) {
+	res, ok, err := a.destinationResource("kinesis", "aws.kinesis.stream")
+	if err != nil || !ok {
+		a.KinesisStream.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, err
+	}
+	return res.(*mqlAwsKinesisStream), nil
+}
+
+func (a *mqlAwsCloudwatchLoggroupSubscriptionfilter) firehoseDeliveryStream() (*mqlAwsKinesisFirehoseDeliveryStream, error) {
+	res, ok, err := a.destinationResource("firehose", "aws.kinesis.firehoseDeliveryStream")
+	if err != nil || !ok {
+		a.FirehoseDeliveryStream.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, err
+	}
+	return res.(*mqlAwsKinesisFirehoseDeliveryStream), nil
+}
+
 func (a *mqlAwsCloudwatchLoggroup) logStreams() ([]any, error) {
 	arnValue := a.Arn.Data
 


### PR DESCRIPTION
Adds outbound log-delivery lineage to `aws.cloudwatch.loggroup.subscriptionfilter`.

A subscription filter streams matching log events to exactly one destination — a Lambda function, a Kinesis data stream, or a Firehose delivery stream — identified today only by the raw `destinationArn` string. This adds three typed accessors that resolve that ARN to the modeled resource:

- `lambdaFunction() aws.lambda.function`
- `kinesisStream() aws.kinesis.stream`
- `firehoseDeliveryStream() aws.kinesis.firehoseDeliveryStream`

Each resolves only when the ARN's service segment matches; the other two return null for a given filter. `destinationArn` is retained (it is a cross-service ARN, not a duplicate of any single typed ref). No new API calls or IAM permissions are needed — the destination ARN already comes back on `DescribeSubscriptionFilters`.

This lets a query walk from a log group to whatever consumes its events, e.g.:

```
aws.cloudwatch.loggroups.subscriptionFilters {
  filterName
  lambdaFunction { arn runtime }
  firehoseDeliveryStream { name }
}
```