### PR TITLE
✨ gcp: compute provenance (managedBy + typed refs)

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -644,7 +644,10 @@ func (g *mqlGcpProjectComputeServiceAttachedDisk) source() (*mqlGcpProjectComput
 }
 
 type mqlGcpProjectComputeServiceInstanceInternal struct {
-	instanceMachineType string
+	instanceMachineType       string
+	cacheNetworkUrls          []string
+	cacheSubnetworkUrls       []string
+	cacheServiceAccountEmails []string
 }
 
 func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeServiceZone, runtime *plugin.Runtime, instance *compute.Instance) (*mqlGcpProjectComputeServiceInstance, error) {
@@ -715,8 +718,18 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 
 	stackTypeSet := map[string]struct{}{}
 	networkStackTypes := []any{}
+	var networkUrls, subnetworkUrls []string
 	for _, ni := range instance.NetworkInterfaces {
-		if ni == nil || ni.StackType == "" {
+		if ni == nil {
+			continue
+		}
+		if ni.Network != "" {
+			networkUrls = append(networkUrls, ni.Network)
+		}
+		if ni.Subnetwork != "" {
+			subnetworkUrls = append(subnetworkUrls, ni.Subnetwork)
+		}
+		if ni.StackType == "" {
 			continue
 		}
 		if _, ok := stackTypeSet[ni.StackType]; ok {
@@ -724,6 +737,13 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		}
 		stackTypeSet[ni.StackType] = struct{}{}
 		networkStackTypes = append(networkStackTypes, ni.StackType)
+	}
+
+	var serviceAccountEmails []string
+	for _, sa := range instance.ServiceAccounts {
+		if sa != nil && sa.Email != "" {
+			serviceAccountEmails = append(serviceAccountEmails, sa.Email)
+		}
 	}
 
 	var mqlWorkloadIdentityConfig map[string]any
@@ -861,7 +881,60 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 	}
 	mqlR := entry.(*mqlGcpProjectComputeServiceInstance)
 	mqlR.instanceMachineType = instance.MachineType
+	mqlR.cacheNetworkUrls = networkUrls
+	mqlR.cacheSubnetworkUrls = subnetworkUrls
+	mqlR.cacheServiceAccountEmails = serviceAccountEmails
 	return mqlR, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) networks() ([]any, error) {
+	res := make([]any, 0, len(g.cacheNetworkUrls))
+	for _, url := range g.cacheNetworkUrls {
+		network, err := getNetworkByUrl(url, g.MqlRuntime)
+		if err != nil {
+			return nil, err
+		}
+		if network != nil {
+			res = append(res, network)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) subnetworks() ([]any, error) {
+	res := make([]any, 0, len(g.cacheSubnetworkUrls))
+	for _, url := range g.cacheSubnetworkUrls {
+		subnet, err := getSubnetworkByUrl(url, g.MqlRuntime)
+		if err != nil {
+			return nil, err
+		}
+		if subnet != nil {
+			res = append(res, subnet)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) serviceAccountRefs() ([]any, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	projectId := g.ProjectId.Data
+	res := make([]any, 0, len(g.cacheServiceAccountEmails))
+	for _, email := range g.cacheServiceAccountEmails {
+		sa, err := resolveServiceAccountRef(g.MqlRuntime, email, projectId)
+		if err != nil {
+			return nil, err
+		}
+		if sa != nil {
+			res = append(res, sa)
+		}
+	}
+	return res, nil
 }
 
 func (g *mqlGcpProjectComputeService) instances() ([]any, error) {
@@ -944,6 +1017,10 @@ func (g *mqlGcpProjectComputeServiceDisk) id() (string, error) {
 	}
 	id := g.Id.Data
 	return "gcloud.compute.disk/" + id, nil
+}
+
+func (g *mqlGcpProjectComputeServiceDisk) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
 }
 
 type mqlGcpProjectComputeServiceDiskInternal struct {
@@ -1221,6 +1298,39 @@ func (g *mqlGcpProjectComputeServiceFirewall) network() (*mqlGcpProjectComputeSe
 	return getNetworkByUrl(g.cacheNetworkUrl, g.MqlRuntime)
 }
 
+func (g *mqlGcpProjectComputeServiceFirewall) resolveServiceAccountRefs(emails *plugin.TValue[[]any]) ([]any, error) {
+	if emails.Error != nil {
+		return nil, emails.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	projectId := g.ProjectId.Data
+	res := make([]any, 0, len(emails.Data))
+	for _, e := range emails.Data {
+		email, ok := e.(string)
+		if !ok || email == "" {
+			continue
+		}
+		sa, err := resolveServiceAccountRef(g.MqlRuntime, email, projectId)
+		if err != nil {
+			return nil, err
+		}
+		if sa != nil {
+			res = append(res, sa)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) sourceServiceAccountRefs() ([]any, error) {
+	return g.resolveServiceAccountRefs(g.GetSourceServiceAccounts())
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) targetServiceAccountRefs() ([]any, error) {
+	return g.resolveServiceAccountRefs(g.GetTargetServiceAccounts())
+}
+
 func (g *mqlGcpProjectComputeServiceFirewall) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -1378,6 +1488,10 @@ func (g *mqlGcpProjectComputeServiceSnapshot) id() (string, error) {
 	return "gcloud.compute.snapshot/" + id, nil
 }
 
+func (g *mqlGcpProjectComputeServiceSnapshot) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 	// when the service is not enabled, we return nil
 	if !g.GetEnabled().Data {
@@ -1461,6 +1575,10 @@ func (g *mqlGcpProjectComputeServiceImage) id() (string, error) {
 	}
 	id := g.Id.Data
 	return "gcloud.compute.image/" + id, nil
+}
+
+func (g *mqlGcpProjectComputeServiceImage) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
 }
 
 func initGcpProjectComputeServiceImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -1698,6 +1816,51 @@ func (g *mqlGcpProjectComputeServiceNetwork) id() (string, error) {
 	}
 	id := g.Id.Data
 	return "gcloud.compute.network/" + id, nil
+}
+
+func (g *mqlGcpProjectComputeServiceNetwork) firewallPolicyRef() (*mqlGcpProjectComputeServiceFirewallPolicy, error) {
+	if g.FirewallPolicy.Error != nil {
+		return nil, g.FirewallPolicy.Error
+	}
+	url := g.FirewallPolicy.Data
+	if url == "" {
+		g.FirewallPolicyRef.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+
+	obj, err := CreateResource(g.MqlRuntime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(g.ProjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	policies := obj.(*mqlGcpProjectComputeService).GetFirewallPolicies()
+	if policies.Error != nil {
+		return nil, policies.Error
+	}
+
+	// The network's firewallPolicy is a self-link URL; match it against the
+	// listed policies by selfLink, then fall back to the trailing name/id
+	// segment for shapes that omit the full self-link.
+	lastSegment := url[strings.LastIndex(url, "/")+1:]
+	for _, p := range policies.Data {
+		policy := p.(*mqlGcpProjectComputeServiceFirewallPolicy)
+		if policy.SelfLink.Error == nil && policy.SelfLink.Data == url {
+			return policy, nil
+		}
+		if policy.Name.Error == nil && policy.Name.Data == lastSegment {
+			return policy, nil
+		}
+		if policy.Id.Error == nil && policy.Id.Data == lastSegment {
+			return policy, nil
+		}
+	}
+
+	g.FirewallPolicyRef.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }
 
 func (g *mqlGcpProjectComputeServiceNetwork) networkPeerings() ([]any, error) {

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1492,6 +1492,30 @@ gcp.project.computeService.instance @defaults("name id") {
   inventory() gcp.project.computeService.instance.osInventory
   // VM Manager vulnerability report for the instance
   vulnerabilityReport() gcp.project.computeService.instance.vulnerabilityReport
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
+  // VPC networks the instance is attached to
+  //
+  // Networks resolved from every network interface, letting audits traverse the
+  // network configuration directly instead of reading self-link URLs out of the
+  // network interface list.
+  networks() []gcp.project.computeService.network
+  // VPC subnetworks the instance is attached to
+  //
+  // Subnetworks resolved from every network interface, letting audits traverse
+  // the subnetwork configuration directly instead of reading self-link URLs out
+  // of the network interface list.
+  subnetworks() []gcp.project.computeService.subnetwork
+  // IAM service accounts the instance runs as
+  //
+  // Service accounts resolved from the instance service account bindings,
+  // letting audits traverse the role bindings and keys of each identity the VM
+  // authenticates with.
+  serviceAccountRefs() []gcp.project.iamService.serviceAccount
 }
 
 // Compute instance internet-exposure breakdown
@@ -1785,6 +1809,12 @@ private gcp.project.computeService.disk @defaults("name") {
   satisfiesPzs bool
   // Source disk used to create this disk
   sourceDisk() gcp.project.computeService.disk
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Compute attached disk
@@ -1899,6 +1929,12 @@ private gcp.project.computeService.snapshot @defaults("name") {
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the snapshot's IAM policy grants any role to allUsers or allAuthenticatedUsers
   public() bool
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Compute Engine custom or public machine image
@@ -1963,6 +1999,12 @@ private gcp.project.computeService.image @defaults("id name") {
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the image's IAM policy grants any role to allUsers or allAuthenticatedUsers
   public() bool
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Compute Engine VPC firewall rule
@@ -2000,12 +2042,24 @@ private gcp.project.computeService.firewall @defaults("name") {
   allowsRdpFromInternet() bool
   // Source service accounts
   sourceServiceAccounts []string
+  // IAM service accounts whose instances this rule matches as traffic source
+  //
+  // Service accounts resolved from the source service account emails, letting
+  // audits traverse the role bindings and keys of each identity this ingress
+  // rule applies to.
+  sourceServiceAccountRefs() []gcp.project.iamService.serviceAccount
   // Source tags
   sourceTags []string
   // Range of destination IP addresses for which the rule applies to traffic
   destinationRanges []string
   // List of service accounts
   targetServiceAccounts []string
+  // IAM service accounts whose instances this rule applies to as traffic target
+  //
+  // Service accounts resolved from the target service account emails, letting
+  // audits traverse the role bindings and keys of each identity this rule
+  // governs.
+  targetServiceAccountRefs() []gcp.project.iamService.serviceAccount
   // Creation timestamp
   created time
   // List of ALLOW rules specified by this firewall
@@ -2073,6 +2127,11 @@ gcp.project.computeService.network @defaults("name") {
   internalIpv6Range string
   // URL of the firewall policy applied to this network
   firewallPolicy string
+  // Firewall policy applied to this network
+  //
+  // Network firewall policy resolved from the associated policy reference,
+  // letting audits traverse the policy rules directly.
+  firewallPolicyRef() gcp.project.computeService.firewallPolicy
   // URL of the network profile applied to this network
   networkProfile string
   // Legacy single-region IPv4 range for non-subnetted networks

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -3937,6 +3937,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.vulnerabilityReport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetVulnerabilityReport()).ToDataRes(types.Resource("gcp.project.computeService.instance.vulnerabilityReport"))
 	},
+	"gcp.project.computeService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetManagedBy()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.instance.networks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetNetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.network")))
+	},
+	"gcp.project.computeService.instance.subnetworks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetSubnetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.subnetwork")))
+	},
+	"gcp.project.computeService.instance.serviceAccountRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetServiceAccountRefs()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.serviceAccount")))
+	},
 	"gcp.project.computeService.instance.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetInternetReachable()).ToDataRes(types.Bool)
 	},
@@ -4186,6 +4198,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.disk.sourceDisk": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceDisk()).ToDataRes(types.Resource("gcp.project.computeService.disk"))
 	},
+	"gcp.project.computeService.disk.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.attachedDisk.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAttachedDisk).GetId()).ToDataRes(types.String)
 	},
@@ -4321,6 +4336,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.public": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetPublic()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.snapshot.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetId()).ToDataRes(types.String)
 	},
@@ -4393,6 +4411,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.image.public": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetPublic()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.image.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.firewall.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetId()).ToDataRes(types.String)
 	},
@@ -4429,6 +4450,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.firewall.sourceServiceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceServiceAccounts()).ToDataRes(types.Array(types.String))
 	},
+	"gcp.project.computeService.firewall.sourceServiceAccountRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceServiceAccountRefs()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.serviceAccount")))
+	},
 	"gcp.project.computeService.firewall.sourceTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceTags()).ToDataRes(types.Array(types.String))
 	},
@@ -4437,6 +4461,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewall.targetServiceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetTargetServiceAccounts()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.computeService.firewall.targetServiceAccountRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetTargetServiceAccountRefs()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.serviceAccount")))
 	},
 	"gcp.project.computeService.firewall.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetCreated()).ToDataRes(types.Time)
@@ -4518,6 +4545,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.network.firewallPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetFirewallPolicy()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.network.firewallPolicyRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetFirewallPolicyRef()).ToDataRes(types.Resource("gcp.project.computeService.firewallPolicy"))
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetNetworkProfile()).ToDataRes(types.String)
@@ -19261,6 +19291,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).VulnerabilityReport, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceVulnerabilityReport](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.networks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).Networks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.subnetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).Subnetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.serviceAccountRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).ServiceAccountRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceExposure).__id, ok = v.Value.(string)
 		return
@@ -19629,6 +19675,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceDisk).SourceDisk, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceDisk](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.disk.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.attachedDisk.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAttachedDisk).__id, ok = v.Value.(string)
 		return
@@ -19817,6 +19867,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.snapshot.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).__id, ok = v.Value.(string)
 		return
@@ -19917,6 +19971,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceImage).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.image.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).__id, ok = v.Value.(string)
 		return
@@ -19969,6 +20027,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceFirewall).SourceServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.firewall.sourceServiceAccountRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).SourceServiceAccountRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.firewall.sourceTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).SourceTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -19979,6 +20041,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.firewall.targetServiceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).TargetServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewall.targetServiceAccountRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).TargetServiceAccountRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewall.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20091,6 +20157,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.firewallPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).FirewallPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.firewallPolicyRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).FirewallPolicyRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceFirewallPolicy](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44191,6 +44261,10 @@ type mqlGcpProjectComputeServiceInstance struct {
 	AdvancedMachineFeatures         plugin.TValue[any]
 	Inventory                       plugin.TValue[*mqlGcpProjectComputeServiceInstanceOsInventory]
 	VulnerabilityReport             plugin.TValue[*mqlGcpProjectComputeServiceInstanceVulnerabilityReport]
+	ManagedBy                       plugin.TValue[string]
+	Networks                        plugin.TValue[[]any]
+	Subnetworks                     plugin.TValue[[]any]
+	ServiceAccountRefs              plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceInstance creates a new instance of this resource
@@ -44525,6 +44599,60 @@ func (c *mqlGcpProjectComputeServiceInstance) GetVulnerabilityReport() *plugin.T
 		}
 
 		return c.vulnerabilityReport()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetNetworks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Networks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "networks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.networks()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetSubnetworks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnetworks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "subnetworks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnetworks()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetServiceAccountRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceAccountRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "serviceAccountRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceAccountRefs()
 	})
 }
 
@@ -45136,6 +45264,7 @@ type mqlGcpProjectComputeServiceDisk struct {
 	SatisfiesPzi                plugin.TValue[bool]
 	SatisfiesPzs                plugin.TValue[bool]
 	SourceDisk                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
+	ManagedBy                   plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceDisk creates a new instance of this resource
@@ -45379,6 +45508,12 @@ func (c *mqlGcpProjectComputeServiceDisk) GetSourceDisk() *plugin.TValue[*mqlGcp
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceDisk) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectComputeServiceAttachedDisk for the gcp.project.computeService.attachedDisk resource
 type mqlGcpProjectComputeServiceAttachedDisk struct {
 	MqlRuntime *plugin.Runtime
@@ -45549,6 +45684,7 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	SnapshotEncryptionKey          plugin.TValue[any]
 	IamPolicy                      plugin.TValue[[]any]
 	Public                         plugin.TValue[bool]
+	ManagedBy                      plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceSnapshot creates a new instance of this resource
@@ -45742,6 +45878,12 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetPublic() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceSnapshot) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectComputeServiceImage for the gcp.project.computeService.image resource
 type mqlGcpProjectComputeServiceImage struct {
 	MqlRuntime *plugin.Runtime
@@ -45771,6 +45913,7 @@ type mqlGcpProjectComputeServiceImage struct {
 	ShieldedInstanceInitialState plugin.TValue[any]
 	IamPolicy                    plugin.TValue[[]any]
 	Public                       plugin.TValue[bool]
+	ManagedBy                    plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceImage creates a new instance of this resource
@@ -45968,34 +46111,42 @@ func (c *mqlGcpProjectComputeServiceImage) GetPublic() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceImage) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectComputeServiceFirewall for the gcp.project.computeService.firewall resource
 type mqlGcpProjectComputeServiceFirewall struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectComputeServiceFirewallInternal
-	Id                    plugin.TValue[string]
-	ProjectId             plugin.TValue[string]
-	Name                  plugin.TValue[string]
-	Description           plugin.TValue[string]
-	Priority              plugin.TValue[int64]
-	Direction             plugin.TValue[string]
-	Disabled              plugin.TValue[bool]
-	SourceRanges          plugin.TValue[[]any]
-	OpenToInternet        plugin.TValue[bool]
-	AllowsSshFromInternet plugin.TValue[bool]
-	AllowsRdpFromInternet plugin.TValue[bool]
-	SourceServiceAccounts plugin.TValue[[]any]
-	SourceTags            plugin.TValue[[]any]
-	DestinationRanges     plugin.TValue[[]any]
-	TargetServiceAccounts plugin.TValue[[]any]
-	Created               plugin.TValue[*time.Time]
-	Allowed               plugin.TValue[[]any]
-	Denied                plugin.TValue[[]any]
-	TargetTags            plugin.TValue[[]any]
-	LoggingEnabled        plugin.TValue[bool]
-	LogConfig             plugin.TValue[any]
-	LogConfigMetadata     plugin.TValue[string]
-	Network               plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	Id                       plugin.TValue[string]
+	ProjectId                plugin.TValue[string]
+	Name                     plugin.TValue[string]
+	Description              plugin.TValue[string]
+	Priority                 plugin.TValue[int64]
+	Direction                plugin.TValue[string]
+	Disabled                 plugin.TValue[bool]
+	SourceRanges             plugin.TValue[[]any]
+	OpenToInternet           plugin.TValue[bool]
+	AllowsSshFromInternet    plugin.TValue[bool]
+	AllowsRdpFromInternet    plugin.TValue[bool]
+	SourceServiceAccounts    plugin.TValue[[]any]
+	SourceServiceAccountRefs plugin.TValue[[]any]
+	SourceTags               plugin.TValue[[]any]
+	DestinationRanges        plugin.TValue[[]any]
+	TargetServiceAccounts    plugin.TValue[[]any]
+	TargetServiceAccountRefs plugin.TValue[[]any]
+	Created                  plugin.TValue[*time.Time]
+	Allowed                  plugin.TValue[[]any]
+	Denied                   plugin.TValue[[]any]
+	TargetTags               plugin.TValue[[]any]
+	LoggingEnabled           plugin.TValue[bool]
+	LogConfig                plugin.TValue[any]
+	LogConfigMetadata        plugin.TValue[string]
+	Network                  plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 }
 
 // createGcpProjectComputeServiceFirewall creates a new instance of this resource
@@ -46089,6 +46240,22 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetSourceServiceAccounts() *plugin
 	return &c.SourceServiceAccounts
 }
 
+func (c *mqlGcpProjectComputeServiceFirewall) GetSourceServiceAccountRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SourceServiceAccountRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.firewall", c.__id, "sourceServiceAccountRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.sourceServiceAccountRefs()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceFirewall) GetSourceTags() *plugin.TValue[[]any] {
 	return &c.SourceTags
 }
@@ -46099,6 +46266,22 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetDestinationRanges() *plugin.TVa
 
 func (c *mqlGcpProjectComputeServiceFirewall) GetTargetServiceAccounts() *plugin.TValue[[]any] {
 	return &c.TargetServiceAccounts
+}
+
+func (c *mqlGcpProjectComputeServiceFirewall) GetTargetServiceAccountRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TargetServiceAccountRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.firewall", c.__id, "targetServiceAccountRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.targetServiceAccountRefs()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceFirewall) GetCreated() *plugin.TValue[*time.Time] {
@@ -46169,6 +46352,7 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	Subnetworks                           plugin.TValue[[]any]
 	InternalIpv6Range                     plugin.TValue[string]
 	FirewallPolicy                        plugin.TValue[string]
+	FirewallPolicyRef                     plugin.TValue[*mqlGcpProjectComputeServiceFirewallPolicy]
 	NetworkProfile                        plugin.TValue[string]
 	Ipv4Range                             plugin.TValue[string]
 }
@@ -46310,6 +46494,22 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetInternalIpv6Range() *plugin.TVal
 
 func (c *mqlGcpProjectComputeServiceNetwork) GetFirewallPolicy() *plugin.TValue[string] {
 	return &c.FirewallPolicy
+}
+
+func (c *mqlGcpProjectComputeServiceNetwork) GetFirewallPolicyRef() *plugin.TValue[*mqlGcpProjectComputeServiceFirewallPolicy] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceFirewallPolicy](&c.FirewallPolicyRef, func() (*mqlGcpProjectComputeServiceFirewallPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.network", c.__id, "firewallPolicyRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceFirewallPolicy), nil
+			}
+		}
+
+		return c.firewallPolicyRef()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkProfile() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1552,6 +1552,7 @@ gcp.project.computeService.disk.lastAttachTimestamp 9.0.0
 gcp.project.computeService.disk.lastDetachTimestamp 9.0.0
 gcp.project.computeService.disk.licenses 9.0.0
 gcp.project.computeService.disk.locationHint 9.0.0
+gcp.project.computeService.disk.managedBy 13.27.2
 gcp.project.computeService.disk.name 9.0.0
 gcp.project.computeService.disk.physicalBlockSizeBytes 9.0.0
 gcp.project.computeService.disk.provisionedIops 9.0.0
@@ -1604,8 +1605,10 @@ gcp.project.computeService.firewall.openToInternet 13.12.2
 gcp.project.computeService.firewall.priority 9.0.0
 gcp.project.computeService.firewall.projectId 9.0.0
 gcp.project.computeService.firewall.sourceRanges 9.0.0
+gcp.project.computeService.firewall.sourceServiceAccountRefs 13.27.2
 gcp.project.computeService.firewall.sourceServiceAccounts 9.0.0
 gcp.project.computeService.firewall.sourceTags 9.0.0
+gcp.project.computeService.firewall.targetServiceAccountRefs 13.27.2
 gcp.project.computeService.firewall.targetServiceAccounts 9.0.0
 gcp.project.computeService.firewall.targetTags 11.6.6
 gcp.project.computeService.firewallPolicies 11.6.6
@@ -1716,6 +1719,7 @@ gcp.project.computeService.image.imageEncryptionKey 13.19.2
 gcp.project.computeService.image.kmsKey 13.12.2
 gcp.project.computeService.image.labels 9.0.0
 gcp.project.computeService.image.licenses 9.0.0
+gcp.project.computeService.image.managedBy 13.27.2
 gcp.project.computeService.image.name 9.0.0
 gcp.project.computeService.image.projectId 9.0.0
 gcp.project.computeService.image.public 13.12.2
@@ -1765,11 +1769,13 @@ gcp.project.computeService.instance.lastStartTimestamp 9.0.0
 gcp.project.computeService.instance.lastStopTimestamp 9.0.0
 gcp.project.computeService.instance.lastSuspendedTimestamp 9.0.0
 gcp.project.computeService.instance.machineType 9.0.0
+gcp.project.computeService.instance.managedBy 13.27.2
 gcp.project.computeService.instance.metadata 9.0.0
 gcp.project.computeService.instance.minCpuPlatform 9.0.0
 gcp.project.computeService.instance.name 9.0.0
 gcp.project.computeService.instance.networkInterfaces 9.0.0
 gcp.project.computeService.instance.networkStackTypes 13.18.1
+gcp.project.computeService.instance.networks 13.27.2
 gcp.project.computeService.instance.osInventory 13.15.1
 gcp.project.computeService.instance.osInventory.inventoryItems 13.18.1
 gcp.project.computeService.instance.osInventory.item 13.18.1
@@ -1802,6 +1808,7 @@ gcp.project.computeService.instance.satisfiesPzi 11.6.6
 gcp.project.computeService.instance.satisfiesPzs 11.6.6
 gcp.project.computeService.instance.scheduling 9.0.0
 gcp.project.computeService.instance.serialPortEnabled 13.12.2
+gcp.project.computeService.instance.serviceAccountRefs 13.27.2
 gcp.project.computeService.instance.serviceAccounts 9.0.0
 gcp.project.computeService.instance.shieldedInstanceConfig 11.6.3
 gcp.project.computeService.instance.shieldedInstanceConfig.enableIntegrityMonitoring 11.6.3
@@ -1814,6 +1821,7 @@ gcp.project.computeService.instance.sourceMachineImageEncryptionKey 13.16.3
 gcp.project.computeService.instance.startRestricted 9.0.0
 gcp.project.computeService.instance.status 9.0.0
 gcp.project.computeService.instance.statusMessage 9.0.0
+gcp.project.computeService.instance.subnetworks 13.27.2
 gcp.project.computeService.instance.tags 9.0.0
 gcp.project.computeService.instance.totalEgressBandwidthTier 9.0.0
 gcp.project.computeService.instance.usesDefaultServiceAccount 13.12.2
@@ -1958,6 +1966,7 @@ gcp.project.computeService.network.created 9.0.0
 gcp.project.computeService.network.description 9.0.0
 gcp.project.computeService.network.enableUlaInternalIpv6 9.0.0
 gcp.project.computeService.network.firewallPolicy 11.6.6
+gcp.project.computeService.network.firewallPolicyRef 13.27.2
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0
 gcp.project.computeService.network.internalIpv6Range 11.6.6
@@ -2179,6 +2188,7 @@ gcp.project.computeService.snapshot.id 9.0.0
 gcp.project.computeService.snapshot.kmsKey 13.12.2
 gcp.project.computeService.snapshot.labels 9.0.0
 gcp.project.computeService.snapshot.licenses 9.0.0
+gcp.project.computeService.snapshot.managedBy 13.27.2
 gcp.project.computeService.snapshot.name 9.0.0
 gcp.project.computeService.snapshot.projectId 13.10.1
 gcp.project.computeService.snapshot.public 13.12.2

--- a/providers/gcp/resources/gcp_managed_by.go
+++ b/providers/gcp/resources/gcp_managed_by.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromLabels infers the infrastructure-management system that owns a
+// GCP resource from the provenance labels and annotations Google and common
+// IaC tools stamp on managed resources. Callers pass every label/annotation map
+// the resource exposes; the maps are inspected in priority order and the first
+// recognized signal wins. It returns an empty string when no management signal
+// is present (a resource created manually or through the console) and propagates
+// any error from resolving a computed map.
+//
+// Recognized signals, highest priority first:
+//   - "terraform": the goog-terraform-provisioned label Google stamps on
+//     resources created through the Terraform Google provider.
+//   - "config-connector": the cnrm.cloud.google.com/* annotations (or the
+//     managed-by-cnrm label) the GKE Config Connector controller applies to
+//     resources it reconciles.
+//   - "cloud-composer": the goog-composer-* labels applied to resources a Cloud
+//     Composer environment provisions.
+func managedByFromLabels(maps ...*plugin.TValue[map[string]any]) (string, error) {
+	for _, m := range maps {
+		if m != nil && m.Error != nil {
+			return "", m.Error
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if v, ok := m.Data["goog-terraform-provisioned"]; ok && labelValueTrue(v) {
+			return "terraform", nil
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if k == "managed-by-cnrm" || strings.HasPrefix(k, "cnrm.cloud.google.com/") {
+				return "config-connector", nil
+			}
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if strings.HasPrefix(k, "goog-composer-") {
+				return "cloud-composer", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// labelValueTrue reports whether a label value is the string "true"
+// (case-insensitive). GCP label values are always strings.
+func labelValueTrue(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.EqualFold(s, "true")
+}


### PR DESCRIPTION
Adds infrastructure-management provenance and typed cross-references to the GCP Compute subsystem. All additions are additive computed fields; no existing field changes shape or type.

## Resources

- **gcp.project.computeService.instance**
  - `managedBy()` derived from labels (terraform / config-connector / cloud-composer)
  - `networks()` and `subnetworks()` resolved from the network interface self-link URLs
  - `serviceAccountRefs()` resolving the attached service account emails to typed `gcp.project.iamService.serviceAccount`
- **gcp.project.computeService.image** — `managedBy()` from labels
- **gcp.project.computeService.disk** — `managedBy()` from labels
- **gcp.project.computeService.snapshot** — `managedBy()` from labels
- **gcp.project.computeService.network** — `firewallPolicyRef()` resolving the associated firewall policy
- **gcp.project.computeService.firewall** — `sourceServiceAccountRefs()` / `targetServiceAccountRefs()` resolving the raw source/target service account emails (raw `[]string` lists retained)

Introduces the shared `managedByFromLabels` helper in `gcp_managed_by.go`.

## Notes
- Instance network/subnetwork/service-account URLs are cached on the resource Internal struct and resolved lazily via the existing `getNetworkByUrl` / `getSubnetworkByUrl` / `resolveServiceAccountRef` helpers.
- Network `firewallPolicyRef` resolves through the project's firewall policy list (the firewall policy resource has no fetching init), matching by self-link then by trailing name/id segment.
- No new IAM permissions required; `gcp.permissions.json` is unchanged.
- New `.lr.versions` entries at 13.27.2.

## Verification
- `go build ./...` and `go vet ./resources/` pass
- `make providers/build/gcp` succeeds