### PR TITLE
✨ aws: add change provenance to es/opensearch domains and software parity

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4933,6 +4933,16 @@ private aws.es.domain @defaults("arn name") {
   serviceSoftwareCancellable bool
   // Date until which a service software update can be manually requested before it auto-updates
   serviceSoftwareAutomatedUpdateDate time
+  // ID of the most recent configuration change to the domain
+  lastConfigChangeId string
+  // Who initiated the most recent configuration change (CUSTOMER or SERVICE)
+  lastConfigChangeInitiatedBy string
+  // Status of the most recent configuration change (for example PENDING, APPLYING_CHANGES, or COMPLETED)
+  lastConfigChangeStatus string
+  // Time the most recent configuration change was initiated
+  lastConfigChangeStartedAt time
+  // Time the most recent configuration change was last updated
+  lastConfigChangeUpdatedAt time
   // Whether audit logging is enabled for the domain
   auditLogEnabled bool
   // CloudWatch log group receiving audit logs
@@ -5066,6 +5076,26 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   ipAddressType string
   // New service software version available for the domain (empty string if up to date)
   serviceSoftwareNewVersion string
+  // Current service software version present on the domain
+  serviceSoftwareCurrentVersion string
+  // Whether a service software update is available
+  serviceSoftwareUpdateAvailable bool
+  // Status of the service software update (ELIGIBLE, PENDING_UPDATE, IN_PROGRESS, COMPLETED, NOT_ELIGIBLE)
+  serviceSoftwareUpdateStatus string
+  // Whether an in-progress service software update can be cancelled
+  serviceSoftwareCancellable bool
+  // Date until which a service software update can be manually requested before it auto-updates
+  serviceSoftwareAutomatedUpdateDate time
+  // ID of the most recent configuration change to the domain
+  lastConfigChangeId string
+  // Who initiated the most recent configuration change (CUSTOMER or SERVICE)
+  lastConfigChangeInitiatedBy string
+  // Status of the most recent configuration change (for example PENDING, APPLYING_CHANGES, or COMPLETED)
+  lastConfigChangeStatus string
+  // Time the most recent configuration change was initiated
+  lastConfigChangeStartedAt time
+  // Time the most recent configuration change was last updated
+  lastConfigChangeUpdatedAt time
   // Whether automatic software updates are enabled
   autoSoftwareUpdateEnabled bool
   // Whether the off-peak maintenance window is enabled

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10236,6 +10236,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.es.domain.serviceSoftwareAutomatedUpdateDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetServiceSoftwareAutomatedUpdateDate()).ToDataRes(types.Time)
 	},
+	"aws.es.domain.lastConfigChangeId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetLastConfigChangeId()).ToDataRes(types.String)
+	},
+	"aws.es.domain.lastConfigChangeInitiatedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetLastConfigChangeInitiatedBy()).ToDataRes(types.String)
+	},
+	"aws.es.domain.lastConfigChangeStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetLastConfigChangeStatus()).ToDataRes(types.String)
+	},
+	"aws.es.domain.lastConfigChangeStartedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetLastConfigChangeStartedAt()).ToDataRes(types.Time)
+	},
+	"aws.es.domain.lastConfigChangeUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetLastConfigChangeUpdatedAt()).ToDataRes(types.Time)
+	},
 	"aws.es.domain.auditLogEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetAuditLogEnabled()).ToDataRes(types.Bool)
 	},
@@ -10403,6 +10418,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.opensearch.domain.serviceSoftwareNewVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareNewVersion()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.serviceSoftwareCurrentVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareCurrentVersion()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.serviceSoftwareUpdateAvailable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareUpdateAvailable()).ToDataRes(types.Bool)
+	},
+	"aws.opensearch.domain.serviceSoftwareUpdateStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareUpdateStatus()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.serviceSoftwareCancellable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareCancellable()).ToDataRes(types.Bool)
+	},
+	"aws.opensearch.domain.serviceSoftwareAutomatedUpdateDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareAutomatedUpdateDate()).ToDataRes(types.Time)
+	},
+	"aws.opensearch.domain.lastConfigChangeId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetLastConfigChangeId()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.lastConfigChangeInitiatedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetLastConfigChangeInitiatedBy()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.lastConfigChangeStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetLastConfigChangeStatus()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.lastConfigChangeStartedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetLastConfigChangeStartedAt()).ToDataRes(types.Time)
+	},
+	"aws.opensearch.domain.lastConfigChangeUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetLastConfigChangeUpdatedAt()).ToDataRes(types.Time)
 	},
 	"aws.opensearch.domain.autoSoftwareUpdateEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetAutoSoftwareUpdateEnabled()).ToDataRes(types.Bool)
@@ -41566,6 +41611,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEsDomain).ServiceSoftwareAutomatedUpdateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.es.domain.lastConfigChangeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).LastConfigChangeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.lastConfigChangeInitiatedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).LastConfigChangeInitiatedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.lastConfigChangeStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).LastConfigChangeStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.lastConfigChangeStartedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).LastConfigChangeStartedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.lastConfigChangeUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).LastConfigChangeUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.es.domain.auditLogEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEsDomain).AuditLogEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -41796,6 +41861,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.opensearch.domain.serviceSoftwareNewVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOpensearchDomain).ServiceSoftwareNewVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareCurrentVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareCurrentVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareUpdateAvailable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareUpdateAvailable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareUpdateStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareUpdateStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareCancellable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareCancellable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareAutomatedUpdateDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareAutomatedUpdateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.lastConfigChangeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).LastConfigChangeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.lastConfigChangeInitiatedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).LastConfigChangeInitiatedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.lastConfigChangeStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).LastConfigChangeStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.lastConfigChangeStartedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).LastConfigChangeStartedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.lastConfigChangeUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).LastConfigChangeUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.opensearch.domain.autoSoftwareUpdateEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -97288,6 +97393,11 @@ type mqlAwsEsDomain struct {
 	ServiceSoftwareUpdateStatus        plugin.TValue[string]
 	ServiceSoftwareCancellable         plugin.TValue[bool]
 	ServiceSoftwareAutomatedUpdateDate plugin.TValue[*time.Time]
+	LastConfigChangeId                 plugin.TValue[string]
+	LastConfigChangeInitiatedBy        plugin.TValue[string]
+	LastConfigChangeStatus             plugin.TValue[string]
+	LastConfigChangeStartedAt          plugin.TValue[*time.Time]
+	LastConfigChangeUpdatedAt          plugin.TValue[*time.Time]
 	AuditLogEnabled                    plugin.TValue[bool]
 	AuditLogGroup                      plugin.TValue[*mqlAwsCloudwatchLoggroup]
 	IndexSlowLogEnabled                plugin.TValue[bool]
@@ -97675,6 +97785,26 @@ func (c *mqlAwsEsDomain) GetServiceSoftwareAutomatedUpdateDate() *plugin.TValue[
 	return &c.ServiceSoftwareAutomatedUpdateDate
 }
 
+func (c *mqlAwsEsDomain) GetLastConfigChangeId() *plugin.TValue[string] {
+	return &c.LastConfigChangeId
+}
+
+func (c *mqlAwsEsDomain) GetLastConfigChangeInitiatedBy() *plugin.TValue[string] {
+	return &c.LastConfigChangeInitiatedBy
+}
+
+func (c *mqlAwsEsDomain) GetLastConfigChangeStatus() *plugin.TValue[string] {
+	return &c.LastConfigChangeStatus
+}
+
+func (c *mqlAwsEsDomain) GetLastConfigChangeStartedAt() *plugin.TValue[*time.Time] {
+	return &c.LastConfigChangeStartedAt
+}
+
+func (c *mqlAwsEsDomain) GetLastConfigChangeUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastConfigChangeUpdatedAt
+}
+
 func (c *mqlAwsEsDomain) GetAuditLogEnabled() *plugin.TValue[bool] {
 	return &c.AuditLogEnabled
 }
@@ -97821,62 +97951,72 @@ type mqlAwsOpensearchDomain struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsOpensearchDomainInternal
-	Arn                             plugin.TValue[string]
-	Name                            plugin.TValue[string]
-	DomainId                        plugin.TValue[string]
-	Region                          plugin.TValue[string]
-	EngineVersion                   plugin.TValue[string]
-	Endpoint                        plugin.TValue[string]
-	EncryptionAtRestEnabled         plugin.TValue[bool]
-	EncryptionAtRestKmsKeyId        plugin.TValue[string]
-	EncryptionAtRestKmsKey          plugin.TValue[*mqlAwsKmsKey]
-	NodeToNodeEncryptionEnabled     plugin.TValue[bool]
-	DedicatedMasterEnabled          plugin.TValue[bool]
-	DedicatedMasterType             plugin.TValue[string]
-	DedicatedMasterCount            plugin.TValue[int64]
-	InstanceType                    plugin.TValue[string]
-	InstanceCount                   plugin.TValue[int64]
-	ZoneAwarenessEnabled            plugin.TValue[bool]
-	AvailabilityZoneCount           plugin.TValue[int64]
-	WarmEnabled                     plugin.TValue[bool]
-	WarmType                        plugin.TValue[string]
-	WarmCount                       plugin.TValue[int64]
-	ColdStorageEnabled              plugin.TValue[bool]
-	EbsEnabled                      plugin.TValue[bool]
-	EbsVolumeType                   plugin.TValue[string]
-	EbsVolumeSize                   plugin.TValue[int64]
-	EbsIops                         plugin.TValue[int64]
-	EbsThroughput                   plugin.TValue[int64]
-	VpcId                           plugin.TValue[string]
-	Vpc                             plugin.TValue[*mqlAwsVpc]
-	VpcEgressEnabled                plugin.TValue[bool]
-	EnforceHTTPS                    plugin.TValue[bool]
-	TlsSecurityPolicy               plugin.TValue[string]
-	CustomEndpointEnabled           plugin.TValue[bool]
-	CustomEndpoint                  plugin.TValue[string]
-	CustomEndpointCertificate       plugin.TValue[*mqlAwsAcmCertificate]
-	SamlEnabled                     plugin.TValue[bool]
-	JwtEnabled                      plugin.TValue[bool]
-	JwksUrl                         plugin.TValue[string]
-	AnonymousAuthEnabled            plugin.TValue[bool]
-	InternalUserDatabaseEnabled     plugin.TValue[bool]
-	AdvancedSecurityEnabled         plugin.TValue[bool]
-	Processing                      plugin.TValue[bool]
-	UpgradeProcessing               plugin.TValue[bool]
-	CreatedAt                       plugin.TValue[*time.Time]
-	AutoTuneState                   plugin.TValue[string]
-	AuditLogEnabled                 plugin.TValue[bool]
-	IpAddressType                   plugin.TValue[string]
-	ServiceSoftwareNewVersion       plugin.TValue[string]
-	AutoSoftwareUpdateEnabled       plugin.TValue[bool]
-	OffPeakWindowEnabled            plugin.TValue[bool]
-	AutomatedSnapshotPauseEnabled   plugin.TValue[bool]
-	AutomatedSnapshotPauseState     plugin.TValue[string]
-	AutomatedSnapshotPauseStartTime plugin.TValue[*time.Time]
-	AutomatedSnapshotPauseEndTime   plugin.TValue[*time.Time]
-	Tags                            plugin.TValue[map[string]any]
-	SecurityGroups                  plugin.TValue[[]any]
-	Subnets                         plugin.TValue[[]any]
+	Arn                                plugin.TValue[string]
+	Name                               plugin.TValue[string]
+	DomainId                           plugin.TValue[string]
+	Region                             plugin.TValue[string]
+	EngineVersion                      plugin.TValue[string]
+	Endpoint                           plugin.TValue[string]
+	EncryptionAtRestEnabled            plugin.TValue[bool]
+	EncryptionAtRestKmsKeyId           plugin.TValue[string]
+	EncryptionAtRestKmsKey             plugin.TValue[*mqlAwsKmsKey]
+	NodeToNodeEncryptionEnabled        plugin.TValue[bool]
+	DedicatedMasterEnabled             plugin.TValue[bool]
+	DedicatedMasterType                plugin.TValue[string]
+	DedicatedMasterCount               plugin.TValue[int64]
+	InstanceType                       plugin.TValue[string]
+	InstanceCount                      plugin.TValue[int64]
+	ZoneAwarenessEnabled               plugin.TValue[bool]
+	AvailabilityZoneCount              plugin.TValue[int64]
+	WarmEnabled                        plugin.TValue[bool]
+	WarmType                           plugin.TValue[string]
+	WarmCount                          plugin.TValue[int64]
+	ColdStorageEnabled                 plugin.TValue[bool]
+	EbsEnabled                         plugin.TValue[bool]
+	EbsVolumeType                      plugin.TValue[string]
+	EbsVolumeSize                      plugin.TValue[int64]
+	EbsIops                            plugin.TValue[int64]
+	EbsThroughput                      plugin.TValue[int64]
+	VpcId                              plugin.TValue[string]
+	Vpc                                plugin.TValue[*mqlAwsVpc]
+	VpcEgressEnabled                   plugin.TValue[bool]
+	EnforceHTTPS                       plugin.TValue[bool]
+	TlsSecurityPolicy                  plugin.TValue[string]
+	CustomEndpointEnabled              plugin.TValue[bool]
+	CustomEndpoint                     plugin.TValue[string]
+	CustomEndpointCertificate          plugin.TValue[*mqlAwsAcmCertificate]
+	SamlEnabled                        plugin.TValue[bool]
+	JwtEnabled                         plugin.TValue[bool]
+	JwksUrl                            plugin.TValue[string]
+	AnonymousAuthEnabled               plugin.TValue[bool]
+	InternalUserDatabaseEnabled        plugin.TValue[bool]
+	AdvancedSecurityEnabled            plugin.TValue[bool]
+	Processing                         plugin.TValue[bool]
+	UpgradeProcessing                  plugin.TValue[bool]
+	CreatedAt                          plugin.TValue[*time.Time]
+	AutoTuneState                      plugin.TValue[string]
+	AuditLogEnabled                    plugin.TValue[bool]
+	IpAddressType                      plugin.TValue[string]
+	ServiceSoftwareNewVersion          plugin.TValue[string]
+	ServiceSoftwareCurrentVersion      plugin.TValue[string]
+	ServiceSoftwareUpdateAvailable     plugin.TValue[bool]
+	ServiceSoftwareUpdateStatus        plugin.TValue[string]
+	ServiceSoftwareCancellable         plugin.TValue[bool]
+	ServiceSoftwareAutomatedUpdateDate plugin.TValue[*time.Time]
+	LastConfigChangeId                 plugin.TValue[string]
+	LastConfigChangeInitiatedBy        plugin.TValue[string]
+	LastConfigChangeStatus             plugin.TValue[string]
+	LastConfigChangeStartedAt          plugin.TValue[*time.Time]
+	LastConfigChangeUpdatedAt          plugin.TValue[*time.Time]
+	AutoSoftwareUpdateEnabled          plugin.TValue[bool]
+	OffPeakWindowEnabled               plugin.TValue[bool]
+	AutomatedSnapshotPauseEnabled      plugin.TValue[bool]
+	AutomatedSnapshotPauseState        plugin.TValue[string]
+	AutomatedSnapshotPauseStartTime    plugin.TValue[*time.Time]
+	AutomatedSnapshotPauseEndTime      plugin.TValue[*time.Time]
+	Tags                               plugin.TValue[map[string]any]
+	SecurityGroups                     plugin.TValue[[]any]
+	Subnets                            plugin.TValue[[]any]
 }
 
 // createAwsOpensearchDomain creates a new instance of this resource
@@ -98138,6 +98278,46 @@ func (c *mqlAwsOpensearchDomain) GetIpAddressType() *plugin.TValue[string] {
 
 func (c *mqlAwsOpensearchDomain) GetServiceSoftwareNewVersion() *plugin.TValue[string] {
 	return &c.ServiceSoftwareNewVersion
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareCurrentVersion() *plugin.TValue[string] {
+	return &c.ServiceSoftwareCurrentVersion
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareUpdateAvailable() *plugin.TValue[bool] {
+	return &c.ServiceSoftwareUpdateAvailable
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareUpdateStatus() *plugin.TValue[string] {
+	return &c.ServiceSoftwareUpdateStatus
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareCancellable() *plugin.TValue[bool] {
+	return &c.ServiceSoftwareCancellable
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareAutomatedUpdateDate() *plugin.TValue[*time.Time] {
+	return &c.ServiceSoftwareAutomatedUpdateDate
+}
+
+func (c *mqlAwsOpensearchDomain) GetLastConfigChangeId() *plugin.TValue[string] {
+	return &c.LastConfigChangeId
+}
+
+func (c *mqlAwsOpensearchDomain) GetLastConfigChangeInitiatedBy() *plugin.TValue[string] {
+	return &c.LastConfigChangeInitiatedBy
+}
+
+func (c *mqlAwsOpensearchDomain) GetLastConfigChangeStatus() *plugin.TValue[string] {
+	return &c.LastConfigChangeStatus
+}
+
+func (c *mqlAwsOpensearchDomain) GetLastConfigChangeStartedAt() *plugin.TValue[*time.Time] {
+	return &c.LastConfigChangeStartedAt
+}
+
+func (c *mqlAwsOpensearchDomain) GetLastConfigChangeUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastConfigChangeUpdatedAt
 }
 
 func (c *mqlAwsOpensearchDomain) GetAutoSoftwareUpdateEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4534,6 +4534,11 @@ aws.es.domain.instanceType 13.21.4
 aws.es.domain.internalUserDatabaseEnabled 13.21.4
 aws.es.domain.isPublic 13.37.1
 aws.es.domain.kmsKey 13.21.4
+aws.es.domain.lastConfigChangeId 13.39.2
+aws.es.domain.lastConfigChangeInitiatedBy 13.39.2
+aws.es.domain.lastConfigChangeStartedAt 13.39.2
+aws.es.domain.lastConfigChangeStatus 13.39.2
+aws.es.domain.lastConfigChangeUpdatedAt 13.39.2
 aws.es.domain.managedBy 13.39.2
 aws.es.domain.name 11.15.2
 aws.es.domain.nodeToNodeEncryptionEnabled 11.15.2
@@ -7002,6 +7007,11 @@ aws.opensearch.domain.internalUserDatabaseEnabled 11.15.2
 aws.opensearch.domain.ipAddressType 11.15.2
 aws.opensearch.domain.jwksUrl 13.18.1
 aws.opensearch.domain.jwtEnabled 13.18.1
+aws.opensearch.domain.lastConfigChangeId 13.39.2
+aws.opensearch.domain.lastConfigChangeInitiatedBy 13.39.2
+aws.opensearch.domain.lastConfigChangeStartedAt 13.39.2
+aws.opensearch.domain.lastConfigChangeStatus 13.39.2
+aws.opensearch.domain.lastConfigChangeUpdatedAt 13.39.2
 aws.opensearch.domain.name 11.15.2
 aws.opensearch.domain.nodeToNodeEncryptionEnabled 11.15.2
 aws.opensearch.domain.offPeakWindowEnabled 11.16.1
@@ -7009,7 +7019,12 @@ aws.opensearch.domain.processing 11.15.2
 aws.opensearch.domain.region 11.15.2
 aws.opensearch.domain.samlEnabled 11.15.2
 aws.opensearch.domain.securityGroups 11.15.2
+aws.opensearch.domain.serviceSoftwareAutomatedUpdateDate 13.39.2
+aws.opensearch.domain.serviceSoftwareCancellable 13.39.2
+aws.opensearch.domain.serviceSoftwareCurrentVersion 13.39.2
 aws.opensearch.domain.serviceSoftwareNewVersion 11.15.2
+aws.opensearch.domain.serviceSoftwareUpdateAvailable 13.39.2
+aws.opensearch.domain.serviceSoftwareUpdateStatus 13.39.2
 aws.opensearch.domain.subnets 11.15.2
 aws.opensearch.domain.tags 11.15.2
 aws.opensearch.domain.tlsSecurityPolicy 11.15.2

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -299,6 +299,19 @@ func newMqlAwsEsDomain(runtime *plugin.Runtime, region, accountID string, svc *e
 		serviceSoftwareAutomatedUpdateDate = llx.NilData
 	}
 
+	// Last configuration change progress (change provenance: who initiated the
+	// most recent change and when).
+	var lastConfigChangeId, lastConfigChangeInitiatedBy, lastConfigChangeStatus string
+	lastConfigChangeStartedAt := llx.NilData
+	lastConfigChangeUpdatedAt := llx.NilData
+	if cpd := status.ChangeProgressDetails; cpd != nil {
+		lastConfigChangeId = convert.ToValue(cpd.ChangeId)
+		lastConfigChangeInitiatedBy = string(cpd.InitiatedBy)
+		lastConfigChangeStatus = string(cpd.ConfigChangeStatus)
+		lastConfigChangeStartedAt = llx.TimeDataPtr(cpd.StartTime)
+		lastConfigChangeUpdatedAt = llx.TimeDataPtr(cpd.LastUpdatedTime)
+	}
+
 	// endpoints map
 	endpointsMap := make(map[string]any)
 	for k, v := range status.Endpoints {
@@ -364,6 +377,11 @@ func newMqlAwsEsDomain(runtime *plugin.Runtime, region, accountID string, svc *e
 		"serviceSoftwareCancellable":         llx.BoolData(serviceSoftwareCancellable),
 		"serviceSoftwareUpdateStatus":        llx.StringData(serviceSoftwareUpdateStatus),
 		"serviceSoftwareAutomatedUpdateDate": serviceSoftwareAutomatedUpdateDate,
+		"lastConfigChangeId":                 llx.StringData(lastConfigChangeId),
+		"lastConfigChangeInitiatedBy":        llx.StringData(lastConfigChangeInitiatedBy),
+		"lastConfigChangeStatus":             llx.StringData(lastConfigChangeStatus),
+		"lastConfigChangeStartedAt":          lastConfigChangeStartedAt,
+		"lastConfigChangeUpdatedAt":          lastConfigChangeUpdatedAt,
 		"auditLogEnabled":                    llx.BoolData(auditLogEnabled),
 		"indexSlowLogEnabled":                llx.BoolData(indexSlowLogEnabled),
 		"searchSlowLogEnabled":               llx.BoolData(searchSlowLogEnabled),

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -315,9 +315,29 @@ func newMqlAwsOpensearchDomain(runtime *plugin.Runtime, region string, accountID
 	auditLogEnabled := parseAuditLogEnabled(domain.LogPublishingOptions)
 
 	// Service software options
-	var serviceSoftwareNewVersion string
-	if domain.ServiceSoftwareOptions != nil {
-		serviceSoftwareNewVersion = convert.ToValue(domain.ServiceSoftwareOptions.NewVersion)
+	var serviceSoftwareCurrentVersion, serviceSoftwareNewVersion, serviceSoftwareUpdateStatus string
+	var serviceSoftwareUpdateAvailable, serviceSoftwareCancellable bool
+	serviceSoftwareAutomatedUpdateDate := llx.NilData
+	if s := domain.ServiceSoftwareOptions; s != nil {
+		serviceSoftwareCurrentVersion = convert.ToValue(s.CurrentVersion)
+		serviceSoftwareNewVersion = convert.ToValue(s.NewVersion)
+		serviceSoftwareUpdateAvailable = convert.ToValue(s.UpdateAvailable)
+		serviceSoftwareCancellable = convert.ToValue(s.Cancellable)
+		serviceSoftwareUpdateStatus = string(s.UpdateStatus)
+		serviceSoftwareAutomatedUpdateDate = llx.TimeDataPtr(s.AutomatedUpdateDate)
+	}
+
+	// Last configuration change progress (change provenance: who initiated the
+	// most recent change and when).
+	var lastConfigChangeId, lastConfigChangeInitiatedBy, lastConfigChangeStatus string
+	lastConfigChangeStartedAt := llx.NilData
+	lastConfigChangeUpdatedAt := llx.NilData
+	if cpd := domain.ChangeProgressDetails; cpd != nil {
+		lastConfigChangeId = convert.ToValue(cpd.ChangeId)
+		lastConfigChangeInitiatedBy = string(cpd.InitiatedBy)
+		lastConfigChangeStatus = string(cpd.ConfigChangeStatus)
+		lastConfigChangeStartedAt = llx.TimeDataPtr(cpd.StartTime)
+		lastConfigChangeUpdatedAt = llx.TimeDataPtr(cpd.LastUpdatedTime)
 	}
 
 	// Software update options
@@ -355,56 +375,66 @@ func newMqlAwsOpensearchDomain(runtime *plugin.Runtime, region string, accountID
 
 	resource, err := CreateResource(runtime, ResourceAwsOpensearchDomain,
 		map[string]*llx.RawData{
-			"arn":                             llx.StringDataPtr(domain.ARN),
-			"name":                            llx.StringDataPtr(domain.DomainName),
-			"domainId":                        llx.StringDataPtr(domain.DomainId),
-			"region":                          llx.StringData(region),
-			"engineVersion":                   llx.StringDataPtr(domain.EngineVersion),
-			"endpoint":                        llx.StringData(endpoint),
-			"encryptionAtRestEnabled":         llx.BoolData(encryptionAtRestEnabled),
-			"encryptionAtRestKmsKeyId":        llx.StringData(encryptionAtRestKmsKeyId),
-			"nodeToNodeEncryptionEnabled":     llx.BoolData(nodeToNodeEncryptionEnabled),
-			"dedicatedMasterEnabled":          llx.BoolData(dedicatedMasterEnabled),
-			"dedicatedMasterType":             llx.StringData(dedicatedMasterType),
-			"dedicatedMasterCount":            llx.IntData(dedicatedMasterCount),
-			"instanceType":                    llx.StringData(instanceType),
-			"instanceCount":                   llx.IntData(instanceCount),
-			"zoneAwarenessEnabled":            llx.BoolData(zoneAwarenessEnabled),
-			"availabilityZoneCount":           llx.IntData(availabilityZoneCount),
-			"warmEnabled":                     llx.BoolData(warmEnabled),
-			"warmType":                        llx.StringData(warmType),
-			"warmCount":                       llx.IntData(warmCount),
-			"coldStorageEnabled":              llx.BoolData(coldStorageEnabled),
-			"ebsEnabled":                      llx.BoolData(ebsEnabled),
-			"ebsVolumeType":                   llx.StringData(ebsVolumeType),
-			"ebsVolumeSize":                   llx.IntData(ebsVolumeSize),
-			"ebsIops":                         llx.IntData(ebsIops),
-			"ebsThroughput":                   llx.IntData(ebsThroughput),
-			"vpcId":                           llx.StringData(vpcId),
-			"vpcEgressEnabled":                llx.BoolData(vpcEgressEnabled),
-			"enforceHTTPS":                    llx.BoolData(enforceHTTPS),
-			"tlsSecurityPolicy":               llx.StringData(tlsSecurityPolicy),
-			"customEndpointEnabled":           llx.BoolData(customEndpointEnabled),
-			"customEndpoint":                  llx.StringData(customEndpoint),
-			"samlEnabled":                     llx.BoolData(samlEnabled),
-			"jwtEnabled":                      llx.BoolData(jwtEnabled),
-			"jwksUrl":                         llx.StringData(jwksUrl),
-			"anonymousAuthEnabled":            llx.BoolData(anonymousAuthEnabled),
-			"internalUserDatabaseEnabled":     llx.BoolData(internalUserDatabaseEnabled),
-			"advancedSecurityEnabled":         llx.BoolData(advancedSecurityEnabled),
-			"processing":                      llx.BoolDataPtr(domain.Processing),
-			"upgradeProcessing":               llx.BoolDataPtr(domain.UpgradeProcessing),
-			"createdAt":                       createdAt,
-			"autoTuneState":                   llx.StringData(autoTuneState),
-			"auditLogEnabled":                 llx.BoolData(auditLogEnabled),
-			"ipAddressType":                   llx.StringData(string(domain.IPAddressType)),
-			"serviceSoftwareNewVersion":       llx.StringData(serviceSoftwareNewVersion),
-			"autoSoftwareUpdateEnabled":       llx.BoolData(autoSoftwareUpdateEnabled),
-			"offPeakWindowEnabled":            llx.BoolData(offPeakWindowEnabled),
-			"automatedSnapshotPauseEnabled":   llx.BoolData(automatedSnapshotPauseEnabled),
-			"automatedSnapshotPauseState":     llx.StringData(automatedSnapshotPauseState),
-			"automatedSnapshotPauseStartTime": automatedSnapshotPauseStartTime,
-			"automatedSnapshotPauseEndTime":   automatedSnapshotPauseEndTime,
+			"arn":                                llx.StringDataPtr(domain.ARN),
+			"name":                               llx.StringDataPtr(domain.DomainName),
+			"domainId":                           llx.StringDataPtr(domain.DomainId),
+			"region":                             llx.StringData(region),
+			"engineVersion":                      llx.StringDataPtr(domain.EngineVersion),
+			"endpoint":                           llx.StringData(endpoint),
+			"encryptionAtRestEnabled":            llx.BoolData(encryptionAtRestEnabled),
+			"encryptionAtRestKmsKeyId":           llx.StringData(encryptionAtRestKmsKeyId),
+			"nodeToNodeEncryptionEnabled":        llx.BoolData(nodeToNodeEncryptionEnabled),
+			"dedicatedMasterEnabled":             llx.BoolData(dedicatedMasterEnabled),
+			"dedicatedMasterType":                llx.StringData(dedicatedMasterType),
+			"dedicatedMasterCount":               llx.IntData(dedicatedMasterCount),
+			"instanceType":                       llx.StringData(instanceType),
+			"instanceCount":                      llx.IntData(instanceCount),
+			"zoneAwarenessEnabled":               llx.BoolData(zoneAwarenessEnabled),
+			"availabilityZoneCount":              llx.IntData(availabilityZoneCount),
+			"warmEnabled":                        llx.BoolData(warmEnabled),
+			"warmType":                           llx.StringData(warmType),
+			"warmCount":                          llx.IntData(warmCount),
+			"coldStorageEnabled":                 llx.BoolData(coldStorageEnabled),
+			"ebsEnabled":                         llx.BoolData(ebsEnabled),
+			"ebsVolumeType":                      llx.StringData(ebsVolumeType),
+			"ebsVolumeSize":                      llx.IntData(ebsVolumeSize),
+			"ebsIops":                            llx.IntData(ebsIops),
+			"ebsThroughput":                      llx.IntData(ebsThroughput),
+			"vpcId":                              llx.StringData(vpcId),
+			"vpcEgressEnabled":                   llx.BoolData(vpcEgressEnabled),
+			"enforceHTTPS":                       llx.BoolData(enforceHTTPS),
+			"tlsSecurityPolicy":                  llx.StringData(tlsSecurityPolicy),
+			"customEndpointEnabled":              llx.BoolData(customEndpointEnabled),
+			"customEndpoint":                     llx.StringData(customEndpoint),
+			"samlEnabled":                        llx.BoolData(samlEnabled),
+			"jwtEnabled":                         llx.BoolData(jwtEnabled),
+			"jwksUrl":                            llx.StringData(jwksUrl),
+			"anonymousAuthEnabled":               llx.BoolData(anonymousAuthEnabled),
+			"internalUserDatabaseEnabled":        llx.BoolData(internalUserDatabaseEnabled),
+			"advancedSecurityEnabled":            llx.BoolData(advancedSecurityEnabled),
+			"processing":                         llx.BoolDataPtr(domain.Processing),
+			"upgradeProcessing":                  llx.BoolDataPtr(domain.UpgradeProcessing),
+			"createdAt":                          createdAt,
+			"autoTuneState":                      llx.StringData(autoTuneState),
+			"auditLogEnabled":                    llx.BoolData(auditLogEnabled),
+			"ipAddressType":                      llx.StringData(string(domain.IPAddressType)),
+			"serviceSoftwareNewVersion":          llx.StringData(serviceSoftwareNewVersion),
+			"serviceSoftwareCurrentVersion":      llx.StringData(serviceSoftwareCurrentVersion),
+			"serviceSoftwareUpdateAvailable":     llx.BoolData(serviceSoftwareUpdateAvailable),
+			"serviceSoftwareCancellable":         llx.BoolData(serviceSoftwareCancellable),
+			"serviceSoftwareUpdateStatus":        llx.StringData(serviceSoftwareUpdateStatus),
+			"serviceSoftwareAutomatedUpdateDate": serviceSoftwareAutomatedUpdateDate,
+			"lastConfigChangeId":                 llx.StringData(lastConfigChangeId),
+			"lastConfigChangeInitiatedBy":        llx.StringData(lastConfigChangeInitiatedBy),
+			"lastConfigChangeStatus":             llx.StringData(lastConfigChangeStatus),
+			"lastConfigChangeStartedAt":          lastConfigChangeStartedAt,
+			"lastConfigChangeUpdatedAt":          lastConfigChangeUpdatedAt,
+			"autoSoftwareUpdateEnabled":          llx.BoolData(autoSoftwareUpdateEnabled),
+			"offPeakWindowEnabled":               llx.BoolData(offPeakWindowEnabled),
+			"automatedSnapshotPauseEnabled":      llx.BoolData(automatedSnapshotPauseEnabled),
+			"automatedSnapshotPauseState":        llx.StringData(automatedSnapshotPauseState),
+			"automatedSnapshotPauseStartTime":    automatedSnapshotPauseStartTime,
+			"automatedSnapshotPauseEndTime":      automatedSnapshotPauseEndTime,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Two related additions to the Elasticsearch and OpenSearch service domain resources.

## Change provenance (both `aws.es.domain` and `aws.opensearch.domain`)
Exposes `DomainStatus.ChangeProgressDetails` — genuine "who changed this and when" lineage:
- `lastConfigChangeInitiatedBy` — **`CUSTOMER` or `SERVICE`**: was the most recent configuration change operator-driven or an AWS-initiated maintenance action?
- `lastConfigChangeId` — identifies the specific change (audit correlation)
- `lastConfigChangeStatus` — e.g. `PENDING`, `APPLYING_CHANGES`, `COMPLETED`
- `lastConfigChangeStartedAt` / `lastConfigChangeUpdatedAt` — when it began and was last updated

## Service-software parity (`aws.opensearch.domain`)
`aws.es.domain` already exposed the full `ServiceSoftwareOptions` set; OpenSearch only had `serviceSoftwareNewVersion`. This adds the rest for software-version provenance parity: `serviceSoftwareCurrentVersion`, `serviceSoftwareUpdateAvailable`, `serviceSoftwareUpdateStatus`, `serviceSoftwareCancellable`, `serviceSoftwareAutomatedUpdateDate`.

All values come back on the existing `DescribeDomain(s)` calls — no new API calls or IAM permissions.