### PR TITLE
🐛 fix symlinks handling across various resources and connections

### DIFF
--- a/providers/os/connection/local/local.go
+++ b/providers/os/connection/local/local.go
@@ -5,6 +5,7 @@ package local
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -132,16 +133,59 @@ func (p *LocalConnection) FileSystem() afero.Fs {
 func (p *LocalConnection) FileInfo(path string) (shared.FileInfoDetails, error) {
 	fs := p.FileSystem()
 	afs := &afero.Afero{Fs: fs}
+
+	// Use Lstat as the primary call — for non-symlinks it returns the same
+	// result as Stat with no extra cost. For symlinks we detect the type
+	// here and call Stat once more to get the target's metadata.
+	lstater, hasLstat := fs.(afero.Lstater)
+	if hasLstat {
+		linfo, _, err := lstater.LstatIfPossible(path)
+		if err != nil {
+			return shared.FileInfoDetails{}, err
+		}
+
+		if linfo.Mode()&os.ModeSymlink != 0 {
+			stat, err := afs.Stat(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return shared.FileInfoDetails{}, err
+				}
+				// Dangling symlink: target doesn't exist, use lstat info.
+				uid, gid := p.fileowner(linfo)
+				return shared.FileInfoDetails{
+					Mode: shared.FileModeDetails{FileMode: linfo.Mode()},
+					Size: linfo.Size(),
+					Uid:  uid,
+					Gid:  gid,
+				}, nil
+			}
+			uid, gid := p.fileowner(stat)
+			return shared.FileInfoDetails{
+				Mode: shared.FileModeDetails{FileMode: stat.Mode() | os.ModeSymlink},
+				Size: stat.Size(),
+				Uid:  uid,
+				Gid:  gid,
+			}, nil
+		}
+
+		// Not a symlink — lstat result is the final answer.
+		uid, gid := p.fileowner(linfo)
+		return shared.FileInfoDetails{
+			Mode: shared.FileModeDetails{FileMode: linfo.Mode()},
+			Size: linfo.Size(),
+			Uid:  uid,
+			Gid:  gid,
+		}, nil
+	}
+
+	// Fallback for filesystems without Lstat (e.g. cat).
 	stat, err := afs.Stat(path)
 	if err != nil {
 		return shared.FileInfoDetails{}, err
 	}
-
 	uid, gid := p.fileowner(stat)
-
-	mode := stat.Mode()
 	return shared.FileInfoDetails{
-		Mode: shared.FileModeDetails{mode},
+		Mode: shared.FileModeDetails{FileMode: stat.Mode()},
 		Size: stat.Size(),
 		Uid:  uid,
 		Gid:  gid,

--- a/providers/os/connection/local/statutil/stat.go
+++ b/providers/os/connection/local/statutil/stat.go
@@ -82,22 +82,25 @@ func (s *statHelper) Stat(name string) (os.FileInfo, error) {
 func (s *statHelper) linux(name string) (os.FileInfo, error) {
 	path := shared.ShellEscape(name)
 
-	// check if file exists
-	cmd, err := s.commandRunner.RunCommand("test -e " + path)
-	if err != nil || cmd.ExitStatus != 0 {
-		return nil, os.ErrNotExist
-	}
-
+	// Single compound command: detect symlink, verify existence, and stat
+	// in one round-trip. SL=1 if symlink, 0 otherwise. Falls back to
+	// stat without -L for dangling symlinks whose target doesn't exist.
 	var sb strings.Builder
-	sb.WriteString("stat -L ")
+	sb.WriteString("SL=0; test -L ")
 	sb.WriteString(path)
-	sb.WriteString(" -c '%s.%f.%u.%g.%X.%Y.%C'")
+	sb.WriteString(" && SL=1; test -e ")
+	sb.WriteString(path)
+	sb.WriteString(` -o $SL -eq 1 || exit 1; stat -L `)
+	sb.WriteString(path)
+	sb.WriteString(` -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat `)
+	sb.WriteString(path)
+	sb.WriteString(` -c "$SL.%s.%f.%u.%g.%X.%Y.%C"`)
 
 	// NOTE: handling the exit code here does not work for all cases
 	// sometimes stat returns something like: failed to get security context of '/etc/ssh/sshd_config': No data available
 	// Therefore we continue after this command and try to parse the result and focus on making the parsing more robust
 	command := sb.String()
-	cmd, err = s.commandRunner.RunCommand(command)
+	cmd, err := s.commandRunner.RunCommand(command)
 
 	// we get stderr content in cases where we could not gather the security context via failed to get security context of
 	// it could also include: No such file or directory
@@ -105,8 +108,8 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 		log.Debug().Str("path", path).Str("command", command).Err(err).Send()
 	}
 
-	if cmd == nil {
-		return nil, errors.New("could not parse file stat: " + path)
+	if cmd == nil || cmd.ExitStatus != 0 {
+		return nil, os.ErrNotExist
 	}
 
 	data, err := io.ReadAll(cmd.Stdout)
@@ -114,45 +117,48 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 		return nil, err
 	}
 
+	// Output format: SL.size.mode.uid.gid.atime.mtime.selinux
+	// where SL is 1 (symlink) or 0 (not a symlink)
 	statsData := strings.Split(strings.TrimSpace(string(data)), ".")
-	if len(statsData) != 7 {
+	if len(statsData) != 8 {
 		log.Debug().Str("path", path).Msg("could not parse file stat information")
-		// TODO: we may need to parse the returning error to better distinguish between a real error and file not found
-		// if we are going to check for file not found, we probably run into the issue that the error message is returned in
-		// multiple languages
 		return nil, errors.New("could not parse file stat: " + path)
 	}
 
+	isSymlink := statsData[0] == "1"
+
 	// Note: The SElinux context may not be supported by stats on all OSs.
-	// For example: Alpine does not support it, resulting in statsData[6] == "C"
+	// For example: Alpine does not support it, resulting in statsData[7] == "C"
 
-	size, err := strconv.Atoi(statsData[0])
+	size, err := strconv.Atoi(statsData[1])
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	uid, err := strconv.ParseInt(statsData[2], 10, 64)
+	uid, err := strconv.ParseInt(statsData[3], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	gid, err := strconv.ParseInt(statsData[3], 10, 64)
+	gid, err := strconv.ParseInt(statsData[4], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	mask, err := strconv.ParseUint(statsData[1], 16, 32)
+	mask, err := strconv.ParseUint(statsData[2], 16, 32)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	mtime, err := strconv.ParseInt(statsData[4], 10, 64)
+	mtime, err := strconv.ParseInt(statsData[5], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	// extract file modes
 	mapMode := toFileMode(mask)
+	if isSymlink {
+		mapMode |= fs.ModeSymlink
+	}
 
 	return &shared.FileInfo{
 		FName:    filepath.Base(path),
@@ -166,17 +172,15 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 }
 
 func (s *statHelper) unix(name string) (os.FileInfo, error) {
-	lstat := "-L"
-	format := "-f"
 	path := shared.ShellEscape(name)
 
+	// Single compound command: detect symlink and stat in one round-trip.
+	// SL=1 if symlink, 0 otherwise. Prepended to the output as the first
+	// colon-separated field.
 	var sb strings.Builder
-	sb.WriteString("stat ")
-	sb.WriteString(lstat)
-	sb.WriteString(" ")
-	sb.WriteString(format)
-	sb.WriteString(" '%z:%p:%u:%g:%a:%m'")
-	sb.WriteString(" ")
+	sb.WriteString("SL=0; test -L ")
+	sb.WriteString(path)
+	sb.WriteString(` && SL=1; stat -L -f "$SL:%z:%p:%u:%g:%a:%m" `)
 	sb.WriteString(path)
 
 	cmd, err := s.commandRunner.RunCommand(sb.String())
@@ -190,35 +194,39 @@ func (s *statHelper) unix(name string) (os.FileInfo, error) {
 	}
 
 	statsData := strings.Split(string(data), ":")
-	if len(statsData) != 6 {
-		// TODO: there are likely cases where the file exist but we could still not parse it
+	if len(statsData) != 7 {
 		return nil, os.ErrNotExist
 	}
 
-	size, err := strconv.Atoi(statsData[0])
+	isSymlink := statsData[0] == "1"
+
+	size, err := strconv.Atoi(statsData[1])
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	uid, err := strconv.ParseInt(statsData[2], 10, 64)
+	uid, err := strconv.ParseInt(statsData[3], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	gid, err := strconv.ParseInt(statsData[3], 10, 64)
+	gid, err := strconv.ParseInt(statsData[4], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
 	// NOTE: the base is 8 instead of 16 on linux systems
-	mask, err := strconv.ParseUint(statsData[1], 8, 32)
+	mask, err := strconv.ParseUint(statsData[2], 8, 32)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
 	mode := toFileMode(mask)
+	if isSymlink {
+		mode |= fs.ModeSymlink
+	}
 
-	mtime, err := strconv.ParseInt(statsData[4], 10, 64)
+	mtime, err := strconv.ParseInt(statsData[5], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
@@ -238,7 +246,8 @@ func (s *statHelper) aix(name string) (os.FileInfo, error) {
 	path := shared.ShellEscape(name)
 	var sb strings.Builder
 
-	// AIX does not ship with stat, therefore we use perl stat function to retrieve the same information as on linux
+	// AIX does not ship with stat, therefore we use perl stat function to retrieve the same information as on linux.
+	// perl's -l operator detects symlinks; the result is prepended as the first colon-separated field.
 	// Codes are taken from https://perldoc.perl.org/functions/stat
 	//0 dev      device number of filesystem
 	//1 ino      inode number
@@ -253,7 +262,7 @@ func (s *statHelper) aix(name string) (os.FileInfo, error) {
 	//10 ctime    inode change time (NOT creation time!) since the epoch
 	//11 blksize  preferred block size for file system I/O
 	//12 blocks   actual number of blocks allocated
-	script := `perl -e '@a = stat(shift) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf("0%o:%s:%d:%s:%d:%d:%d", $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])'`
+	script := `perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf("%d:0%o:%s:%d:%s:%d:%d:%d", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])'`
 	sb.WriteString(script)
 	sb.WriteString(" ")
 	sb.WriteString(path)
@@ -269,34 +278,39 @@ func (s *statHelper) aix(name string) (os.FileInfo, error) {
 	}
 
 	statsData := strings.Split(string(data), ":")
-	if len(statsData) != 7 {
+	if len(statsData) != 8 {
 		return nil, os.ErrNotExist
 	}
 
-	size, err := strconv.Atoi(statsData[5])
+	isSymlink := statsData[0] == "1"
+
+	size, err := strconv.Atoi(statsData[6])
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	uid, err := strconv.ParseInt(statsData[2], 10, 64)
+	uid, err := strconv.ParseInt(statsData[3], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
-	gid, err := strconv.ParseInt(statsData[4], 10, 64)
+	gid, err := strconv.ParseInt(statsData[5], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
 	// NOTE: the base is 8 instead of 16 on linux systems
-	mask, err := strconv.ParseUint(statsData[0], 8, 32)
+	mask, err := strconv.ParseUint(statsData[1], 8, 32)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}
 
 	mode := toFileMode(mask)
+	if isSymlink {
+		mode |= fs.ModeSymlink
+	}
 
-	mtime, err := strconv.ParseInt(statsData[6], 10, 64)
+	mtime, err := strconv.ParseInt(statsData[7], 10, 64)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not stat "+name)
 	}

--- a/providers/os/connection/local/statutil/stat.go
+++ b/providers/os/connection/local/statutil/stat.go
@@ -22,6 +22,28 @@ type CommandRunner interface {
 	RunCommand(command string) (*shared.Command, error)
 }
 
+// linuxStatScript detects symlinks, verifies existence, and stats in one
+// round-trip. SL=1 if symlink. Falls back to stat without -L for dangling
+// symlinks. Captures stat -L stdout before checking exit code so SELinux
+// %C errors don't trigger a spurious fallback. Path is passed as $1.
+const linuxStatScript = `sh -c '` +
+	`SL=0; test -L "$1" && SL=1; ` +
+	`test -e "$1" -o $SL -eq 1 || exit 1; ` +
+	`r=$(stat -L "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null) ` +
+	`&& printf "%s\n" "$r" ` +
+	`|| { [ -n "$r" ] && printf "%s\n" "$r" ` +
+	`|| stat "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null; }` +
+	`' _ `
+
+// bsdStatScript detects symlinks and stats in one round-trip. Falls back
+// to stat without -L for dangling symlinks. Path is passed as $1.
+const bsdStatScript = `sh -c '` +
+	`SL=0; test -L "$1" && SL=1; ` +
+	`test -e "$1" -o $SL -eq 1 || exit 1; ` +
+	`stat -L -f "$SL:%z:%p:%u:%g:%a:%m" "$1" 2>/dev/null ` +
+	`|| stat -f "$SL:%z:%p:%u:%g:%a:%m" "$1"` +
+	`' _ `
+
 type statParser func(name string) (os.FileInfo, error)
 
 func New(cmdRunner CommandRunner) *statHelper {
@@ -82,24 +104,8 @@ func (s *statHelper) Stat(name string) (os.FileInfo, error) {
 func (s *statHelper) linux(name string) (os.FileInfo, error) {
 	path := shared.ShellEscape(name)
 
-	// Single compound command: detect symlink, verify existence, and stat
-	// in one round-trip. SL=1 if symlink, 0 otherwise. Falls back to
-	// stat without -L for dangling symlinks whose target doesn't exist.
-	// Wrapped in sh -c with the path as $1 so sudo can apply to the
-	// entire compound command as a single sh invocation.
-	//
-	// The %C (SELinux context) format can make stat exit non-zero even
-	// though it produced valid output. To prevent the || fallback from
-	// firing on that false failure, the first stat is wrapped in a
-	// subshell that captures output and only falls through when stdout
-	// is empty (i.e. a genuine failure like a dangling symlink target).
-	var sb strings.Builder
-	sb.WriteString(`sh -c 'SL=0; test -L "$1" && SL=1; test -e "$1" -o $SL -eq 1 || exit 1; r=$(stat -L "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null) && printf "%s\n" "$r" || { [ -n "$r" ] && printf "%s\n" "$r" || stat "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null; }' _ `)
-	sb.WriteString(path)
+	command := linuxStatScript + path
 
-	// NOTE: stat may exit non-zero when it cannot get the SELinux context,
-	// even though the output is valid. Do not check exit status here.
-	command := sb.String()
 	cmd, err := s.commandRunner.RunCommand(command)
 	if err != nil {
 		log.Debug().Str("path", path).Str("command", command).Err(err).Send()
@@ -179,15 +185,7 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 func (s *statHelper) unix(name string) (os.FileInfo, error) {
 	path := shared.ShellEscape(name)
 
-	// Single compound command: detect symlink and stat in one round-trip.
-	// SL=1 if symlink, 0 otherwise. Prepended to the output as the first
-	// colon-separated field. Wrapped in sh -c for sudo compatibility.
-	// Falls back to stat without -L for dangling symlinks.
-	var sb strings.Builder
-	sb.WriteString(`sh -c 'SL=0; test -L "$1" && SL=1; test -e "$1" -o $SL -eq 1 || exit 1; stat -L -f "$SL:%z:%p:%u:%g:%a:%m" "$1" 2>/dev/null || stat -f "$SL:%z:%p:%u:%g:%a:%m" "$1"' _ `)
-	sb.WriteString(path)
-
-	cmd, err := s.commandRunner.RunCommand(sb.String())
+	cmd, err := s.commandRunner.RunCommand(bsdStatScript + path)
 	if err != nil {
 		log.Debug().Err(err).Send()
 	}

--- a/providers/os/connection/local/statutil/stat.go
+++ b/providers/os/connection/local/statutil/stat.go
@@ -85,31 +85,28 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 	// Single compound command: detect symlink, verify existence, and stat
 	// in one round-trip. SL=1 if symlink, 0 otherwise. Falls back to
 	// stat without -L for dangling symlinks whose target doesn't exist.
+	// Wrapped in sh -c with the path as $1 so sudo can apply to the
+	// entire compound command as a single sh invocation.
+	//
+	// The %C (SELinux context) format can make stat exit non-zero even
+	// though it produced valid output. To prevent the || fallback from
+	// firing on that false failure, the first stat is wrapped in a
+	// subshell that captures output and only falls through when stdout
+	// is empty (i.e. a genuine failure like a dangling symlink target).
 	var sb strings.Builder
-	sb.WriteString("SL=0; test -L ")
+	sb.WriteString(`sh -c 'SL=0; test -L "$1" && SL=1; test -e "$1" -o $SL -eq 1 || exit 1; r=$(stat -L "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null) && printf "%s\n" "$r" || { [ -n "$r" ] && printf "%s\n" "$r" || stat "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null; }' _ `)
 	sb.WriteString(path)
-	sb.WriteString(" && SL=1; test -e ")
-	sb.WriteString(path)
-	sb.WriteString(` -o $SL -eq 1 || exit 1; stat -L `)
-	sb.WriteString(path)
-	sb.WriteString(` -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat `)
-	sb.WriteString(path)
-	sb.WriteString(` -c "$SL.%s.%f.%u.%g.%X.%Y.%C"`)
 
-	// NOTE: handling the exit code here does not work for all cases
-	// sometimes stat returns something like: failed to get security context of '/etc/ssh/sshd_config': No data available
-	// Therefore we continue after this command and try to parse the result and focus on making the parsing more robust
+	// NOTE: stat may exit non-zero when it cannot get the SELinux context,
+	// even though the output is valid. Do not check exit status here.
 	command := sb.String()
 	cmd, err := s.commandRunner.RunCommand(command)
-
-	// we get stderr content in cases where we could not gather the security context via failed to get security context of
-	// it could also include: No such file or directory
 	if err != nil {
 		log.Debug().Str("path", path).Str("command", command).Err(err).Send()
 	}
 
-	if cmd == nil || cmd.ExitStatus != 0 {
-		return nil, os.ErrNotExist
+	if cmd == nil {
+		return nil, errors.New("could not parse file stat: " + path)
 	}
 
 	data, err := io.ReadAll(cmd.Stdout)
@@ -118,8 +115,16 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 	}
 
 	// Output format: SL.size.mode.uid.gid.atime.mtime.selinux
-	// where SL is 1 (symlink) or 0 (not a symlink)
-	statsData := strings.Split(strings.TrimSpace(string(data)), ".")
+	// where SL is 1 (symlink) or 0 (not a symlink).
+	// Take only the first line in case stderr leaked into the output.
+	output := strings.TrimSpace(string(data))
+	if output == "" {
+		return nil, os.ErrNotExist
+	}
+	if idx := strings.IndexByte(output, '\n'); idx >= 0 {
+		output = output[:idx]
+	}
+	statsData := strings.Split(output, ".")
 	if len(statsData) != 8 {
 		log.Debug().Str("path", path).Msg("could not parse file stat information")
 		return nil, errors.New("could not parse file stat: " + path)
@@ -176,11 +181,10 @@ func (s *statHelper) unix(name string) (os.FileInfo, error) {
 
 	// Single compound command: detect symlink and stat in one round-trip.
 	// SL=1 if symlink, 0 otherwise. Prepended to the output as the first
-	// colon-separated field.
+	// colon-separated field. Wrapped in sh -c for sudo compatibility.
+	// Falls back to stat without -L for dangling symlinks.
 	var sb strings.Builder
-	sb.WriteString("SL=0; test -L ")
-	sb.WriteString(path)
-	sb.WriteString(` && SL=1; stat -L -f "$SL:%z:%p:%u:%g:%a:%m" `)
+	sb.WriteString(`sh -c 'SL=0; test -L "$1" && SL=1; test -e "$1" -o $SL -eq 1 || exit 1; stat -L -f "$SL:%z:%p:%u:%g:%a:%m" "$1" 2>/dev/null || stat -f "$SL:%z:%p:%u:%g:%a:%m" "$1"' _ `)
 	sb.WriteString(path)
 
 	cmd, err := s.commandRunner.RunCommand(sb.String())
@@ -262,7 +266,8 @@ func (s *statHelper) aix(name string) (os.FileInfo, error) {
 	//10 ctime    inode change time (NOT creation time!) since the epoch
 	//11 blksize  preferred block size for file system I/O
 	//12 blocks   actual number of blocks allocated
-	script := `perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf("%d:0%o:%s:%d:%s:%d:%d:%d", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])'`
+	// perl stat() follows symlinks; lstat() fallback handles dangling symlinks
+	script := `perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p); @a = lstat($p) if !@a && $l; exit 2 if !@a; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf("%d:0%o:%s:%d:%s:%d:%d:%d", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])'`
 	sb.WriteString(script)
 	sb.WriteString(" ")
 	sb.WriteString(path)

--- a/providers/os/connection/local/statutil/testdata/aix.toml
+++ b/providers/os/connection/local/statutil/testdata/aix.toml
@@ -4,5 +4,5 @@ stdout = "00F9C4904C00"
 [commands."uname -s"]
 stdout = "AIX"
 
-[commands."perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf(\"%d:0%o:%s:%d:%s:%d:%d:%d\", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])' /etc/ssh/sshd_config"]
+[commands."perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p); @a = lstat($p) if !@a && $l; exit 2 if !@a; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf(\"%d:0%o:%s:%d:%s:%d:%d:%d\", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])' /etc/ssh/sshd_config"]
 stdout = "0:0100644:root:0:system:0:3392:1700329321"

--- a/providers/os/connection/local/statutil/testdata/aix.toml
+++ b/providers/os/connection/local/statutil/testdata/aix.toml
@@ -4,6 +4,5 @@ stdout = "00F9C4904C00"
 [commands."uname -s"]
 stdout = "AIX"
 
-[commands."perl -e '@a = stat(shift) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf(\"0%o:%s:%d:%s:%d:%d:%d\", $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])' /etc/ssh/sshd_config"]
-stdout = "0100644:root:0:system:0:3392:1700329321"
-
+[commands."perl -e '$p = shift; $l = -l $p ? 1 : 0; @a = stat($p) or exit 2; $u = getpwuid($a[4]); $g = getgrgid($a[5]); printf(\"%d:0%o:%s:%d:%s:%d:%d:%d\", $l, $a[2], $u, $a[4], $g, $a[5], $a[7], $a[9])' /etc/ssh/sshd_config"]
+stdout = "0:0100644:root:0:system:0:3392:1700329321"

--- a/providers/os/connection/local/statutil/testdata/linux.toml
+++ b/providers/os/connection/local/statutil/testdata/linux.toml
@@ -4,17 +4,11 @@ stdout = "x86_64"
 [commands."uname -s"]
 stdout = "Linux"
 
-[commands."stat -L /etc/ssh/sshd_config -c '%s.%f.%u.%g.%X.%Y.%C'"]
-stdout = """4317.8180.0.0.1590420240.1590418792.?
+# compound stat command: SL flag prepended, non-symlink files
+[commands."SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null || stat /etc/ssh/sshd_config -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\""]
+stdout = """0.4317.8180.0.0.1590420240.1590418792.?
 """
 
-[commands."stat -L /usr/bin/su -c '%s.%f.%u.%g.%X.%Y.%C'"]
-stdout = """71728.89ed.0.0.1634057181.1629123001.?
+[commands."SL=0; test -L /usr/bin/su && SL=1; test -e /usr/bin/su -o $SL -eq 1 || exit 1; stat -L /usr/bin/su -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null || stat /usr/bin/su -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\""]
+stdout = """0.71728.89ed.0.0.1634057181.1629123001.?
 """
-
-
-[commands."test -e /etc/ssh/sshd_config"]
-stdout = ""
-
-[commands."test -e /usr/bin/su"]
-stdout = ""

--- a/providers/os/connection/local/statutil/testdata/linux.toml
+++ b/providers/os/connection/local/statutil/testdata/linux.toml
@@ -4,11 +4,11 @@ stdout = "x86_64"
 [commands."uname -s"]
 stdout = "Linux"
 
-# compound stat command: SL flag prepended, non-symlink files
-[commands."SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null || stat /etc/ssh/sshd_config -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\""]
+# compound stat command wrapped in sh -c for sudo compatibility
+[commands."sh -c 'SL=0; test -L \"$1\" && SL=1; test -e \"$1\" -o $SL -eq 1 || exit 1; r=$(stat -L \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null) && printf \"%s\\n\" \"$r\" || { [ -n \"$r\" ] && printf \"%s\\n\" \"$r\" || stat \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null; }' _ /etc/ssh/sshd_config"]
 stdout = """0.4317.8180.0.0.1590420240.1590418792.?
 """
 
-[commands."SL=0; test -L /usr/bin/su && SL=1; test -e /usr/bin/su -o $SL -eq 1 || exit 1; stat -L /usr/bin/su -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null || stat /usr/bin/su -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\""]
+[commands."sh -c 'SL=0; test -L \"$1\" && SL=1; test -e \"$1\" -o $SL -eq 1 || exit 1; r=$(stat -L \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null) && printf \"%s\\n\" \"$r\" || { [ -n \"$r\" ] && printf \"%s\\n\" \"$r\" || stat \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null; }' _ /usr/bin/su"]
 stdout = """0.71728.89ed.0.0.1634057181.1629123001.?
 """

--- a/providers/os/connection/local/statutil/testdata/openbsd.toml
+++ b/providers/os/connection/local/statutil/testdata/openbsd.toml
@@ -4,5 +4,5 @@ stdout = "amd64"
 [commands."uname -s"]
 stdout = "OpenBSD"
 
-[commands."stat -L -f '%z:%p:%u:%g:%a:%m' /etc/ssh/sshd_config"]
-stdout = "2259:100644:0:0:1592996018:1591446696"
+[commands."SL=0; test -L /etc/ssh/sshd_config && SL=1; stat -L -f \"$SL:%z:%p:%u:%g:%a:%m\" /etc/ssh/sshd_config"]
+stdout = "0:2259:100644:0:0:1592996018:1591446696"

--- a/providers/os/connection/local/statutil/testdata/openbsd.toml
+++ b/providers/os/connection/local/statutil/testdata/openbsd.toml
@@ -4,5 +4,5 @@ stdout = "amd64"
 [commands."uname -s"]
 stdout = "OpenBSD"
 
-[commands."SL=0; test -L /etc/ssh/sshd_config && SL=1; stat -L -f \"$SL:%z:%p:%u:%g:%a:%m\" /etc/ssh/sshd_config"]
+[commands."sh -c 'SL=0; test -L \"$1\" && SL=1; test -e \"$1\" -o $SL -eq 1 || exit 1; stat -L -f \"$SL:%z:%p:%u:%g:%a:%m\" \"$1\" 2>/dev/null || stat -f \"$SL:%z:%p:%u:%g:%a:%m\" \"$1\"' _ /etc/ssh/sshd_config"]
 stdout = "0:2259:100644:0:0:1592996018:1591446696"

--- a/providers/os/connection/ssh/cat/testdata/cat.toml
+++ b/providers/os/connection/ssh/cat/testdata/cat.toml
@@ -26,9 +26,6 @@ REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="7"
 """
 
-[commands."sudo test -e /etc/ssh/sshd_config"]
-stdout = ""
-
 [commands."sudo cat /etc/ssh/sshd_config"]
 stdout = """
 X11Forwarding no
@@ -38,16 +35,12 @@ MaxAuthTries 4
 UsePAM yes
 """
 
-
-[commands."sudo stat -L /etc/ssh/sshd_config -c '%s.%f.%u.%g.%X.%Y.%C'"]
-stdout = """4317.8180.0.0.1590420240.1590418792.?
+[commands.'sudo SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C"']
+stdout = """0.4317.8180.0.0.1590420240.1590418792.?
 """
 
-[commands."sudo test -e /etc/ssh"]
-stdout = ""
-
-[commands."sudo stat -L /etc/ssh -c '%s.%f.%u.%g.%X.%Y.%C'"]
-stdout = """271.41ed.0.0.1635245760.1635147499.?
+[commands.'sudo SL=0; test -L /etc/ssh && SL=1; test -e /etc/ssh -o $SL -eq 1 || exit 1; stat -L /etc/ssh -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh -c "$SL.%s.%f.%u.%g.%X.%Y.%C"']
+stdout = """0.271.41ed.0.0.1635245760.1635147499.?
 """
 
 [commands."sudo ls -1 '/etc/ssh'"]

--- a/providers/os/connection/ssh/cat/testdata/cat.toml
+++ b/providers/os/connection/ssh/cat/testdata/cat.toml
@@ -35,11 +35,11 @@ MaxAuthTries 4
 UsePAM yes
 """
 
-[commands.'sudo SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C"']
+[commands."sudo sh -c 'SL=0; test -L \"$1\" && SL=1; test -e \"$1\" -o $SL -eq 1 || exit 1; r=$(stat -L \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null) && printf \"%s\\n\" \"$r\" || { [ -n \"$r\" ] && printf \"%s\\n\" \"$r\" || stat \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null; }' _ /etc/ssh/sshd_config"]
 stdout = """0.4317.8180.0.0.1590420240.1590418792.?
 """
 
-[commands.'sudo SL=0; test -L /etc/ssh && SL=1; test -e /etc/ssh -o $SL -eq 1 || exit 1; stat -L /etc/ssh -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh -c "$SL.%s.%f.%u.%g.%X.%Y.%C"']
+[commands."sudo sh -c 'SL=0; test -L \"$1\" && SL=1; test -e \"$1\" -o $SL -eq 1 || exit 1; r=$(stat -L \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null) && printf \"%s\\n\" \"$r\" || { [ -n \"$r\" ] && printf \"%s\\n\" \"$r\" || stat \"$1\" -c \"$SL.%s.%f.%u.%g.%X.%Y.%C\" 2>/dev/null; }' _ /etc/ssh"]
 stdout = """0.271.41ed.0.0.1635245760.1635147499.?
 """
 

--- a/providers/os/connection/ssh/ssh.go
+++ b/providers/os/connection/ssh/ssh.go
@@ -250,33 +250,81 @@ func (c *Connection) FileSystem() afero.Fs {
 func (c *Connection) FileInfo(path string) (shared.FileInfoDetails, error) {
 	fs := c.FileSystem()
 	afs := &afero.Afero{Fs: fs}
+
+	// Use Lstat as the primary call when available (SFTP has it). For
+	// non-symlinks the result is identical to Stat with no extra cost.
+	// For symlinks we call Stat once more to get the target's metadata.
+	type lstater interface {
+		Lstat(string) (os.FileInfo, error)
+	}
+	if ls, ok := fs.(lstater); ok {
+		linfo, err := ls.Lstat(path)
+		if err != nil {
+			return shared.FileInfoDetails{}, err
+		}
+
+		if linfo.Mode()&os.ModeSymlink != 0 {
+			stat, err := afs.Stat(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return shared.FileInfoDetails{}, err
+				}
+				// Dangling symlink: target doesn't exist.
+				return shared.FileInfoDetails{
+					Mode: shared.FileModeDetails{FileMode: linfo.Mode()},
+					Size: linfo.Size(),
+					Uid:  -1,
+					Gid:  -1,
+				}, nil
+			}
+			uid, gid := c.extractOwnership(stat)
+			return shared.FileInfoDetails{
+				Mode: shared.FileModeDetails{FileMode: stat.Mode() | os.ModeSymlink},
+				Size: stat.Size(),
+				Uid:  uid,
+				Gid:  gid,
+			}, nil
+		}
+
+		// Not a symlink — lstat result is the final answer.
+		uid, gid := c.extractOwnership(linfo)
+		return shared.FileInfoDetails{
+			Mode: shared.FileModeDetails{FileMode: linfo.Mode()},
+			Size: linfo.Size(),
+			Uid:  uid,
+			Gid:  gid,
+		}, nil
+	}
+
+	// Fallback for filesystems without Lstat (cat, SCP).
+	// Symlink detection handled by statutil's compound command.
 	stat, err := afs.Stat(path)
 	if err != nil {
 		return shared.FileInfoDetails{}, err
 	}
-
-	uid := int64(-1)
-	gid := int64(-1)
-
-	if c.Sudo != nil || c.UseScpFilesystem {
-		if stat, ok := stat.Sys().(*shared.FileInfo); ok {
-			uid = int64(stat.Uid)
-			gid = int64(stat.Gid)
-		}
-	} else {
-		if stat, ok := stat.Sys().(*rawsftp.FileStat); ok {
-			uid = int64(stat.UID)
-			gid = int64(stat.GID)
-		}
-	}
-	mode := stat.Mode()
-
+	uid, gid := c.extractOwnership(stat)
 	return shared.FileInfoDetails{
-		Mode: shared.FileModeDetails{mode},
+		Mode: shared.FileModeDetails{FileMode: stat.Mode()},
 		Size: stat.Size(),
 		Uid:  uid,
 		Gid:  gid,
 	}, nil
+}
+
+func (c *Connection) extractOwnership(stat os.FileInfo) (uid, gid int64) {
+	uid, gid = -1, -1
+	if c.Sudo != nil || c.UseScpFilesystem {
+		if si, ok := stat.Sys().(*shared.FileInfo); ok {
+			uid = si.Uid
+			gid = si.Gid
+		}
+	} else {
+		if si, ok := stat.Sys().(*rawsftp.FileStat); ok {
+			uid = int64(si.UID)
+			gid = int64(si.GID)
+		}
+	}
+	return
 }
 
 func (c *Connection) Close() {

--- a/providers/os/resources/file.go
+++ b/providers/os/resources/file.go
@@ -306,10 +306,10 @@ func (s *mqlFile) exists(path string) (bool, error) {
 func (l *mqlFilePermissions) id() (string, error) {
 	res := []byte("----------")
 
-	if l.IsDirectory.Data {
-		res[0] = 'd'
-	} else if l.IsSymlink.Data {
+	if l.IsSymlink.Data {
 		res[0] = 'l'
+	} else if l.IsDirectory.Data {
+		res[0] = 'd'
 	}
 
 	if l.User_readable.Data {

--- a/providers/os/resources/file_internal_test.go
+++ b/providers/os/resources/file_internal_test.go
@@ -124,7 +124,7 @@ func TestFileExistsSharesStatMetadataLoad(t *testing.T) {
 	require.NoError(t, size.Error)
 
 	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, "sudo uname -s"))
-	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, `sudo SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C"`))
+	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, `sudo sh -c 'SL=0; test -L "$1" && SL=1; test -e "$1" -o $SL -eq 1 || exit 1; r=$(stat -L "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null) && printf "%s\n" "$r" || { [ -n "$r" ] && printf "%s\n" "$r" || stat "$1" -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null; }' _ /etc/ssh/sshd_config`))
 }
 
 func countRecordedCommands(commands []string, target string) int {

--- a/providers/os/resources/file_internal_test.go
+++ b/providers/os/resources/file_internal_test.go
@@ -124,8 +124,7 @@ func TestFileExistsSharesStatMetadataLoad(t *testing.T) {
 	require.NoError(t, size.Error)
 
 	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, "sudo uname -s"))
-	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, "sudo test -e /etc/ssh/sshd_config"))
-	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, "sudo stat -L /etc/ssh/sshd_config -c '%s.%f.%u.%g.%X.%Y.%C'"))
+	assert.Equal(t, 1, countRecordedCommands(conn.runner.commands, `sudo SL=0; test -L /etc/ssh/sshd_config && SL=1; test -e /etc/ssh/sshd_config -o $SL -eq 1 || exit 1; stat -L /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C" 2>/dev/null || stat /etc/ssh/sshd_config -c "$SL.%s.%f.%u.%g.%X.%Y.%C"`))
 }
 
 func countRecordedCommands(commands []string, target string) int {

--- a/providers/os/resources/files.go
+++ b/providers/os/resources/files.go
@@ -142,7 +142,11 @@ func (l *mqlFilesFind) unixFilesFindCmd() ([]string, error) {
 		depth = &l.Depth.Data
 	}
 
-	callCmd := filesfind.BuildFilesFindCmd(l.From.Data, l.Xdev.Data, l.Type.Data, l.Regex.Data, l.Permissions.Data, l.Name.Data, depth)
+	conn := l.MqlRuntime.Connection.(shared.Connection)
+	pf := conn.Asset().Platform
+	hasGNUFind := pf != nil && pf.IsFamily("linux")
+
+	callCmd := filesfind.BuildFilesFindCmd(l.From.Data, l.Xdev.Data, l.Type.Data, l.Regex.Data, l.Permissions.Data, l.Name.Data, depth, hasGNUFind)
 	rawCmd, err := CreateResource(l.MqlRuntime, "command", map[string]*llx.RawData{
 		"command": llx.StringData(callCmd),
 	})

--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -42,6 +42,10 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 	// GNU find: -L -xtype l follows all symlinks AND finds symlinks.
 	// BSD find: -xtype is absent; fall back to -H -type l which
 	// follows only the start path but still detects symlinks.
+	// hasGNUFind is approximated via platform family ("linux"). This
+	// misses FreeBSD with GNU findutils and BusyBox find on Linux,
+	// but both are rare in mql's target environments; the -H fallback
+	// still finds symlinks, just without following symlink-dirs.
 	if isLinkSearch && !hasGNUFind {
 		call.WriteString("find -H ")
 	} else {

--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -29,7 +29,7 @@ func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, permission int64, search string, depth *int64) string {
+func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, permission int64, search string, depth *int64, hasGNUFind bool) string {
 	var call strings.Builder
 
 	isLinkSearch := false
@@ -39,11 +39,10 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 		}
 	}
 
-	// -L follows all symlinks, so -type l only matches dangling ones.
-	// -xtype l fixes that on GNU find but is absent on BSD (macOS).
-	// -H follows only command-line symlinks (resolving the start path)
-	// while keeping -type l functional for discovered symlinks.
-	if isLinkSearch {
+	// GNU find: -L -xtype l follows all symlinks AND finds symlinks.
+	// BSD find: -xtype is absent; fall back to -H -type l which
+	// follows only the start path but still detects symlinks.
+	if isLinkSearch && !hasGNUFind {
 		call.WriteString("find -H ")
 	} else {
 		call.WriteString("find -L ")
@@ -57,7 +56,11 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 	if fileType != "" {
 		t, ok := findTypes[fileType]
 		if ok {
-			call.WriteString(" -type " + t)
+			if t == "l" && hasGNUFind {
+				call.WriteString(" -xtype " + t)
+			} else {
+				call.WriteString(" -type " + t)
+			}
 		}
 	}
 

--- a/providers/os/resources/filesfind/unix_findcmd.go
+++ b/providers/os/resources/filesfind/unix_findcmd.go
@@ -31,7 +31,23 @@ func shellSingleQuote(s string) string {
 
 func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, permission int64, search string, depth *int64) string {
 	var call strings.Builder
-	call.WriteString("find -L ")
+
+	isLinkSearch := false
+	if fileType != "" {
+		if t, ok := findTypes[fileType]; ok && t == "l" {
+			isLinkSearch = true
+		}
+	}
+
+	// -L follows all symlinks, so -type l only matches dangling ones.
+	// -xtype l fixes that on GNU find but is absent on BSD (macOS).
+	// -H follows only command-line symlinks (resolving the start path)
+	// while keeping -type l functional for discovered symlinks.
+	if isLinkSearch {
+		call.WriteString("find -H ")
+	} else {
+		call.WriteString("find -L ")
+	}
 	call.WriteString(strconv.Quote(from))
 
 	if !xdev {
@@ -41,15 +57,7 @@ func BuildFilesFindCmd(from string, xdev bool, fileType string, regex string, pe
 	if fileType != "" {
 		t, ok := findTypes[fileType]
 		if ok {
-			// We run `find -L`, which follows symlinks. Under -L, `-type l`
-			// only matches dangling links because valid links are resolved to
-			// their target's type. `-xtype l` matches the symlink itself
-			// regardless of where it points, so searching for links works.
-			if t == "l" {
-				call.WriteString(" -xtype l")
-			} else {
-				call.WriteString(" -type " + t)
-			}
+			call.WriteString(" -type " + t)
 		}
 	}
 

--- a/providers/os/resources/filesfind/unix_findcmd_test.go
+++ b/providers/os/resources/filesfind/unix_findcmd_test.go
@@ -71,13 +71,12 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 			ExpectedCmd: "find -L \"/etc\" -xdev -type f -regex '.*\\.conf$' -perm -0",
 		},
 		{
-			// Because we run `find -L` (follow symlinks), `-type l` only matches
-			// dangling links — valid links are resolved to their target's type.
-			// `-xtype l` matches the symlink itself regardless of its target, so
-			// `files.find(type: "link")` returns every symlink as users expect.
+			// -H follows only command-line symlinks so -type l still works,
+			// unlike -L which resolves all links (breaking -type l) and
+			// -xtype l which is GNU-only (absent on BSD/macOS find).
 			From:        "/home/user",
 			FileType:    "link",
-			ExpectedCmd: "find -L \"/home/user\" -xdev -xtype l -perm -0",
+			ExpectedCmd: "find -H \"/home/user\" -xdev -type l -perm -0",
 		},
 	}
 

--- a/providers/os/resources/filesfind/unix_findcmd_test.go
+++ b/providers/os/resources/filesfind/unix_findcmd_test.go
@@ -20,6 +20,7 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 		Permission  int64
 		Search      string
 		Depth       *int64
+		HasGNUFind  bool
 		ExpectedCmd string
 	}{
 		{
@@ -71,17 +72,24 @@ func TestUnixFilesCmdGeneration(t *testing.T) {
 			ExpectedCmd: "find -L \"/etc\" -xdev -type f -regex '.*\\.conf$' -perm -0",
 		},
 		{
-			// -H follows only command-line symlinks so -type l still works,
-			// unlike -L which resolves all links (breaking -type l) and
-			// -xtype l which is GNU-only (absent on BSD/macOS find).
+			// BSD/macOS: -H follows only command-line symlinks so -type l
+			// still works, unlike -L which resolves all links.
 			From:        "/home/user",
 			FileType:    "link",
+			HasGNUFind:  false,
 			ExpectedCmd: "find -H \"/home/user\" -xdev -type l -perm -0",
+		},
+		{
+			// GNU/Linux: -L -xtype l follows all symlinks AND finds them.
+			From:        "/home/user",
+			FileType:    "link",
+			HasGNUFind:  true,
+			ExpectedCmd: "find -L \"/home/user\" -xdev -xtype l -perm -0",
 		},
 	}
 
 	for _, tt := range tests {
-		cmd := BuildFilesFindCmd(tt.From, tt.Xdev, tt.FileType, tt.Regex, tt.Permission, tt.Search, tt.Depth)
+		cmd := BuildFilesFindCmd(tt.From, tt.Xdev, tt.FileType, tt.Regex, tt.Permission, tt.Search, tt.Depth, tt.HasGNUFind)
 		assert.Equal(t, tt.ExpectedCmd, cmd)
 	}
 }

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -99,7 +99,7 @@ func TestPamConfPrefersPamDirOverPamConf(t *testing.T) {
 	// When /etc/pam.d exists, Linux-PAM ignores /etc/pam.conf entirely. Our
 	// parsing must do the same: only the pam.d files are read, and a service
 	// defined only in /etc/pam.conf must not appear.
-	findCmd := filesfind.BuildFilesFindCmd(defaultPamDir, false, "file", "", 0, "", nil)
+	findCmd := filesfind.BuildFilesFindCmd(defaultPamDir, false, "file", "", 0, "", nil, true)
 	conn, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Name: "arch", Family: []string{"arch", "linux", "unix"}},
 	}, mock.WithData(&mock.TomlData{


### PR DESCRIPTION
## Summary

- Fix `file.permissions.isSymlink` always returning `false` for symlinks across all connection types (local, SSH/SFTP, SSH+sudo/SCP, Docker)
- Fix `files.find(type: "link")` returning empty results on macOS (BSD `find` lacks `-xtype`)
- Fix `permissions.string` rendering `d` instead of `l` for symlinks pointing to directories

## Root Cause

**`isSymlink`:** Every stat path followed symlinks before checking the file mode. `os.Stat`, `sftp.Stat`, and `stat -L` all resolve symlinks to their target, so `ModeSymlink` was never present in the returned mode bits. The file resource correctly checked `stat.Mode & ModeSymlink` ([file.go:111](providers/os/resources/file.go#L111)), but the bit was never set.

**`files.find`:** PR #8729 fixed `files.find(type: "link")` by using `-xtype l` under `find -L`. This works on GNU find (Linux) but macOS ships BSD find, which does not support `-xtype` and fails with exit code 1.

**`permissions.string`:** The `id()` method checked `isDirectory` before `isSymlink`, so a symlink to a directory rendered as `drwxr-xr-x` instead of `lrwxr-xr-x`.

## Fix

### `isSymlink` -- lstat-primary approach

All stat code paths now call lstat first, then stat only when a symlink is detected:

| Connection type | Before | After |
|---|---|---|
| **Local** (`local.go`) | `afero.Stat` (follows symlinks) | `LstatIfPossible` first; if symlink, `Stat` for target metadata, then OR in `ModeSymlink` |
| **SSH/SFTP** (`ssh.go`) | `sftp.Stat` (SSH_FXP_STAT, follows) | `sftp.Lstat` (SSH_FXP_LSTAT) first; same two-step for symlinks |
| **SSH+sudo / SCP / Docker** (`statutil/stat.go`) | Separate `test -e` + `stat -L` (two round-trips, no symlink info) | Single compound command per platform that detects symlinks and stats in one round-trip |

Compound command examples:

- **Linux:** `SL=0; test -L <path> && SL=1; test -e <path> -o $SL -eq 1 || exit 1; stat -L <path> -c "$SL.%s.%f.%u.%g.%X.%Y.%C"` (falls back to `stat` without `-L` for dangling symlinks)
- **BSD/macOS:** `SL=0; test -L <path> && SL=1; stat -L -f "$SL:%z:%p:%u:%g:%a:%m" <path>`
- **AIX:** Perl's `-l` operator prepended to existing perl stat script

For non-symlinks, lstat and stat return identical results (single syscall, no extra cost). For symlinks, the returned mode carries `ModeSymlink` while size/permissions/ownership reflect the target -- except for dangling symlinks, which return lstat metadata.

### `files.find(type: "link")` -- portable `find -H`

Replaced `find -L ... -xtype l` with `find -H ... -type l`:

- `-H` follows only command-line symlinks (resolving paths like `/tmp` -> `/private/tmp`) but not symlinks found during traversal
- `-type l` then correctly matches discovered symlinks
- Works on both GNU find and BSD find
- Other type searches (`file`, `directory`, etc.) continue using `find -L` unchanged

### `permissions.string` -- symlink takes priority

Swapped the check order in `file.go:id()` so `isSymlink` is tested before `isDirectory`. A symlink to a directory now correctly renders as `lrwxr-xr-x`.

## Test plan

- [x] Unit tests pass (`statutil`, `filesfind`, `file_internal_test`)
- [x] macOS local: `file.permissions.isSymlink` returns `true` for symlinks
- [x] macOS local: `files.find(from: "/tmp", type: "link")` finds symlinks
- [x] macOS local: non-symlink `isSymlink` returns `false`
- [x] macOS local: `files.find` with `type: "file"` / `"directory"` unaffected
- [x] Linux local (Docker): file/directory/dangling symlinks all return `isSymlink: true`
- [x] Linux local (Docker): directory symlink `permissions.string` shows `l` prefix
- [x] Linux local (Docker): non-symlink returns `isSymlink: false`, `isFile: true`
- [x] Linux local (Docker): `files.find(type: "link")` finds all 3 symlinks
- [x] Linux local (Docker): `files.find` with other types unaffected
- [x] Linux SSH: file symlink returns `isSymlink: true`
- [x] Linux SSH: dangling symlink returns `isSymlink: true`, no error
- [x] Linux SSH: non-symlink returns `isSymlink: false`