### PR TITLE
✨ aws: add managedBy and cloudformationStack to opensearch domain

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5116,6 +5116,12 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   automatedSnapshotPauseEndTime time
   // Tags for the domain
   tags() map[string]string
+  // CloudFormation stack that manages this domain, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this domain
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the domain is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
   // Security groups associated with the VPC domain
   securityGroups() []aws.ec2.securitygroup
   // Subnets for the VPC domain

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10479,6 +10479,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.opensearch.domain.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.opensearch.domain.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.opensearch.domain.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.opensearch.domain.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
@@ -41956,6 +41962,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.opensearch.domain.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOpensearchDomain).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.opensearch.domain.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -98081,6 +98095,8 @@ type mqlAwsOpensearchDomain struct {
 	AutomatedSnapshotPauseStartTime    plugin.TValue[*time.Time]
 	AutomatedSnapshotPauseEndTime      plugin.TValue[*time.Time]
 	Tags                               plugin.TValue[map[string]any]
+	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                          plugin.TValue[string]
 	SecurityGroups                     plugin.TValue[[]any]
 	Subnets                            plugin.TValue[[]any]
 }
@@ -98413,6 +98429,28 @@ func (c *mqlAwsOpensearchDomain) GetAutomatedSnapshotPauseEndTime() *plugin.TVal
 func (c *mqlAwsOpensearchDomain) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsOpensearchDomain) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.opensearch.domain", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsOpensearchDomain) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6986,6 +6986,7 @@ aws.opensearch.domain.automatedSnapshotPauseEndTime 13.25.1
 aws.opensearch.domain.automatedSnapshotPauseStartTime 13.25.1
 aws.opensearch.domain.automatedSnapshotPauseState 13.25.1
 aws.opensearch.domain.availabilityZoneCount 11.15.2
+aws.opensearch.domain.cloudformationStack 13.39.2
 aws.opensearch.domain.coldStorageEnabled 11.15.2
 aws.opensearch.domain.createdAt 11.15.2
 aws.opensearch.domain.customEndpoint 13.15.2
@@ -7017,6 +7018,7 @@ aws.opensearch.domain.lastConfigChangeInitiatedBy 13.39.2
 aws.opensearch.domain.lastConfigChangeStartedAt 13.39.2
 aws.opensearch.domain.lastConfigChangeStatus 13.39.2
 aws.opensearch.domain.lastConfigChangeUpdatedAt 13.39.2
+aws.opensearch.domain.managedBy 13.39.2
 aws.opensearch.domain.name 11.15.2
 aws.opensearch.domain.nodeToNodeEncryptionEnabled 11.15.2
 aws.opensearch.domain.offPeakWindowEnabled 11.16.1

--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -116,6 +116,14 @@ func (a *mqlAwsEcsInstance) cloudformationStack() (*mqlAwsCloudformationStack, e
 	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
 }
 
+func (a *mqlAwsOpensearchDomain) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsOpensearchDomain) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
 func (a *mqlAwsApigatewayRestapi) managedBy() (string, error) {
 	return managedByFromResourceTags(a.GetTags())
 }


### PR DESCRIPTION
`aws.opensearch.domain` exposed `tags()` but was missing the `managedBy()` + `cloudformationStack()` ownership inference that the provider-wide provenance sweep added to tag-bearing resources — its sibling `aws.es.domain` has both, so the two were inconsistent.

This adds the standard trio's two derived accessors for parity:
- `managedBy() string` — infrastructure-management system inferred from AWS-injected provenance tags.
- `cloudformationStack() aws.cloudformation.stack` — the typed CloudFormation stack owner.

Both reuse the existing tag-based helpers (`managedByFromResourceTags` / `cloudformationStackFromResourceTags`) and the resource's existing `tags()`, so there are no new API calls or IAM permissions.