### PR TITLE
✨ gcp: database provenance (managedBy + replication/typed refs)

### DIFF
--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -190,6 +190,15 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 		if cluster.EncryptionConfig != nil {
 			mqlAlloyCluster.cacheKmsKeyName = cluster.EncryptionConfig.KmsKeyName
 		}
+		if cluster.NetworkConfig != nil {
+			mqlAlloyCluster.cacheNetworkName = cluster.NetworkConfig.Network
+		}
+		if cluster.SecondaryConfig != nil {
+			mqlAlloyCluster.cachePrimaryClusterName = cluster.SecondaryConfig.PrimaryClusterName
+		}
+		if cluster.PrimaryConfig != nil {
+			mqlAlloyCluster.cacheSecondaryClusterNames = cluster.PrimaryConfig.SecondaryClusterNames
+		}
 		res = append(res, mqlCluster)
 	}
 
@@ -197,7 +206,91 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 }
 
 type mqlGcpProjectAlloydbServiceClusterInternal struct {
+	cacheKmsKeyName            string
+	cacheNetworkName           string
+	cachePrimaryClusterName    string
+	cacheSecondaryClusterNames []string
+}
+
+type mqlGcpProjectAlloydbServiceBackupInternal struct {
 	cacheKmsKeyName string
+}
+
+// getAlloyDBClusterByName resolves an AlloyDB cluster by its full resource name
+// (projects/{project}/locations/{location}/clusters/{cluster}). It lists the
+// referenced project's clusters (served from the runtime cache when the parent
+// traversal already listed them) and matches by full name. Returns nil when the
+// name is empty, malformed, or no matching cluster exists (for example a source
+// cluster that has since been deleted).
+func getAlloyDBClusterByName(runtime *plugin.Runtime, resourceName string) (*mqlGcpProjectAlloydbServiceCluster, error) {
+	if resourceName == "" {
+		return nil, nil
+	}
+	parts := parseAlloyDBClusterName(resourceName)
+	if parts == nil {
+		return nil, nil
+	}
+	obj, err := CreateResource(runtime, "gcp.project.alloydbService", map[string]*llx.RawData{
+		"projectId": llx.StringData(parts.project),
+	})
+	if err != nil {
+		return nil, err
+	}
+	svc := obj.(*mqlGcpProjectAlloydbService)
+	clusters := svc.GetClusters()
+	if clusters.Error != nil {
+		return nil, clusters.Error
+	}
+	for _, c := range clusters.Data {
+		cluster := c.(*mqlGcpProjectAlloydbServiceCluster)
+		if cluster.Name.Error != nil {
+			return nil, cluster.Name.Error
+		}
+		if cluster.Name.Data == resourceName {
+			return cluster, nil
+		}
+	}
+	return nil, nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceCluster) network() (*mqlGcpProjectComputeServiceNetwork, error) {
+	n, err := getNetworkByUrl(g.cacheNetworkName, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if n == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return n, nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceCluster) primaryCluster() (*mqlGcpProjectAlloydbServiceCluster, error) {
+	c, err := getAlloyDBClusterByName(g.MqlRuntime, g.cachePrimaryClusterName)
+	if err != nil {
+		return nil, err
+	}
+	if c == nil {
+		g.PrimaryCluster.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return c, nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceCluster) secondaryClusters() ([]any, error) {
+	res := []any{}
+	for _, name := range g.cacheSecondaryClusterNames {
+		c, err := getAlloyDBClusterByName(g.MqlRuntime, name)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
+			res = append(res, c)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceCluster) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels(), g.GetAnnotations())
 }
 
 func (g *mqlGcpProjectAlloydbServiceCluster) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -609,6 +702,10 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlAlloyBackup := mqlBackup.(*mqlGcpProjectAlloydbServiceBackup)
+		if backup.EncryptionConfig != nil {
+			mqlAlloyBackup.cacheKmsKeyName = backup.EncryptionConfig.KmsKeyName
+		}
 		res = append(res, mqlBackup)
 	}
 
@@ -623,4 +720,31 @@ func (g *mqlGcpProjectAlloydbServiceBackup) id() (string, error) {
 		return "", g.Name.Error
 	}
 	return fmt.Sprintf("gcp.project/%s/alloydbService/%s", g.ProjectId.Data, g.Name.Data), nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceBackup) sourceCluster() (*mqlGcpProjectAlloydbServiceCluster, error) {
+	if g.ClusterName.Error != nil {
+		return nil, g.ClusterName.Error
+	}
+	c, err := getAlloyDBClusterByName(g.MqlRuntime, g.ClusterName.Data)
+	if err != nil {
+		return nil, err
+	}
+	if c == nil {
+		g.SourceCluster.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return c, nil
+}
+
+func (g *mqlGcpProjectAlloydbServiceBackup) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	if g.cacheKmsKeyName == "" {
+		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey",
+		map[string]*llx.RawData{"resourcePath": llx.StringData(g.cacheKmsKeyName)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -185,6 +185,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) id() (string, error) {
 	return fmt.Sprintf("gcp.project/%s/bigtableService/%s", g.ProjectId.Data, g.Name.Data), nil
 }
 
+func (g *mqlGcpProjectBigtableServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
 func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
@@ -654,6 +658,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlBackup.(*mqlGcpProjectBigtableServiceBackup).cacheSourceBackup = backup.SourceBackup
 			res = append(res, mqlBackup)
 		}
 	}
@@ -672,4 +677,126 @@ func (g *mqlGcpProjectBigtableServiceBackup) id() (string, error) {
 		return "", g.Name.Error
 	}
 	return fmt.Sprintf("gcp.project/%s/bigtableService/%s/backup/%s", g.ProjectId.Data, g.ClusterName.Data, g.Name.Data), nil
+}
+
+type mqlGcpProjectBigtableServiceBackupInternal struct {
+	cacheSourceBackup string
+}
+
+// bigtableInstanceIDFromClusterName extracts the short instance ID from a full
+// cluster resource name (projects/{project}/instances/{instance}/clusters/{cluster}).
+// Returns "" when the name does not match that shape.
+func bigtableInstanceIDFromClusterName(clusterName string) string {
+	parts := strings.Split(clusterName, "/")
+	if len(parts) < 4 || parts[0] != "projects" || parts[2] != "instances" {
+		return ""
+	}
+	return parts[3]
+}
+
+// getBigtableTableByName resolves a Bigtable table by its short ID within an
+// instance. The instance list is served from the runtime cache when the parent
+// traversal already listed it. Returns nil when the table name is empty or no
+// matching table exists.
+func getBigtableTableByName(runtime *plugin.Runtime, projectId, instanceName, tableName string) (*mqlGcpProjectBigtableServiceTable, error) {
+	if tableName == "" || instanceName == "" {
+		return nil, nil
+	}
+	obj, err := CreateResource(runtime, "gcp.project.bigtableService.instance", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"name":      llx.StringData(instanceName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	inst := obj.(*mqlGcpProjectBigtableServiceInstance)
+	tables := inst.GetTables()
+	if tables.Error != nil {
+		return nil, tables.Error
+	}
+	for _, t := range tables.Data {
+		table := t.(*mqlGcpProjectBigtableServiceTable)
+		if table.Name.Error != nil {
+			return nil, table.Name.Error
+		}
+		if table.Name.Data == tableName {
+			return table, nil
+		}
+	}
+	return nil, nil
+}
+
+// getBigtableBackupByName resolves a Bigtable backup by its full resource name
+// (projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}).
+// Returns nil when the name is empty, malformed, or no matching backup exists.
+func getBigtableBackupByName(runtime *plugin.Runtime, backupResourceName string) (*mqlGcpProjectBigtableServiceBackup, error) {
+	if backupResourceName == "" {
+		return nil, nil
+	}
+	parts := strings.Split(backupResourceName, "/")
+	if len(parts) < 8 || parts[0] != "projects" || parts[2] != "instances" || parts[4] != "clusters" || parts[6] != "backups" {
+		return nil, nil
+	}
+	projectId := parts[1]
+	instanceName := parts[3]
+	clusterFullName := fmt.Sprintf("projects/%s/instances/%s/clusters/%s", parts[1], parts[3], parts[5])
+	backupShort := parts[7]
+
+	obj, err := CreateResource(runtime, "gcp.project.bigtableService.instance", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"name":      llx.StringData(instanceName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	inst := obj.(*mqlGcpProjectBigtableServiceInstance)
+	backups := inst.GetBackups()
+	if backups.Error != nil {
+		return nil, backups.Error
+	}
+	for _, b := range backups.Data {
+		backup := b.(*mqlGcpProjectBigtableServiceBackup)
+		if backup.Name.Error != nil {
+			return nil, backup.Name.Error
+		}
+		if backup.ClusterName.Error != nil {
+			return nil, backup.ClusterName.Error
+		}
+		if backup.Name.Data == backupShort && backup.ClusterName.Data == clusterFullName {
+			return backup, nil
+		}
+	}
+	return nil, nil
+}
+
+func (g *mqlGcpProjectBigtableServiceBackup) sourceTableRef() (*mqlGcpProjectBigtableServiceTable, error) {
+	if g.SourceTable.Error != nil {
+		return nil, g.SourceTable.Error
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	if g.ClusterName.Error != nil {
+		return nil, g.ClusterName.Error
+	}
+	instanceName := bigtableInstanceIDFromClusterName(g.ClusterName.Data)
+	table, err := getBigtableTableByName(g.MqlRuntime, g.ProjectId.Data, instanceName, g.SourceTable.Data)
+	if err != nil {
+		return nil, err
+	}
+	if table == nil {
+		g.SourceTableRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return table, nil
+}
+
+func (g *mqlGcpProjectBigtableServiceBackup) sourceBackup() (*mqlGcpProjectBigtableServiceBackup, error) {
+	backup, err := getBigtableBackupByName(g.MqlRuntime, g.cacheSourceBackup)
+	if err != nil {
+		return nil, err
+	}
+	if backup == nil {
+		g.SourceBackup.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return backup, nil
 }

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -183,10 +183,29 @@ func (g *mqlGcpProjectFirestoreService) databases() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlFirestoreDb := mqlDb.(*mqlGcpProjectFirestoreServiceDatabase)
+		mqlFirestoreDb.cacheKmsKeyName = db.GetCmekConfig().GetKmsKeyName()
 		res = append(res, mqlDb)
 	}
 
 	return res, nil
+}
+
+type mqlGcpProjectFirestoreServiceDatabaseInternal struct {
+	cacheKmsKeyName string
+}
+
+func (g *mqlGcpProjectFirestoreServiceDatabase) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+	if g.cacheKmsKeyName == "" {
+		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey",
+		map[string]*llx.RawData{"resourcePath": llx.StringData(g.cacheKmsKeyName)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
 func (g *mqlGcpProjectFirestoreServiceDatabase) id() (string, error) {

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2682,6 +2682,12 @@ private gcp.project.sqlService.instance @defaults("name") {
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Name and status of the failover replica
   failoverReplica dict
+  // Standby instance designated as the high-availability failover target
+  //
+  // Resolves the instance named by the failover replica configuration, the
+  // standby the primary fails over to for high availability. Null when the
+  // instance has no failover replica.
+  failoverReplicaRef() gcp.project.sqlService.instance
   // Raw GCE zone name
   //
   // Deprecated in favor of `zone`.
@@ -2784,8 +2790,21 @@ private gcp.project.sqlService.instance @defaults("name") {
   // `failoverDrReplicaName` is set on the primary to designate the DR
   // replica.
   replicationCluster dict
+  // Cross-region disaster-recovery replica designated by this primary
+  //
+  // Resolves the instance named as the cross-region disaster-recovery
+  // replica of the replication cluster, the target an Enterprise Plus
+  // primary fails over to in another region. Null when no such replica is
+  // designated.
+  drReplica() gcp.project.sqlService.instance
   // Expiration time of the instance's server CA certificate used for TLS
   serverCaCertExpiration time
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) SQL instance database
@@ -7302,6 +7321,11 @@ private gcp.project.firestoreService.database @defaults("name") {
   tags map[string]string
   // Customer-managed encryption key configuration
   cmekConfig dict
+  // Customer-managed KMS key used for encryption (null when Google-managed)
+  //
+  // Resolves the key named in the customer-managed encryption configuration.
+  // Null when the database uses Google-managed encryption.
+  kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Version retention period
   versionRetentionPeriod string
   // Earliest timestamp to which the database can be restored
@@ -7418,6 +7442,12 @@ private gcp.project.spannerService.instance @defaults("name") {
   backupSchedules() []gcp.project.spannerService.instance.backupSchedule
   // List of instance partitions
   instancePartitions() []gcp.project.spannerService.instance.instancePartition
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Spanner database
@@ -7459,6 +7489,12 @@ private gcp.project.spannerService.instance.database @defaults("name") {
   createdAt time
   // Restore source information if the database was restored from a backup
   restoreInfo dict
+  // Backup this database was restored from
+  //
+  // Resolves the backup named in the restore information when the database
+  // was created by restoring a backup. Null for databases created empty or
+  // when the source backup no longer exists.
+  sourceBackup() gcp.project.spannerService.instance.backup
   // Database DDL statements (schema definition)
   ddl() []string
   // IAM policy bindings for the database
@@ -7485,6 +7521,11 @@ private gcp.project.spannerService.instance.backup @defaults("name") {
   name string
   // Source database of the backup
   database string
+  // Database this backup was taken from
+  //
+  // Resolves the source database named in the backup. Null when the source
+  // database no longer exists.
+  sourceDatabase() gcp.project.spannerService.instance.database
   // Current state of the backup
   state string
   // Expiration time
@@ -7678,6 +7719,12 @@ private gcp.project.bigtableService.instance @defaults("name") {
   backups() []gcp.project.bigtableService.backup
   // IAM policy bindings for the Bigtable instance
   iamPolicy() []gcp.resourcemanager.binding
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) Bigtable cluster
@@ -7777,6 +7824,16 @@ private gcp.project.bigtableService.backup @defaults("name") {
   name string
   // Source table of the backup
   sourceTable string
+  // Table this backup was taken from
+  //
+  // Resolves the source table named in the backup. Null when the source
+  // table no longer exists.
+  sourceTableRef() gcp.project.bigtableService.table
+  // Backup this backup was copied from
+  //
+  // Set on a backup created by copying another backup, resolving the source
+  // backup in the copy chain. Null for backups taken directly from a table.
+  sourceBackup() gcp.project.bigtableService.backup
   // Expiration time
   expireTime time
   // Start time
@@ -7875,6 +7932,27 @@ private gcp.project.alloydbService.cluster @defaults("name") {
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Database users defined on the cluster (built-in or AlloyDB IAM users)
   users() []gcp.project.alloydbService.cluster.user
+  // VPC network the cluster is attached to for private connectivity
+  //
+  // Resolves the network named in the cluster network configuration. Null
+  // when the cluster uses Private Service Connect instead of a peered VPC.
+  network() gcp.project.computeService.network
+  // Primary cluster this secondary cluster replicates from
+  //
+  // Set on a SECONDARY cluster, resolving the cross-region primary named in
+  // its secondary configuration. Null on primary clusters.
+  primaryCluster() gcp.project.alloydbService.cluster
+  // Secondary clusters replicating from this primary cluster
+  //
+  // Set on a PRIMARY cluster, resolving each cross-region secondary named in
+  // its primary configuration. Empty on secondary clusters.
+  secondaryClusters() []gcp.project.alloydbService.cluster
+  // Infrastructure-management system that provisioned the resource
+  //
+  // Value derived from the provenance labels and annotations Google and IaC
+  // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
+  // when the resource carries no management signal.
+  managedBy() string
 }
 
 // Google Cloud (GCP) AlloyDB cluster user
@@ -7990,6 +8068,11 @@ private gcp.project.alloydbService.backup @defaults("name") {
   description string
   // Source cluster name
   clusterName string
+  // Cluster this backup was taken from
+  //
+  // Resolves the source cluster named in the backup. Null when the source
+  // cluster no longer exists.
+  sourceCluster() gcp.project.alloydbService.cluster
   // Database version
   databaseVersion string
   // Encryption configuration
@@ -8012,6 +8095,8 @@ private gcp.project.alloydbService.backup @defaults("name") {
   createdAt time
   // Last update time
   updatedAt time
+  // Customer-managed KMS key used for backup encryption (null when Google-managed)
+  kmsKey() gcp.project.kmsService.keyring.cryptokey
 }
 
 // Google Cloud (GCP) Compute Cloud Armor security policy

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5107,6 +5107,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.failoverReplica": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetFailoverReplica()).ToDataRes(types.Dict)
 	},
+	"gcp.project.sqlService.instance.failoverReplicaRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetFailoverReplicaRef()).ToDataRes(types.Resource("gcp.project.sqlService.instance"))
+	},
 	"gcp.project.sqlService.instance.gceZone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetGceZone()).ToDataRes(types.String)
 	},
@@ -5239,8 +5242,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.replicationCluster": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetReplicationCluster()).ToDataRes(types.Dict)
 	},
+	"gcp.project.sqlService.instance.drReplica": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetDrReplica()).ToDataRes(types.Resource("gcp.project.sqlService.instance"))
+	},
 	"gcp.project.sqlService.instance.serverCaCertExpiration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetServerCaCertExpiration()).ToDataRes(types.Time)
+	},
+	"gcp.project.sqlService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.sqlService.instance.database.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceDatabase).GetProjectId()).ToDataRes(types.String)
@@ -9607,6 +9616,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.firestoreService.database.cmekConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetCmekConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.firestoreService.database.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
 	"gcp.project.firestoreService.database.versionRetentionPeriod": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetVersionRetentionPeriod()).ToDataRes(types.String)
 	},
@@ -9739,6 +9751,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.spannerService.instance.instancePartitions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstance).GetInstancePartitions()).ToDataRes(types.Array(types.Resource("gcp.project.spannerService.instance.instancePartition")))
 	},
+	"gcp.project.spannerService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSpannerServiceInstance).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.spannerService.instance.database.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstanceDatabase).GetProjectId()).ToDataRes(types.String)
 	},
@@ -9784,6 +9799,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.spannerService.instance.database.restoreInfo": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstanceDatabase).GetRestoreInfo()).ToDataRes(types.Dict)
 	},
+	"gcp.project.spannerService.instance.database.sourceBackup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSpannerServiceInstanceDatabase).GetSourceBackup()).ToDataRes(types.Resource("gcp.project.spannerService.instance.backup"))
+	},
 	"gcp.project.spannerService.instance.database.ddl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstanceDatabase).GetDdl()).ToDataRes(types.Array(types.String))
 	},
@@ -9804,6 +9822,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.spannerService.instance.backup.database": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstanceBackup).GetDatabase()).ToDataRes(types.String)
+	},
+	"gcp.project.spannerService.instance.backup.sourceDatabase": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSpannerServiceInstanceBackup).GetSourceDatabase()).ToDataRes(types.Resource("gcp.project.spannerService.instance.database"))
 	},
 	"gcp.project.spannerService.instance.backup.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSpannerServiceInstanceBackup).GetState()).ToDataRes(types.String)
@@ -10012,6 +10033,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigtableService.instance.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigtableServiceInstance).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
+	"gcp.project.bigtableService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigtableServiceInstance).GetManagedBy()).ToDataRes(types.String)
+	},
 	"gcp.project.bigtableService.cluster.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigtableServiceCluster).GetProjectId()).ToDataRes(types.String)
 	},
@@ -10101,6 +10125,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigtableService.backup.sourceTable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigtableServiceBackup).GetSourceTable()).ToDataRes(types.String)
+	},
+	"gcp.project.bigtableService.backup.sourceTableRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigtableServiceBackup).GetSourceTableRef()).ToDataRes(types.Resource("gcp.project.bigtableService.table"))
+	},
+	"gcp.project.bigtableService.backup.sourceBackup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigtableServiceBackup).GetSourceBackup()).ToDataRes(types.Resource("gcp.project.bigtableService.backup"))
 	},
 	"gcp.project.bigtableService.backup.expireTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigtableServiceBackup).GetExpireTime()).ToDataRes(types.Time)
@@ -10215,6 +10245,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.alloydbService.cluster.users": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAlloydbServiceCluster).GetUsers()).ToDataRes(types.Array(types.Resource("gcp.project.alloydbService.cluster.user")))
+	},
+	"gcp.project.alloydbService.cluster.network": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceCluster).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
+	"gcp.project.alloydbService.cluster.primaryCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceCluster).GetPrimaryCluster()).ToDataRes(types.Resource("gcp.project.alloydbService.cluster"))
+	},
+	"gcp.project.alloydbService.cluster.secondaryClusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceCluster).GetSecondaryClusters()).ToDataRes(types.Array(types.Resource("gcp.project.alloydbService.cluster")))
+	},
+	"gcp.project.alloydbService.cluster.managedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceCluster).GetManagedBy()).ToDataRes(types.String)
 	},
 	"gcp.project.alloydbService.cluster.user.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAlloydbServiceClusterUser).GetProjectId()).ToDataRes(types.String)
@@ -10342,6 +10384,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.alloydbService.backup.clusterName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAlloydbServiceBackup).GetClusterName()).ToDataRes(types.String)
 	},
+	"gcp.project.alloydbService.backup.sourceCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceBackup).GetSourceCluster()).ToDataRes(types.Resource("gcp.project.alloydbService.cluster"))
+	},
 	"gcp.project.alloydbService.backup.databaseVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAlloydbServiceBackup).GetDatabaseVersion()).ToDataRes(types.String)
 	},
@@ -10374,6 +10419,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.alloydbService.backup.updatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAlloydbServiceBackup).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"gcp.project.alloydbService.backup.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAlloydbServiceBackup).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
 	"gcp.project.computeService.securityPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetId()).ToDataRes(types.String)
@@ -20929,6 +20977,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).FailoverReplica, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.failoverReplicaRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).FailoverReplicaRef, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstance](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.gceZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).GceZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -21105,8 +21157,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).ReplicationCluster, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.drReplica": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).DrReplica, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstance](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.serverCaCertExpiration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).ServerCaCertExpiration, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27517,6 +27577,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectFirestoreServiceDatabase).CmekConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.firestoreService.database.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectFirestoreServiceDatabase).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
 	"gcp.project.firestoreService.database.versionRetentionPeriod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectFirestoreServiceDatabase).VersionRetentionPeriod, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -27709,6 +27773,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSpannerServiceInstance).InstancePartitions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.spannerService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSpannerServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.spannerService.instance.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSpannerServiceInstanceDatabase).__id, ok = v.Value.(string)
 		return
@@ -27773,6 +27841,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSpannerServiceInstanceDatabase).RestoreInfo, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.spannerService.instance.database.sourceBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSpannerServiceInstanceDatabase).SourceBackup, ok = plugin.RawToTValue[*mqlGcpProjectSpannerServiceInstanceBackup](v.Value, v.Error)
+		return
+	},
 	"gcp.project.spannerService.instance.database.ddl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSpannerServiceInstanceDatabase).Ddl, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -27803,6 +27875,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.spannerService.instance.backup.database": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSpannerServiceInstanceBackup).Database, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.spannerService.instance.backup.sourceDatabase": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSpannerServiceInstanceBackup).SourceDatabase, ok = plugin.RawToTValue[*mqlGcpProjectSpannerServiceInstanceDatabase](v.Value, v.Error)
 		return
 	},
 	"gcp.project.spannerService.instance.backup.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28105,6 +28181,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigtableServiceInstance).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.bigtableService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigtableServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.bigtableService.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigtableServiceCluster).__id, ok = v.Value.(string)
 		return
@@ -28239,6 +28319,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigtableService.backup.sourceTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigtableServiceBackup).SourceTable, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigtableService.backup.sourceTableRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigtableServiceBackup).SourceTableRef, ok = plugin.RawToTValue[*mqlGcpProjectBigtableServiceTable](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigtableService.backup.sourceBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigtableServiceBackup).SourceBackup, ok = plugin.RawToTValue[*mqlGcpProjectBigtableServiceBackup](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigtableService.backup.expireTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28399,6 +28487,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.alloydbService.cluster.users": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectAlloydbServiceCluster).Users, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.alloydbService.cluster.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceCluster).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
+	"gcp.project.alloydbService.cluster.primaryCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceCluster).PrimaryCluster, ok = plugin.RawToTValue[*mqlGcpProjectAlloydbServiceCluster](v.Value, v.Error)
+		return
+	},
+	"gcp.project.alloydbService.cluster.secondaryClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceCluster).SecondaryClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.alloydbService.cluster.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceCluster).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.alloydbService.cluster.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28581,6 +28685,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectAlloydbServiceBackup).ClusterName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.alloydbService.backup.sourceCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceBackup).SourceCluster, ok = plugin.RawToTValue[*mqlGcpProjectAlloydbServiceCluster](v.Value, v.Error)
+		return
+	},
 	"gcp.project.alloydbService.backup.databaseVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectAlloydbServiceBackup).DatabaseVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -28623,6 +28731,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.alloydbService.backup.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectAlloydbServiceBackup).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.alloydbService.backup.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAlloydbServiceBackup).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.securityPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47916,6 +48028,7 @@ type mqlGcpProjectSqlServiceInstance struct {
 	DiskEncryptionStatus                       plugin.TValue[any]
 	KmsKey                                     plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	FailoverReplica                            plugin.TValue[any]
+	FailoverReplicaRef                         plugin.TValue[*mqlGcpProjectSqlServiceInstance]
 	GceZone                                    plugin.TValue[string]
 	Zone                                       plugin.TValue[*mqlGcpProjectComputeServiceZone]
 	InstanceType                               plugin.TValue[string]
@@ -47960,7 +48073,9 @@ type mqlGcpProjectSqlServiceInstance struct {
 	ScheduledMaintenance                       plugin.TValue[any]
 	UpgradableDatabaseVersions                 plugin.TValue[[]any]
 	ReplicationCluster                         plugin.TValue[any]
+	DrReplica                                  plugin.TValue[*mqlGcpProjectSqlServiceInstance]
 	ServerCaCertExpiration                     plugin.TValue[*time.Time]
+	ManagedBy                                  plugin.TValue[string]
 }
 
 // createGcpProjectSqlServiceInstance creates a new instance of this resource
@@ -48054,6 +48169,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetKmsKey() *plugin.TValue[*mqlGcpProj
 
 func (c *mqlGcpProjectSqlServiceInstance) GetFailoverReplica() *plugin.TValue[any] {
 	return &c.FailoverReplica
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetFailoverReplicaRef() *plugin.TValue[*mqlGcpProjectSqlServiceInstance] {
+	return plugin.GetOrCompute[*mqlGcpProjectSqlServiceInstance](&c.FailoverReplicaRef, func() (*mqlGcpProjectSqlServiceInstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "failoverReplicaRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectSqlServiceInstance), nil
+			}
+		}
+
+		return c.failoverReplicaRef()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstance) GetGceZone() *plugin.TValue[string] {
@@ -48354,8 +48485,30 @@ func (c *mqlGcpProjectSqlServiceInstance) GetReplicationCluster() *plugin.TValue
 	return &c.ReplicationCluster
 }
 
+func (c *mqlGcpProjectSqlServiceInstance) GetDrReplica() *plugin.TValue[*mqlGcpProjectSqlServiceInstance] {
+	return plugin.GetOrCompute[*mqlGcpProjectSqlServiceInstance](&c.DrReplica, func() (*mqlGcpProjectSqlServiceInstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "drReplica")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectSqlServiceInstance), nil
+			}
+		}
+
+		return c.drReplica()
+	})
+}
+
 func (c *mqlGcpProjectSqlServiceInstance) GetServerCaCertExpiration() *plugin.TValue[*time.Time] {
 	return &c.ServerCaCertExpiration
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
 }
 
 // mqlGcpProjectSqlServiceInstanceDatabase for the gcp.project.sqlService.instance.database resource
@@ -63360,7 +63513,7 @@ func (c *mqlGcpProjectFirestoreService) GetDatabases() *plugin.TValue[[]any] {
 type mqlGcpProjectFirestoreServiceDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectFirestoreServiceDatabaseInternal it will be used here
+	mqlGcpProjectFirestoreServiceDatabaseInternal
 	ProjectId                     plugin.TValue[string]
 	Name                          plugin.TValue[string]
 	Uid                           plugin.TValue[string]
@@ -63372,6 +63525,7 @@ type mqlGcpProjectFirestoreServiceDatabase struct {
 	DeleteProtectionState         plugin.TValue[string]
 	Tags                          plugin.TValue[map[string]any]
 	CmekConfig                    plugin.TValue[any]
+	KmsKey                        plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	VersionRetentionPeriod        plugin.TValue[string]
 	EarliestVersionTime           plugin.TValue[*time.Time]
 	Etag                          plugin.TValue[string]
@@ -63460,6 +63614,22 @@ func (c *mqlGcpProjectFirestoreServiceDatabase) GetTags() *plugin.TValue[map[str
 
 func (c *mqlGcpProjectFirestoreServiceDatabase) GetCmekConfig() *plugin.TValue[any] {
 	return &c.CmekConfig
+}
+
+func (c *mqlGcpProjectFirestoreServiceDatabase) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.KmsKey, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.firestoreService.database", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 func (c *mqlGcpProjectFirestoreServiceDatabase) GetVersionRetentionPeriod() *plugin.TValue[string] {
@@ -63768,6 +63938,7 @@ type mqlGcpProjectSpannerServiceInstance struct {
 	Backups                   plugin.TValue[[]any]
 	BackupSchedules           plugin.TValue[[]any]
 	InstancePartitions        plugin.TValue[[]any]
+	ManagedBy                 plugin.TValue[string]
 }
 
 // createGcpProjectSpannerServiceInstance creates a new instance of this resource
@@ -63971,6 +64142,12 @@ func (c *mqlGcpProjectSpannerServiceInstance) GetInstancePartitions() *plugin.TV
 	})
 }
 
+func (c *mqlGcpProjectSpannerServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
+	})
+}
+
 // mqlGcpProjectSpannerServiceInstanceDatabase for the gcp.project.spannerService.instance.database resource
 type mqlGcpProjectSpannerServiceInstanceDatabase struct {
 	MqlRuntime *plugin.Runtime
@@ -63991,6 +64168,7 @@ type mqlGcpProjectSpannerServiceInstanceDatabase struct {
 	Reconciling            plugin.TValue[bool]
 	CreatedAt              plugin.TValue[*time.Time]
 	RestoreInfo            plugin.TValue[any]
+	SourceBackup           plugin.TValue[*mqlGcpProjectSpannerServiceInstanceBackup]
 	Ddl                    plugin.TValue[[]any]
 	IamPolicy              plugin.TValue[[]any]
 	DatabaseRoles          plugin.TValue[[]any]
@@ -64105,6 +64283,22 @@ func (c *mqlGcpProjectSpannerServiceInstanceDatabase) GetRestoreInfo() *plugin.T
 	return &c.RestoreInfo
 }
 
+func (c *mqlGcpProjectSpannerServiceInstanceDatabase) GetSourceBackup() *plugin.TValue[*mqlGcpProjectSpannerServiceInstanceBackup] {
+	return plugin.GetOrCompute[*mqlGcpProjectSpannerServiceInstanceBackup](&c.SourceBackup, func() (*mqlGcpProjectSpannerServiceInstanceBackup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.spannerService.instance.database", c.__id, "sourceBackup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectSpannerServiceInstanceBackup), nil
+			}
+		}
+
+		return c.sourceBackup()
+	})
+}
+
 func (c *mqlGcpProjectSpannerServiceInstanceDatabase) GetDdl() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Ddl, func() ([]any, error) {
 		return c.ddl()
@@ -64152,6 +64346,7 @@ type mqlGcpProjectSpannerServiceInstanceBackup struct {
 	InstanceName             plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Database                 plugin.TValue[string]
+	SourceDatabase           plugin.TValue[*mqlGcpProjectSpannerServiceInstanceDatabase]
 	State                    plugin.TValue[string]
 	ExpireTime               plugin.TValue[*time.Time]
 	VersionTime              plugin.TValue[*time.Time]
@@ -64220,6 +64415,22 @@ func (c *mqlGcpProjectSpannerServiceInstanceBackup) GetName() *plugin.TValue[str
 
 func (c *mqlGcpProjectSpannerServiceInstanceBackup) GetDatabase() *plugin.TValue[string] {
 	return &c.Database
+}
+
+func (c *mqlGcpProjectSpannerServiceInstanceBackup) GetSourceDatabase() *plugin.TValue[*mqlGcpProjectSpannerServiceInstanceDatabase] {
+	return plugin.GetOrCompute[*mqlGcpProjectSpannerServiceInstanceDatabase](&c.SourceDatabase, func() (*mqlGcpProjectSpannerServiceInstanceDatabase, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.spannerService.instance.backup", c.__id, "sourceDatabase")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectSpannerServiceInstanceDatabase), nil
+			}
+		}
+
+		return c.sourceDatabase()
+	})
 }
 
 func (c *mqlGcpProjectSpannerServiceInstanceBackup) GetState() *plugin.TValue[string] {
@@ -64741,6 +64952,7 @@ type mqlGcpProjectBigtableServiceInstance struct {
 	Tables       plugin.TValue[[]any]
 	Backups      plugin.TValue[[]any]
 	IamPolicy    plugin.TValue[[]any]
+	ManagedBy    plugin.TValue[string]
 }
 
 // createGcpProjectBigtableServiceInstance creates a new instance of this resource
@@ -64885,6 +65097,12 @@ func (c *mqlGcpProjectBigtableServiceInstance) GetIamPolicy() *plugin.TValue[[]a
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectBigtableServiceInstance) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -65166,11 +65384,13 @@ func (c *mqlGcpProjectBigtableServiceAppProfile) GetEtag() *plugin.TValue[string
 type mqlGcpProjectBigtableServiceBackup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectBigtableServiceBackupInternal it will be used here
+	mqlGcpProjectBigtableServiceBackupInternal
 	ProjectId      plugin.TValue[string]
 	ClusterName    plugin.TValue[string]
 	Name           plugin.TValue[string]
 	SourceTable    plugin.TValue[string]
+	SourceTableRef plugin.TValue[*mqlGcpProjectBigtableServiceTable]
+	SourceBackup   plugin.TValue[*mqlGcpProjectBigtableServiceBackup]
 	ExpireTime     plugin.TValue[*time.Time]
 	StartTime      plugin.TValue[*time.Time]
 	EndTime        plugin.TValue[*time.Time]
@@ -65230,6 +65450,38 @@ func (c *mqlGcpProjectBigtableServiceBackup) GetName() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectBigtableServiceBackup) GetSourceTable() *plugin.TValue[string] {
 	return &c.SourceTable
+}
+
+func (c *mqlGcpProjectBigtableServiceBackup) GetSourceTableRef() *plugin.TValue[*mqlGcpProjectBigtableServiceTable] {
+	return plugin.GetOrCompute[*mqlGcpProjectBigtableServiceTable](&c.SourceTableRef, func() (*mqlGcpProjectBigtableServiceTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigtableService.backup", c.__id, "sourceTableRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBigtableServiceTable), nil
+			}
+		}
+
+		return c.sourceTableRef()
+	})
+}
+
+func (c *mqlGcpProjectBigtableServiceBackup) GetSourceBackup() *plugin.TValue[*mqlGcpProjectBigtableServiceBackup] {
+	return plugin.GetOrCompute[*mqlGcpProjectBigtableServiceBackup](&c.SourceBackup, func() (*mqlGcpProjectBigtableServiceBackup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigtableService.backup", c.__id, "sourceBackup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBigtableServiceBackup), nil
+			}
+		}
+
+		return c.sourceBackup()
+	})
 }
 
 func (c *mqlGcpProjectBigtableServiceBackup) GetExpireTime() *plugin.TValue[*time.Time] {
@@ -65357,6 +65609,10 @@ type mqlGcpProjectAlloydbServiceCluster struct {
 	Backups                 plugin.TValue[[]any]
 	KmsKey                  plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	Users                   plugin.TValue[[]any]
+	Network                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	PrimaryCluster          plugin.TValue[*mqlGcpProjectAlloydbServiceCluster]
+	SecondaryClusters       plugin.TValue[[]any]
+	ManagedBy               plugin.TValue[string]
 }
 
 // createGcpProjectAlloydbServiceCluster creates a new instance of this resource
@@ -65561,6 +65817,60 @@ func (c *mqlGcpProjectAlloydbServiceCluster) GetUsers() *plugin.TValue[[]any] {
 		}
 
 		return c.users()
+	})
+}
+
+func (c *mqlGcpProjectAlloydbServiceCluster) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.alloydbService.cluster", c.__id, "network")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceNetwork), nil
+			}
+		}
+
+		return c.network()
+	})
+}
+
+func (c *mqlGcpProjectAlloydbServiceCluster) GetPrimaryCluster() *plugin.TValue[*mqlGcpProjectAlloydbServiceCluster] {
+	return plugin.GetOrCompute[*mqlGcpProjectAlloydbServiceCluster](&c.PrimaryCluster, func() (*mqlGcpProjectAlloydbServiceCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.alloydbService.cluster", c.__id, "primaryCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectAlloydbServiceCluster), nil
+			}
+		}
+
+		return c.primaryCluster()
+	})
+}
+
+func (c *mqlGcpProjectAlloydbServiceCluster) GetSecondaryClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecondaryClusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.alloydbService.cluster", c.__id, "secondaryClusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.secondaryClusters()
+	})
+}
+
+func (c *mqlGcpProjectAlloydbServiceCluster) GetManagedBy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
+		return c.managedBy()
 	})
 }
 
@@ -65826,7 +66136,7 @@ func (c *mqlGcpProjectAlloydbServiceInstance) GetUpdatedAt() *plugin.TValue[*tim
 type mqlGcpProjectAlloydbServiceBackup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectAlloydbServiceBackupInternal it will be used here
+	mqlGcpProjectAlloydbServiceBackupInternal
 	ProjectId        plugin.TValue[string]
 	Name             plugin.TValue[string]
 	DisplayName      plugin.TValue[string]
@@ -65835,6 +66145,7 @@ type mqlGcpProjectAlloydbServiceBackup struct {
 	Type             plugin.TValue[string]
 	Description      plugin.TValue[string]
 	ClusterName      plugin.TValue[string]
+	SourceCluster    plugin.TValue[*mqlGcpProjectAlloydbServiceCluster]
 	DatabaseVersion  plugin.TValue[string]
 	EncryptionConfig plugin.TValue[any]
 	EncryptionInfo   plugin.TValue[any]
@@ -65846,6 +66157,7 @@ type mqlGcpProjectAlloydbServiceBackup struct {
 	Reconciling      plugin.TValue[bool]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
+	KmsKey           plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 }
 
 // createGcpProjectAlloydbServiceBackup creates a new instance of this resource
@@ -65917,6 +66229,22 @@ func (c *mqlGcpProjectAlloydbServiceBackup) GetClusterName() *plugin.TValue[stri
 	return &c.ClusterName
 }
 
+func (c *mqlGcpProjectAlloydbServiceBackup) GetSourceCluster() *plugin.TValue[*mqlGcpProjectAlloydbServiceCluster] {
+	return plugin.GetOrCompute[*mqlGcpProjectAlloydbServiceCluster](&c.SourceCluster, func() (*mqlGcpProjectAlloydbServiceCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.alloydbService.backup", c.__id, "sourceCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectAlloydbServiceCluster), nil
+			}
+		}
+
+		return c.sourceCluster()
+	})
+}
+
 func (c *mqlGcpProjectAlloydbServiceBackup) GetDatabaseVersion() *plugin.TValue[string] {
 	return &c.DatabaseVersion
 }
@@ -65959,6 +66287,22 @@ func (c *mqlGcpProjectAlloydbServiceBackup) GetCreatedAt() *plugin.TValue[*time.
 
 func (c *mqlGcpProjectAlloydbServiceBackup) GetUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.UpdatedAt
+}
+
+func (c *mqlGcpProjectAlloydbServiceBackup) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokey](&c.KmsKey, func() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.alloydbService.backup", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 // mqlGcpProjectComputeServiceSecurityPolicy for the gcp.project.computeService.securityPolicy resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -224,11 +224,13 @@ gcp.project.alloydbService.backup.encryptionInfo 11.3.1
 gcp.project.alloydbService.backup.etag 11.3.1
 gcp.project.alloydbService.backup.expiryQuantity 11.3.1
 gcp.project.alloydbService.backup.expiryTime 11.3.1
+gcp.project.alloydbService.backup.kmsKey 13.27.2
 gcp.project.alloydbService.backup.labels 11.3.1
 gcp.project.alloydbService.backup.name 11.3.1
 gcp.project.alloydbService.backup.projectId 11.3.1
 gcp.project.alloydbService.backup.reconciling 11.3.1
 gcp.project.alloydbService.backup.sizeBytes 11.3.1
+gcp.project.alloydbService.backup.sourceCluster 13.27.2
 gcp.project.alloydbService.backup.state 11.3.1
 gcp.project.alloydbService.backup.type 11.3.1
 gcp.project.alloydbService.backup.uid 11.3.1
@@ -252,12 +254,16 @@ gcp.project.alloydbService.cluster.labels 11.3.1
 gcp.project.alloydbService.cluster.location 11.3.1
 gcp.project.alloydbService.cluster.maintenanceSchedule 11.3.1
 gcp.project.alloydbService.cluster.maintenanceUpdatePolicy 11.3.1
+gcp.project.alloydbService.cluster.managedBy 13.27.2
 gcp.project.alloydbService.cluster.name 11.3.1
+gcp.project.alloydbService.cluster.network 13.27.2
 gcp.project.alloydbService.cluster.networkConfig 11.3.1
+gcp.project.alloydbService.cluster.primaryCluster 13.27.2
 gcp.project.alloydbService.cluster.primaryConfig 11.3.1
 gcp.project.alloydbService.cluster.projectId 11.3.1
 gcp.project.alloydbService.cluster.pscEnabled 13.18.1
 gcp.project.alloydbService.cluster.reconciling 11.3.1
+gcp.project.alloydbService.cluster.secondaryClusters 13.27.2
 gcp.project.alloydbService.cluster.secondaryConfig 11.3.1
 gcp.project.alloydbService.cluster.sslConfig 11.3.1
 gcp.project.alloydbService.cluster.state 11.3.1
@@ -738,7 +744,9 @@ gcp.project.bigtableService.backup.expireTime 11.3.1
 gcp.project.bigtableService.backup.name 11.3.1
 gcp.project.bigtableService.backup.projectId 11.3.1
 gcp.project.bigtableService.backup.sizeBytes 11.3.1
+gcp.project.bigtableService.backup.sourceBackup 13.27.2
 gcp.project.bigtableService.backup.sourceTable 11.3.1
+gcp.project.bigtableService.backup.sourceTableRef 13.27.2
 gcp.project.bigtableService.backup.startTime 11.3.1
 gcp.project.bigtableService.backup.state 11.3.1
 gcp.project.bigtableService.cluster 11.3.1
@@ -762,6 +770,7 @@ gcp.project.bigtableService.instance.displayName 11.3.1
 gcp.project.bigtableService.instance.iamPolicy 13.12.2
 gcp.project.bigtableService.instance.instanceType 11.3.1
 gcp.project.bigtableService.instance.labels 11.3.1
+gcp.project.bigtableService.instance.managedBy 13.27.2
 gcp.project.bigtableService.instance.name 11.3.1
 gcp.project.bigtableService.instance.projectId 11.3.1
 gcp.project.bigtableService.instance.state 11.3.1
@@ -3042,6 +3051,7 @@ gcp.project.firestoreService.database.index.name 13.6.1
 gcp.project.firestoreService.database.index.queryScope 13.6.1
 gcp.project.firestoreService.database.index.state 13.6.1
 gcp.project.firestoreService.database.indexes 13.6.1
+gcp.project.firestoreService.database.kmsKey 13.27.2
 gcp.project.firestoreService.database.locationId 11.3.1
 gcp.project.firestoreService.database.name 11.3.1
 gcp.project.firestoreService.database.pointInTimeRecoveryEnablement 11.3.1
@@ -4330,6 +4340,7 @@ gcp.project.spannerService.instance.backup.projectId 11.3.1
 gcp.project.spannerService.instance.backup.referencingBackups 13.11.2
 gcp.project.spannerService.instance.backup.referencingDatabases 13.11.2
 gcp.project.spannerService.instance.backup.sizeBytes 11.3.1
+gcp.project.spannerService.instance.backup.sourceDatabase 13.27.2
 gcp.project.spannerService.instance.backup.state 11.3.1
 gcp.project.spannerService.instance.backup.versionTime 11.3.1
 gcp.project.spannerService.instance.backupSchedule 13.11.2
@@ -4368,6 +4379,7 @@ gcp.project.spannerService.instance.database.role.databaseName 13.11.2
 gcp.project.spannerService.instance.database.role.instanceName 13.11.2
 gcp.project.spannerService.instance.database.role.name 13.11.2
 gcp.project.spannerService.instance.database.role.projectId 13.11.2
+gcp.project.spannerService.instance.database.sourceBackup 13.27.2
 gcp.project.spannerService.instance.database.state 11.3.1
 gcp.project.spannerService.instance.database.versionRetentionPeriod 11.3.1
 gcp.project.spannerService.instance.databases 11.3.1
@@ -4395,6 +4407,7 @@ gcp.project.spannerService.instance.instancePartition.updatedAt 13.11.2
 gcp.project.spannerService.instance.instancePartitions 13.11.2
 gcp.project.spannerService.instance.instanceType 11.3.1
 gcp.project.spannerService.instance.labels 11.3.1
+gcp.project.spannerService.instance.managedBy 13.27.2
 gcp.project.spannerService.instance.name 11.3.1
 gcp.project.spannerService.instance.nodeCount 11.3.1
 gcp.project.spannerService.instance.processingUnits 11.3.1
@@ -4464,8 +4477,10 @@ gcp.project.sqlService.instance.diskEncryptionConfiguration 9.0.0
 gcp.project.sqlService.instance.diskEncryptionStatus 9.0.0
 gcp.project.sqlService.instance.dnsName 11.6.6
 gcp.project.sqlService.instance.dnsNames 13.16.3
+gcp.project.sqlService.instance.drReplica 13.27.2
 gcp.project.sqlService.instance.etag 13.1.2
 gcp.project.sqlService.instance.failoverReplica 9.0.0
+gcp.project.sqlService.instance.failoverReplicaRef 13.27.2
 gcp.project.sqlService.instance.gceZone 9.0.0
 gcp.project.sqlService.instance.hasBuiltInUsers 13.12.2
 gcp.project.sqlService.instance.iamAuthenticationEnabled 13.21.2
@@ -4480,6 +4495,7 @@ gcp.project.sqlService.instance.ipMapping.type 9.0.0
 gcp.project.sqlService.instance.kmsKey 13.12.2
 gcp.project.sqlService.instance.localRootEnabled 13.12.2
 gcp.project.sqlService.instance.maintenanceVersion 9.0.0
+gcp.project.sqlService.instance.managedBy 13.27.2
 gcp.project.sqlService.instance.master 13.25.2
 gcp.project.sqlService.instance.masterInstanceName 9.0.0
 gcp.project.sqlService.instance.maxDiskSize 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.27.0",
-  "generated_at": "2026-06-30T09:47:52-07:00",
+  "version": "13.27.1",
+  "generated_at": "2026-06-30T22:31:53-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/gcp_managed_by.go
+++ b/providers/gcp/resources/gcp_managed_by.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// managedByFromLabels infers the infrastructure-management system that owns a
+// GCP resource from the provenance labels and annotations Google and common
+// IaC tools stamp on managed resources. Callers pass every label/annotation map
+// the resource exposes; the maps are inspected in priority order and the first
+// recognized signal wins. It returns an empty string when no management signal
+// is present (a resource created manually or through the console) and propagates
+// any error from resolving a computed map.
+//
+// Recognized signals, highest priority first:
+//   - "terraform": the goog-terraform-provisioned label Google stamps on
+//     resources created through the Terraform Google provider.
+//   - "config-connector": the cnrm.cloud.google.com/* annotations (or the
+//     managed-by-cnrm label) the GKE Config Connector controller applies to
+//     resources it reconciles.
+//   - "cloud-composer": the goog-composer-* labels applied to resources a Cloud
+//     Composer environment provisions.
+func managedByFromLabels(maps ...*plugin.TValue[map[string]any]) (string, error) {
+	for _, m := range maps {
+		if m != nil && m.Error != nil {
+			return "", m.Error
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if v, ok := m.Data["goog-terraform-provisioned"]; ok && labelValueTrue(v) {
+			return "terraform", nil
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if k == "managed-by-cnrm" || strings.HasPrefix(k, "cnrm.cloud.google.com/") {
+				return "config-connector", nil
+			}
+		}
+	}
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for k := range m.Data {
+			if strings.HasPrefix(k, "goog-composer-") {
+				return "cloud-composer", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// labelValueTrue reports whether a label value is the string "true"
+// (case-insensitive). GCP label values are always strings.
+func labelValueTrue(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.EqualFold(s, "true")
+}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -310,6 +310,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 		if db.EncryptionConfig != nil {
 			mqlSpannerDb.cacheKmsKeyNames = collectSpannerKmsKeyNames(db.EncryptionConfig)
 		}
+		mqlSpannerDb.cacheSourceBackupName = db.RestoreInfo.GetBackupInfo().GetBackup()
 		res = append(res, mqlDb)
 	}
 
@@ -340,7 +341,116 @@ func collectSpannerKmsKeyNames(cfg *databasepb.EncryptionConfig) []string {
 }
 
 type mqlGcpProjectSpannerServiceInstanceDatabaseInternal struct {
-	cacheKmsKeyNames []string
+	cacheKmsKeyNames      []string
+	cacheSourceBackupName string
+}
+
+func (g *mqlGcpProjectSpannerServiceInstance) managedBy() (string, error) {
+	return managedByFromLabels(g.GetLabels())
+}
+
+// getSpannerInstanceForList creates a Spanner instance resource keyed only by
+// project and full instance name so its databases()/backups() lists can be
+// walked to resolve lineage. When the parent traversal already listed the
+// instance, the fully populated resource is returned from the runtime cache.
+func getSpannerInstanceForList(runtime *plugin.Runtime, projectId, instanceName string) (*mqlGcpProjectSpannerServiceInstance, error) {
+	obj, err := CreateResource(runtime, "gcp.project.spannerService.instance", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+		"name":      llx.StringData(instanceName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*mqlGcpProjectSpannerServiceInstance), nil
+}
+
+// getSpannerBackupByName resolves a Spanner backup by its full resource name
+// (projects/{project}/instances/{instance}/backups/{backup}). Returns nil when
+// the name is empty, malformed, or no matching backup exists.
+func getSpannerBackupByName(runtime *plugin.Runtime, backupName string) (*mqlGcpProjectSpannerServiceInstanceBackup, error) {
+	if backupName == "" {
+		return nil, nil
+	}
+	parts := strings.Split(backupName, "/")
+	if len(parts) < 6 || parts[0] != "projects" || parts[2] != "instances" || parts[4] != "backups" {
+		return nil, nil
+	}
+	instanceName := fmt.Sprintf("projects/%s/instances/%s", parts[1], parts[3])
+	inst, err := getSpannerInstanceForList(runtime, parts[1], instanceName)
+	if err != nil {
+		return nil, err
+	}
+	backups := inst.GetBackups()
+	if backups.Error != nil {
+		return nil, backups.Error
+	}
+	for _, b := range backups.Data {
+		backup := b.(*mqlGcpProjectSpannerServiceInstanceBackup)
+		if backup.Name.Error != nil {
+			return nil, backup.Name.Error
+		}
+		if backup.Name.Data == backupName {
+			return backup, nil
+		}
+	}
+	return nil, nil
+}
+
+// getSpannerDatabaseByName resolves a Spanner database by its full resource name
+// (projects/{project}/instances/{instance}/databases/{database}). Returns nil
+// when the name is empty, malformed, or no matching database exists.
+func getSpannerDatabaseByName(runtime *plugin.Runtime, dbName string) (*mqlGcpProjectSpannerServiceInstanceDatabase, error) {
+	if dbName == "" {
+		return nil, nil
+	}
+	parts := strings.Split(dbName, "/")
+	if len(parts) < 6 || parts[0] != "projects" || parts[2] != "instances" || parts[4] != "databases" {
+		return nil, nil
+	}
+	instanceName := fmt.Sprintf("projects/%s/instances/%s", parts[1], parts[3])
+	inst, err := getSpannerInstanceForList(runtime, parts[1], instanceName)
+	if err != nil {
+		return nil, err
+	}
+	dbs := inst.GetDatabases()
+	if dbs.Error != nil {
+		return nil, dbs.Error
+	}
+	for _, d := range dbs.Data {
+		db := d.(*mqlGcpProjectSpannerServiceInstanceDatabase)
+		if db.Name.Error != nil {
+			return nil, db.Name.Error
+		}
+		if db.Name.Data == dbName {
+			return db, nil
+		}
+	}
+	return nil, nil
+}
+
+func (g *mqlGcpProjectSpannerServiceInstanceDatabase) sourceBackup() (*mqlGcpProjectSpannerServiceInstanceBackup, error) {
+	b, err := getSpannerBackupByName(g.MqlRuntime, g.cacheSourceBackupName)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		g.SourceBackup.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return b, nil
+}
+
+func (g *mqlGcpProjectSpannerServiceInstanceBackup) sourceDatabase() (*mqlGcpProjectSpannerServiceInstanceDatabase, error) {
+	if g.Database.Error != nil {
+		return nil, g.Database.Error
+	}
+	d, err := getSpannerDatabaseByName(g.MqlRuntime, g.Database.Data)
+	if err != nil {
+		return nil, err
+	}
+	if d == nil {
+		g.SourceDatabase.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return d, nil
 }
 
 func (g *mqlGcpProjectSpannerServiceInstanceDatabase) kmsKeys() ([]any, error) {

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -177,6 +177,45 @@ func (g *mqlGcpProjectSqlServiceInstance) replicas() ([]any, error) {
 	return res, nil
 }
 
+func (g *mqlGcpProjectSqlServiceInstance) failoverReplicaRef() (*mqlGcpProjectSqlServiceInstance, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	replica, err := getSqlInstanceByName(g.MqlRuntime, g.ProjectId.Data, g.cacheFailoverReplicaName)
+	if err != nil {
+		return nil, err
+	}
+	if replica == nil {
+		g.FailoverReplicaRef.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return replica, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) drReplica() (*mqlGcpProjectSqlServiceInstance, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	replica, err := getSqlInstanceByName(g.MqlRuntime, g.ProjectId.Data, g.cacheDrReplicaName)
+	if err != nil {
+		return nil, err
+	}
+	if replica == nil {
+		g.DrReplica.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return replica, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) managedBy() (string, error) {
+	settings := g.GetSettings()
+	if settings.Error != nil {
+		return "", settings.Error
+	}
+	if settings.Data == nil {
+		return "", nil
+	}
+	return managedByFromLabels(settings.Data.GetUserLabels())
+}
+
 // sqlIPMappingID returns a cache-stable identifier for a Cloud SQL instance
 // IP address. A single instance can expose more than one IP of the same
 // Type (e.g., two PRIVATE IPs across distinct VPCs), so the address itself
@@ -747,6 +786,12 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			if instance.DiskEncryptionConfiguration != nil {
 				mqlSqlInstance.cacheKmsKeyName = instance.DiskEncryptionConfiguration.KmsKeyName
 			}
+			if instance.FailoverReplica != nil {
+				mqlSqlInstance.cacheFailoverReplicaName = instance.FailoverReplica.Name
+			}
+			if instance.ReplicationCluster != nil {
+				mqlSqlInstance.cacheDrReplicaName = instance.ReplicationCluster.FailoverDrReplicaName
+			}
 			res = append(res, mqlInstance)
 		}
 		return nil
@@ -821,8 +866,10 @@ func (g *mqlGcpProjectSqlServiceInstance) databases() ([]any, error) {
 }
 
 type mqlGcpProjectSqlServiceInstanceInternal struct {
-	cacheSecondaryGceZone string
-	cacheKmsKeyName       string
+	cacheSecondaryGceZone    string
+	cacheKmsKeyName          string
+	cacheFailoverReplicaName string
+	cacheDrReplicaName       string
 }
 
 func (g *mqlGcpProjectSqlServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {


### PR DESCRIPTION
Additive, non-breaking provenance additions across the GCP DATABASES subsystem: a `managedBy` signal derived from the provenance labels/annotations Google and IaC tools stamp on managed resources, plus typed replication and backup lineage references. No existing fields change behavior; nothing is removed.

## Cloud SQL (`gcp.project.sqlService.instance`)
- `managedBy()` from `settings.userLabels`
- `failoverReplicaRef()` resolves the HA failover target instance (`FailoverReplica.Name`). Named `*Ref` to avoid colliding with the existing `failoverReplica` dict.
- `drReplica()` resolves the cross-region DR replica designated on the primary (`replicationCluster.failoverDrReplicaName`)

## AlloyDB (`gcp.project.alloydbService.cluster` / `.backup`)
- `cluster.network()` resolves the peered VPC from the cluster network config
- `cluster.primaryCluster()` resolves the cross-region primary named on a SECONDARY cluster
- `cluster.secondaryClusters()` resolves the cross-region secondaries named on a PRIMARY cluster
- `cluster.managedBy()` from labels + annotations
- `backup.sourceCluster()` resolves the source cluster; `backup.kmsKey()` resolves the CMEK key

## Spanner (`gcp.project.spannerService.instance` / `.database` / `.backup`)
- `instance.managedBy()` from labels
- `database.sourceBackup()` resolves the backup a restored database came from (restore info)
- `backup.sourceDatabase()` resolves the backup's source database

## Firestore (`gcp.project.firestoreService.database`)
- `database.kmsKey()` resolves the CMEK key from the encryption config (no `managedBy`; Firestore exposes only Resource Manager tags, not user labels)

## Bigtable (`gcp.project.bigtableService.instance` / `.backup`)
- `instance.managedBy()` from labels
- `backup.sourceTableRef()` resolves the source table (named `*Ref` to avoid colliding with the existing `sourceTable` string)
- `backup.sourceBackup()` resolves the copy-chain source backup

## Notes
- Shared `managedByFromLabels` helper (`gcp_managed_by.go`) recognizes `terraform` (goog-terraform-provisioned), `config-connector` (cnrm annotations), and `cloud-composer` (goog-composer-* labels).
- Typed refs reuse existing list APIs and `getNetworkByUrl`; no new IAM permissions (permissions.json diff is only the regenerated version/timestamp metadata).
- Lineage resolvers walk cached parent lists, so per-instance lineage adds no extra API calls when the parent traversal already listed the siblings.
- New `.lr.versions` entries at 13.27.2.

## Verification
`go build ./...` and `go vet ./resources/` pass. Smoke-tested live against a project: all new fields compile and execute; Firestore returned a real database with `kmsKey` resolving to null (Google-managed encryption), confirming the singular-null return path sets `StateIsNull` correctly without panic.