### PR TITLE
✨ aws: add revisionId to aws.lambda.function

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -14544,6 +14544,8 @@ private aws.lambda.function @defaults("arn") {
   packageType string
   // SHA-256 hash of the function deployment package
   codeSha256 string
+  // Latest revision of the function's configuration and code, updated on every change
+  revisionId string
   // Human-readable description of the function
   description string
   // When the function was last updated

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -20586,6 +20586,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.codeSha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetCodeSha256()).ToDataRes(types.String)
 	},
+	"aws.lambda.function.revisionId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetRevisionId()).ToDataRes(types.String)
+	},
 	"aws.lambda.function.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetDescription()).ToDataRes(types.String)
 	},
@@ -56625,6 +56628,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.codeSha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).CodeSha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.revisionId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).RevisionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.lambda.function.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -136053,6 +136060,7 @@ type mqlAwsLambdaFunction struct {
 	TracingMode                   plugin.TValue[string]
 	PackageType                   plugin.TValue[string]
 	CodeSha256                    plugin.TValue[string]
+	RevisionId                    plugin.TValue[string]
 	Description                   plugin.TValue[string]
 	LastModifiedAt                plugin.TValue[*time.Time]
 	UrlConfig                     plugin.TValue[*mqlAwsLambdaFunctionUrlConfig]
@@ -136316,6 +136324,10 @@ func (c *mqlAwsLambdaFunction) GetPackageType() *plugin.TValue[string] {
 
 func (c *mqlAwsLambdaFunction) GetCodeSha256() *plugin.TValue[string] {
 	return &c.CodeSha256
+}
+
+func (c *mqlAwsLambdaFunction) GetRevisionId() *plugin.TValue[string] {
+	return &c.RevisionId
 }
 
 func (c *mqlAwsLambdaFunction) GetDescription() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6016,6 +6016,7 @@ aws.lambda.function.provisionedConcurrencyConfigs 11.15.2
 aws.lambda.function.recursiveLoop 13.29.1
 aws.lambda.function.region 11.15.2
 aws.lambda.function.resolvedImageUri 13.26.2
+aws.lambda.function.revisionId 13.39.2
 aws.lambda.function.role 11.15.2
 aws.lambda.function.runtime 11.15.2
 aws.lambda.function.runtimeManagementConfig 13.6.3

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -269,6 +269,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"tracingMode":                 llx.StringData(tracingMode),
 		"packageType":                 llx.StringData(string(function.PackageType)),
 		"codeSha256":                  llx.StringDataPtr(function.CodeSha256),
+		"revisionId":                  llx.StringDataPtr(function.RevisionId),
 		"description":                 llx.StringDataPtr(function.Description),
 		"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
 		"state":                       llx.StringData(string(function.State)),


### PR DESCRIPTION
Exposes `revisionId` on `aws.lambda.function`, mapped from the SDK `FunctionConfiguration.RevisionId`.

The revision id changes on every code or configuration update to the function, so it lets an audit detect configuration drift or pin "this is the exact revision I reviewed." It comes back on the existing `ListFunctions`/`GetFunction` data — no new API calls or IAM permissions.