### PR TITLE
🐛 status: drop redundant header line and stop provider list from wrapping

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/cli/components"
 	"go.mondoo.com/mql/v13/cli/config"
 	cli_errors "go.mondoo.com/mql/v13/cli/errors"
 	"go.mondoo.com/mql/v13/providers"
@@ -135,7 +136,8 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		case "json":
 			s.RenderJson()
 		default:
-			fmt.Fprint(os.Stdout, s.RenderCli(RenderOptions{Color: defaultRenderColor(), Binary: cmd.Root().Name()}))
+			width, _ := components.TerminalWidth(os.Stdout)
+			fmt.Fprint(os.Stdout, s.RenderCli(RenderOptions{Color: defaultRenderColor(), Binary: cmd.Root().Name(), Width: width}))
 		}
 
 		if !s.Client.Registered || s.Client.PingPongError != nil {

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -37,6 +37,7 @@ type styler struct {
 	profile termenv.Profile
 	palette colors.Theme
 	binary  string
+	width   int
 }
 
 // defaultRenderColor reports whether the status screen should be rendered with
@@ -46,7 +47,7 @@ func defaultRenderColor() bool {
 	return colors.Profile != termenv.Ascii
 }
 
-func newStyler(color bool, binary string) styler {
+func newStyler(color bool, binary string, width int) styler {
 	p := colors.Profile
 	if !color {
 		p = termenv.Ascii
@@ -54,7 +55,13 @@ func newStyler(color bool, binary string) styler {
 	if binary == "" {
 		binary = "mql"
 	}
-	return styler{on: color, profile: p, palette: theme.DefaultTheme.Colors, binary: binary}
+	// When the width is unknown (non-TTY output, tests) fall back to a standard
+	// 80-column budget so long lists still collapse rather than assuming an
+	// unbounded terminal.
+	if width <= 0 {
+		width = 80
+	}
+	return styler{on: color, profile: p, palette: theme.DefaultTheme.Colors, binary: binary, width: width}
 }
 
 func (st styler) fg(c termenv.Color, s string) string {
@@ -84,10 +91,9 @@ func (st styler) accent(s string) string { return st.fg(st.palette.Secondary, s)
 // I/O and reads no globals: everything it needs is on the Status value, which
 // makes it directly unit-testable.
 func (s Status) RenderCli(opts RenderOptions) string {
-	st := newStyler(opts.Color, opts.Binary)
+	st := newStyler(opts.Color, opts.Binary, opts.Width)
 	var b strings.Builder
 
-	s.renderHeader(&b, st)
 	s.renderHealth(&b, st)
 	s.renderSystem(&b, st)
 	s.renderMql(&b, st)
@@ -202,20 +208,6 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 	for _, w := range s.Upstream.Warnings {
 		st.rowRaw(b, st.warn("⚠ "+w))
 	}
-}
-
-func (s Status) renderHeader(b *strings.Builder, st styler) {
-	meta := fmt.Sprintf("%s · %s · %s", s.Client.Version, s.osArch(), s.Client.Timestamp)
-	fmt.Fprintf(b, "\n  %s    %s\n", st.bold(st.binary+" status"), st.dim(meta))
-}
-
-// osArch returns "<os>/<arch>" for the header, or "unknown" when platform info
-// could not be determined.
-func (s Status) osArch() string {
-	if s.Client.Platform == nil {
-		return "unknown"
-	}
-	return s.Client.Platform.Name + "/" + s.Client.Platform.Arch
 }
 
 // renderHealth renders the at-a-glance summary: one dot per dimension (Client,
@@ -388,18 +380,42 @@ func (s Status) renderProviders(b *strings.Builder, st styler) {
 	}
 	if len(currentNames) > 0 {
 		st.rowRaw(b, "")
-		extra := 0
-		const currentLimit = 12
-		if len(currentNames) > currentLimit {
-			extra = len(currentNames) - currentLimit
-			currentNames = currentNames[:currentLimit]
-		}
-		line := st.ok("✓ current") + "  " + st.dim(strings.Join(currentNames, ", "))
+		shown, extra := st.fitNames(currentNames)
+		line := st.ok("✓ current") + "  " + st.dim(strings.Join(shown, ", "))
 		if extra > 0 {
 			line += st.dim(fmt.Sprintf(", +%d", extra))
 		}
 		st.rowRaw(b, line)
 	}
+}
+
+// fitNames trims a comma-separated provider list to what fits on one terminal
+// line, returning the names to show and how many were dropped into the "+N"
+// marker. It measures visible width only (the styling escapes don't occupy
+// columns) and always keeps at least the first name so the row is never empty.
+func (st styler) fitNames(names []string) (shown []string, extra int) {
+	// Columns consumed before the first name: the row gutter ("  │  ") plus the
+	// "✓ current  " label.
+	const prefix = len("  │  ") + len("✓ current  ")
+	budget := st.width - prefix
+
+	used := 0
+	for i, name := range names {
+		add := len(name)
+		if i > 0 {
+			add += len(", ")
+		}
+		// Reserve room for a ", +N" marker when names would remain after this one.
+		marker := 0
+		if remaining := len(names) - i - 1; remaining > 0 {
+			marker = len(fmt.Sprintf(", +%d", remaining))
+		}
+		if i > 0 && used+add+marker > budget {
+			return names[:i], len(names) - i
+		}
+		used += add
+	}
+	return names, 0
 }
 
 func (s Status) renderFooter(b *strings.Builder, st styler) {

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -54,20 +54,6 @@ func healthyRegisteredStatus() Status {
 	return s
 }
 
-func TestRenderCli_Header(t *testing.T) {
-	s := healthyRegisteredStatus()
-
-	out := s.RenderCli(RenderOptions{Color: false})
-
-	// The header is the first line: the command name plus a metadata strip with
-	// the version, os/arch, and the timestamp.
-	firstLine := strings.SplitN(strings.TrimLeft(out, "\n"), "\n", 2)[0]
-	assert.Contains(t, firstLine, "mql status")
-	assert.Contains(t, firstLine, "13.25.0")
-	assert.Contains(t, firstLine, "macos/arm64")
-	assert.Contains(t, firstLine, "2026-06-29")
-}
-
 func TestRenderCli_NoColorHasNoEscapes(t *testing.T) {
 	s := healthyRegisteredStatus()
 
@@ -345,20 +331,71 @@ func TestRenderCli_Footer_SingleOutdatedKeepsInstallHint(t *testing.T) {
 	assert.NotContains(t, out, "mql providers update")
 }
 
+// manyCurrentProviders returns a registered status whose providers are all
+// current, with long names, so the "✓ current" list is long enough to exercise
+// the width budgeting.
+func manyCurrentProviders() Status {
+	s := healthyRegisteredStatus()
+	s.Client.Providers = nil
+	for _, name := range []string{
+		"ansible", "arista", "atlassian", "aws", "azure", "cloudflare",
+		"equinix", "gcp", "github", "gitlab", "google-workspace", "k8s",
+		"ms365", "network", "oci", "okta", "opcua", "os", "slack",
+		"terraform", "vcd", "vsphere",
+	} {
+		s.Client.Providers = append(s.Client.Providers,
+			ProviderStatus{Name: name, Installed: "13.25.0", Latest: "13.25.0", Outdated: false})
+	}
+	return s
+}
+
+// currentLine returns the "✓ current ..." row from a rendered status screen.
+func currentLine(out string) string {
+	for ln := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(ln, "✓ current") {
+			return ln
+		}
+	}
+	return ""
+}
+
+func TestRenderCli_CurrentProviders_NarrowWidthCollapses(t *testing.T) {
+	s := manyCurrentProviders()
+
+	out := s.RenderCli(RenderOptions{Color: false, Width: 60})
+
+	line := currentLine(out)
+	assert.NotEmpty(t, line)
+	// the list must be trimmed to fit and the remainder folded into a "+N" marker
+	assert.Contains(t, line, "+")
+	// the provider list must fit inside the terminal so it doesn't wrap
+	assert.LessOrEqual(t, len([]rune(line)), 60, "current-providers line exceeds width: %q", line)
+}
+
+func TestRenderCli_CurrentProviders_WideWidthShowsAll(t *testing.T) {
+	s := manyCurrentProviders()
+
+	out := s.RenderCli(RenderOptions{Color: false, Width: 500})
+
+	line := currentLine(out)
+	assert.NotEmpty(t, line)
+	// with room to spare, no provider is dropped
+	assert.NotContains(t, line, "+")
+	assert.Contains(t, line, "vsphere")
+}
+
 func TestRenderCli_BinaryNameDrivesCommandHints(t *testing.T) {
-	// stale + unregistered surfaces the header plus login/update hints, so a
-	// single render exercises several command strings at once.
+	// stale + unregistered surfaces the login/update hints, so a single render
+	// exercises several command strings at once.
 	s := staleNotRegisteredStatus()
 
 	out := s.RenderCli(RenderOptions{Color: false, Binary: "cnspec"})
 
-	assert.Contains(t, out, "cnspec status")
 	assert.Contains(t, out, "cnspec login")
 	assert.Contains(t, out, "cnspec providers update")
 	// no command hint should leak the other binary's name
 	assert.NotContains(t, out, "mql login")
 	assert.NotContains(t, out, "mql providers")
-	assert.NotContains(t, out, "mql status")
 }
 
 func TestRenderCli_BinaryNameDefaultsToMql(t *testing.T) {
@@ -367,7 +404,6 @@ func TestRenderCli_BinaryNameDefaultsToMql(t *testing.T) {
 	// empty Binary (as the existing tests and goldens use) falls back to "mql"
 	out := s.RenderCli(RenderOptions{Color: false})
 
-	assert.Contains(t, out, "mql status")
 	assert.Contains(t, out, "mql login")
 	assert.NotContains(t, out, "cnspec")
 }

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -1,6 +1,4 @@
 
-  mql status    13.25.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
-
   ● Client     registered   ✓ authenticated
   ● Platform   reachable · SERVING   ✓ healthy
   ● Updates    2 providers outdated

--- a/apps/mql/cmd/testdata/status_registered_auth_failed.golden
+++ b/apps/mql/cmd/testdata/status_registered_auth_failed.golden
@@ -1,6 +1,4 @@
 
-  mql status    13.25.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
-
   ● Client     registered   ✗ authentication failed
   ● Platform   reachable · SERVING   ✓ healthy
   ● Updates    up to date

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -1,6 +1,4 @@
 
-  mql status    13.22.0 · macos/arm64 · 2026-06-29T14:37:00-07:00
-
   ● Client     not registered   ✗ action needed
   ● Platform   reachable · SERVING   ✓ healthy
   ● Updates    mql 13.22.0 → 13.25.0 · 2 providers outdated


### PR DESCRIPTION
## What

Two small `mql status` display fixes.

### 1. Drop the redundant header line

The status screen opened with a header that duplicated information already shown below:

```
  mql status    v13.27.0 · macos/arm64 · 2026-07-01T13:03:34-07:00
```

The version already appears in the `mql` section and the os/arch under `System → Platform`, so the header carried nothing new. Removed it, along with the now-dead `osArch` helper. The client timestamp is still emitted in `--output json`, so no data is lost for machine consumers.

### 2. Stop the `✓ current` provider list from wrapping

The current-providers list capped by a fixed name count (12) rather than by visible width, so on narrower terminals — or with longer provider names — it wrapped past the console edge.

It now budgets the list to the actual terminal width and folds the overflow into a `+N` marker. Width is plumbed through the existing (previously unwired) `RenderOptions.Width` field, populated at the CLI edge via `components.TerminalWidth`; `RenderCli` itself stays pure. Non-TTY / piped output falls back to an 80-column budget.

## Tests

- Regenerated the status golden files (the only change is the removed header line).
- Added `TestRenderCli_CurrentProviders_NarrowWidthCollapses` (narrow width → `+N`, line fits) and `TestRenderCli_CurrentProviders_WideWidthShowsAll` (wide width → nothing dropped).
- Updated the header/binary-name tests that asserted on the removed `"<binary> status"` string.

`go vet` and `go test ./apps/mql/cmd/` pass.

## Note

The fixed-width section rules (`── Providers ─────`) and full-length MRNs/endpoints can still exceed a very narrow terminal, but that's pre-existing and out of scope for this change.