### PR TITLE
✨ gcp: serverless/containers provenance (managedBy + typed refs)

### DIFF
--- a/providers/gcp/resources/artifactregistry.go
+++ b/providers/gcp/resources/artifactregistry.go
@@ -180,6 +180,10 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepository) id() (string, error) {
 	return g.ResourcePath.Data, g.ResourcePath.Error
 }
 
+func (g *mqlGcpProjectArtifactRegistryServiceRepository) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func (g *mqlGcpProjectArtifactRegistryServiceRepository) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
 	keyName := g.GetKmsKeyName()
 	if keyName.Error != nil {

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -138,6 +139,7 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 		}
 
 		var httpsTrigger, eventTrigger map[string]any
+		var eventTriggerResource string
 		switch f.Trigger.(type) {
 		case *functionspb.CloudFunction_HttpsTrigger:
 			pbHttpsTrigger := f.GetHttpsTrigger()
@@ -147,6 +149,7 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			}
 		case *functionspb.CloudFunction_EventTrigger:
 			pbEventTrigger := f.GetEventTrigger()
+			eventTriggerResource = pbEventTrigger.Resource
 			eventTrigger, err = convert.JsonToDict(mqlEventTrigger{
 				EventType:     pbEventTrigger.EventType,
 				Resource:      pbEventTrigger.Resource,
@@ -200,14 +203,55 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 		mqlFunc := mqlCloudFuncs.(*mqlGcpProjectCloudFunction)
 		mqlFunc.cacheKmsKeyName = f.KmsKeyName
 		mqlFunc.cacheBuildServiceAccount = f.BuildServiceAccount
+		mqlFunc.cacheEventTriggerResource = eventTriggerResource
 		cloudFunctions = append(cloudFunctions, mqlCloudFuncs)
 	}
 	return cloudFunctions, nil
 }
 
 type mqlGcpProjectCloudFunctionInternal struct {
-	cacheKmsKeyName          string
-	cacheBuildServiceAccount string
+	cacheKmsKeyName           string
+	cacheBuildServiceAccount  string
+	cacheEventTriggerResource string
+}
+
+func (g *mqlGcpProjectCloudFunction) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
+func (g *mqlGcpProjectCloudFunction) dockerRepositoryRef() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+	if g.DockerRepository.Error != nil {
+		return nil, g.DockerRepository.Error
+	}
+	project, location, repo := artifactRegistryRepoFromPath(g.DockerRepository.Data)
+	ref, err := resolveArtifactRegistryRepoRef(g.MqlRuntime, project, location, repo)
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		g.DockerRepositoryRef.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
+}
+
+func (g *mqlGcpProjectCloudFunction) eventTriggerTopic() (*mqlGcpProjectPubsubServiceTopic, error) {
+	resource := g.cacheEventTriggerResource
+	if !strings.Contains(resource, "/topics/") {
+		g.EventTriggerTopic.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	projectId := projectFromResourceName(resource)
+	if projectId == "" && g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
+		"name":      llx.StringData(parseResourceName(resource)),
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectPubsubServiceTopic), nil
 }
 
 func (g *mqlGcpProjectCloudFunction) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -160,6 +160,10 @@ func (g *mqlGcpProjectCloudFunctionV2) kmsKey() (*mqlGcpProjectKmsServiceKeyring
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
+func (g *mqlGcpProjectCloudFunctionV2) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func (g *mqlGcpProjectCloudFunctionV2) iamPolicy() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
@@ -268,6 +272,21 @@ func (g *mqlGcpProjectCloudFunctionV2BuildConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProjectCloudFunctionV2BuildConfig) dockerRepositoryRef() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+	if g.DockerRepository.Error != nil {
+		return nil, g.DockerRepository.Error
+	}
+	project, location, repo := artifactRegistryRepoFromPath(g.DockerRepository.Data)
+	ref, err := resolveArtifactRegistryRepoRef(g.MqlRuntime, project, location, repo)
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		g.DockerRepositoryRef.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
+}
+
 func fnV2ServiceConfig(runtime *plugin.Runtime, parentName string, projectId string, cfg *functionspb.ServiceConfig) (*mqlGcpProjectCloudFunctionV2ServiceConfig, error) {
 	if cfg == nil {
 		return nil, nil
@@ -330,6 +349,30 @@ func fnV2ServiceConfig(runtime *plugin.Runtime, parentName string, projectId str
 
 func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) serviceRef() (*mqlGcpProjectCloudRunServiceService, error) {
+	if g.Service.Error != nil {
+		return nil, g.Service.Error
+	}
+	service := g.Service.Data
+	if service == "" {
+		g.ServiceRef.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	projectId := parseProjectFromPath(service)
+	if projectId == "" {
+		projectId = g.cacheProjectId
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.cloudRunService.service", map[string]*llx.RawData{
+		"name":      llx.StringData(parseResourceName(service)),
+		"region":    llx.StringData(parseLocationFromPath(service)),
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectCloudRunServiceService), nil
 }
 
 type mqlGcpProjectCloudFunctionV2ServiceConfigInternal struct {

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -146,6 +146,18 @@ func initGcpProjectCloudRunServiceService(runtime *plugin.Runtime, args map[stri
 	return nil, nil, fmt.Errorf("cloud run service %q not found", nameVal)
 }
 
+type mqlGcpProjectCloudRunServiceServiceInternal struct {
+	cacheEncryptionKey string
+}
+
+func (g *mqlGcpProjectCloudRunServiceService) encryptionKeyRef() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.EncryptionKeyRef, g.cacheEncryptionKey)
+}
+
+func (g *mqlGcpProjectCloudRunServiceService) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels(), g.GetAnnotations())
+}
+
 func (g *mqlGcpProjectCloudRunServiceJob) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -199,12 +211,39 @@ func initGcpProjectCloudRunServiceJob(runtime *plugin.Runtime, args map[string]*
 	return nil, nil, fmt.Errorf("cloud run job %q not found", nameVal)
 }
 
+type mqlGcpProjectCloudRunServiceJobInternal struct {
+	cacheEncryptionKey string
+}
+
+func (g *mqlGcpProjectCloudRunServiceJob) encryptionKeyRef() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.EncryptionKeyRef, g.cacheEncryptionKey)
+}
+
+func (g *mqlGcpProjectCloudRunServiceJob) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels(), g.GetAnnotations())
+}
+
 func (g *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
 func (g *mqlGcpProjectCloudRunServiceContainer) id() (string, error) {
 	return g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectCloudRunServiceContainer) imageRepository() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+	if g.Image.Error != nil {
+		return nil, g.Image.Error
+	}
+	project, location, repo := artifactRegistryRepoFromImage(g.Image.Data)
+	ref, err := resolveArtifactRegistryRepoRef(g.MqlRuntime, project, location, repo)
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		g.ImageRepository.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
 }
 
 func (g *mqlGcpProjectCloudRunServiceContainerProbe) id() (string, error) {
@@ -529,6 +568,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 				if err != nil {
 					log.Error().Err(err).Send()
 				}
+				mqlS.(*mqlGcpProjectCloudRunServiceService).cacheEncryptionKey = s.GetTemplate().GetEncryptionKey()
 				mux.Lock()
 				services = append(services, mqlS)
 				mux.Unlock()
@@ -834,6 +874,7 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 					log.Error().Err(err).Send()
 					return
 				}
+				mqlJob.(*mqlGcpProjectCloudRunServiceJob).cacheEncryptionKey = j.GetTemplate().GetTemplate().GetEncryptionKey()
 				mux.Lock()
 				jobs = append(jobs, mqlJob)
 				mux.Unlock()

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -116,6 +116,62 @@ func projectRefById(runtime *plugin.Runtime, projectId string) (*mqlGcpProject, 
 	return res.(*mqlGcpProject), nil
 }
 
+// artifactRegistryRepoFromPath parses an Artifact Registry repository resource
+// name of the form "projects/{project}/locations/{location}/repositories/{repo}"
+// and returns its project, location, and repository components. Any component
+// not present in the path is returned empty.
+func artifactRegistryRepoFromPath(path string) (project, location, repo string) {
+	parts := strings.Split(path, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		switch parts[i] {
+		case "projects":
+			project = parts[i+1]
+		case "locations":
+			location = parts[i+1]
+		case "repositories":
+			repo = parts[i+1]
+		}
+	}
+	return project, location, repo
+}
+
+// artifactRegistryRepoFromImage parses an Artifact Registry container image URL
+// of the form "{location}-docker.pkg.dev/{project}/{repo}/{image}[:tag|@digest]"
+// and returns its project, location, and repository components. It returns empty
+// strings for images that are not hosted in Artifact Registry (for example
+// Container Registry "gcr.io" images or external registries).
+func artifactRegistryRepoFromImage(image string) (project, location, repo string) {
+	s := strings.TrimPrefix(image, "https://")
+	parts := strings.Split(s, "/")
+	if len(parts) < 3 {
+		return "", "", ""
+	}
+	host := parts[0]
+	const suffix = "-docker.pkg.dev"
+	if !strings.HasSuffix(host, suffix) {
+		return "", "", ""
+	}
+	return parts[1], strings.TrimSuffix(host, suffix), parts[2]
+}
+
+// resolveArtifactRegistryRepoRef resolves the typed Artifact Registry repository
+// resource for a given project, location, and repository name. It returns nil
+// when any component is empty so callers can mark the field null.
+func resolveArtifactRegistryRepoRef(runtime *plugin.Runtime, project, location, repo string) (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+	if project == "" || location == "" || repo == "" {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "gcp.project.artifactRegistryService.repository", map[string]*llx.RawData{
+		"name":      llx.StringData(repo),
+		"location":  llx.StringData(location),
+		"projectId": llx.StringData(project),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectArtifactRegistryServiceRepository), nil
+}
+
 // parentFolderFromId resolves the typed folder for a Cloud Resource Manager
 // parent reference. It returns nil when the parent is not a folder (for example
 // an organization or an empty reference), leaving the caller to mark the field

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -4122,6 +4122,12 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   databaseEncryptionState string
   // Cloud KMS key used for etcd encryption
   databaseEncryptionKey() gcp.project.kmsService.keyring.cryptokey
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
   // Configuration for Shielded Nodes feature
   shieldedNodesConfig dict
   // Whether Shielded Nodes is enabled cluster-wide
@@ -4518,6 +4524,8 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   kubeletConfig gcp.project.gkeService.cluster.nodepool.config.kubeletConfig
   // The Customer Managed Encryption Key used to encrypt the boot disk attached to each node
   bootDiskKmsKey string
+  // Customer-managed Cloud KMS key used to encrypt each node's boot disk
+  bootDiskKmsKeyRef() gcp.project.kmsService.keyring.cryptokey
   // Encryption mode for node Local SSDs (STANDARD_ENCRYPTION uses Google-managed keys; EPHEMERAL_KEY_ENCRYPTION uses per-boot ephemeral keys)
   localSsdEncryptionMode string
   // Google Container File System (image streaming) configuration
@@ -5846,6 +5854,11 @@ private gcp.project.cloudFunction @defaults("name") {
   httpsTrigger dict
   // Source that fires events in response to a condition in another service
   eventTrigger dict
+  // Pub/Sub topic that fires this function's event trigger
+  //
+  // Resolves the Pub/Sub topic when the event trigger's resource is a Pub/Sub
+  // topic. Empty for triggers backed by other event sources.
+  eventTriggerTopic() gcp.project.pubsubService.topic
   // Status of the function deployment
   status string
   // Name of the function (as defined in source code) that is executed
@@ -5903,13 +5916,24 @@ private gcp.project.cloudFunction @defaults("name") {
   // Secret volumes
   secretVolumes []dict
   // User-managed repository created in Artifact Registry
-  dockerRepository string
+  //
+  // Deprecated in favor of `dockerRepositoryRef`, which resolves the Artifact
+  // Registry repository resource.
+  dockerRepository @maturity("deprecated") string
+  // Artifact Registry repository that stores the function's built image
+  dockerRepositoryRef() gcp.project.artifactRegistryService.repository
   // Docker registry to use for this deployment
   dockerRegistry string
   // IAM policy bindings controlling who can invoke and manage the function
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the IAM policy grants an invoker role to allUsers or allAuthenticatedUsers, making the function callable without authentication
   allowsUnauthenticated() bool
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Cloud Function (v2 / 2nd gen)
@@ -5953,6 +5977,12 @@ private gcp.project.cloudFunctionV2 @defaults("name state environment") {
   createTime time
   // Last update time
   updateTime time
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Cloud Function v2 build configuration
@@ -5970,7 +6000,12 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   // Build environment variables
   environmentVariables map[string]string
   // User-managed repository in Artifact Registry for storing built images
-  dockerRepository string
+  //
+  // Deprecated in favor of `dockerRepositoryRef`, which resolves the Artifact
+  // Registry repository resource.
+  dockerRepository @maturity("deprecated") string
+  // Artifact Registry repository that stores the function's built images
+  dockerRepositoryRef() gcp.project.artifactRegistryService.repository
   // Service account to use for the build
   //
   // Deprecated in favor of `serviceAccountRef`, which resolves the service account resource.
@@ -5994,6 +6029,8 @@ private gcp.project.cloudFunctionV2.serviceConfig @defaults("service timeoutSeco
   id string
   // Cloud Run service resource name
   service string
+  // Cloud Run service that backs the function
+  serviceRef() gcp.project.cloudRunService.service
   // Function execution timeout in seconds
   timeoutSeconds int
   // Amount of memory available (e.g. "256M", "1Gi")
@@ -6746,6 +6783,14 @@ private gcp.project.cloudRunService.service @defaults("name") {
   iamPolicy() []gcp.resourcemanager.binding
   // Whether the service is reachable from the public internet: ingress allows all traffic AND IAM grants invoke to allUsers or allAuthenticatedUsers
   publicInvocable() bool
+  // Customer-managed Cloud KMS key used to encrypt the service's container image
+  encryptionKeyRef() gcp.project.kmsService.keyring.cryptokey
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Run service revision template
@@ -6795,6 +6840,12 @@ private gcp.project.cloudRunService.container @defaults("name image") {
   name string
   // URL of the container image in Google Container Registry or Google Artifact Registry
   image string
+  // Artifact Registry repository that stores the container image
+  //
+  // Resolves the repository when the image is hosted in Artifact Registry
+  // (a `*-docker.pkg.dev` image URL). Empty for images stored elsewhere,
+  // such as Container Registry or an external registry.
+  imageRepository() gcp.project.artifactRegistryService.repository
   // Entrypoint array
   command []string
   // Arguments to the entrypoint
@@ -6934,6 +6985,14 @@ private gcp.project.cloudRunService.job {
   etag string
   // IAM policy bindings for this Cloud Run job
   iamPolicy() []gcp.resourcemanager.binding
+  // Customer-managed Cloud KMS key used to encrypt the job's container image
+  encryptionKeyRef() gcp.project.kmsService.keyring.cryptokey
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Run job execution template
@@ -10992,6 +11051,12 @@ private gcp.project.artifactRegistryService.repository @defaults("name format lo
   public() bool
   // Packages stored in the repository
   packages() []gcp.project.artifactRegistryService.repository.package
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Artifact Registry package

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -6457,6 +6457,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.databaseEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetDatabaseEncryptionKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
+	"gcp.project.gkeService.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.gkeService.cluster.shieldedNodesConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetShieldedNodesConfig()).ToDataRes(types.Dict)
 	},
@@ -6891,6 +6894,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetBootDiskKmsKey()).ToDataRes(types.String)
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKeyRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetBootDiskKmsKeyRef()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.localSsdEncryptionMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetLocalSsdEncryptionMode()).ToDataRes(types.String)
@@ -8038,6 +8044,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.eventTrigger": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetEventTrigger()).ToDataRes(types.Dict)
 	},
+	"gcp.project.cloudFunction.eventTriggerTopic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetEventTriggerTopic()).ToDataRes(types.Resource("gcp.project.pubsubService.topic"))
+	},
 	"gcp.project.cloudFunction.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetStatus()).ToDataRes(types.String)
 	},
@@ -8122,6 +8131,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.dockerRepository": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetDockerRepository()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudFunction.dockerRepositoryRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetDockerRepositoryRef()).ToDataRes(types.Resource("gcp.project.artifactRegistryService.repository"))
+	},
 	"gcp.project.cloudFunction.dockerRegistry": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetDockerRegistry()).ToDataRes(types.String)
 	},
@@ -8130,6 +8142,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunction.allowsUnauthenticated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetAllowsUnauthenticated()).ToDataRes(types.Bool)
+	},
+	"gcp.project.cloudFunction.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudFunctionV2.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2).GetProjectId()).ToDataRes(types.String)
@@ -8179,6 +8194,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunctionV2.updateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2).GetUpdateTime()).ToDataRes(types.Time)
 	},
+	"gcp.project.cloudFunctionV2.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.cloudFunctionV2.buildConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetId()).ToDataRes(types.String)
 	},
@@ -8200,6 +8218,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunctionV2.buildConfig.dockerRepository": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetDockerRepository()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetDockerRepositoryRef()).ToDataRes(types.Resource("gcp.project.artifactRegistryService.repository"))
+	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccount()).ToDataRes(types.String)
 	},
@@ -8220,6 +8241,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).GetService()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudFunctionV2.serviceConfig.serviceRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).GetServiceRef()).ToDataRes(types.Resource("gcp.project.cloudRunService.service"))
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.timeoutSeconds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).GetTimeoutSeconds()).ToDataRes(types.Int)
@@ -9004,6 +9028,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudRunService.service.publicInvocable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceService).GetPublicInvocable()).ToDataRes(types.Bool)
 	},
+	"gcp.project.cloudRunService.service.encryptionKeyRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetEncryptionKeyRef()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
+	"gcp.project.cloudRunService.service.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.cloudRunService.service.revisionTemplate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetId()).ToDataRes(types.String)
 	},
@@ -9060,6 +9090,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.container.image": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceContainer).GetImage()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.container.imageRepository": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceContainer).GetImageRepository()).ToDataRes(types.Resource("gcp.project.artifactRegistryService.repository"))
 	},
 	"gcp.project.cloudRunService.container.command": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceContainer).GetCommand()).ToDataRes(types.Array(types.String))
@@ -9213,6 +9246,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.job.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJob).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.cloudRunService.job.encryptionKeyRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceJob).GetEncryptionKeyRef()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
+	"gcp.project.cloudRunService.job.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceJob).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplate).GetId()).ToDataRes(types.String)
@@ -13284,6 +13323,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.artifactRegistryService.repository.packages": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectArtifactRegistryServiceRepository).GetPackages()).ToDataRes(types.Array(types.Resource("gcp.project.artifactRegistryService.repository.package")))
+	},
+	"gcp.project.artifactRegistryService.repository.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectArtifactRegistryServiceRepository).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.artifactRegistryService.repository.package.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectArtifactRegistryServiceRepositoryPackage).GetProjectId()).ToDataRes(types.String)
@@ -22978,6 +23020,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).DatabaseEncryptionKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.shieldedNodesConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).ShieldedNodesConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -23608,6 +23654,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).BootDiskKmsKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKeyRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).BootDiskKmsKeyRef, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.localSsdEncryptionMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25338,6 +25388,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).EventTrigger, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunction.eventTriggerTopic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).EventTriggerTopic, ok = plugin.RawToTValue[*mqlGcpProjectPubsubServiceTopic](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunction.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -25450,6 +25504,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).DockerRepository, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunction.dockerRepositoryRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).DockerRepositoryRef, ok = plugin.RawToTValue[*mqlGcpProjectArtifactRegistryServiceRepository](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunction.dockerRegistry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).DockerRegistry, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -25460,6 +25518,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunction.allowsUnauthenticated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).AllowsUnauthenticated, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunction.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25530,6 +25592,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunctionV2).UpdateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunctionV2.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunctionV2.buildConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).__id, ok = v.Value.(string)
 		return
@@ -25562,6 +25628,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).DockerRepository, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).DockerRepositoryRef, ok = plugin.RawToTValue[*mqlGcpProjectArtifactRegistryServiceRepository](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -25592,6 +25662,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.service": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).Service, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.serviceConfig.serviceRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2ServiceConfig).ServiceRef, ok = plugin.RawToTValue[*mqlGcpProjectCloudRunServiceService](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.serviceConfig.timeoutSeconds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26734,6 +26808,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudRunServiceService).PublicInvocable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudRunService.service.encryptionKeyRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).EncryptionKeyRef, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.service.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudRunService.service.revisionTemplate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).__id, ok = v.Value.(string)
 		return
@@ -26816,6 +26898,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.container.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceContainer).Image, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.container.imageRepository": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceContainer).ImageRepository, ok = plugin.RawToTValue[*mqlGcpProjectArtifactRegistryServiceRepository](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.container.command": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27036,6 +27122,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.job.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceJob).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.job.encryptionKeyRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceJob).EncryptionKeyRef, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.job.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceJob).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32972,6 +33066,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.artifactRegistryService.repository.packages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectArtifactRegistryServiceRepository).Packages, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.artifactRegistryService.repository.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectArtifactRegistryServiceRepository).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.artifactRegistryService.repository.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52149,6 +52247,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	DatabaseEncryption                       plugin.TValue[any]
 	DatabaseEncryptionState                  plugin.TValue[string]
 	DatabaseEncryptionKey                    plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	ManagedBy                                plugin.TValue[string]
 	ShieldedNodesConfig                      plugin.TValue[any]
 	ShieldedNodesEnabled                     plugin.TValue[bool]
 	CostManagementConfig                     plugin.TValue[any]
@@ -52501,6 +52600,12 @@ func (c *mqlGcpProjectGkeServiceCluster) GetDatabaseEncryptionKey() *plugin.TVal
 		}
 
 		return c.databaseEncryptionKey()
+	})
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -53684,6 +53789,7 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfig struct {
 	WindowsNodeConfig         plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig]
 	KubeletConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig]
 	BootDiskKmsKey            plugin.TValue[string]
+	BootDiskKmsKeyRef         plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	LocalSsdEncryptionMode    plugin.TValue[string]
 	GcfsConfig                plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGcfsConfig]
 	GcfsEnabled               plugin.TValue[bool]
@@ -53854,6 +53960,22 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetKubeletConfig() *plugi
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetBootDiskKmsKey() *plugin.TValue[string] {
 	return &c.BootDiskKmsKey
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetBootDiskKmsKeyRef() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.BootDiskKmsKeyRef, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.gkeService.cluster.nodepool.config", c.__id, "bootDiskKmsKeyRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.bootDiskKmsKeyRef()
+	})
 }
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetLocalSsdEncryptionMode() *plugin.TValue[string] {
@@ -58471,6 +58593,7 @@ type mqlGcpProjectCloudFunction struct {
 	SourceUploadUrl       plugin.TValue[string]
 	HttpsTrigger          plugin.TValue[any]
 	EventTrigger          plugin.TValue[any]
+	EventTriggerTopic     plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	Status                plugin.TValue[string]
 	EntryPoint            plugin.TValue[string]
 	Runtime               plugin.TValue[string]
@@ -58499,9 +58622,11 @@ type mqlGcpProjectCloudFunction struct {
 	SecretEnvVars         plugin.TValue[map[string]any]
 	SecretVolumes         plugin.TValue[[]any]
 	DockerRepository      plugin.TValue[string]
+	DockerRepositoryRef   plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository]
 	DockerRegistry        plugin.TValue[string]
 	IamPolicy             plugin.TValue[[]any]
 	AllowsUnauthenticated plugin.TValue[bool]
+	ManagedBy             plugin.TValue[string]
 }
 
 // createGcpProjectCloudFunction creates a new instance of this resource
@@ -58575,6 +58700,22 @@ func (c *mqlGcpProjectCloudFunction) GetHttpsTrigger() *plugin.TValue[any] {
 
 func (c *mqlGcpProjectCloudFunction) GetEventTrigger() *plugin.TValue[any] {
 	return &c.EventTrigger
+}
+
+func (c *mqlGcpProjectCloudFunction) GetEventTriggerTopic() *plugin.TValue[*mqlGcpProjectPubsubServiceTopic] {
+	return plugin.GetOrCompute[*mqlGcpProjectPubsubServiceTopic](&c.EventTriggerTopic, func() (*mqlGcpProjectPubsubServiceTopic, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "eventTriggerTopic")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectPubsubServiceTopic), nil
+			}
+		}
+
+		return c.eventTriggerTopic()
+	})
 }
 
 func (c *mqlGcpProjectCloudFunction) GetStatus() *plugin.TValue[string] {
@@ -58737,6 +58878,22 @@ func (c *mqlGcpProjectCloudFunction) GetDockerRepository() *plugin.TValue[string
 	return &c.DockerRepository
 }
 
+func (c *mqlGcpProjectCloudFunction) GetDockerRepositoryRef() *plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository] {
+	return plugin.GetOrCompute[*mqlGcpProjectArtifactRegistryServiceRepository](&c.DockerRepositoryRef, func() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "dockerRepositoryRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectArtifactRegistryServiceRepository), nil
+			}
+		}
+
+		return c.dockerRepositoryRef()
+	})
+}
+
 func (c *mqlGcpProjectCloudFunction) GetDockerRegistry() *plugin.TValue[string] {
 	return &c.DockerRegistry
 }
@@ -58763,6 +58920,12 @@ func (c *mqlGcpProjectCloudFunction) GetAllowsUnauthenticated() *plugin.TValue[b
 	})
 }
 
+func (c *mqlGcpProjectCloudFunction) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectCloudFunctionV2 for the gcp.project.cloudFunctionV2 resource
 type mqlGcpProjectCloudFunctionV2 struct {
 	MqlRuntime *plugin.Runtime
@@ -58784,6 +58947,7 @@ type mqlGcpProjectCloudFunctionV2 struct {
 	EventTrigger          plugin.TValue[*mqlGcpProjectCloudFunctionV2EventTrigger]
 	CreateTime            plugin.TValue[*time.Time]
 	UpdateTime            plugin.TValue[*time.Time]
+	ManagedBy             plugin.TValue[string]
 }
 
 // createGcpProjectCloudFunctionV2 creates a new instance of this resource
@@ -58913,6 +59077,12 @@ func (c *mqlGcpProjectCloudFunctionV2) GetUpdateTime() *plugin.TValue[*time.Time
 	return &c.UpdateTime
 }
 
+func (c *mqlGcpProjectCloudFunctionV2) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectCloudFunctionV2BuildConfig for the gcp.project.cloudFunctionV2.buildConfig resource
 type mqlGcpProjectCloudFunctionV2BuildConfig struct {
 	MqlRuntime *plugin.Runtime
@@ -58925,6 +59095,7 @@ type mqlGcpProjectCloudFunctionV2BuildConfig struct {
 	BuildWorkerPool      plugin.TValue[string]
 	EnvironmentVariables plugin.TValue[map[string]any]
 	DockerRepository     plugin.TValue[string]
+	DockerRepositoryRef  plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository]
 	ServiceAccount       plugin.TValue[string]
 	ServiceAccountRef    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Build                plugin.TValue[string]
@@ -58997,6 +59168,22 @@ func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepository() *plugin.
 	return &c.DockerRepository
 }
 
+func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepositoryRef() *plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository] {
+	return plugin.GetOrCompute[*mqlGcpProjectArtifactRegistryServiceRepository](&c.DockerRepositoryRef, func() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunctionV2.buildConfig", c.__id, "dockerRepositoryRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectArtifactRegistryServiceRepository), nil
+			}
+		}
+
+		return c.dockerRepositoryRef()
+	})
+}
+
 func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccount() *plugin.TValue[string] {
 	return &c.ServiceAccount
 }
@@ -59036,6 +59223,7 @@ type mqlGcpProjectCloudFunctionV2ServiceConfig struct {
 	mqlGcpProjectCloudFunctionV2ServiceConfigInternal
 	Id                         plugin.TValue[string]
 	Service                    plugin.TValue[string]
+	ServiceRef                 plugin.TValue[*mqlGcpProjectCloudRunServiceService]
 	TimeoutSeconds             plugin.TValue[int64]
 	AvailableMemory            plugin.TValue[string]
 	AvailableCpu               plugin.TValue[string]
@@ -59095,6 +59283,22 @@ func (c *mqlGcpProjectCloudFunctionV2ServiceConfig) GetId() *plugin.TValue[strin
 
 func (c *mqlGcpProjectCloudFunctionV2ServiceConfig) GetService() *plugin.TValue[string] {
 	return &c.Service
+}
+
+func (c *mqlGcpProjectCloudFunctionV2ServiceConfig) GetServiceRef() *plugin.TValue[*mqlGcpProjectCloudRunServiceService] {
+	return plugin.GetOrCompute[*mqlGcpProjectCloudRunServiceService](&c.ServiceRef, func() (*mqlGcpProjectCloudRunServiceService, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunctionV2.serviceConfig", c.__id, "serviceRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectCloudRunServiceService), nil
+			}
+		}
+
+		return c.serviceRef()
+	})
 }
 
 func (c *mqlGcpProjectCloudFunctionV2ServiceConfig) GetTimeoutSeconds() *plugin.TValue[int64] {
@@ -61438,7 +61642,7 @@ func (c *mqlGcpProjectCloudRunServiceOperation) GetDone() *plugin.TValue[bool] {
 type mqlGcpProjectCloudRunServiceService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudRunServiceServiceInternal it will be used here
+	mqlGcpProjectCloudRunServiceServiceInternal
 	Id                                         plugin.TValue[string]
 	ProjectId                                  plugin.TValue[string]
 	Region                                     plugin.TValue[string]
@@ -61477,6 +61681,8 @@ type mqlGcpProjectCloudRunServiceService struct {
 	ClientVersion                              plugin.TValue[string]
 	IamPolicy                                  plugin.TValue[[]any]
 	PublicInvocable                            plugin.TValue[bool]
+	EncryptionKeyRef                           plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	ManagedBy                                  plugin.TValue[string]
 }
 
 // createGcpProjectCloudRunServiceService creates a new instance of this resource
@@ -61682,6 +61888,28 @@ func (c *mqlGcpProjectCloudRunServiceService) GetPublicInvocable() *plugin.TValu
 	})
 }
 
+func (c *mqlGcpProjectCloudRunServiceService) GetEncryptionKeyRef() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.EncryptionKeyRef, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudRunService.service", c.__id, "encryptionKeyRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.encryptionKeyRef()
+	})
+}
+
+func (c *mqlGcpProjectCloudRunServiceService) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectCloudRunServiceServiceRevisionTemplate for the gcp.project.cloudRunService.service.revisionTemplate resource
 type mqlGcpProjectCloudRunServiceServiceRevisionTemplate struct {
 	MqlRuntime *plugin.Runtime
@@ -61823,18 +62051,19 @@ type mqlGcpProjectCloudRunServiceContainer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectCloudRunServiceContainerInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Image         plugin.TValue[string]
-	Command       plugin.TValue[[]any]
-	Args          plugin.TValue[[]any]
-	Env           plugin.TValue[[]any]
-	Resources     plugin.TValue[any]
-	Ports         plugin.TValue[[]any]
-	VolumeMounts  plugin.TValue[[]any]
-	WorkingDir    plugin.TValue[string]
-	LivenessProbe plugin.TValue[*mqlGcpProjectCloudRunServiceContainerProbe]
-	StartupProbe  plugin.TValue[*mqlGcpProjectCloudRunServiceContainerProbe]
+	Id              plugin.TValue[string]
+	Name            plugin.TValue[string]
+	Image           plugin.TValue[string]
+	ImageRepository plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository]
+	Command         plugin.TValue[[]any]
+	Args            plugin.TValue[[]any]
+	Env             plugin.TValue[[]any]
+	Resources       plugin.TValue[any]
+	Ports           plugin.TValue[[]any]
+	VolumeMounts    plugin.TValue[[]any]
+	WorkingDir      plugin.TValue[string]
+	LivenessProbe   plugin.TValue[*mqlGcpProjectCloudRunServiceContainerProbe]
+	StartupProbe    plugin.TValue[*mqlGcpProjectCloudRunServiceContainerProbe]
 }
 
 // createGcpProjectCloudRunServiceContainer creates a new instance of this resource
@@ -61884,6 +62113,22 @@ func (c *mqlGcpProjectCloudRunServiceContainer) GetName() *plugin.TValue[string]
 
 func (c *mqlGcpProjectCloudRunServiceContainer) GetImage() *plugin.TValue[string] {
 	return &c.Image
+}
+
+func (c *mqlGcpProjectCloudRunServiceContainer) GetImageRepository() *plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository] {
+	return plugin.GetOrCompute[*mqlGcpProjectArtifactRegistryServiceRepository](&c.ImageRepository, func() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudRunService.container", c.__id, "imageRepository")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectArtifactRegistryServiceRepository), nil
+			}
+		}
+
+		return c.imageRepository()
+	})
 }
 
 func (c *mqlGcpProjectCloudRunServiceContainer) GetCommand() *plugin.TValue[[]any] {
@@ -62133,7 +62378,7 @@ func (c *mqlGcpProjectCloudRunServiceCondition) GetSeverity() *plugin.TValue[str
 type mqlGcpProjectCloudRunServiceJob struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudRunServiceJobInternal it will be used here
+	mqlGcpProjectCloudRunServiceJobInternal
 	Id                 plugin.TValue[string]
 	ProjectId          plugin.TValue[string]
 	Region             plugin.TValue[string]
@@ -62160,6 +62405,8 @@ type mqlGcpProjectCloudRunServiceJob struct {
 	Uid                plugin.TValue[string]
 	Etag               plugin.TValue[string]
 	IamPolicy          plugin.TValue[[]any]
+	EncryptionKeyRef   plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	ManagedBy          plugin.TValue[string]
 }
 
 // createGcpProjectCloudRunServiceJob creates a new instance of this resource
@@ -62312,6 +62559,28 @@ func (c *mqlGcpProjectCloudRunServiceJob) GetIamPolicy() *plugin.TValue[[]any] {
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectCloudRunServiceJob) GetEncryptionKeyRef() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.EncryptionKeyRef, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudRunService.job", c.__id, "encryptionKeyRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.encryptionKeyRef()
+	})
+}
+
+func (c *mqlGcpProjectCloudRunServiceJob) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -76088,6 +76357,7 @@ type mqlGcpProjectArtifactRegistryServiceRepository struct {
 	IamPolicy                   plugin.TValue[[]any]
 	Public                      plugin.TValue[bool]
 	Packages                    plugin.TValue[[]any]
+	ManagedBy                   plugin.TValue[string]
 }
 
 // createGcpProjectArtifactRegistryServiceRepository creates a new instance of this resource
@@ -76258,6 +76528,12 @@ func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetPackages() *plugin.T
 		}
 
 		return c.packages()
+	})
+}
+
+func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -446,6 +446,7 @@ gcp.project.artifactRegistryService.repository.kmsKey 13.19.2
 gcp.project.artifactRegistryService.repository.kmsKeyName 11.6.1
 gcp.project.artifactRegistryService.repository.labels 11.6.1
 gcp.project.artifactRegistryService.repository.location 11.6.1
+gcp.project.artifactRegistryService.repository.managedBy 13.27.2
 gcp.project.artifactRegistryService.repository.mode 11.6.1
 gcp.project.artifactRegistryService.repository.modeConfig 11.6.1
 gcp.project.artifactRegistryService.repository.modeConfig.disableUpstreamValidation 11.6.1
@@ -1129,10 +1130,12 @@ gcp.project.cloudFunction.buildWorkerPool 9.0.0
 gcp.project.cloudFunction.description 9.0.0
 gcp.project.cloudFunction.dockerRegistry 9.0.0
 gcp.project.cloudFunction.dockerRepository 9.0.0
+gcp.project.cloudFunction.dockerRepositoryRef 13.27.2
 gcp.project.cloudFunction.egressSettings 9.0.0
 gcp.project.cloudFunction.entryPoint 9.0.0
 gcp.project.cloudFunction.envVars 9.0.0
 gcp.project.cloudFunction.eventTrigger 9.0.0
+gcp.project.cloudFunction.eventTriggerTopic 13.27.2
 gcp.project.cloudFunction.httpsTrigger 9.0.0
 gcp.project.cloudFunction.iamPolicy 13.19.2
 gcp.project.cloudFunction.ingressSettings 9.0.0
@@ -1140,6 +1143,7 @@ gcp.project.cloudFunction.kmsKey 13.2.3
 gcp.project.cloudFunction.kmsKeyName 9.0.0
 gcp.project.cloudFunction.labels 9.0.0
 gcp.project.cloudFunction.location 11.2.1
+gcp.project.cloudFunction.managedBy 13.27.2
 gcp.project.cloudFunction.maxInstances 9.0.0
 gcp.project.cloudFunction.minInstances 9.0.0
 gcp.project.cloudFunction.name 9.0.0
@@ -1165,6 +1169,7 @@ gcp.project.cloudFunctionV2.buildConfig 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.build 13.25.2
 gcp.project.cloudFunctionV2.buildConfig.buildWorkerPool 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.dockerRepository 13.7.2
+gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef 13.27.2
 gcp.project.cloudFunctionV2.buildConfig.entryPoint 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.environmentVariables 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.gitUri 13.25.2
@@ -1193,6 +1198,7 @@ gcp.project.cloudFunctionV2.iamPolicy 13.19.2
 gcp.project.cloudFunctionV2.kmsKey 13.7.2
 gcp.project.cloudFunctionV2.kmsKeyName 13.7.2
 gcp.project.cloudFunctionV2.labels 13.7.2
+gcp.project.cloudFunctionV2.managedBy 13.27.2
 gcp.project.cloudFunctionV2.name 13.7.2
 gcp.project.cloudFunctionV2.projectId 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig 13.7.2
@@ -1209,6 +1215,7 @@ gcp.project.cloudFunctionV2.serviceConfig.secretEnvironmentVariables 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig.secretVolumes 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig.service 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig.serviceAccountEmail 13.7.2
+gcp.project.cloudFunctionV2.serviceConfig.serviceRef 13.27.2
 gcp.project.cloudFunctionV2.serviceConfig.timeoutSeconds 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig.vpcConnector 13.7.2
 gcp.project.cloudFunctionV2.serviceConfig.vpcConnectorEgressSettings 13.7.2
@@ -1232,6 +1239,7 @@ gcp.project.cloudRunService.container.command 9.0.0
 gcp.project.cloudRunService.container.env 9.0.0
 gcp.project.cloudRunService.container.id 9.0.0
 gcp.project.cloudRunService.container.image 9.0.0
+gcp.project.cloudRunService.container.imageRepository 13.27.2
 gcp.project.cloudRunService.container.livenessProbe 9.0.0
 gcp.project.cloudRunService.container.name 9.0.0
 gcp.project.cloudRunService.container.ports 9.0.0
@@ -1255,6 +1263,7 @@ gcp.project.cloudRunService.job.conditions 9.0.0
 gcp.project.cloudRunService.job.created 9.0.0
 gcp.project.cloudRunService.job.creator 9.0.0
 gcp.project.cloudRunService.job.deleted 9.0.0
+gcp.project.cloudRunService.job.encryptionKeyRef 13.27.2
 gcp.project.cloudRunService.job.etag 13.1.2
 gcp.project.cloudRunService.job.executionCount 9.0.0
 gcp.project.cloudRunService.job.executionTemplate 9.0.0
@@ -1284,6 +1293,7 @@ gcp.project.cloudRunService.job.id 9.0.0
 gcp.project.cloudRunService.job.labels 9.0.0
 gcp.project.cloudRunService.job.lastModifier 9.0.0
 gcp.project.cloudRunService.job.launchStage 9.0.0
+gcp.project.cloudRunService.job.managedBy 13.27.2
 gcp.project.cloudRunService.job.name 9.0.0
 gcp.project.cloudRunService.job.observedGeneration 9.0.0
 gcp.project.cloudRunService.job.projectId 9.0.0
@@ -1316,6 +1326,7 @@ gcp.project.cloudRunService.service.customAudiences 13.1.2
 gcp.project.cloudRunService.service.defaultUriDisabled 13.1.2
 gcp.project.cloudRunService.service.deleted 9.0.0
 gcp.project.cloudRunService.service.description 9.0.0
+gcp.project.cloudRunService.service.encryptionKeyRef 13.27.2
 gcp.project.cloudRunService.service.etag 13.1.2
 gcp.project.cloudRunService.service.expired 9.0.0
 gcp.project.cloudRunService.service.generation 9.0.0
@@ -1327,6 +1338,7 @@ gcp.project.cloudRunService.service.lastModifier 9.0.0
 gcp.project.cloudRunService.service.latestCreatedRevision 9.0.0
 gcp.project.cloudRunService.service.latestReadyRevision 9.0.0
 gcp.project.cloudRunService.service.launchStage 9.0.0
+gcp.project.cloudRunService.service.managedBy 13.27.2
 gcp.project.cloudRunService.service.name 9.0.0
 gcp.project.cloudRunService.service.observedGeneration 9.0.0
 gcp.project.cloudRunService.service.projectId 9.0.0
@@ -3191,6 +3203,7 @@ gcp.project.gkeService.cluster.maintenancePolicy.recurringWindowEndTime 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.recurringWindowRecurrence 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.recurringWindowStartTime 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.resourceVersion 11.6.6
+gcp.project.gkeService.cluster.managedBy 13.27.2
 gcp.project.gkeService.cluster.masterAuth 9.0.0
 gcp.project.gkeService.cluster.masterAuthorizedNetworksAllowed 13.18.1
 gcp.project.gkeService.cluster.masterAuthorizedNetworksCidrs 13.18.1
@@ -3251,6 +3264,7 @@ gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures.id 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures.threadsPerCore 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKey 9.0.0
+gcp.project.gkeService.cluster.nodepool.config.bootDiskKmsKeyRef 13.27.2
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes.enabled 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.confidentialNodes.id 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -246,6 +246,18 @@ func (g *mqlGcpProjectGkeServiceCluster) databaseEncryptionKey() (*mqlGcpProject
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
+func (g *mqlGcpProjectGkeServiceCluster) managedBy() (string, error) {
+	return managedByFromLabels(g.GetResourceLabels())
+}
+
+func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) bootDiskKmsKeyRef() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	keyName := g.GetBootDiskKmsKey()
+	if keyName.Error != nil {
+		return nil, keyName.Error
+	}
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.BootDiskKmsKeyRef, keyName.Data)
+}
+
 func (g *mqlGcpProjectGkeServiceCluster) networkPolicy() (*mqlGcpProjectGkeServiceClusterNetworkPolicy, error) {
 	if g.NetworkPolicyConfig.Error != nil {
 		return nil, g.NetworkPolicyConfig.Error


### PR DESCRIPTION
## Summary

Adds infrastructure-management provenance and typed cross-references to the GCP serverless and container subsystem. All changes are additive and non-breaking; raw scalars that are fully replaced by a typed reference are marked `@maturity("deprecated")`.

### managedBy()

A new computed `managedBy()` field derived from the provenance labels and annotations Google and IaC tools stamp on resources (`terraform`, `config-connector`, `cloud-composer`; empty when no signal). Added to:

- `gcp.project.gkeService.cluster` (from resourceLabels)
- `gcp.project.cloudRunService.service` and `.job` (labels + annotations)
- `gcp.project.cloudFunction` (v1) and `gcp.project.cloudFunctionV2` (labels)
- `gcp.project.artifactRegistryService.repository` (labels)

### Typed references

| Resource | New accessor | Resolves to | Notes |
|---|---|---|---|
| `gkeService.cluster.nodepool.config` | `bootDiskKmsKeyRef()` | KMS cryptokey | from BootDiskKmsKey (raw kept, consistent with kmsKeyName convention) |
| `cloudRunService.service` | `encryptionKeyRef()` | KMS cryptokey | from revision template EncryptionKey |
| `cloudRunService.job` | `encryptionKeyRef()` | KMS cryptokey | from task template EncryptionKey |
| `cloudRunService.container` | `imageRepository()` | Artifact Registry repo | parsed from `*-docker.pkg.dev` image URL; shared by service and job |
| `cloudFunction` (v1) | `dockerRepositoryRef()` | Artifact Registry repo | deprecates `dockerRepository` |
| `cloudFunction` (v1) | `eventTriggerTopic()` | Pub/Sub topic | when the event trigger resource is a Pub/Sub topic (parity with v2) |
| `cloudFunctionV2.buildConfig` | `dockerRepositoryRef()` | Artifact Registry repo | deprecates `dockerRepository` |
| `cloudFunctionV2.serviceConfig` | `serviceRef()` | Cloud Run service | from the backing service resource name |

### Implementation notes

- Shared `managedByFromLabels` helper (`gcp_managed_by.go`) inspects label/annotation maps in priority order.
- Shared Artifact Registry resolver + URL/path parsers in `common.go`; typed repo refs reuse the existing repository init (list-and-match by name/location/project), so no new IAM permissions are required.
- New Internal cache fields for the Cloud Run service/job encryption key and the v1 Cloud Function event-trigger resource (Pattern D).
- All singular nil returns set `StateIsNull | StateIsSet` before returning.
- New `.lr.versions` entries at 13.27.2.

### Verification

- `go build ./...` passes
- `go vet ./resources/` passes
- `make providers/build/gcp` succeeds; `gcp.permissions.json` changed only in version/timestamp metadata (no new permissions)