### PR TITLE
🐛 status: don't nag source builds about updates; drop redundant provider hint

### DIFF
--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -278,11 +278,16 @@ func clientAPINewer(clientVersion, serverVersion string) bool {
 	return client > server
 }
 
-// updateAvailable reports whether a newer mql release exists. Development
-// builds ("unstable") never count as outdated.
+// updateAvailable reports whether a newer mql release exists. Builds made
+// locally from source stamp a "v"-prefixed git-describe version that surfaces
+// as an "unstable" API version; they update by rebuilding, so they never nag
+// about released versions. Official release binaries carry a bare semver and a
+// real API version, so they still get update checks.
 func (s Status) updateAvailable() bool {
+	if s.Client.APIVersion == "unstable" {
+		return false
+	}
 	return s.Client.LatestVersion != "" &&
-		s.Client.Version != "unstable" &&
 		newerAvailable(s.Client.Version, s.Client.LatestVersion)
 }
 
@@ -389,11 +394,6 @@ func (s Status) renderProviders(b *strings.Builder, st styler) {
 			line += st.dim(fmt.Sprintf(", +%d", extra))
 		}
 		st.rowRaw(b, line)
-	}
-
-	if outdated > 0 {
-		st.rowRaw(b, st.dim("providers refresh automatically on next run")+" "+st.dim("·")+" "+
-			st.cmd(st.binary+" providers install <name>")+st.dim(" to update one now"))
 	}
 }
 

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -479,6 +479,21 @@ func TestUpdateAvailable_ClientAheadIsNotOutdated(t *testing.T) {
 	assert.NotContains(t, out, "update recommended")
 }
 
+func TestUpdateAvailable_UnstableDevBuildDoesNotNag(t *testing.T) {
+	// A binary built locally from source stamps a "v"-prefixed git-describe
+	// version that surfaces as an "unstable" API version; it must not suggest an
+	// update even when a newer release exists.
+	s := healthyRegisteredStatus()
+	s.Client.APIVersion = "unstable"
+	s.Client.Version = "v13.27.0+1234"
+	s.Client.LatestVersion = "13.30.0"
+
+	assert.False(t, s.updateAvailable())
+
+	out := s.RenderCli(RenderOptions{Color: false})
+	assert.NotContains(t, out, "update recommended")
+}
+
 func TestUpdateAvailable_NewerReleaseIsFlagged(t *testing.T) {
 	s := healthyRegisteredStatus()
 	s.Client.Version = "v13.22.0"

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -30,7 +30,6 @@
   │  os                13.22.0  →  13.25.2
   │
   │  ✓ current  core
-  │  providers refresh automatically on next run · mql providers install <name> to update one now
 
   next steps:
     → mql providers update            update 2 outdated providers

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -29,7 +29,6 @@
   │  os                13.22.0  →  13.25.2
   │
   │  ✓ current  core
-  │  providers refresh automatically on next run · mql providers install <name> to update one now
 
   ✗ not registered · exit 1 · next steps:
     → mql login                       register this client with Mondoo Platform


### PR DESCRIPTION
Follow-up to #8878 (merged). Two refinements to `mql status` output. Both also flow to `cnspec`, which reuses these commands.

## 1. Don't suggest updates on locally-built (source) binaries
A `make`/source build stamps a `v`-prefixed `git describe` version (e.g. `v13.27.0+1234`), which surfaces as an `unstable` API version. Those update by rebuilding, so `updateAvailable()` now short-circuits when the API version is `unstable`. Official release binaries (bare semver, real API version) still get update checks.

```go
func (s Status) updateAvailable() bool {
    if s.Client.APIVersion == "unstable" {
        return false
    }
    return s.Client.LatestVersion != "" &&
        newerAvailable(s.Client.Version, s.Client.LatestVersion)
}
```

## 2. Drop the duplicate provider-update hint
Removed the `providers refresh automatically on next run · mql providers install <name> to update one now` line from the Providers section — the footer's **next steps** already recommends the update command. The Providers section now shows status only.

## Tests
- `TestUpdateAvailable_UnstableDevBuildDoesNotNag` — an `unstable` build with a newer release reports no update.
- Existing `updateAvailable` tests (v-prefix parity, client-ahead, newer-release) still pass.
- Golden files regenerated (only the removed line changes).

`go test ./apps/mql/cmd/` passes; `go vet` clean.

---
The config-log-noise cleanup (debug-level message) is split into #8880.