### PR TITLE
✨ gcp: storage/data/DNS provenance (managedBy + typed refs)

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -297,6 +297,10 @@ func (g *mqlGcpProjectBigqueryServiceDataset) kmsKey() (*mqlGcpProjectKmsService
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
+func (g *mqlGcpProjectBigqueryServiceDataset) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
 func (g *mqlGcpProjectBigqueryServiceTable) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
 	if g.cacheKmsKeyName == "" {
 		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -136,6 +136,28 @@ func initGcpProjectDnsService(runtime *plugin.Runtime, args map[string]*llx.RawD
 	return args, nil, nil
 }
 
+type mqlGcpProjectDnsServiceManagedzoneInternal struct {
+	cacheAuthorizedNetworkUrls []string
+}
+
+func (g *mqlGcpProjectDnsServiceManagedzone) authorizedNetworks() ([]any, error) {
+	res := make([]any, 0, len(g.cacheAuthorizedNetworkUrls))
+	for _, url := range g.cacheAuthorizedNetworkUrls {
+		n, err := getNetworkByUrl(url, g.MqlRuntime)
+		if err != nil {
+			return nil, err
+		}
+		if n != nil {
+			res = append(res, n)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectDnsServiceManagedzone) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
 func (g *mqlGcpProjectDnsServiceManagedzone) peeringNetworkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
 	if g.PeeringNetwork.Error != nil {
 		return nil, g.PeeringNetwork.Error
@@ -220,12 +242,16 @@ func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
 			}
 
 			var mqlPrivateVisibilityCfg map[string]any
+			authorizedNetworkUrls := []string{}
 			if managedZone.PrivateVisibilityConfig != nil {
 				networks := make([]any, 0, len(managedZone.PrivateVisibilityConfig.Networks))
 				for _, n := range managedZone.PrivateVisibilityConfig.Networks {
 					networks = append(networks, map[string]any{
 						"networkUrl": n.NetworkUrl,
 					})
+					if n.NetworkUrl != "" {
+						authorizedNetworkUrls = append(authorizedNetworkUrls, n.NetworkUrl)
+					}
 				}
 				gkeClusters := make([]any, 0, len(managedZone.PrivateVisibilityConfig.GkeClusters))
 				for _, c := range managedZone.PrivateVisibilityConfig.GkeClusters {
@@ -276,6 +302,7 @@ func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
 			if err != nil {
 				return err
 			}
+			mqlManagedZone.(*mqlGcpProjectDnsServiceManagedzone).cacheAuthorizedNetworkUrls = authorizedNetworkUrls
 			res = append(res, mqlManagedZone)
 		}
 		return nil

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2526,6 +2526,17 @@ private gcp.project.storageService.bucket @defaults("id") {
   // optional prefix applied to log object names. Use this to find where logs
   // go; the `loggingEnabled` predicate is the simple is-it-on check.
   logging dict
+  // Access-log destination bucket
+  //
+  // Bucket that receives this bucket's access logs. Null when access logging
+  // is disabled. The `loggingEnabled` predicate is the simple is-it-on check.
+  logBucket() gcp.project.storageService.bucket
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
   // Cross-Origin Resource Sharing (CORS) rules
   //
   // Each rule is shaped `{origin, method, responseHeader, maxAgeSeconds}`.
@@ -3227,6 +3238,12 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   defaultCollation string
   // Default partition expiration time in milliseconds
   defaultPartitionExpirationMs int
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
   // Whether field names are treated as case insensitive
   isCaseInsensitive bool
   // External source backing this dataset
@@ -3625,6 +3642,11 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   dnssecDefaultKeyAlgorithms []string
   // Authorized VPC networks and GKE clusters for a private zone (empty for public zones)
   privateVisibilityConfig dict
+  // Authorized VPC networks for a private zone
+  //
+  // VPC networks permitted to query this private zone. Empty for public zones
+  // and for private zones without network authorization.
+  authorizedNetworks() []gcp.project.computeService.network
   // IPv4 addresses of the name servers this private zone forwards outbound queries to (empty when forwarding is not configured)
   forwardingTargets []string
   // Fully qualified URL of the VPC network this private zone peers with for DNS resolution (empty when peering is not configured)
@@ -3637,6 +3659,12 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   recordSets() []gcp.project.dnsService.recordset
   // IAM policy bindings for this managed zone
   iamPolicy() []gcp.resourcemanager.binding
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud DNS record set
@@ -5239,6 +5267,18 @@ private gcp.project.loggingservice.bucket @defaults("name") {
   cmekSettings @maturity("deprecated") dict
   // Customer-managed KMS key used to encrypt log entries in this bucket (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
+  // CMEK service-agent identity
+  //
+  // Email of the Google-managed service agent that encrypts and decrypts log
+  // entries in this bucket with the customer-managed key. Empty when the
+  // bucket uses Google-managed encryption.
+  cmekServiceAccountId string
+  // Service account that encrypts log entries with the customer-managed key
+  //
+  // Resolved from the CMEK service-agent identity. Null when the bucket uses
+  // Google-managed encryption or the identity does not map to a service
+  // account resource.
+  cmekServiceAccount() gcp.project.iamService.serviceAccount
   // Creation timestamp
   created time
   // Description of the bucket

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5005,6 +5005,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.storageService.bucket.logging": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetLogging()).ToDataRes(types.Dict)
 	},
+	"gcp.project.storageService.bucket.logBucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetLogBucket()).ToDataRes(types.Resource("gcp.project.storageService.bucket"))
+	},
+	"gcp.project.storageService.bucket.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.storageService.bucket.cors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetCors()).ToDataRes(types.Array(types.Dict))
 	},
@@ -5707,6 +5713,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.dataset.defaultPartitionExpirationMs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetDefaultPartitionExpirationMs()).ToDataRes(types.Int)
 	},
+	"gcp.project.bigqueryService.dataset.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.bigqueryService.dataset.isCaseInsensitive": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetIsCaseInsensitive()).ToDataRes(types.Bool)
 	},
@@ -6097,6 +6106,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dnsService.managedzone.privateVisibilityConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPrivateVisibilityConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.dnsService.managedzone.authorizedNetworks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetAuthorizedNetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.network")))
+	},
 	"gcp.project.dnsService.managedzone.forwardingTargets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetForwardingTargets()).ToDataRes(types.Array(types.String))
 	},
@@ -6111,6 +6123,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dnsService.managedzone.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.dnsService.managedzone.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.dnsService.recordset.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceRecordset).GetProjectId()).ToDataRes(types.String)
@@ -7521,6 +7536,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.loggingservice.bucket.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceBucket).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
+	"gcp.project.loggingservice.bucket.cmekServiceAccountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceBucket).GetCmekServiceAccountId()).ToDataRes(types.String)
+	},
+	"gcp.project.loggingservice.bucket.cmekServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceBucket).GetCmekServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.loggingservice.bucket.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceBucket).GetCreated()).ToDataRes(types.Time)
@@ -20773,6 +20794,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectStorageServiceBucket).Logging, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.storageService.bucket.logBucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).LogBucket, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucket](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.storageService.bucket.cors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).Cors, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -21789,6 +21818,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceDataset).DefaultPartitionExpirationMs, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"gcp.project.bigqueryService.dataset.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceDataset).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.bigqueryService.dataset.isCaseInsensitive": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceDataset).IsCaseInsensitive, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -22349,6 +22382,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDnsServiceManagedzone).PrivateVisibilityConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.dnsService.managedzone.authorizedNetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).AuthorizedNetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.dnsService.managedzone.forwardingTargets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).ForwardingTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -22367,6 +22404,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dnsService.managedzone.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dnsService.managedzone.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dnsService.recordset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24467,6 +24508,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.loggingservice.bucket.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceBucket).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.bucket.cmekServiceAccountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceBucket).CmekServiceAccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.bucket.cmekServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceBucket).CmekServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.loggingservice.bucket.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47351,6 +47400,8 @@ type mqlGcpProjectStorageServiceBucket struct {
 	HierarchicalNamespace           plugin.TValue[any]
 	CustomPlacementConfig           plugin.TValue[any]
 	Logging                         plugin.TValue[any]
+	LogBucket                       plugin.TValue[*mqlGcpProjectStorageServiceBucket]
+	ManagedBy                       plugin.TValue[string]
 	Cors                            plugin.TValue[[]any]
 	Website                         plugin.TValue[any]
 	Billing                         plugin.TValue[any]
@@ -47615,6 +47666,28 @@ func (c *mqlGcpProjectStorageServiceBucket) GetCustomPlacementConfig() *plugin.T
 
 func (c *mqlGcpProjectStorageServiceBucket) GetLogging() *plugin.TValue[any] {
 	return &c.Logging
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetLogBucket() *plugin.TValue[*mqlGcpProjectStorageServiceBucket] {
+	return plugin.GetOrCompute[*mqlGcpProjectStorageServiceBucket](&c.LogBucket, func() (*mqlGcpProjectStorageServiceBucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.storageService.bucket", c.__id, "logBucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectStorageServiceBucket), nil
+			}
+		}
+
+		return c.logBucket()
+	})
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlGcpProjectStorageServiceBucket) GetCors() *plugin.TValue[[]any] {
@@ -49715,6 +49788,7 @@ type mqlGcpProjectBigqueryServiceDataset struct {
 	StorageBillingModel          plugin.TValue[string]
 	DefaultCollation             plugin.TValue[string]
 	DefaultPartitionExpirationMs plugin.TValue[int64]
+	ManagedBy                    plugin.TValue[string]
 	IsCaseInsensitive            plugin.TValue[bool]
 	ExternalDatasetReference     plugin.TValue[any]
 }
@@ -49888,6 +49962,12 @@ func (c *mqlGcpProjectBigqueryServiceDataset) GetDefaultCollation() *plugin.TVal
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetDefaultPartitionExpirationMs() *plugin.TValue[int64] {
 	return &c.DefaultPartitionExpirationMs
+}
+
+func (c *mqlGcpProjectBigqueryServiceDataset) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetIsCaseInsensitive() *plugin.TValue[bool] {
@@ -50970,7 +51050,7 @@ func (c *mqlGcpProjectDnsService) GetResponsePolicies() *plugin.TValue[[]any] {
 type mqlGcpProjectDnsServiceManagedzone struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectDnsServiceManagedzoneInternal it will be used here
+	mqlGcpProjectDnsServiceManagedzoneInternal
 	Id                         plugin.TValue[string]
 	ProjectId                  plugin.TValue[string]
 	Name                       plugin.TValue[string]
@@ -50988,11 +51068,13 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	DnsSecAlgorithmWeak        plugin.TValue[bool]
 	DnssecDefaultKeyAlgorithms plugin.TValue[[]any]
 	PrivateVisibilityConfig    plugin.TValue[any]
+	AuthorizedNetworks         plugin.TValue[[]any]
 	ForwardingTargets          plugin.TValue[[]any]
 	PeeringNetwork             plugin.TValue[string]
 	PeeringNetworkRef          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	RecordSets                 plugin.TValue[[]any]
 	IamPolicy                  plugin.TValue[[]any]
+	ManagedBy                  plugin.TValue[string]
 }
 
 // createGcpProjectDnsServiceManagedzone creates a new instance of this resource
@@ -51102,6 +51184,22 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetPrivateVisibilityConfig() *plugi
 	return &c.PrivateVisibilityConfig
 }
 
+func (c *mqlGcpProjectDnsServiceManagedzone) GetAuthorizedNetworks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AuthorizedNetworks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dnsService.managedzone", c.__id, "authorizedNetworks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.authorizedNetworks()
+	})
+}
+
 func (c *mqlGcpProjectDnsServiceManagedzone) GetForwardingTargets() *plugin.TValue[[]any] {
 	return &c.ForwardingTargets
 }
@@ -51155,6 +51253,12 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetIamPolicy() *plugin.TValue[[]any
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectDnsServiceManagedzone) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -56268,21 +56372,23 @@ type mqlGcpProjectLoggingserviceBucket struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectLoggingserviceBucketInternal
-	ProjectId           plugin.TValue[string]
-	Location            plugin.TValue[string]
-	CmekSettings        plugin.TValue[any]
-	KmsKey              plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	Created             plugin.TValue[*time.Time]
-	Description         plugin.TValue[string]
-	IndexConfigs        plugin.TValue[[]any]
-	LifecycleState      plugin.TValue[string]
-	Locked              plugin.TValue[bool]
-	Name                plugin.TValue[string]
-	RestrictedFields    plugin.TValue[[]any]
-	RetentionDays       plugin.TValue[int64]
-	Updated             plugin.TValue[*time.Time]
-	LogAnalyticsEnabled plugin.TValue[bool]
-	Views               plugin.TValue[[]any]
+	ProjectId            plugin.TValue[string]
+	Location             plugin.TValue[string]
+	CmekSettings         plugin.TValue[any]
+	KmsKey               plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	CmekServiceAccountId plugin.TValue[string]
+	CmekServiceAccount   plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Created              plugin.TValue[*time.Time]
+	Description          plugin.TValue[string]
+	IndexConfigs         plugin.TValue[[]any]
+	LifecycleState       plugin.TValue[string]
+	Locked               plugin.TValue[bool]
+	Name                 plugin.TValue[string]
+	RestrictedFields     plugin.TValue[[]any]
+	RetentionDays        plugin.TValue[int64]
+	Updated              plugin.TValue[*time.Time]
+	LogAnalyticsEnabled  plugin.TValue[bool]
+	Views                plugin.TValue[[]any]
 }
 
 // createGcpProjectLoggingserviceBucket creates a new instance of this resource
@@ -56347,6 +56453,26 @@ func (c *mqlGcpProjectLoggingserviceBucket) GetKmsKey() *plugin.TValue[*mqlGcpPr
 		}
 
 		return c.kmsKey()
+	})
+}
+
+func (c *mqlGcpProjectLoggingserviceBucket) GetCmekServiceAccountId() *plugin.TValue[string] {
+	return &c.CmekServiceAccountId
+}
+
+func (c *mqlGcpProjectLoggingserviceBucket) GetCmekServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.CmekServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.loggingservice.bucket", c.__id, "cmekServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.cmekServiceAccount()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -637,6 +637,7 @@ gcp.project.bigqueryService.dataset.kmsKey 13.12.2
 gcp.project.bigqueryService.dataset.kmsName 9.0.0
 gcp.project.bigqueryService.dataset.labels 9.0.0
 gcp.project.bigqueryService.dataset.location 9.0.0
+gcp.project.bigqueryService.dataset.managedBy 13.27.2
 gcp.project.bigqueryService.dataset.maxTimeTravelHours 13.1.2
 gcp.project.bigqueryService.dataset.models 9.0.0
 gcp.project.bigqueryService.dataset.modified 9.0.0
@@ -2901,6 +2902,7 @@ gcp.project.dns 9.0.0
 gcp.project.dnsService 9.0.0
 gcp.project.dnsService.managedZones 9.0.0
 gcp.project.dnsService.managedzone 9.0.0
+gcp.project.dnsService.managedzone.authorizedNetworks 13.27.2
 gcp.project.dnsService.managedzone.cloudLoggingEnabled 11.6.6
 gcp.project.dnsService.managedzone.created 9.0.0
 gcp.project.dnsService.managedzone.description 9.0.0
@@ -2914,6 +2916,7 @@ gcp.project.dnsService.managedzone.forwardingTargets 13.18.1
 gcp.project.dnsService.managedzone.iamPolicy 13.9.1
 gcp.project.dnsService.managedzone.id 9.0.0
 gcp.project.dnsService.managedzone.labels 11.6.6
+gcp.project.dnsService.managedzone.managedBy 13.27.2
 gcp.project.dnsService.managedzone.name 9.0.0
 gcp.project.dnsService.managedzone.nameServerSet 9.0.0
 gcp.project.dnsService.managedzone.nameServers 9.0.0
@@ -3614,6 +3617,8 @@ gcp.project.liens 13.18.1
 gcp.project.logging 9.0.0
 gcp.project.loggingservice 9.0.0
 gcp.project.loggingservice.bucket 9.0.0
+gcp.project.loggingservice.bucket.cmekServiceAccount 13.27.2
+gcp.project.loggingservice.bucket.cmekServiceAccountId 13.27.2
 gcp.project.loggingservice.bucket.cmekSettings 9.0.0
 gcp.project.loggingservice.bucket.created 9.0.0
 gcp.project.loggingservice.bucket.description 9.0.0
@@ -4662,8 +4667,10 @@ gcp.project.storageService.bucket.lifecycleRuleCondition.noncurrentTimeBefore 11
 gcp.project.storageService.bucket.lifecycleRuleCondition.numNewerVersions 11.0.79
 gcp.project.storageService.bucket.location 9.0.0
 gcp.project.storageService.bucket.locationType 9.0.0
+gcp.project.storageService.bucket.logBucket 13.27.2
 gcp.project.storageService.bucket.logging 13.16.3
 gcp.project.storageService.bucket.loggingEnabled 13.12.2
+gcp.project.storageService.bucket.managedBy 13.27.2
 gcp.project.storageService.bucket.metageneration 13.1.2
 gcp.project.storageService.bucket.name 9.0.0
 gcp.project.storageService.bucket.objectRetentionMode 13.7.2

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.27.0",
-  "generated_at": "2026-06-30T09:47:52-07:00",
+  "version": "13.27.1",
+  "generated_at": "2026-06-30T22:31:53-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/gcp_managed_by.go
+++ b/providers/gcp/resources/gcp_managed_by.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromLabels infers the infrastructure-management system that owns a
+// GCP resource from the provenance labels and annotations Google and common
+// IaC tools stamp on managed resources. Callers pass every label/annotation map
+// the resource exposes; the maps are inspected in priority order and the first
+// recognized signal wins. It returns an empty string when no management signal
+// is present (a resource created manually or through the console) and propagates
+// any error from resolving a computed map.
+//
+// Recognized signals, highest priority first:
+//   - "terraform": the goog-terraform-provisioned label Google stamps on
+//     resources created through the Terraform Google provider.
+//   - "config-connector": the cnrm.cloud.google.com/* annotations (or the
+//     managed-by-cnrm label) the GKE Config Connector controller applies to
+//     resources it reconciles.
+//   - "cloud-composer": the goog-composer-* labels applied to resources a Cloud
+//     Composer environment provisions.
+func managedByFromLabels(maps ...*plugin.TValue[map[string]any]) (string, error) {
+	for _, m := range maps {
+		if m != nil && m.Error != nil {
+			return "", m.Error
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if v, ok := m.Data["goog-terraform-provisioned"]; ok && labelValueTrue(v) {
+			return "terraform", nil
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if k == "managed-by-cnrm" || strings.HasPrefix(k, "cnrm.cloud.google.com/") {
+				return "config-connector", nil
+			}
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if strings.HasPrefix(k, "goog-composer-") {
+				return "cloud-composer", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// labelValueTrue reports whether a label value is the string "true"
+// (case-insensitive). GCP label values are always strings.
+func labelValueTrue(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.EqualFold(s, "true")
+}

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -147,23 +147,26 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 			}
 
 			var bucketKmsKeyName string
+			var cmekServiceAccountId string
 			if bucket.CmekSettings != nil {
 				bucketKmsKeyName = bucket.CmekSettings.KmsKeyName
+				cmekServiceAccountId = bucket.CmekSettings.ServiceAccountId
 			}
 			mqlBucket, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket", map[string]*llx.RawData{
-				"projectId":           llx.StringData(projectId),
-				"location":            llx.StringData(parseLocationFromPath(bucket.Name)),
-				"cmekSettings":        llx.DictData(mqlCmekSettingsDict),
-				"created":             llx.TimeDataPtr(parseTime(bucket.CreateTime)),
-				"description":         llx.StringData(bucket.Description),
-				"indexConfigs":        llx.ArrayData(indexConfigs, types.Resource("gcp.project.loggingservice.bucket.indexConfig")),
-				"lifecycleState":      llx.StringData(bucket.LifecycleState),
-				"locked":              llx.BoolData(bucket.Locked),
-				"name":                llx.StringData(bucket.Name),
-				"restrictedFields":    llx.ArrayData(convert.SliceAnyToInterface(bucket.RestrictedFields), types.String),
-				"retentionDays":       llx.IntData(bucket.RetentionDays),
-				"updated":             llx.TimeDataPtr(parseTime(bucket.UpdateTime)),
-				"logAnalyticsEnabled": llx.BoolData(bucket.AnalyticsEnabled),
+				"projectId":            llx.StringData(projectId),
+				"location":             llx.StringData(parseLocationFromPath(bucket.Name)),
+				"cmekSettings":         llx.DictData(mqlCmekSettingsDict),
+				"cmekServiceAccountId": llx.StringData(cmekServiceAccountId),
+				"created":              llx.TimeDataPtr(parseTime(bucket.CreateTime)),
+				"description":          llx.StringData(bucket.Description),
+				"indexConfigs":         llx.ArrayData(indexConfigs, types.Resource("gcp.project.loggingservice.bucket.indexConfig")),
+				"lifecycleState":       llx.StringData(bucket.LifecycleState),
+				"locked":               llx.BoolData(bucket.Locked),
+				"name":                 llx.StringData(bucket.Name),
+				"restrictedFields":     llx.ArrayData(convert.SliceAnyToInterface(bucket.RestrictedFields), types.String),
+				"retentionDays":        llx.IntData(bucket.RetentionDays),
+				"updated":              llx.TimeDataPtr(parseTime(bucket.UpdateTime)),
+				"logAnalyticsEnabled":  llx.BoolData(bucket.AnalyticsEnabled),
 			})
 			if err != nil {
 				return err
@@ -537,6 +540,23 @@ func (g *mqlGcpProjectLoggingserviceBucket) kmsKey() (*mqlGcpProjectKmsServiceKe
 		return nil, err
 	}
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+}
+
+func (g *mqlGcpProjectLoggingserviceBucket) cmekServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.CmekServiceAccountId.Error != nil {
+		return nil, g.CmekServiceAccountId.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.CmekServiceAccountId.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.CmekServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return sa, nil
 }
 
 func (g *mqlGcpProjectLoggingserviceBucket) id() (string, error) {

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -280,11 +280,15 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 	if bucket.Encryption != nil {
 		mqlBucket.cacheDefaultKmsKeyName = bucket.Encryption.DefaultKmsKeyName
 	}
+	if bucket.Logging != nil {
+		mqlBucket.cacheLogBucket = bucket.Logging.LogBucket
+	}
 	return mqlBucket, nil
 }
 
 type mqlGcpProjectStorageServiceBucketInternal struct {
 	cacheDefaultKmsKeyName string
+	cacheLogBucket         string
 
 	aclLock            sync.Mutex
 	aclFetched         bool
@@ -307,6 +311,23 @@ func (g *mqlGcpProjectStorageServiceBucket) defaultKmsKey() (*mqlGcpProjectKmsSe
 
 func (g *mqlGcpProjectStorageServiceBucket) defaultEncryptionEnabled() (bool, error) {
 	return g.cacheDefaultKmsKeyName != "", nil
+}
+
+func (g *mqlGcpProjectStorageServiceBucket) logBucket() (*mqlGcpProjectStorageServiceBucket, error) {
+	if g.cacheLogBucket == "" {
+		g.LogBucket.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.storageService.bucket",
+		map[string]*llx.RawData{"name": llx.StringData(g.cacheLogBucket)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectStorageServiceBucket), nil
+}
+
+func (g *mqlGcpProjectStorageServiceBucket) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
 }
 
 func (g *mqlGcpProjectStorageServiceBucket) tags() (map[string]interface{}, error) {


### PR DESCRIPTION
## What

Additive, non-breaking provenance additions for the GCP storage/data/DNS subsystem: a `managedBy` provisioning signal on labelled resources and typed references replacing raw ID/URL values that lived only inside deprecated dicts.

## Changes

### gcp.project.storageService.bucket
- `logBucket()` — resolves the access-log destination bucket from the logging config to a typed bucket reference (null when access logging is disabled).
- `managedBy()` — derives the provisioning system (`terraform`, `config-connector`, `cloud-composer`) from provenance labels.

### gcp.project.bigqueryService.dataset
- `managedBy()` — same label-derived provisioning signal.

### gcp.project.loggingservice.bucket
- `cmekServiceAccountId` — CMEK service-agent email, hoisted out of the deprecated `cmekSettings` dict so it survives that dict's removal.
- `cmekServiceAccount()` — resolves the identity to a typed service account when it maps to one (Google-managed service agents cleanly return null).

### gcp.project.dnsService.managedzone
- `authorizedNetworks()` — resolves a private zone's authorized VPC networks (previously only reachable inside the `privateVisibilityConfig` dict) to typed network references.
- `managedBy()` — same label-derived provisioning signal.

## Notes

- Shared `managedByFromLabels` helper added in `gcp_managed_by.go`; per-resource `managedBy()` methods live in the respective resource files.
- All new `.lr.versions` entries at `13.27.2`.
- `gcp.permissions.json` regenerated (version/timestamp only; no new API calls).
- `go build ./...` and `go vet ./resources/` pass.