### PR TITLE
✨ azure: add managed-identity and network provenance to app/web resources

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -23,8 +23,9 @@ import (
 )
 
 type mqlAzureSubscriptionContainerAppServiceContainerAppInternal struct {
-	cacheSystemData any
-	cacheRGAndName  struct {
+	cacheSystemData              any
+	cacheUserAssignedIdentityIds []string
+	cacheRGAndName               struct {
 		resourceGroup string
 		name          string
 	}
@@ -240,6 +241,78 @@ func initAzureSubscriptionContainerAppServiceContainerApp(runtime *plugin.Runtim
 		return nil, nil, err
 	}
 	return args, mql, nil
+}
+
+func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+// managedEnvironment resolves the parent managed environment of the container
+// app from its ARM resource ID. The runtime cache short-circuits environments
+// already listed by managedEnvironments(); otherwise the init fetches it on
+// demand.
+func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) managedEnvironment() (*mqlAzureSubscriptionContainerAppServiceManagedEnvironment, error) {
+	if a.ManagedEnvironmentId.Data == "" {
+		a.ManagedEnvironment.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.containerAppService.managedEnvironment",
+		map[string]*llx.RawData{"id": llx.StringData(a.ManagedEnvironmentId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment), nil
+}
+
+// initAzureSubscriptionContainerAppServiceManagedEnvironment resolves a single
+// managed environment by its ARM resource ID so typed cross-references (and
+// platform-discovered assets) can be queried directly without re-listing every
+// environment in the subscription.
+func initAzureSubscriptionContainerAppServiceManagedEnvironment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	envName, err := resourceID.Component("managedEnvironments")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := apps.NewManagedEnvironmentsClient(resourceID.SubscriptionID, conn.Token(), acaClientOptions(conn))
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, envName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlEnv, err := acaManagedEnvironmentToMQL(runtime, &resp.ManagedEnvironment)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlEnv, nil
 }
 
 // resourceGroupAndName parses an ARM resource ID and returns the resource
@@ -811,12 +884,16 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 		}
 	}
 
+	var principalId *string
+	var userAssignedIdentityIds []string
 	if entry.Identity != nil {
 		d, err := convert.JsonToDict(entry.Identity)
 		if err != nil {
 			return nil, err
 		}
 		identity = d
+		principalId = entry.Identity.PrincipalID
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(entry.Identity.UserAssignedIdentities)
 	}
 	if entry.Kind != nil {
 		kind = string(*entry.Kind)
@@ -851,6 +928,7 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 			"maxReplicas":              llx.IntDataDefault(maxReplicas, 0),
 			"scaleRules":               llx.ArrayData(scaleRules, types.Dict),
 			"identity":                 llx.DictData(identity),
+			"principalId":              llx.StringDataPtr(principalId),
 			"registries":               llx.ArrayData(registries, types.Dict),
 			"registryAuthUsesIdentity": llx.BoolData(registryUsesIdentity),
 			"secretNames":              llx.ArrayData(secretNames, types.String),
@@ -861,6 +939,7 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 	}
 
 	appRes := mqlApp.(*mqlAzureSubscriptionContainerAppServiceContainerApp)
+	appRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	rg, name := resourceGroupAndName(appRes.Id.Data, "containerApps")
 	appRes.cacheRGAndName.resourceGroup = rg
 	appRes.cacheRGAndName.name = name

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -4309,9 +4309,15 @@ azure.subscription.webService.appsite @defaults("id name location") {
   // App site properties
   properties dict
   // App site identity
-  identity dict
+  //
+  // Deprecated in favor of principalId, userAssignedIdentities, and identityType.
+  identity @maturity("deprecated") dict
   // Managed identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned,UserAssigned")
   identityType string
+  // Principal ID of the app's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the app
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Whether the app requires HTTPS only
   httpsOnly bool
   // Whether client certificate authentication is enabled
@@ -4356,6 +4362,8 @@ azure.subscription.webService.appsite @defaults("id name location") {
   sshEnabled bool
   // ARM resource ID of the user-assigned identity used to fetch Key Vault references in app settings (empty when system-assigned identity is used)
   keyVaultReferenceIdentity string
+  // User-assigned managed identity used to fetch Key Vault references in app settings; null when the system-assigned identity is used
+  keyVaultReferenceIdentityRef() azure.subscription.managedIdentity
   // Whether public network access is enabled ("Enabled" or "Disabled")
   publicNetworkAccess string
   // IP address mode for the app ("IPv4", "IPv4AndIPv6", "IPv6")
@@ -8152,10 +8160,16 @@ azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   staticIp string
   // Subnet ID for VNet-injected caches
   subnetId string
+  // Subnet the cache is injected into; null when the cache is not VNet-injected
+  subnet() azure.subscription.networkService.subnet
   // Availability zones for the cache
   zones []string
   // Managed identity information
   identity dict
+  // Principal ID of the cache's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the cache
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Key Vault key used for customer-managed encryption (null if platform-managed)
   encryptionKey() azure.subscription.keyVaultService.key
   // Private endpoint connections for the Redis cache
@@ -9256,11 +9270,21 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   // Client certificate mode (Required, Optional, OptionalInteractiveUser)
   clientCertMode string
   // Managed service identity ID
-  managedServiceIdentityId string
+  //
+  // Deprecated in favor of principalId and userAssignedIdentities.
+  managedServiceIdentityId @maturity("deprecated") string
+  // Principal ID of the function app's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the function app
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Identity used to resolve Key Vault references in app settings and connection strings (resource ID of a user-assigned identity, or "SystemAssigned")
   keyVaultReferenceIdentity string
   // Whether public network access is enabled ("Enabled" or "Disabled")
   publicNetworkAccess string
+  // ARM resource ID of the subnet the function app is regionally VNet-integrated with; empty when no regional VNet integration is configured
+  virtualNetworkSubnetId string
+  // Subnet the function app is regionally VNet-integrated with; null when no regional VNet integration is configured
+  virtualNetworkSubnet() azure.subscription.networkService.subnet
   // Function App properties
   properties dict
   // Site configuration: minimum TLS version, FTPS state, HTTP/2, always-on, remote debugging, and IP restrictions
@@ -10290,6 +10314,8 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   outboundIpAddresses []string
   // ARM resource ID of the parent managed environment
   managedEnvironmentId string
+  // Parent managed environment that hosts the container app
+  managedEnvironment() azure.subscription.containerAppService.managedEnvironment
   // Active revision mode ("Single" or "Multiple")
   revisionMode string
   // Latest revision name
@@ -10333,7 +10359,13 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   //   custom:     {type, metadata, identity}
   scaleRules []dict
   // Identity block (system + user-assigned principal IDs)
-  identity dict
+  //
+  // Deprecated in favor of principalId and userAssignedIdentities.
+  identity @maturity("deprecated") dict
+  // Principal ID of the container app's system-assigned managed identity; empty when no system-assigned identity is enabled
+  principalId string
+  // User-assigned managed identities attached to the container app
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Container registry references (server, identity, passwordSecretRef)
   registries []dict
   // Whether any registry credential uses managed identity

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -1787,7 +1787,7 @@ func init() {
 			Create: createAzureSubscriptionContainerAppService,
 		},
 		"azure.subscription.containerAppService.managedEnvironment": {
-			// to override args, implement: initAzureSubscriptionContainerAppServiceManagedEnvironment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionContainerAppServiceManagedEnvironment,
 			Create: createAzureSubscriptionContainerAppServiceManagedEnvironment,
 		},
 		"azure.subscription.containerAppService.managedEnvironment.privateEndpointConnection": {
@@ -6817,6 +6817,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.identityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetIdentityType()).ToDataRes(types.String)
 	},
+	"azure.subscription.webService.appsite.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.webService.appsite.httpsOnly": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetHttpsOnly()).ToDataRes(types.Bool)
 	},
@@ -6882,6 +6888,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsite.keyVaultReferenceIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetKeyVaultReferenceIdentity()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.keyVaultReferenceIdentityRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetKeyVaultReferenceIdentityRef()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
 	},
 	"azure.subscription.webService.appsite.publicNetworkAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetPublicNetworkAccess()).ToDataRes(types.String)
@@ -11383,11 +11392,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cacheService.redisInstance.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetSubnetId()).ToDataRes(types.String)
 	},
+	"azure.subscription.cacheService.redisInstance.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
 	"azure.subscription.cacheService.redisInstance.zones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetZones()).ToDataRes(types.Array(types.String))
 	},
 	"azure.subscription.cacheService.redisInstance.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cacheService.redisInstance.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.cacheService.redisInstance.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
 	"azure.subscription.cacheService.redisInstance.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetEncryptionKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
@@ -12604,11 +12622,23 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.functionsService.functionApp.managedServiceIdentityId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetManagedServiceIdentityId()).ToDataRes(types.String)
 	},
+	"azure.subscription.functionsService.functionApp.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.functionsService.functionApp.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetKeyVaultReferenceIdentity()).ToDataRes(types.String)
 	},
 	"azure.subscription.functionsService.functionApp.publicNetworkAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetPublicNetworkAccess()).ToDataRes(types.String)
+	},
+	"azure.subscription.functionsService.functionApp.virtualNetworkSubnetId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetVirtualNetworkSubnetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.functionsService.functionApp.virtualNetworkSubnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetVirtualNetworkSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
 	},
 	"azure.subscription.functionsService.functionApp.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetProperties()).ToDataRes(types.Dict)
@@ -13693,6 +13723,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.containerApp.managedEnvironmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetManagedEnvironmentId()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerAppService.containerApp.managedEnvironment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetManagedEnvironment()).ToDataRes(types.Resource("azure.subscription.containerAppService.managedEnvironment"))
+	},
 	"azure.subscription.containerAppService.containerApp.revisionMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetRevisionMode()).ToDataRes(types.String)
 	},
@@ -13743,6 +13776,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerAppService.containerApp.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.containerAppService.containerApp.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerAppService.containerApp.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
 	"azure.subscription.containerAppService.containerApp.registries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetRegistries()).ToDataRes(types.Array(types.Dict))
@@ -22556,6 +22595,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsite).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsite.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.httpsOnly": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).HttpsOnly, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -22642,6 +22689,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsite.keyVaultReferenceIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).KeyVaultReferenceIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.keyVaultReferenceIdentityRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).KeyVaultReferenceIdentityRef, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsite.publicNetworkAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29188,12 +29239,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cacheService.redisInstance.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cacheService.redisInstance.zones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).Zones, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cacheService.redisInstance.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cacheService.redisInstance.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cacheService.redisInstance.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cacheService.redisInstance.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31000,12 +31063,28 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).ManagedServiceIdentityId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.functionsService.functionApp.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).KeyVaultReferenceIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.functionsService.functionApp.publicNetworkAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).PublicNetworkAccess, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.virtualNetworkSubnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).VirtualNetworkSubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.virtualNetworkSubnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).VirtualNetworkSubnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.functionsService.functionApp.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32612,6 +32691,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).ManagedEnvironmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.containerApp.managedEnvironment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).ManagedEnvironment, ok = plugin.RawToTValue[*mqlAzureSubscriptionContainerAppServiceManagedEnvironment](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.containerApp.revisionMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).RevisionMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -32678,6 +32761,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerAppService.containerApp.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.containerApp.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerAppService.containerApp.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerAppService.containerApp.registries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51416,46 +51507,49 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionWebServiceAppsiteInternal
-	Id                         plugin.TValue[string]
-	Name                       plugin.TValue[string]
-	Kind                       plugin.TValue[string]
-	Location                   plugin.TValue[string]
-	Type                       plugin.TValue[string]
-	Tags                       plugin.TValue[map[string]any]
-	Properties                 plugin.TValue[any]
-	Identity                   plugin.TValue[any]
-	IdentityType               plugin.TValue[string]
-	HttpsOnly                  plugin.TValue[bool]
-	ClientCertEnabled          plugin.TValue[bool]
-	ClientCertMode             plugin.TValue[string]
-	Enabled                    plugin.TValue[bool]
-	State                      plugin.TValue[string]
-	DefaultHostName            plugin.TValue[string]
-	EnabledHostNames           plugin.TValue[[]any]
-	Slots                      plugin.TValue[[]any]
-	Configuration              plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
-	AuthenticationSettings     plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings]
-	Metadata                   plugin.TValue[any]
-	ApplicationSettings        plugin.TValue[any]
-	ConnectionSettings         plugin.TValue[any]
-	Stack                      plugin.TValue[any]
-	DiagnosticSettings         plugin.TValue[[]any]
-	Functions                  plugin.TValue[[]any]
-	Ftp                        plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
-	Scm                        plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
-	PrivateEndpointConnections plugin.TValue[[]any]
-	EndToEndEncryptionEnabled  plugin.TValue[bool]
-	SshEnabled                 plugin.TValue[bool]
-	KeyVaultReferenceIdentity  plugin.TValue[string]
-	PublicNetworkAccess        plugin.TValue[string]
-	IpMode                     plugin.TValue[string]
-	RedundancyMode             plugin.TValue[string]
-	OutboundVnetRouting        plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting]
-	HostNameBindings           plugin.TValue[[]any]
-	VirtualNetworkConnections  plugin.TValue[[]any]
-	VirtualNetworkSubnetId     plugin.TValue[string]
-	VirtualNetworkSubnet       plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
-	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
+	Id                           plugin.TValue[string]
+	Name                         plugin.TValue[string]
+	Kind                         plugin.TValue[string]
+	Location                     plugin.TValue[string]
+	Type                         plugin.TValue[string]
+	Tags                         plugin.TValue[map[string]any]
+	Properties                   plugin.TValue[any]
+	Identity                     plugin.TValue[any]
+	IdentityType                 plugin.TValue[string]
+	PrincipalId                  plugin.TValue[string]
+	UserAssignedIdentities       plugin.TValue[[]any]
+	HttpsOnly                    plugin.TValue[bool]
+	ClientCertEnabled            plugin.TValue[bool]
+	ClientCertMode               plugin.TValue[string]
+	Enabled                      plugin.TValue[bool]
+	State                        plugin.TValue[string]
+	DefaultHostName              plugin.TValue[string]
+	EnabledHostNames             plugin.TValue[[]any]
+	Slots                        plugin.TValue[[]any]
+	Configuration                plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
+	AuthenticationSettings       plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings]
+	Metadata                     plugin.TValue[any]
+	ApplicationSettings          plugin.TValue[any]
+	ConnectionSettings           plugin.TValue[any]
+	Stack                        plugin.TValue[any]
+	DiagnosticSettings           plugin.TValue[[]any]
+	Functions                    plugin.TValue[[]any]
+	Ftp                          plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+	Scm                          plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+	PrivateEndpointConnections   plugin.TValue[[]any]
+	EndToEndEncryptionEnabled    plugin.TValue[bool]
+	SshEnabled                   plugin.TValue[bool]
+	KeyVaultReferenceIdentity    plugin.TValue[string]
+	KeyVaultReferenceIdentityRef plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+	PublicNetworkAccess          plugin.TValue[string]
+	IpMode                       plugin.TValue[string]
+	RedundancyMode               plugin.TValue[string]
+	OutboundVnetRouting          plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting]
+	HostNameBindings             plugin.TValue[[]any]
+	VirtualNetworkConnections    plugin.TValue[[]any]
+	VirtualNetworkSubnetId       plugin.TValue[string]
+	VirtualNetworkSubnet         plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
+	SystemMetadata               plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppsite creates a new instance of this resource
@@ -51529,6 +51623,26 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentity() *plugin.TValue[any
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentityType() *plugin.TValue[string] {
 	return &c.IdentityType
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetHttpsOnly() *plugin.TValue[bool] {
@@ -51721,6 +51835,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetSshEnabled() *plugin.TValue[b
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetKeyVaultReferenceIdentity() *plugin.TValue[string] {
 	return &c.KeyVaultReferenceIdentity
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetKeyVaultReferenceIdentityRef() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.KeyVaultReferenceIdentityRef, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "keyVaultReferenceIdentityRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.keyVaultReferenceIdentityRef()
+	})
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetPublicNetworkAccess() *plugin.TValue[string] {
@@ -67264,8 +67394,11 @@ type mqlAzureSubscriptionCacheServiceRedisInstance struct {
 	ShardCount                 plugin.TValue[int64]
 	StaticIp                   plugin.TValue[string]
 	SubnetId                   plugin.TValue[string]
+	Subnet                     plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	Zones                      plugin.TValue[[]any]
 	Identity                   plugin.TValue[any]
+	PrincipalId                plugin.TValue[string]
+	UserAssignedIdentities     plugin.TValue[[]any]
 	EncryptionKey              plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	PrivateEndpointConnections plugin.TValue[[]any]
 	FirewallRules              plugin.TValue[[]any]
@@ -67393,12 +67526,48 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetSubnetId() *plugin.TV
 	return &c.SubnetId
 }
 
+func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
+}
+
 func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetZones() *plugin.TValue[[]any] {
 	return &c.Zones
 }
 
 func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetEncryptionKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
@@ -72001,8 +72170,12 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	ClientCertEnabled         plugin.TValue[bool]
 	ClientCertMode            plugin.TValue[string]
 	ManagedServiceIdentityId  plugin.TValue[string]
+	PrincipalId               plugin.TValue[string]
+	UserAssignedIdentities    plugin.TValue[[]any]
 	KeyVaultReferenceIdentity plugin.TValue[string]
 	PublicNetworkAccess       plugin.TValue[string]
+	VirtualNetworkSubnetId    plugin.TValue[string]
+	VirtualNetworkSubnet      plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	Properties                plugin.TValue[any]
 	Configuration             plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
 	Functions                 plugin.TValue[[]any]
@@ -72092,12 +72265,52 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetManagedServiceIdent
 	return &c.ManagedServiceIdentityId
 }
 
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetKeyVaultReferenceIdentity() *plugin.TValue[string] {
 	return &c.KeyVaultReferenceIdentity
 }
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetPublicNetworkAccess() *plugin.TValue[string] {
 	return &c.PublicNetworkAccess
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetVirtualNetworkSubnetId() *plugin.TValue[string] {
+	return &c.VirtualNetworkSubnetId
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetVirtualNetworkSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.VirtualNetworkSubnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp", c.__id, "virtualNetworkSubnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.virtualNetworkSubnet()
+	})
 }
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetProperties() *plugin.TValue[any] {
@@ -76298,6 +76511,7 @@ type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	EventStreamEndpoint      plugin.TValue[string]
 	OutboundIpAddresses      plugin.TValue[[]any]
 	ManagedEnvironmentId     plugin.TValue[string]
+	ManagedEnvironment       plugin.TValue[*mqlAzureSubscriptionContainerAppServiceManagedEnvironment]
 	RevisionMode             plugin.TValue[string]
 	LatestRevisionName       plugin.TValue[string]
 	LatestRevisionFqdn       plugin.TValue[string]
@@ -76315,6 +76529,8 @@ type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	MaxReplicas              plugin.TValue[int64]
 	ScaleRules               plugin.TValue[[]any]
 	Identity                 plugin.TValue[any]
+	PrincipalId              plugin.TValue[string]
+	UserAssignedIdentities   plugin.TValue[[]any]
 	Registries               plugin.TValue[[]any]
 	RegistryAuthUsesIdentity plugin.TValue[bool]
 	SecretNames              plugin.TValue[[]any]
@@ -76403,6 +76619,22 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetManagedEnvironm
 	return &c.ManagedEnvironmentId
 }
 
+func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetManagedEnvironment() *plugin.TValue[*mqlAzureSubscriptionContainerAppServiceManagedEnvironment] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionContainerAppServiceManagedEnvironment](&c.ManagedEnvironment, func() (*mqlAzureSubscriptionContainerAppServiceManagedEnvironment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp", c.__id, "managedEnvironment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionContainerAppServiceManagedEnvironment), nil
+			}
+		}
+
+		return c.managedEnvironment()
+	})
+}
+
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetRevisionMode() *plugin.TValue[string] {
 	return &c.RevisionMode
 }
@@ -76469,6 +76701,26 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetScaleRules() *p
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
 }
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetRegistries() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -404,6 +404,7 @@ azure.subscription.cacheService.redisInstance.patchSchedule.location 11.4.32
 azure.subscription.cacheService.redisInstance.patchSchedule.name 11.4.32
 azure.subscription.cacheService.redisInstance.patchSchedules 11.4.32
 azure.subscription.cacheService.redisInstance.port 11.4.4
+azure.subscription.cacheService.redisInstance.principalId 13.23.1
 azure.subscription.cacheService.redisInstance.privateEndpointConnection 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.description 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.id 11.4.32
@@ -425,9 +426,11 @@ azure.subscription.cacheService.redisInstance.shardCount 11.4.32
 azure.subscription.cacheService.redisInstance.sku 11.4.4
 azure.subscription.cacheService.redisInstance.sslPort 11.4.4
 azure.subscription.cacheService.redisInstance.staticIp 11.4.32
+azure.subscription.cacheService.redisInstance.subnet 13.23.1
 azure.subscription.cacheService.redisInstance.subnetId 11.4.32
 azure.subscription.cacheService.redisInstance.tags 11.4.4
 azure.subscription.cacheService.redisInstance.type 11.4.4
+azure.subscription.cacheService.redisInstance.userAssignedIdentities 13.23.1
 azure.subscription.cacheService.redisInstance.zones 11.4.32
 azure.subscription.cacheService.subscriptionId 11.4.4
 azure.subscription.cloudDefender 9.0.0
@@ -1259,11 +1262,13 @@ azure.subscription.containerAppService.containerApp.kind 13.11.3
 azure.subscription.containerAppService.containerApp.latestRevisionFqdn 13.10.2
 azure.subscription.containerAppService.containerApp.latestRevisionName 13.10.2
 azure.subscription.containerAppService.containerApp.location 13.10.2
+azure.subscription.containerAppService.containerApp.managedEnvironment 13.23.1
 azure.subscription.containerAppService.containerApp.managedEnvironmentId 13.10.2
 azure.subscription.containerAppService.containerApp.maxReplicas 13.10.2
 azure.subscription.containerAppService.containerApp.minReplicas 13.10.2
 azure.subscription.containerAppService.containerApp.name 13.10.2
 azure.subscription.containerAppService.containerApp.outboundIpAddresses 13.11.3
+azure.subscription.containerAppService.containerApp.principalId 13.23.1
 azure.subscription.containerAppService.containerApp.provisioningState 13.10.2
 azure.subscription.containerAppService.containerApp.registries 13.10.2
 azure.subscription.containerAppService.containerApp.registryAuthUsesIdentity 13.10.2
@@ -1290,6 +1295,7 @@ azure.subscription.containerAppService.containerApp.systemMetadata 13.22.1
 azure.subscription.containerAppService.containerApp.tags 13.10.2
 azure.subscription.containerAppService.containerApp.targetPort 13.10.2
 azure.subscription.containerAppService.containerApp.transport 13.10.2
+azure.subscription.containerAppService.containerApp.userAssignedIdentities 13.23.1
 azure.subscription.containerAppService.containerApp.volumes 13.10.2
 azure.subscription.containerAppService.containerApp.workloadProfileName 13.10.2
 azure.subscription.containerAppService.containerApps 13.10.2
@@ -2114,11 +2120,15 @@ azure.subscription.functionsService.functionApp.kind 13.3.3
 azure.subscription.functionsService.functionApp.location 13.3.3
 azure.subscription.functionsService.functionApp.managedServiceIdentityId 13.3.3
 azure.subscription.functionsService.functionApp.name 13.3.3
+azure.subscription.functionsService.functionApp.principalId 13.23.1
 azure.subscription.functionsService.functionApp.properties 13.3.3
 azure.subscription.functionsService.functionApp.publicNetworkAccess 13.18.1
 azure.subscription.functionsService.functionApp.state 13.3.3
 azure.subscription.functionsService.functionApp.systemMetadata 13.22.1
 azure.subscription.functionsService.functionApp.tags 13.3.3
+azure.subscription.functionsService.functionApp.userAssignedIdentities 13.23.1
+azure.subscription.functionsService.functionApp.virtualNetworkSubnet 13.23.1
+azure.subscription.functionsService.functionApp.virtualNetworkSubnetId 13.23.1
 azure.subscription.functionsService.functionApps 13.3.3
 azure.subscription.functionsService.subscriptionId 13.3.3
 azure.subscription.iam 11.4.28
@@ -4731,6 +4741,7 @@ azure.subscription.webService.appsite.identity 9.0.1
 azure.subscription.webService.appsite.identityType 13.1.8
 azure.subscription.webService.appsite.ipMode 13.1.8
 azure.subscription.webService.appsite.keyVaultReferenceIdentity 13.5.1
+azure.subscription.webService.appsite.keyVaultReferenceIdentityRef 13.23.1
 azure.subscription.webService.appsite.kind 9.0.1
 azure.subscription.webService.appsite.location 9.0.1
 azure.subscription.webService.appsite.metadata 9.0.1
@@ -4742,6 +4753,7 @@ azure.subscription.webService.appsite.outboundVnetRouting.backupRestoreTrafficEn
 azure.subscription.webService.appsite.outboundVnetRouting.contentShareTrafficEnabled 13.1.8
 azure.subscription.webService.appsite.outboundVnetRouting.id 13.1.8
 azure.subscription.webService.appsite.outboundVnetRouting.imagePullTrafficEnabled 13.1.8
+azure.subscription.webService.appsite.principalId 13.23.1
 azure.subscription.webService.appsite.privateEndpointConnections 11.4.4
 azure.subscription.webService.appsite.properties 9.0.1
 azure.subscription.webService.appsite.publicNetworkAccess 13.1.8
@@ -4754,6 +4766,7 @@ azure.subscription.webService.appsite.state 11.4.28
 azure.subscription.webService.appsite.systemMetadata 13.19.2
 azure.subscription.webService.appsite.tags 9.0.1
 azure.subscription.webService.appsite.type 9.0.1
+azure.subscription.webService.appsite.userAssignedIdentities 13.23.1
 azure.subscription.webService.appsite.virtualNetworkConnection 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.id 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.isSwift 11.4.32

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.23.0",
-  "generated_at": "2026-06-29T23:43:33-07:00",
+  "generated_at": "2026-06-30T21:33:11-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -311,7 +311,7 @@
     {
       "permission": "Microsoft.App/managedEnvironments/read",
       "service": "Microsoft.App",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "appcontainers.go"
     },
     {

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -162,7 +162,7 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 	}
 
 	var state, defaultHostName, clientCertMode, managedServiceIdentityId string
-	var keyVaultReferenceIdentity string
+	var keyVaultReferenceIdentity, virtualNetworkSubnetId string
 	var httpsOnly, clientCertEnabled bool
 	publicNetworkAccess := functionAppPublicNetworkAccess(site.Properties)
 	if site.Properties != nil {
@@ -184,9 +184,18 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		if site.Properties.KeyVaultReferenceIdentity != nil {
 			keyVaultReferenceIdentity = *site.Properties.KeyVaultReferenceIdentity
 		}
+		if site.Properties.VirtualNetworkSubnetID != nil {
+			virtualNetworkSubnetId = *site.Properties.VirtualNetworkSubnetID
+		}
 	}
-	if site.Identity != nil && site.Identity.PrincipalID != nil {
-		managedServiceIdentityId = *site.Identity.PrincipalID
+	var principalId *string
+	var userAssignedIdentityIds []string
+	if site.Identity != nil {
+		principalId = site.Identity.PrincipalID
+		if principalId != nil {
+			managedServiceIdentityId = *principalId
+		}
+		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(site.Identity.UserAssignedIdentities)
 	}
 
 	res, err := CreateResource(runtime, "azure.subscription.functionsService.functionApp", map[string]*llx.RawData{
@@ -201,8 +210,10 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		"clientCertEnabled":         llx.BoolData(clientCertEnabled),
 		"clientCertMode":            llx.StringData(clientCertMode),
 		"managedServiceIdentityId":  llx.StringData(managedServiceIdentityId),
+		"principalId":               llx.StringDataPtr(principalId),
 		"keyVaultReferenceIdentity": llx.StringData(keyVaultReferenceIdentity),
 		"publicNetworkAccess":       llx.StringData(publicNetworkAccess),
+		"virtualNetworkSubnetId":    llx.StringData(virtualNetworkSubnetId),
 		"properties":                llx.DictData(properties),
 	})
 	if err != nil {
@@ -212,12 +223,32 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 	if err != nil {
 		return nil, err
 	}
-	res.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).cacheSystemData = sysData
+	mqlApp := res.(*mqlAzureSubscriptionFunctionsServiceFunctionApp)
+	mqlApp.cacheSystemData = sysData
+	mqlApp.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	return res, nil
 }
 
 type mqlAzureSubscriptionFunctionsServiceFunctionAppInternal struct {
-	cacheSystemData any
+	cacheSystemData              any
+	cacheUserAssignedIdentityIds []string
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) virtualNetworkSubnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.VirtualNetworkSubnetId.Data == "" {
+		a.VirtualNetworkSubnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.VirtualNetworkSubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
 }
 
 type mqlAzureSubscriptionFunctionsServiceFunctionAppFunctionInternal struct {

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -28,10 +28,28 @@ type mqlAzureSubscriptionCacheServiceRedisInstanceInternal struct {
 	// This will be populated when the SDK adds support for CMK encryption configuration.
 	cacheEncryptionKeyURI           string
 	cachePrivateEndpointConnections []*armredis.PrivateEndpointConnection
+	cacheUserAssignedIdentityIds    []string
 }
 
 func (a *mqlAzureSubscriptionCacheServiceRedisInstance) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionCacheServiceRedisInstance) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionCacheServiceRedisInstance) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.SubnetId.Data == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.SubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
 }
 
 func initAzureSubscriptionCacheService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -102,6 +120,9 @@ func initAzureSubscriptionCacheServiceRedisInstance(runtime *plugin.Runtime, arg
 	if resp.Properties != nil {
 		mqlRedis.cachePrivateEndpointConnections = resp.Properties.PrivateEndpointConnections
 	}
+	if resp.Identity != nil {
+		mqlRedis.cacheUserAssignedIdentityIds = sortedUserAssignedIdentityIDs(resp.Identity.UserAssignedIdentities)
+	}
 	return args, mqlRedis, nil
 }
 
@@ -149,6 +170,9 @@ func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {
 			mqlRedis := cacheData.(*mqlAzureSubscriptionCacheServiceRedisInstance)
 			if cache.Properties != nil {
 				mqlRedis.cachePrivateEndpointConnections = cache.Properties.PrivateEndpointConnections
+			}
+			if cache.Identity != nil {
+				mqlRedis.cacheUserAssignedIdentityIds = sortedUserAssignedIdentityIDs(cache.Identity.UserAssignedIdentities)
 			}
 			caches = append(caches, mqlRedis)
 		}
@@ -203,6 +227,11 @@ func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.Resourc
 		return nil, err
 	}
 
+	var principalId *string
+	if cache.Identity != nil {
+		principalId = cache.Identity.PrincipalID
+	}
+
 	zones := []any{}
 	for _, z := range cache.Zones {
 		if z != nil {
@@ -234,6 +263,7 @@ func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.Resourc
 		"subnetId":            llx.StringDataPtr(cache.Properties.SubnetID),
 		"zones":               llx.ArrayData(zones, types.String),
 		"identity":            llx.DictData(identity),
+		"principalId":         llx.StringDataPtr(principalId),
 	}, nil
 }
 

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -88,6 +88,8 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 		}
 	}
 
+	var userAssignedIdentityIds []string
+
 	args := map[string]*llx.RawData{
 		"id":         llx.StringDataPtr(site.ID),
 		"name":       llx.StringDataPtr(site.Name),
@@ -144,6 +146,12 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 			identityType = string(*site.Identity.Type)
 		}
 		args["identityType"] = llx.StringData(identityType)
+		var principalId *string
+		if site.Identity != nil {
+			principalId = site.Identity.PrincipalID
+			userAssignedIdentityIds = sortedUserAssignedIdentityIDs(site.Identity.UserAssignedIdentities)
+		}
+		args["principalId"] = llx.StringDataPtr(principalId)
 	}
 
 	res, err := CreateResource(runtime, resourceType, args)
@@ -156,7 +164,9 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 	}
 	switch resourceType {
 	case ResourceAzureSubscriptionWebServiceAppsite:
-		res.(*mqlAzureSubscriptionWebServiceAppsite).cacheSystemData = sysData
+		mqlAppsite := res.(*mqlAzureSubscriptionWebServiceAppsite)
+		mqlAppsite.cacheSystemData = sysData
+		mqlAppsite.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	case ResourceAzureSubscriptionWebServiceAppslot:
 		res.(*mqlAzureSubscriptionWebServiceAppslot).cacheSystemData = sysData
 	}
@@ -164,7 +174,8 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 }
 
 type mqlAzureSubscriptionWebServiceAppsiteInternal struct {
-	cacheSystemData any
+	cacheSystemData              any
+	cacheUserAssignedIdentityIds []string
 }
 
 type mqlAzureSubscriptionWebServiceAppslotInternal struct {
@@ -641,6 +652,28 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsite) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+// keyVaultReferenceIdentityRef resolves the user-assigned managed identity used
+// to fetch Key Vault references in app settings. When the app uses its
+// system-assigned identity the raw value is "SystemAssigned" (not a resource
+// ID), so the reference is null.
+func (a *mqlAzureSubscriptionWebServiceAppsite) keyVaultReferenceIdentityRef() (*mqlAzureSubscriptionManagedIdentity, error) {
+	id := a.KeyVaultReferenceIdentity.Data
+	if id == "" || strings.EqualFold(id, "SystemAssigned") {
+		a.KeyVaultReferenceIdentityRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{"__id": llx.StringData(id)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionManagedIdentity), nil
 }
 
 func (a *mqlAzureSubscriptionWebServiceAppsite) virtualNetworkSubnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {


### PR DESCRIPTION
## What

Adds typed managed-identity and network cross-references to Azure app/web resources so audits can traverse from a workload to the identities and subnets it uses, instead of parsing raw ID strings out of dicts. Purely additive: every existing raw field is retained, and superseded ones are marked `@maturity("deprecated")`.

## Changes

**`azure.subscription.webService.appsite`**
- `principalId string` — system-assigned identity principal ID
- `userAssignedIdentities() []azure.subscription.managedIdentity`
- `keyVaultReferenceIdentityRef() azure.subscription.managedIdentity` — resolves the existing `keyVaultReferenceIdentity` (null when it is `SystemAssigned`/empty)
- deprecate raw `identity dict` (superseded by `principalId`, `userAssignedIdentities`, and the existing `identityType`)

**`azure.subscription.functionsService.functionApp`**
- `principalId string`
- `userAssignedIdentities() []azure.subscription.managedIdentity`
- `virtualNetworkSubnetId string` + `virtualNetworkSubnet() azure.subscription.networkService.subnet` (previously unsurfaced)
- deprecate `managedServiceIdentityId` (it was just the principal ID — a duplicate of the new `principalId`)

**`azure.subscription.containerAppService.containerApp`**
- `managedEnvironment() azure.subscription.containerAppService.managedEnvironment` — resolves the existing `managedEnvironmentId` (new init-by-id on the managed environment resource)
- `principalId string`
- `userAssignedIdentities() []azure.subscription.managedIdentity`
- deprecate raw `identity dict`

**`azure.subscription.cacheService.redisInstance`**
- `subnet() azure.subscription.networkService.subnet` — resolves the existing `subnetId`
- `principalId string`
- `userAssignedIdentities() []azure.subscription.managedIdentity`
- (no `systemMetadata` — armredis exposes no SystemData)

## Notes

- Typed identities resolve via `NewResource("azure.subscription.managedIdentity", {__id: <UAI resource ID>})`, reusing the existing `resolveUserAssignedIdentities` helper and managed-identity init.
- No new IAM permissions: the managed-environment `Get` used by the new init falls under the already-required `Microsoft.App/managedEnvironments/read` (the permissions manifest only re-attributes that permission from the list pager to `Get`).
- New `.lr.versions` entries are all at `13.23.1` (next patch after the provider's shipped `13.23.0`).
- Generated code regenerated; provider builds and vets clean.