### PR TITLE
✨ aws: add macAlgorithms, cloudHsmCluster, currentKeyMaterialId to kms key

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1767,6 +1767,10 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   multiRegionConfiguration() aws.kms.key.multiRegionConfiguration
   // Origin of the key material: AWS_KMS, EXTERNAL, AWS_CLOUDHSM, EXTERNAL_KEY_STORE
   origin() string
+  // Identifier of the current key material version backing the key
+  currentKeyMaterialId() string
+  // CloudHSM cluster hosting the key's material (null unless the key origin is AWS_CLOUDHSM)
+  cloudHsmCluster() aws.cloudhsm.cluster
   // Custom key store that hosts the key's material (null when AWS-managed)
   customKeyStore() aws.kms.customKeyStore
   // External key associated with this key when the key store is an External Key Store (xks)
@@ -1785,6 +1789,8 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   signingAlgorithms() []string
   // Key agreement algorithms the key supports (e.g., ECDH)
   keyAgreementAlgorithms() []string
+  // MAC algorithms the key supports (e.g., HMAC_SHA_256), for HMAC keys
+  macAlgorithms() []string
   // Whether imported key material expires: KEY_MATERIAL_EXPIRES or KEY_MATERIAL_DOES_NOT_EXPIRE
   expirationModel() string
   // Expiration date for imported key material (null if key material does not expire)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6492,6 +6492,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.origin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetOrigin()).ToDataRes(types.String)
 	},
+	"aws.kms.key.currentKeyMaterialId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetCurrentKeyMaterialId()).ToDataRes(types.String)
+	},
+	"aws.kms.key.cloudHsmCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetCloudHsmCluster()).ToDataRes(types.Resource("aws.cloudhsm.cluster"))
+	},
 	"aws.kms.key.customKeyStore": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetCustomKeyStore()).ToDataRes(types.Resource("aws.kms.customKeyStore"))
 	},
@@ -6515,6 +6521,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.kms.key.keyAgreementAlgorithms": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetKeyAgreementAlgorithms()).ToDataRes(types.Array(types.String))
+	},
+	"aws.kms.key.macAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetMacAlgorithms()).ToDataRes(types.Array(types.String))
 	},
 	"aws.kms.key.expirationModel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetExpirationModel()).ToDataRes(types.String)
@@ -36098,6 +36107,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKmsKey).Origin, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.kms.key.currentKeyMaterialId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).CurrentKeyMaterialId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.cloudHsmCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).CloudHsmCluster, ok = plugin.RawToTValue[*mqlAwsCloudhsmCluster](v.Value, v.Error)
+		return
+	},
 	"aws.kms.key.customKeyStore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).CustomKeyStore, ok = plugin.RawToTValue[*mqlAwsKmsCustomKeyStore](v.Value, v.Error)
 		return
@@ -36128,6 +36145,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.kms.key.keyAgreementAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).KeyAgreementAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.macAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).MacAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.kms.key.expirationModel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -82523,6 +82544,8 @@ type mqlAwsKmsKey struct {
 	MultiRegion               plugin.TValue[bool]
 	MultiRegionConfiguration  plugin.TValue[*mqlAwsKmsKeyMultiRegionConfiguration]
 	Origin                    plugin.TValue[string]
+	CurrentKeyMaterialId      plugin.TValue[string]
+	CloudHsmCluster           plugin.TValue[*mqlAwsCloudhsmCluster]
 	CustomKeyStore            plugin.TValue[*mqlAwsKmsCustomKeyStore]
 	XksKeyConfiguration       plugin.TValue[any]
 	RotationPeriodInDays      plugin.TValue[int64]
@@ -82531,6 +82554,7 @@ type mqlAwsKmsKey struct {
 	EncryptionAlgorithms      plugin.TValue[[]any]
 	SigningAlgorithms         plugin.TValue[[]any]
 	KeyAgreementAlgorithms    plugin.TValue[[]any]
+	MacAlgorithms             plugin.TValue[[]any]
 	ExpirationModel           plugin.TValue[string]
 	ValidTo                   plugin.TValue[*time.Time]
 	LastUsageOperation        plugin.TValue[string]
@@ -82769,6 +82793,28 @@ func (c *mqlAwsKmsKey) GetOrigin() *plugin.TValue[string] {
 	})
 }
 
+func (c *mqlAwsKmsKey) GetCurrentKeyMaterialId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.CurrentKeyMaterialId, func() (string, error) {
+		return c.currentKeyMaterialId()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetCloudHsmCluster() *plugin.TValue[*mqlAwsCloudhsmCluster] {
+	return plugin.GetOrCompute[*mqlAwsCloudhsmCluster](&c.CloudHsmCluster, func() (*mqlAwsCloudhsmCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kms.key", c.__id, "cloudHsmCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudhsmCluster), nil
+			}
+		}
+
+		return c.cloudHsmCluster()
+	})
+}
+
 func (c *mqlAwsKmsKey) GetCustomKeyStore() *plugin.TValue[*mqlAwsKmsCustomKeyStore] {
 	return plugin.GetOrCompute[*mqlAwsKmsCustomKeyStore](&c.CustomKeyStore, func() (*mqlAwsKmsCustomKeyStore, error) {
 		if c.MqlRuntime.HasRecording {
@@ -82824,6 +82870,12 @@ func (c *mqlAwsKmsKey) GetSigningAlgorithms() *plugin.TValue[[]any] {
 func (c *mqlAwsKmsKey) GetKeyAgreementAlgorithms() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.KeyAgreementAlgorithms, func() ([]any, error) {
 		return c.keyAgreementAlgorithms()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetMacAlgorithms() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.MacAlgorithms, func() ([]any, error) {
+		return c.macAlgorithms()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5861,8 +5861,10 @@ aws.kms.grants 13.26.3
 aws.kms.key 11.15.2
 aws.kms.key.aliases 11.15.2
 aws.kms.key.arn 11.15.2
+aws.kms.key.cloudHsmCluster 13.39.2
 aws.kms.key.cloudformationStack 13.39.2
 aws.kms.key.createdAt 11.15.2
+aws.kms.key.currentKeyMaterialId 13.39.2
 aws.kms.key.customKeyStore 13.26.3
 aws.kms.key.deletedAt 11.15.2
 aws.kms.key.description 11.15.2
@@ -5882,6 +5884,7 @@ aws.kms.key.keyState 11.15.2
 aws.kms.key.keyUsage 13.6.3
 aws.kms.key.lastUsageOperation 13.18.1
 aws.kms.key.lastUsedAt 13.18.1
+aws.kms.key.macAlgorithms 13.39.2
 aws.kms.key.managedBy 13.39.2
 aws.kms.key.metadata 11.15.2
 aws.kms.key.multiRegion 13.6.3

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -679,6 +679,33 @@ func (a *mqlAwsKmsKey) origin() (string, error) {
 	return string(md.Origin), nil
 }
 
+func (a *mqlAwsKmsKey) currentKeyMaterialId() (string, error) {
+	md, err := a.getKeyMetadata()
+	if err != nil {
+		return "", err
+	}
+	return convert.ToValue(md.CurrentKeyMaterialId), nil
+}
+
+func (a *mqlAwsKmsKey) cloudHsmCluster() (*mqlAwsCloudhsmCluster, error) {
+	md, err := a.getKeyMetadata()
+	if err != nil {
+		return nil, err
+	}
+	if md.CloudHsmClusterId == nil || *md.CloudHsmClusterId == "" {
+		a.CloudHsmCluster.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	cluster, err := NewResource(a.MqlRuntime, "aws.cloudhsm.cluster",
+		map[string]*llx.RawData{
+			"clusterId": llx.StringDataPtr(md.CloudHsmClusterId),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return cluster.(*mqlAwsCloudhsmCluster), nil
+}
+
 func (a *mqlAwsKmsKey) customKeyStore() (*mqlAwsKmsCustomKeyStore, error) {
 	md, err := a.getKeyMetadata()
 	if err != nil {
@@ -733,6 +760,18 @@ func (a *mqlAwsKmsKey) signingAlgorithms() ([]any, error) {
 	}
 	res := make([]any, len(md.SigningAlgorithms))
 	for i, alg := range md.SigningAlgorithms {
+		res[i] = string(alg)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsKmsKey) macAlgorithms() ([]any, error) {
+	md, err := a.getKeyMetadata()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]any, len(md.MacAlgorithms))
+	for i, alg := range md.MacAlgorithms {
 		res[i] = string(alg)
 	}
 	return res, nil


### PR DESCRIPTION
Fills three gaps on `aws.kms.key`, all from the already-fetched `DescribeKey` metadata.

- **`macAlgorithms() []string`** — the MAC algorithm list for HMAC keys. Completes the algorithm-list set, which already had `encryptionAlgorithms()`, `signingAlgorithms()`, and `keyAgreementAlgorithms()`.
- **`cloudHsmCluster() aws.cloudhsm.cluster`** — typed reference to the CloudHSM cluster hosting the key material, for `AWS_CLOUDHSM`-origin keys. Null for other origins. Complements the existing `origin()` and `customKeyStore()`.
- **`currentKeyMaterialId() string`** — identifier of the current key-material version (material rotation/import provenance).

All read from the cached key metadata; `cloudHsmCluster()` resolves lazily against the modeled `aws.cloudhsm.cluster`. No new KMS API calls or IAM permissions. `CustomerMasterKeySpec` was intentionally skipped (deprecated by AWS in favor of the already-exposed `keySpec()`).