### PR TITLE
✨ aws: expose IAM Identity Center instance region metadata

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -24402,7 +24402,10 @@ private aws.identitycenter.instance @defaults("arn name status") {
   createdAt time
   // Owner account ID
   ownerAccountId string
-  // Additional context about the current status, populated when the instance is in a non-ACTIVE state such as CREATE_FAILED
+  // Status reason
+  //
+  // Additional context about the current status, populated when the
+  // instance is in a non-ACTIVE state such as CREATE_FAILED.
   statusReason string
   // Primary Region where the instance was originally enabled and which cannot be removed
   primaryRegion string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -24402,6 +24402,17 @@ private aws.identitycenter.instance @defaults("arn name status") {
   createdAt time
   // Owner account ID
   ownerAccountId string
+  // Additional context about the current status, populated when the instance is in a non-ACTIVE state such as CREATE_FAILED
+  statusReason string
+  // Primary Region where the instance was originally enabled and which cannot be removed
+  primaryRegion string
+  // Regions enabled in the instance
+  //
+  // Each entry describes one enabled Region, including Regions still being
+  // added or removed. The keys are `regionName` (the Region name), `status`
+  // (ACTIVE, ADDING, or REMOVING), and `isPrimaryRegion` (whether it is the
+  // primary Region).
+  regions []dict
   // Permission sets in this instance
   permissionSets() []aws.identitycenter.permissionSet
   // Account assignments in this instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -31834,6 +31834,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.identitycenter.instance.ownerAccountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterInstance).GetOwnerAccountId()).ToDataRes(types.String)
 	},
+	"aws.identitycenter.instance.statusReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIdentitycenterInstance).GetStatusReason()).ToDataRes(types.String)
+	},
+	"aws.identitycenter.instance.primaryRegion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIdentitycenterInstance).GetPrimaryRegion()).ToDataRes(types.String)
+	},
+	"aws.identitycenter.instance.regions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIdentitycenterInstance).GetRegions()).ToDataRes(types.Array(types.Dict))
+	},
 	"aws.identitycenter.instance.permissionSets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIdentitycenterInstance).GetPermissionSets()).ToDataRes(types.Array(types.Resource("aws.identitycenter.permissionSet")))
 	},
@@ -73188,6 +73197,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.identitycenter.instance.ownerAccountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIdentitycenterInstance).OwnerAccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.identitycenter.instance.statusReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIdentitycenterInstance).StatusReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.identitycenter.instance.primaryRegion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIdentitycenterInstance).PrimaryRegion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.identitycenter.instance.regions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIdentitycenterInstance).Regions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.identitycenter.instance.permissionSets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -177254,6 +177275,9 @@ type mqlAwsIdentitycenterInstance struct {
 	Status             plugin.TValue[string]
 	CreatedAt          plugin.TValue[*time.Time]
 	OwnerAccountId     plugin.TValue[string]
+	StatusReason       plugin.TValue[string]
+	PrimaryRegion      plugin.TValue[string]
+	Regions            plugin.TValue[[]any]
 	PermissionSets     plugin.TValue[[]any]
 	AccountAssignments plugin.TValue[[]any]
 	Groups             plugin.TValue[[]any]
@@ -177320,6 +177344,18 @@ func (c *mqlAwsIdentitycenterInstance) GetCreatedAt() *plugin.TValue[*time.Time]
 
 func (c *mqlAwsIdentitycenterInstance) GetOwnerAccountId() *plugin.TValue[string] {
 	return &c.OwnerAccountId
+}
+
+func (c *mqlAwsIdentitycenterInstance) GetStatusReason() *plugin.TValue[string] {
+	return &c.StatusReason
+}
+
+func (c *mqlAwsIdentitycenterInstance) GetPrimaryRegion() *plugin.TValue[string] {
+	return &c.PrimaryRegion
+}
+
+func (c *mqlAwsIdentitycenterInstance) GetRegions() *plugin.TValue[[]any] {
+	return &c.Regions
 }
 
 func (c *mqlAwsIdentitycenterInstance) GetPermissionSets() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5566,7 +5566,10 @@ aws.identitycenter.instance.identityStoreId 13.6.3
 aws.identitycenter.instance.name 13.6.3
 aws.identitycenter.instance.ownerAccountId 13.6.3
 aws.identitycenter.instance.permissionSets 13.6.3
+aws.identitycenter.instance.primaryRegion 13.40.1
+aws.identitycenter.instance.regions 13.40.1
 aws.identitycenter.instance.status 13.6.3
+aws.identitycenter.instance.statusReason 13.40.1
 aws.identitycenter.instance.users 13.12.1
 aws.identitycenter.instances 13.6.3
 aws.identitycenter.permissionSet 13.6.3

--- a/providers/aws/resources/aws_identitycenter.go
+++ b/providers/aws/resources/aws_identitycenter.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (a *mqlAwsIdentitycenter) id() (string, error) {
@@ -68,6 +69,15 @@ func (a *mqlAwsIdentitycenter) getInstances(conn *connection.AwsConnection) []*j
 			}
 
 			for _, instance := range page.Instances {
+				regions := make([]any, 0, len(instance.Regions))
+				for _, r := range instance.Regions {
+					regions = append(regions, map[string]any{
+						"regionName":      convert.ToValue(r.RegionName),
+						"status":          string(r.Status),
+						"isPrimaryRegion": r.IsPrimaryRegion,
+					})
+				}
+
 				mqlInstance, err := CreateResource(a.MqlRuntime, "aws.identitycenter.instance",
 					map[string]*llx.RawData{
 						"__id":            llx.StringDataPtr(instance.InstanceArn),
@@ -75,8 +85,11 @@ func (a *mqlAwsIdentitycenter) getInstances(conn *connection.AwsConnection) []*j
 						"name":            llx.StringDataPtr(instance.Name),
 						"identityStoreId": llx.StringDataPtr(instance.IdentityStoreId),
 						"status":          llx.StringData(string(instance.Status)),
+						"statusReason":    llx.StringDataPtr(instance.StatusReason),
 						"createdAt":       llx.TimeDataPtr(instance.CreatedDate),
 						"ownerAccountId":  llx.StringDataPtr(instance.OwnerAccountId),
+						"primaryRegion":   llx.StringDataPtr(instance.PrimaryRegion),
+						"regions":         llx.ArrayData(regions, types.Dict),
 					})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
## What

Surfaces three fields newly available on the `ListInstances` response after the `ssoadmin` SDK bump to **v1.40.0** (pulled in by the dependency refresh in #8862) onto `aws.identitycenter.instance`:

| Field | Type | Description |
|---|---|---|
| `primaryRegion` | `string` | The Region where the Identity Center instance was originally enabled (cannot be removed). |
| `regions` | `[]dict` | Enabled Regions, including those still `ADDING`/`REMOVING`. Each entry has `regionName`, `status` (`ACTIVE`/`ADDING`/`REMOVING`), and `isPrimaryRegion`. |
| `statusReason` | `string` | Additional context populated when an instance is in a non-`ACTIVE` state (e.g. `CREATE_FAILED`). |

`regions` is modeled as `[]dict` rather than a sub-resource: `RegionMetadata` has no stable ID and carries no typed refs, so it fails the sub-resource bar.

## Why

Multi-region IAM Identity Center visibility (which Regions an instance spans, and whether any are mid-add/remove) is a real audit signal that we weren't exposing. The data is already in the response we call — this is a pure mapping add.

## Notes

- No new API calls; `aws.permissions.json` is unchanged.
- New `.lr.versions` entries at `13.40.1` (next patch after the provider's current `13.40.0`).

## Testing

- `make providers/build/aws && make providers/install/aws` — builds clean.
- `mql run aws -c "aws.identitycenter.instances { arn name status statusReason primaryRegion regions }"` — compiles and executes; the test account has no Identity Center org enabled, so it returns empty (schema/resolution verified, no live data available).