### PR TITLE
🐛 status: don't warn about API version mismatch on local dev builds

### DIFF
--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -168,13 +168,18 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 	}
 	sync := st.ok("✓ in sync")
 	if s.Upstream.API.Version != s.Client.APIVersion {
-		// A client running a newer API version than the server is expected
-		// during a staged rollout (the CLI updates ahead of the platform) and
-		// is not a problem, so only flag a mismatch when the client trails the
-		// server (or the versions can't be compared numerically).
-		if clientAPINewer(s.Client.APIVersion, s.Upstream.API.Version) {
+		// A development build reports its API version as "unstable" and is
+		// expected to run against any released platform, so it never counts as
+		// a mismatch. A client running a newer API version than the server is
+		// likewise fine during a staged rollout (the CLI updates ahead of the
+		// platform), so only flag a mismatch when the client trails the server
+		// (or the versions can't be compared numerically).
+		switch {
+		case s.Client.APIVersion == "unstable":
+			sync = st.ok("✓ dev build")
+		case clientAPINewer(s.Client.APIVersion, s.Upstream.API.Version):
 			sync = st.ok("✓ client ahead")
-		} else {
+		default:
 			sync = st.warn("⚠ version mismatch")
 		}
 	}

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -241,14 +241,18 @@ func TestRenderCli_PlatformSection_ClientBehindWarns(t *testing.T) {
 	assert.Contains(t, out, "version mismatch")
 }
 
-func TestRenderCli_PlatformSection_UnstableClientWarns(t *testing.T) {
+func TestRenderCli_PlatformSection_UnstableClientIsNotAWarning(t *testing.T) {
 	s := healthyRegisteredStatus()
-	s.Client.APIVersion = "unstable" // dev build can't be compared numerically
+	s.Client.APIVersion = "unstable" // local dev build, no version stamped in
 	s.Upstream.API.Version = "13"
 
 	out := s.RenderCli(RenderOptions{Color: false})
 
-	assert.Contains(t, out, "version mismatch")
+	// A dev build is expected to run against any released platform, so it must
+	// not be flagged as a mismatch; it's surfaced as a healthy dev build with
+	// the same ✓ treatment as an in-sync production release.
+	assert.NotContains(t, out, "version mismatch")
+	assert.Contains(t, out, "✓ dev build")
 }
 
 func TestRenderCli_PlatformSection_NotRegisteredShowsLoginHint(t *testing.T) {


### PR DESCRIPTION
## Problem

Running `mql status` on a **locally built** binary always shows a spurious API version mismatch:

```
│  Status   SERVING   API v13 ⚠ version mismatch
```

A local build has no version stamped in via ldflags, so `mql.APIVersion()` returns the `"unstable"` sentinel. The platform section renderer then compared `"unstable"` against the platform's numeric API version (e.g. `"13"`):

- the plain string compare `"13" != "unstable"` is always true, so it enters the mismatch branch, and
- `clientAPINewer("unstable", "13")` can't `strconv.Atoi("unstable")`, so it returns `false` → the code falls through to `⚠ version mismatch`.

This isn't a real skew — it's just an unstamped dev binary, which is expected to run against any released platform.

## Fix

Treat an `"unstable"` client API version as an expected dev build and render it with the same `✓` OK styling an in-sync production release gets:

```
│  Status   SERVING   API v13 ✓ dev build
```

Behavior for released clients is unchanged: equal → `✓ in sync`, client numerically ahead → `✓ client ahead`, client behind (or otherwise incomparable) → `⚠ version mismatch`.

## Test

- Updated the test that encoded the old behavior (`…_UnstableClientWarns` → `…_UnstableClientIsNotAWarning`) to assert `✓ dev build` and no mismatch.
- Golden fixtures use matching `"13"`/`"13"` versions (the in-sync path), so they're unaffected.
- `go test ./apps/mql/cmd/ -run 'TestRenderCli_PlatformSection|TestRenderCli_Golden'` passes; `gofmt` clean.