### PR TITLE
✨ aws: add kmsKey typed ref to ecr repository

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13644,6 +13644,8 @@ private aws.ecr.repository @defaults("uri region") {
   imageTagMutability string
   // Encryption type for images at rest (AES256, KMS, or KMS_DSSE)
   encryptionType string
+  // KMS key protecting images at rest, when encryptionType is KMS or KMS_DSSE
+  kmsKey() aws.kms.key
   // When the repository was created
   createdAt time
   // Scanning frequency for the repository: SCAN_ON_PUSH, CONTINUOUS_SCAN, or MANUAL

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -19620,6 +19620,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecr.repository.encryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetEncryptionType()).ToDataRes(types.String)
 	},
+	"aws.ecr.repository.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.ecr.repository.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -55324,6 +55327,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecr.repository.encryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrRepository).EncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecr.repository.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.ecr.repository.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -132919,6 +132926,7 @@ type mqlAwsEcrRepository struct {
 	ImageScanOnPush     plugin.TValue[bool]
 	ImageTagMutability  plugin.TValue[string]
 	EncryptionType      plugin.TValue[string]
+	KmsKey              plugin.TValue[*mqlAwsKmsKey]
 	CreatedAt           plugin.TValue[*time.Time]
 	ScanningFrequency   plugin.TValue[string]
 	Policy              plugin.TValue[any]
@@ -133022,6 +133030,22 @@ func (c *mqlAwsEcrRepository) GetImageTagMutability() *plugin.TValue[string] {
 
 func (c *mqlAwsEcrRepository) GetEncryptionType() *plugin.TValue[string] {
 	return &c.EncryptionType
+}
+
+func (c *mqlAwsEcrRepository) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecr.repository", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 func (c *mqlAwsEcrRepository) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3557,6 +3557,7 @@ aws.ecr.repository.imageScanOnPush 11.15.2
 aws.ecr.repository.imageTagMutability 11.15.2
 aws.ecr.repository.images 11.15.2
 aws.ecr.repository.isPublic 13.37.1
+aws.ecr.repository.kmsKey 13.39.2
 aws.ecr.repository.lifecyclePolicy 11.15.2
 aws.ecr.repository.managedBy 13.39.2
 aws.ecr.repository.name 11.15.2

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -572,8 +572,10 @@ func buildEcrPrivateRepositoryResource(runtime *plugin.Runtime, region string, r
 		imageScanOnPush = r.ImageScanningConfiguration.ScanOnPush
 	}
 	var encryptionType string
+	var kmsKeyArn *string
 	if r.EncryptionConfiguration != nil {
 		encryptionType = string(r.EncryptionConfiguration.EncryptionType)
+		kmsKeyArn = r.EncryptionConfiguration.KmsKey
 	}
 	mqlRepoResource, err := CreateResource(runtime, ResourceAwsEcrRepository,
 		map[string]*llx.RawData{
@@ -591,7 +593,9 @@ func buildEcrPrivateRepositoryResource(runtime *plugin.Runtime, region string, r
 	if err != nil {
 		return nil, err
 	}
-	return mqlRepoResource.(*mqlAwsEcrRepository), nil
+	res := mqlRepoResource.(*mqlAwsEcrRepository)
+	res.cacheKmsKeyArn = kmsKeyArn
+	return res, nil
 }
 
 func buildEcrPublicRepositoryResource(runtime *plugin.Runtime, r ecrpublic_types.Repository) (*mqlAwsEcrRepository, error) {
@@ -621,6 +625,20 @@ type mqlAwsEcrRepositoryInternal struct {
 	catalogFetched bool
 	catalogData    *ecrpublic_types.RepositoryCatalogData
 	catalogLock    sync.Mutex
+	cacheKmsKeyArn *string
+}
+
+func (a *mqlAwsEcrRepository) kmsKey() (*mqlAwsKmsKey, error) {
+	if a.cacheKmsKeyArn == nil || *a.cacheKmsKeyArn == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.kms.key",
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheKmsKeyArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsKmsKey), nil
 }
 
 func (a *mqlAwsEcrRepository) fetchCatalogData() (*ecrpublic_types.RepositoryCatalogData, error) {


### PR DESCRIPTION
Adds `kmsKey() aws.kms.key` to `aws.ecr.repository`.

The resource already exposed `encryptionType` (AES256 / KMS / KMS_DSSE) but not the actual key. This resolves the CMK protecting images at rest from `EncryptionConfiguration.KmsKey`, giving a typed encryption-provenance ref consistent with `kmsKey()` on other resources. Null for AES256-encrypted repositories (which have no customer key).

Comes back on the existing `DescribeRepositories` data — no new API calls or IAM permissions.