### PR TITLE
✨ aws: add ecrImage and repositoryCredentialsSecret refs to ecs container

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7238,6 +7238,12 @@ private aws.ecs.container @defaults("containerName runtimeId clusterName region"
   image string
   // Resolved digest of the image actually running in the container
   imageDigest string
+  // ECR image the container is running, when the image is hosted in Elastic Container Registry in this account
+  //
+  // Resolved from the image URI and imageDigest. Null for images pulled from Docker Hub, public registries, or ECR repositories in another account.
+  ecrImage() aws.ecr.image
+  // Secrets Manager secret holding the private registry credentials used to pull the image, when configured on the task definition
+  repositoryCredentialsSecret() aws.secretsmanager.secret
   // Cluster associated with the ECS container
   clusterName string
   // Task definition associated with the ECS container

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12771,6 +12771,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.container.imageDigest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsContainer).GetImageDigest()).ToDataRes(types.String)
 	},
+	"aws.ecs.container.ecrImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsContainer).GetEcrImage()).ToDataRes(types.Resource("aws.ecr.image"))
+	},
+	"aws.ecs.container.repositoryCredentialsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsContainer).GetRepositoryCredentialsSecret()).ToDataRes(types.Resource("aws.secretsmanager.secret"))
+	},
 	"aws.ecs.container.clusterName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsContainer).GetClusterName()).ToDataRes(types.String)
 	},
@@ -45209,6 +45215,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecs.container.imageDigest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsContainer).ImageDigest, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.container.ecrImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsContainer).EcrImage, ok = plugin.RawToTValue[*mqlAwsEcrImage](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.container.repositoryCredentialsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsContainer).RepositoryCredentialsSecret, ok = plugin.RawToTValue[*mqlAwsSecretsmanagerSecret](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.container.clusterName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -106714,31 +106728,33 @@ func (c *mqlAwsEcsTask) GetFargateEphemeralStorageKmsKey() *plugin.TValue[*mqlAw
 type mqlAwsEcsContainer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEcsContainerInternal it will be used here
-	Name               plugin.TValue[string]
-	Arn                plugin.TValue[string]
-	PublicIp           plugin.TValue[string]
-	Image              plugin.TValue[string]
-	ImageDigest        plugin.TValue[string]
-	ClusterName        plugin.TValue[string]
-	TaskDefinition     plugin.TValue[*mqlAwsEcsTaskDefinition]
-	TaskDefinitionArn  plugin.TValue[string]
-	LogDriver          plugin.TValue[string]
-	PlatformFamily     plugin.TValue[string]
-	PlatformVersion    plugin.TValue[string]
-	Status             plugin.TValue[string]
-	Region             plugin.TValue[string]
-	Command            plugin.TValue[[]any]
-	Task               plugin.TValue[*mqlAwsEcsTask]
-	TaskArn            plugin.TValue[string]
-	RuntimeId          plugin.TValue[string]
-	ContainerName      plugin.TValue[string]
-	CpuUnits           plugin.TValue[string]
-	MemorySoftLimit    plugin.TValue[string]
-	MemoryHardLimit    plugin.TValue[string]
-	Reason             plugin.TValue[string]
-	User               plugin.TValue[string]
-	InitProcessEnabled plugin.TValue[bool]
+	mqlAwsEcsContainerInternal
+	Name                        plugin.TValue[string]
+	Arn                         plugin.TValue[string]
+	PublicIp                    plugin.TValue[string]
+	Image                       plugin.TValue[string]
+	ImageDigest                 plugin.TValue[string]
+	EcrImage                    plugin.TValue[*mqlAwsEcrImage]
+	RepositoryCredentialsSecret plugin.TValue[*mqlAwsSecretsmanagerSecret]
+	ClusterName                 plugin.TValue[string]
+	TaskDefinition              plugin.TValue[*mqlAwsEcsTaskDefinition]
+	TaskDefinitionArn           plugin.TValue[string]
+	LogDriver                   plugin.TValue[string]
+	PlatformFamily              plugin.TValue[string]
+	PlatformVersion             plugin.TValue[string]
+	Status                      plugin.TValue[string]
+	Region                      plugin.TValue[string]
+	Command                     plugin.TValue[[]any]
+	Task                        plugin.TValue[*mqlAwsEcsTask]
+	TaskArn                     plugin.TValue[string]
+	RuntimeId                   plugin.TValue[string]
+	ContainerName               plugin.TValue[string]
+	CpuUnits                    plugin.TValue[string]
+	MemorySoftLimit             plugin.TValue[string]
+	MemoryHardLimit             plugin.TValue[string]
+	Reason                      plugin.TValue[string]
+	User                        plugin.TValue[string]
+	InitProcessEnabled          plugin.TValue[bool]
 }
 
 // createAwsEcsContainer creates a new instance of this resource
@@ -106796,6 +106812,38 @@ func (c *mqlAwsEcsContainer) GetImage() *plugin.TValue[string] {
 
 func (c *mqlAwsEcsContainer) GetImageDigest() *plugin.TValue[string] {
 	return &c.ImageDigest
+}
+
+func (c *mqlAwsEcsContainer) GetEcrImage() *plugin.TValue[*mqlAwsEcrImage] {
+	return plugin.GetOrCompute[*mqlAwsEcrImage](&c.EcrImage, func() (*mqlAwsEcrImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.container", c.__id, "ecrImage")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEcrImage), nil
+			}
+		}
+
+		return c.ecrImage()
+	})
+}
+
+func (c *mqlAwsEcsContainer) GetRepositoryCredentialsSecret() *plugin.TValue[*mqlAwsSecretsmanagerSecret] {
+	return plugin.GetOrCompute[*mqlAwsSecretsmanagerSecret](&c.RepositoryCredentialsSecret, func() (*mqlAwsSecretsmanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.container", c.__id, "repositoryCredentialsSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsSecretsmanagerSecret), nil
+			}
+		}
+
+		return c.repositoryCredentialsSecret()
+	})
 }
 
 func (c *mqlAwsEcsContainer) GetClusterName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3626,6 +3626,7 @@ aws.ecs.container.clusterName 11.15.2
 aws.ecs.container.command 11.15.2
 aws.ecs.container.containerName 11.15.2
 aws.ecs.container.cpuUnits 11.15.2
+aws.ecs.container.ecrImage 13.39.2
 aws.ecs.container.image 11.15.2
 aws.ecs.container.imageDigest 13.35.2
 aws.ecs.container.initProcessEnabled 13.2.7
@@ -3638,6 +3639,7 @@ aws.ecs.container.platformVersion 11.15.2
 aws.ecs.container.publicIp 11.15.2
 aws.ecs.container.reason 11.15.2
 aws.ecs.container.region 11.15.2
+aws.ecs.container.repositoryCredentialsSecret 13.39.2
 aws.ecs.container.runtimeId 11.15.2
 aws.ecs.container.status 11.15.2
 aws.ecs.container.task 13.12.1

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -568,6 +568,7 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 	containerCommandMap := make(map[string][]string)
 	containerUserMap := make(map[string]string)
 	containerInitProcessMap := make(map[string]bool)
+	containerRepoCredsMap := make(map[string]string)
 
 	for i := range definition.TaskDefinition.ContainerDefinitions {
 		cd := definition.TaskDefinition.ContainerDefinitions[i]
@@ -581,6 +582,9 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 			containerUserMap[*cd.Name] = convert.ToValue(cd.User)
 			if cd.LinuxParameters != nil {
 				containerInitProcessMap[*cd.Name] = convert.ToValue(cd.LinuxParameters.InitProcessEnabled)
+			}
+			if cd.RepositoryCredentials != nil {
+				containerRepoCredsMap[*cd.Name] = convert.ToValue(cd.RepositoryCredentials.CredentialsParameter)
 			}
 		}
 	}
@@ -633,9 +637,69 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlContainer.(*mqlAwsEcsContainer).cacheRepositoryCredentialsArn = containerRepoCredsMap[convert.ToValue(c.Name)]
 		containers = append(containers, mqlContainer)
 	}
 	return containers, nil
+}
+
+type mqlAwsEcsContainerInternal struct {
+	cacheRepositoryCredentialsArn string
+}
+
+// ecrImage resolves the ECR image the container is running, when the image is
+// hosted in Elastic Container Registry in this account. The image is frequently
+// pulled from Docker Hub, a public registry, or a cross-account ECR repository,
+// in which case there is no matching aws.ecr.image and the reference is null.
+func (a *mqlAwsEcsContainer) ecrImage() (*mqlAwsEcrImage, error) {
+	image := a.Image.Data
+	digest := a.ImageDigest.Data
+	if digest == "" || !strings.Contains(image, ".dkr.ecr.") {
+		a.EcrImage.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	// <registryId>.dkr.ecr.<region>.amazonaws.com/<repoName>[:tag][@digest]
+	host, path, ok := strings.Cut(image, "/")
+	if !ok {
+		a.EcrImage.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	hostParts := strings.Split(host, ".")
+	if len(hostParts) < 4 {
+		a.EcrImage.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	repoName := path
+	if i := strings.IndexByte(repoName, '@'); i >= 0 {
+		repoName = repoName[:i]
+	}
+	if i := strings.IndexByte(repoName, ':'); i >= 0 {
+		repoName = repoName[:i]
+	}
+	arnVal := ecrImageArn(ImageInfo{Region: hostParts[3], RegistryId: hostParts[0], RepoName: repoName, Digest: digest})
+	res, err := NewResource(a.MqlRuntime, "aws.ecr.image",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.EcrImage.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsEcrImage), nil
+}
+
+// repositoryCredentialsSecret resolves the Secrets Manager secret holding the
+// private registry credentials used to pull the image. Only set when the task
+// definition configures repositoryCredentials.
+func (a *mqlAwsEcsContainer) repositoryCredentialsSecret() (*mqlAwsSecretsmanagerSecret, error) {
+	if a.cacheRepositoryCredentialsArn == "" {
+		a.RepositoryCredentialsSecret.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.secretsmanager.secret",
+		map[string]*llx.RawData{"arn": llx.StringData(a.cacheRepositoryCredentialsArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsSecretsmanagerSecret), nil
 }
 
 func getContainerIP(eniPublicIPs map[string]string, attachments []ecstypes.Attachment, c ecstypes.Container) string {

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -680,6 +680,10 @@ func (a *mqlAwsEcsContainer) ecrImage() (*mqlAwsEcrImage, error) {
 	res, err := NewResource(a.MqlRuntime, "aws.ecr.image",
 		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
 	if err != nil {
+		// The image is commonly absent (deleted, or in another account), which
+		// surfaces here as an error; log it so genuine API/permission failures
+		// are still visible, but leave the reference null rather than failing.
+		log.Warn().Err(err).Str("arn", arnVal).Msg("could not resolve ECR image for ECS container")
 		a.EcrImage.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}


### PR DESCRIPTION
Adds two typed cross-references to `aws.ecs.container` for supply-chain provenance.

## `ecrImage() aws.ecr.image`
Resolves the image a container is actually running to its modeled ECR image, so you can walk from a running container to its push time, `scanFinding` sub-resources, tags, and lifecycle. The container already resolves `image` (URI) and `imageDigest`; this parses the registry id, region, and repo name out of the ECR image URI and constructs the ECR image ARN (`arn:aws:ecr:<region>:<registry>:image/<repo>/<digest>`) to look it up.

Resolves to null (not an error) when the image isn't a linkable ECR image in this account — Docker Hub, public registries, deleted images, and cross-account ECR repositories are all expected and common.

## `repositoryCredentialsSecret() aws.secretsmanager.secret`
The Secrets Manager secret holding the private-registry credentials used to pull the image, taken from the task definition's `repositoryCredentials`. Null when the task definition configures no pull credentials.

Both resolve from data already gathered (`DescribeTasks` + `DescribeTaskDefinition`), so there are no new API calls or IAM permissions.