### PR TITLE
🧹 config: quiet the no-config-file message to debug

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -185,7 +185,10 @@ func DisplayUsedConfig() {
 	} else if Source == configSourceBase64 {
 		log.Info().Msg("loaded configuration from environment using source " + Source)
 	} else {
-		log.Info().Msg("no Mondoo configuration file provided, using defaults")
+		// Running without a config file is a normal, common case (e.g. `mql
+		// status` with no credentials), so this is debug-only noise rather than
+		// something worth printing on every run.
+		log.Debug().Msg("no Mondoo configuration file provided, using defaults")
 	}
 }
 

--- a/test/commands/testdata/mql_run_exit_1_on_failure.ct
+++ b/test/commands/testdata/mql_run_exit_1_on_failure.ct
@@ -1,11 +1,9 @@
 $ mql run local -c 1==2
-→ no Mondoo configuration file provided, using defaults
 [failed]  == 2
   expected: == 2
   actual:   1
 
 $ mql run local -c 1==2 --exit-1-on-failure --> FAIL
-→ no Mondoo configuration file provided, using defaults
 [failed]  == 2
   expected: == 2
   actual:   1


### PR DESCRIPTION
`config.DisplayUsedConfig()` logged `no Mondoo configuration file provided, using defaults` at **info** on every invocation with no config file. Running without a config file is the normal case (e.g. `mql status` / `cnspec` with no credentials), so this is now **debug**. The load-failure (`warn`) and loaded-config (`info`) branches are unchanged.

Also flows to `cnspec`, which reuses this config package.

`go build ./cli/config/` passes; `gofmt` clean.