### PR TITLE
✨ aws: add managedBy and callerReference to route53 hosted zone

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12844,6 +12844,14 @@ private aws.route53.hostedZone @defaults("id name type isPrivate") {
   isPrivate bool
   // Comment associated with the hosted zone
   comment string
+  // Idempotency token supplied when the hosted zone was created
+  //
+  // Infrastructure-as-code tools set this to a meaningful value; the Terraform AWS provider auto-generates one with a "terraform-" prefix, which managedBy uses as a fallback signal.
+  callerReference string
+  // Infrastructure-management system that owns this hosted zone
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Falls back to "terraform" when no provenance tag is present but the callerReference carries Terraform's "terraform-" prefix. Empty when the hosted zone is unmanaged or managed by a tool that leaves no recognizable signal.
+  managedBy() string
   // List of VPCs associated with a private hosted zone
   vpcs() []dict
   // ARN of the hosted zone

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -18831,6 +18831,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.route53.hostedZone.comment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53HostedZone).GetComment()).ToDataRes(types.String)
 	},
+	"aws.route53.hostedZone.callerReference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRoute53HostedZone).GetCallerReference()).ToDataRes(types.String)
+	},
+	"aws.route53.hostedZone.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRoute53HostedZone).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.route53.hostedZone.vpcs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53HostedZone).GetVpcs()).ToDataRes(types.Array(types.Dict))
 	},
@@ -54188,6 +54194,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.route53.hostedZone.comment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRoute53HostedZone).Comment, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.route53.hostedZone.callerReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRoute53HostedZone).CallerReference, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.route53.hostedZone.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRoute53HostedZone).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.route53.hostedZone.vpcs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -130276,6 +130290,8 @@ type mqlAwsRoute53HostedZone struct {
 	Config                 plugin.TValue[any]
 	IsPrivate              plugin.TValue[bool]
 	Comment                plugin.TValue[string]
+	CallerReference        plugin.TValue[string]
+	ManagedBy              plugin.TValue[string]
 	Vpcs                   plugin.TValue[[]any]
 	Arn                    plugin.TValue[string]
 	Tags                   plugin.TValue[map[string]any]
@@ -130350,6 +130366,16 @@ func (c *mqlAwsRoute53HostedZone) GetIsPrivate() *plugin.TValue[bool] {
 
 func (c *mqlAwsRoute53HostedZone) GetComment() *plugin.TValue[string] {
 	return &c.Comment
+}
+
+func (c *mqlAwsRoute53HostedZone) GetCallerReference() *plugin.TValue[string] {
+	return &c.CallerReference
+}
+
+func (c *mqlAwsRoute53HostedZone) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlAwsRoute53HostedZone) GetVpcs() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -7668,6 +7668,7 @@ aws.route53.healthCheck.type 11.15.3
 aws.route53.healthChecks 11.15.3
 aws.route53.hostedZone 11.15.3
 aws.route53.hostedZone.arn 11.15.3
+aws.route53.hostedZone.callerReference 13.39.2
 aws.route53.hostedZone.comment 11.15.3
 aws.route53.hostedZone.config 11.15.3
 aws.route53.hostedZone.dnssec 13.26.3
@@ -7678,6 +7679,7 @@ aws.route53.hostedZone.dnssecStatus 11.15.3
 aws.route53.hostedZone.id 11.15.3
 aws.route53.hostedZone.isPrivate 11.15.3
 aws.route53.hostedZone.keySigningKeys 11.15.3
+aws.route53.hostedZone.managedBy 13.39.2
 aws.route53.hostedZone.name 11.15.3
 aws.route53.hostedZone.nameServers 11.15.3
 aws.route53.hostedZone.queryLoggingConfig 11.15.3

--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -70,11 +70,12 @@ func (a *mqlAwsEc2Snapshot) cloudformationStack() (*mqlAwsCloudformationStack, e
 	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
 }
 
-// managedByWithCreationToken augments the tag-based owner with an EFS-specific
-// Terraform fallback. Terraform injects no provenance tag, but when
-// creation_token is left unset the Terraform AWS provider auto-generates one
-// with a "terraform-" prefix, which is the only managed-by signal it leaves.
-// The tag-based owner always wins when present.
+// managedByWithCreationToken augments the tag-based owner with a Terraform
+// fallback. Terraform injects no provenance tag, but for idempotency tokens it
+// leaves unset (the EFS creation token, the Route 53 hosted zone caller
+// reference) the Terraform AWS provider auto-generates a "terraform-" prefixed
+// value, which is the only managed-by signal it leaves. The tag-based owner
+// always wins when present.
 func managedByWithCreationToken(tagOwner, creationToken string) string {
 	if tagOwner != "" {
 		return tagOwner
@@ -83,6 +84,23 @@ func managedByWithCreationToken(tagOwner, creationToken string) string {
 		return "terraform"
 	}
 	return ""
+}
+
+func (a *mqlAwsRoute53HostedZone) managedBy() (string, error) {
+	owner, err := managedByFromResourceTags(a.GetTags())
+	if err != nil {
+		return "", err
+	}
+	if owner != "" {
+		return owner, nil
+	}
+	// Route 53 injects no provenance tag, but Terraform sets the hosted zone
+	// caller reference to a "terraform-" prefixed value; fall back to that.
+	cr := a.GetCallerReference()
+	if cr.Error != nil {
+		return "", cr.Error
+	}
+	return managedByWithCreationToken("", cr.Data), nil
 }
 
 func (a *mqlAwsEfsFilesystem) managedBy() (string, error) {

--- a/providers/aws/resources/aws_route53.go
+++ b/providers/aws/resources/aws_route53.go
@@ -98,6 +98,7 @@ func (a *mqlAwsRoute53) hostedZones() ([]any, error) {
 				"comment":                llx.StringData(comment),
 				"tags":                   llx.MapData(tags, types.String),
 				"config":                 llx.DictData(config),
+				"callerReference":        llx.StringData(convert.ToValue(hz.CallerReference)),
 			})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`aws.route53.hostedZone` exposed `tags` but lacked the ownership inference the provider-wide sweep added elsewhere. Adds:

- **`managedBy() string`** — infrastructure-management system inferred from AWS-injected provenance tags, **with a Terraform fallback**: the Terraform AWS provider sets a hosted zone's `CallerReference` to a `terraform-` prefixed value (via `create.UniqueId`), which is the only managed-by signal Terraform leaves. When no provenance tag matches, `managedBy` reports `"terraform"` for `terraform-` caller references — the same heuristic used on `aws.efs.filesystem`. The shared helper's doc was generalized accordingly.
- **`callerReference string`** — the idempotency token supplied at `CreateHostedZone` (creation provenance; IaC tools set it to meaningful values).

### Note on `cloudformationStack()`
Intentionally **not** added. Route 53 hosted zones are global and the resource carries no region, but `cloudformationStackForTags` needs a region to `DescribeStacks`. There's no precedent for a global resource exposing `cloudformationStack()`, and a guessed-region lookup would resolve unreliably (mostly null), so it's deferred rather than shipped misleading.

Both fields come off the existing `ListHostedZones` data — no new API calls or IAM permissions.