### PR TITLE
🐛 status: don't report an update when versions match modulo the "v" prefix

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -344,7 +344,7 @@ func getProviders(ctx context.Context) ([]ProviderStatus, error) {
 				}
 			} else {
 				ps.Latest = latestVersion
-				if latestVersion != provider.Version && provider.Name != "core" {
+				if provider.Name != "core" && newerAvailable(provider.Version, latestVersion) {
 					ps.Outdated = true
 				}
 			}

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -12,6 +12,7 @@ import (
 	"github.com/muesli/termenv"
 	"go.mondoo.com/mql/v13/cli/theme"
 	"go.mondoo.com/mql/v13/cli/theme/colors"
+	"go.mondoo.com/mql/v13/providers/core/resources/versions/semver"
 )
 
 // RenderOptions controls how RenderCli formats the status screen. Color is
@@ -281,8 +282,24 @@ func clientAPINewer(clientVersion, serverVersion string) bool {
 // builds ("unstable") never count as outdated.
 func (s Status) updateAvailable() bool {
 	return s.Client.LatestVersion != "" &&
-		s.Client.Version != s.Client.LatestVersion &&
-		s.Client.Version != "unstable"
+		s.Client.Version != "unstable" &&
+		newerAvailable(s.Client.Version, s.Client.LatestVersion)
+}
+
+// newerAvailable reports whether latest is a strictly newer release than
+// current, compared semantically. The build stamps a "v"-prefixed version
+// (e.g. "v13.27.0") while the release feed reports it bare ("13.27.0"), so a
+// raw string compare treats identical releases as different; a semver compare
+// ignores the prefix. It also means a local build ahead of the latest published
+// release is not flagged as outdated. When either version can't be parsed as
+// semver (a rolling dev build, say) it falls back to an exact string compare,
+// preserving the previous behavior.
+func newerAvailable(current, latest string) bool {
+	diff, err := semver.Parser{}.Compare(current, latest)
+	if err != nil {
+		return current != latest
+	}
+	return diff < 0
 }
 
 func (s Status) outdatedCount() int {

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -427,6 +427,69 @@ func TestPadRight_CountsRunesNotBytes(t *testing.T) {
 	assert.Equal(t, "café  ", padRight("café", 6))
 }
 
+func TestNewerAvailable(t *testing.T) {
+	cases := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		// The build stamps a "v"-prefixed version while the release feed reports
+		// it without the prefix; these are the same release, not an update.
+		{"v13.27.0", "13.27.0", false},
+		{"13.27.0", "v13.27.0", false},
+		// A locally built binary ahead of the latest release is not outdated.
+		{"13.30.0", "13.25.0", false},
+		{"v13.30.0", "13.25.0", false},
+		// A genuinely newer release is an available update.
+		{"13.22.0", "13.25.0", true},
+		{"v13.22.0", "13.25.0", true},
+		// Equal versions never report an update.
+		{"13.25.0", "13.25.0", false},
+		// Unparseable versions fall back to an exact string comparison.
+		{"unstable", "13.25.0", true},
+		{"13.25.0", "13.25.0", false},
+	}
+
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, newerAvailable(tc.current, tc.latest),
+			"newerAvailable(%q, %q)", tc.current, tc.latest)
+	}
+}
+
+func TestUpdateAvailable_IgnoresVPrefix(t *testing.T) {
+	// v-prefixed running version vs. bare latest is the same release: no update.
+	s := healthyRegisteredStatus()
+	s.Client.Version = "v13.27.0"
+	s.Client.LatestVersion = "13.27.0"
+
+	assert.False(t, s.updateAvailable())
+
+	out := s.RenderCli(RenderOptions{Color: false})
+	assert.NotContains(t, out, "update recommended")
+}
+
+func TestUpdateAvailable_ClientAheadIsNotOutdated(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Version = "13.30.0"
+	s.Client.LatestVersion = "13.25.0"
+
+	assert.False(t, s.updateAvailable())
+
+	out := s.RenderCli(RenderOptions{Color: false})
+	assert.NotContains(t, out, "update recommended")
+}
+
+func TestUpdateAvailable_NewerReleaseIsFlagged(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Version = "v13.22.0"
+	s.Client.LatestVersion = "13.25.0"
+
+	assert.True(t, s.updateAvailable())
+
+	out := s.RenderCli(RenderOptions{Color: false})
+	assert.Contains(t, out, "update recommended")
+}
+
 func TestRenderCli_PlatformSection_WarningsAndFeatures(t *testing.T) {
 	s := healthyRegisteredStatus()
 	s.Upstream.Features = []string{"alpha", "beta"}


### PR DESCRIPTION
## Problem

`mql status` reported an available update even when the running version equaled the latest release:

```
● Updates    mql v13.27.0 → 13.27.0 · 12 providers outdated
│  Version    v13.27.0  →  13.27.0   ⚠ update recommended
```

The running version is stamped with a leading `v` via ldflags (`v13.27.0`), while the release feed (`latest.json`) reports it bare (`13.27.0`). Both the mql `updateAvailable()` check (`status_render.go`) and the provider outdated check (`status.go`) compared the two with a raw string `!=`, so the `v` prefix alone read as a difference and falsely triggered "⚠ update recommended".

## Fix

Both checks now route through a shared `newerAvailable(current, latest)` helper backed by the repo's existing semver comparator (`providers/core/resources/versions/semver`, the same one the real `providers update` logic uses). It:

- **Ignores the `v` prefix** — `NewVersion` normalizes it, so `v13.27.0` and `13.27.0` compare equal.
- **Only flags an update when the latest release is strictly newer** — a locally built binary ahead of the latest published release is no longer reported as outdated (mirrors the existing "client ahead is fine" API-version handling).
- **Falls back to an exact string compare** when a version can't be parsed as semver (e.g. a rolling dev build), preserving prior behavior.

## Tests

- `TestNewerAvailable` — table covering `v`-prefix parity, client-ahead, genuine update, equality, and the unparseable fallback.
- `TestUpdateAvailable_IgnoresVPrefix` — reproduces the exact reported scenario (`v13.27.0` vs `13.27.0`) and asserts no "update recommended".
- `TestUpdateAvailable_ClientAheadIsNotOutdated` / `TestUpdateAvailable_NewerReleaseIsFlagged`.

The existing golden-file tests are unchanged (rendering is untouched). `go test ./apps/mql/cmd/` passes; `go vet` clean.