### PR TITLE
✨ providers: add `providers delete <name>` command

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -30,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(ProvidersCmd)
 	ProvidersCmd.AddCommand(listProvidersCmd)
 	ProvidersCmd.AddCommand(installProviderCmd)
+	ProvidersCmd.AddCommand(deleteProviderCmd)
 	ProvidersCmd.AddCommand(infoProviderCmd)
 	ProvidersCmd.AddCommand(resourcesProviderCmd)
 
@@ -39,6 +40,7 @@ func init() {
 	resourcesProviderCmd.Flags().Bool("json", false, "Output in JSON format")
 	installProviderCmd.Flags().StringP("file", "f", "", "Install a provider via a file")
 	installProviderCmd.Flags().String("url", "", "Install a provider via a URL")
+	deleteProviderCmd.Flags().Bool("yes", false, "Confirm removal of all providers when using the 'all' target")
 }
 
 var ProvidersCmd = &cobra.Command{
@@ -87,6 +89,42 @@ var installProviderCmd = &cobra.Command{
 
 		// if no url or file is specified, we default to installing by name from the default upstream
 		installProviderByName(args[0])
+	},
+}
+
+var deleteProviderCmd = &cobra.Command{
+	Use:   "delete <NAME>",
+	Short: "Remove an installed provider from disk",
+	Long: `Remove an installed provider plugin from disk. The provider is
+re-downloaded automatically the next time it's needed.
+
+Use the special target "all" to remove every installed provider at once. Because
+that wipes your whole provider footprint, it requires the --yes flag to confirm.
+
+Examples:
+  mql providers delete aws          # remove the aws provider
+  mql providers delete all --yes    # remove every installed provider`,
+	Args:   cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if name == "all" {
+			yes, _ := cmd.Flags().GetBool("yes")
+			if !yes {
+				return fmt.Errorf("removing all providers wipes your entire provider footprint; re-run with --yes to confirm")
+			}
+			if err := providers.DeleteAll(); err != nil {
+				return err
+			}
+			log.Info().Msg("removed all installed providers")
+			return nil
+		}
+
+		if err := providers.Delete(name); err != nil {
+			return err
+		}
+		log.Info().Str("provider", name).Msg("removed installed provider")
+		return nil
 	},
 }
 

--- a/providers/delete_test.go
+++ b/providers/delete_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// mkProviderDir lays down a fake installed-provider directory (a subdir named
+// after the provider containing its binary) under root and returns its path.
+func mkProviderDir(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("binary"), 0o644))
+	return dir
+}
+
+// seedCachedProviders sets the package-global provider cache for the duration
+// of a test so ListAll returns exactly the given set without touching disk.
+func seedCachedProviders(t *testing.T, providers []*Provider) {
+	t.Helper()
+	orig := CachedProviders
+	t.Cleanup(func() { CachedProviders = orig })
+	CachedProviders = providers
+}
+
+func TestDelete(t *testing.T) {
+	t.Run("removes the named provider only", func(t *testing.T) {
+		root := t.TempDir()
+		awsPath := mkProviderDir(t, root, "aws")
+		osPath := mkProviderDir(t, root, "os")
+		seedCachedProviders(t, []*Provider{
+			{Provider: &plugin.Provider{Name: "aws"}, Path: awsPath},
+			{Provider: &plugin.Provider{Name: "os"}, Path: osPath},
+		})
+
+		require.NoError(t, Delete("aws"))
+
+		assert.NoDirExists(t, awsPath, "named provider dir should be removed")
+		assert.DirExists(t, osPath, "other providers should be untouched")
+	})
+
+	t.Run("errors when the provider is not installed", func(t *testing.T) {
+		seedCachedProviders(t, []*Provider{})
+		assert.Error(t, Delete("aws"))
+	})
+
+	t.Run("errors when the provider is builtin", func(t *testing.T) {
+		seedCachedProviders(t, []*Provider{
+			{Provider: &plugin.Provider{Name: "core"}, Path: ""},
+		})
+		assert.Error(t, Delete("core"))
+	})
+}
+
+func TestDeleteAll(t *testing.T) {
+	root := t.TempDir()
+	awsPath := mkProviderDir(t, root, "aws")
+	osPath := mkProviderDir(t, root, "os")
+	missingPath := filepath.Join(root, "gone") // never created on disk
+
+	seedCachedProviders(t, []*Provider{
+		{Provider: &plugin.Provider{Name: "aws"}, Path: awsPath},
+		{Provider: &plugin.Provider{Name: "os"}, Path: osPath},
+		{Provider: &plugin.Provider{Name: "core"}, Path: ""},          // builtin: no on-disk path, must be skipped
+		{Provider: &plugin.Provider{Name: "gone"}, Path: missingPath}, // already absent: RemoveAll is a no-op
+	})
+
+	require.NoError(t, DeleteAll())
+
+	assert.NoDirExists(t, awsPath, "loaded provider dir should be removed")
+	assert.NoDirExists(t, osPath, "loaded provider dir should be removed")
+	assert.NoDirExists(t, missingPath, "missing provider path stays absent")
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -68,6 +68,58 @@ func init() {
 	Coordinator = coordinator
 }
 
+// deleteProvider removes a single resolved provider from disk. The path it
+// removes is the exact one the provider was loaded from, which already honors a
+// PROVIDERS_PATH override (or the system/home paths otherwise). Builtin
+// providers have no on-disk path and cannot be removed.
+func deleteProvider(provider *Provider) error {
+	if provider.Path == "" {
+		return errors.Newf("provider %q is builtin and cannot be removed", provider.Name)
+	}
+	log.Debug().Str("path", provider.Path).Msg("removing installed provider")
+	if err := os.RemoveAll(provider.Path); err != nil {
+		return errors.Wrapf(err, "failed to remove provider %q", provider.Name)
+	}
+	return nil
+}
+
+// Delete removes a single installed provider from disk by name. It resolves the
+// provider through ListAll and delegates the removal to deleteProvider.
+func Delete(name string) error {
+	all, err := ListAll()
+	if err != nil {
+		return err
+	}
+	for _, provider := range all {
+		if provider.Name == name {
+			return deleteProvider(provider)
+		}
+	}
+	return errors.Newf("provider %q not found", name)
+}
+
+// DeleteAll removes every installed provider from disk. It goes through ListAll
+// — not the raw CachedProviders global — on purpose: ListAll returns the warm
+// cache when it's populated and otherwise rescans the provider dirs, so it works
+// regardless of cache state. A ListAll error bails rather than acting on a
+// partial list; builtin providers are skipped, and per-provider removal errors
+// are logged, not fatal (a non-root run can't remove a root-owned system path).
+func DeleteAll() error {
+	all, err := ListAll()
+	if err != nil {
+		return err
+	}
+	for _, provider := range all {
+		if provider.Path == "" {
+			continue
+		}
+		if err := deleteProvider(provider); err != nil {
+			log.Warn().Err(err).Str("path", provider.Path).Msg("failed to remove installed provider")
+		}
+	}
+	return nil
+}
+
 type ProviderLookup struct {
 	ID           string
 	ProviderName string

--- a/test/commands/testdata/mql_providers.ct
+++ b/test/commands/testdata/mql_providers.ct
@@ -6,6 +6,7 @@ Usage:
   mql providers [command]
 
 Available Commands:
+  delete      Remove an installed provider from disk
   info        Show detailed information about one or more providers
   install     Install or update a provider
   list        List all providers on the system


### PR DESCRIPTION
## What

Adds an explicit `mql providers delete <name>` command that removes an installed provider plugin from disk. The provider is re-downloaded automatically the next time it's needed.

`delete all` is a special case that removes **every** installed provider — turning a run into a true one-off with zero provider footprint on the host. Because that wipes the whole provider footprint, it requires a `--yes` flag to confirm.

This replaces the earlier `DELETE_PROVIDERS` env var / shutdown-hook approach with a plain, discoverable CLI command.

## How

- `providers/providers.go`: exported `Delete(name)` (removes a single named provider; errors on not-found or builtin) and `DeleteAll()` (removes every on-disk provider, skipping builtins). Both resolve providers through `ListAll()` so removal targets the exact path each was loaded from (honoring a `PROVIDERS_PATH` override or the system/home paths otherwise). Dropped the `DELETE_PROVIDERS` env var and `deleteProvidersEnabled()`.
- `providers/coordinator.go`: reverted the `Shutdown()` deletion hook — deletion is now user-triggered, not automatic.
- `apps/mql/cmd/providers.go`: new `deleteProviderCmd` wired under `providers`, with the `all` + `--yes` guard.

## Usage

```
mql providers delete aws          # remove the aws provider
mql providers delete all --yes    # remove every installed provider
```

Without `--yes`, `delete all` refuses and prints a confirmation hint.

## Tests

`providers/delete_test.go`:
- `TestDelete` — removes only the named provider, errors on not-installed, errors on builtin.
- `TestDeleteAll` — removes all loaded provider dirs; builtin (empty path) and already-missing paths handled cleanly.

Full `providers` suite passes; `gofmt` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)