### PR TITLE
✨ gcp: hierarchy/IAM/keys provenance (managedBy + typed refs)

### DIFF
--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -160,16 +160,17 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 		}
 
 		mqlKey, err := CreateResource(g.MqlRuntime, "gcp.project.apiKey", map[string]*llx.RawData{
-			"projectId":    llx.StringData(projectId),
-			"id":           llx.StringData(parseResourceName(k.Name)),
-			"name":         llx.StringData(k.DisplayName),
-			"resourcePath": llx.StringData(k.Name),
-			"annotations":  llx.MapData(convert.MapToInterfaceMap(k.Annotations), types.String),
-			"created":      llx.TimeDataPtr(parseTime(k.CreateTime)),
-			"deleted":      llx.TimeDataPtr(parseTime(k.DeleteTime)),
-			"keyString":    llx.StringData(k.KeyString),
-			"restrictions": llx.ResourceData(mqlRestrictions, "gcp.project.apiKey.restrictions"),
-			"updated":      llx.TimeDataPtr(parseTime(k.UpdateTime)),
+			"projectId":           llx.StringData(projectId),
+			"id":                  llx.StringData(parseResourceName(k.Name)),
+			"name":                llx.StringData(k.DisplayName),
+			"resourcePath":        llx.StringData(k.Name),
+			"annotations":         llx.MapData(convert.MapToInterfaceMap(k.Annotations), types.String),
+			"created":             llx.TimeDataPtr(parseTime(k.CreateTime)),
+			"deleted":             llx.TimeDataPtr(parseTime(k.DeleteTime)),
+			"keyString":           llx.StringData(k.KeyString),
+			"restrictions":        llx.ResourceData(mqlRestrictions, "gcp.project.apiKey.restrictions"),
+			"updated":             llx.TimeDataPtr(parseTime(k.UpdateTime)),
+			"serviceAccountEmail": llx.StringData(k.ServiceAccountEmail),
 		})
 		if err != nil {
 			return nil, err
@@ -181,6 +182,41 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 
 func (g *mqlGcpProjectApiKey) id() (string, error) {
 	return g.ResourcePath.Data, g.ResourcePath.Error
+}
+
+func (g *mqlGcpProjectApiKey) project() (*mqlGcpProject, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	proj, err := projectRefById(g.MqlRuntime, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		g.Project.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return proj, nil
+}
+
+func (g *mqlGcpProjectApiKey) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccountEmail.Error != nil {
+		return nil, g.ServiceAccountEmail.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccountEmail.Data, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return sa, nil
+}
+
+func (g *mqlGcpProjectApiKey) managedBy() (string, error) {
+	return managedByFromLabels(g.GetAnnotations())
 }
 
 func initGcpProjectApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -101,6 +101,21 @@ func resolveServiceAccountRef(runtime *plugin.Runtime, raw, fallbackProjectId st
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
+// projectRefById resolves the typed gcp.project resource for a project id.
+// Returns nil when the id is empty, leaving the caller to mark the field null.
+func projectRefById(runtime *plugin.Runtime, projectId string) (*mqlGcpProject, error) {
+	if projectId == "" {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProject), nil
+}
+
 // parentFolderFromId resolves the typed folder for a Cloud Resource Manager
 // parent reference. It returns nil when the parent is not a folder (for example
 // an organization or an empty reference), leaving the caller to mark the field

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -131,6 +131,21 @@ func (g *mqlGcpFolder) parentOrganization() (*mqlGcpOrganization, error) {
 	return o, nil
 }
 
+func (g *mqlGcpFolder) managementProjectRef() (*mqlGcpProject, error) {
+	mp := g.GetManagementProject()
+	if mp.Error != nil {
+		return nil, mp.Error
+	}
+	proj, err := projectRefById(g.MqlRuntime, projectFromResourceName(mp.Data))
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		g.ManagementProjectRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return proj, nil
+}
+
 func (g *mqlGcpFolders) children() ([]any, error) {
 	if g.ParentId.Error != nil {
 		return nil, g.ParentId.Error

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -648,6 +648,12 @@ private gcp.folder @defaults("name") {
   parentOrganization() gcp.organization
   // Resource name of the management project associated with this folder
   managementProject string
+  // Management project associated with this folder
+  //
+  // Resolves the managementProject resource name to the project that holds
+  // the folder's management resources. Null when the folder has no
+  // management project.
+  managementProjectRef() gcp.project
   // Folder state
   state string
   // Timestamp when deletion was requested
@@ -867,6 +873,12 @@ gcp.project @defaults("name number") {
   liens() []gcp.project.lien
   // Resource Manager tag bindings attached to the project
   tagBindings() []gcp.project.tagBinding
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Resource Manager lien
@@ -4869,6 +4881,10 @@ private gcp.project.kmsService {
 private gcp.project.kmsService.keyring @defaults("name") {
   // Project ID
   projectId string
+  // Project that owns the key ring
+  //
+  // Resolves projectId to the owning project.
+  project() gcp.project
   // Full resource path
   resourcePath string
   // Keyring name
@@ -4933,6 +4949,12 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the key's IAM policy grants any role to allUsers or allAuthenticatedUsers
   public() bool
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) KMS crypto key version
@@ -5147,6 +5169,18 @@ private gcp.project.apiKey @defaults("name") {
   id string
   // Project ID
   projectId string
+  // Project that owns the API key
+  //
+  // Resolves projectId to the owning project.
+  project() gcp.project
+  // Email of the service account the key acts as
+  serviceAccountEmail string
+  // Service account the key acts as
+  //
+  // Resolves serviceAccountEmail to the service account whose identity the
+  // key assumes when calling APIs. Null when the key is not bound to a
+  // service account.
+  serviceAccount() gcp.project.iamService.serviceAccount
   // Human-readable display name of this key
   name string
   // Full resource path
@@ -5163,6 +5197,12 @@ private gcp.project.apiKey @defaults("name") {
   restrictions gcp.project.apiKey.restrictions
   // Update timestamp
   updated time
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) project API key restrictions
@@ -5446,6 +5486,10 @@ private gcp.project.iamService.role @defaults("title name") {
 private gcp.project.iamService.serviceAccount @defaults("displayName name") {
   // Project ID
   projectId string
+  // Project that owns the service account
+  //
+  // Resolves projectId to the owning project.
+  project() gcp.project
   // Service account name
   name string
   // Unique, stable, numeric ID for the service account
@@ -7192,6 +7236,11 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   replicationType string
   // Pub/Sub topics for event notifications
   topics []string
+  // Pub/Sub topics that receive event notifications for this secret
+  //
+  // Resolves the topics resource names to the notification topics that
+  // receive secret lifecycle events.
+  topicRefs() []gcp.project.pubsubService.topic
   // Expiration time (if set)
   expireTime time
   // Input-only time-to-live duration after which the secret is scheduled to expire (empty when an absolute expireTime is set instead)
@@ -7228,6 +7277,12 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the secret's IAM policy grants any role to allUsers or allAuthenticatedUsers
   public() bool
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Secret Manager secret version

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2989,6 +2989,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.folder.managementProject": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpFolder).GetManagementProject()).ToDataRes(types.String)
 	},
+	"gcp.folder.managementProjectRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpFolder).GetManagementProjectRef()).ToDataRes(types.Resource("gcp.project"))
+	},
 	"gcp.folder.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpFolder).GetState()).ToDataRes(types.String)
 	},
@@ -3279,6 +3282,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.tagBindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetTagBindings()).ToDataRes(types.Array(types.Resource("gcp.project.tagBinding")))
+	},
+	"gcp.project.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.lien.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLien).GetName()).ToDataRes(types.String)
@@ -7189,6 +7195,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.kmsService.keyring.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyring).GetProjectId()).ToDataRes(types.String)
 	},
+	"gcp.project.kmsService.keyring.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyring).GetProject()).ToDataRes(types.Resource("gcp.project"))
+	},
 	"gcp.project.kmsService.keyring.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyring).GetResourcePath()).ToDataRes(types.String)
 	},
@@ -7266,6 +7275,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.kmsService.keyring.cryptokey.public": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetPublic()).ToDataRes(types.Bool)
+	},
+	"gcp.project.kmsService.keyring.cryptokey.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.kmsService.keyring.cryptokey.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetResourcePath()).ToDataRes(types.String)
@@ -7444,6 +7456,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.apiKey.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiKey).GetProjectId()).ToDataRes(types.String)
 	},
+	"gcp.project.apiKey.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiKey).GetProject()).ToDataRes(types.Resource("gcp.project"))
+	},
+	"gcp.project.apiKey.serviceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiKey).GetServiceAccountEmail()).ToDataRes(types.String)
+	},
+	"gcp.project.apiKey.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiKey).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.apiKey.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiKey).GetName()).ToDataRes(types.String)
 	},
@@ -7467,6 +7488,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.apiKey.updated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiKey).GetUpdated()).ToDataRes(types.Time)
+	},
+	"gcp.project.apiKey.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiKey).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.apiKey.restrictions.parentResourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiKeyRestrictions).GetParentResourcePath()).ToDataRes(types.String)
@@ -7713,6 +7737,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.iamService.serviceAccount.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetProjectId()).ToDataRes(types.String)
+	},
+	"gcp.project.iamService.serviceAccount.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetProject()).ToDataRes(types.Resource("gcp.project"))
 	},
 	"gcp.project.iamService.serviceAccount.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetName()).ToDataRes(types.String)
@@ -9490,6 +9517,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.secretmanagerService.secret.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetTopics()).ToDataRes(types.Array(types.String))
 	},
+	"gcp.project.secretmanagerService.secret.topicRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetTopicRefs()).ToDataRes(types.Array(types.Resource("gcp.project.pubsubService.topic")))
+	},
 	"gcp.project.secretmanagerService.secret.expireTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetExpireTime()).ToDataRes(types.Time)
 	},
@@ -9540,6 +9570,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.secretmanagerService.secret.public": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetPublic()).ToDataRes(types.Bool)
+	},
+	"gcp.project.secretmanagerService.secret.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.secretmanagerService.secret.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecretVersion).GetResourcePath()).ToDataRes(types.String)
@@ -17941,6 +17974,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpFolder).ManagementProject, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.folder.managementProjectRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpFolder).ManagementProjectRef, ok = plugin.RawToTValue[*mqlGcpProject](v.Value, v.Error)
+		return
+	},
 	"gcp.folder.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpFolder).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -18335,6 +18372,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.tagBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProject).TagBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.lien.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23973,6 +24014,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectKmsServiceKeyring).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.kmsService.keyring.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyring).Project, ok = plugin.RawToTValue[*mqlGcpProject](v.Value, v.Error)
+		return
+	},
 	"gcp.project.kmsService.keyring.resourcePath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyring).ResourcePath, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -24079,6 +24124,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.kmsService.keyring.cryptokey.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.kmsService.keyring.cryptokey.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24353,6 +24402,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectApiKey).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.apiKey.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiKey).Project, ok = plugin.RawToTValue[*mqlGcpProject](v.Value, v.Error)
+		return
+	},
+	"gcp.project.apiKey.serviceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiKey).ServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.apiKey.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiKey).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.apiKey.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectApiKey).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -24383,6 +24444,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.apiKey.updated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectApiKey).Updated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.apiKey.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiKey).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.apiKey.restrictions.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24755,6 +24820,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.iamService.serviceAccount.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceServiceAccount).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.serviceAccount.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccount).Project, ok = plugin.RawToTValue[*mqlGcpProject](v.Value, v.Error)
 		return
 	},
 	"gcp.project.iamService.serviceAccount.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27349,6 +27418,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).Topics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.secretmanagerService.secret.topicRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSecretmanagerServiceSecret).TopicRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.secretmanagerService.secret.expireTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).ExpireTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -27415,6 +27488,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.secretmanagerService.secret.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.secretmanagerService.secret.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSecretmanagerServiceSecret).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.secretmanagerService.secret.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40579,23 +40656,24 @@ type mqlGcpFolder struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpFolderInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Created            plugin.TValue[*time.Time]
-	Updated            plugin.TValue[*time.Time]
-	ParentId           plugin.TValue[string]
-	ParentFolder       plugin.TValue[*mqlGcpFolder]
-	ParentOrganization plugin.TValue[*mqlGcpOrganization]
-	ManagementProject  plugin.TValue[string]
-	State              plugin.TValue[string]
-	DeleteTime         plugin.TValue[*time.Time]
-	Folders            plugin.TValue[*mqlGcpFolders]
-	Projects           plugin.TValue[*mqlGcpProjects]
-	OrgPolicies        plugin.TValue[[]any]
-	IamPolicy          plugin.TValue[[]any]
-	AuditConfig        plugin.TValue[[]any]
-	Logging            plugin.TValue[*mqlGcpFolderLoggingService]
-	EssentialContacts  plugin.TValue[[]any]
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	Created              plugin.TValue[*time.Time]
+	Updated              plugin.TValue[*time.Time]
+	ParentId             plugin.TValue[string]
+	ParentFolder         plugin.TValue[*mqlGcpFolder]
+	ParentOrganization   plugin.TValue[*mqlGcpOrganization]
+	ManagementProject    plugin.TValue[string]
+	ManagementProjectRef plugin.TValue[*mqlGcpProject]
+	State                plugin.TValue[string]
+	DeleteTime           plugin.TValue[*time.Time]
+	Folders              plugin.TValue[*mqlGcpFolders]
+	Projects             plugin.TValue[*mqlGcpProjects]
+	OrgPolicies          plugin.TValue[[]any]
+	IamPolicy            plugin.TValue[[]any]
+	AuditConfig          plugin.TValue[[]any]
+	Logging              plugin.TValue[*mqlGcpFolderLoggingService]
+	EssentialContacts    plugin.TValue[[]any]
 }
 
 // createGcpFolder creates a new instance of this resource
@@ -40689,6 +40767,22 @@ func (c *mqlGcpFolder) GetParentOrganization() *plugin.TValue[*mqlGcpOrganizatio
 
 func (c *mqlGcpFolder) GetManagementProject() *plugin.TValue[string] {
 	return &c.ManagementProject
+}
+
+func (c *mqlGcpFolder) GetManagementProjectRef() *plugin.TValue[*mqlGcpProject] {
+	return plugin.GetOrCompute[*mqlGcpProject](&c.ManagementProjectRef, func() (*mqlGcpProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.folder", c.__id, "managementProjectRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProject), nil
+			}
+		}
+
+		return c.managementProjectRef()
+	})
 }
 
 func (c *mqlGcpFolder) GetState() *plugin.TValue[string] {
@@ -40984,6 +41078,7 @@ type mqlGcpProject struct {
 	CloudDomains             plugin.TValue[*mqlGcpProjectCloudDomainsService]
 	Liens                    plugin.TValue[[]any]
 	TagBindings              plugin.TValue[[]any]
+	ManagedBy                plugin.TValue[string]
 }
 
 // createGcpProject creates a new instance of this resource
@@ -42268,6 +42363,12 @@ func (c *mqlGcpProject) GetTagBindings() *plugin.TValue[[]any] {
 		}
 
 		return c.tagBindings()
+	})
+}
+
+func (c *mqlGcpProject) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -55037,6 +55138,7 @@ type mqlGcpProjectKmsServiceKeyring struct {
 	__id       string
 	// optional: if you define mqlGcpProjectKmsServiceKeyringInternal it will be used here
 	ProjectId    plugin.TValue[string]
+	Project      plugin.TValue[*mqlGcpProject]
 	ResourcePath plugin.TValue[string]
 	Name         plugin.TValue[string]
 	Created      plugin.TValue[*time.Time]
@@ -55086,6 +55188,22 @@ func (c *mqlGcpProjectKmsServiceKeyring) MqlID() string {
 
 func (c *mqlGcpProjectKmsServiceKeyring) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
+}
+
+func (c *mqlGcpProjectKmsServiceKeyring) GetProject() *plugin.TValue[*mqlGcpProject] {
+	return plugin.GetOrCompute[*mqlGcpProject](&c.Project, func() (*mqlGcpProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.kmsService.keyring", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 func (c *mqlGcpProjectKmsServiceKeyring) GetResourcePath() *plugin.TValue[string] {
@@ -55181,6 +55299,7 @@ type mqlGcpProjectKmsServiceKeyringCryptokey struct {
 	Versions                      plugin.TValue[[]any]
 	IamPolicy                     plugin.TValue[[]any]
 	Public                        plugin.TValue[bool]
+	ManagedBy                     plugin.TValue[string]
 }
 
 // createGcpProjectKmsServiceKeyringCryptokey creates a new instance of this resource
@@ -55317,6 +55436,12 @@ func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetIamPolicy() *plugin.TValue[
 func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
 		return c.public()
+	})
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -55962,16 +56087,20 @@ type mqlGcpProjectApiKey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectApiKeyInternal it will be used here
-	Id           plugin.TValue[string]
-	ProjectId    plugin.TValue[string]
-	Name         plugin.TValue[string]
-	ResourcePath plugin.TValue[string]
-	Annotations  plugin.TValue[map[string]any]
-	Created      plugin.TValue[*time.Time]
-	Deleted      plugin.TValue[*time.Time]
-	KeyString    plugin.TValue[string]
-	Restrictions plugin.TValue[*mqlGcpProjectApiKeyRestrictions]
-	Updated      plugin.TValue[*time.Time]
+	Id                  plugin.TValue[string]
+	ProjectId           plugin.TValue[string]
+	Project             plugin.TValue[*mqlGcpProject]
+	ServiceAccountEmail plugin.TValue[string]
+	ServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	Name                plugin.TValue[string]
+	ResourcePath        plugin.TValue[string]
+	Annotations         plugin.TValue[map[string]any]
+	Created             plugin.TValue[*time.Time]
+	Deleted             plugin.TValue[*time.Time]
+	KeyString           plugin.TValue[string]
+	Restrictions        plugin.TValue[*mqlGcpProjectApiKeyRestrictions]
+	Updated             plugin.TValue[*time.Time]
+	ManagedBy           plugin.TValue[string]
 }
 
 // createGcpProjectApiKey creates a new instance of this resource
@@ -56019,6 +56148,42 @@ func (c *mqlGcpProjectApiKey) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
 }
 
+func (c *mqlGcpProjectApiKey) GetProject() *plugin.TValue[*mqlGcpProject] {
+	return plugin.GetOrCompute[*mqlGcpProject](&c.Project, func() (*mqlGcpProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.apiKey", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProject), nil
+			}
+		}
+
+		return c.project()
+	})
+}
+
+func (c *mqlGcpProjectApiKey) GetServiceAccountEmail() *plugin.TValue[string] {
+	return &c.ServiceAccountEmail
+}
+
+func (c *mqlGcpProjectApiKey) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.apiKey", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
+}
+
 func (c *mqlGcpProjectApiKey) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -56049,6 +56214,12 @@ func (c *mqlGcpProjectApiKey) GetRestrictions() *plugin.TValue[*mqlGcpProjectApi
 
 func (c *mqlGcpProjectApiKey) GetUpdated() *plugin.TValue[*time.Time] {
 	return &c.Updated
+}
+
+func (c *mqlGcpProjectApiKey) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectApiKeyRestrictions for the gcp.project.apiKey.restrictions resource
@@ -57076,6 +57247,7 @@ type mqlGcpProjectIamServiceServiceAccount struct {
 	__id       string
 	mqlGcpProjectIamServiceServiceAccountInternal
 	ProjectId             plugin.TValue[string]
+	Project               plugin.TValue[*mqlGcpProject]
 	Name                  plugin.TValue[string]
 	UniqueId              plugin.TValue[string]
 	Email                 plugin.TValue[string]
@@ -57131,6 +57303,22 @@ func (c *mqlGcpProjectIamServiceServiceAccount) MqlID() string {
 
 func (c *mqlGcpProjectIamServiceServiceAccount) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccount) GetProject() *plugin.TValue[*mqlGcpProject] {
+	return plugin.GetOrCompute[*mqlGcpProject](&c.Project, func() (*mqlGcpProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.iamService.serviceAccount", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 func (c *mqlGcpProjectIamServiceServiceAccount) GetName() *plugin.TValue[string] {
@@ -63003,6 +63191,7 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	Replication                      plugin.TValue[any]
 	ReplicationType                  plugin.TValue[string]
 	Topics                           plugin.TValue[[]any]
+	TopicRefs                        plugin.TValue[[]any]
 	ExpireTime                       plugin.TValue[*time.Time]
 	Ttl                              plugin.TValue[string]
 	Etag                             plugin.TValue[string]
@@ -63020,6 +63209,7 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	Versions                         plugin.TValue[[]any]
 	IamPolicy                        plugin.TValue[[]any]
 	Public                           plugin.TValue[bool]
+	ManagedBy                        plugin.TValue[string]
 }
 
 // createGcpProjectSecretmanagerServiceSecret creates a new instance of this resource
@@ -63089,6 +63279,22 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetReplicationType() *plugin.T
 
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetTopics() *plugin.TValue[[]any] {
 	return &c.Topics
+}
+
+func (c *mqlGcpProjectSecretmanagerServiceSecret) GetTopicRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TopicRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.secretmanagerService.secret", c.__id, "topicRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.topicRefs()
+	})
 }
 
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetExpireTime() *plugin.TValue[*time.Time] {
@@ -63198,6 +63404,12 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetIamPolicy() *plugin.TValue[
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
 		return c.public()
+	})
+}
+
+func (c *mqlGcpProjectSecretmanagerServiceSecret) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -92,6 +92,7 @@ gcp.folder.loggingService.sink.updated 13.16.3
 gcp.folder.loggingService.sink.writerIdentity 13.16.3
 gcp.folder.loggingService.sinks 13.16.3
 gcp.folder.managementProject 13.25.2
+gcp.folder.managementProjectRef 13.27.2
 gcp.folder.name 9.0.0
 gcp.folder.orgPolicies 13.16.3
 gcp.folder.parentFolder 13.25.2
@@ -345,7 +346,9 @@ gcp.project.apiKey.created 9.0.0
 gcp.project.apiKey.deleted 9.0.0
 gcp.project.apiKey.id 9.0.0
 gcp.project.apiKey.keyString 9.0.0
+gcp.project.apiKey.managedBy 13.27.2
 gcp.project.apiKey.name 9.0.0
+gcp.project.apiKey.project 13.27.2
 gcp.project.apiKey.projectId 9.0.0
 gcp.project.apiKey.resourcePath 9.0.0
 gcp.project.apiKey.restrictions 9.0.0
@@ -357,6 +360,8 @@ gcp.project.apiKey.restrictions.iosKeyRestrictions 9.0.0
 gcp.project.apiKey.restrictions.parentResourcePath 9.0.0
 gcp.project.apiKey.restrictions.serverKeyRestrictions 9.0.0
 gcp.project.apiKey.restrictions.unrestricted 13.12.2
+gcp.project.apiKey.serviceAccount 13.27.2
+gcp.project.apiKey.serviceAccountEmail 13.27.2
 gcp.project.apiKey.updated 9.0.0
 gcp.project.apiKeys 9.0.0
 gcp.project.appEngine 11.6.6
@@ -3436,6 +3441,7 @@ gcp.project.iamService.serviceAccount.keys 9.0.0
 gcp.project.iamService.serviceAccount.lastAuthenticatedTime 13.9.1
 gcp.project.iamService.serviceAccount.name 9.0.0
 gcp.project.iamService.serviceAccount.oauth2ClientId 9.0.0
+gcp.project.iamService.serviceAccount.project 13.27.2
 gcp.project.iamService.serviceAccount.projectId 9.0.0
 gcp.project.iamService.serviceAccount.uniqueId 9.0.0
 gcp.project.iamService.serviceAccounts 9.0.0
@@ -3534,6 +3540,7 @@ gcp.project.kmsService.keyring.cryptokey.iamPolicy 9.0.0
 gcp.project.kmsService.keyring.cryptokey.importOnly 9.0.0
 gcp.project.kmsService.keyring.cryptokey.keyAccessJustificationsPolicy 13.7.2
 gcp.project.kmsService.keyring.cryptokey.labels 9.0.0
+gcp.project.kmsService.keyring.cryptokey.managedBy 13.27.2
 gcp.project.kmsService.keyring.cryptokey.name 9.0.0
 gcp.project.kmsService.keyring.cryptokey.nextRotation 9.0.0
 gcp.project.kmsService.keyring.cryptokey.primary 9.0.0
@@ -3591,6 +3598,7 @@ gcp.project.kmsService.keyring.importJob.state 13.16.3
 gcp.project.kmsService.keyring.importJobs 13.16.3
 gcp.project.kmsService.keyring.location 9.0.0
 gcp.project.kmsService.keyring.name 9.0.0
+gcp.project.kmsService.keyring.project 13.27.2
 gcp.project.kmsService.keyring.projectId 9.0.0
 gcp.project.kmsService.keyring.public 13.19.2
 gcp.project.kmsService.keyring.resourcePath 9.0.0
@@ -3678,6 +3686,7 @@ gcp.project.loggingservice.sink.projectId 9.0.0
 gcp.project.loggingservice.sink.storageBucket 9.0.0
 gcp.project.loggingservice.sink.writerIdentity 9.0.0
 gcp.project.loggingservice.sinks 9.0.0
+gcp.project.managedBy 13.27.2
 gcp.project.memcache 13.11.2
 gcp.project.memcacheService 13.11.2
 gcp.project.memcacheService.instance 13.11.2
@@ -4266,6 +4275,7 @@ gcp.project.secretmanagerService.secret.expireTime 11.1.0
 gcp.project.secretmanagerService.secret.iamPolicy 11.1.0
 gcp.project.secretmanagerService.secret.kmsKeys 13.12.2
 gcp.project.secretmanagerService.secret.labels 11.1.0
+gcp.project.secretmanagerService.secret.managedBy 13.27.2
 gcp.project.secretmanagerService.secret.name 11.1.0
 gcp.project.secretmanagerService.secret.nextRotationTime 13.18.1
 gcp.project.secretmanagerService.secret.projectId 11.1.0
@@ -4277,6 +4287,7 @@ gcp.project.secretmanagerService.secret.rotation 11.1.0
 gcp.project.secretmanagerService.secret.rotationEnabled 13.12.2
 gcp.project.secretmanagerService.secret.rotationPeriod 13.18.1
 gcp.project.secretmanagerService.secret.tags 13.12.2
+gcp.project.secretmanagerService.secret.topicRefs 13.27.2
 gcp.project.secretmanagerService.secret.topics 11.1.0
 gcp.project.secretmanagerService.secret.ttl 13.18.1
 gcp.project.secretmanagerService.secret.version 11.1.0

--- a/providers/gcp/resources/gcp_managed_by.go
+++ b/providers/gcp/resources/gcp_managed_by.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromLabels infers the infrastructure-management system that owns a
+// GCP resource from the provenance labels and annotations Google and common
+// IaC tools stamp on managed resources. Callers pass every label/annotation map
+// the resource exposes; the maps are inspected in priority order and the first
+// recognized signal wins. It returns an empty string when no management signal
+// is present (a resource created manually or through the console) and propagates
+// any error from resolving a computed map.
+//
+// Recognized signals, highest priority first:
+//   - "terraform": the goog-terraform-provisioned label Google stamps on
+//     resources created through the Terraform Google provider.
+//   - "config-connector": the cnrm.cloud.google.com/* annotations (or the
+//     managed-by-cnrm label) the GKE Config Connector controller applies to
+//     resources it reconciles.
+//   - "cloud-composer": the goog-composer-* labels applied to resources a Cloud
+//     Composer environment provisions.
+func managedByFromLabels(maps ...*plugin.TValue[map[string]any]) (string, error) {
+	for _, m := range maps {
+		if m != nil && m.Error != nil {
+			return "", m.Error
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if v, ok := m.Data["goog-terraform-provisioned"]; ok && labelValueTrue(v) {
+			return "terraform", nil
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if k == "managed-by-cnrm" || strings.HasPrefix(k, "cnrm.cloud.google.com/") {
+				return "config-connector", nil
+			}
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if strings.HasPrefix(k, "goog-composer-") {
+				return "cloud-composer", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// labelValueTrue reports whether a label value is the string "true"
+// (case-insensitive). GCP label values are always strings.
+func labelValueTrue(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.EqualFold(s, "true")
+}

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -128,6 +128,20 @@ func (g *mqlGcpProjectIamServiceServiceAccount) id() (string, error) {
 	return g.UniqueId.Data, nil
 }
 
+func (g *mqlGcpProjectIamServiceServiceAccount) project() (*mqlGcpProject, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	proj, err := projectRefById(g.MqlRuntime, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		g.Project.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return proj, nil
+}
+
 func (g *mqlGcpProjectIamServiceServiceAccountKey) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -141,6 +141,24 @@ func (g *mqlGcpProjectKmsServiceKeyring) id() (string, error) {
 	return g.ResourcePath.Data, g.ResourcePath.Error
 }
 
+func (g *mqlGcpProjectKmsServiceKeyring) project() (*mqlGcpProject, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	proj, err := projectRefById(g.MqlRuntime, g.ProjectId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		g.Project.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return proj, nil
+}
+
+func (g *mqlGcpProjectKmsServiceKeyringCryptokey) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func initGcpProjectKmsServiceKeyringCryptokey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -153,6 +153,10 @@ func (g *mqlGcpProject) deleteTime() (*time.Time, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (g *mqlGcpProject) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func (g *mqlGcpProject) number() (string, error) {
 	return "", errors.New("not implemented")
 }

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -370,6 +370,40 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) kmsKeys() ([]any, error) {
 	return res, nil
 }
 
+func (g *mqlGcpProjectSecretmanagerServiceSecret) topicRefs() ([]any, error) {
+	if g.Topics.Error != nil {
+		return nil, g.Topics.Error
+	}
+	topics := g.Topics.Data
+	if len(topics) == 0 {
+		return []any{}, nil
+	}
+	res := make([]any, 0, len(topics))
+	for _, raw := range topics {
+		name, ok := raw.(string)
+		if !ok || name == "" {
+			continue
+		}
+		projectId := projectFromResourceName(name)
+		if projectId == "" {
+			continue
+		}
+		t, err := NewResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
+			"projectId": llx.StringData(projectId),
+			"name":      llx.StringData(lastPathSegment(name)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, t)
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectSecretmanagerServiceSecret) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels(), g.GetAnnotations())
+}
+
 func (g *mqlGcpProjectSecretmanagerServiceSecret) customerManagedEncryptionEnabled() (bool, error) {
 	if g.CustomerManagedEncryption.Error != nil {
 		return false, g.CustomerManagedEncryption.Error


### PR DESCRIPTION
## What

Adds provenance and lineage signals across the GCP hierarchy, IAM, and keys subsystem. All changes are additive and non-breaking.

### managedBy() (derived from provenance labels/annotations: terraform, config-connector, cloud-composer)
- `gcp.project` (from labels)
- `gcp.project.apiKey` (from annotations)
- `gcp.project.kmsService.keyring.cryptokey` (from labels)
- `gcp.project.secretmanagerService.secret` (from labels and annotations)

### Typed references
- `gcp.folder.managementProjectRef()` -> `gcp.project` (resolves the raw `managementProject` resource name; raw field kept to avoid a name collision)
- `gcp.project.iamService.serviceAccount.project()` -> `gcp.project` (from `projectId`, which is retained for init/lookup)
- `gcp.project.apiKey.project()` -> `gcp.project` (from `projectId`)
- `gcp.project.apiKey.serviceAccount()` -> `gcp.project.iamService.serviceAccount` (via new `serviceAccountEmail`, previously unmapped from the SDK)
- `gcp.project.kmsService.keyring.project()` -> `gcp.project` (from `projectId`)
- `gcp.project.secretmanagerService.secret.topicRefs()` -> `[]gcp.project.pubsubService.topic` (notification lineage; raw `topics []string` kept)

### New scalar
- `gcp.project.apiKey.serviceAccountEmail` (maps SDK `V2Key.ServiceAccountEmail`)

## Notes
- New `.lr.versions` entries at `13.27.2`.
- No IAM permission changes (all data comes from existing list calls).
- Shared `managedByFromLabels` helper added in `gcp_managed_by.go`; a small `projectRefById` helper added in `common.go`.