### PR TITLE
✨ aws: add typed refs to ecr image and ssm instance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13716,12 +13716,16 @@ private aws.ecr.image @defaults("uri region") {
   digest string
   // Type of image manifest
   mediaType string
+  // Media type of the artifact, when the image is an attached artifact rather than a container image (for example an SBOM or signature)
+  artifactMediaType string
   // List of tags associated with image
   tags []string
   // AWS account ID associated with public registry for this image
   registryId string
   // Name of the repository for the image
   repoName string
+  // ECR repository that contains the image
+  repository() aws.ecr.repository
   // Region where the ECR image is located
   region string
   // ARN for the image
@@ -15026,6 +15030,12 @@ private aws.ssm.instance @defaults("instanceId region platformName platformVersi
   activationId string
   // Type of the managed resource: EC2Instance or ManagedInstance
   resourceType string
+  // EC2 instance backing this managed node, when it is an EC2 instance rather than a hybrid/on-premises node
+  ec2Instance() aws.ec2.instance
+  // Time the managed node was registered with Systems Manager
+  registeredAt time
+  // Whether the instance is running the latest version of the SSM Agent
+  isLatestVersion bool
 }
 
 // Amazon Elastic Compute Cloud (EC2)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -19707,6 +19707,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecr.image.mediaType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrImage).GetMediaType()).ToDataRes(types.String)
 	},
+	"aws.ecr.image.artifactMediaType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrImage).GetArtifactMediaType()).ToDataRes(types.String)
+	},
 	"aws.ecr.image.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrImage).GetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -19715,6 +19718,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ecr.image.repoName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrImage).GetRepoName()).ToDataRes(types.String)
+	},
+	"aws.ecr.image.repository": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrImage).GetRepository()).ToDataRes(types.Resource("aws.ecr.repository"))
 	},
 	"aws.ecr.image.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrImage).GetRegion()).ToDataRes(types.String)
@@ -21167,6 +21173,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ssm.instance.resourceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmInstance).GetResourceType()).ToDataRes(types.String)
+	},
+	"aws.ssm.instance.ec2Instance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetEc2Instance()).ToDataRes(types.Resource("aws.ec2.instance"))
+	},
+	"aws.ssm.instance.registeredAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetRegisteredAt()).ToDataRes(types.Time)
+	},
+	"aws.ssm.instance.isLatestVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmInstance).GetIsLatestVersion()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
@@ -55454,6 +55469,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcrImage).MediaType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ecr.image.artifactMediaType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrImage).ArtifactMediaType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ecr.image.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrImage).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -55464,6 +55483,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecr.image.repoName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrImage).RepoName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecr.image.repository": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrImage).Repository, ok = plugin.RawToTValue[*mqlAwsEcrRepository](v.Value, v.Error)
 		return
 	},
 	"aws.ecr.image.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -57564,6 +57587,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ssm.instance.resourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmInstance).ResourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.ec2Instance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).Ec2Instance, ok = plugin.RawToTValue[*mqlAwsEc2Instance](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.registeredAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).RegisteredAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ssm.instance.isLatestVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmInstance).IsLatestVersion, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -133296,9 +133331,11 @@ type mqlAwsEcrImage struct {
 	mqlAwsEcrImageInternal
 	Digest                    plugin.TValue[string]
 	MediaType                 plugin.TValue[string]
+	ArtifactMediaType         plugin.TValue[string]
 	Tags                      plugin.TValue[[]any]
 	RegistryId                plugin.TValue[string]
 	RepoName                  plugin.TValue[string]
+	Repository                plugin.TValue[*mqlAwsEcrRepository]
 	Region                    plugin.TValue[string]
 	Arn                       plugin.TValue[string]
 	Uri                       plugin.TValue[string]
@@ -133355,6 +133392,10 @@ func (c *mqlAwsEcrImage) GetMediaType() *plugin.TValue[string] {
 	return &c.MediaType
 }
 
+func (c *mqlAwsEcrImage) GetArtifactMediaType() *plugin.TValue[string] {
+	return &c.ArtifactMediaType
+}
+
 func (c *mqlAwsEcrImage) GetTags() *plugin.TValue[[]any] {
 	return &c.Tags
 }
@@ -133365,6 +133406,22 @@ func (c *mqlAwsEcrImage) GetRegistryId() *plugin.TValue[string] {
 
 func (c *mqlAwsEcrImage) GetRepoName() *plugin.TValue[string] {
 	return &c.RepoName
+}
+
+func (c *mqlAwsEcrImage) GetRepository() *plugin.TValue[*mqlAwsEcrRepository] {
+	return plugin.GetOrCompute[*mqlAwsEcrRepository](&c.Repository, func() (*mqlAwsEcrRepository, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecr.image", c.__id, "repository")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEcrRepository), nil
+			}
+		}
+
+		return c.repository()
+	})
 }
 
 func (c *mqlAwsEcrImage) GetRegion() *plugin.TValue[string] {
@@ -138340,6 +138397,9 @@ type mqlAwsSsmInstance struct {
 	SourceId            plugin.TValue[string]
 	ActivationId        plugin.TValue[string]
 	ResourceType        plugin.TValue[string]
+	Ec2Instance         plugin.TValue[*mqlAwsEc2Instance]
+	RegisteredAt        plugin.TValue[*time.Time]
+	IsLatestVersion     plugin.TValue[bool]
 }
 
 // createAwsSsmInstance creates a new instance of this resource
@@ -138481,6 +138541,30 @@ func (c *mqlAwsSsmInstance) GetActivationId() *plugin.TValue[string] {
 
 func (c *mqlAwsSsmInstance) GetResourceType() *plugin.TValue[string] {
 	return &c.ResourceType
+}
+
+func (c *mqlAwsSsmInstance) GetEc2Instance() *plugin.TValue[*mqlAwsEc2Instance] {
+	return plugin.GetOrCompute[*mqlAwsEc2Instance](&c.Ec2Instance, func() (*mqlAwsEc2Instance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ssm.instance", c.__id, "ec2Instance")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Instance), nil
+			}
+		}
+
+		return c.ec2Instance()
+	})
+}
+
+func (c *mqlAwsSsmInstance) GetRegisteredAt() *plugin.TValue[*time.Time] {
+	return &c.RegisteredAt
+}
+
+func (c *mqlAwsSsmInstance) GetIsLatestVersion() *plugin.TValue[bool] {
+	return &c.IsLatestVersion
 }
 
 // mqlAwsEc2 for the aws.ec2 resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3507,6 +3507,7 @@ aws.ec2.vpnconnection.vpnGateway 13.6.3
 aws.ecr 11.15.2
 aws.ecr.image 11.15.2
 aws.ecr.image.arn 11.15.2
+aws.ecr.image.artifactMediaType 13.39.2
 aws.ecr.image.digest 11.15.2
 aws.ecr.image.lastRecordedPullTime 11.15.2
 aws.ecr.image.mediaType 11.15.2
@@ -3514,6 +3515,7 @@ aws.ecr.image.pushedAt 11.15.2
 aws.ecr.image.region 11.15.2
 aws.ecr.image.registryId 11.15.2
 aws.ecr.image.repoName 11.15.2
+aws.ecr.image.repository 13.39.2
 aws.ecr.image.scanFinding 13.12.1
 aws.ecr.image.scanFinding.attributes 13.12.1
 aws.ecr.image.scanFinding.description 13.12.1
@@ -9414,9 +9416,11 @@ aws.ssm.instance.agentVersion 11.15.2
 aws.ssm.instance.arn 11.15.2
 aws.ssm.instance.cloudformationStack 13.39.2
 aws.ssm.instance.computerName 11.15.2
+aws.ssm.instance.ec2Instance 13.39.2
 aws.ssm.instance.iamRole 13.38.2
 aws.ssm.instance.instanceId 11.15.2
 aws.ssm.instance.ipAddress 11.15.2
+aws.ssm.instance.isLatestVersion 13.39.2
 aws.ssm.instance.lastPingedAt 11.15.2
 aws.ssm.instance.managedBy 13.39.2
 aws.ssm.instance.pingStatus 11.15.2
@@ -9424,6 +9428,7 @@ aws.ssm.instance.platformName 11.15.2
 aws.ssm.instance.platformType 11.15.2
 aws.ssm.instance.platformVersion 11.15.2
 aws.ssm.instance.region 11.15.2
+aws.ssm.instance.registeredAt 13.39.2
 aws.ssm.instance.resourceType 13.38.2
 aws.ssm.instance.sourceId 13.38.2
 aws.ssm.instance.sourceType 13.38.2

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -273,14 +273,15 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 				}
 				mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 					map[string]*llx.RawData{
-						"digest":     llx.StringDataPtr(image.ImageDigest),
-						"mediaType":  llx.StringDataPtr(image.ImageManifestMediaType),
-						"tags":       llx.ArrayData(toInterfaceArr(image.ImageTags), types.String),
-						"registryId": llx.StringDataPtr(image.RegistryId),
-						"repoName":   llx.StringData(name),
-						"region":     llx.StringData(region),
-						"arn":        llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})),
-						"uri":        llx.StringData(uri),
+						"digest":            llx.StringDataPtr(image.ImageDigest),
+						"mediaType":         llx.StringDataPtr(image.ImageManifestMediaType),
+						"artifactMediaType": llx.StringDataPtr(image.ArtifactMediaType),
+						"tags":              llx.ArrayData(toInterfaceArr(image.ImageTags), types.String),
+						"registryId":        llx.StringDataPtr(image.RegistryId),
+						"repoName":          llx.StringData(name),
+						"region":            llx.StringData(region),
+						"arn":               llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})),
+						"uri":               llx.StringData(uri),
 					})
 				if err != nil {
 					return nil, err
@@ -315,6 +316,7 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 					"digest":               llx.StringDataPtr(image.ImageDigest),
 					"lastRecordedPullTime": llx.TimeDataPtr(image.LastRecordedPullTime),
 					"mediaType":            llx.StringDataPtr(image.ImageManifestMediaType),
+					"artifactMediaType":    llx.StringDataPtr(image.ArtifactMediaType),
 					"pushedAt":             llx.TimeDataPtr(image.ImagePushedAt),
 					"region":               llx.StringData(region),
 					"registryId":           llx.StringDataPtr(image.RegistryId),
@@ -480,6 +482,24 @@ func ecrImageArn(i ImageInfo) string {
 
 func EcrImageName(i ImageInfo) string {
 	return i.RepoName + "@" + i.Digest
+}
+
+func (a *mqlAwsEcrImage) repository() (*mqlAwsEcrRepository, error) {
+	repoName := a.RepoName.Data
+	if repoName == "" {
+		a.Repository.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	arnVal := fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", a.Region.Data, a.RegistryId.Data, repoName)
+	res, err := NewResource(a.MqlRuntime, "aws.ecr.repository",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		// Public-gallery images and cross-account repositories won't resolve to a
+		// repository in this account; leave the reference null rather than failing.
+		a.Repository.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsEcrRepository), nil
 }
 
 func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -205,6 +205,8 @@ func (a *mqlAwsSsm) getInstances(conn *connection.AwsConnection) []*jobpool.Job 
 						"sourceId":        llx.StringDataPtr(instance.SourceId),
 						"activationId":    llx.StringDataPtr(instance.ActivationId),
 						"resourceType":    llx.StringData(string(instance.ResourceType)),
+						"registeredAt":    llx.TimeDataPtr(instance.RegistrationDate),
+						"isLatestVersion": llx.BoolDataPtr(instance.IsLatestVersion),
 					})
 				if err != nil {
 					return nil, err
@@ -229,6 +231,24 @@ func (a *mqlAwsSsmParameter) id() (string, error) {
 
 func (a *mqlAwsSsmInstance) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsSsmInstance) ec2Instance() (*mqlAwsEc2Instance, error) {
+	// Only EC2-registered managed nodes map to an EC2 instance; hybrid and
+	// on-premises nodes (ManagedInstance) have no EC2 instance.
+	if a.ResourceType.Data != "EC2Instance" || a.InstanceId.Data == "" {
+		a.Ec2Instance.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnVal := fmt.Sprintf(ec2InstanceArnPattern, a.Region.Data, conn.AccountId(), a.InstanceId.Data)
+	res, err := NewResource(a.MqlRuntime, "aws.ec2.instance",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.Ec2Instance.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsEc2Instance), nil
 }
 
 type mqlAwsSsmInstanceInternal struct {


### PR DESCRIPTION
Adds typed cross-references (and two completeness fields) to two resources.

## `aws.ecr.image`
- **`repository() aws.ecr.repository`** — typed reference to the containing repository, resolved from the image's region/registryId/repoName. Lets you walk image → repo (scan config, lifecycle policy, immutability, encryption). Null for public-gallery or cross-account images that don't resolve to a repository in this account.
- `artifactMediaType` — media type distinguishing an attached artifact (SBOM, signature, Helm chart) from a container image.

## `aws.ssm.instance`
- **`ec2Instance() aws.ec2.instance`** — typed reference to the backing EC2 instance when `resourceType == EC2Instance` (null for hybrid/on-premises `ManagedInstance` nodes). Links a managed node to its EC2 identity.
- `registeredAt` — when the node was registered with Systems Manager (registration provenance, most meaningful for hybrid/activation nodes).
- `isLatestVersion` — whether the SSM Agent is the latest version (agent-currency hygiene).

Everything resolves from data these resources already gather (`DescribeImages` / `DescribeInstanceInformation`, and the target resources' existing arn-based inits), so there are **no new API calls or IAM permissions**.