### PR TITLE
✨ aws: add runtimeVersionArn to aws.lambda.function

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -14570,6 +14570,10 @@ private aws.lambda.function @defaults("arn") {
   codeSha256 string
   // Latest revision of the function's configuration and code, updated on every change
   revisionId string
+  // ARN of the resolved managed runtime version the function runs on
+  //
+  // Identifies the exact patched build of the managed runtime, distinct from runtimeManagementConfig, which only reports the update mode. Empty for OS-only runtimes and container-image functions.
+  runtimeVersionArn string
   // Human-readable description of the function
   description string
   // When the function was last updated

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -20619,6 +20619,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.revisionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetRevisionId()).ToDataRes(types.String)
 	},
+	"aws.lambda.function.runtimeVersionArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetRuntimeVersionArn()).ToDataRes(types.String)
+	},
 	"aws.lambda.function.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetDescription()).ToDataRes(types.String)
 	},
@@ -56711,6 +56714,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.revisionId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).RevisionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.runtimeVersionArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).RuntimeVersionArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.lambda.function.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -136252,6 +136259,7 @@ type mqlAwsLambdaFunction struct {
 	PackageType                   plugin.TValue[string]
 	CodeSha256                    plugin.TValue[string]
 	RevisionId                    plugin.TValue[string]
+	RuntimeVersionArn             plugin.TValue[string]
 	Description                   plugin.TValue[string]
 	LastModifiedAt                plugin.TValue[*time.Time]
 	UrlConfig                     plugin.TValue[*mqlAwsLambdaFunctionUrlConfig]
@@ -136519,6 +136527,10 @@ func (c *mqlAwsLambdaFunction) GetCodeSha256() *plugin.TValue[string] {
 
 func (c *mqlAwsLambdaFunction) GetRevisionId() *plugin.TValue[string] {
 	return &c.RevisionId
+}
+
+func (c *mqlAwsLambdaFunction) GetRuntimeVersionArn() *plugin.TValue[string] {
+	return &c.RuntimeVersionArn
 }
 
 func (c *mqlAwsLambdaFunction) GetDescription() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6033,6 +6033,7 @@ aws.lambda.function.revisionId 13.39.2
 aws.lambda.function.role 11.15.2
 aws.lambda.function.runtime 11.15.2
 aws.lambda.function.runtimeManagementConfig 13.6.3
+aws.lambda.function.runtimeVersionArn 13.39.2
 aws.lambda.function.securityGroups 13.2.7
 aws.lambda.function.signingJobArn 11.15.2
 aws.lambda.function.signingProfileVersionArn 11.15.2

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -254,6 +254,11 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		layers = append(layers, mqlLayer)
 	}
 
+	var runtimeVersionArn string
+	if function.RuntimeVersionConfig != nil {
+		runtimeVersionArn = convert.ToValue(function.RuntimeVersionConfig.RuntimeVersionArn)
+	}
+
 	args := map[string]*llx.RawData{
 		"arn":                         llx.StringDataPtr(function.FunctionArn),
 		"name":                        llx.StringDataPtr(function.FunctionName),
@@ -270,6 +275,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"packageType":                 llx.StringData(string(function.PackageType)),
 		"codeSha256":                  llx.StringDataPtr(function.CodeSha256),
 		"revisionId":                  llx.StringDataPtr(function.RevisionId),
+		"runtimeVersionArn":           llx.StringData(runtimeVersionArn),
 		"description":                 llx.StringDataPtr(function.Description),
 		"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
 		"state":                       llx.StringData(string(function.State)),


### PR DESCRIPTION
Exposes `runtimeVersionArn` on `aws.lambda.function`, mapped from `FunctionConfiguration.RuntimeVersionConfig.RuntimeVersionArn`.

This is the ARN of the **resolved, patched build of the managed runtime** the function actually runs on — the true runtime-supply-chain provenance. It is distinct from the existing `runtimeManagementConfig()`, which only reports the *update mode* (Auto/FunctionUpdate/Manual), not the concrete version in use. Empty for OS-only runtimes and container-image functions.

Comes back on the existing `ListFunctions`/`GetFunction` data — no new API calls or IAM permissions.