### PR TITLE
✨ aws: add id, tags, managedBy, staging, callerReference to cloudfront distribution

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9566,6 +9566,20 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   viewerMtlsMode string
   // ID of the trust store associated with the viewer mTLS configuration (empty string when none)
   viewerMtlsTrustStoreId string
+  // ID of the distribution
+  id string
+  // Whether this is a staging distribution used for continuous deployment
+  staging bool
+  // Idempotency token supplied when the distribution was created
+  //
+  // Infrastructure-as-code tools set this to a meaningful value; the Terraform AWS provider auto-generates one with a "terraform-" prefix, which managedBy uses as a fallback signal.
+  callerReference() string
+  // Tags for the distribution
+  tags() map[string]string
+  // Infrastructure-management system that owns this distribution
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Falls back to "terraform" when no provenance tag is present but the callerReference carries Terraform's "terraform-" prefix. Empty when the distribution is unmanaged or managed by a tool that leaves no recognizable signal.
+  managedBy() string
 }
 
 // Amazon CloudFront distribution logging configuration

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -15249,6 +15249,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudfront.distribution.viewerMtlsTrustStoreId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetViewerMtlsTrustStoreId()).ToDataRes(types.String)
 	},
+	"aws.cloudfront.distribution.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetId()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.staging": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetStaging()).ToDataRes(types.Bool)
+	},
+	"aws.cloudfront.distribution.callerReference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetCallerReference()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.cloudfront.distribution.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetManagedBy()).ToDataRes(types.String)
+	},
 	"aws.cloudfront.distribution.loggingConfig.enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistributionLoggingConfig).GetEnabled()).ToDataRes(types.Bool)
 	},
@@ -49004,6 +49019,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudfront.distribution.viewerMtlsTrustStoreId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudfrontDistribution).ViewerMtlsTrustStoreId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.staging": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).Staging, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.callerReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).CallerReference, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.cloudfront.distribution.loggingConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -117229,6 +117264,11 @@ type mqlAwsCloudfrontDistribution struct {
 	Logging                      plugin.TValue[*mqlAwsCloudfrontDistributionLoggingConfig]
 	ViewerMtlsMode               plugin.TValue[string]
 	ViewerMtlsTrustStoreId       plugin.TValue[string]
+	Id                           plugin.TValue[string]
+	Staging                      plugin.TValue[bool]
+	CallerReference              plugin.TValue[string]
+	Tags                         plugin.TValue[map[string]any]
+	ManagedBy                    plugin.TValue[string]
 }
 
 // createAwsCloudfrontDistribution creates a new instance of this resource
@@ -117396,6 +117436,32 @@ func (c *mqlAwsCloudfrontDistribution) GetViewerMtlsMode() *plugin.TValue[string
 
 func (c *mqlAwsCloudfrontDistribution) GetViewerMtlsTrustStoreId() *plugin.TValue[string] {
 	return &c.ViewerMtlsTrustStoreId
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetStaging() *plugin.TValue[bool] {
+	return &c.Staging
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetCallerReference() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.CallerReference, func() (string, error) {
+		return c.callerReference()
+	})
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlAwsCloudfrontDistributionLoggingConfig for the aws.cloudfront.distribution.loggingConfig resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1453,6 +1453,7 @@ aws.cloudfront.continuousDeploymentPolicy.trafficConfig 13.26.3
 aws.cloudfront.distribution 11.15.2
 aws.cloudfront.distribution.arn 11.15.2
 aws.cloudfront.distribution.cacheBehaviors 11.15.2
+aws.cloudfront.distribution.callerReference 13.39.2
 aws.cloudfront.distribution.cnames 11.15.2
 aws.cloudfront.distribution.comment 11.15.2
 aws.cloudfront.distribution.continuousDeploymentPolicyId 13.29.1
@@ -1462,6 +1463,7 @@ aws.cloudfront.distribution.enabled 11.15.2
 aws.cloudfront.distribution.enforcesHttps 13.37.1
 aws.cloudfront.distribution.geoRestrictionType 11.15.2
 aws.cloudfront.distribution.httpVersion 11.15.2
+aws.cloudfront.distribution.id 13.39.2
 aws.cloudfront.distribution.isIPV6Enabled 11.15.2
 aws.cloudfront.distribution.lastModifiedAt 11.15.2
 aws.cloudfront.distribution.logging 13.6.0
@@ -1470,6 +1472,7 @@ aws.cloudfront.distribution.loggingConfig.bucket 13.6.0
 aws.cloudfront.distribution.loggingConfig.enabled 13.6.0
 aws.cloudfront.distribution.loggingConfig.includeCookies 13.6.0
 aws.cloudfront.distribution.loggingConfig.prefix 13.6.0
+aws.cloudfront.distribution.managedBy 13.39.2
 aws.cloudfront.distribution.minimumProtocolVersion 11.15.2
 aws.cloudfront.distribution.origin 11.15.2
 aws.cloudfront.distribution.origin.account 11.15.2
@@ -1485,7 +1488,9 @@ aws.cloudfront.distribution.origins 11.15.2
 aws.cloudfront.distribution.priceClass 11.15.2
 aws.cloudfront.distribution.protectedByWaf 13.37.1
 aws.cloudfront.distribution.sslSupportMethod 13.3.1
+aws.cloudfront.distribution.staging 13.39.2
 aws.cloudfront.distribution.status 11.15.2
+aws.cloudfront.distribution.tags 13.39.2
 aws.cloudfront.distribution.viewerMtlsMode 13.25.1
 aws.cloudfront.distribution.viewerMtlsTrustStoreId 13.25.1
 aws.cloudfront.distribution.viewerProtocolPolicy 11.15.2

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -126,6 +126,8 @@ func (a *mqlAwsCloudfront) distributions() ([]any, error) {
 
 			args := map[string]*llx.RawData{
 				"arn":                    llx.StringDataPtr(distribution.ARN),
+				"id":                     llx.StringDataPtr(distribution.Id),
+				"staging":                llx.BoolDataPtr(distribution.Staging),
 				"cacheBehaviors":         llx.ArrayData(cacheBehaviors, types.Any),
 				"cnames":                 llx.ArrayData(cnames, types.String),
 				"defaultCacheBehavior":   llx.MapData(defaultCacheBehavior, types.Any),
@@ -238,6 +240,57 @@ func (a *mqlAwsCloudfrontDistribution) continuousDeploymentPolicyId() (string, e
 		return "", nil
 	}
 	return convert.ToValue(resp.Distribution.DistributionConfig.ContinuousDeploymentPolicyId), nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) callerReference() (string, error) {
+	resp, err := a.fetchDistributionDetail()
+	if err != nil {
+		return "", err
+	}
+	if resp.Distribution == nil || resp.Distribution.DistributionConfig == nil {
+		return "", nil
+	}
+	return convert.ToValue(resp.Distribution.DistributionConfig.CallerReference), nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Cloudfront("")
+	ctx := context.Background()
+
+	resp, err := svc.ListTagsForResource(ctx, &cloudfront.ListTagsForResourceInput{
+		Resource: &a.Arn.Data,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	tags := make(map[string]any)
+	if resp.Tags != nil {
+		for _, t := range resp.Tags.Items {
+			tags[convert.ToValue(t.Key)] = convert.ToValue(t.Value)
+		}
+	}
+	return tags, nil
+}
+
+func (a *mqlAwsCloudfrontDistribution) managedBy() (string, error) {
+	owner, err := managedByFromResourceTags(a.GetTags())
+	if err != nil {
+		return "", err
+	}
+	if owner != "" {
+		return owner, nil
+	}
+	// CloudFront injects no provenance tag, but Terraform sets the distribution
+	// caller reference to a "terraform-" prefixed value; fall back to that.
+	cr := a.GetCallerReference()
+	if cr.Error != nil {
+		return "", cr.Error
+	}
+	return managedByWithCreationToken("", cr.Data), nil
 }
 
 func (a *mqlAwsCloudfrontDistribution) logging() (*mqlAwsCloudfrontDistributionLoggingConfig, error) {


### PR DESCRIPTION
`aws.cloudfront.distribution` was notably under-modeled — no ownership inference and no primary ID. Adds:

- **`id`** — the distribution ID (previously only `arn`/`domainName` were exposed).
- **`tags()`** — via `ListTagsForResource` (CloudFront supports tags; none were exposed).
- **`managedBy()`** — tag-based ownership inference, **with a Terraform fallback**: the Terraform AWS provider sets a distribution's `CallerReference` to a `terraform-` prefixed value (`sdkid.UniqueId()`), the only managed-by signal Terraform leaves — same heuristic as `route53.hostedZone`/`efs.filesystem`.
- **`callerReference`** — the creation idempotency token (from `GetDistribution`).
- **`staging`** — whether this is a continuous-deployment staging distribution (pairs with the existing `continuousDeploymentPolicyId`).

### Note on `cloudformationStack()`
Intentionally **not** added — CloudFront is global and the resource carries no region, but `cloudformationStackForTags` needs one to `DescribeStacks` (same reasoning as the route53 hosted zone PR). Deferred rather than shipped unreliable.

`id`/`staging` come off the existing `ListDistributions` data; `callerReference` reuses the existing lazy `GetDistribution` detail fetch; `tags()` uses `cloudfront:ListTagsForResource`, which is already in the provider's permission set. No new IAM permissions.