### PR TITLE
🐛 aws/azure/gcp: fix 6 provenance/typed-ref field bugs from live verification

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -14748,7 +14748,7 @@ private aws.lambda.function @defaults("arn") {
   // ARN of the resolved managed runtime version the function runs on
   //
   // Identifies the exact patched build of the managed runtime, distinct from runtimeManagementConfig, which only reports the update mode. Empty for OS-only runtimes and container-image functions.
-  runtimeVersionArn string
+  runtimeVersionArn() string
   // Human-readable description of the function
   description string
   // When the function was last updated

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -137774,7 +137774,9 @@ func (c *mqlAwsLambdaFunction) GetRevisionId() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsLambdaFunction) GetRuntimeVersionArn() *plugin.TValue[string] {
-	return &c.RuntimeVersionArn
+	return plugin.GetOrCompute[string](&c.RuntimeVersionArn, func() (string, error) {
+		return c.runtimeVersionArn()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetDescription() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.40.0",
-  "generated_at": "2026-06-30T21:58:44-07:00",
+  "generated_at": "2026-06-30T23:35:09-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -526,6 +526,7 @@
     "lambda:GetFunction",
     "lambda:GetFunctionCodeSigningConfig",
     "lambda:GetFunctionConcurrency",
+    "lambda:GetFunctionConfiguration",
     "lambda:GetFunctionEventInvokeConfig",
     "lambda:GetFunctionRecursionConfig",
     "lambda:GetFunctionUrlConfig",
@@ -4146,6 +4147,12 @@
       "permission": "lambda:GetFunctionConcurrency",
       "service": "lambda",
       "action": "GetFunctionConcurrency",
+      "source_file": "aws_lambda.go"
+    },
+    {
+      "permission": "lambda:GetFunctionConfiguration",
+      "service": "lambda",
+      "action": "GetFunctionConfiguration",
       "source_file": "aws_lambda.go"
     },
     {

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -798,7 +798,9 @@ func (a *mqlAwsCloudwatchLoggroup) tags() (map[string]any, error) {
 	svc := conn.CloudwatchLogs(a.Region.Data)
 	ctx := context.Background()
 
-	arnVal := a.Arn.Data
+	// CloudWatch Logs stores the log-group ARN with a trailing ":*" wildcard,
+	// which ListTagsForResource rejects as an invalid resourceArn. Strip it.
+	arnVal := strings.TrimSuffix(a.Arn.Data, ":*")
 	tagsResp, err := svc.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{ResourceArn: &arnVal})
 	if err != nil {
 		if Is400AccessDeniedError(err) {

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -294,7 +294,13 @@ func newMqlAwsEsDomain(runtime *plugin.Runtime, region, accountID string, svc *e
 		serviceSoftwareUpdateAvailable = convert.ToValue(s.UpdateAvailable)
 		serviceSoftwareCancellable = convert.ToValue(s.Cancellable)
 		serviceSoftwareUpdateStatus = string(s.UpdateStatus)
-		serviceSoftwareAutomatedUpdateDate = llx.TimeDataPtr(s.AutomatedUpdateDate)
+		// AWS returns the Unix epoch when no automated update is scheduled;
+		// surface that sentinel as null rather than a 1970 timestamp.
+		if d := s.AutomatedUpdateDate; d != nil && d.Unix() > 0 {
+			serviceSoftwareAutomatedUpdateDate = llx.TimeDataPtr(d)
+		} else {
+			serviceSoftwareAutomatedUpdateDate = llx.NilData
+		}
 	} else {
 		serviceSoftwareAutomatedUpdateDate = llx.NilData
 	}

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -489,6 +489,11 @@ func (a *mqlAwsKmsKey) tags() (map[string]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
+			// AWS-managed keys reject ListResourceTags with AccessDenied;
+			// treat that as no tags rather than failing managedBy/tags.
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 		for i := range page.Tags {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -254,11 +254,6 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		layers = append(layers, mqlLayer)
 	}
 
-	var runtimeVersionArn string
-	if function.RuntimeVersionConfig != nil {
-		runtimeVersionArn = convert.ToValue(function.RuntimeVersionConfig.RuntimeVersionArn)
-	}
-
 	args := map[string]*llx.RawData{
 		"arn":                         llx.StringDataPtr(function.FunctionArn),
 		"name":                        llx.StringDataPtr(function.FunctionName),
@@ -275,7 +270,6 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"packageType":                 llx.StringData(string(function.PackageType)),
 		"codeSha256":                  llx.StringDataPtr(function.CodeSha256),
 		"revisionId":                  llx.StringDataPtr(function.RevisionId),
-		"runtimeVersionArn":           llx.StringData(runtimeVersionArn),
 		"description":                 llx.StringDataPtr(function.Description),
 		"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
 		"state":                       llx.StringData(string(function.State)),
@@ -1304,6 +1298,37 @@ func (a *mqlAwsLambdaFunction) eventInvokeConfig() (any, error) {
 		result["destinationConfig"] = destConfig
 	}
 	return result, nil
+}
+
+// runtimeVersionArn resolves the exact patched managed-runtime build the
+// function runs on. The ListFunctions summary omits RuntimeVersionConfig, so
+// this is fetched per function via GetFunctionConfiguration.
+func (a *mqlAwsLambdaFunction) runtimeVersionArn() (string, error) {
+	funcName := a.Name.Data
+	region := a.Region.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Lambda(region)
+	ctx := context.Background()
+
+	resp, err := svc.GetFunctionConfiguration(ctx, &lambda.GetFunctionConfigurationInput{
+		FunctionName: &funcName,
+	})
+	if err != nil {
+		var respErr *http.ResponseError
+		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+			return "", nil
+		}
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if resp.RuntimeVersionConfig != nil {
+		return convert.ToValue(resp.RuntimeVersionConfig.RuntimeVersionArn), nil
+	}
+	return "", nil
 }
 
 func (a *mqlAwsLambdaFunction) runtimeManagementConfig() (any, error) {

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -324,7 +324,11 @@ func newMqlAwsOpensearchDomain(runtime *plugin.Runtime, region string, accountID
 		serviceSoftwareUpdateAvailable = convert.ToValue(s.UpdateAvailable)
 		serviceSoftwareCancellable = convert.ToValue(s.Cancellable)
 		serviceSoftwareUpdateStatus = string(s.UpdateStatus)
-		serviceSoftwareAutomatedUpdateDate = llx.TimeDataPtr(s.AutomatedUpdateDate)
+		// AWS returns the Unix epoch when no automated update is scheduled;
+		// surface that sentinel as null rather than a 1970 timestamp.
+		if d := s.AutomatedUpdateDate; d != nil && d.Unix() > 0 {
+			serviceSoftwareAutomatedUpdateDate = llx.TimeDataPtr(d)
+		}
 	}
 
 	// Last configuration change progress (change provenance: who initiated the

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.23.0",
-  "generated_at": "2026-06-30T21:33:11-07:00",
+  "generated_at": "2026-06-30T23:35:09-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -1091,7 +1091,7 @@
     {
       "permission": "Microsoft.Network/networkWatchers/flowLogs/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1195,11 +1195,42 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) defaultNatGateway() (
 // empty list when none are configured.
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) flowLogs() ([]any, error) {
 	res := []any{}
+	if len(a.cacheFlowLogs) == 0 {
+		return res, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
 	for _, flowLog := range a.cacheFlowLogs {
-		if flowLog == nil {
+		if flowLog == nil || flowLog.ID == nil {
 			continue
 		}
-		mqlFlowLog, err := flowLogToMql(a.MqlRuntime, *flowLog)
+		// The flow logs embedded on the virtual network are ID-only
+		// references (their Properties are nil), so resolve each by ID to
+		// populate enabled, targetResourceId, retention, analytics, etc.
+		resourceID, err := ParseResourceID(*flowLog.ID)
+		if err != nil {
+			return nil, err
+		}
+		watcherName, err := resourceID.Component("networkWatchers")
+		if err != nil {
+			return nil, err
+		}
+		flowLogName, err := resourceID.Component("flowLogs")
+		if err != nil {
+			return nil, err
+		}
+		client, err := network.NewFlowLogsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		flowLogRes, err := client.Get(ctx, resourceID.ResourceGroup, watcherName, flowLogName, &network.FlowLogsClientGetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		mqlFlowLog, err := flowLogToMql(a.MqlRuntime, flowLogRes.FlowLog)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -659,6 +659,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 				return nil, err
 			}
 			mqlBackup.(*mqlGcpProjectBigtableServiceBackup).cacheSourceBackup = backup.SourceBackup
+			mqlBackup.(*mqlGcpProjectBigtableServiceBackup).cacheInstanceName = instanceName
 			res = append(res, mqlBackup)
 		}
 	}
@@ -681,6 +682,7 @@ func (g *mqlGcpProjectBigtableServiceBackup) id() (string, error) {
 
 type mqlGcpProjectBigtableServiceBackupInternal struct {
 	cacheSourceBackup string
+	cacheInstanceName string
 }
 
 // bigtableInstanceIDFromClusterName extracts the short instance ID from a full
@@ -779,7 +781,13 @@ func (g *mqlGcpProjectBigtableServiceBackup) sourceTableRef() (*mqlGcpProjectBig
 	if g.ClusterName.Error != nil {
 		return nil, g.ClusterName.Error
 	}
-	instanceName := bigtableInstanceIDFromClusterName(g.ClusterName.Data)
+	// Backups are keyed by the short cluster ID, so the instance cannot be
+	// re-derived from ClusterName; use the instance name cached at creation
+	// (falling back to the cluster-name parse for backups built elsewhere).
+	instanceName := g.cacheInstanceName
+	if instanceName == "" {
+		instanceName = bigtableInstanceIDFromClusterName(g.ClusterName.Data)
+	}
 	table, err := getBigtableTableByName(g.MqlRuntime, g.ProjectId.Data, instanceName, g.SourceTable.Data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Live verification of the recent AWS/Azure/GCP provenance + typed-reference sweeps (the `managedBy()` / `cloudformationStack()` / managed-identity / typed-ref additions) surfaced six field bugs. Each fix below was confirmed against real, provisioned cloud infrastructure before this PR.

## Fixes

### AWS
- **`cloudwatch.loggroup` — tags / managedBy / cloudformationStack all errored.** The stored log-group ARN ends in `:*`, which `ListTagsForResource` rejects (`Invalid resourceArn`), breaking all three fields on every log group. Strip the trailing wildcard. Verified: CFN-provisioned log groups now resolve `managedBy=cloudformation` and their stack.
- **`lambda.function.runtimeVersionArn` — always empty.** The `ListFunctions` summary omits `RuntimeVersionConfig`. Converted the field to a lazy accessor backed by `GetFunctionConfiguration`; it now returns the real runtime-version ARN. Adds the `lambda:GetFunctionConfiguration` permission.
- **`es.domain` / `opensearch.domain` `serviceSoftwareAutomatedUpdateDate` — rendered "719528 days".** AWS returns the Unix epoch when no automated update is scheduled; map that sentinel to null.
- **`kms.key` — `managedBy` errored on AWS-managed keys.** `ListResourceTags` returns `AccessDenied` for AWS-managed keys; swallow it so the field returns empty rather than failing the query.

### Azure
- **`networkService.virtualNetwork.flowLogs()` — husk entries.** The flow logs embedded on the VNet are ID-only references (`Properties` nil), so every field but `id` errored with "cannot convert primitive with NO type information". Resolve each flow log by ID via `FlowLogsClient.Get`. Verified: `enabled`, `targetResourceId`, `storageAccountId`, `retentionDays` now populate.

### GCP
- **`bigtableService.backup.sourceTableRef()` — always null.** The backup was keyed by the short cluster id, from which the instance cannot be re-derived. Cache the instance name at creation and use it directly. Verified: the typed table reference now resolves.

## Verification

Each fix was proven against live infrastructure stood up for this purpose (cheapest-tier resources in AWS/Azure/GCP), then re-queried with the fixed providers. No schema version bumps (the Lambda change is a field→computed-accessor conversion, not a new field). `aws.permissions.json` and `azure.permissions.json` regenerated to reflect the new `GetFunctionConfiguration` call and the flow-log `Get` action.
