### PR TITLE
🐛 cloudflare: decode polymorphic audit-log oldValue/newValue

### DIFF
--- a/providers/cloudflare/resources/audit_logs.go
+++ b/providers/cloudflare/resources/audit_logs.go
@@ -32,8 +32,11 @@ type auditLogEntry struct {
 	Owner struct {
 		ID string `json:"id"`
 	} `json:"owner"`
-	OldValue map[string]any `json:"oldValue"`
-	NewValue map[string]any `json:"newValue"`
+	// oldValue/newValue are polymorphic: Cloudflare returns an object for most
+	// changes but a bare string (or other scalar) for simple settings, so decode
+	// them as any and let the dict field carry whatever shape the API sends.
+	OldValue any `json:"oldValue"`
+	NewValue any `json:"newValue"`
 }
 
 func (c *mqlCloudflareAccountAuditLog) id() (string, error) {
@@ -83,8 +86,9 @@ func (c *mqlCloudflareAccount) auditLogs() ([]any, error) {
 
 // anyMap returns an empty map[string]any when v is nil so DictData stays
 // non-nil; the .lr `dict` field type tolerates nil but a stable empty map
-// reads more cleanly in MQL queries.
-func anyMap(v map[string]any) map[string]any {
+// reads more cleanly in MQL queries. Non-nil values (objects, strings, or
+// other scalars the API may send) pass through unchanged.
+func anyMap(v any) any {
 	if v == nil {
 		return map[string]any{}
 	}

--- a/providers/cloudflare/resources/audit_logs.go
+++ b/providers/cloudflare/resources/audit_logs.go
@@ -73,8 +73,8 @@ func (c *mqlCloudflareAccount) auditLogs() ([]any, error) {
 			"resourceId":   llx.StringData(entry.Resource.ID),
 			"resourceType": llx.StringData(entry.Resource.Type),
 			"ownerId":      llx.StringData(entry.Owner.ID),
-			"oldValue":     llx.DictData(anyMap(entry.OldValue)),
-			"newValue":     llx.DictData(anyMap(entry.NewValue)),
+			"oldValue":     llx.DictData(dictValue(entry.OldValue)),
+			"newValue":     llx.DictData(dictValue(entry.NewValue)),
 		})
 		if err != nil {
 			return nil, err
@@ -84,11 +84,11 @@ func (c *mqlCloudflareAccount) auditLogs() ([]any, error) {
 	return results, nil
 }
 
-// anyMap returns an empty map[string]any when v is nil so DictData stays
-// non-nil; the .lr `dict` field type tolerates nil but a stable empty map
-// reads more cleanly in MQL queries. Non-nil values (objects, strings, or
-// other scalars the API may send) pass through unchanged.
-func anyMap(v any) any {
+// dictValue prepares a value for a `dict` .lr field: nil becomes an empty
+// map[string]any so DictData stays non-nil (the field tolerates nil but a
+// stable empty map reads more cleanly in MQL), while non-nil values (objects,
+// strings, or other scalars the API may send) pass through unchanged.
+func dictValue(v any) any {
 	if v == nil {
 		return map[string]any{}
 	}

--- a/providers/cloudflare/resources/notifications.go
+++ b/providers/cloudflare/resources/notifications.go
@@ -75,7 +75,7 @@ func (c *mqlCloudflareAccount) notificationPolicies() ([]any, error) {
 			"enabled":     llx.BoolData(p.Enabled),
 			"alertType":   llx.StringData(p.AlertType),
 			"mechanisms":  llx.DictData(mechanisms),
-			"conditions":  llx.DictData(anyMap(p.Conditions)),
+			"conditions":  llx.DictData(dictValue(p.Conditions)),
 			"filters":     llx.DictData(filters),
 			"created":     llx.TimeData(p.Created),
 			"modified":    llx.TimeData(p.Modified),


### PR DESCRIPTION
## What

`cloudflare.account.auditLogs` errors out entirely on real accounts:

```
error parsing response json: json: cannot unmarshal string into Go struct
field auditLogEntry.result.newValue of type map[string]interface {}
```

## Why

The cloudflare-go v6 migration (#8226) replaced the SDK's `GetOrganizationAuditLogs` call with a hand-rolled `auditLogEntry` struct decoded via the generic paged client. It types the API's `oldValue`/`newValue` as `map[string]any`. Cloudflare returns an **object** for most changes but a **bare string** (or other scalar) for many entries — `token_create`, `login`, etc. — so `json.Unmarshal` fails and aborts the whole audit-log query.

The pre-v6 code used the SDK's lenient `OldValueJSON`/`NewValueJSON` path, which only populated the map when the value was an object, so the regression is specific to the v6 rewrite.

## Fix

Widen `OldValue`/`NewValue` to `any` so a string, object, list, or null all decode. The `.lr` field is already `dict`, and `llx.DictData(any)` carries any of those shapes — no schema/`.lr.versions` change. The shared `anyMap` helper is widened to `any`; the `notifications.go` call site (which passes a map) is unaffected.

## Verification

Built the patched provider and ran it against a live Cloudflare account:

- Before: `cloudflare.accounts { auditLogs }` → unmarshal error, query aborts
- After: returns all 11 entries, including string-valued `oldValue`/`newValue`

`go test ./resources/` passes.

Found while validating the cloudflare 13.5.5 release (#8804), which is the first release to ship the v6 migration.