### PR TITLE
✨ azure: add managed identity provenance to storage accounts and container registries

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3606,7 +3606,19 @@ private azure.subscription.storageService.account @defaults("id name location") 
   // Storage account properties
   properties dict
   // Storage account identity
-  identity dict
+  //
+  // Deprecated in favor of principalId, tenantId, userAssignedIdentities,
+  // and encryptionIdentity, which expose the managed identity configuration
+  // as typed accessors.
+  identity @maturity("deprecated") dict
+  // Principal ID of the account's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // Tenant ID of the account's managed identity; empty when no managed identity is configured
+  tenantId string
+  // User-assigned managed identities attached to the storage account
+  userAssignedIdentities() []azure.subscription.managedIdentity
+  // User-assigned managed identity used to access the customer-managed encryption key; null when account-level encryption identity is not configured
+  encryptionIdentity() azure.subscription.managedIdentity
   // Storage account SKU
   sku dict
   // Storage account kind
@@ -8469,7 +8481,16 @@ azure.subscription.containerRegistryService.registry @defaults("id name location
   // SKU name ("Basic", "Standard", or "Premium")
   skuName string
   // Identity configuration
-  identity dict
+  //
+  // Deprecated in favor of principalId, tenantId, and userAssignedIdentities,
+  // which expose the managed identity configuration as typed accessors.
+  identity @maturity("deprecated") dict
+  // Principal ID of the registry's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // Tenant ID of the registry's managed identity; empty when no managed identity is configured
+  tenantId string
+  // User-assigned managed identities attached to the registry
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Whether admin user is enabled
   adminUserEnabled bool
   // Whether registry-wide pull from unauthenticated clients is enabled

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6034,6 +6034,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetIdentity()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.storageService.account.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
+	"azure.subscription.storageService.account.encryptionIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetEncryptionIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.storageService.account.sku": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetSku()).ToDataRes(types.Dict)
 	},
@@ -11697,6 +11709,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerRegistryService.registry.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.containerRegistryService.registry.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerRegistryService.registry.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerRegistryService.registry.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
 	"azure.subscription.containerRegistryService.registry.adminUserEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetAdminUserEnabled()).ToDataRes(types.Bool)
@@ -21404,6 +21425,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccount).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.encryptionIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).EncryptionIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.sku": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccount).Sku, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -29658,6 +29695,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerRegistryService.registry.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.registry.adminUserEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48664,6 +48713,10 @@ type mqlAzureSubscriptionStorageServiceAccount struct {
 	Type                                             plugin.TValue[string]
 	Properties                                       plugin.TValue[any]
 	Identity                                         plugin.TValue[any]
+	PrincipalId                                      plugin.TValue[string]
+	TenantId                                         plugin.TValue[string]
+	UserAssignedIdentities                           plugin.TValue[[]any]
+	EncryptionIdentity                               plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	Sku                                              plugin.TValue[any]
 	Kind                                             plugin.TValue[string]
 	MinimumTlsVersion                                plugin.TValue[string]
@@ -48789,6 +48842,46 @@ func (c *mqlAzureSubscriptionStorageServiceAccount) GetProperties() *plugin.TVal
 
 func (c *mqlAzureSubscriptionStorageServiceAccount) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetEncryptionIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.EncryptionIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account", c.__id, "encryptionIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.encryptionIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionStorageServiceAccount) GetSku() *plugin.TValue[any] {
@@ -68561,6 +68654,9 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistry struct {
 	Tags                             plugin.TValue[map[string]any]
 	SkuName                          plugin.TValue[string]
 	Identity                         plugin.TValue[any]
+	PrincipalId                      plugin.TValue[string]
+	TenantId                         plugin.TValue[string]
+	UserAssignedIdentities           plugin.TValue[[]any]
 	AdminUserEnabled                 plugin.TValue[bool]
 	AnonymousPullEnabled             plugin.TValue[bool]
 	NetworkRuleBypassAllowedForTasks plugin.TValue[bool]
@@ -68649,6 +68745,30 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetSkuName() *plu
 
 func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetAdminUserEnabled() *plugin.TValue[bool] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1536,6 +1536,7 @@ azure.subscription.containerRegistryService.registry.policies.retentionPolicyDay
 azure.subscription.containerRegistryService.registry.policies.retentionPolicyEnabled 13.3.3
 azure.subscription.containerRegistryService.registry.policies.trustPolicyEnabled 13.3.3
 azure.subscription.containerRegistryService.registry.policies.trustPolicyType 13.3.3
+azure.subscription.containerRegistryService.registry.principalId 13.23.1
 azure.subscription.containerRegistryService.registry.privateEndpointConnections 13.3.3
 azure.subscription.containerRegistryService.registry.provisioningState 13.3.3
 azure.subscription.containerRegistryService.registry.publicNetworkAccess 13.3.3
@@ -1562,6 +1563,7 @@ azure.subscription.containerRegistryService.registry.scopeMaps 13.3.3
 azure.subscription.containerRegistryService.registry.skuName 13.3.3
 azure.subscription.containerRegistryService.registry.systemMetadata 13.19.2
 azure.subscription.containerRegistryService.registry.tags 13.3.3
+azure.subscription.containerRegistryService.registry.tenantId 13.23.1
 azure.subscription.containerRegistryService.registry.token 13.3.3
 azure.subscription.containerRegistryService.registry.token.certificates 13.3.3
 azure.subscription.containerRegistryService.registry.token.creationDate 13.3.3
@@ -1574,6 +1576,7 @@ azure.subscription.containerRegistryService.registry.token.status 13.3.3
 azure.subscription.containerRegistryService.registry.token.type 13.3.3
 azure.subscription.containerRegistryService.registry.tokens 13.3.3
 azure.subscription.containerRegistryService.registry.type 13.3.3
+azure.subscription.containerRegistryService.registry.userAssignedIdentities 13.23.1
 azure.subscription.containerRegistryService.registry.webhook 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.actions 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.id 13.3.3
@@ -4409,6 +4412,7 @@ azure.subscription.storageService.account.defenderForStorageSetting.sensitiveDat
 azure.subscription.storageService.account.defenderForStorageSetting.sensitiveDataDiscoveryStatus 13.11.2
 azure.subscription.storageService.account.enableHttpsTrafficOnly 11.4.28
 azure.subscription.storageService.account.enableNfsV3 11.6.2
+azure.subscription.storageService.account.encryptionIdentity 13.23.1
 azure.subscription.storageService.account.encryptionKey 13.1.8
 azure.subscription.storageService.account.encryptionKeySource 13.1.8
 azure.subscription.storageService.account.encryptionScope 13.3.3
@@ -4540,6 +4544,7 @@ azure.subscription.storageService.account.objectReplicationPolicy.sourceAccount 
 azure.subscription.storageService.account.objectReplicationPolicy.tagsReplicationEnabled 13.12.2
 azure.subscription.storageService.account.objectReplicationPolicy.type 13.10.2
 azure.subscription.storageService.account.primaryLocation 11.6.2
+azure.subscription.storageService.account.principalId 13.23.1
 azure.subscription.storageService.account.privateEndpointConnection 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.actionsRequired 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.description 13.10.2
@@ -4612,7 +4617,9 @@ azure.subscription.storageService.account.table.signedIdentifiers 13.10.2
 azure.subscription.storageService.account.tableProperties 9.0.1
 azure.subscription.storageService.account.tables 13.10.2
 azure.subscription.storageService.account.tags 9.0.1
+azure.subscription.storageService.account.tenantId 13.23.1
 azure.subscription.storageService.account.type 9.0.1
+azure.subscription.storageService.account.userAssignedIdentities 13.23.1
 azure.subscription.storageService.accounts 9.0.1
 azure.subscription.storageService.subscriptionId 9.0.1
 azure.subscription.subscriptionId 11.4.28

--- a/providers/azure/resources/containerregistry.go
+++ b/providers/azure/resources/containerregistry.go
@@ -25,6 +25,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryInternal struct {
 	cacheEncryption                 *armcontainerregistry.EncryptionProperty
 	cachePrivateEndpointConnections []*armcontainerregistry.PrivateEndpointConnection
 	cacheSystemData                 any
+	cacheUserAssignedIdentityIds    []string
 }
 
 type mqlAzureSubscriptionContainerRegistryServiceRegistryTokenInternal struct {
@@ -146,6 +147,13 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 	if err != nil {
 		return nil, err
 	}
+	var regPrincipalId, regTenantId *string
+	var userAssignedIdentityIds []string
+	if reg.Identity != nil {
+		regPrincipalId = reg.Identity.PrincipalID
+		regTenantId = reg.Identity.TenantID
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(reg.Identity.UserAssignedIdentities)
+	}
 
 	var skuName string
 	if reg.SKU != nil && reg.SKU.Name != nil {
@@ -193,6 +201,8 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 			"tags":                             llx.MapData(convert.PtrMapStrToInterface(reg.Tags), types.String),
 			"skuName":                          llx.StringData(skuName),
 			"identity":                         llx.DictData(identity),
+			"principalId":                      llx.StringDataPtr(regPrincipalId),
+			"tenantId":                         llx.StringDataPtr(regTenantId),
 			"adminUserEnabled":                 llx.BoolDataPtr(props.AdminUserEnabled),
 			"anonymousPullEnabled":             llx.BoolDataPtr(props.AnonymousPullEnabled),
 			"networkRuleBypassAllowedForTasks": llx.BoolDataPtr(props.NetworkRuleBypassAllowedForTasks),
@@ -214,6 +224,7 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 	mqlReg.cachePolicies = props.Policies
 	mqlReg.cacheEncryption = props.Encryption
 	mqlReg.cachePrivateEndpointConnections = props.PrivateEndpointConnections
+	mqlReg.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	sysData, err := convert.JsonToDict(reg.SystemData)
 	if err != nil {
 		return nil, err
@@ -221,6 +232,10 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 	mqlReg.cacheSystemData = sysData
 
 	return mqlReg, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 // networkRuleSet builds the network rule set sub-resource from cached data.

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -52,11 +52,13 @@ func initAzureSubscriptionStorageService(runtime *plugin.Runtime, args map[strin
 }
 
 type mqlAzureSubscriptionStorageServiceAccountInternal struct {
-	cacheSystemData            any
-	cacheEncryptionKeySource   string
-	cacheEncryptionKeyVaultURI string
-	cacheEncryptionKeyName     string
-	cacheEncryptionKeyVersion  string
+	cacheSystemData              any
+	cacheEncryptionKeySource     string
+	cacheEncryptionKeyVaultURI   string
+	cacheEncryptionKeyName       string
+	cacheEncryptionKeyVersion    string
+	cacheUserAssignedIdentityIds []string
+	cacheEncryptionIdentityId    string
 
 	fetchBlobSvcOnce sync.Once
 	fetchBlobSvcResp *storage.BlobServicesClientGetServicePropertiesResponse
@@ -939,6 +941,13 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 	if err != nil {
 		return nil, err
 	}
+	var accountPrincipalId, accountTenantId *string
+	var userAssignedIdentityIds []string
+	if account.Identity != nil {
+		accountPrincipalId = account.Identity.PrincipalID
+		accountTenantId = account.Identity.TenantID
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(account.Identity.UserAssignedIdentities)
+	}
 
 	sku, err := convert.JsonToDict(account.SKU)
 	if err != nil {
@@ -958,6 +967,8 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 			"type":                               llx.StringDataPtr(account.Type),
 			"properties":                         llx.DictData(properties),
 			"identity":                           llx.DictData(identity),
+			"principalId":                        llx.StringDataPtr(accountPrincipalId),
+			"tenantId":                           llx.StringDataPtr(accountTenantId),
 			"sku":                                llx.DictData(sku),
 			"kind":                               llx.StringData(kind),
 			"minimumTlsVersion":                  llx.StringDataPtr(minimumTlsVersion),
@@ -1002,6 +1013,7 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 		return nil, err
 	}
 	mqlRes := res.(*mqlAzureSubscriptionStorageServiceAccount)
+	mqlRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	sysData, err := convert.JsonToDict(account.SystemData)
 	if err != nil {
 		return nil, err
@@ -1009,6 +1021,9 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 	mqlRes.cacheSystemData = sysData
 	if account.Properties != nil && account.Properties.Encryption != nil {
 		enc := account.Properties.Encryption
+		if enc.EncryptionIdentity != nil && enc.EncryptionIdentity.EncryptionUserAssignedIdentity != nil {
+			mqlRes.cacheEncryptionIdentityId = *enc.EncryptionIdentity.EncryptionUserAssignedIdentity
+		}
 		if enc.KeySource != nil {
 			mqlRes.cacheEncryptionKeySource = string(*enc.KeySource)
 		}
@@ -1025,6 +1040,23 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 		}
 	}
 	return mqlRes, nil
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccount) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccount) encryptionIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	if a.cacheEncryptionIdentityId == "" {
+		a.EncryptionIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{"__id": llx.StringData(a.cacheEncryptionIdentityId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionManagedIdentity), nil
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) encryptionKeySource() (string, error) {


### PR DESCRIPTION
## What

Adds typed managed-identity provenance accessors to Azure storage and container registry resources.

### `azure.subscription.storageService.account`
- `principalId` / `tenantId` — from `armstorage.Account.Identity`
- `userAssignedIdentities()` — typed `[]azure.subscription.managedIdentity` from the account's user-assigned identity map
- `encryptionIdentity()` — typed `azure.subscription.managedIdentity` resolved from `Encryption.EncryptionIdentity.EncryptionUserAssignedIdentity` (the identity used for account-level customer-managed-key encryption)

### `azure.subscription.containerRegistryService.registry`
- `principalId` / `tenantId` — from `IdentityProperties`
- `userAssignedIdentities()` — typed `[]azure.subscription.managedIdentity`

## Non-breaking

No fields removed. The raw `identity dict` on both resources is retained and marked `@maturity("deprecated")` in favor of the new typed accessors. User-assigned identities resolve via `NewResource(runtime, "azure.subscription.managedIdentity", {"__id": <ARM resource ID>})`, reusing the existing `resolveUserAssignedIdentities` / `sortedUserAssignedIdentityIDs` helpers (same pattern as compute VM / VMSS).

## Notes / skips

- **Storage container `systemMetadata()` was not implemented.** The armstorage SDK (v1.8.1) `ListContainerItem` / `BlobContainer` / `ContainerProperties` types carry no `SystemData` field — the blob-container ARM API doesn't return system metadata — so there is nothing to wire. Skipped rather than fabricating empty provenance.
- No new API calls; `azure.permissions.json` is unchanged.

New `.lr.versions` entries are at `13.23.1` (next patch after the provider's current `13.23.0`).