### PR TITLE
✨ azure: add compute/batch provenance typed accessors

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -21,10 +21,12 @@ import (
 )
 
 type mqlAzureSubscriptionAksServiceClusterInternal struct {
-	cacheKmsKeyId          string
-	cacheKubeletIdentityId string
-	cacheProperties        *clusters.ManagedClusterProperties
-	cacheSystemData        any
+	cacheKmsKeyId                string
+	cacheKubeletIdentityId       string
+	cacheDiskEncryptionSetId     string
+	cacheUserAssignedIdentityIds []string
+	cacheProperties              *clusters.ManagedClusterProperties
+	cacheSystemData              any
 }
 
 type mqlAzureSubscriptionAksServiceClusterIdentityBindingInternal struct {
@@ -275,8 +277,15 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 				return nil, err
 			}
 			var principalId *string
+			var userAssignedIdentityIds []string
 			if entry.Identity != nil {
 				principalId = entry.Identity.PrincipalID
+				userAssignedIdentityIds = sortedUserAssignedIdentityIDs(entry.Identity.UserAssignedIdentities)
+			}
+
+			diskEncryptionSetId := ""
+			if entry.Properties != nil && entry.Properties.DiskEncryptionSetID != nil {
+				diskEncryptionSetId = *entry.Properties.DiskEncryptionSetID
 			}
 
 			servicePrincipalClientId := ""
@@ -352,6 +361,8 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 			mqlCluster := mqlAksCluster.(*mqlAzureSubscriptionAksServiceCluster)
 			mqlCluster.cacheKmsKeyId = azureKeyVaultKmsKeyId
 			mqlCluster.cacheKubeletIdentityId = kubeletIdentityId
+			mqlCluster.cacheDiskEncryptionSetId = diskEncryptionSetId
+			mqlCluster.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 			mqlCluster.cacheProperties = entry.Properties
 			sysData, err := convert.JsonToDict(entry.SystemData)
 			if err != nil {
@@ -647,6 +658,23 @@ func (a *mqlAzureSubscriptionAksServiceCluster) kubeletIdentity() (*mqlAzureSubs
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionManagedIdentity), nil
+}
+
+func (a *mqlAzureSubscriptionAksServiceCluster) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionAksServiceCluster) diskEncryptionSet() (*mqlAzureSubscriptionComputeServiceDiskEncryptionSet, error) {
+	if a.cacheDiskEncryptionSetId == "" {
+		a.DiskEncryptionSet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.computeService.diskEncryptionSet",
+		map[string]*llx.RawData{"id": llx.StringData(strings.ToLower(a.cacheDiskEncryptionSetId))})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet), nil
 }
 
 func (a *mqlAzureSubscriptionAksServiceClusterNodePool) recentlyUsedVersions() ([]any, error) {

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1268,8 +1268,14 @@ azure.subscription.batchService.account @defaults("id name location") {
   tags map[string]string
   // Batch account type
   type string
-  // Batch account identity
-  identity dict
+  // Raw identity block for the Batch account
+  //
+  // Deprecated in favor of principalId and userAssignedIdentities.
+  identity @maturity("deprecated") dict
+  // Principal ID of the account's system-assigned managed identity; empty when only user-assigned identities are used
+  principalId string
+  // User-assigned managed identities attached to the Batch account
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Batch account properties
   properties dict
   // Batch account endpoint
@@ -1297,11 +1303,23 @@ azure.subscription.batchService.account @defaults("id name location") {
   // Batch account allowed authentication modes
   allowedAuthenticationModes []string
   // Batch account auto storage settings
-  autoStorage dict
+  //
+  // Deprecated in favor of autoStorageAccount.
+  autoStorage @maturity("deprecated") dict
   // Batch account encryption settings
-  encryption dict
+  //
+  // Deprecated in favor of encryptionKey.
+  encryption @maturity("deprecated") dict
   // Batch account key vault reference
-  keyVaultReference dict
+  //
+  // Deprecated in favor of keyVault.
+  keyVaultReference @maturity("deprecated") dict
+  // Storage account used for auto-storage by the Batch account
+  autoStorageAccount() azure.subscription.storageService.account
+  // Key Vault associated with the Batch account for user-subscription pool allocation
+  keyVault() azure.subscription.keyVaultService.vault
+  // Key Vault key used to encrypt Batch account data with a customer-managed key
+  encryptionKey() azure.subscription.keyVaultService.key
   // Batch account network profile
   networkProfile dict
   // Batch account private endpoint connections
@@ -7651,6 +7669,10 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   identity dict
   // Principal ID of the cluster's system-assigned control-plane managed identity; empty when a user-assigned identity is used
   principalId string
+  // User-assigned managed identities attached to the cluster control plane
+  userAssignedIdentities() []azure.subscription.managedIdentity
+  // Disk encryption set used to encrypt cluster OS and data disks with a customer-managed key
+  diskEncryptionSet() azure.subscription.computeService.diskEncryptionSet
   // Managed identity used by the kubelet to pull images from Azure Container Registry
   kubeletIdentity() azure.subscription.managedIdentity
   // Client ID of the legacy service principal used by the cluster; empty when the cluster uses a managed identity

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3517,6 +3517,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.batchService.account.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetIdentity()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.batchService.account.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.batchService.account.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.batchService.account.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetProperties()).ToDataRes(types.Dict)
 	},
@@ -3564,6 +3570,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.batchService.account.keyVaultReference": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetKeyVaultReference()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.batchService.account.autoStorageAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetAutoStorageAccount()).ToDataRes(types.Resource("azure.subscription.storageService.account"))
+	},
+	"azure.subscription.batchService.account.keyVault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetKeyVault()).ToDataRes(types.Resource("azure.subscription.keyVaultService.vault"))
+	},
+	"azure.subscription.batchService.account.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetEncryptionKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
 	},
 	"azure.subscription.batchService.account.networkProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetNetworkProfile()).ToDataRes(types.Dict)
@@ -10792,6 +10807,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.aksService.cluster.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
+	"azure.subscription.aksService.cluster.diskEncryptionSet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetDiskEncryptionSet()).ToDataRes(types.Resource("azure.subscription.computeService.diskEncryptionSet"))
+	},
 	"azure.subscription.aksService.cluster.kubeletIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetKubeletIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
 	},
@@ -17764,6 +17785,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionBatchServiceAccount).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.batchService.account.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.batchService.account.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.batchService.account.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccount).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -17826,6 +17855,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.batchService.account.keyVaultReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccount).KeyVaultReference, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.batchService.account.autoStorageAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).AutoStorageAccount, ok = plugin.RawToTValue[*mqlAzureSubscriptionStorageServiceAccount](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.batchService.account.keyVault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).KeyVault, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceVault](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.batchService.account.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionBatchServiceAccount).EncryptionKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.batchService.account.networkProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28318,6 +28359,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.aksService.cluster.diskEncryptionSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).DiskEncryptionSet, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.aksService.cluster.kubeletIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40172,6 +40221,8 @@ type mqlAzureSubscriptionBatchServiceAccount struct {
 	Tags                                  plugin.TValue[map[string]any]
 	Type                                  plugin.TValue[string]
 	Identity                              plugin.TValue[any]
+	PrincipalId                           plugin.TValue[string]
+	UserAssignedIdentities                plugin.TValue[[]any]
 	Properties                            plugin.TValue[any]
 	AccountEndpoint                       plugin.TValue[string]
 	ProvisioningState                     plugin.TValue[string]
@@ -40188,6 +40239,9 @@ type mqlAzureSubscriptionBatchServiceAccount struct {
 	AutoStorage                           plugin.TValue[any]
 	Encryption                            plugin.TValue[any]
 	KeyVaultReference                     plugin.TValue[any]
+	AutoStorageAccount                    plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount]
+	KeyVault                              plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceVault]
+	EncryptionKey                         plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	NetworkProfile                        plugin.TValue[any]
 	PrivateEndpointConnections            plugin.TValue[[]any]
 	Pools                                 plugin.TValue[[]any]
@@ -40256,6 +40310,26 @@ func (c *mqlAzureSubscriptionBatchServiceAccount) GetIdentity() *plugin.TValue[a
 	return &c.Identity
 }
 
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
 }
@@ -40318,6 +40392,54 @@ func (c *mqlAzureSubscriptionBatchServiceAccount) GetEncryption() *plugin.TValue
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetKeyVaultReference() *plugin.TValue[any] {
 	return &c.KeyVaultReference
+}
+
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetAutoStorageAccount() *plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionStorageServiceAccount](&c.AutoStorageAccount, func() (*mqlAzureSubscriptionStorageServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account", c.__id, "autoStorageAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionStorageServiceAccount), nil
+			}
+		}
+
+		return c.autoStorageAccount()
+	})
+}
+
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetKeyVault() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceVault] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceVault](&c.KeyVault, func() (*mqlAzureSubscriptionKeyVaultServiceVault, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account", c.__id, "keyVault")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceVault), nil
+			}
+		}
+
+		return c.keyVault()
+	})
+}
+
+func (c *mqlAzureSubscriptionBatchServiceAccount) GetEncryptionKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceKey](&c.EncryptionKey, func() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.batchService.account", c.__id, "encryptionKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
+			}
+		}
+
+		return c.encryptionKey()
+	})
 }
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetNetworkProfile() *plugin.TValue[any] {
@@ -65007,6 +65129,8 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	IdentityBindings                  plugin.TValue[[]any]
 	Identity                          plugin.TValue[any]
 	PrincipalId                       plugin.TValue[string]
+	UserAssignedIdentities            plugin.TValue[[]any]
+	DiskEncryptionSet                 plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
 	KubeletIdentity                   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	ServicePrincipalClientId          plugin.TValue[string]
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
@@ -65320,6 +65444,38 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetIdentity() *plugin.TValue[any
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetDiskEncryptionSet() *plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet](&c.DiskEncryptionSet, func() (*mqlAzureSubscriptionComputeServiceDiskEncryptionSet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "diskEncryptionSet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet), nil
+			}
+		}
+
+		return c.diskEncryptionSet()
+	})
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetKubeletIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -70,6 +70,7 @@ azure.subscription.aksService.cluster.defenderEnabled 11.4.28
 azure.subscription.aksService.cluster.disableLocalAccounts 11.4.28
 azure.subscription.aksService.cluster.disableRunCommand 11.4.28
 azure.subscription.aksService.cluster.diskCsiDriverEnabled 13.18.1
+azure.subscription.aksService.cluster.diskEncryptionSet 13.23.1
 azure.subscription.aksService.cluster.dnsPrefix 9.0.1
 azure.subscription.aksService.cluster.enablePrivateCluster 11.4.28
 azure.subscription.aksService.cluster.enablePrivateClusterPublicFQDN 11.4.28
@@ -163,6 +164,7 @@ azure.subscription.aksService.cluster.storageProfile 9.0.1
 azure.subscription.aksService.cluster.supportPlan 13.1.8
 azure.subscription.aksService.cluster.systemMetadata 13.19.2
 azure.subscription.aksService.cluster.tags 9.0.1
+azure.subscription.aksService.cluster.userAssignedIdentities 13.23.1
 azure.subscription.aksService.cluster.workloadAutoScalerProfile 9.0.1
 azure.subscription.aksService.cluster.workloadIdentityEnabled 11.4.28
 azure.subscription.aksService.clusters 9.0.1
@@ -335,13 +337,16 @@ azure.subscription.batchService.account.accountEndpoint 11.4.0
 azure.subscription.batchService.account.activeJobAndJobScheduleQuota 11.4.0
 azure.subscription.batchService.account.allowedAuthenticationModes 11.4.0
 azure.subscription.batchService.account.autoStorage 11.4.0
+azure.subscription.batchService.account.autoStorageAccount 13.23.1
 azure.subscription.batchService.account.dedicatedCoreQuota 11.4.0
 azure.subscription.batchService.account.dedicatedCoreQuotaPerVmFamily 11.4.0
 azure.subscription.batchService.account.dedicatedCoreQuotaPerVmFamilyEnforced 11.4.0
 azure.subscription.batchService.account.diagnosticSettings 11.4.0
 azure.subscription.batchService.account.encryption 11.4.0
+azure.subscription.batchService.account.encryptionKey 13.23.1
 azure.subscription.batchService.account.id 11.4.0
 azure.subscription.batchService.account.identity 11.4.0
+azure.subscription.batchService.account.keyVault 13.23.1
 azure.subscription.batchService.account.keyVaultReference 11.4.0
 azure.subscription.batchService.account.location 11.4.0
 azure.subscription.batchService.account.lowPriorityCoreQuota 11.4.0
@@ -369,6 +374,7 @@ azure.subscription.batchService.account.pool.vmSize 11.4.0
 azure.subscription.batchService.account.poolAllocationMode 11.4.0
 azure.subscription.batchService.account.poolQuota 11.4.0
 azure.subscription.batchService.account.pools 11.4.0
+azure.subscription.batchService.account.principalId 13.23.1
 azure.subscription.batchService.account.privateEndpointConnections 11.4.0
 azure.subscription.batchService.account.properties 11.4.0
 azure.subscription.batchService.account.provisioningState 11.4.0
@@ -376,6 +382,7 @@ azure.subscription.batchService.account.publicNetworkAccess 11.4.0
 azure.subscription.batchService.account.systemMetadata 13.22.1
 azure.subscription.batchService.account.tags 11.4.0
 azure.subscription.batchService.account.type 11.4.0
+azure.subscription.batchService.account.userAssignedIdentities 13.23.1
 azure.subscription.batchService.accounts 11.4.0
 azure.subscription.batchService.subscriptionId 11.4.0
 azure.subscription.cache 11.4.28

--- a/providers/azure/resources/batch.go
+++ b/providers/azure/resources/batch.go
@@ -121,12 +121,16 @@ func (a *mqlAzureSubscriptionBatchService) accounts() ([]any, error) {
 
 func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawData, error) {
 	identityData := llx.NilData
+	principalId := llx.StringData("")
 	if account.Identity != nil {
 		identity, err := convert.JsonToDict(account.Identity)
 		if err != nil {
 			return nil, err
 		}
 		identityData = llx.DictData(identity)
+		if account.Identity.PrincipalID != nil {
+			principalId = llx.StringData(*account.Identity.PrincipalID)
+		}
 	}
 
 	propertiesData := llx.NilData
@@ -268,6 +272,7 @@ func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawDa
 		"tags":                                  llx.MapData(convert.PtrMapStrToInterface(account.Tags), types.String),
 		"type":                                  llx.StringDataPtr(account.Type),
 		"identity":                              identityData,
+		"principalId":                           principalId,
 		"properties":                            propertiesData,
 		"accountEndpoint":                       accountEndpoint,
 		"provisioningState":                     provisioningState,
@@ -304,13 +309,72 @@ func batchAccountToMql(runtime *plugin.Runtime, account *armbatch.Account) (*mql
 	if err != nil {
 		return nil, err
 	}
-	res.(*mqlAzureSubscriptionBatchServiceAccount).cacheSystemData = sysData
+	mqlAccount := res.(*mqlAzureSubscriptionBatchServiceAccount)
+	mqlAccount.cacheSystemData = sysData
 
-	return res.(*mqlAzureSubscriptionBatchServiceAccount), nil
+	if account.Identity != nil {
+		mqlAccount.cacheUserAssignedIdentityIds = sortedUserAssignedIdentityIDs(account.Identity.UserAssignedIdentities)
+	}
+	if account.Properties != nil {
+		props := account.Properties
+		if props.KeyVaultReference != nil && props.KeyVaultReference.ID != nil {
+			mqlAccount.cacheKeyVaultId = *props.KeyVaultReference.ID
+		}
+		if props.AutoStorage != nil && props.AutoStorage.StorageAccountID != nil {
+			mqlAccount.cacheAutoStorageAccountId = *props.AutoStorage.StorageAccountID
+		}
+		if props.Encryption != nil && props.Encryption.KeyVaultProperties != nil && props.Encryption.KeyVaultProperties.KeyIdentifier != nil {
+			mqlAccount.cacheEncryptionKeyId = *props.Encryption.KeyVaultProperties.KeyIdentifier
+		}
+	}
+
+	return mqlAccount, nil
 }
 
 type mqlAzureSubscriptionBatchServiceAccountInternal struct {
-	cacheSystemData any
+	cacheSystemData              any
+	cacheKeyVaultId              string
+	cacheEncryptionKeyId         string
+	cacheAutoStorageAccountId    string
+	cacheUserAssignedIdentityIds []string
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccount) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccount) keyVault() (*mqlAzureSubscriptionKeyVaultServiceVault, error) {
+	if a.cacheKeyVaultId == "" {
+		a.KeyVault.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.keyVaultService.vault",
+		map[string]*llx.RawData{"id": llx.StringData(a.cacheKeyVaultId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionKeyVaultServiceVault), nil
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccount) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+	if a.cacheEncryptionKeyId == "" {
+		a.EncryptionKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return newKeyVaultKeyResource(a.MqlRuntime, a.cacheEncryptionKeyId)
+}
+
+func (a *mqlAzureSubscriptionBatchServiceAccount) autoStorageAccount() (*mqlAzureSubscriptionStorageServiceAccount, error) {
+	if a.cacheAutoStorageAccountId == "" {
+		a.AutoStorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.storageService.account",
+		map[string]*llx.RawData{"id": llx.StringData(a.cacheAutoStorageAccountId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionStorageServiceAccount), nil
 }
 
 func (a *mqlAzureSubscriptionBatchServiceAccount) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {


### PR DESCRIPTION
## Summary

Adds typed provenance accessors to Azure compute/batch resources, following the established managed-identity / key-vault / storage typed-reference patterns.

### `azure.subscription.aksService.cluster`
- `userAssignedIdentities() []azure.subscription.managedIdentity` — control-plane user-assigned identities from `ManagedClusterIdentity.UserAssignedIdentities` (previously only `principalId` was exposed for the system-assigned identity).
- `diskEncryptionSet() azure.subscription.computeService.diskEncryptionSet` — customer-managed disk encryption from `ManagedClusterProperties.DiskEncryptionSetID`.

### `azure.subscription.batchService.account`
- `keyVault() azure.subscription.keyVaultService.vault` — from `KeyVaultReference.ID`.
- `encryptionKey() azure.subscription.keyVaultService.key` — customer-managed key from `EncryptionProperties.KeyVaultProperties.KeyIdentifier`.
- `autoStorageAccount() azure.subscription.storageService.account` — from `AutoStorageProperties.StorageAccountID`.
- `principalId` and `userAssignedIdentities() []azure.subscription.managedIdentity` — from the account identity.

### Deprecations (non-breaking)
The raw `autoStorage`, `encryption`, `keyVaultReference`, and `identity` dict fields on the Batch account are marked `@maturity("deprecated")` in favor of the new typed accessors. They are retained for backward compatibility.

## Notes
- No new API calls: the new accessors resolve existing modeled resources via `NewResource` init paths / `newKeyVaultKeyResource`. `azure.permissions.json` regenerated and unchanged (237 permissions).
- New `.lr.versions` entries at `13.23.1` (next patch after the current `13.23.0`).
- Both resources already had `systemMetadata()`; left as-is.

## Test plan
- `cd providers/azure && go build ./...` passes.
- Code generation in sync (`./mqlr generate`).