### PR TITLE
✨ providers: add `providers update` command and use it in status

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,6 +31,7 @@ func init() {
 	rootCmd.AddCommand(ProvidersCmd)
 	ProvidersCmd.AddCommand(listProvidersCmd)
 	ProvidersCmd.AddCommand(installProviderCmd)
+	ProvidersCmd.AddCommand(updateProviderCmd)
 	ProvidersCmd.AddCommand(deleteProviderCmd)
 	ProvidersCmd.AddCommand(infoProviderCmd)
 	ProvidersCmd.AddCommand(resourcesProviderCmd)
@@ -89,6 +91,27 @@ var installProviderCmd = &cobra.Command{
 
 		// if no url or file is specified, we default to installing by name from the default upstream
 		installProviderByName(args[0])
+	},
+}
+
+var updateProviderCmd = &cobra.Command{
+	Use:   "update [<NAME>...]",
+	Short: "Update installed providers to their latest versions",
+	Long: `Update installed providers to their latest versions.
+
+With no arguments, every installed provider is updated. Pass one or more
+provider names to update just those. Providers already on the latest version
+are skipped, and naming a provider that isn't installed is reported and skipped
+rather than treated as an error.
+
+Examples:
+  mql providers update              # update every installed provider
+  mql providers update aws          # update just the aws provider
+  mql providers update aws gcp      # update the aws and gcp providers`,
+	Args:   cobra.ArbitraryArgs,
+	PreRun: func(cmd *cobra.Command, args []string) {},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return updateProviders(cmd.Root().Name(), args)
 	},
 }
 
@@ -560,6 +583,97 @@ func showResource(cmd *cobra.Command, providerName string, resourceName string) 
 			f.Type, mandatory, title)
 	}
 	fmt.Println()
+	return nil
+}
+
+// --- providers update ---
+
+// selectProvidersToUpdate resolves which installed providers an update run
+// should act on. With no names it returns every installed provider (sorted);
+// with names it returns the matching installed providers and reports any names
+// that aren't installed so the caller can note them without treating them as an
+// error. Builtin providers (Path == "") are compiled into the binary and can't
+// be updated independently, so they are never selected.
+func selectProvidersToUpdate(all []*providers.Provider, names []string) (toUpdate []*providers.Provider, notInstalled []string) {
+	installed := map[string]*providers.Provider{}
+	ordered := make([]*providers.Provider, 0, len(all))
+	for _, p := range all {
+		if p.Path == "" {
+			continue // builtin, not independently updatable
+		}
+		installed[p.Name] = p
+		ordered = append(ordered, p)
+	}
+
+	if len(names) == 0 {
+		sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+		return ordered, nil
+	}
+
+	for _, name := range names {
+		if p, ok := installed[name]; ok {
+			toUpdate = append(toUpdate, p)
+		} else {
+			notInstalled = append(notInstalled, name)
+		}
+	}
+	return toUpdate, notInstalled
+}
+
+// updateProviders updates the named installed providers (or all of them when no
+// names are given) to their latest versions. Providers already on the latest
+// version are skipped so they aren't re-downloaded, and naming a provider that
+// isn't installed is reported and skipped rather than treated as an error.
+func updateProviders(binary string, names []string) error {
+	if binary == "" {
+		binary = "mql"
+	}
+
+	all, err := providers.ListAll()
+	if err != nil {
+		return fmt.Errorf("failed to list providers: %w", err)
+	}
+
+	toUpdate, notInstalled := selectProvidersToUpdate(all, names)
+	for _, name := range notInstalled {
+		// Not an error: there's nothing to update for a provider that isn't
+		// installed. Point the user at install if they meant to add it.
+		log.Info().Str("provider", name).
+			Msg("not installed, skipping (run '" + binary + " providers install " + name + "' to add it)")
+	}
+
+	ctx := context.Background()
+	var updated []*providers.Provider
+	var current, failed int
+	for _, p := range toUpdate {
+		latest, err := providers.LatestVersion(ctx, p.Name)
+		if err != nil {
+			log.Warn().Err(err).Str("provider", p.Name).Msg("failed to check for updates")
+			failed++
+			continue
+		}
+		if latest == p.Version {
+			current++
+			continue
+		}
+
+		installed, err := providers.Install(p.Name, latest)
+		if err != nil {
+			log.Warn().Err(err).Str("provider", p.Name).Msg("failed to update provider")
+			failed++
+			continue
+		}
+		updated = append(updated, installed)
+	}
+
+	if len(updated) > 0 {
+		providers.PrintInstallResults(updated)
+	}
+	log.Info().Msgf("%d updated · %d already current · %d failed", len(updated), current, failed)
+
+	if failed > 0 {
+		return fmt.Errorf("%d provider(s) failed to update", failed)
+	}
 	return nil
 }
 

--- a/apps/mql/cmd/providers_test.go
+++ b/apps/mql/cmd/providers_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// updateTestProvider builds a minimal Provider for selectProvidersToUpdate
+// tests. A non-empty path marks an installed (external) provider; an empty path
+// marks a builtin one compiled into the binary.
+func updateTestProvider(name, path string) *providers.Provider {
+	return &providers.Provider{Provider: &plugin.Provider{Name: name}, Path: path}
+}
+
+func updateProviderNames(ps []*providers.Provider) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Name
+	}
+	return out
+}
+
+func TestSelectProvidersToUpdate_NoNamesReturnsAllInstalledSorted(t *testing.T) {
+	all := []*providers.Provider{
+		updateTestProvider("os", "/p/os"),
+		updateTestProvider("aws", "/p/aws"),
+		updateTestProvider("core", ""), // builtin, must be excluded
+	}
+
+	toUpdate, notInstalled := selectProvidersToUpdate(all, nil)
+
+	assert.Equal(t, []string{"aws", "os"}, updateProviderNames(toUpdate), "all installed providers, sorted, builtin excluded")
+	assert.Empty(t, notInstalled)
+}
+
+func TestSelectProvidersToUpdate_NamedSubset(t *testing.T) {
+	all := []*providers.Provider{
+		updateTestProvider("aws", "/p/aws"),
+		updateTestProvider("gcp", "/p/gcp"),
+		updateTestProvider("os", "/p/os"),
+	}
+
+	toUpdate, notInstalled := selectProvidersToUpdate(all, []string{"aws", "os"})
+
+	assert.Equal(t, []string{"aws", "os"}, updateProviderNames(toUpdate))
+	assert.Empty(t, notInstalled)
+}
+
+func TestSelectProvidersToUpdate_MissingNameReportedNotFatal(t *testing.T) {
+	all := []*providers.Provider{updateTestProvider("aws", "/p/aws")}
+
+	toUpdate, notInstalled := selectProvidersToUpdate(all, []string{"aws", "notreal"})
+
+	assert.Equal(t, []string{"aws"}, updateProviderNames(toUpdate))
+	assert.Equal(t, []string{"notreal"}, notInstalled, "unknown names are reported, not selected")
+}
+
+func TestSelectProvidersToUpdate_BuiltinNameIsNotUpdatable(t *testing.T) {
+	all := []*providers.Provider{
+		updateTestProvider("core", ""), // builtin
+		updateTestProvider("aws", "/p/aws"),
+	}
+
+	// A builtin provider is compiled into the binary, so naming it is treated
+	// the same as an uninstalled provider: reported and skipped, never selected.
+	toUpdate, notInstalled := selectProvidersToUpdate(all, []string{"core"})
+
+	assert.Empty(t, toUpdate)
+	assert.Equal(t, []string{"core"}, notInstalled)
+}

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -135,7 +135,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		case "json":
 			s.RenderJson()
 		default:
-			fmt.Fprint(os.Stdout, s.RenderCli(RenderOptions{Color: defaultRenderColor()}))
+			fmt.Fprint(os.Stdout, s.RenderCli(RenderOptions{Color: defaultRenderColor(), Binary: cmd.Root().Name()}))
 		}
 
 		if !s.Client.Registered || s.Client.PingPongError != nil {

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -20,6 +20,11 @@ import (
 type RenderOptions struct {
 	Color bool
 	Width int
+	// Binary is the name of the invoking CLI ("mql" or "cnspec"), used in the
+	// command hints so the same renderer tells cnspec users to run
+	// "cnspec providers update" rather than "mql ...". Callers derive it from
+	// cmd.Root().Name(); an empty value falls back to "mql".
+	Binary string
 }
 
 // styler applies (or, when disabled, passes through) terminal styling. When
@@ -30,6 +35,7 @@ type styler struct {
 	on      bool
 	profile termenv.Profile
 	palette colors.Theme
+	binary  string
 }
 
 // defaultRenderColor reports whether the status screen should be rendered with
@@ -39,12 +45,15 @@ func defaultRenderColor() bool {
 	return colors.Profile != termenv.Ascii
 }
 
-func newStyler(color bool) styler {
+func newStyler(color bool, binary string) styler {
 	p := colors.Profile
 	if !color {
 		p = termenv.Ascii
 	}
-	return styler{on: color, profile: p, palette: theme.DefaultTheme.Colors}
+	if binary == "" {
+		binary = "mql"
+	}
+	return styler{on: color, profile: p, palette: theme.DefaultTheme.Colors, binary: binary}
 }
 
 func (st styler) fg(c termenv.Color, s string) string {
@@ -74,7 +83,7 @@ func (st styler) accent(s string) string { return st.fg(st.palette.Secondary, s)
 // I/O and reads no globals: everything it needs is on the Status value, which
 // makes it directly unit-testable.
 func (s Status) RenderCli(opts RenderOptions) string {
-	st := newStyler(opts.Color)
+	st := newStyler(opts.Color, opts.Binary)
 	var b strings.Builder
 
 	s.renderHeader(&b, st)
@@ -175,7 +184,7 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 		st.row(b, "Client", st.value(s.Client.Mrn))
 		st.row(b, "Account", st.value(s.Client.ServiceAccount))
 	} else {
-		st.row(b, "Client", st.bad("✗ not registered")+" "+st.dim("—")+" run "+st.cmd("mql login"))
+		st.row(b, "Client", st.bad("✗ not registered")+" "+st.dim("—")+" run "+st.cmd(st.binary+" login"))
 	}
 
 	if len(s.Upstream.Features) > 0 {
@@ -191,7 +200,7 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 
 func (s Status) renderHeader(b *strings.Builder, st styler) {
 	meta := fmt.Sprintf("%s · %s · %s", s.Client.Version, s.osArch(), s.Client.Timestamp)
-	fmt.Fprintf(b, "\n  %s    %s\n", st.bold("mql status"), st.dim(meta))
+	fmt.Fprintf(b, "\n  %s    %s\n", st.bold(st.binary+" status"), st.dim(meta))
 }
 
 // osArch returns "<os>/<arch>" for the header, or "unknown" when platform info
@@ -230,7 +239,7 @@ func (s Status) renderHealth(b *strings.Builder, st styler) {
 
 	var parts []string
 	if s.updateAvailable() {
-		parts = append(parts, "mql "+st.dim(s.Client.Version)+" "+st.accent("→")+" "+st.warn(s.Client.LatestVersion))
+		parts = append(parts, st.binary+" "+st.dim(s.Client.Version)+" "+st.accent("→")+" "+st.warn(s.Client.LatestVersion))
 	}
 	if n := s.outdatedCount(); n > 0 {
 		parts = append(parts, st.warn(fmt.Sprintf("%d providers outdated", n)))
@@ -340,7 +349,7 @@ func (s Status) renderProviders(b *strings.Builder, st styler) {
 		}
 		if outdated > providerTableLimit {
 			st.rowRaw(b, st.dim(fmt.Sprintf("+ %d more outdated", outdated-providerTableLimit))+" "+
-				st.dim("·")+" "+st.cmd("mql providers list")+st.dim(" to see all"))
+				st.dim("·")+" "+st.cmd(st.binary+" providers list")+st.dim(" to see all"))
 		}
 	}
 
@@ -367,7 +376,7 @@ func (s Status) renderProviders(b *strings.Builder, st styler) {
 
 	if outdated > 0 {
 		st.rowRaw(b, st.dim("providers refresh automatically on next run")+" "+st.dim("·")+" "+
-			st.cmd("mql providers install <name>")+st.dim(" to update one now"))
+			st.cmd(st.binary+" providers install <name>")+st.dim(" to update one now"))
 	}
 }
 
@@ -393,16 +402,21 @@ func (s Status) renderFooter(b *strings.Builder, st styler) {
 	}
 
 	if !s.Client.Registered {
-		st.footerStep(b, "mql login", "register this client with Mondoo Platform")
+		st.footerStep(b, st.binary+" login", "register this client with Mondoo Platform")
 	}
 	if authFailed {
-		st.footerStep(b, "mql login --token <token>", "re-register with a fresh token from Mondoo Platform")
+		st.footerStep(b, st.binary+" login --token <token>", "re-register with a fresh token from Mondoo Platform")
 	}
 	if s.updateAvailable() {
 		st.footerStep(b, "visit "+s.Client.UpdatesURL, "upgrade "+s.Client.Version+" → "+s.Client.LatestVersion)
 	}
-	if s.outdatedCount() > 0 {
-		st.footerStep(b, "mql providers install <name>", fmt.Sprintf("update %d outdated providers", s.outdatedCount()))
+	// With a single outdated provider, point at the targeted install; with
+	// several, recommend the bulk `providers update` (no args updates them all)
+	// so the user doesn't have to name each one.
+	if n := s.outdatedCount(); n == 1 {
+		st.footerStep(b, st.binary+" providers install <name>", fmt.Sprintf("update %d outdated providers", n))
+	} else if n > 1 {
+		st.footerStep(b, st.binary+" providers update", fmt.Sprintf("update %d outdated providers", n))
 	}
 	b.WriteString("\n")
 }

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -309,6 +309,65 @@ func TestRenderCli_Footer_NotRegistered(t *testing.T) {
 	assert.Contains(t, out, "mql login")
 }
 
+func TestRenderCli_Footer_MultipleOutdatedRecommendsBulkUpdate(t *testing.T) {
+	s := healthyRegisteredStatus() // fixture has 2 outdated providers
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// with 2+ outdated, the footer's next step recommends the bulk update
+	// (the per-provider install hint still appears in the Providers section)
+	assert.Contains(t, out, "next steps")
+	assert.Contains(t, out, "mql providers update")
+	assert.Contains(t, out, "update 2 outdated providers")
+}
+
+func TestRenderCli_Footer_SingleOutdatedKeepsInstallHint(t *testing.T) {
+	s := healthyRegisteredStatus()
+	// leave exactly one provider outdated
+	firstOutdated := false
+	for i := range s.Client.Providers {
+		if s.Client.Providers[i].Outdated && !firstOutdated {
+			firstOutdated = true
+			continue
+		}
+		s.Client.Providers[i].Outdated = false
+		s.Client.Providers[i].Latest = s.Client.Providers[i].Installed
+	}
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// a single outdated provider keeps the targeted install hint
+	assert.Contains(t, out, "mql providers install <name>")
+	assert.NotContains(t, out, "mql providers update")
+}
+
+func TestRenderCli_BinaryNameDrivesCommandHints(t *testing.T) {
+	// stale + unregistered surfaces the header plus login/update hints, so a
+	// single render exercises several command strings at once.
+	s := staleNotRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false, Binary: "cnspec"})
+
+	assert.Contains(t, out, "cnspec status")
+	assert.Contains(t, out, "cnspec login")
+	assert.Contains(t, out, "cnspec providers update")
+	// no command hint should leak the other binary's name
+	assert.NotContains(t, out, "mql login")
+	assert.NotContains(t, out, "mql providers")
+	assert.NotContains(t, out, "mql status")
+}
+
+func TestRenderCli_BinaryNameDefaultsToMql(t *testing.T) {
+	s := staleNotRegisteredStatus()
+
+	// empty Binary (as the existing tests and goldens use) falls back to "mql"
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "mql status")
+	assert.Contains(t, out, "mql login")
+	assert.NotContains(t, out, "cnspec")
+}
+
 func TestRenderCli_Footer_AllHealthyHasNoExitBanner(t *testing.T) {
 	s := healthyRegisteredStatus()
 	for i := range s.Client.Providers {

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -33,5 +33,5 @@
   │  providers refresh automatically on next run · mql providers install <name> to update one now
 
   next steps:
-    → mql providers install <name>    update 2 outdated providers
+    → mql providers update            update 2 outdated providers
 

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -34,5 +34,5 @@
   ✗ not registered · exit 1 · next steps:
     → mql login                       register this client with Mondoo Platform
     → visit https://releases.mondoo.com    upgrade 13.22.0 → 13.25.0
-    → mql providers install <name>    update 2 outdated providers
+    → mql providers update            update 2 outdated providers
 

--- a/test/commands/testdata/mql_providers.ct
+++ b/test/commands/testdata/mql_providers.ct
@@ -11,6 +11,7 @@ Available Commands:
   install     Install or update a provider
   list        List all providers on the system
   resources   List resources or show resource details for a provider
+  update      Update installed providers to their latest versions
 
 Flags:
   -h, --help   help for providers


### PR DESCRIPTION
## What

Adds a dedicated `mql providers update` command, wires it into `mql status`, and makes the status renderer binary-name aware so cnspec can reuse it cleanly.

### `mql providers update [<name>...]`

| Invocation | Behavior |
|---|---|
| `mql providers update` | update **every** installed provider to latest |
| `mql providers update aws` | update just `aws` |
| `mql providers update aws gcp` | update those two |
| `mql providers update notreal` | "not installed, skipping" → **exit 0** (not an error) |

- **Already-current providers are skipped** so they aren't re-downloaded (`installVersion` always re-downloads otherwise). The run ends with a quiet summary: `N updated · N already current · N failed`.
- **Builtin providers** (`core`, `network` — compiled into the binary) are skipped.
- **Real update/registry failures** are reported per-provider and don't abort the sweep; the command exits non-zero only if an attempted update actually failed. Not-installed and already-current stay exit 0.
- No `--all` flag — bare `update` means "all" (safe because non-destructive, unlike `providers delete all` which requires `--yes`).

The provider-selection logic lives in a pure, unit-tested `selectProvidersToUpdate` helper; the network-touching resolve-latest + install part stays a thin wrapper over `providers.Install`, matching the existing `install` command.

### `mql status` footer

When **2+** providers are outdated, the footer now recommends the bulk command (`mql providers update`); a **single** outdated provider keeps the targeted `mql providers install <name>` hint.

### Binary-name aware rendering

The status renderer previously hardcoded `mql` in every command hint and the header. `RenderOptions` now carries a `Binary` field, derived at the call site from `cmd.Root().Name()` (empty falls back to `"mql"`). So the same renderer emits `cnspec providers update` / `cnspec login` / `cnspec status` when cnspec reuses it, and `mql ...` otherwise. The binary name is threaded once via the `styler`, so all nine former literals resolve from a single source.

## Tests

- `providers_test.go`: unit tests for `selectProvidersToUpdate` (no-names-returns-all-sorted, named subset, missing-name-reported-not-fatal, builtin-not-updatable).
- `status_render_test.go`: footer routing (1 vs 2+ outdated), plus `TestRenderCli_BinaryNameDrivesCommandHints` (Binary:"cnspec" → `cnspec ...`, no `mql ...` leakage) and `TestRenderCli_BinaryNameDefaultsToMql`.
- `healthy_registered` / `stale_not_registered` goldens regenerated for the footer hint; the binary-name change leaves them unchanged (they render with the `"mql"` default).

## Verification

- `go test ./apps/mql/cmd/` passes; `go vet` clean; `gofmt` clean.
- Live smoke test: `providers update <unknown>` reports "not installed, skipping" and exits 0; `--help` renders the usage/examples correctly.
- The network update path reuses the same `providers.LatestVersion` / `providers.Install` calls as the existing `install` command.

## Note for cnspec

This makes the *renderer* binary-aware. For `cnspec providers update` to actually exist, cnspec must also carry the `update` command (the providers commands live in the app `cmd` package, which cnspec maintains its own copy of) — that port happens in the cnspec repo.