### PR TITLE
✨ aws: add deployments sub-resource to apigateway rest api

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13986,6 +13986,8 @@ private aws.apigateway.restapi @defaults("name id") {
   authorizers() []aws.apigateway.authorizer
   // Request validators for the REST API
   requestValidators() []aws.apigateway.requestValidator
+  // Deployments of the REST API
+  deployments() []aws.apigateway.deployment
   // Region where the REST API exists
   region string
   // Tags for the REST API
@@ -14109,6 +14111,28 @@ private aws.apigateway.requestValidator @defaults("name restApiId") {
   // Whether request parameters are validated
   validateRequestParameters bool
   // Region where the request validator exists
+  region string
+}
+
+// Deployment of an API Gateway REST API
+//
+// Examine a single deployment of a REST API: when it was created, its
+// description, and a snapshot of the API methods it captured. The deployment
+// history records when each version of the API was pushed live, which is the
+// change provenance for the API. Select by the deployment `id` within a REST
+// API.
+private aws.apigateway.deployment @defaults("id createdDate") {
+  // Identifier of the deployment
+  id string
+  // Identifier of the REST API the deployment belongs to
+  restApiId string
+  // Time when the deployment was created
+  createdDate time
+  // Description of the deployment
+  description string
+  // Snapshot of the API methods captured at deployment time, keyed by resource path then HTTP method
+  apiSummary dict
+  // Region where the deployment exists
   region string
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -521,6 +521,7 @@ const (
 	ResourceAwsApigatewayStage                                                  string = "aws.apigateway.stage"
 	ResourceAwsApigatewayAuthorizer                                             string = "aws.apigateway.authorizer"
 	ResourceAwsApigatewayRequestValidator                                       string = "aws.apigateway.requestValidator"
+	ResourceAwsApigatewayDeployment                                             string = "aws.apigateway.deployment"
 	ResourceAwsApigatewayApiKey                                                 string = "aws.apigateway.apiKey"
 	ResourceAwsApigatewayUsagePlan                                              string = "aws.apigateway.usagePlan"
 	ResourceAwsApigatewayVpcLink                                                string = "aws.apigateway.vpcLink"
@@ -2944,6 +2945,10 @@ func init() {
 		"aws.apigateway.requestValidator": {
 			// to override args, implement: initAwsApigatewayRequestValidator(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsApigatewayRequestValidator,
+		},
+		"aws.apigateway.deployment": {
+			// to override args, implement: initAwsApigatewayDeployment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsApigatewayDeployment,
 		},
 		"aws.apigateway.apiKey": {
 			// to override args, implement: initAwsApigatewayApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -20025,6 +20030,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.apigateway.restapi.requestValidators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayRestapi).GetRequestValidators()).ToDataRes(types.Array(types.Resource("aws.apigateway.requestValidator")))
 	},
+	"aws.apigateway.restapi.deployments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayRestapi).GetDeployments()).ToDataRes(types.Array(types.Resource("aws.apigateway.deployment")))
+	},
 	"aws.apigateway.restapi.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayRestapi).GetRegion()).ToDataRes(types.String)
 	},
@@ -20183,6 +20191,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.apigateway.requestValidator.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayRequestValidator).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.apigateway.deployment.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetId()).ToDataRes(types.String)
+	},
+	"aws.apigateway.deployment.restApiId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetRestApiId()).ToDataRes(types.String)
+	},
+	"aws.apigateway.deployment.createdDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetCreatedDate()).ToDataRes(types.Time)
+	},
+	"aws.apigateway.deployment.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.apigateway.deployment.apiSummary": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetApiSummary()).ToDataRes(types.Dict)
+	},
+	"aws.apigateway.deployment.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayDeployment).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.apigateway.apiKey.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayApiKey).GetArn()).ToDataRes(types.String)
@@ -55918,6 +55944,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsApigatewayRestapi).RequestValidators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.apigateway.restapi.deployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayRestapi).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.apigateway.restapi.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayRestapi).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -56140,6 +56170,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apigateway.requestValidator.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayRequestValidator).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.apigateway.deployment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.restApiId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).RestApiId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.createdDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).CreatedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.apiSummary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).ApiSummary, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.deployment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayDeployment).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.apigateway.apiKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -134486,6 +134544,7 @@ type mqlAwsApigatewayRestapi struct {
 	Stages                    plugin.TValue[[]any]
 	Authorizers               plugin.TValue[[]any]
 	RequestValidators         plugin.TValue[[]any]
+	Deployments               plugin.TValue[[]any]
 	Region                    plugin.TValue[string]
 	Tags                      plugin.TValue[map[string]any]
 	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
@@ -134603,6 +134662,22 @@ func (c *mqlAwsApigatewayRestapi) GetRequestValidators() *plugin.TValue[[]any] {
 		}
 
 		return c.requestValidators()
+	})
+}
+
+func (c *mqlAwsApigatewayRestapi) GetDeployments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Deployments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.apigateway.restapi", c.__id, "deployments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.deployments()
 	})
 }
 
@@ -135049,6 +135124,75 @@ func (c *mqlAwsApigatewayRequestValidator) GetValidateRequestParameters() *plugi
 }
 
 func (c *mqlAwsApigatewayRequestValidator) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+// mqlAwsApigatewayDeployment for the aws.apigateway.deployment resource
+type mqlAwsApigatewayDeployment struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsApigatewayDeploymentInternal it will be used here
+	Id          plugin.TValue[string]
+	RestApiId   plugin.TValue[string]
+	CreatedDate plugin.TValue[*time.Time]
+	Description plugin.TValue[string]
+	ApiSummary  plugin.TValue[any]
+	Region      plugin.TValue[string]
+}
+
+// createAwsApigatewayDeployment creates a new instance of this resource
+func createAwsApigatewayDeployment(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsApigatewayDeployment{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.apigateway.deployment", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsApigatewayDeployment) MqlName() string {
+	return "aws.apigateway.deployment"
+}
+
+func (c *mqlAwsApigatewayDeployment) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsApigatewayDeployment) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsApigatewayDeployment) GetRestApiId() *plugin.TValue[string] {
+	return &c.RestApiId
+}
+
+func (c *mqlAwsApigatewayDeployment) GetCreatedDate() *plugin.TValue[*time.Time] {
+	return &c.CreatedDate
+}
+
+func (c *mqlAwsApigatewayDeployment) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsApigatewayDeployment) GetApiSummary() *plugin.TValue[any] {
+	return &c.ApiSummary
+}
+
+func (c *mqlAwsApigatewayDeployment) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -80,6 +80,13 @@ aws.apigateway.authorizer.region 13.20.1
 aws.apigateway.authorizer.restApiId 13.20.1
 aws.apigateway.authorizer.type 13.20.1
 aws.apigateway.authorizer.userPools 13.20.1
+aws.apigateway.deployment 13.39.2
+aws.apigateway.deployment.apiSummary 13.39.2
+aws.apigateway.deployment.createdDate 13.39.2
+aws.apigateway.deployment.description 13.39.2
+aws.apigateway.deployment.id 13.39.2
+aws.apigateway.deployment.region 13.39.2
+aws.apigateway.deployment.restApiId 13.39.2
 aws.apigateway.requestValidator 13.20.1
 aws.apigateway.requestValidator.arn 13.20.1
 aws.apigateway.requestValidator.id 13.20.1
@@ -96,6 +103,7 @@ aws.apigateway.restapi.authorizers 13.20.1
 aws.apigateway.restapi.binaryMediaTypes 11.15.2
 aws.apigateway.restapi.cloudformationStack 13.39.2
 aws.apigateway.restapi.createdDate 11.15.2
+aws.apigateway.restapi.deployments 13.39.2
 aws.apigateway.restapi.description 11.15.2
 aws.apigateway.restapi.disableExecuteApiEndpoint 11.15.2
 aws.apigateway.restapi.endpointTypes 13.15.2

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -288,6 +288,53 @@ func (a *mqlAwsApigatewayRestapi) authorizers() ([]any, error) {
 	return res, nil
 }
 
+func (a *mqlAwsApigatewayRestapi) deployments() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	restApiId := a.Id.Data
+	svc := conn.Apigateway(region)
+	ctx := context.Background()
+
+	res := []any{}
+	var position *string
+	for {
+		resp, err := svc.GetDeployments(ctx, &apigateway.GetDeploymentsInput{RestApiId: &restApiId, Position: position})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				log.Warn().Str("region", region).Str("restApiId", restApiId).Msg("error accessing API gateway deployments")
+				return res, nil
+			}
+			return nil, errors.Wrap(err, "could not gather AWS API Gateway deployments")
+		}
+		for _, d := range resp.Items {
+			depId := convert.ToValue(d.Id)
+			apiSummary, err := convert.JsonToDict(d.ApiSummary)
+			if err != nil {
+				return nil, err
+			}
+			mqlDep, err := CreateResource(a.MqlRuntime, "aws.apigateway.deployment",
+				map[string]*llx.RawData{
+					"__id":        llx.StringData(restApiId + "/" + depId),
+					"id":          llx.StringData(depId),
+					"restApiId":   llx.StringData(restApiId),
+					"createdDate": llx.TimeDataPtr(d.CreatedDate),
+					"description": llx.StringData(convert.ToValue(d.Description)),
+					"apiSummary":  llx.DictData(apiSummary),
+					"region":      llx.StringData(region),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlDep)
+		}
+		if resp.Position == nil {
+			break
+		}
+		position = resp.Position
+	}
+	return res, nil
+}
+
 func (a *mqlAwsApigatewayAuthorizer) id() (string, error) {
 	return a.Arn.Data, nil
 }


### PR DESCRIPTION
Adds `deployments() []aws.apigateway.deployment` to `aws.apigateway.restapi` — the REST API's deployment history, which is its **change provenance**: when each version of the API was pushed live.

The new `aws.apigateway.deployment` sub-resource exposes:
- `id` — the deployment identifier (selection key within the API)
- `restApiId` — the owning REST API
- `createdDate` — when the deployment was created
- `description` — the deployment description
- `apiSummary` — snapshot of the API methods captured at deployment time (keyed by resource path then HTTP method)
- `region`

Fetched via `GetDeployments` (paginated), mirroring the existing `authorizers()`/`stages()` accessors. `apigateway:GET` is already in the provider's permission set, so there's **no new IAM permission**.

Example:
```
aws.apigateway.restapis {
  name
  deployments { id createdDate description }
}
```