### PR TITLE
🐛 status: don't warn when the client API version is newer than the server

### DIFF
--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -158,7 +158,15 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 	}
 	sync := st.ok("✓ in sync")
 	if s.Upstream.API.Version != s.Client.APIVersion {
-		sync = st.warn("⚠ version mismatch")
+		// A client running a newer API version than the server is expected
+		// during a staged rollout (the CLI updates ahead of the platform) and
+		// is not a problem, so only flag a mismatch when the client trails the
+		// server (or the versions can't be compared numerically).
+		if clientAPINewer(s.Client.APIVersion, s.Upstream.API.Version) {
+			sync = st.ok("✓ client ahead")
+		} else {
+			sync = st.warn("⚠ version mismatch")
+		}
 	}
 	st.row(b, "Status", statusStr+"   "+st.dim("API v"+s.Upstream.API.Version)+" "+sync)
 	st.row(b, "Time", s.Upstream.API.Timestamp)
@@ -243,6 +251,22 @@ func (st styler) summaryRow(b *strings.Builder, dot, label, body, trailing strin
 }
 
 func (s Status) platformHealthy() bool { return s.Upstream.API.Status == "SERVING" }
+
+// clientAPINewer reports whether the client's API version is strictly newer
+// than the server's. Both are major-version strings (e.g. "13"); if either
+// isn't a plain integer (a development "unstable" build, say), we can't prove
+// the client is ahead and return false so the caller falls back to warning.
+func clientAPINewer(clientVersion, serverVersion string) bool {
+	client, err := strconv.Atoi(clientVersion)
+	if err != nil {
+		return false
+	}
+	server, err := strconv.Atoi(serverVersion)
+	if err != nil {
+		return false
+	}
+	return client > server
+}
 
 // updateAvailable reports whether a newer mql release exists. Development
 // builds ("unstable") never count as outdated.

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -220,6 +220,37 @@ func TestRenderCli_PlatformSection(t *testing.T) {
 	assert.Contains(t, out, "2026-06-29T21:37:00Z")
 }
 
+func TestRenderCli_PlatformSection_ClientAheadIsNotAWarning(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.APIVersion = "14" // client updated ahead of the platform
+	s.Upstream.API.Version = "13"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.NotContains(t, out, "version mismatch")
+	assert.Contains(t, out, "client ahead")
+}
+
+func TestRenderCli_PlatformSection_ClientBehindWarns(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.APIVersion = "12" // client trails the platform
+	s.Upstream.API.Version = "13"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "version mismatch")
+}
+
+func TestRenderCli_PlatformSection_UnstableClientWarns(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.APIVersion = "unstable" // dev build can't be compared numerically
+	s.Upstream.API.Version = "13"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "version mismatch")
+}
+
 func TestRenderCli_PlatformSection_NotRegisteredShowsLoginHint(t *testing.T) {
 	s := healthyRegisteredStatus()
 	s.Client.Registered = false


### PR DESCRIPTION
## What

In `mql status`, any difference between the client and server API version was rendered as `⚠ version mismatch`. During a staged rollout the CLI is commonly upgraded ahead of the platform, so a **newer client** is an expected, healthy state — flagging it as a warning is misleading.

## Change

`renderPlatform` now compares the two major-version strings numerically and only warns when the client **trails** the server:

- client **ahead** of server → `✓ client ahead` (no warning)
- client **behind** server → `⚠ version mismatch`
- versions equal → `✓ in sync` (unchanged)
- either side not a plain integer (e.g. an `unstable` dev build) → falls back to `⚠ version mismatch`, preserving prior behavior for the ambiguous case

A small `clientAPINewer` helper parses both major-version strings and returns `true` only when the client is strictly greater.

## Tests

Added three cases to `status_render_test.go`: client ahead (no warning), client behind (warning), and an `unstable` client (still warns).