### PR TITLE
✨ azure: add typed provenance to data factory, synapse, and recovery vaults

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -8259,14 +8259,28 @@ azure.subscription.dataFactoryService.factory @defaults("name location") {
   // Deprecated in favor of cmkKeyName, cmkKeyVaultUri, cmkKeyVersion, and
   // cmkUserAssignedIdentity.
   encryption @maturity("deprecated") dict
-  // Customer-managed key name in Key Vault used to encrypt the factory (empty for platform-managed encryption)
-  cmkKeyName string
+  // Customer-managed key name in Key Vault used to encrypt the factory
+  //
+  // Deprecated in favor of cmkKey.
+  cmkKeyName @maturity("deprecated") string
   // Key Vault base URL backing the customer-managed encryption key
-  cmkKeyVaultUri string
-  // Version of the customer-managed encryption key (empty means the latest key version is used)
-  cmkKeyVersion string
-  // User-assigned identity resource ID used to access the customer-managed key; empty when the factory's system-assigned identity is used
-  cmkUserAssignedIdentity string
+  //
+  // Deprecated in favor of cmkKey.
+  cmkKeyVaultUri @maturity("deprecated") string
+  // Version of the customer-managed encryption key
+  //
+  // Deprecated in favor of cmkKey.
+  cmkKeyVersion @maturity("deprecated") string
+  // User-assigned identity resource ID used to access the customer-managed key
+  //
+  // Deprecated in favor of cmkIdentity.
+  cmkUserAssignedIdentity @maturity("deprecated") string
+  // Customer-managed key in Key Vault used to encrypt the factory (null for platform-managed encryption)
+  cmkKey() azure.subscription.keyVaultService.key
+  // User-assigned managed identity used to access the customer-managed encryption key (null when the factory's system-assigned identity is used)
+  cmkIdentity() azure.subscription.managedIdentity
+  // User-assigned managed identities associated with the factory
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Time the factory was created
   created time
   // Linked services configured on the factory (connection info for external systems)
@@ -8435,6 +8449,14 @@ azure.subscription.synapseService.workspace @defaults("name location") {
   trustedServiceBypassEnabled bool
   // Whether Azure AD-only authentication is enabled
   azureADOnlyAuthentication bool
+  // Name of the filesystem in the default Data Lake Storage account
+  defaultStorageFilesystem string
+  // Default Data Lake Storage account for the workspace (null when none is configured)
+  defaultStorage() azure.subscription.storageService.account
+  // Customer-managed key in Key Vault used to encrypt the workspace (null for platform-managed encryption)
+  cmkKey() azure.subscription.keyVaultService.key
+  // User-assigned managed identities associated with the workspace
+  userAssignedIdentities() []azure.subscription.managedIdentity
 }
 
 // Azure Container Registry service
@@ -9083,6 +9105,8 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   tags map[string]string
   // Identity configuration
   identity dict
+  // User-assigned managed identities associated with the vault
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // SKU name ("Standard" or "RS0")
   skuName string
   // Provisioning state

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -11506,6 +11506,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.dataFactoryService.factory.cmkUserAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkUserAssignedIdentity()).ToDataRes(types.String)
 	},
+	"azure.subscription.dataFactoryService.factory.cmkKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
+	},
+	"azure.subscription.dataFactoryService.factory.cmkIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
+	"azure.subscription.dataFactoryService.factory.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.dataFactoryService.factory.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCreated()).ToDataRes(types.Time)
 	},
@@ -11670,6 +11679,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.synapseService.workspace.azureADOnlyAuthentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetAzureADOnlyAuthentication()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.synapseService.workspace.defaultStorageFilesystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetDefaultStorageFilesystem()).ToDataRes(types.String)
+	},
+	"azure.subscription.synapseService.workspace.defaultStorage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetDefaultStorage()).ToDataRes(types.Resource("azure.subscription.storageService.account"))
+	},
+	"azure.subscription.synapseService.workspace.cmkKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetCmkKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
+	},
+	"azure.subscription.synapseService.workspace.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
 	"azure.subscription.containerRegistryService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12414,6 +12435,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.recoveryServicesService.vault.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.recoveryServicesService.vault.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
 	"azure.subscription.recoveryServicesService.vault.skuName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSkuName()).ToDataRes(types.String)
@@ -29372,6 +29396,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkUserAssignedIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.dataFactoryService.factory.cmkKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.dataFactoryService.factory.cmkIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.dataFactoryService.factory.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.dataFactoryService.factory.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -29614,6 +29650,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.synapseService.workspace.azureADOnlyAuthentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).AzureADOnlyAuthentication, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.synapseService.workspace.defaultStorageFilesystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).DefaultStorageFilesystem, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.synapseService.workspace.defaultStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).DefaultStorage, ok = plugin.RawToTValue[*mqlAzureSubscriptionStorageServiceAccount](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.synapseService.workspace.cmkKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).CmkKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.synapseService.workspace.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30710,6 +30762,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.skuName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -67764,7 +67820,7 @@ func (c *mqlAzureSubscriptionDataFactoryService) GetFactories() *plugin.TValue[[
 type mqlAzureSubscriptionDataFactoryServiceFactory struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDataFactoryServiceFactoryInternal it will be used here
+	mqlAzureSubscriptionDataFactoryServiceFactoryInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	Location                plugin.TValue[string]
@@ -67781,6 +67837,9 @@ type mqlAzureSubscriptionDataFactoryServiceFactory struct {
 	CmkKeyVaultUri          plugin.TValue[string]
 	CmkKeyVersion           plugin.TValue[string]
 	CmkUserAssignedIdentity plugin.TValue[string]
+	CmkKey                  plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
+	CmkIdentity             plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+	UserAssignedIdentities  plugin.TValue[[]any]
 	Created                 plugin.TValue[*time.Time]
 	LinkedServices          plugin.TValue[[]any]
 	IntegrationRuntimes     plugin.TValue[[]any]
@@ -67886,6 +67945,54 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKeyVersion() *plug
 
 func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkUserAssignedIdentity() *plugin.TValue[string] {
 	return &c.CmkUserAssignedIdentity
+}
+
+func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceKey](&c.CmkKey, func() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory", c.__id, "cmkKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
+			}
+		}
+
+		return c.cmkKey()
+	})
+}
+
+func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.CmkIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory", c.__id, "cmkIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.cmkIdentity()
+	})
+}
+
+func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCreated() *plugin.TValue[*time.Time] {
@@ -68368,7 +68475,7 @@ func (c *mqlAzureSubscriptionSynapseService) GetWorkspaces() *plugin.TValue[[]an
 type mqlAzureSubscriptionSynapseServiceWorkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSynapseServiceWorkspaceInternal it will be used here
+	mqlAzureSubscriptionSynapseServiceWorkspaceInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	Location                    plugin.TValue[string]
@@ -68384,6 +68491,10 @@ type mqlAzureSubscriptionSynapseServiceWorkspace struct {
 	ProvisioningState           plugin.TValue[string]
 	TrustedServiceBypassEnabled plugin.TValue[bool]
 	AzureADOnlyAuthentication   plugin.TValue[bool]
+	DefaultStorageFilesystem    plugin.TValue[string]
+	DefaultStorage              plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount]
+	CmkKey                      plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
+	UserAssignedIdentities      plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionSynapseServiceWorkspace creates a new instance of this resource
@@ -68481,6 +68592,58 @@ func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetTrustedServiceBypassEna
 
 func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetAzureADOnlyAuthentication() *plugin.TValue[bool] {
 	return &c.AzureADOnlyAuthentication
+}
+
+func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetDefaultStorageFilesystem() *plugin.TValue[string] {
+	return &c.DefaultStorageFilesystem
+}
+
+func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetDefaultStorage() *plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionStorageServiceAccount](&c.DefaultStorage, func() (*mqlAzureSubscriptionStorageServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.synapseService.workspace", c.__id, "defaultStorage")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionStorageServiceAccount), nil
+			}
+		}
+
+		return c.defaultStorage()
+	})
+}
+
+func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetCmkKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceKey](&c.CmkKey, func() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.synapseService.workspace", c.__id, "cmkKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
+			}
+		}
+
+		return c.cmkKey()
+	})
+}
+
+func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.synapseService.workspace", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 // mqlAzureSubscriptionContainerRegistryService for the azure.subscription.containerRegistryService resource
@@ -71178,6 +71341,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	Type                                plugin.TValue[string]
 	Tags                                plugin.TValue[map[string]any]
 	Identity                            plugin.TValue[any]
+	UserAssignedIdentities              plugin.TValue[[]any]
 	SkuName                             plugin.TValue[string]
 	ProvisioningState                   plugin.TValue[string]
 	PublicNetworkAccess                 plugin.TValue[string]
@@ -71255,6 +71419,22 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetTags() *plugin.TVa
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.recoveryServicesService.vault", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSkuName() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1731,6 +1731,8 @@ azure.subscription.dataFactory 13.3.0
 azure.subscription.dataFactoryService 13.3.0
 azure.subscription.dataFactoryService.factories 13.3.0
 azure.subscription.dataFactoryService.factory 13.3.0
+azure.subscription.dataFactoryService.factory.cmkIdentity 13.23.1
+azure.subscription.dataFactoryService.factory.cmkKey 13.23.1
 azure.subscription.dataFactoryService.factory.cmkKeyName 13.16.2
 azure.subscription.dataFactoryService.factory.cmkKeyVaultUri 13.16.2
 azure.subscription.dataFactoryService.factory.cmkKeyVersion 13.16.2
@@ -1787,6 +1789,7 @@ azure.subscription.dataFactoryService.factory.publicNetworkAccess 13.3.0
 azure.subscription.dataFactoryService.factory.repoConfiguration 13.3.0
 azure.subscription.dataFactoryService.factory.tags 13.3.0
 azure.subscription.dataFactoryService.factory.type 13.3.0
+azure.subscription.dataFactoryService.factory.userAssignedIdentities 13.23.1
 azure.subscription.dataFactoryService.factory.version 13.3.0
 azure.subscription.dataFactoryService.subscriptionId 13.3.0
 azure.subscription.databricks 11.4.28
@@ -3843,6 +3846,7 @@ azure.subscription.recoveryServicesService.vault.skuName 13.3.3
 azure.subscription.recoveryServicesService.vault.systemMetadata 13.22.1
 azure.subscription.recoveryServicesService.vault.tags 13.3.3
 azure.subscription.recoveryServicesService.vault.type 13.3.3
+azure.subscription.recoveryServicesService.vault.userAssignedIdentities 13.23.1
 azure.subscription.recoveryServicesService.vaults 13.3.3
 azure.subscription.resource 9.0.0
 azure.subscription.resource.changedTime 9.0.0
@@ -4622,6 +4626,9 @@ azure.subscription.synapseService 13.3.0
 azure.subscription.synapseService.subscriptionId 13.3.0
 azure.subscription.synapseService.workspace 13.3.0
 azure.subscription.synapseService.workspace.azureADOnlyAuthentication 13.3.0
+azure.subscription.synapseService.workspace.cmkKey 13.23.1
+azure.subscription.synapseService.workspace.defaultStorage 13.23.1
+azure.subscription.synapseService.workspace.defaultStorageFilesystem 13.23.1
 azure.subscription.synapseService.workspace.encryption 13.3.0
 azure.subscription.synapseService.workspace.id 13.3.0
 azure.subscription.synapseService.workspace.identity 13.3.0
@@ -4636,6 +4643,7 @@ azure.subscription.synapseService.workspace.sqlAdministratorLogin 13.3.0
 azure.subscription.synapseService.workspace.tags 13.3.0
 azure.subscription.synapseService.workspace.trustedServiceBypassEnabled 13.3.0
 azure.subscription.synapseService.workspace.type 13.3.0
+azure.subscription.synapseService.workspace.userAssignedIdentities 13.23.1
 azure.subscription.synapseService.workspaces 13.3.0
 azure.subscription.systemData 13.19.2
 azure.subscription.systemData.createdAt 13.19.2

--- a/providers/azure/resources/datafactory.go
+++ b/providers/azure/resources/datafactory.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -18,6 +20,10 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlAzureSubscriptionDataFactoryServiceFactoryInternal struct {
+	cacheUserAssignedIdentityIds []string
+}
 
 func (a *mqlAzureSubscriptionDataFactoryService) id() (string, error) {
 	return "azure.subscription.dataFactory/" + a.SubscriptionId.Data, nil
@@ -73,6 +79,14 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 			identity, err := convert.JsonToDict(factory.Identity)
 			if err != nil {
 				return nil, err
+			}
+
+			var userAssignedIdentityIds []string
+			if factory.Identity != nil && len(factory.Identity.UserAssignedIdentities) > 0 {
+				for k := range factory.Identity.UserAssignedIdentities {
+					userAssignedIdentityIds = append(userAssignedIdentityIds, k)
+				}
+				sort.Strings(userAssignedIdentityIds)
 			}
 
 			var publicNetworkAccess string
@@ -147,7 +161,9 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, mqlFactory)
+			factoryRes := mqlFactory.(*mqlAzureSubscriptionDataFactoryServiceFactory)
+			factoryRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			res = append(res, factoryRes)
 		}
 	}
 	return res, nil
@@ -155,6 +171,41 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 
 func (a *mqlAzureSubscriptionDataFactoryServiceFactory) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+// cmkKey returns a typed reference to the Key Vault key used for customer-managed encryption.
+func (a *mqlAzureSubscriptionDataFactoryServiceFactory) cmkKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+	vaultURI := strings.TrimSuffix(a.CmkKeyVaultUri.Data, "/")
+	keyName := a.CmkKeyName.Data
+	if vaultURI == "" || keyName == "" {
+		a.CmkKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	keyURI := vaultURI + "/keys/" + keyName
+	if version := a.CmkKeyVersion.Data; version != "" {
+		keyURI += "/" + version
+	}
+	return newKeyVaultKeyResource(a.MqlRuntime, keyURI)
+}
+
+// cmkIdentity returns the user-assigned managed identity used to access the CMK.
+func (a *mqlAzureSubscriptionDataFactoryServiceFactory) cmkIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	id := a.CmkUserAssignedIdentity.Data
+	if id == "" {
+		a.CmkIdentity.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{"__id": llx.StringData(id)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionManagedIdentity), nil
+}
+
+// userAssignedIdentities returns the typed user-assigned managed identities of the factory.
+func (a *mqlAzureSubscriptionDataFactoryServiceFactory) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 func initAzureSubscriptionDataFactoryServiceFactory(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/azure/resources/datafactory.go
+++ b/providers/azure/resources/datafactory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"sort"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -82,11 +81,8 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 			}
 
 			var userAssignedIdentityIds []string
-			if factory.Identity != nil && len(factory.Identity.UserAssignedIdentities) > 0 {
-				for k := range factory.Identity.UserAssignedIdentities {
-					userAssignedIdentityIds = append(userAssignedIdentityIds, k)
-				}
-				sort.Strings(userAssignedIdentityIds)
+			if factory.Identity != nil {
+				userAssignedIdentityIds = sortedUserAssignedIdentityIDs(factory.Identity.UserAssignedIdentities)
 			}
 
 			var publicNetworkAccess string

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -23,7 +23,7 @@ import (
 // sortedUserAssignedIdentityIDs returns the keys of a UserAssignedIdentities
 // map (the ARM resource IDs of the assigned managed identities) in stable
 // sorted order. Returns nil when the map is empty.
-func sortedUserAssignedIdentityIDs[V any](m map[string]*V) []string {
+func sortedUserAssignedIdentityIDs[V any](m map[string]V) []string {
 	if len(m) == 0 {
 		return nil
 	}

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -21,12 +21,13 @@ import (
 )
 
 type mqlAzureSubscriptionRecoveryServicesServiceVaultInternal struct {
-	cacheSecuritySettings    *armrecoveryservices.SecuritySettings
-	cacheEncryption          *armrecoveryservices.VaultPropertiesEncryption
-	cacheMonitoringSettings  *armrecoveryservices.MonitoringSettings
-	cacheRedundancySettings  *armrecoveryservices.VaultPropertiesRedundancySettings
-	cachePrivateEndpointConn []*armrecoveryservices.PrivateEndpointConnectionVaultProperties
-	cacheSystemData          any
+	cacheSecuritySettings        *armrecoveryservices.SecuritySettings
+	cacheEncryption              *armrecoveryservices.VaultPropertiesEncryption
+	cacheMonitoringSettings      *armrecoveryservices.MonitoringSettings
+	cacheRedundancySettings      *armrecoveryservices.VaultPropertiesRedundancySettings
+	cachePrivateEndpointConn     []*armrecoveryservices.PrivateEndpointConnectionVaultProperties
+	cacheSystemData              any
+	cacheUserAssignedIdentityIds []string
 }
 
 func (a *mqlAzureSubscriptionRecoveryServicesService) id() (string, error) {
@@ -149,6 +150,11 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 		return nil, err
 	}
 
+	var userAssignedIdentityIds []string
+	if vault.Identity != nil {
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(vault.Identity.UserAssignedIdentities)
+	}
+
 	var skuName string
 	if vault.SKU != nil && vault.SKU.Name != nil {
 		skuName = string(*vault.SKU.Name)
@@ -210,6 +216,7 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 	mqlVault.cacheMonitoringSettings = props.MonitoringSettings
 	mqlVault.cacheRedundancySettings = props.RedundancySettings
 	mqlVault.cachePrivateEndpointConn = props.PrivateEndpointConnections
+	mqlVault.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 
 	sysData, err := convert.JsonToDict(vault.SystemData)
 	if err != nil {
@@ -222,6 +229,11 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 
 func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+// userAssignedIdentities returns the typed user-assigned managed identities of the vault.
+func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 // securitySettings builds the security settings sub-resource from cached data.

--- a/providers/azure/resources/synapse.go
+++ b/providers/azure/resources/synapse.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -18,6 +19,12 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlAzureSubscriptionSynapseServiceWorkspaceInternal struct {
+	cacheDefaultStorageId        string
+	cacheCmkKeyURI               string
+	cacheUserAssignedIdentityIds []string
+}
 
 func (a *mqlAzureSubscriptionSynapseService) id() (string, error) {
 	return "azure.subscription.synapse/" + a.SubscriptionId.Data, nil
@@ -83,6 +90,9 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 			var provisioningState string
 			var trustedServiceBypassEnabled *bool
 			var azureADOnlyAuthentication *bool
+			var defaultStorageFilesystem string
+			var defaultStorageId string
+			var cmkKeyURI string
 
 			if ws.Properties != nil {
 				if ws.Properties.ManagedVirtualNetwork != nil {
@@ -96,6 +106,17 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 					if err != nil {
 						return nil, err
 					}
+					if ws.Properties.Encryption.Cmk != nil && ws.Properties.Encryption.Cmk.Key != nil {
+						cmkKeyURI = synapseKeyURI(ws.Properties.Encryption.Cmk.Key)
+					}
+				}
+				if ws.Properties.DefaultDataLakeStorage != nil {
+					if ws.Properties.DefaultDataLakeStorage.Filesystem != nil {
+						defaultStorageFilesystem = *ws.Properties.DefaultDataLakeStorage.Filesystem
+					}
+					if ws.Properties.DefaultDataLakeStorage.ResourceID != nil {
+						defaultStorageId = *ws.Properties.DefaultDataLakeStorage.ResourceID
+					}
 				}
 				if ws.Properties.ManagedResourceGroupName != nil {
 					managedResourceGroupName = *ws.Properties.ManagedResourceGroupName
@@ -108,6 +129,11 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 				}
 				trustedServiceBypassEnabled = ws.Properties.TrustedServiceBypassEnabled
 				azureADOnlyAuthentication = ws.Properties.AzureADOnlyAuthentication
+			}
+
+			var userAssignedIdentityIds []string
+			if ws.Identity != nil {
+				userAssignedIdentityIds = sortedUserAssignedIdentityIDs(ws.Identity.UserAssignedIdentities)
 			}
 
 			mqlWorkspace, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionSynapseServiceWorkspace,
@@ -128,11 +154,16 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 					"provisioningState":           llx.StringData(provisioningState),
 					"trustedServiceBypassEnabled": llx.BoolDataPtr(trustedServiceBypassEnabled),
 					"azureADOnlyAuthentication":   llx.BoolDataPtr(azureADOnlyAuthentication),
+					"defaultStorageFilesystem":    llx.StringData(defaultStorageFilesystem),
 				})
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, mqlWorkspace)
+			workspaceRes := mqlWorkspace.(*mqlAzureSubscriptionSynapseServiceWorkspace)
+			workspaceRes.cacheDefaultStorageId = defaultStorageId
+			workspaceRes.cacheCmkKeyURI = cmkKeyURI
+			workspaceRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			res = append(res, workspaceRes)
 		}
 	}
 	return res, nil
@@ -140,6 +171,55 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 
 func (a *mqlAzureSubscriptionSynapseServiceWorkspace) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+// synapseKeyURI normalizes the workspace CMK reference into a full Key Vault key
+// identifier. The SDK's KeyVaultURL is documented as the full key identifier
+// (https://{vault}.vault.azure.net/keys/{name}); if only a vault base URL is
+// returned it is combined with the key name.
+func synapseKeyURI(key *armsynapse.WorkspaceKeyDetails) string {
+	if key == nil || key.KeyVaultURL == nil {
+		return ""
+	}
+	url := strings.TrimSuffix(*key.KeyVaultURL, "/")
+	if url == "" {
+		return ""
+	}
+	if strings.Contains(url, "/keys/") {
+		return url
+	}
+	if key.Name == nil || *key.Name == "" {
+		return ""
+	}
+	return url + "/keys/" + *key.Name
+}
+
+// defaultStorage returns a typed reference to the workspace's default Data Lake Storage account.
+func (a *mqlAzureSubscriptionSynapseServiceWorkspace) defaultStorage() (*mqlAzureSubscriptionStorageServiceAccount, error) {
+	if a.cacheDefaultStorageId == "" {
+		a.DefaultStorage.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.storageService.account",
+		map[string]*llx.RawData{"id": llx.StringData(a.cacheDefaultStorageId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionStorageServiceAccount), nil
+}
+
+// cmkKey returns a typed reference to the Key Vault key used for customer-managed encryption.
+func (a *mqlAzureSubscriptionSynapseServiceWorkspace) cmkKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+	if a.cacheCmkKeyURI == "" {
+		a.CmkKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return newKeyVaultKeyResource(a.MqlRuntime, a.cacheCmkKeyURI)
+}
+
+// userAssignedIdentities returns the typed user-assigned managed identities of the workspace.
+func (a *mqlAzureSubscriptionSynapseServiceWorkspace) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
 func initAzureSubscriptionSynapseServiceWorkspace(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## What

Adds typed accessors that resolve raw customer-managed-key (CMK), managed-identity, and storage-account references into navigable resources for Azure data and backup services. Non-breaking: only additions; superseded raw scalars are kept and marked `@maturity("deprecated")`.

### `azure.subscription.dataFactoryService.factory`
- `cmkKey() azure.subscription.keyVaultService.key` — the Key Vault key used for CMK encryption, built from the existing `cmkKeyVaultUri` + `cmkKeyName` (+ `cmkKeyVersion`).
- `cmkIdentity() azure.subscription.managedIdentity` — the user-assigned identity that accesses the CMK.
- `userAssignedIdentities() []azure.subscription.managedIdentity` — from `Factory.Identity`.
- Deprecated in favor of the above: `cmkKeyName`, `cmkKeyVaultUri`, `cmkKeyVersion` (→ `cmkKey`) and `cmkUserAssignedIdentity` (→ `cmkIdentity`). Scalars retained.

### `azure.subscription.synapseService.workspace`
- `defaultStorage() azure.subscription.storageService.account` — the default Data Lake Storage account, from `DefaultDataLakeStorage.ResourceID`.
- `defaultStorageFilesystem string` — the filesystem name.
- `cmkKey() azure.subscription.keyVaultService.key` — from `Encryption.Cmk.Key`.
- `userAssignedIdentities() []azure.subscription.managedIdentity` — from `Workspace.Identity`.
- The `encryption`/`identity` dicts are retained (they carry more than the CMK/identity parts, so not fully superseded).

### `azure.subscription.recoveryServicesService.vault`
- `userAssignedIdentities() []azure.subscription.managedIdentity` — from the vault identity block. Existing `systemMetadata()` and typed CMK key are unchanged.

## Notes
- No new API calls; every accessor resolves from data already fetched during listing. `azure.permissions.json` is unchanged.
- No `SystemData` for data factory / synapse (the SDKs don't expose it).
- New `.lr.versions` entries at `13.23.1`.

## Test plan
- `go build ./resources/...` and `go vet ./resources/...` pass.
- Generated code regenerated via `mqlr generate`; `.lr.versions` shows additions only.