### PR TITLE
✨ aws: add ec2 instance attributes to emr cluster

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7864,7 +7864,7 @@ private aws.emr.cluster @defaults("arn") {
   // Name of the EC2 key pair used for SSH access to the cluster instances
   ec2KeyName() string
   // EC2 instance profile the cluster nodes run as
-  ec2InstanceProfile() string
+  ec2InstanceProfile() aws.iam.instanceProfile
   // Whether Spark Connect sessions are enabled on the cluster
   sessionEnabled() bool
 }

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7857,6 +7857,14 @@ private aws.emr.cluster @defaults("arn") {
   autoScalingRole() aws.iam.role
   // IAM service role assumed by EMR to access AWS resources
   serviceRole() aws.iam.role
+  // Subnets the cluster EC2 instances are launched into
+  subnets() []aws.vpc.subnet
+  // Security groups attached to the cluster EC2 instances (EMR-managed and additional)
+  securityGroups() []aws.ec2.securitygroup
+  // Name of the EC2 key pair used for SSH access to the cluster instances
+  ec2KeyName() string
+  // EC2 instance profile the cluster nodes run as
+  ec2InstanceProfile() string
   // Whether Spark Connect sessions are enabled on the cluster
   sessionEnabled() bool
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -13518,6 +13518,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.emr.cluster.serviceRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetServiceRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
+	"aws.emr.cluster.subnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetSubnets()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
+	},
+	"aws.emr.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.emr.cluster.ec2KeyName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetEc2KeyName()).ToDataRes(types.String)
+	},
+	"aws.emr.cluster.ec2InstanceProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetEc2InstanceProfile()).ToDataRes(types.String)
+	},
 	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetSessionEnabled()).ToDataRes(types.Bool)
 	},
@@ -46404,6 +46416,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.emr.cluster.serviceRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrCluster).ServiceRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.ec2KeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).Ec2KeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.ec2InstanceProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).Ec2InstanceProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -109506,6 +109534,10 @@ type mqlAwsEmrCluster struct {
 	VisibleToAllUsers          plugin.TValue[bool]
 	AutoScalingRole            plugin.TValue[*mqlAwsIamRole]
 	ServiceRole                plugin.TValue[*mqlAwsIamRole]
+	Subnets                    plugin.TValue[[]any]
+	SecurityGroups             plugin.TValue[[]any]
+	Ec2KeyName                 plugin.TValue[string]
+	Ec2InstanceProfile         plugin.TValue[string]
 	SessionEnabled             plugin.TValue[bool]
 }
 
@@ -109847,6 +109879,50 @@ func (c *mqlAwsEmrCluster) GetServiceRole() *plugin.TValue[*mqlAwsIamRole] {
 		}
 
 		return c.serviceRole()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.emr.cluster", c.__id, "subnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnets()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.emr.cluster", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetEc2KeyName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Ec2KeyName, func() (string, error) {
+		return c.ec2KeyName()
+	})
+}
+
+func (c *mqlAwsEmrCluster) GetEc2InstanceProfile() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Ec2InstanceProfile, func() (string, error) {
+		return c.ec2InstanceProfile()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -13528,7 +13528,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsEmrCluster).GetEc2KeyName()).ToDataRes(types.String)
 	},
 	"aws.emr.cluster.ec2InstanceProfile": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsEmrCluster).GetEc2InstanceProfile()).ToDataRes(types.String)
+		return (r.(*mqlAwsEmrCluster).GetEc2InstanceProfile()).ToDataRes(types.Resource("aws.iam.instanceProfile"))
 	},
 	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetSessionEnabled()).ToDataRes(types.Bool)
@@ -46431,7 +46431,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"aws.emr.cluster.ec2InstanceProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsEmrCluster).Ec2InstanceProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlAwsEmrCluster).Ec2InstanceProfile, ok = plugin.RawToTValue[*mqlAwsIamInstanceProfile](v.Value, v.Error)
 		return
 	},
 	"aws.emr.cluster.sessionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -109537,7 +109537,7 @@ type mqlAwsEmrCluster struct {
 	Subnets                    plugin.TValue[[]any]
 	SecurityGroups             plugin.TValue[[]any]
 	Ec2KeyName                 plugin.TValue[string]
-	Ec2InstanceProfile         plugin.TValue[string]
+	Ec2InstanceProfile         plugin.TValue[*mqlAwsIamInstanceProfile]
 	SessionEnabled             plugin.TValue[bool]
 }
 
@@ -109920,8 +109920,18 @@ func (c *mqlAwsEmrCluster) GetEc2KeyName() *plugin.TValue[string] {
 	})
 }
 
-func (c *mqlAwsEmrCluster) GetEc2InstanceProfile() *plugin.TValue[string] {
-	return plugin.GetOrCompute[string](&c.Ec2InstanceProfile, func() (string, error) {
+func (c *mqlAwsEmrCluster) GetEc2InstanceProfile() *plugin.TValue[*mqlAwsIamInstanceProfile] {
+	return plugin.GetOrCompute[*mqlAwsIamInstanceProfile](&c.Ec2InstanceProfile, func() (*mqlAwsIamInstanceProfile, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.emr.cluster", c.__id, "ec2InstanceProfile")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamInstanceProfile), nil
+			}
+		}
+
 		return c.ec2InstanceProfile()
 	})
 }

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4395,6 +4395,8 @@ aws.emr.cluster.createdAt 13.38.2
 aws.emr.cluster.ebsRootVolumeIops 13.21.4
 aws.emr.cluster.ebsRootVolumeSize 13.21.4
 aws.emr.cluster.ebsRootVolumeThroughput 13.21.4
+aws.emr.cluster.ec2InstanceProfile 13.39.2
+aws.emr.cluster.ec2KeyName 13.39.2
 aws.emr.cluster.encryptionConfiguration 13.3.0
 aws.emr.cluster.encryptionConfiguration.atRestConfiguration 13.3.0
 aws.emr.cluster.encryptionConfiguration.atRestEnabled 13.3.0
@@ -4433,6 +4435,7 @@ aws.emr.cluster.repoUpgradeOnBoot 13.21.4
 aws.emr.cluster.scaleDownBehavior 13.21.4
 aws.emr.cluster.securityConfig 13.21.4
 aws.emr.cluster.securityConfiguration 13.3.0
+aws.emr.cluster.securityGroups 13.39.2
 aws.emr.cluster.serviceRole 13.21.4
 aws.emr.cluster.sessionEnabled 13.32.2
 aws.emr.cluster.status 11.15.2
@@ -4454,6 +4457,7 @@ aws.emr.cluster.step.stateChangeReason 13.21.4
 aws.emr.cluster.step.status 13.12.1
 aws.emr.cluster.stepConcurrencyLevel 13.21.4
 aws.emr.cluster.steps 13.12.1
+aws.emr.cluster.subnets 13.39.2
 aws.emr.cluster.tags 11.15.2
 aws.emr.cluster.terminationProtected 13.3.1
 aws.emr.cluster.visibleToAllUsers 13.21.4

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -282,13 +283,26 @@ func (a *mqlAwsEmrCluster) fetchClusterDetails() error {
 			a.cacheEc2SubnetIds = []string{*attr.Ec2SubnetId}
 		}
 		sgIds := []string{}
-		for _, sg := range []*string{attr.EmrManagedMasterSecurityGroup, attr.EmrManagedSlaveSecurityGroup, attr.ServiceAccessSecurityGroup} {
-			if sg != nil && *sg != "" {
-				sgIds = append(sgIds, *sg)
+		seen := map[string]struct{}{}
+		addSG := func(id string) {
+			if id == "" {
+				return
 			}
+			if _, ok := seen[id]; ok {
+				return
+			}
+			seen[id] = struct{}{}
+			sgIds = append(sgIds, id)
 		}
-		sgIds = append(sgIds, attr.AdditionalMasterSecurityGroups...)
-		sgIds = append(sgIds, attr.AdditionalSlaveSecurityGroups...)
+		addSG(convert.ToValue(attr.EmrManagedMasterSecurityGroup))
+		addSG(convert.ToValue(attr.EmrManagedSlaveSecurityGroup))
+		addSG(convert.ToValue(attr.ServiceAccessSecurityGroup))
+		for _, id := range attr.AdditionalMasterSecurityGroups {
+			addSG(id)
+		}
+		for _, id := range attr.AdditionalSlaveSecurityGroups {
+			addSG(id)
+		}
 		a.cacheEc2SecurityGroupIds = sgIds
 		a.cacheEc2KeyName = convert.ToValue(attr.Ec2KeyName)
 		a.cacheEc2InstanceProfile = convert.ToValue(attr.IamInstanceProfile)
@@ -347,11 +361,29 @@ func (a *mqlAwsEmrCluster) ec2KeyName() (string, error) {
 	return a.cacheEc2KeyName, nil
 }
 
-func (a *mqlAwsEmrCluster) ec2InstanceProfile() (string, error) {
+func (a *mqlAwsEmrCluster) ec2InstanceProfile() (*mqlAwsIamInstanceProfile, error) {
 	if err := a.fetchClusterDetails(); err != nil {
-		return "", err
+		return nil, err
 	}
-	return a.cacheEc2InstanceProfile, nil
+	profile := a.cacheEc2InstanceProfile
+	if profile == "" {
+		a.Ec2InstanceProfile.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	// EMR returns the instance profile as a name or an ARN; build the ARN when
+	// only a name is present (IAM is global, so no region in the ARN).
+	arnVal := profile
+	if !strings.HasPrefix(arnVal, "arn:") {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		arnVal = fmt.Sprintf("arn:aws:iam::%s:instance-profile/%s", conn.AccountId(), profile)
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.instanceProfile",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		a.Ec2InstanceProfile.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return res.(*mqlAwsIamInstanceProfile), nil
 }
 
 // redactedKerberosAttributes returns a sanitized view of KerberosAttributes

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -174,6 +174,10 @@ type mqlAwsEmrClusterInternal struct {
 	autoTerminationFetched          bool
 	autoTerminationLock             sync.Mutex
 	cacheAutoTerminationIdleTimeout int64
+	cacheEc2SubnetIds               []string
+	cacheEc2SecurityGroupIds        []string
+	cacheEc2KeyName                 string
+	cacheEc2InstanceProfile         string
 }
 
 func (a *mqlAwsEmrCluster) fetchClusterDetails() error {
@@ -269,8 +273,85 @@ func (a *mqlAwsEmrCluster) fetchClusterDetails() error {
 		a.cacheSessionEnabled = *resp.Cluster.SessionEnabled
 	}
 
+	if attr := resp.Cluster.Ec2InstanceAttributes; attr != nil {
+		// RequestedEc2SubnetIds covers all configured subnets; fall back to the
+		// single launched subnet when the requested list is empty.
+		if len(attr.RequestedEc2SubnetIds) > 0 {
+			a.cacheEc2SubnetIds = attr.RequestedEc2SubnetIds
+		} else if attr.Ec2SubnetId != nil && *attr.Ec2SubnetId != "" {
+			a.cacheEc2SubnetIds = []string{*attr.Ec2SubnetId}
+		}
+		sgIds := []string{}
+		for _, sg := range []*string{attr.EmrManagedMasterSecurityGroup, attr.EmrManagedSlaveSecurityGroup, attr.ServiceAccessSecurityGroup} {
+			if sg != nil && *sg != "" {
+				sgIds = append(sgIds, *sg)
+			}
+		}
+		sgIds = append(sgIds, attr.AdditionalMasterSecurityGroups...)
+		sgIds = append(sgIds, attr.AdditionalSlaveSecurityGroups...)
+		a.cacheEc2SecurityGroupIds = sgIds
+		a.cacheEc2KeyName = convert.ToValue(attr.Ec2KeyName)
+		a.cacheEc2InstanceProfile = convert.ToValue(attr.IamInstanceProfile)
+	}
+
 	a.clusterDetailsFetched = true
 	return nil
+}
+
+func (a *mqlAwsEmrCluster) subnets() ([]any, error) {
+	if err := a.fetchClusterDetails(); err != nil {
+		return nil, err
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region, err := GetRegionFromArn(a.Arn.Data)
+	if err != nil {
+		return nil, err
+	}
+	res := []any{}
+	for _, id := range a.cacheEc2SubnetIds {
+		ref, err := NewResource(a.MqlRuntime, ResourceAwsVpcSubnet,
+			map[string]*llx.RawData{"arn": llx.StringData(fmt.Sprintf(subnetArnPattern, region, conn.AccountId(), id))})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, ref)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsEmrCluster) securityGroups() ([]any, error) {
+	if err := a.fetchClusterDetails(); err != nil {
+		return nil, err
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region, err := GetRegionFromArn(a.Arn.Data)
+	if err != nil {
+		return nil, err
+	}
+	res := []any{}
+	for _, id := range a.cacheEc2SecurityGroupIds {
+		ref, err := NewResource(a.MqlRuntime, ResourceAwsEc2Securitygroup,
+			map[string]*llx.RawData{"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, conn.AccountId(), id))})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, ref)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsEmrCluster) ec2KeyName() (string, error) {
+	if err := a.fetchClusterDetails(); err != nil {
+		return "", err
+	}
+	return a.cacheEc2KeyName, nil
+}
+
+func (a *mqlAwsEmrCluster) ec2InstanceProfile() (string, error) {
+	if err := a.fetchClusterDetails(); err != nil {
+		return "", err
+	}
+	return a.cacheEc2InstanceProfile, nil
 }
 
 // redactedKerberosAttributes returns a sanitized view of KerberosAttributes


### PR DESCRIPTION
Exposes `aws.emr.cluster`'s `Ec2InstanceAttributes`, which were entirely unmodeled — the cluster's network placement and node identity:

- **`subnets() []aws.vpc.subnet`** — the subnets the cluster instances launch into (from `RequestedEc2SubnetIds`, falling back to `Ec2SubnetId`).
- **`securityGroups() []aws.ec2.securitygroup`** — the EMR-managed master/slave/service-access groups plus any additional master/slave groups.
- **`ec2KeyName`** — the EC2 key pair for SSH access.
- **`ec2InstanceProfile`** — the EC2 instance profile the cluster nodes run as (distinct from the already-exposed `serviceRole()` and `autoScalingRole()`).

All read from the existing lazy `DescribeCluster` detail fetch, so no new API calls or IAM permissions.