### PR TITLE
✨ aws: add subnets and state to aws.elb.loadbalancer

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5372,6 +5372,10 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   createdAt time
   // Availability zone where the load balancer runs
   availabilityZones []string
+  // Subnets the load balancer is attached to
+  subnets() []aws.vpc.subnet
+  // Provisioning state of the load balancer (active, provisioning, active_impaired, or failed; null for classic load balancers)
+  state string
   // VPC security groups for the load balancer
   securityGroups []aws.ec2.securitygroup
   // Internet-exposure breakdown (internet-facing scheme combined with security group ingress)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10779,6 +10779,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
 	},
+	"aws.elb.loadbalancer.subnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetSubnets()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
+	},
+	"aws.elb.loadbalancer.state": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetState()).ToDataRes(types.String)
+	},
 	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
@@ -42332,6 +42338,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.loadbalancer.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).AvailabilityZones, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -99282,6 +99296,8 @@ type mqlAwsElbLoadbalancer struct {
 	Attributes           plugin.TValue[[]any]
 	CreatedAt            plugin.TValue[*time.Time]
 	AvailabilityZones    plugin.TValue[[]any]
+	Subnets              plugin.TValue[[]any]
+	State                plugin.TValue[string]
 	SecurityGroups       plugin.TValue[[]any]
 	Exposure             plugin.TValue[*mqlAwsNetworkExposure]
 	HostedZoneId         plugin.TValue[string]
@@ -99371,6 +99387,26 @@ func (c *mqlAwsElbLoadbalancer) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsElbLoadbalancer) GetAvailabilityZones() *plugin.TValue[[]any] {
 	return &c.AvailabilityZones
+}
+
+func (c *mqlAwsElbLoadbalancer) GetSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elb.loadbalancer", c.__id, "subnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnets()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetState() *plugin.TValue[string] {
+	return &c.State
 }
 
 func (c *mqlAwsElbLoadbalancer) GetSecurityGroups() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4335,6 +4335,8 @@ aws.elb.loadbalancer.name 11.15.2
 aws.elb.loadbalancer.region 11.15.2
 aws.elb.loadbalancer.scheme 11.15.2
 aws.elb.loadbalancer.securityGroups 11.15.2
+aws.elb.loadbalancer.state 13.39.2
+aws.elb.loadbalancer.subnets 13.39.2
 aws.elb.loadbalancer.tags 11.15.2
 aws.elb.loadbalancer.targetGroups 11.15.2
 aws.elb.loadbalancer.vpc 11.15.2

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -142,6 +142,7 @@ func buildElbClassicLoadBalancerResource(runtime *plugin.Runtime, region, accoun
 		"region":               llx.StringData(region),
 		"scheme":               llx.StringDataPtr(lb.Scheme),
 		"securityGroups":       llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
+		"state":                llx.NilData, // classic load balancers have no provisioning state
 		"vpc":                  llx.NilData,
 	}
 
@@ -162,14 +163,42 @@ func buildElbClassicLoadBalancerResource(runtime *plugin.Runtime, region, accoun
 	if err != nil {
 		return nil, err
 	}
-	return mqlLb.(*mqlAwsElbLoadbalancer), nil
+	res := mqlLb.(*mqlAwsElbLoadbalancer)
+	res.cacheSubnetIds = lb.Subnets
+	return res, nil
 }
 
 func (a *mqlAwsElbLoadbalancer) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsElbLoadbalancer) subnets() ([]any, error) {
+	if len(a.cacheSubnetIds) == 0 {
+		return []any{}, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	res := []any{}
+	for _, subnetId := range a.cacheSubnetIds {
+		mqlSubnet, err := NewResource(a.MqlRuntime, ResourceAwsVpcSubnet,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(subnetArnPattern, region, conn.AccountId(), subnetId)),
+			})
+		if err != nil {
+			// When tag filters are active, the subnet may not be in the filtered
+			// list. Log and continue rather than failing the entire LB.
+			log.Debug().Str("subnet", subnetId).Err(err).Msg("could not resolve subnet for ELB")
+			continue
+		}
+		res = append(res, mqlSubnet)
+	}
+	return res, nil
+}
+
 type mqlAwsElbLoadbalancerInternal struct {
+	// Subnet IDs the load balancer is attached to, resolved lazily by subnets().
+	cacheSubnetIds []string
+
 	// Cached v2 DescribeLoadBalancerAttributes response, shared between attributes() and attribute().
 	cachedV2Attrs  []elbtypes.LoadBalancerAttribute
 	v2AttrsFetched bool
@@ -285,8 +314,17 @@ func (a *mqlAwsElb) getLoadBalancers(conn *connection.AwsConnection) []*jobpool.
 
 func buildElbV2LoadBalancerResource(runtime *plugin.Runtime, region, accountID string, lb elbtypes.LoadBalancer) (*mqlAwsElbLoadbalancer, error) {
 	availabilityZones := []any{}
+	subnetIds := []string{}
 	for _, zone := range lb.AvailabilityZones {
 		availabilityZones = append(availabilityZones, convert.ToValue(zone.ZoneName))
+		if zone.SubnetId != nil {
+			subnetIds = append(subnetIds, *zone.SubnetId)
+		}
+	}
+
+	state := ""
+	if lb.State != nil {
+		state = string(lb.State.Code)
 	}
 
 	sgs := []any{}
@@ -313,6 +351,7 @@ func buildElbV2LoadBalancerResource(runtime *plugin.Runtime, region, accountID s
 		"name":              llx.StringDataPtr(lb.LoadBalancerName),
 		"scheme":            llx.StringData(string(lb.Scheme)),
 		"securityGroups":    llx.ArrayData(sgs, types.Resource(ResourceAwsEc2Securitygroup)),
+		"state":             llx.StringData(state),
 		"elbType":           llx.StringData(string(lb.Type)),
 		"ipAddressType":     llx.StringData(string(lb.IpAddressType)),
 		"region":            llx.StringData(region),
@@ -338,7 +377,9 @@ func buildElbV2LoadBalancerResource(runtime *plugin.Runtime, region, accountID s
 	if err != nil {
 		return nil, err
 	}
-	return mqlLb.(*mqlAwsElbLoadbalancer), nil
+	res := mqlLb.(*mqlAwsElbLoadbalancer)
+	res.cacheSubnetIds = subnetIds
+	return res, nil
 }
 
 func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
Fills two SDK-completeness gaps on `aws.elb.loadbalancer` (classic ELB + ALB/NLB).

- `subnets() []aws.vpc.subnet` — a typed accessor for the subnets the load balancer is attached to. Resolved from the classic ELB `Subnets` field and from the ALB/NLB availability-zone subnet ids. Follows the existing `securityGroups` resolution pattern (log-and-continue when a subnet isn't resolvable, e.g. under active tag filters).
- `state string` — the ALB/NLB provisioning state (`active`, `provisioning`, `active_impaired`, `failed`). Null for classic load balancers, which have no provisioning state.

Both come back on the existing `DescribeLoadBalancers` calls — no new API calls or IAM permissions. These are config/operational completeness fields rather than provenance.