### PR TITLE
🧹 aws: unit-test managedBy tag inference and terraform heuristic

### DIFF
--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -99,7 +99,9 @@ func (a *mqlAwsEfsFilesystem) managedBy() (string, error) {
 	if ct.Error != nil {
 		return "", ct.Error
 	}
-	return managedByWithCreationToken(owner, ct.Data), nil
+	// owner is "" here (the early return above handled the non-empty case); pass
+	// it explicitly so the call doesn't read as depending on a live value.
+	return managedByWithCreationToken("", ct.Data), nil
 }
 
 func (a *mqlAwsEfsFilesystem) cloudformationStack() (*mqlAwsCloudformationStack, error) {

--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -70,25 +70,36 @@ func (a *mqlAwsEc2Snapshot) cloudformationStack() (*mqlAwsCloudformationStack, e
 	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
 }
 
+// managedByWithCreationToken augments the tag-based owner with an EFS-specific
+// Terraform fallback. Terraform injects no provenance tag, but when
+// creation_token is left unset the Terraform AWS provider auto-generates one
+// with a "terraform-" prefix, which is the only managed-by signal it leaves.
+// The tag-based owner always wins when present.
+func managedByWithCreationToken(tagOwner, creationToken string) string {
+	if tagOwner != "" {
+		return tagOwner
+	}
+	if strings.HasPrefix(creationToken, "terraform-") {
+		return "terraform"
+	}
+	return ""
+}
+
 func (a *mqlAwsEfsFilesystem) managedBy() (string, error) {
 	owner, err := managedByFromResourceTags(a.GetTags())
 	if err != nil {
 		return "", err
 	}
+	// A definitive tag-based owner short-circuits before touching the creation
+	// token, so a token resolution error never masks a known owner.
 	if owner != "" {
 		return owner, nil
 	}
-	// Terraform injects no provenance tag, but when creation_token is left
-	// unset the Terraform AWS provider auto-generates one with a "terraform-"
-	// prefix. Fall back to that heuristic only when no tag-based owner matched.
 	ct := a.GetCreationToken()
 	if ct.Error != nil {
 		return "", ct.Error
 	}
-	if strings.HasPrefix(ct.Data, "terraform-") {
-		return "terraform", nil
-	}
-	return "", nil
+	return managedByWithCreationToken(owner, ct.Data), nil
 }
 
 func (a *mqlAwsEfsFilesystem) cloudformationStack() (*mqlAwsCloudformationStack, error) {

--- a/providers/aws/resources/aws_managed_by_test.go
+++ b/providers/aws/resources/aws_managed_by_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManagedByFromTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]any
+		want string
+	}{
+		{"nil tags", nil, ""},
+		{"empty tags", map[string]any{}, ""},
+		{"unrelated tags", map[string]any{"Name": "web", "env": "prod"}, ""},
+		{"cloudformation", map[string]any{"aws:cloudformation:stack-name": "my-stack"}, "cloudformation"},
+		{"elasticbeanstalk", map[string]any{"elasticbeanstalk:environment-name": "my-env"}, "elasticbeanstalk"},
+		{"eks", map[string]any{"eks:cluster-name": "my-cluster"}, "eks"},
+		{"servicecatalog", map[string]any{"aws:servicecatalog:provisioningPrincipalArn": "arn:aws:iam::1:user/x"}, "servicecatalog"},
+		{"autoscaling", map[string]any{"aws:autoscaling:groupName": "my-asg"}, "autoscaling"},
+		// The signal list is ordered; cloudformation is checked before eks, so a
+		// resource carrying both reports cloudformation.
+		{"precedence cloudformation over eks", map[string]any{
+			"eks:cluster-name":              "my-cluster",
+			"aws:cloudformation:stack-name": "my-stack",
+		}, "cloudformation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, managedByFromTags(tt.tags))
+		})
+	}
+}
+
+func TestManagedByWithCreationToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		tagOwner      string
+		creationToken string
+		want          string
+	}{
+		{"tag owner wins over terraform token", "cloudformation", "terraform-20240101000000000000000001", "cloudformation"},
+		{"terraform token when no tag owner", "", "terraform-20240101000000000000000001", "terraform"},
+		{"custom token, no tag owner", "", "my-own-token", ""},
+		{"empty token, no tag owner", "", "", ""},
+		{"tag owner with no token", "eks", "", "eks"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, managedByWithCreationToken(tt.tagOwner, tt.creationToken))
+		})
+	}
+}


### PR DESCRIPTION
Adds unit coverage for the `managedBy` provenance inference logic that the recent AWS provenance work added across ~30 resources.

- **Extracts** the EFS Terraform creation-token fallback out of the `aws.efs.filesystem` method into a pure helper, `managedByWithCreationToken(tagOwner, creationToken)`, so the heuristic is testable without constructing a resource + runtime. The EFS method keeps its short-circuit (a definitive tag-based owner returns before the creation token is touched, so a token resolution error never masks a known owner).
- **Tests `managedByFromTags`** — the tag-signal inference shared across all `managedBy()` implementations: each of the five AWS-injected provenance tags (cloudformation, elasticbeanstalk, eks, servicecatalog, autoscaling), the nil/empty/unrelated-tags cases, and signal precedence (cloudformation before eks).
- **Tests `managedByWithCreationToken`** — the Terraform `terraform-` prefix fallback, the tag-owner-wins rule, and the no-signal cases.

Pure-function tests only; no runtime mocking. No schema or generated-code changes.