### PR TITLE
✨ gcp: cache/messaging provenance (managedBy + typed refs)

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -330,6 +330,8 @@ private gcp.project.redisService.instance @defaults("name") {
   network() gcp.project.computeService.network
   // Cloud IAM identity used by import / export operations to transfer data to/from Cloud Storage
   persistenceIamIdentity string
+  // Service account used by import and export operations to transfer data to and from Cloud Storage
+  persistenceServiceAccount() gcp.project.iamService.serviceAccount
   // The network connect mode of the Redis instance
   connectMode string
   // Redis AUTH is enabled or not for the instance. If set to "true" AUTH is enabled on the instance
@@ -370,6 +372,12 @@ private gcp.project.redisService.instance @defaults("name") {
   maintenanceSchedule dict
   // List of server CA certificates for the instance
   serverCaCerts []gcp.project.redisService.instance.serverCaCert
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Redis instance node information
@@ -490,6 +498,8 @@ private gcp.project.redisService.cluster.pscConfig {
   clusterName string
   // The network where the IP address of the discovery endpoint will be reserved
   network string
+  // VPC network where the discovery endpoint IP address is reserved
+  networkRef() gcp.project.computeService.network
 }
 
 // Google Cloud (GCP) Redis Cluster discovery endpoint
@@ -522,6 +532,8 @@ private gcp.project.redisService.cluster.pscConnection @defaults("pscConnectionI
   connectionProjectId string
   // The consumer network the PSC connection was created in
   network string
+  // VPC network the PSC connection was created in
+  networkRef() gcp.project.computeService.network
   // The service attachment which is the target of the PSC connection
   serviceAttachment string
   // The status of the PSC connection
@@ -613,6 +625,8 @@ private gcp.project.redisService.cluster.connectionDetail @defaults("pscConnecti
   connectionProjectId string
   // The consumer network the PSC connection was created in
   network string
+  // VPC network the PSC connection was created in
+  networkRef() gcp.project.computeService.network
   // The service attachment which is the target of the PSC connection
   serviceAttachment string
   // The status of the PSC connection
@@ -4656,6 +4670,12 @@ private gcp.project.pubsubService.topic.config @defaults("kmsKeyName messageStor
   // Ordered list of transforms applied to messages published to the topic,
   // each typically backed by a JavaScript user-defined function (UDF).
   messageTransforms []dict
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Pub/Sub topic schema settings
@@ -4748,6 +4768,8 @@ private gcp.project.pubsubService.subscription.config @defaults("topic.name ackD
   topicMessageRetentionDuration time
   // Dead-letter queue configuration (deadLetterTopic, maxDeliveryAttempts)
   deadLetterPolicy dict
+  // Dead-letter topic that receives messages this subscription fails to deliver
+  deadLetterTopic() gcp.project.pubsubService.topic
   // Message retry backoff configuration (minimumBackoff, maximumBackoff)
   retryPolicy dict
   // BigQuery delivery sink
@@ -4777,6 +4799,20 @@ private gcp.project.pubsubService.subscription.config @defaults("topic.name ackD
   // to Bigtable. A populated value is an egress path that moves topic data into
   // a queryable store, so it widens the data's exposure surface.
   bigtableConfig dict
+  // Service account used to generate the OIDC token for authenticated push delivery
+  oidcTokenServiceAccount() gcp.project.iamService.serviceAccount
+  // BigQuery table this subscription writes messages to
+  bigqueryTable() gcp.project.bigqueryService.table
+  // Cloud Storage bucket this subscription writes messages to
+  cloudStorageBucket() gcp.project.storageService.bucket
+  // Service account the Bigtable export runs as
+  bigtableServiceAccount() gcp.project.iamService.serviceAccount
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Pub/Sub configuration for subscriptions that operate in push mode
@@ -4817,6 +4853,12 @@ private gcp.project.pubsubService.snapshot @defaults("name") {
   expiration time
   // Labels associated with this snapshot
   labels map[string]string
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Pub/Sub schema
@@ -14276,6 +14318,12 @@ private gcp.project.memcacheService.instance @defaults("name state") {
   updateTime time
   // Memcached nodes in the instance
   nodes []gcp.project.memcacheService.instance.node
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Memcached node
@@ -14617,6 +14665,12 @@ private gcp.project.memorystoreService.instance @defaults("name state mode") {
   createTime time
   // Last update time
   updateTime time
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Memorystore instance PSC attachment detail

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2623,6 +2623,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.redisService.instance.persistenceIamIdentity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetPersistenceIamIdentity()).ToDataRes(types.String)
 	},
+	"gcp.project.redisService.instance.persistenceServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceInstance).GetPersistenceServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.redisService.instance.connectMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetConnectMode()).ToDataRes(types.String)
 	},
@@ -2679,6 +2682,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.redisService.instance.serverCaCerts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetServerCaCerts()).ToDataRes(types.Array(types.Resource("gcp.project.redisService.instance.serverCaCert")))
+	},
+	"gcp.project.redisService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceInstance).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.redisService.instance.nodeInfo.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstanceNodeInfo).GetProjectId()).ToDataRes(types.String)
@@ -2815,6 +2821,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.redisService.cluster.pscConfig.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterPscConfig).GetNetwork()).ToDataRes(types.String)
 	},
+	"gcp.project.redisService.cluster.pscConfig.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceClusterPscConfig).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
 	"gcp.project.redisService.cluster.discoveryEndpoint.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterDiscoveryEndpoint).GetProjectId()).ToDataRes(types.String)
 	},
@@ -2850,6 +2859,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.redisService.cluster.pscConnection.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterPscConnection).GetNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.redisService.cluster.pscConnection.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceClusterPscConnection).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.redisService.cluster.pscConnection.serviceAttachment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterPscConnection).GetServiceAttachment()).ToDataRes(types.String)
@@ -2952,6 +2964,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.redisService.cluster.connectionDetail.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterConnectionDetail).GetNetwork()).ToDataRes(types.String)
+	},
+	"gcp.project.redisService.cluster.connectionDetail.networkRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectRedisServiceClusterConnectionDetail).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
 	"gcp.project.redisService.cluster.connectionDetail.serviceAttachment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceClusterConnectionDetail).GetServiceAttachment()).ToDataRes(types.String)
@@ -7018,6 +7033,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.pubsubService.topic.config.messageTransforms": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetMessageTransforms()).ToDataRes(types.Array(types.Dict))
 	},
+	"gcp.project.pubsubService.topic.config.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.pubsubService.topic.config.schemaSettings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopicConfigSchemaSettings).GetId()).ToDataRes(types.String)
 	},
@@ -7108,6 +7126,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.pubsubService.subscription.config.deadLetterPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetDeadLetterPolicy()).ToDataRes(types.Dict)
 	},
+	"gcp.project.pubsubService.subscription.config.deadLetterTopic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetDeadLetterTopic()).ToDataRes(types.Resource("gcp.project.pubsubService.topic"))
+	},
 	"gcp.project.pubsubService.subscription.config.retryPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetRetryPolicy()).ToDataRes(types.Dict)
 	},
@@ -7119,6 +7140,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.pubsubService.subscription.config.bigtableConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetBigtableConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.pubsubService.subscription.config.oidcTokenServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetOidcTokenServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.pubsubService.subscription.config.bigqueryTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetBigqueryTable()).ToDataRes(types.Resource("gcp.project.bigqueryService.table"))
+	},
+	"gcp.project.pubsubService.subscription.config.cloudStorageBucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetCloudStorageBucket()).ToDataRes(types.Resource("gcp.project.storageService.bucket"))
+	},
+	"gcp.project.pubsubService.subscription.config.bigtableServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetBigtableServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.pubsubService.subscription.config.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.pubsubService.subscription.config.pushconfig.configId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig).GetConfigId()).ToDataRes(types.String)
@@ -7152,6 +7188,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.pubsubService.snapshot.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSnapshot).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.pubsubService.snapshot.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSnapshot).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.pubsubService.schema.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSchema).GetProjectId()).ToDataRes(types.String)
@@ -16450,6 +16489,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.memcacheService.instance.nodes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMemcacheServiceInstance).GetNodes()).ToDataRes(types.Array(types.Resource("gcp.project.memcacheService.instance.node")))
 	},
+	"gcp.project.memcacheService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectMemcacheServiceInstance).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.memcacheService.instance.node.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMemcacheServiceInstanceNode).GetProjectId()).ToDataRes(types.String)
 	},
@@ -16800,6 +16842,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.memorystoreService.instance.updateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMemorystoreServiceInstance).GetUpdateTime()).ToDataRes(types.Time)
+	},
+	"gcp.project.memorystoreService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectMemorystoreServiceInstance).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.memorystoreService.instance.pscAttachmentDetail.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMemorystoreServiceInstancePscAttachmentDetail).GetProjectId()).ToDataRes(types.String)
@@ -17409,6 +17454,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectRedisServiceInstance).PersistenceIamIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.redisService.instance.persistenceServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceInstance).PersistenceServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.redisService.instance.connectMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceInstance).ConnectMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -17483,6 +17532,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.instance.serverCaCerts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceInstance).ServerCaCerts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.redisService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.instance.nodeInfo.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17681,6 +17734,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectRedisServiceClusterPscConfig).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.redisService.cluster.pscConfig.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceClusterPscConfig).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
 	"gcp.project.redisService.cluster.discoveryEndpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceClusterDiscoveryEndpoint).__id, ok = v.Value.(string)
 		return
@@ -17735,6 +17792,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.cluster.pscConnection.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceClusterPscConnection).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.redisService.cluster.pscConnection.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceClusterPscConnection).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.cluster.pscConnection.serviceAttachment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17887,6 +17948,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.cluster.connectionDetail.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceClusterConnectionDetail).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.redisService.cluster.connectionDetail.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectRedisServiceClusterConnectionDetail).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.cluster.connectionDetail.serviceAttachment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23709,6 +23774,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceTopicConfig).MessageTransforms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.pubsubService.topic.config.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceTopicConfig).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.pubsubService.topic.config.schemaSettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceTopicConfigSchemaSettings).__id, ok = v.Value.(string)
 		return
@@ -23845,6 +23914,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).DeadLetterPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.pubsubService.subscription.config.deadLetterTopic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).DeadLetterTopic, ok = plugin.RawToTValue[*mqlGcpProjectPubsubServiceTopic](v.Value, v.Error)
+		return
+	},
 	"gcp.project.pubsubService.subscription.config.retryPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).RetryPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -23859,6 +23932,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.pubsubService.subscription.config.bigtableConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).BigtableConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.config.oidcTokenServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).OidcTokenServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.config.bigqueryTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).BigqueryTable, ok = plugin.RawToTValue[*mqlGcpProjectBigqueryServiceTable](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.config.cloudStorageBucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).CloudStorageBucket, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucket](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.config.bigtableServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).BigtableServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.config.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.pubsubService.subscription.config.pushconfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23911,6 +24004,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.pubsubService.snapshot.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSnapshot).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.snapshot.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSnapshot).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.pubsubService.schema.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37529,6 +37626,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectMemcacheServiceInstance).Nodes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.memcacheService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectMemcacheServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.memcacheService.instance.node.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectMemcacheServiceInstanceNode).__id, ok = v.Value.(string)
 		return
@@ -38039,6 +38140,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.memorystoreService.instance.updateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectMemorystoreServiceInstance).UpdateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.memorystoreService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectMemorystoreServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.memorystoreService.instance.pscAttachmentDetail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39401,6 +39506,7 @@ type mqlGcpProjectRedisServiceInstance struct {
 	AuthorizedNetwork            plugin.TValue[string]
 	Network                      plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PersistenceIamIdentity       plugin.TValue[string]
+	PersistenceServiceAccount    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	ConnectMode                  plugin.TValue[string]
 	AuthEnabled                  plugin.TValue[bool]
 	ReplicaCount                 plugin.TValue[int64]
@@ -39420,6 +39526,7 @@ type mqlGcpProjectRedisServiceInstance struct {
 	MaintenancePolicy            plugin.TValue[any]
 	MaintenanceSchedule          plugin.TValue[any]
 	ServerCaCerts                plugin.TValue[[]any]
+	ManagedBy                    plugin.TValue[string]
 }
 
 // createGcpProjectRedisServiceInstance creates a new instance of this resource
@@ -39547,6 +39654,22 @@ func (c *mqlGcpProjectRedisServiceInstance) GetPersistenceIamIdentity() *plugin.
 	return &c.PersistenceIamIdentity
 }
 
+func (c *mqlGcpProjectRedisServiceInstance) GetPersistenceServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.PersistenceServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.redisService.instance", c.__id, "persistenceServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.persistenceServiceAccount()
+	})
+}
+
 func (c *mqlGcpProjectRedisServiceInstance) GetConnectMode() *plugin.TValue[string] {
 	return &c.ConnectMode
 }
@@ -39633,6 +39756,12 @@ func (c *mqlGcpProjectRedisServiceInstance) GetMaintenanceSchedule() *plugin.TVa
 
 func (c *mqlGcpProjectRedisServiceInstance) GetServerCaCerts() *plugin.TValue[[]any] {
 	return &c.ServerCaCerts
+}
+
+func (c *mqlGcpProjectRedisServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectRedisServiceInstanceNodeInfo for the gcp.project.redisService.instance.nodeInfo resource
@@ -40009,6 +40138,7 @@ type mqlGcpProjectRedisServiceClusterPscConfig struct {
 	ProjectId   plugin.TValue[string]
 	ClusterName plugin.TValue[string]
 	Network     plugin.TValue[string]
+	NetworkRef  plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 }
 
 // createGcpProjectRedisServiceClusterPscConfig creates a new instance of this resource
@@ -40058,6 +40188,22 @@ func (c *mqlGcpProjectRedisServiceClusterPscConfig) GetClusterName() *plugin.TVa
 
 func (c *mqlGcpProjectRedisServiceClusterPscConfig) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectRedisServiceClusterPscConfig) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.redisService.cluster.pscConfig", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 // mqlGcpProjectRedisServiceClusterDiscoveryEndpoint for the gcp.project.redisService.cluster.discoveryEndpoint resource
@@ -40141,6 +40287,7 @@ type mqlGcpProjectRedisServiceClusterPscConnection struct {
 	ForwardingRule      plugin.TValue[string]
 	ConnectionProjectId plugin.TValue[string]
 	Network             plugin.TValue[string]
+	NetworkRef          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	ServiceAttachment   plugin.TValue[string]
 	PscConnectionStatus plugin.TValue[string]
 	ConnectionType      plugin.TValue[string]
@@ -40209,6 +40356,22 @@ func (c *mqlGcpProjectRedisServiceClusterPscConnection) GetConnectionProjectId()
 
 func (c *mqlGcpProjectRedisServiceClusterPscConnection) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectRedisServiceClusterPscConnection) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.redisService.cluster.pscConnection", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectRedisServiceClusterPscConnection) GetServiceAttachment() *plugin.TValue[string] {
@@ -40487,6 +40650,7 @@ type mqlGcpProjectRedisServiceClusterConnectionDetail struct {
 	ForwardingRule      plugin.TValue[string]
 	ConnectionProjectId plugin.TValue[string]
 	Network             plugin.TValue[string]
+	NetworkRef          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	ServiceAttachment   plugin.TValue[string]
 	PscConnectionStatus plugin.TValue[string]
 	ConnectionType      plugin.TValue[string]
@@ -40556,6 +40720,22 @@ func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) GetConnectionProjectI
 
 func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) GetNetwork() *plugin.TValue[string] {
 	return &c.Network
+}
+
+func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.redisService.cluster.connectionDetail", c.__id, "networkRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.networkRef()
+	})
 }
 
 func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) GetServiceAttachment() *plugin.TValue[string] {
@@ -54224,6 +54404,7 @@ type mqlGcpProjectPubsubServiceTopicConfig struct {
 	SatisfiesPzs                plugin.TValue[bool]
 	IngestionDataSourceSettings plugin.TValue[any]
 	MessageTransforms           plugin.TValue[[]any]
+	ManagedBy                   plugin.TValue[string]
 }
 
 // createGcpProjectPubsubServiceTopicConfig creates a new instance of this resource
@@ -54321,6 +54502,12 @@ func (c *mqlGcpProjectPubsubServiceTopicConfig) GetIngestionDataSourceSettings()
 
 func (c *mqlGcpProjectPubsubServiceTopicConfig) GetMessageTransforms() *plugin.TValue[[]any] {
 	return &c.MessageTransforms
+}
+
+func (c *mqlGcpProjectPubsubServiceTopicConfig) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectPubsubServiceTopicConfigSchemaSettings for the gcp.project.pubsubService.topic.config.schemaSettings resource
@@ -54567,7 +54754,7 @@ func (c *mqlGcpProjectPubsubServiceSubscription) GetPublic() *plugin.TValue[bool
 type mqlGcpProjectPubsubServiceSubscriptionConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectPubsubServiceSubscriptionConfigInternal it will be used here
+	mqlGcpProjectPubsubServiceSubscriptionConfigInternal
 	ProjectId                     plugin.TValue[string]
 	SubscriptionName              plugin.TValue[string]
 	Topic                         plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
@@ -54584,10 +54771,16 @@ type mqlGcpProjectPubsubServiceSubscriptionConfig struct {
 	State                         plugin.TValue[string]
 	TopicMessageRetentionDuration plugin.TValue[*time.Time]
 	DeadLetterPolicy              plugin.TValue[any]
+	DeadLetterTopic               plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	RetryPolicy                   plugin.TValue[any]
 	BigqueryConfig                plugin.TValue[any]
 	CloudStorageConfig            plugin.TValue[any]
 	BigtableConfig                plugin.TValue[any]
+	OidcTokenServiceAccount       plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	BigqueryTable                 plugin.TValue[*mqlGcpProjectBigqueryServiceTable]
+	CloudStorageBucket            plugin.TValue[*mqlGcpProjectStorageServiceBucket]
+	BigtableServiceAccount        plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	ManagedBy                     plugin.TValue[string]
 }
 
 // createGcpProjectPubsubServiceSubscriptionConfig creates a new instance of this resource
@@ -54691,6 +54884,22 @@ func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetDeadLetterPolicy() *pl
 	return &c.DeadLetterPolicy
 }
 
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetDeadLetterTopic() *plugin.TValue[*mqlGcpProjectPubsubServiceTopic] {
+	return plugin.GetOrCompute[*mqlGcpProjectPubsubServiceTopic](&c.DeadLetterTopic, func() (*mqlGcpProjectPubsubServiceTopic, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.pubsubService.subscription.config", c.__id, "deadLetterTopic")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectPubsubServiceTopic), nil
+			}
+		}
+
+		return c.deadLetterTopic()
+	})
+}
+
 func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetRetryPolicy() *plugin.TValue[any] {
 	return &c.RetryPolicy
 }
@@ -54705,6 +54914,76 @@ func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetCloudStorageConfig() *
 
 func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetBigtableConfig() *plugin.TValue[any] {
 	return &c.BigtableConfig
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetOidcTokenServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.OidcTokenServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.pubsubService.subscription.config", c.__id, "oidcTokenServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.oidcTokenServiceAccount()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetBigqueryTable() *plugin.TValue[*mqlGcpProjectBigqueryServiceTable] {
+	return plugin.GetOrCompute[*mqlGcpProjectBigqueryServiceTable](&c.BigqueryTable, func() (*mqlGcpProjectBigqueryServiceTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.pubsubService.subscription.config", c.__id, "bigqueryTable")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBigqueryServiceTable), nil
+			}
+		}
+
+		return c.bigqueryTable()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetCloudStorageBucket() *plugin.TValue[*mqlGcpProjectStorageServiceBucket] {
+	return plugin.GetOrCompute[*mqlGcpProjectStorageServiceBucket](&c.CloudStorageBucket, func() (*mqlGcpProjectStorageServiceBucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.pubsubService.subscription.config", c.__id, "cloudStorageBucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectStorageServiceBucket), nil
+			}
+		}
+
+		return c.cloudStorageBucket()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetBigtableServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.BigtableServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.pubsubService.subscription.config", c.__id, "bigtableServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.bigtableServiceAccount()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscriptionConfig) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectPubsubServiceSubscriptionConfigPushconfig for the gcp.project.pubsubService.subscription.config.pushconfig resource
@@ -54791,6 +55070,7 @@ type mqlGcpProjectPubsubServiceSnapshot struct {
 	Topic      plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	Expiration plugin.TValue[*time.Time]
 	Labels     plugin.TValue[map[string]any]
+	ManagedBy  plugin.TValue[string]
 }
 
 // createGcpProjectPubsubServiceSnapshot creates a new instance of this resource
@@ -54848,6 +55128,12 @@ func (c *mqlGcpProjectPubsubServiceSnapshot) GetExpiration() *plugin.TValue[*tim
 
 func (c *mqlGcpProjectPubsubServiceSnapshot) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
+}
+
+func (c *mqlGcpProjectPubsubServiceSnapshot) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectPubsubServiceSchema for the gcp.project.pubsubService.schema resource
@@ -87485,6 +87771,7 @@ type mqlGcpProjectMemcacheServiceInstance struct {
 	CreateTime          plugin.TValue[*time.Time]
 	UpdateTime          plugin.TValue[*time.Time]
 	Nodes               plugin.TValue[[]any]
+	ManagedBy           plugin.TValue[string]
 }
 
 // createGcpProjectMemcacheServiceInstance creates a new instance of this resource
@@ -87614,6 +87901,12 @@ func (c *mqlGcpProjectMemcacheServiceInstance) GetUpdateTime() *plugin.TValue[*t
 
 func (c *mqlGcpProjectMemcacheServiceInstance) GetNodes() *plugin.TValue[[]any] {
 	return &c.Nodes
+}
+
+func (c *mqlGcpProjectMemcacheServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectMemcacheServiceInstanceNode for the gcp.project.memcacheService.instance.node resource
@@ -88646,6 +88939,7 @@ type mqlGcpProjectMemorystoreServiceInstance struct {
 	Endpoints                      plugin.TValue[[]any]
 	CreateTime                     plugin.TValue[*time.Time]
 	UpdateTime                     plugin.TValue[*time.Time]
+	ManagedBy                      plugin.TValue[string]
 }
 
 // createGcpProjectMemorystoreServiceInstance creates a new instance of this resource
@@ -88851,6 +89145,12 @@ func (c *mqlGcpProjectMemorystoreServiceInstance) GetCreateTime() *plugin.TValue
 
 func (c *mqlGcpProjectMemorystoreServiceInstance) GetUpdateTime() *plugin.TValue[*time.Time] {
 	return &c.UpdateTime
+}
+
+func (c *mqlGcpProjectMemorystoreServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectMemorystoreServiceInstancePscAttachmentDetail for the gcp.project.memorystoreService.instance.pscAttachmentDetail resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3688,6 +3688,7 @@ gcp.project.memcacheService.instance.instanceMessages 13.11.2
 gcp.project.memcacheService.instance.labels 13.11.2
 gcp.project.memcacheService.instance.maintenancePolicy 13.11.2
 gcp.project.memcacheService.instance.maintenanceSchedule 13.11.2
+gcp.project.memcacheService.instance.managedBy 13.27.2
 gcp.project.memcacheService.instance.memcacheFullVersion 13.11.2
 gcp.project.memcacheService.instance.memcacheVersion 13.11.2
 gcp.project.memcacheService.instance.name 13.11.2
@@ -3777,6 +3778,7 @@ gcp.project.memorystoreService.instance.labels 13.11.2
 gcp.project.memorystoreService.instance.maintenancePolicy 13.11.2
 gcp.project.memorystoreService.instance.maintenanceSchedule 13.11.2
 gcp.project.memorystoreService.instance.maintenanceVersion 13.11.2
+gcp.project.memorystoreService.instance.managedBy 13.27.2
 gcp.project.memorystoreService.instance.mode 13.11.2
 gcp.project.memorystoreService.instance.name 13.11.2
 gcp.project.memorystoreService.instance.nodeSizeGb 13.11.2
@@ -4035,6 +4037,7 @@ gcp.project.pubsubService.schemas 13.7.2
 gcp.project.pubsubService.snapshot 9.0.0
 gcp.project.pubsubService.snapshot.expiration 9.0.0
 gcp.project.pubsubService.snapshot.labels 13.23.2
+gcp.project.pubsubService.snapshot.managedBy 13.27.2
 gcp.project.pubsubService.snapshot.name 9.0.0
 gcp.project.pubsubService.snapshot.projectId 9.0.0
 gcp.project.pubsubService.snapshot.topic 9.0.0
@@ -4043,15 +4046,21 @@ gcp.project.pubsubService.subscription 9.0.0
 gcp.project.pubsubService.subscription.config 9.0.0
 gcp.project.pubsubService.subscription.config.ackDeadline 9.0.0
 gcp.project.pubsubService.subscription.config.bigqueryConfig 13.21.2
+gcp.project.pubsubService.subscription.config.bigqueryTable 13.27.2
 gcp.project.pubsubService.subscription.config.bigtableConfig 13.23.2
+gcp.project.pubsubService.subscription.config.bigtableServiceAccount 13.27.2
+gcp.project.pubsubService.subscription.config.cloudStorageBucket 13.27.2
 gcp.project.pubsubService.subscription.config.cloudStorageConfig 13.21.2
 gcp.project.pubsubService.subscription.config.deadLetterPolicy 13.7.2
+gcp.project.pubsubService.subscription.config.deadLetterTopic 13.27.2
 gcp.project.pubsubService.subscription.config.detached 11.0.146
 gcp.project.pubsubService.subscription.config.enableExactlyOnceDelivery 11.0.146
 gcp.project.pubsubService.subscription.config.enableMessageOrdering 11.0.146
 gcp.project.pubsubService.subscription.config.expirationPolicy 9.0.0
 gcp.project.pubsubService.subscription.config.filter 11.0.146
 gcp.project.pubsubService.subscription.config.labels 9.0.0
+gcp.project.pubsubService.subscription.config.managedBy 13.27.2
+gcp.project.pubsubService.subscription.config.oidcTokenServiceAccount 13.27.2
 gcp.project.pubsubService.subscription.config.projectId 9.0.0
 gcp.project.pubsubService.subscription.config.pushConfig 9.0.0
 gcp.project.pubsubService.subscription.config.pushconfig 9.0.0
@@ -4079,6 +4088,7 @@ gcp.project.pubsubService.topic.config.ingestionDataSourceSettings 13.16.3
 gcp.project.pubsubService.topic.config.kmsKey 13.12.2
 gcp.project.pubsubService.topic.config.kmsKeyName 9.0.0
 gcp.project.pubsubService.topic.config.labels 9.0.0
+gcp.project.pubsubService.topic.config.managedBy 13.27.2
 gcp.project.pubsubService.topic.config.messageStoragePolicy 9.0.0
 gcp.project.pubsubService.topic.config.messageTransforms 13.16.3
 gcp.project.pubsubService.topic.config.messagestoragepolicy 9.0.0
@@ -4146,6 +4156,7 @@ gcp.project.redisService.cluster.connectionDetail.connectionProjectId 11.1.0
 gcp.project.redisService.cluster.connectionDetail.connectionType 11.1.0
 gcp.project.redisService.cluster.connectionDetail.forwardingRule 11.1.0
 gcp.project.redisService.cluster.connectionDetail.network 11.1.0
+gcp.project.redisService.cluster.connectionDetail.networkRef 13.27.2
 gcp.project.redisService.cluster.connectionDetail.projectId 11.1.0
 gcp.project.redisService.cluster.connectionDetail.pscConnectionId 11.1.0
 gcp.project.redisService.cluster.connectionDetail.pscConnectionStatus 11.1.0
@@ -4173,6 +4184,7 @@ gcp.project.redisService.cluster.projectId 11.1.0
 gcp.project.redisService.cluster.pscConfig 11.1.0
 gcp.project.redisService.cluster.pscConfig.clusterName 11.1.0
 gcp.project.redisService.cluster.pscConfig.network 11.1.0
+gcp.project.redisService.cluster.pscConfig.networkRef 13.27.2
 gcp.project.redisService.cluster.pscConfig.projectId 11.1.0
 gcp.project.redisService.cluster.pscConfigs 11.1.0
 gcp.project.redisService.cluster.pscConnection 11.1.0
@@ -4182,6 +4194,7 @@ gcp.project.redisService.cluster.pscConnection.connectionProjectId 11.1.0
 gcp.project.redisService.cluster.pscConnection.connectionType 11.1.0
 gcp.project.redisService.cluster.pscConnection.forwardingRule 11.1.0
 gcp.project.redisService.cluster.pscConnection.network 11.1.0
+gcp.project.redisService.cluster.pscConnection.networkRef 13.27.2
 gcp.project.redisService.cluster.pscConnection.projectId 11.1.0
 gcp.project.redisService.cluster.pscConnection.pscConnectionId 11.1.0
 gcp.project.redisService.cluster.pscConnection.pscConnectionStatus 11.1.0
@@ -4217,6 +4230,7 @@ gcp.project.redisService.instance.locationId 11.0.79
 gcp.project.redisService.instance.maintenancePolicy 11.0.79
 gcp.project.redisService.instance.maintenanceSchedule 11.0.79
 gcp.project.redisService.instance.maintenanceVersion 11.0.79
+gcp.project.redisService.instance.managedBy 13.27.2
 gcp.project.redisService.instance.memorySizeGb 11.0.79
 gcp.project.redisService.instance.name 11.0.79
 gcp.project.redisService.instance.network 13.21.2
@@ -4227,6 +4241,7 @@ gcp.project.redisService.instance.nodeInfo.zone 11.0.79
 gcp.project.redisService.instance.nodes 11.0.79
 gcp.project.redisService.instance.persistenceConfig 11.0.79
 gcp.project.redisService.instance.persistenceIamIdentity 11.0.79
+gcp.project.redisService.instance.persistenceServiceAccount 13.27.2
 gcp.project.redisService.instance.port 11.0.79
 gcp.project.redisService.instance.projectId 11.0.79
 gcp.project.redisService.instance.readEndpoint 11.0.79

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.27.0",
-  "generated_at": "2026-06-30T09:47:52-07:00",
+  "version": "13.27.1",
+  "generated_at": "2026-06-30T22:31:53-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/gcp_managed_by.go
+++ b/providers/gcp/resources/gcp_managed_by.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromLabels infers the infrastructure-management system that owns a
+// GCP resource from the provenance labels and annotations Google and common
+// IaC tools stamp on managed resources. Callers pass every label/annotation map
+// the resource exposes; the maps are inspected in priority order and the first
+// recognized signal wins. It returns an empty string when no management signal
+// is present (a resource created manually or through the console) and propagates
+// any error from resolving a computed map.
+//
+// Recognized signals, highest priority first:
+//   - "terraform": the goog-terraform-provisioned label Google stamps on
+//     resources created through the Terraform Google provider.
+//   - "config-connector": the cnrm.cloud.google.com/* annotations (or the
+//     managed-by-cnrm label) the GKE Config Connector controller applies to
+//     resources it reconciles.
+//   - "cloud-composer": the goog-composer-* labels applied to resources a Cloud
+//     Composer environment provisions.
+func managedByFromLabels(maps ...*plugin.TValue[map[string]any]) (string, error) {
+	for _, m := range maps {
+		if m != nil && m.Error != nil {
+			return "", m.Error
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if v, ok := m.Data["goog-terraform-provisioned"]; ok && labelValueTrue(v) {
+			return "terraform", nil
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if k == "managed-by-cnrm" || strings.HasPrefix(k, "cnrm.cloud.google.com/") {
+				return "config-connector", nil
+			}
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if strings.HasPrefix(k, "goog-composer-") {
+				return "cloud-composer", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// labelValueTrue reports whether a label value is the string "true"
+// (case-insensitive). GCP label values are always strings.
+func labelValueTrue(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.EqualFold(s, "true")
+}

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -168,6 +168,10 @@ func (g *mqlGcpProjectMemcacheServiceInstance) network() (*mqlGcpProjectComputeS
 	return getNetworkByUrl(g.cacheAuthorizedNetwork, g.MqlRuntime)
 }
 
+func (g *mqlGcpProjectMemcacheServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
 func (g *mqlGcpProjectMemcacheService) instances() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -68,6 +68,10 @@ type mqlGcpProjectMemorystoreServiceInstanceInternal struct {
 	cacheBackupCollection string
 }
 
+func (g *mqlGcpProjectMemorystoreServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
 func (g *mqlGcpProjectMemorystoreServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
 	if g.cacheKmsKey == "" {
 		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -577,23 +577,32 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 	}
 
 	var bigqueryConfigDict, cloudStorageConfigDict, bigtableConfigDict map[string]any
+	var bigqueryTable, cloudStorageBucket, bigtableServiceAccount string
 	if bq := cfg.GetBigqueryConfig(); bq != nil {
 		bigqueryConfigDict, err = protoToDict(bq)
 		if err != nil {
 			return nil, err
 		}
+		bigqueryTable = bq.GetTable()
 	}
 	if cs := cfg.GetCloudStorageConfig(); cs != nil {
 		cloudStorageConfigDict, err = protoToDict(cs)
 		if err != nil {
 			return nil, err
 		}
+		cloudStorageBucket = cs.GetBucket()
 	}
 	if bt := cfg.GetBigtableConfig(); bt != nil {
 		bigtableConfigDict, err = protoToDict(bt)
 		if err != nil {
 			return nil, err
 		}
+		bigtableServiceAccount = bt.GetServiceAccountEmail()
+	}
+
+	deadLetterTopic := ""
+	if cfg.DeadLetterPolicy != nil {
+		deadLetterTopic = cfg.DeadLetterPolicy.DeadLetterTopic
 	}
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.pubsubService.subscription.config", map[string]*llx.RawData{
@@ -621,7 +630,13 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectPubsubServiceSubscriptionConfig), nil
+	cfgRes := res.(*mqlGcpProjectPubsubServiceSubscriptionConfig)
+	cfgRes.cacheDeadLetterTopic = deadLetterTopic
+	cfgRes.cacheOidcServiceAccount = oidcServiceAccountEmail
+	cfgRes.cacheBigqueryTable = bigqueryTable
+	cfgRes.cacheCloudStorageBucket = cloudStorageBucket
+	cfgRes.cacheBigtableServiceAccount = bigtableServiceAccount
+	return cfgRes, nil
 }
 
 func (g *mqlGcpProjectPubsubService) snapshots() ([]any, error) {
@@ -1070,6 +1085,108 @@ func (g *mqlGcpProjectPubsubServiceSubscription) public() (bool, error) {
 		return false, bindings.Error
 	}
 	return iamPolicyHasPublicMember(bindings.Data)
+}
+
+func (g *mqlGcpProjectPubsubServiceTopicConfig) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
+type mqlGcpProjectPubsubServiceSubscriptionConfigInternal struct {
+	cacheDeadLetterTopic        string
+	cacheOidcServiceAccount     string
+	cacheBigqueryTable          string
+	cacheCloudStorageBucket     string
+	cacheBigtableServiceAccount string
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) deadLetterTopic() (*mqlGcpProjectPubsubServiceTopic, error) {
+	if g.cacheDeadLetterTopic == "" {
+		g.DeadLetterTopic.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	projectId := projectFromResourceName(g.cacheDeadLetterTopic)
+	if projectId == "" && g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	res, err := CreateResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"name":      llx.StringData(lastPathSegment(g.cacheDeadLetterTopic)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) oidcTokenServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	projectId := ""
+	if g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheOidcServiceAccount, projectId)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.OidcTokenServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return sa, nil
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) bigtableServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	projectId := ""
+	if g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheBigtableServiceAccount, projectId)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.BigtableServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return sa, nil
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) bigqueryTable() (*mqlGcpProjectBigqueryServiceTable, error) {
+	// Pub/Sub carries the destination as "{projectId}.{datasetId}.{tableId}".
+	parts := strings.SplitN(g.cacheBigqueryTable, ".", 3)
+	if g.cacheBigqueryTable == "" || len(parts) != 3 {
+		g.BigqueryTable.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
+		"id":        llx.StringData(parts[2]),
+		"projectId": llx.StringData(parts[0]),
+		"datasetId": llx.StringData(parts[1]),
+		"name":      llx.StringData(parts[2]),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectBigqueryServiceTable), nil
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscriptionConfig) cloudStorageBucket() (*mqlGcpProjectStorageServiceBucket, error) {
+	if g.cacheCloudStorageBucket == "" {
+		g.CloudStorageBucket.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.storageService.bucket", map[string]*llx.RawData{
+		"name": llx.StringData(g.cacheCloudStorageBucket),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectStorageServiceBucket), nil
+}
+
+func (g *mqlGcpProjectPubsubServiceSnapshot) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
 }
 
 func (g *mqlGcpProjectPubsubServiceTopicConfig) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -152,6 +152,30 @@ func (g *mqlGcpProjectRedisServiceInstance) network() (*mqlGcpProjectComputeServ
 	return n, nil
 }
 
+func (g *mqlGcpProjectRedisServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(&g.Labels)
+}
+
+func (g *mqlGcpProjectRedisServiceInstance) persistenceServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.PersistenceIamIdentity.Error != nil {
+		return nil, g.PersistenceIamIdentity.Error
+	}
+	// The persistence IAM identity is carried as "serviceAccount:{email}".
+	raw := strings.TrimPrefix(g.PersistenceIamIdentity.Data, "serviceAccount:")
+	projectId := ""
+	if g.ProjectId.Error == nil {
+		projectId = g.ProjectId.Data
+	}
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, raw, projectId)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		g.PersistenceServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return sa, nil
+}
+
 func (g *mqlGcpProjectRedisServiceInstance) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -688,6 +712,20 @@ func (c *mqlGcpProjectRedisServiceClusterPscConfig) id() (string, error) {
 	), nil
 }
 
+func (c *mqlGcpProjectRedisServiceClusterPscConfig) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if c.Network.Error != nil {
+		return nil, c.Network.Error
+	}
+	n, err := getNetworkByUrl(c.Network.Data, c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		c.NetworkRef.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return n, nil
+}
+
 func (c *mqlGcpProjectRedisServiceClusterDiscoveryEndpoint) id() (string, error) {
 	return fmt.Sprintf(
 		"gcp.project.redisService.cluster.discoveryEndpoint/%s/%s/%s", c.ProjectId.Data, c.ClusterName.Data, c.Address.Data,
@@ -698,6 +736,20 @@ func (c *mqlGcpProjectRedisServiceClusterPscConnection) id() (string, error) {
 	return fmt.Sprintf(
 		"gcp.project.redisService.cluster.pscConnection/%s/%s/%s", c.ProjectId.Data, c.ClusterName.Data, c.PscConnectionId.Data,
 	), nil
+}
+
+func (c *mqlGcpProjectRedisServiceClusterPscConnection) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if c.Network.Error != nil {
+		return nil, c.Network.Error
+	}
+	n, err := getNetworkByUrl(c.Network.Data, c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		c.NetworkRef.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return n, nil
 }
 
 func (c *mqlGcpProjectRedisServiceClusterBackup) id() (string, error) {
@@ -716,6 +768,20 @@ func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) id() (string, error) 
 	return fmt.Sprintf(
 		"gcp.project.redisService.cluster.connectionDetail/%s/%s/%s", c.ProjectId.Data, c.ClusterName.Data, c.PscConnectionId.Data,
 	), nil
+}
+
+func (c *mqlGcpProjectRedisServiceClusterConnectionDetail) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
+	if c.Network.Error != nil {
+		return nil, c.Network.Error
+	}
+	n, err := getNetworkByUrl(c.Network.Data, c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		c.NetworkRef.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return n, nil
 }
 
 // ===== Cluster sub-resource converters =====


### PR DESCRIPTION
## Summary

Additive, non-breaking provenance and typed-reference accessors across the GCP cache (Redis, Memorystore, Memcache) and messaging (Pub/Sub) subsystems. No existing fields removed; new accessors sit alongside the raw values they enrich.

### `managedBy()` — infrastructure-management provenance
Derived from the provenance labels/annotations Google and IaC tools stamp (`terraform`, `config-connector`, `cloud-composer`), via a shared `managedByFromLabels` helper:

- `gcp.project.redisService.instance`
- `gcp.project.memorystoreService.instance`
- `gcp.project.memcacheService.instance`
- `gcp.project.pubsubService.topic.config`
- `gcp.project.pubsubService.subscription.config`
- `gcp.project.pubsubService.snapshot`

Redis Cluster carries no `Labels` field in its API, so it intentionally gets no `managedBy()`.

### Typed references
- `redisService.instance.persistenceServiceAccount()` → `iamService.serviceAccount` (from the persistence IAM identity, stripping the `serviceAccount:` prefix)
- `redisService.cluster.pscConfig.networkRef()`, `pscConnection.networkRef()`, `connectionDetail.networkRef()` → `computeService.network` (`networkRef` avoids collision with the existing raw `network` field, which is retained as part of each sub-resource's id)
- `pubsubService.subscription.config.deadLetterTopic()` → `pubsubService.topic` — the missing dead-letter lineage edge
- `pubsubService.subscription.config.oidcTokenServiceAccount()` and `bigtableServiceAccount()` → `iamService.serviceAccount`
- `pubsubService.subscription.config.bigqueryTable()` → `bigqueryService.table`
- `pubsubService.subscription.config.cloudStorageBucket()` → `storageService.bucket`

Raw scalar fields and existing dict fields (`deadLetterPolicy`, `bigqueryConfig`, `cloudStorageConfig`, `bigtableConfig`, `pushConfig`) are all left in place; the typed accessors are strictly additive lineage edges.

## Verification
- `mqlr generate` (twice, for the new subscription-config Internal struct) — clean
- `go build ./...` and `go vet ./resources/` — pass
- `make providers/build/gcp` — regenerated `gcp.permissions.json` (version header sync only; no permission list changes since all new accessors reuse existing clients)
- New `.lr.versions` entries at `13.27.2` (15 additions, no existing entries modified)
