### PR TITLE
✨ aws: add ownership trio, readerEndpoint, iamRoles to neptune cluster

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17510,6 +17510,8 @@ private aws.neptune.cluster @defaults("arn name status") {
   enabledCloudwatchLogsExports []string
   // Connection endpoint for the primary instance
   endpoint string
+  // Reader endpoint for the cluster, balancing read connections across replicas
+  readerEndpoint string
   // Whether mapping of Amazon Identity and Access Management (IAM) accounts to database accounts is enabled
   iamDatabaseAuthenticationEnabled bool
   // Latest time to which a database can be restored
@@ -17534,6 +17536,16 @@ private aws.neptune.cluster @defaults("arn name status") {
   networkType string
   // List of VPC security groups associated with the DB cluster
   securityGroups() []aws.ec2.securitygroup
+  // IAM roles associated with the cluster
+  iamRoles() []aws.iam.role
+  // Tags for the cluster
+  tags() map[string]string
+  // CloudFormation stack that manages this cluster, if any
+  cloudformationStack() aws.cloudformation.stack
+  // Infrastructure-management system that owns this cluster
+  //
+  // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the cluster is unmanaged or managed by a tool that leaves no recognizable tag.
+  managedBy() string
 }
 
 // Amazon Neptune instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -24124,6 +24124,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.neptune.cluster.endpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneCluster).GetEndpoint()).ToDataRes(types.String)
 	},
+	"aws.neptune.cluster.readerEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetReaderEndpoint()).ToDataRes(types.String)
+	},
 	"aws.neptune.cluster.iamDatabaseAuthenticationEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneCluster).GetIamDatabaseAuthenticationEnabled()).ToDataRes(types.Bool)
 	},
@@ -24159,6 +24162,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.neptune.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.neptune.cluster.iamRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetIamRoles()).ToDataRes(types.Array(types.Resource("aws.iam.role")))
+	},
+	"aws.neptune.cluster.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.neptune.cluster.cloudformationStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetCloudformationStack()).ToDataRes(types.Resource("aws.cloudformation.stack"))
+	},
+	"aws.neptune.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"aws.neptune.instance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneInstance).GetArn()).ToDataRes(types.String)
@@ -61999,6 +62014,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsNeptuneCluster).Endpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.neptune.cluster.readerEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).ReaderEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.neptune.cluster.iamDatabaseAuthenticationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsNeptuneCluster).IamDatabaseAuthenticationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -62045,6 +62064,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.neptune.cluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsNeptuneCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.iamRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).IamRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.cloudformationStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).CloudformationStack, ok = plugin.RawToTValue[*mqlAwsCloudformationStack](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.neptune.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -149435,6 +149470,7 @@ type mqlAwsNeptuneCluster struct {
 	EarliestRestorableTime           plugin.TValue[*time.Time]
 	EnabledCloudwatchLogsExports     plugin.TValue[[]any]
 	Endpoint                         plugin.TValue[string]
+	ReaderEndpoint                   plugin.TValue[string]
 	IamDatabaseAuthenticationEnabled plugin.TValue[bool]
 	LatestRestorableTime             plugin.TValue[*time.Time]
 	MasterUsername                   plugin.TValue[string]
@@ -149447,6 +149483,10 @@ type mqlAwsNeptuneCluster struct {
 	StorageType                      plugin.TValue[string]
 	NetworkType                      plugin.TValue[string]
 	SecurityGroups                   plugin.TValue[[]any]
+	IamRoles                         plugin.TValue[[]any]
+	Tags                             plugin.TValue[map[string]any]
+	CloudformationStack              plugin.TValue[*mqlAwsCloudformationStack]
+	ManagedBy                        plugin.TValue[string]
 }
 
 // createAwsNeptuneCluster creates a new instance of this resource
@@ -149593,6 +149633,10 @@ func (c *mqlAwsNeptuneCluster) GetEndpoint() *plugin.TValue[string] {
 	return &c.Endpoint
 }
 
+func (c *mqlAwsNeptuneCluster) GetReaderEndpoint() *plugin.TValue[string] {
+	return &c.ReaderEndpoint
+}
+
 func (c *mqlAwsNeptuneCluster) GetIamDatabaseAuthenticationEnabled() *plugin.TValue[bool] {
 	return &c.IamDatabaseAuthenticationEnabled
 }
@@ -149650,6 +149694,50 @@ func (c *mqlAwsNeptuneCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsNeptuneCluster) GetIamRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IamRoles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune.cluster", c.__id, "iamRoles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.iamRoles()
+	})
+}
+
+func (c *mqlAwsNeptuneCluster) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
+func (c *mqlAwsNeptuneCluster) GetCloudformationStack() *plugin.TValue[*mqlAwsCloudformationStack] {
+	return plugin.GetOrCompute[*mqlAwsCloudformationStack](&c.CloudformationStack, func() (*mqlAwsCloudformationStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune.cluster", c.__id, "cloudformationStack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudformationStack), nil
+			}
+		}
+
+		return c.cloudformationStack()
+	})
+}
+
+func (c *mqlAwsNeptuneCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6789,6 +6789,7 @@ aws.neptune.cluster.arn 11.15.2
 aws.neptune.cluster.automaticRestartTime 11.15.2
 aws.neptune.cluster.availabilityZones 11.15.2
 aws.neptune.cluster.backupRetentionPeriod 11.15.2
+aws.neptune.cluster.cloudformationStack 13.39.2
 aws.neptune.cluster.clusterIdentifier 11.15.2
 aws.neptune.cluster.clusterParameterGroup 11.15.2
 aws.neptune.cluster.clusterResourceId 11.15.2
@@ -6802,9 +6803,11 @@ aws.neptune.cluster.engine 11.15.2
 aws.neptune.cluster.engineVersion 11.15.2
 aws.neptune.cluster.globalClusterIdentifier 11.15.2
 aws.neptune.cluster.iamDatabaseAuthenticationEnabled 11.15.2
+aws.neptune.cluster.iamRoles 13.39.2
 aws.neptune.cluster.kmsKey 11.16.1
 aws.neptune.cluster.kmsKeyId 11.15.2
 aws.neptune.cluster.latestRestorableTime 11.15.2
+aws.neptune.cluster.managedBy 13.39.2
 aws.neptune.cluster.masterUsername 11.15.2
 aws.neptune.cluster.multiAZ 11.15.2
 aws.neptune.cluster.name 11.15.2
@@ -6812,6 +6815,7 @@ aws.neptune.cluster.networkType 13.35.2
 aws.neptune.cluster.port 11.15.2
 aws.neptune.cluster.preferredBackupWindow 11.15.2
 aws.neptune.cluster.preferredMaintenanceWindow 11.15.2
+aws.neptune.cluster.readerEndpoint 13.39.2
 aws.neptune.cluster.region 11.15.2
 aws.neptune.cluster.securityGroups 13.3.1
 aws.neptune.cluster.snapshots 11.15.2
@@ -6819,6 +6823,7 @@ aws.neptune.cluster.status 11.15.2
 aws.neptune.cluster.storageEncrypted 11.15.2
 aws.neptune.cluster.storageType 11.15.2
 aws.neptune.cluster.subnetGroup 11.15.2
+aws.neptune.cluster.tags 13.39.2
 aws.neptune.clusters 11.15.2
 aws.neptune.instance 11.15.2
 aws.neptune.instance.arn 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.39.1",
-  "generated_at": "2026-06-30T23:48:59+02:00",
+  "generated_at": "2026-06-30T20:58:00-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -14,6 +14,7 @@
     "acm:ListCertificates",
     "acm:ListTagsForCertificate",
     "apigateway:GET",
+    "apigateway:GetDeployments",
     "application-autoscaling:DescribeScalableTargets",
     "application-autoscaling:DescribeScalingPolicies",
     "application-autoscaling:DescribeScheduledActions",
@@ -997,6 +998,12 @@
       "service": "apigateway",
       "action": "GetApis",
       "source_file": "aws_apigatewayv2.go"
+    },
+    {
+      "permission": "apigateway:GetDeployments",
+      "service": "apigateway",
+      "action": "GetDeployments",
+      "source_file": "aws_apigateway.go"
     },
     {
       "permission": "application-autoscaling:DescribeScalableTargets",
@@ -4891,6 +4898,12 @@
       "service": "rds",
       "action": "ListTagsForResource",
       "source_file": "aws_documentdb.go"
+    },
+    {
+      "permission": "rds:ListTagsForResource",
+      "service": "rds",
+      "action": "ListTagsForResource",
+      "source_file": "aws_neptune.go"
     },
     {
       "permission": "rds:ListTagsForResource",

--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -103,6 +103,14 @@ func (a *mqlAwsRoute53HostedZone) managedBy() (string, error) {
 	return managedByWithCreationToken("", cr.Data), nil
 }
 
+func (a *mqlAwsNeptuneCluster) managedBy() (string, error) {
+	return managedByFromResourceTags(a.GetTags())
+}
+
+func (a *mqlAwsNeptuneCluster) cloudformationStack() (*mqlAwsCloudformationStack, error) {
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
+}
+
 func (a *mqlAwsEfsFilesystem) managedBy() (string, error) {
 	owner, err := managedByFromResourceTags(a.GetTags())
 	if err != nil {

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -94,6 +94,7 @@ func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool
 
 type mqlAwsNeptuneClusterInternal struct {
 	securityGroupIdHandler
+	cacheRoleArns []string
 }
 
 func newMqlAwsNeptuneCluster(runtime *plugin.Runtime, region string, accountID string, cluster neptune_types.DBCluster) (*mqlAwsNeptuneCluster, error) {
@@ -120,6 +121,7 @@ func newMqlAwsNeptuneCluster(runtime *plugin.Runtime, region string, accountID s
 			"earliestRestorableTime":           llx.TimeDataPtr(cluster.EarliestRestorableTime),
 			"enabledCloudwatchLogsExports":     llx.ArrayData(convert.SliceAnyToInterface(cluster.EnabledCloudwatchLogsExports), types.String),
 			"endpoint":                         llx.StringDataPtr(cluster.Endpoint),
+			"readerEndpoint":                   llx.StringDataPtr(cluster.ReaderEndpoint),
 			"iamDatabaseAuthenticationEnabled": llx.BoolDataPtr(cluster.IAMDatabaseAuthenticationEnabled),
 			"latestRestorableTime":             llx.TimeDataPtr(cluster.LatestRestorableTime),
 			"masterUsername":                   llx.StringDataPtr(cluster.MasterUsername),
@@ -141,9 +143,50 @@ func newMqlAwsNeptuneCluster(runtime *plugin.Runtime, region string, accountID s
 			sgsArn = append(sgsArn, NewSecurityGroupArn(region, accountID, *sg.VpcSecurityGroupId))
 		}
 	}
+	roleArns := []string{}
+	for _, r := range cluster.AssociatedRoles {
+		if r.RoleArn != nil {
+			roleArns = append(roleArns, *r.RoleArn)
+		}
+	}
 	mqlCluster := resource.(*mqlAwsNeptuneCluster)
 	mqlCluster.setSecurityGroupArns(sgsArn)
+	mqlCluster.cacheRoleArns = roleArns
 	return mqlCluster, nil
+}
+
+func (a *mqlAwsNeptuneCluster) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Neptune(a.Region.Data)
+	ctx := context.Background()
+	arnVal := a.Arn.Data
+	resp, err := svc.ListTagsForResource(ctx, &neptune.ListTagsForResourceInput{ResourceName: &arnVal})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	tags := map[string]any{}
+	for _, t := range resp.TagList {
+		if t.Key != nil && t.Value != nil {
+			tags[*t.Key] = *t.Value
+		}
+	}
+	return tags, nil
+}
+
+func (a *mqlAwsNeptuneCluster) iamRoles() ([]any, error) {
+	res := []any{}
+	for _, roleArn := range a.cacheRoleArns {
+		ref, err := NewResource(a.MqlRuntime, ResourceAwsIamRole,
+			map[string]*llx.RawData{"arn": llx.StringData(roleArn)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, ref)
+	}
+	return res, nil
 }
 
 func (a *mqlAwsNeptuneCluster) securityGroups() ([]any, error) {


### PR DESCRIPTION
`aws.neptune.cluster` uses the same `DescribeDBClusters` API as `aws.documentdb.cluster` but was far less modeled — notably it had **no ownership inference at all**. This closes the core of that gap:

- **`tags()` + `managedBy()` + `cloudformationStack()`** — the ownership trio (Neptune clusters support tags; none were exposed). `tags()` uses Neptune `ListTagsForResource`.
- **`readerEndpoint`** — the reader endpoint balancing reads across replicas (only the primary `endpoint` was exposed).
- **`iamRoles() []aws.iam.role`** — IAM roles associated with the cluster (from `AssociatedRoles`).

`permissions.json` regenerated to include `rds:ListTagsForResource` (Neptune's management actions use the `rds:` IAM prefix), sourced from `aws_neptune.go`.

### Deferred
The DocumentDB twin also has `vpc()`/`subnets()` (subnet-group resolution), `members()`/`writer()`, and `replicationSource()`/`readReplicas()`. Those need the subnet-group resolver + cluster-member plumbing ported over and are a good follow-up; this PR covers the high-value ownership + endpoint + IAM core. `globalCluster()` stays out — `aws.neptune.globalCluster` isn't modeled.