### PR TITLE
✨ status: give an actionable next step when auth fails

### DIFF
--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -348,13 +348,19 @@ func (s Status) renderProviders(b *strings.Builder, st styler) {
 }
 
 func (s Status) renderFooter(b *strings.Builder, st styler) {
+	// authFailed is the "registered but the platform rejected the credential"
+	// case (revoked or expired service account) — distinct from never having
+	// registered at all, and remediated by re-registering with a fresh token.
+	authFailed := s.Client.Registered && s.Client.PingPongError != nil
 	hasError := !s.Client.Registered || s.Client.PingPongError != nil
 	actionable := hasError || s.updateAvailable() || s.outdatedCount() > 0
 
 	b.WriteString("\n")
 	switch {
-	case hasError:
+	case !s.Client.Registered:
 		fmt.Fprintf(b, "  %s %s\n", st.bad("✗ not registered"), st.dim("· exit 1 · next steps:"))
+	case authFailed:
+		fmt.Fprintf(b, "  %s %s\n", st.bad("✗ authentication failed"), st.dim("· exit 1 · next steps:"))
 	case !actionable:
 		fmt.Fprintf(b, "  %s\n\n", st.ok("✓ all systems healthy"))
 		return
@@ -364,6 +370,9 @@ func (s Status) renderFooter(b *strings.Builder, st styler) {
 
 	if !s.Client.Registered {
 		st.footerStep(b, "mql login", "register this client with Mondoo Platform")
+	}
+	if authFailed {
+		st.footerStep(b, "mql login --token <token>", "re-register with a fresh token from Mondoo Platform")
 	}
 	if s.updateAvailable() {
 		st.footerStep(b, "visit "+s.Client.UpdatesURL, "upgrade "+s.Client.Version+" → "+s.Client.LatestVersion)

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -86,6 +87,45 @@ func TestRenderCli_HealthSummary_NotRegistered(t *testing.T) {
 	assert.Contains(t, out, "Client")
 	assert.Contains(t, out, "not registered")
 	assert.Contains(t, out, "action needed")
+}
+
+// registeredAuthFailedStatus mirrors a client whose config is present and
+// registered, but whose service account was revoked or expired on the platform:
+// the ping fails even though the API itself is reachable and SERVING.
+func registeredAuthFailedStatus() Status {
+	s := healthyRegisteredStatus()
+	s.Client.PingPongError = errors.New("rpc error: code = Unauthenticated desc = invalid service account")
+	// isolate the auth-failed path: everything else current
+	for i := range s.Client.Providers {
+		s.Client.Providers[i].Outdated = false
+		s.Client.Providers[i].Latest = s.Client.Providers[i].Installed
+	}
+	return s
+}
+
+func TestRenderCli_HealthSummary_AuthFailed(t *testing.T) {
+	s := registeredAuthFailedStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// still registered, but the ping was rejected
+	assert.Contains(t, out, "registered")
+	assert.Contains(t, out, "authentication failed")
+}
+
+func TestRenderCli_Footer_AuthFailed(t *testing.T) {
+	s := registeredAuthFailedStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// footer must flag the error and give an actionable re-registration step
+	// rather than the misleading "not registered" line.
+	assert.Contains(t, out, "authentication failed")
+	assert.Contains(t, out, "exit 1")
+	assert.Contains(t, out, "next steps")
+	assert.Contains(t, out, "mql login --token <token>")
+	assert.Contains(t, out, "fresh token")
+	assert.NotContains(t, out, "not registered")
 }
 
 func TestRenderCli_HealthSummary_RegisteredAndHealthy(t *testing.T) {
@@ -271,6 +311,7 @@ func TestRenderCli_Golden(t *testing.T) {
 	}{
 		{"healthy_registered", healthyRegisteredStatus()},
 		{"stale_not_registered", staleNotRegisteredStatus()},
+		{"registered_auth_failed", registeredAuthFailedStatus()},
 	}
 
 	for _, tc := range cases {

--- a/apps/mql/cmd/testdata/status_registered_auth_failed.golden
+++ b/apps/mql/cmd/testdata/status_registered_auth_failed.golden
@@ -1,0 +1,32 @@
+
+  mql status    13.25.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
+
+  ● Client     registered   ✗ authentication failed
+  ● Platform   reachable · SERVING   ✓ healthy
+  ● Updates    up to date
+
+  ── System ──────────────────────────────────────────────
+  │  Host       workstation.localdomain · 192.0.2.10
+  │  Platform   macos 26.5.1 · arm64
+
+  ── mql ──────────────────────────────────────────────
+  │  Version    13.25.0
+  │  API        v13
+  │  Config     defaults — no config file loaded
+  │  Updates    https://releases.mondoo.com
+
+  ── Mondoo Platform ──────────────────────────────────────────────
+  │  Endpoint   https://us.api.mondoo.com
+  │  Status     SERVING   API v13 ✓ in sync
+  │  Time       2026-06-29T21:37:00Z
+  │  Client     //agents.api.mondoo.app/spaces/test/agents/123
+  │  Account    //agents.api.mondoo.app/spaces/test/serviceaccounts/abc
+
+  ── Providers ──────────────────────────────────────────────
+  │  3 installed · 0 outdated · 3 current
+  │
+  │  ✓ current  aws, core, os
+
+  ✗ authentication failed · exit 1 · next steps:
+    → mql login --token <token>       re-register with a fresh token from Mondoo Platform
+


### PR DESCRIPTION
## Problem

When `mql status` runs for a client that **is** registered but whose service account has been revoked or has expired on the platform, the footer was both wrong and useless:

```
  ✗ not registered · exit 1 · next steps:

```

- The header said **not registered**, even though the client is registered (the health-summary line correctly says `✗ authentication failed` just above it).
- **No next step** was printed. The three footer steps are gated on `!Registered`, `updateAvailable()`, and `outdatedCount() > 0` — a registered-but-rejected credential matches none of them, so the user is told "next steps:" and given nothing.

## Fix

Split the footer's error branch so the registered-but-ping-rejected case gets its own header and an actionable remediation step:

```
  ✗ authentication failed · exit 1 · next steps:
    → mql login --token <token>       re-register with a fresh token from Mondoo Platform
```

The hint points at `mql login --token <token>` rather than a bare `mql login`: a revoked/expired service account can't self-renew, since `login` without a token only re-authenticates from an already-valid stored credential. A fresh registration token is the only recovery path.

This brings the footer in line with the health-summary line, which already distinguished the three states (not registered / auth failed / healthy).

## Tests

- `TestRenderCli_HealthSummary_AuthFailed` and `TestRenderCli_Footer_AuthFailed` cover the new branch.
- New `registered_auth_failed` golden fixture.
- Existing `healthy_registered` and `stale_not_registered` goldens are unchanged, confirming no regression on the other paths.
- `go test ./apps/mql/cmd/` passes; `gofmt` clean.