### PR TITLE
✨ aws: add typed refs and config to elasticache cluster

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12243,6 +12243,8 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   cacheSecurityGroups []string
   // Name of the cache subnet group associated with the cluster
   cacheSubnetGroupName string
+  // Cache subnet group the cluster is deployed in
+  subnetGroup() aws.elasticache.subnetGroup
   // URL of the web page where you can download the latest ElastiCache client library
   clientDownloadLandingPage string
   // Node type for the nodes in the cluster
@@ -12259,6 +12261,8 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   networkType string
   // Describes a notification topic and its status
   notificationConfiguration string
+  // SNS topic that receives cluster event notifications
+  notificationTopic() aws.sns.topic
   // Number of cache nodes in the cluster
   numCacheNodes int
   // Name of the availability zone in which the cluster is located or "Multiple" if the cache nodes are located in different availability zones
@@ -12283,6 +12287,14 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   replicationGroupLogDeliveryEnabled bool
   // Identifier of the replication group the cluster belongs to, when part of one
   replicationGroupId string
+  // Name of the cache parameter group applied to the cluster
+  cacheParameterGroupName string
+  // Cache parameter group applied to the cluster
+  parameterGroup() aws.elasticache.parameterGroup
+  // Address of the cluster configuration endpoint (Memcached clusters)
+  configurationEndpointAddress string
+  // Port of the cluster configuration endpoint (Memcached clusters)
+  configurationEndpointPort int
   // Resource tags for the cluster
   tags() map[string]string
   // CloudFormation stack that manages this cluster, if any

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -18096,6 +18096,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elasticache.cluster.cacheSubnetGroupName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetCacheSubnetGroupName()).ToDataRes(types.String)
 	},
+	"aws.elasticache.cluster.subnetGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetSubnetGroup()).ToDataRes(types.Resource("aws.elasticache.subnetGroup"))
+	},
 	"aws.elasticache.cluster.clientDownloadLandingPage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetClientDownloadLandingPage()).ToDataRes(types.String)
 	},
@@ -18119,6 +18122,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.cluster.notificationConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetNotificationConfiguration()).ToDataRes(types.String)
+	},
+	"aws.elasticache.cluster.notificationTopic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetNotificationTopic()).ToDataRes(types.Resource("aws.sns.topic"))
 	},
 	"aws.elasticache.cluster.numCacheNodes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetNumCacheNodes()).ToDataRes(types.Int)
@@ -18155,6 +18161,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.cluster.replicationGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetReplicationGroupId()).ToDataRes(types.String)
+	},
+	"aws.elasticache.cluster.cacheParameterGroupName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetCacheParameterGroupName()).ToDataRes(types.String)
+	},
+	"aws.elasticache.cluster.parameterGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetParameterGroup()).ToDataRes(types.Resource("aws.elasticache.parameterGroup"))
+	},
+	"aws.elasticache.cluster.configurationEndpointAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetConfigurationEndpointAddress()).ToDataRes(types.String)
+	},
+	"aws.elasticache.cluster.configurationEndpointPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetConfigurationEndpointPort()).ToDataRes(types.Int)
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -53146,6 +53164,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElasticacheCluster).CacheSubnetGroupName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.elasticache.cluster.subnetGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).SubnetGroup, ok = plugin.RawToTValue[*mqlAwsElasticacheSubnetGroup](v.Value, v.Error)
+		return
+	},
 	"aws.elasticache.cluster.clientDownloadLandingPage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).ClientDownloadLandingPage, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -53176,6 +53198,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.cluster.notificationConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).NotificationConfiguration, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.notificationTopic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).NotificationTopic, ok = plugin.RawToTValue[*mqlAwsSnsTopic](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.cluster.numCacheNodes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -53224,6 +53250,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.cluster.replicationGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).ReplicationGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.cacheParameterGroupName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).CacheParameterGroupName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.parameterGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).ParameterGroup, ok = plugin.RawToTValue[*mqlAwsElasticacheParameterGroup](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.configurationEndpointAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).ConfigurationEndpointAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.cluster.configurationEndpointPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).ConfigurationEndpointPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -127785,6 +127827,7 @@ type mqlAwsElasticacheCluster struct {
 	CacheNodes                         plugin.TValue[[]any]
 	CacheSecurityGroups                plugin.TValue[[]any]
 	CacheSubnetGroupName               plugin.TValue[string]
+	SubnetGroup                        plugin.TValue[*mqlAwsElasticacheSubnetGroup]
 	ClientDownloadLandingPage          plugin.TValue[string]
 	NodeType                           plugin.TValue[string]
 	Engine                             plugin.TValue[string]
@@ -127793,6 +127836,7 @@ type mqlAwsElasticacheCluster struct {
 	LogDeliveryConfigurations          plugin.TValue[[]any]
 	NetworkType                        plugin.TValue[string]
 	NotificationConfiguration          plugin.TValue[string]
+	NotificationTopic                  plugin.TValue[*mqlAwsSnsTopic]
 	NumCacheNodes                      plugin.TValue[int64]
 	PreferredAvailabilityZone          plugin.TValue[string]
 	Region                             plugin.TValue[string]
@@ -127805,6 +127849,10 @@ type mqlAwsElasticacheCluster struct {
 	PreferredMaintenanceWindow         plugin.TValue[string]
 	ReplicationGroupLogDeliveryEnabled plugin.TValue[bool]
 	ReplicationGroupId                 plugin.TValue[string]
+	CacheParameterGroupName            plugin.TValue[string]
+	ParameterGroup                     plugin.TValue[*mqlAwsElasticacheParameterGroup]
+	ConfigurationEndpointAddress       plugin.TValue[string]
+	ConfigurationEndpointPort          plugin.TValue[int64]
 	Tags                               plugin.TValue[map[string]any]
 	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
 	ManagedBy                          plugin.TValue[string]
@@ -127890,6 +127938,22 @@ func (c *mqlAwsElasticacheCluster) GetCacheSubnetGroupName() *plugin.TValue[stri
 	return &c.CacheSubnetGroupName
 }
 
+func (c *mqlAwsElasticacheCluster) GetSubnetGroup() *plugin.TValue[*mqlAwsElasticacheSubnetGroup] {
+	return plugin.GetOrCompute[*mqlAwsElasticacheSubnetGroup](&c.SubnetGroup, func() (*mqlAwsElasticacheSubnetGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "subnetGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsElasticacheSubnetGroup), nil
+			}
+		}
+
+		return c.subnetGroup()
+	})
+}
+
 func (c *mqlAwsElasticacheCluster) GetClientDownloadLandingPage() *plugin.TValue[string] {
 	return &c.ClientDownloadLandingPage
 }
@@ -127920,6 +127984,22 @@ func (c *mqlAwsElasticacheCluster) GetNetworkType() *plugin.TValue[string] {
 
 func (c *mqlAwsElasticacheCluster) GetNotificationConfiguration() *plugin.TValue[string] {
 	return &c.NotificationConfiguration
+}
+
+func (c *mqlAwsElasticacheCluster) GetNotificationTopic() *plugin.TValue[*mqlAwsSnsTopic] {
+	return plugin.GetOrCompute[*mqlAwsSnsTopic](&c.NotificationTopic, func() (*mqlAwsSnsTopic, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "notificationTopic")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsSnsTopic), nil
+			}
+		}
+
+		return c.notificationTopic()
+	})
 }
 
 func (c *mqlAwsElasticacheCluster) GetNumCacheNodes() *plugin.TValue[int64] {
@@ -127992,6 +128072,34 @@ func (c *mqlAwsElasticacheCluster) GetReplicationGroupLogDeliveryEnabled() *plug
 
 func (c *mqlAwsElasticacheCluster) GetReplicationGroupId() *plugin.TValue[string] {
 	return &c.ReplicationGroupId
+}
+
+func (c *mqlAwsElasticacheCluster) GetCacheParameterGroupName() *plugin.TValue[string] {
+	return &c.CacheParameterGroupName
+}
+
+func (c *mqlAwsElasticacheCluster) GetParameterGroup() *plugin.TValue[*mqlAwsElasticacheParameterGroup] {
+	return plugin.GetOrCompute[*mqlAwsElasticacheParameterGroup](&c.ParameterGroup, func() (*mqlAwsElasticacheParameterGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "parameterGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsElasticacheParameterGroup), nil
+			}
+		}
+
+		return c.parameterGroup()
+	})
+}
+
+func (c *mqlAwsElasticacheCluster) GetConfigurationEndpointAddress() *plugin.TValue[string] {
+	return &c.ConfigurationEndpointAddress
+}
+
+func (c *mqlAwsElasticacheCluster) GetConfigurationEndpointPort() *plugin.TValue[int64] {
+	return &c.ConfigurationEndpointPort
 }
 
 func (c *mqlAwsElasticacheCluster) GetTags() *plugin.TValue[map[string]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4116,10 +4116,13 @@ aws.elasticache.cluster.cacheClusterId 11.15.2
 aws.elasticache.cluster.cacheClusterStatus 11.15.2
 aws.elasticache.cluster.cacheNodeType 11.15.2
 aws.elasticache.cluster.cacheNodes 11.15.2
+aws.elasticache.cluster.cacheParameterGroupName 13.39.2
 aws.elasticache.cluster.cacheSecurityGroups 11.15.2
 aws.elasticache.cluster.cacheSubnetGroupName 11.15.2
 aws.elasticache.cluster.clientDownloadLandingPage 11.15.2
 aws.elasticache.cluster.cloudformationStack 13.39.2
+aws.elasticache.cluster.configurationEndpointAddress 13.39.2
+aws.elasticache.cluster.configurationEndpointPort 13.39.2
 aws.elasticache.cluster.engine 11.15.2
 aws.elasticache.cluster.engineVersion 11.15.2
 aws.elasticache.cluster.ipDiscovery 11.15.2
@@ -4129,7 +4132,9 @@ aws.elasticache.cluster.managedBy 13.39.2
 aws.elasticache.cluster.networkType 11.15.2
 aws.elasticache.cluster.nodeType 11.15.2
 aws.elasticache.cluster.notificationConfiguration 11.15.2
+aws.elasticache.cluster.notificationTopic 13.39.2
 aws.elasticache.cluster.numCacheNodes 11.15.2
+aws.elasticache.cluster.parameterGroup 13.39.2
 aws.elasticache.cluster.preferredAvailabilityZone 11.15.2
 aws.elasticache.cluster.preferredMaintenanceWindow 11.15.2
 aws.elasticache.cluster.region 11.15.2
@@ -4138,6 +4143,7 @@ aws.elasticache.cluster.replicationGroupLogDeliveryEnabled 11.15.2
 aws.elasticache.cluster.securityGroups 11.15.2
 aws.elasticache.cluster.snapshotRetentionLimit 11.15.2
 aws.elasticache.cluster.snapshotWindow 11.15.2
+aws.elasticache.cluster.subnetGroup 13.39.2
 aws.elasticache.cluster.tags 13.12.1
 aws.elasticache.cluster.transitEncryptionEnabled 11.15.2
 aws.elasticache.cluster.transitEncryptionMode 11.15.2

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -166,6 +166,18 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 		notificationConfiguration = convert.ToValue(cluster.NotificationConfiguration.TopicArn)
 	}
 
+	cacheParameterGroupName := ""
+	if cluster.CacheParameterGroup != nil {
+		cacheParameterGroupName = convert.ToValue(cluster.CacheParameterGroup.CacheParameterGroupName)
+	}
+
+	configurationEndpointAddress := ""
+	configurationEndpointPort := int64(0)
+	if cluster.ConfigurationEndpoint != nil {
+		configurationEndpointAddress = convert.ToValue(cluster.ConfigurationEndpoint.Address)
+		configurationEndpointPort = int64(convert.ToValue(cluster.ConfigurationEndpoint.Port))
+	}
+
 	sgs := []string{}
 	for _, sg := range cluster.SecurityGroups {
 		if sg.SecurityGroupId == nil {
@@ -208,6 +220,9 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 			"preferredMaintenanceWindow":         llx.StringDataPtr(cluster.PreferredMaintenanceWindow),
 			"replicationGroupLogDeliveryEnabled": llx.BoolDataPtr(cluster.ReplicationGroupLogDeliveryEnabled),
 			"replicationGroupId":                 llx.StringDataPtr(cluster.ReplicationGroupId),
+			"cacheParameterGroupName":            llx.StringData(cacheParameterGroupName),
+			"configurationEndpointAddress":       llx.StringData(configurationEndpointAddress),
+			"configurationEndpointPort":          llx.IntData(configurationEndpointPort),
 		})
 	if err != nil {
 		return nil, err
@@ -274,6 +289,68 @@ func (a *mqlAwsElasticacheCluster) kmsKey() (*mqlAwsKmsKey, error) {
 		return nil, err
 	}
 	return mqlKey.(*mqlAwsKmsKey), nil
+}
+
+func (a *mqlAwsElasticacheCluster) notificationTopic() (*mqlAwsSnsTopic, error) {
+	arnVal := a.NotificationConfiguration.Data
+	if arnVal == "" {
+		a.NotificationTopic.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.sns.topic",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsSnsTopic), nil
+}
+
+func (a *mqlAwsElasticacheCluster) subnetGroup() (*mqlAwsElasticacheSubnetGroup, error) {
+	name := a.CacheSubnetGroupName.Data
+	if name == "" {
+		a.SubnetGroup.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	parent, err := CreateResource(a.MqlRuntime, "aws.elasticache", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	groups := parent.(*mqlAwsElasticache).GetSubnetGroups()
+	if groups.Error != nil {
+		return nil, groups.Error
+	}
+	for _, g := range groups.Data {
+		sg := g.(*mqlAwsElasticacheSubnetGroup)
+		if sg.Name.Data == name && sg.Region.Data == a.region {
+			return sg, nil
+		}
+	}
+	a.SubnetGroup.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
+}
+
+func (a *mqlAwsElasticacheCluster) parameterGroup() (*mqlAwsElasticacheParameterGroup, error) {
+	name := a.CacheParameterGroupName.Data
+	if name == "" {
+		a.ParameterGroup.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	parent, err := CreateResource(a.MqlRuntime, "aws.elasticache", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	groups := parent.(*mqlAwsElasticache).GetParameterGroups()
+	if groups.Error != nil {
+		return nil, groups.Error
+	}
+	for _, g := range groups.Data {
+		pg := g.(*mqlAwsElasticacheParameterGroup)
+		if pg.Name.Data == name && pg.Region.Data == a.region {
+			return pg, nil
+		}
+	}
+	a.ParameterGroup.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }
 
 func (a *mqlAwsElasticache) serverlessCaches() ([]any, error) {


### PR DESCRIPTION
Fills typed-reference and config gaps on `aws.elasticache.cluster`.

- **`subnetGroup() aws.elasticache.subnetGroup`** and **`parameterGroup() aws.elasticache.parameterGroup`** — typed refs (both targets modeled). Resolved via the cached group lists matched by name + region (Pattern C), so they hydrate fully rather than resolving to husks. `parameterGroup` also comes with a new raw `cacheParameterGroupName` (the applied parameter group was previously unexposed).
- **`notificationTopic() aws.sns.topic`** — the `notificationConfiguration` field is a raw SNS topic ARN; this adds the typed ref (typed-reference gate).
- **`configurationEndpointAddress` / `configurationEndpointPort`** — the cluster configuration endpoint (Memcached), previously unexposed.

`replicationGroupId` stays a raw string — `aws.elasticache.replicationGroup` isn't modeled, so a typed ref would be a husk.

Everything resolves from data already gathered (`DescribeCacheClusters` + the existing subnet/parameter-group listers), so no new API calls or IAM permissions.