### PR TITLE
🎉 azure-13.24.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.23.0",
+	Version:   "13.24.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.24.0)
- ✨ azure: add network-lineage provenance to vnet, peering, app gateway (#8845)
- ✨ azure: add compute/batch provenance typed accessors (#8846)
- ✨ azure: add managed identity provenance to storage accounts and container registries (#8847)
- ✨ azure: add typed managed identity to database servers (#8849)
- ✨ azure: add typed provenance to data factory, synapse, and recovery vaults (#8850)
- ✨ azure: add managed-identity and network provenance to app/web resources (#8852)
- 🧹 Use root provider directory for GCP and Azure to infer permissions. (#8801)