### PR TITLE
🎉 aws-13.40.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.39.1",
+	Version:         "13.40.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.40.0)
- ✨ aws: add ec2 instance attributes to emr cluster (#8843)
- ✨ aws: add ownership trio, readerEndpoint, iamRoles to neptune cluster (#8842)
- ✨ aws: add id, tags, managedBy, staging, callerReference to cloudfront distribution (#8841)
- ✨ aws: add typed refs and config to elasticache cluster (#8840)
- ✨ aws: add managedBy and callerReference to route53 hosted zone (#8839)
- ✨ aws: add managedBy and cloudformationStack to opensearch domain (#8838)
- ✨ aws: add kmsKey typed ref to ecr repository (#8836)
- ✨ aws: add typed refs to ecr image and ssm instance (#8835)
- ✨ aws: add deployments sub-resource to apigateway rest api (#8834)
- ✨ aws: add ML lineage to sagemaker training and processing jobs (#8833)
- ✨ aws: add macAlgorithms, cloudHsmCluster, currentKeyMaterialId to kms key (#8832)
- ✨ aws: add change provenance to es/opensearch domains and software parity (#8831)
- ✨ aws: add subnets and state to aws.elb.loadbalancer (#8830)
- 🧹 aws: unit-test managedBy tag inference and terraform heuristic (#8829)
- ✨ aws: add runtimeVersionArn to aws.lambda.function (#8827)
- ✨ aws: add ecrImage and repositoryCredentialsSecret refs to ecs container (#8828)
- ✨ aws: add provenance fields to ecs container instances and efs file systems (#8826)
- ✨ aws: add typed destination refs to cloudwatch log subscription filters (#8824)
- ✨ aws: add revisionId to aws.lambda.function (#8825)
- ✨ aws: add copy/restore provenance to ec2 volume and snapshot (#8823)
- ✨ aws: add provenance, backup, and security fields to redshift.cluster (#8821)
- ✨ aws: add managedBy and cloudformationStack to 26 more resources (#8822)
- ✨ aws: add replica/backup/backtrack provenance to rds instances and clusters (#8820)
- ✨ aws: add logging start/stop provenance to aws.cloudtrail.trail (#8819)
- ✨ aws: add eventTargets source-to-target lineage to eventbridge rules (#8818)
- ✨ aws: add backup/restore provenance to aws.dynamodb.table (#8817)