### PR TITLE
fix(os): resolve systemd.timesyncd.synchronized on systemd < 239

### DIFF
--- a/providers/os/resources/systemd_timesyncd.go
+++ b/providers/os/resources/systemd_timesyncd.go
@@ -17,6 +17,29 @@ func (t *mqlSystemdTimesyncd) active() (bool, error) {
 	return isSystemdUnitActive(t.MqlRuntime, "systemd-timesyncd")
 }
 
+// parseTimedatectlStatusSynchronized extracts the synchronization state from
+// the human-readable `timedatectl status` output, used as a fallback on
+// systemd versions that lack the `timedatectl show` verb (< 239). The
+// relevant line looks like:
+//
+//	       System clock synchronized: yes
+//
+// and is backed by the same org.freedesktop.timedate1 NTPSynchronized
+// property that `timedatectl show` exposes on newer systemd.
+func parseTimedatectlStatusSynchronized(stdout string) bool {
+	for _, line := range strings.Split(stdout, "\n") {
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		if strings.TrimSpace(key) != "System clock synchronized" {
+			continue
+		}
+		return strings.EqualFold(strings.TrimSpace(value), "yes")
+	}
+	return false
+}
+
 type timesyncdState struct {
 	synchronized     bool
 	servers          []string
@@ -44,13 +67,22 @@ func (t *mqlSystemdTimesyncd) resolveState() (*timesyncdState, error) {
 		fallbackServers: []string{},
 	}
 
-	// Synchronized state lives in `timedatectl show` (the dbus-exposed
-	// org.freedesktop.timedate1 properties), not in show-timesync.
+	// Synchronized state lives in the `NTPSynchronized` property of the
+	// org.freedesktop.timedate1 dbus interface. On systemd >= 239 this is
+	// exposed via `timedatectl show`; that verb does not exist on older
+	// systemd (e.g. v237 on Ubuntu 18.04), where `timedatectl show` exits
+	// non-zero and returns nothing. In that case fall back to parsing the
+	// human-readable `timedatectl status` output, whose "System clock
+	// synchronized: yes/no" line is backed by the same property.
 	if stdout, ok, err := runSystemctl(t.MqlRuntime, "timedatectl show --no-pager"); err != nil {
 		return nil, err
 	} else if ok {
 		props := parseSystemdShowOutput(stdout)
 		state.synchronized = props["NTPSynchronized"] == "yes"
+	} else if stdout, ok, err := runSystemctl(t.MqlRuntime, "timedatectl status --no-pager"); err != nil {
+		return nil, err
+	} else if ok {
+		state.synchronized = parseTimedatectlStatusSynchronized(stdout)
 	}
 
 	// Per-server state comes from show-timesync (org.freedesktop.timesync1).

--- a/providers/os/resources/systemd_timesyncd.go
+++ b/providers/os/resources/systemd_timesyncd.go
@@ -22,7 +22,7 @@ func (t *mqlSystemdTimesyncd) active() (bool, error) {
 // systemd versions that lack the `timedatectl show` verb (< 239). The
 // relevant line looks like:
 //
-//	       System clock synchronized: yes
+//	System clock synchronized: yes
 //
 // and is backed by the same org.freedesktop.timedate1 NTPSynchronized
 // property that `timedatectl show` exposes on newer systemd.

--- a/providers/os/resources/systemd_timesyncd_test.go
+++ b/providers/os/resources/systemd_timesyncd_test.go
@@ -72,3 +72,33 @@ LeapStatus=
 	assert.Equal(t, "", props["SystemNTPServers"])
 	assert.Equal(t, "", props["FallbackNTPServers"])
 }
+
+func TestTimesyncd_StatusFallback(t *testing.T) {
+	// systemd < 239 (e.g. v237 on Ubuntu 18.04) has no `timedatectl show`
+	// verb, so `synchronized` falls back to parsing `timedatectl status`.
+	status := `                      Local time: Wed 2026-06-17 06:34:18 CEST
+                  Universal time: Wed 2026-06-17 04:34:18 UTC
+                        RTC time: Wed 2026-06-17 04:34:18
+                       Time zone: Europe/Berlin (CEST, +0200)
+       System clock synchronized: yes
+systemd-timesyncd.service active: yes
+                 RTC in local TZ: no
+`
+	assert.True(t, parseTimedatectlStatusSynchronized(status))
+
+	notSynced := `       System clock synchronized: no
+systemd-timesyncd.service active: yes
+`
+	assert.False(t, parseTimedatectlStatusSynchronized(notSynced))
+}
+
+func TestTimesyncd_StatusFallbackEdgeCases(t *testing.T) {
+	// Missing line -> not synchronized rather than a false positive.
+	assert.False(t, parseTimedatectlStatusSynchronized(""))
+	assert.False(t, parseTimedatectlStatusSynchronized("Time zone: UTC (UTC, +0000)\n"))
+
+	// Case-insensitive value, and the "active" line must not be mistaken
+	// for the synchronized line.
+	assert.True(t, parseTimedatectlStatusSynchronized("System clock synchronized: Yes\n"))
+	assert.False(t, parseTimedatectlStatusSynchronized("systemd-timesyncd.service active: yes\n"))
+}


### PR DESCRIPTION
## Problem

`systemd.timesyncd.synchronized` reports `false` on hosts whose clock is actually synchronized, when running on older systemd (e.g. systemd 237 on Ubuntu 18.04).

The field derives its value solely from `timedatectl show --no-pager`:

```go
if stdout, ok, err := runSystemctl(t.MqlRuntime, "timedatectl show --no-pager"); err != nil {
    return nil, err
} else if ok {
    props := parseSystemdShowOutput(stdout)
    state.synchronized = props["NTPSynchronized"] == "yes"
}
```

The `show` verb was only added in **systemd 239**. On earlier versions `timedatectl show` is an unknown operation: it exits non-zero and prints nothing, so `runSystemctl` returns `ok == false` and `state.synchronized` is left at its zero value `false` — a false negative. `timedatectl status` (and the `active` field) still work, which is why only `synchronized` is wrong.

## Fix

When `timedatectl show` is unavailable, fall back to parsing the human-readable `timedatectl status` output. Its `System clock synchronized: yes/no` line is backed by the same `org.freedesktop.timedate1` `NTPSynchronized` D-Bus property that `show` exposes on newer systemd, so the semantics are identical.

A dedicated `parseTimedatectlStatusSynchronized` helper parses the `status` format (`Key: Value`), distinct from `parseSystemdShowOutput` which parses the `show` format (`Key=Value`).

## Tests

New unit tests cover:
- synced / not-synced `status` output (real systemd-237 layout)
- missing line → `false` (no false positive)
- case-insensitive value
- the adjacent `systemd-timesyncd.service active: yes` line not being misread as the synchronized line

```
ok  	go.mondoo.com/mql/v13/providers/os/resources
```