### PR TITLE
🎉 gcp-13.28.0, k8s-13.6.0, proxmox-0.3.0, aws-13.40.1, os-13.30.1

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.40.0",
+	Version:         "13.40.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.27.1",
+	Version: "13.28.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.5.3",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.30.0",
+	Version: "13.30.1",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.2.2",
+	Version:         "0.3.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Release version bumps for five providers.

| Provider | From | To | Bump |
|----------|------|-----|------|
| gcp | 13.27.1 | **13.28.0** | minor |
| k8s | 13.5.3 | **13.6.0** | minor |
| proxmox | 0.2.2 | **0.3.0** | minor |
| aws | 13.40.0 | **13.40.1** | patch |
| os  | 13.30.0 | **13.30.1** | patch |

## What's new

### gcp (minor)
- ✨ Provenance sweep across the provider: `managedBy` IaC-owner derivation plus typed cross-resource references for storage/data/DNS (#8855), hierarchy/IAM/keys (#8856), compute (#8857), serverless/containers (#8858), cache/messaging (#8859), Vertex AI + Dataproc (#8860), and database replication (#8861)
- 🐛 Set null state in compute typed-ref accessors; guard subnet URL parse (#8673)
- 🐛 Fix provenance/typed-ref field bugs found in live verification (#8867)
- 🧹 Dependency updates (#8862)

### k8s (minor)
- 🐛 Handle comma-separated staged namespace filters (#8752)
- 🧹 Dependency updates (#8862)

### proxmox (minor)
- ⭐ Dependency bump and refresh (#8779)
- 🧹 Replace stale cnquery references with mql (#8781)
- 🧹 Dependency updates (#8733, #8862)

### aws (patch)
- ✨ Expose IAM Identity Center instance region metadata (#8863)
- 🐛 Fix CloudTrail trail lookup by name (#8677)
- 🐛 Fix invalid `apigateway:GetDeployments` permission (#8851)
- 🐛 Fix provenance/typed-ref field bugs found in live verification (#8867)
- 🧹 Dependency updates (#8862)

### os (patch)
- 🐛 Resolve `systemd.timesyncd.synchronized` on systemd < 239 (#8865)
- 🐛 Quiet noisy SBOM/provider logs for embedders (#8793)