### PR TITLE
🎉 cloudflare-13.6.0

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.5.4",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### cloudflare (13.6.0)
- 🐛 cloudflare: decode polymorphic audit-log oldValue/newValue (#8848)
- 🛑 cloudflare: drop synthetic stream id fields in favor of __id (#8784)
- 🧹 providers: replace stale cnquery references with mql (#8781)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)
- 🧹 Update deps for mql and providers 20260624 (#8706)
- 🧹 Update deps for mql and providers 20260623 (#8690)
- 🧹 Update deps for mql and providers 20260623 (#8645)
- 🧹 Update deps for mql and providers 20260622 (#8595)
- 🐛 cloudflare: guard nil zone account in r2/workers/stream accessors (#8509)
- 🧹 ci: replace check-spelling with typos (#8461)
- 🧹 Update deps for mql and providers 20260615 (#8443)
- 🧹 Cloudflare: migrate provider to cloudflare-go v6 (#7385) (#8226)