### PR TITLE
✨ azure: add network-lineage provenance to vnet, peering, app gateway

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2172,7 +2172,7 @@ azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   flowTimeoutInMinutes int
   // List of virtual network peerings
   peerings() []azure.subscription.networkService.virtualNetwork.peering
-  // Default public NAT gateway providing outbound SNAT for subnets that do not have their own
+  // Default public NAT gateway providing outbound SNAT for subnets that do not have their own NAT gateway
   defaultNatGateway() azure.subscription.networkService.natGateway
   // Flow logs that target this virtual network
   flowLogs() []azure.subscription.networkService.watcher.flowlog
@@ -2830,7 +2830,7 @@ private azure.subscription.networkService.applicationGateway.gatewayIpConfig @de
   id string
   // Gateway IP configuration name
   name string
-  // ARM resource ID of the bound subnet (cached for the typed `subnet` accessor)
+  // ARM resource ID of the bound subnet
   subnetId string
   // Subnet the application gateway is deployed into
   subnet() azure.subscription.networkService.subnet
@@ -2847,7 +2847,7 @@ private azure.subscription.networkService.applicationGateway.frontendIpConfig @d
   id string
   // Frontend IP configuration name
   name string
-  // ARM resource ID of the bound subnet; non-empty for internal (private) frontends (cached for the typed `subnet` accessor)
+  // ARM resource ID of the bound subnet; non-empty for internal (private) frontends
   subnetId string
   // Bound subnet; null for internet-facing frontends that have no subnet
   subnet() azure.subscription.networkService.subnet

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2172,6 +2172,10 @@ azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   flowTimeoutInMinutes int
   // List of virtual network peerings
   peerings() []azure.subscription.networkService.virtualNetwork.peering
+  // Default public NAT gateway providing outbound SNAT for subnets that do not have their own
+  defaultNatGateway() azure.subscription.networkService.natGateway
+  // Flow logs that target this virtual network
+  flowLogs() []azure.subscription.networkService.watcher.flowlog
 }
 
 // Azure VNet peering
@@ -2203,7 +2207,11 @@ azure.subscription.networkService.virtualNetwork.peering @defaults("id name peer
   // The provisioning state: Succeeded, Updating, Deleting, Failed, Creating, Canceled
   provisioningState string
   // The remote virtual network reference ID
-  remoteVirtualNetworkId string
+  //
+  // Deprecated in favor of remoteVirtualNetwork.
+  remoteVirtualNetworkId @maturity("deprecated") string
+  // The peered remote virtual network
+  remoteVirtualNetwork() azure.subscription.networkService.virtualNetwork
   // Whether traffic between the two VNets is encrypted (Azure global VNet peering encryption)
   remoteVirtualNetworkEncryptionEnabled bool
   // Encryption enforcement for the remote VNet ("AllowUnencrypted" or "DropUnencrypted")
@@ -2800,6 +2808,32 @@ azure.subscription.networkService.applicationGateway @defaults("id name location
   sslCertificates []azure.subscription.networkService.applicationGateway.sslCertificate
   // Frontend IP configurations on the application gateway (a config with a subnet is internal/private; one with a public IP is internet-facing)
   frontendIpConfigs []azure.subscription.networkService.applicationGateway.frontendIpConfig
+  // Object ID (principal ID) of the system-assigned managed identity, when one is configured
+  principalId string
+  // Tenant ID of the system-assigned managed identity, when one is configured
+  tenantId string
+  // Managed identity type: None, SystemAssigned, UserAssigned, or "SystemAssigned, UserAssigned"
+  identityType string
+  // User-assigned managed identities associated with the application gateway
+  userAssignedIdentities() []azure.subscription.managedIdentity
+  // Gateway IP configurations that bind the application gateway into a subnet
+  gatewayIpConfigs() []azure.subscription.networkService.applicationGateway.gatewayIpConfig
+}
+
+// Azure Application Gateway IP configuration
+//
+// Gateway IP configuration on an Application Gateway. Each entry binds the
+// gateway into a subnet, from which the gateway draws its private addresses.
+// The `subnet` reference traces the network the gateway is deployed into.
+private azure.subscription.networkService.applicationGateway.gatewayIpConfig @defaults("name subnetId") {
+  // ARM resource ID
+  id string
+  // Gateway IP configuration name
+  name string
+  // ARM resource ID of the bound subnet (cached for the typed `subnet` accessor)
+  subnetId string
+  // Subnet the application gateway is deployed into
+  subnet() azure.subscription.networkService.subnet
 }
 
 // Azure Application Gateway frontend IP configuration

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -91,6 +91,7 @@ const (
 	ResourceAzureSubscriptionNetworkServiceWatcherPacketCapture                                  string = "azure.subscription.networkService.watcher.packetCapture"
 	ResourceAzureSubscriptionNetworkServiceWatcherConnectionMonitor                              string = "azure.subscription.networkService.watcher.connectionMonitor"
 	ResourceAzureSubscriptionNetworkServiceApplicationGateway                                    string = "azure.subscription.networkService.applicationGateway"
+	ResourceAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig                     string = "azure.subscription.networkService.applicationGateway.gatewayIpConfig"
 	ResourceAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig                    string = "azure.subscription.networkService.applicationGateway.frontendIpConfig"
 	ResourceAzureSubscriptionNetworkServiceApplicationGatewayListener                            string = "azure.subscription.networkService.applicationGateway.listener"
 	ResourceAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate                      string = "azure.subscription.networkService.applicationGateway.sslCertificate"
@@ -725,6 +726,10 @@ func init() {
 		"azure.subscription.networkService.applicationGateway": {
 			Init:   initAzureSubscriptionNetworkServiceApplicationGateway,
 			Create: createAzureSubscriptionNetworkServiceApplicationGateway,
+		},
+		"azure.subscription.networkService.applicationGateway.gatewayIpConfig": {
+			// to override args, implement: initAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig,
 		},
 		"azure.subscription.networkService.applicationGateway.frontendIpConfig": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4528,6 +4533,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualNetwork.peerings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).GetPeerings()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.virtualNetwork.peering")))
 	},
+	"azure.subscription.networkService.virtualNetwork.defaultNatGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).GetDefaultNatGateway()).ToDataRes(types.Resource("azure.subscription.networkService.natGateway"))
+	},
+	"azure.subscription.networkService.virtualNetwork.flowLogs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).GetFlowLogs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.watcher.flowlog")))
+	},
 	"azure.subscription.networkService.virtualNetwork.peering.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetId()).ToDataRes(types.String)
 	},
@@ -4557,6 +4568,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetRemoteVirtualNetworkId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetRemoteVirtualNetwork()).ToDataRes(types.Resource("azure.subscription.networkService.virtualNetwork"))
 	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetRemoteVirtualNetworkEncryptionEnabled()).ToDataRes(types.Bool)
@@ -5211,6 +5225,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfigs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetFrontendIpConfigs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.applicationGateway.frontendIpConfig")))
+	},
+	"azure.subscription.networkService.applicationGateway.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.identityType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetIdentityType()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfigs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetGatewayIpConfigs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.applicationGateway.gatewayIpConfig")))
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnetId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).GetSubnetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig).GetId()).ToDataRes(types.String)
@@ -19220,6 +19261,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).Peerings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.virtualNetwork.defaultNatGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).DefaultNatGateway, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceNatGateway](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualNetwork.flowLogs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork).FlowLogs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.virtualNetwork.peering.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).__id, ok = v.Value.(string)
 		return
@@ -19262,6 +19311,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).RemoteVirtualNetworkId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).RemoteVirtualNetwork, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20214,6 +20267,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).FrontendIpConfigs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.identityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GatewayIpConfigs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.applicationGateway.frontendIpConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -43723,7 +43816,7 @@ func (c *mqlAzureSubscriptionNetworkServiceSubnetDelegation) GetProvisioningStat
 type mqlAzureSubscriptionNetworkServiceVirtualNetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceVirtualNetworkInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceVirtualNetworkInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	Location              plugin.TValue[string]
@@ -43741,6 +43834,8 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetwork struct {
 	ProvisioningState     plugin.TValue[string]
 	FlowTimeoutInMinutes  plugin.TValue[int64]
 	Peerings              plugin.TValue[[]any]
+	DefaultNatGateway     plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway]
+	FlowLogs              plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceVirtualNetwork creates a new instance of this resource
@@ -43860,6 +43955,38 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetwork) GetPeerings() *plugin
 	})
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceVirtualNetwork) GetDefaultNatGateway() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceNatGateway](&c.DefaultNatGateway, func() (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.virtualNetwork", c.__id, "defaultNatGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
+			}
+		}
+
+		return c.defaultNatGateway()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualNetwork) GetFlowLogs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.FlowLogs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.virtualNetwork", c.__id, "flowLogs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.flowLogs()
+	})
+}
+
 // mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering for the azure.subscription.networkService.virtualNetwork.peering resource
 type mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering struct {
 	MqlRuntime *plugin.Runtime
@@ -43875,6 +44002,7 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering struct {
 	PeeringSyncLevel                          plugin.TValue[string]
 	ProvisioningState                         plugin.TValue[string]
 	RemoteVirtualNetworkId                    plugin.TValue[string]
+	RemoteVirtualNetwork                      plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork]
 	RemoteVirtualNetworkEncryptionEnabled     plugin.TValue[bool]
 	RemoteVirtualNetworkEncryptionEnforcement plugin.TValue[string]
 }
@@ -43954,6 +44082,22 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetProvisionin
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetRemoteVirtualNetworkId() *plugin.TValue[string] {
 	return &c.RemoteVirtualNetworkId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetRemoteVirtualNetwork() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](&c.RemoteVirtualNetwork, func() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.virtualNetwork.peering", c.__id, "remoteVirtualNetwork")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+			}
+		}
+
+		return c.remoteVirtualNetwork()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetRemoteVirtualNetworkEncryptionEnabled() *plugin.TValue[bool] {
@@ -46024,22 +46168,27 @@ func (c *mqlAzureSubscriptionNetworkServiceWatcherConnectionMonitor) GetOutputs(
 type mqlAzureSubscriptionNetworkServiceApplicationGateway struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceApplicationGatewayInternal it will be used here
-	Id                    plugin.TValue[string]
-	Name                  plugin.TValue[string]
-	Location              plugin.TValue[string]
-	Tags                  plugin.TValue[map[string]any]
-	Type                  plugin.TValue[string]
-	Etag                  plugin.TValue[string]
-	Properties            plugin.TValue[any]
-	Policy                plugin.TValue[*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy]
-	WafConfiguration      plugin.TValue[[]any]
-	SslPolicyType         plugin.TValue[string]
-	SslMinProtocolVersion plugin.TValue[string]
-	SslCipherSuites       plugin.TValue[[]any]
-	Listeners             plugin.TValue[[]any]
-	SslCertificates       plugin.TValue[[]any]
-	FrontendIpConfigs     plugin.TValue[[]any]
+	mqlAzureSubscriptionNetworkServiceApplicationGatewayInternal
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Location               plugin.TValue[string]
+	Tags                   plugin.TValue[map[string]any]
+	Type                   plugin.TValue[string]
+	Etag                   plugin.TValue[string]
+	Properties             plugin.TValue[any]
+	Policy                 plugin.TValue[*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy]
+	WafConfiguration       plugin.TValue[[]any]
+	SslPolicyType          plugin.TValue[string]
+	SslMinProtocolVersion  plugin.TValue[string]
+	SslCipherSuites        plugin.TValue[[]any]
+	Listeners              plugin.TValue[[]any]
+	SslCertificates        plugin.TValue[[]any]
+	FrontendIpConfigs      plugin.TValue[[]any]
+	PrincipalId            plugin.TValue[string]
+	TenantId               plugin.TValue[string]
+	IdentityType           plugin.TValue[string]
+	UserAssignedIdentities plugin.TValue[[]any]
+	GatewayIpConfigs       plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceApplicationGateway creates a new instance of this resource
@@ -46161,6 +46310,126 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetSslCertificate
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetFrontendIpConfigs() *plugin.TValue[[]any] {
 	return &c.FrontendIpConfigs
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetIdentityType() *plugin.TValue[string] {
+	return &c.IdentityType
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetGatewayIpConfigs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.GatewayIpConfigs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway", c.__id, "gatewayIpConfigs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.gatewayIpConfigs()
+	})
+}
+
+// mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig for the azure.subscription.networkService.applicationGateway.gatewayIpConfig resource
+type mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfigInternal it will be used here
+	Id       plugin.TValue[string]
+	Name     plugin.TValue[string]
+	SubnetId plugin.TValue[string]
+	Subnet   plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
+}
+
+// createAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig creates a new instance of this resource
+func createAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.applicationGateway.gatewayIpConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) MqlName() string {
+	return "azure.subscription.networkService.applicationGateway.gatewayIpConfig"
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) GetSubnetId() *plugin.TValue[string] {
+	return &c.SubnetId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway.gatewayIpConfig", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
 }
 
 // mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig for the azure.subscription.networkService.applicationGateway.frontendIpConfig resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2840,7 +2840,14 @@ azure.subscription.networkService.applicationGateway.frontendIpConfig.publicIpAd
 azure.subscription.networkService.applicationGateway.frontendIpConfig.subnet 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.subnetId 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfigs 13.18.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfig 13.23.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfig.id 13.23.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfig.name 13.23.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnet 13.23.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfig.subnetId 13.23.1
+azure.subscription.networkService.applicationGateway.gatewayIpConfigs 13.23.1
 azure.subscription.networkService.applicationGateway.id 9.0.13
+azure.subscription.networkService.applicationGateway.identityType 13.23.1
 azure.subscription.networkService.applicationGateway.listener 13.12.2
 azure.subscription.networkService.applicationGateway.listener.hostName 13.12.2
 azure.subscription.networkService.applicationGateway.listener.hostNames 13.12.2
@@ -2856,6 +2863,7 @@ azure.subscription.networkService.applicationGateway.listeners 13.12.2
 azure.subscription.networkService.applicationGateway.location 9.0.13
 azure.subscription.networkService.applicationGateway.name 9.0.13
 azure.subscription.networkService.applicationGateway.policy 9.0.13
+azure.subscription.networkService.applicationGateway.principalId 13.23.1
 azure.subscription.networkService.applicationGateway.properties 9.0.13
 azure.subscription.networkService.applicationGateway.sslCertificate 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.id 13.12.2
@@ -2868,7 +2876,9 @@ azure.subscription.networkService.applicationGateway.sslCipherSuites 13.1.8
 azure.subscription.networkService.applicationGateway.sslMinProtocolVersion 13.1.8
 azure.subscription.networkService.applicationGateway.sslPolicyType 13.1.8
 azure.subscription.networkService.applicationGateway.tags 9.0.13
+azure.subscription.networkService.applicationGateway.tenantId 13.23.1
 azure.subscription.networkService.applicationGateway.type 9.0.13
+azure.subscription.networkService.applicationGateway.userAssignedIdentities 13.23.1
 azure.subscription.networkService.applicationGateway.wafConfiguration 11.3.3
 azure.subscription.networkService.applicationGateways 9.0.1
 azure.subscription.networkService.applicationSecurityGroups 9.0.8
@@ -3413,6 +3423,7 @@ azure.subscription.networkService.virtualHub.vnetConnections 13.12.2
 azure.subscription.networkService.virtualHubs 13.12.2
 azure.subscription.networkService.virtualNetwork 9.0.8
 azure.subscription.networkService.virtualNetwork.addressPrefixes 13.0.2
+azure.subscription.networkService.virtualNetwork.defaultNatGateway 13.23.1
 azure.subscription.networkService.virtualNetwork.dhcpOptions 9.0.10
 azure.subscription.networkService.virtualNetwork.dhcpOptions.dnsServers 9.0.10
 azure.subscription.networkService.virtualNetwork.dhcpOptions.id 9.0.10
@@ -3421,6 +3432,7 @@ azure.subscription.networkService.virtualNetwork.enableVmProtection 9.0.10
 azure.subscription.networkService.virtualNetwork.encryptionEnabled 13.0.2
 azure.subscription.networkService.virtualNetwork.encryptionEnforcement 13.0.2
 azure.subscription.networkService.virtualNetwork.etag 9.0.8
+azure.subscription.networkService.virtualNetwork.flowLogs 13.23.1
 azure.subscription.networkService.virtualNetwork.flowTimeoutInMinutes 13.0.2
 azure.subscription.networkService.virtualNetwork.id 9.0.8
 azure.subscription.networkService.virtualNetwork.location 9.0.8
@@ -3434,6 +3446,7 @@ azure.subscription.networkService.virtualNetwork.peering.name 13.0.2
 azure.subscription.networkService.virtualNetwork.peering.peeringState 13.0.2
 azure.subscription.networkService.virtualNetwork.peering.peeringSyncLevel 13.0.2
 azure.subscription.networkService.virtualNetwork.peering.provisioningState 13.0.2
+azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork 13.23.1
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnabled 13.5.1
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnforcement 13.5.1
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId 13.0.2

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1364,19 +1364,37 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) id() (string, 
 }
 
 // remoteVirtualNetwork resolves the typed remote virtual network on the far end
-// of the peering from the cached remoteVirtualNetworkId. Returns null when the
-// peering has no remote virtual network reference.
+// of the peering from the cached remoteVirtualNetworkId. The remote network is
+// fetched directly by its ARM resource ID so cross-subscription peerings resolve
+// correctly. Returns null when the peering has no remote virtual network
+// reference.
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) remoteVirtualNetwork() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
 	if a.RemoteVirtualNetworkId.Data == "" {
 		a.RemoteVirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetwork",
-		map[string]*llx.RawData{"id": llx.StringData(a.RemoteVirtualNetworkId.Data)})
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	resourceID, err := ParseResourceID(a.RemoteVirtualNetworkId.Data)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+	vnetName, err := resourceID.Component("virtualNetworks")
+	if err != nil {
+		return nil, err
+	}
+	client, err := network.NewVirtualNetworksClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	vnetRes, err := client.Get(ctx, resourceID.ResourceGroup, vnetName, &network.VirtualNetworksClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return azureVirtualNetworkToMql(a.MqlRuntime, vnetRes.VirtualNetwork)
 }
 
 func (a *mqlAzureSubscriptionNetworkService) applicationSecurityGroups() ([]any, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1144,7 +1144,68 @@ func azureVirtualNetworkToMql(runtime *plugin.Runtime, vn network.VirtualNetwork
 	if err != nil {
 		return nil, err
 	}
-	return mqlVn.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+	res := mqlVn.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork)
+	if vn.Properties != nil {
+		if ng := vn.Properties.DefaultPublicNatGateway; ng != nil {
+			res.cacheDefaultNatGatewayId = ng.ID
+		}
+		res.cacheFlowLogs = vn.Properties.FlowLogs
+	}
+	return res, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceVirtualNetworkInternal struct {
+	cacheDefaultNatGatewayId *string
+	cacheFlowLogs            []*network.FlowLog
+}
+
+// defaultNatGateway resolves the typed default public NAT gateway that provides
+// outbound SNAT for subnets in the virtual network that do not have their own
+// NAT gateway. Returns null when no default NAT gateway is configured.
+func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) defaultNatGateway() (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
+	if a.cacheDefaultNatGatewayId == nil || *a.cacheDefaultNatGatewayId == "" {
+		a.DefaultNatGateway.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	resourceID, err := ParseResourceID(*a.cacheDefaultNatGatewayId)
+	if err != nil {
+		return nil, err
+	}
+	natGatewayName, err := resourceID.Component("natGateways")
+	if err != nil {
+		return nil, err
+	}
+	client, err := network.NewNatGatewaysClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	natGatewayRes, err := client.Get(ctx, resourceID.ResourceGroup, natGatewayName, &network.NatGatewaysClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return azureNatGatewayToMql(a.MqlRuntime, natGatewayRes.NatGateway)
+}
+
+// flowLogs resolves the flow logs that target this virtual network. Returns an
+// empty list when none are configured.
+func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) flowLogs() ([]any, error) {
+	res := []any{}
+	for _, flowLog := range a.cacheFlowLogs {
+		if flowLog == nil {
+			continue
+		}
+		mqlFlowLog, err := flowLogToMql(a.MqlRuntime, *flowLog)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlFlowLog)
+	}
+	return res, nil
 }
 
 func (a *mqlAzureSubscriptionNetworkService) virtualNetworks() ([]any, error) {
@@ -1300,6 +1361,22 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) peerings() ([]any, er
 
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+// remoteVirtualNetwork resolves the typed remote virtual network on the far end
+// of the peering from the cached remoteVirtualNetworkId. Returns null when the
+// peering has no remote virtual network reference.
+func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) remoteVirtualNetwork() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+	if a.RemoteVirtualNetworkId.Data == "" {
+		a.RemoteVirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetwork",
+		map[string]*llx.RawData{"id": llx.StringData(a.RemoteVirtualNetworkId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkService) applicationSecurityGroups() ([]any, error) {
@@ -3165,6 +3242,17 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		}
 	}
 
+	// The gateway's managed identity lives on the top-level ag.Identity, not in
+	// ag.Properties, so it is captured separately here.
+	var principalId, tenantId, identityType *string
+	var userAssignedIdentityIds []string
+	if ag.Identity != nil {
+		principalId = ag.Identity.PrincipalID
+		tenantId = ag.Identity.TenantID
+		identityType = (*string)(ag.Identity.Type)
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(ag.Identity.UserAssignedIdentities)
+	}
+
 	args := map[string]*llx.RawData{
 		"id":                    llx.StringDataPtr(ag.ID),
 		"name":                  llx.StringDataPtr(ag.Name),
@@ -3179,6 +3267,9 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		"listeners":             llx.ArrayData(listeners, types.Resource("azure.subscription.networkService.applicationGateway.listener")),
 		"sslCertificates":       llx.ArrayData(sslCertificates, types.Resource("azure.subscription.networkService.applicationGateway.sslCertificate")),
 		"frontendIpConfigs":     llx.ArrayData(frontendIpConfigs, types.Resource("azure.subscription.networkService.applicationGateway.frontendIpConfig")),
+		"principalId":           llx.StringDataPtr(principalId),
+		"tenantId":              llx.StringDataPtr(tenantId),
+		"identityType":          llx.StringDataPtr(identityType),
 	}
 
 	mqlAg, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway", args)
@@ -3186,7 +3277,85 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		return nil, err
 	}
 
-	return mqlAg.(*mqlAzureSubscriptionNetworkServiceApplicationGateway), nil
+	res := mqlAg.(*mqlAzureSubscriptionNetworkServiceApplicationGateway)
+	res.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+	if ag.Properties != nil {
+		res.cacheGatewayIPConfigs = ag.Properties.GatewayIPConfigurations
+	}
+	return res, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceApplicationGatewayInternal struct {
+	cacheUserAssignedIdentityIds []string
+	cacheGatewayIPConfigs        []*network.ApplicationGatewayIPConfiguration
+}
+
+// userAssignedIdentities resolves the typed user-assigned managed identities
+// associated with the application gateway. Returns an empty list when none are
+// assigned.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGateway) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+// gatewayIpConfigs resolves the gateway IP configurations that bind the
+// application gateway into a subnet. Returns an empty list when none are set.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGateway) gatewayIpConfigs() ([]any, error) {
+	res := []any{}
+	for _, gc := range a.cacheGatewayIPConfigs {
+		if gc == nil {
+			continue
+		}
+		mqlGc, err := azureAppGatewayIpConfigToMql(a.MqlRuntime, gc)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlGc)
+	}
+	return res, nil
+}
+
+func azureAppGatewayIpConfigToMql(runtime *plugin.Runtime, gc *network.ApplicationGatewayIPConfiguration) (*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig, error) {
+	id := ""
+	if gc.ID != nil {
+		id = *gc.ID
+	}
+	name := ""
+	if gc.Name != nil {
+		name = *gc.Name
+	}
+	subnetId := ""
+	if gc.Properties != nil && gc.Properties.Subnet != nil && gc.Properties.Subnet.ID != nil {
+		subnetId = *gc.Properties.Subnet.ID
+	}
+	res, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway.gatewayIpConfig", map[string]*llx.RawData{
+		"id":       llx.StringData(id),
+		"name":     llx.StringData(name),
+		"subnetId": llx.StringData(subnetId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig), nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+// subnet resolves the typed subnet the application gateway is deployed into from
+// the cached subnetId. Returns null when the configuration is not bound to a
+// subnet.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.SubnetId.Data == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.SubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
 }
 
 func azureAppGatewayListenerToMql(runtime *plugin.Runtime, l *network.ApplicationGatewayHTTPListener, frontendPorts map[string]int64, sslCertNames map[string]string) (*mqlAzureSubscriptionNetworkServiceApplicationGatewayListener, error) {


### PR DESCRIPTION
## What

Adds typed provenance/lineage references across four Azure network resources. All changes are additive; the one superseded raw field is kept and marked `@maturity("deprecated")`.

### `azure.subscription.networkService.virtualNetwork`
- `defaultNatGateway()` → typed `natGateway` from `DefaultPublicNatGateway`
- `flowLogs()` → typed `[]watcher.flowlog` from the VNet's `FlowLogs`

### `azure.subscription.networkService.virtualNetwork.peering`
- `remoteVirtualNetwork()` → typed `virtualNetwork`, resolved from the existing `remoteVirtualNetworkId`
- `remoteVirtualNetworkId` is now `@maturity("deprecated")` (kept for back-compat)

### `azure.subscription.networkService.applicationGateway`
- Captures the managed identity that was previously **dropped** (the properties dict was built only from `ag.Properties`, excluding the top-level `ag.Identity`): `principalId`, `tenantId`, `identityType`, and `userAssignedIdentities()`
- New `applicationGateway.gatewayIpConfig` sub-resource with a typed `subnet()` ref, from `GatewayIPConfigurations[].Subnet`

## Notes
- None of these four network types expose `SystemData` in the SDK, so no `systemMetadata` was added.
- Item was scoped to also add source/destination ASG refs on `securityrule`; those already exist in `main`, so they were skipped.
- No new API permissions (`azure.permissions.json` unchanged at 237). Generated code regenerated and in sync.

## Verification
`go build ./resources/...` passes; provider builds via `make providers/build/azure`.