### PR TITLE
🐛 aws: fix invalid apigateway:GetDeployments permission

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -369,6 +369,7 @@ var awsPermissionOverrides = map[string]string{
 	"apigateway:GetApiKeys":           "apigateway:GET",
 	"apigateway:GetApis":              "apigateway:GET",
 	"apigateway:GetAuthorizers":       "apigateway:GET",
+	"apigateway:GetDeployments":       "apigateway:GET",
 	"apigateway:GetDomainNames":       "apigateway:GET",
 	"apigateway:GetRequestValidators": "apigateway:GET",
 	"apigateway:GetRestApis":          "apigateway:GET",

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.39.1",
-  "generated_at": "2026-06-30T20:58:00-07:00",
+  "version": "13.40.0",
+  "generated_at": "2026-06-30T21:58:44-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -14,7 +14,6 @@
     "acm:ListCertificates",
     "acm:ListTagsForCertificate",
     "apigateway:GET",
-    "apigateway:GetDeployments",
     "application-autoscaling:DescribeScalableTargets",
     "application-autoscaling:DescribeScalingPolicies",
     "application-autoscaling:DescribeScheduledActions",
@@ -998,12 +997,6 @@
       "service": "apigateway",
       "action": "GetApis",
       "source_file": "aws_apigatewayv2.go"
-    },
-    {
-      "permission": "apigateway:GetDeployments",
-      "service": "apigateway",
-      "action": "GetDeployments",
-      "source_file": "aws_apigateway.go"
     },
     {
       "permission": "application-autoscaling:DescribeScalableTargets",


### PR DESCRIPTION
## What

Fixes an invalid IAM action in the AWS provider's generated permissions manifest.

`apigateway:GetDeployments` is **not a real IAM action**. API Gateway authorizes requests via HTTP-verb actions (`apigateway:GET`, `apigateway:POST`, …) mapped to resource ARNs, not SDK operation names. The permissions extractor's `awsPermissionOverrides` block already remaps every apigateway `Get*` operation to `apigateway:GET`, but `GetDeployments` (called in `aws_apigateway.go`) was missing from that list, so the raw SDK method name leaked through as a non-existent action. It had been shipping since at least v13.39.1.

## How I found it

Audited all **922** permission strings in `aws.permissions.json` against real AWS IAM actions using **Access Analyzer's `validate-policy` API** (which returns `INVALID_ACTION` for actions that don't exist). This was the **only** invalid entry — the other 921 all validate cleanly.

## Fix

- Added `"apigateway:GetDeployments": "apigateway:GET"` to `awsPermissionOverrides` in `providers-sdk/v1/util/permissions/permissions.go`.
- Regenerated `providers/aws/resources/aws.permissions.json` (`go run .../permissions.go providers/aws`). Count drops 922 → 921 as the phantom action collapses into the existing `apigateway:GET`.

No coverage is lost — `apigateway:GET` (which actually governs deployment reads) was already present.