### PR TITLE
⭐ cloudformation: add file context to template resources

### DIFF
--- a/providers/cloudformation/connection/connection.go
+++ b/providers/cloudformation/connection/connection.go
@@ -22,7 +22,7 @@ type CloudformationConnection struct {
 	asset *inventory.Asset
 	// Add custom connection fields here
 	path        string
-	content     []byte
+	content     string
 	cftTemplate cft.Template
 }
 
@@ -46,7 +46,10 @@ func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *invent
 	if err != nil {
 		return nil, err
 	}
-	conn.content = data
+	// Convert to a string once here; nodeContext extracts source ranges from it
+	// for every resource/output/parameter, and a per-call []byte->string copy of
+	// a large template would be wasteful.
+	conn.content = string(data)
 
 	cftTemplate, err := parse.Reader(bytes.NewReader(data))
 	if err != nil {
@@ -77,8 +80,10 @@ func (c *CloudformationConnection) Path() string {
 	return c.path
 }
 
-// Content returns the raw bytes of the template file, used to extract the
-// source text a resource/output/parameter spans for file-context.
-func (c *CloudformationConnection) Content() []byte {
+// Content returns the raw text of the template file, used to extract the
+// source text a resource/output/parameter spans for file-context. The string
+// is converted once at connection time so repeated range extractions don't
+// each re-copy the whole template.
+func (c *CloudformationConnection) Content() string {
 	return c.content
 }

--- a/providers/cloudformation/connection/connection.go
+++ b/providers/cloudformation/connection/connection.go
@@ -4,6 +4,7 @@
 package connection
 
 import (
+	"bytes"
 	"errors"
 	"os"
 
@@ -21,6 +22,7 @@ type CloudformationConnection struct {
 	asset *inventory.Asset
 	// Add custom connection fields here
 	path        string
+	content     []byte
 	cftTemplate cft.Template
 }
 
@@ -38,13 +40,15 @@ func NewCloudformationConnection(id uint32, asset *inventory.Asset, conf *invent
 	path := cc.Options["path"]
 	conn.path = path
 
-	f, err := os.Open(path)
+	// Read the raw bytes up front and parse from them, so we can later extract
+	// the source text a resource/output/parameter spans for file-context.
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	conn.content = data
 
-	cftTemplate, err := parse.Reader(f)
+	cftTemplate, err := parse.Reader(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
@@ -66,4 +70,15 @@ func (c *CloudformationConnection) Asset() *inventory.Asset {
 
 func (c *CloudformationConnection) CftTemplate() cft.Template {
 	return c.cftTemplate
+}
+
+// Path returns the template file path this connection was opened with.
+func (c *CloudformationConnection) Path() string {
+	return c.path
+}
+
+// Content returns the raw bytes of the template file, used to extract the
+// source text a resource/output/parameter spans for file-context.
+func (c *CloudformationConnection) Content() []byte {
+	return c.content
 }

--- a/providers/cloudformation/resources/cloudformation.lr
+++ b/providers/cloudformation/resources/cloudformation.lr
@@ -53,7 +53,7 @@ cloudformation.template @defaults("description") {
 // condition, full properties body, attributes, dependsOn list, and the
 // documentation URL — the unit IaC policies match against to enforce
 // resource-shape rules (encryption, public access, tags, etc.).
-cloudformation.resource @defaults("name") {
+cloudformation.resource @defaults("name") @context("cloudformation.context") {
   // Resource name
   name string
   // Resource type
@@ -106,7 +106,7 @@ cloudformation.resource @defaults("name") {
 // Examine a single Outputs section entry: name and the properties body
 // (Value, Description, Export, Condition) — useful for spotting outputs
 // that leak resource ARNs, secrets, or sensitive state across stacks.
-cloudformation.output @defaults("name") {
+cloudformation.output @defaults("name") @context("cloudformation.context") {
   // Output name
   name string
   // Output properties
@@ -138,7 +138,7 @@ cloudformation.output @defaults("name") {
 // primary surface for policies that enforce strong input typing, secret
 // masking (`NoEcho: true` for credential-shaped parameters), and bounded
 // inputs.
-cloudformation.parameter @defaults("name type") {
+cloudformation.parameter @defaults("name type") @context("cloudformation.context") {
   // Parameter name
   name string
   // Parameter type
@@ -177,4 +177,18 @@ cloudformation.parameter @defaults("name type") {
   maxValue int
   // `ConstraintDescription` shown when validation fails
   constraintDescription string
+}
+
+// CloudFormation template source context
+//
+// Source location and raw text of a template element: the file path, the
+// line range it spans, and the template text within that range. Points a
+// reviewer at the exact source of a flagged resource, output, or parameter.
+private cloudformation.context @defaults("path range content") {
+  // Path of the template file this element is declared in
+  path string
+  // Line range the element spans in the template
+  range range
+  // Template text within the range, shown as an excerpt
+  content(path, range) string
 }

--- a/providers/cloudformation/resources/cloudformation.lr.go
+++ b/providers/cloudformation/resources/cloudformation.lr.go
@@ -19,6 +19,7 @@ const (
 	ResourceCloudformationResource  string = "cloudformation.resource"
 	ResourceCloudformationOutput    string = "cloudformation.output"
 	ResourceCloudformationParameter string = "cloudformation.parameter"
+	ResourceCloudformationContext   string = "cloudformation.context"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -40,6 +41,10 @@ func init() {
 		"cloudformation.parameter": {
 			// to override args, implement: initCloudformationParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCloudformationParameter,
+		},
+		"cloudformation.context": {
+			// to override args, implement: initCloudformationContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createCloudformationContext,
 		},
 	}
 }
@@ -187,6 +192,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudformation.resource.resourceMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationResource).GetResourceMetadata()).ToDataRes(types.Dict)
 	},
+	"cloudformation.resource.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetContext()).ToDataRes(types.Resource("cloudformation.context"))
+	},
 	"cloudformation.output.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationOutput).GetName()).ToDataRes(types.String)
 	},
@@ -204,6 +212,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cloudformation.output.condition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationOutput).GetCondition()).ToDataRes(types.String)
+	},
+	"cloudformation.output.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationOutput).GetContext()).ToDataRes(types.Resource("cloudformation.context"))
 	},
 	"cloudformation.parameter.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationParameter).GetName()).ToDataRes(types.String)
@@ -240,6 +251,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cloudformation.parameter.constraintDescription": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationParameter).GetConstraintDescription()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetContext()).ToDataRes(types.Resource("cloudformation.context"))
+	},
+	"cloudformation.context.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationContext).GetPath()).ToDataRes(types.String)
+	},
+	"cloudformation.context.range": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationContext).GetRange()).ToDataRes(types.Range)
+	},
+	"cloudformation.context.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationContext).GetContent()).ToDataRes(types.String)
 	},
 }
 
@@ -361,6 +384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudformationResource).ResourceMetadata, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"cloudformation.resource.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).Context, ok = plugin.RawToTValue[*mqlCloudformationContext](v.Value, v.Error)
+		return
+	},
 	"cloudformation.output.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationOutput).__id, ok = v.Value.(string)
 		return
@@ -387,6 +414,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudformation.output.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationOutput).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.output.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationOutput).Context, ok = plugin.RawToTValue[*mqlCloudformationContext](v.Value, v.Error)
 		return
 	},
 	"cloudformation.parameter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -439,6 +470,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudformation.parameter.constraintDescription": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationParameter).ConstraintDescription, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).Context, ok = plugin.RawToTValue[*mqlCloudformationContext](v.Value, v.Error)
+		return
+	},
+	"cloudformation.context.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationContext).__id, ok = v.Value.(string)
+		return
+	},
+	"cloudformation.context.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationContext).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.context.range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationContext).Range, ok = plugin.RawToTValue[llx.Range](v.Value, v.Error)
+		return
+	},
+	"cloudformation.context.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationContext).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -641,6 +692,7 @@ type mqlCloudformationResource struct {
 	CreationPolicy      plugin.TValue[any]
 	UpdatePolicy        plugin.TValue[any]
 	ResourceMetadata    plugin.TValue[any]
+	Context             plugin.TValue[*mqlCloudformationContext]
 }
 
 // createCloudformationResource creates a new instance of this resource
@@ -728,6 +780,22 @@ func (c *mqlCloudformationResource) GetResourceMetadata() *plugin.TValue[any] {
 	return &c.ResourceMetadata
 }
 
+func (c *mqlCloudformationResource) GetContext() *plugin.TValue[*mqlCloudformationContext] {
+	return plugin.GetOrCompute[*mqlCloudformationContext](&c.Context, func() (*mqlCloudformationContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudformation.resource", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudformationContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlCloudformationOutput for the cloudformation.output resource
 type mqlCloudformationOutput struct {
 	MqlRuntime *plugin.Runtime
@@ -739,6 +807,7 @@ type mqlCloudformationOutput struct {
 	Description plugin.TValue[string]
 	ExportName  plugin.TValue[string]
 	Condition   plugin.TValue[string]
+	Context     plugin.TValue[*mqlCloudformationContext]
 }
 
 // createCloudformationOutput creates a new instance of this resource
@@ -802,6 +871,22 @@ func (c *mqlCloudformationOutput) GetCondition() *plugin.TValue[string] {
 	return &c.Condition
 }
 
+func (c *mqlCloudformationOutput) GetContext() *plugin.TValue[*mqlCloudformationContext] {
+	return plugin.GetOrCompute[*mqlCloudformationContext](&c.Context, func() (*mqlCloudformationContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudformation.output", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudformationContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlCloudformationParameter for the cloudformation.parameter resource
 type mqlCloudformationParameter struct {
 	MqlRuntime *plugin.Runtime
@@ -819,6 +904,7 @@ type mqlCloudformationParameter struct {
 	MinValue              plugin.TValue[int64]
 	MaxValue              plugin.TValue[int64]
 	ConstraintDescription plugin.TValue[string]
+	Context               plugin.TValue[*mqlCloudformationContext]
 }
 
 // createCloudformationParameter creates a new instance of this resource
@@ -904,4 +990,91 @@ func (c *mqlCloudformationParameter) GetMaxValue() *plugin.TValue[int64] {
 
 func (c *mqlCloudformationParameter) GetConstraintDescription() *plugin.TValue[string] {
 	return &c.ConstraintDescription
+}
+
+func (c *mqlCloudformationParameter) GetContext() *plugin.TValue[*mqlCloudformationContext] {
+	return plugin.GetOrCompute[*mqlCloudformationContext](&c.Context, func() (*mqlCloudformationContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudformation.parameter", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudformationContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
+// mqlCloudformationContext for the cloudformation.context resource
+type mqlCloudformationContext struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlCloudformationContextInternal it will be used here
+	Path    plugin.TValue[string]
+	Range   plugin.TValue[llx.Range]
+	Content plugin.TValue[string]
+}
+
+// createCloudformationContext creates a new instance of this resource
+func createCloudformationContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlCloudformationContext{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("cloudformation.context", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlCloudformationContext) MqlName() string {
+	return "cloudformation.context"
+}
+
+func (c *mqlCloudformationContext) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlCloudformationContext) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlCloudformationContext) GetRange() *plugin.TValue[llx.Range] {
+	return &c.Range
+}
+
+func (c *mqlCloudformationContext) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		vargPath := c.GetPath()
+		if vargPath.Error != nil {
+			return "", vargPath.Error
+		}
+
+		vargRange := c.GetRange()
+		if vargRange.Error != nil {
+			return "", vargRange.Error
+		}
+
+		return c.content(vargPath.Data, vargRange.Data)
+	})
 }

--- a/providers/cloudformation/resources/cloudformation.lr.versions
+++ b/providers/cloudformation/resources/cloudformation.lr.versions
@@ -1,8 +1,13 @@
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
+cloudformation.context 13.1.8
+cloudformation.context.content 13.1.8
+cloudformation.context.path 13.1.8
+cloudformation.context.range 13.1.8
 cloudformation.output 11.0.0
 cloudformation.output.condition 13.0.13
+cloudformation.output.context 13.1.8
 cloudformation.output.description 13.0.13
 cloudformation.output.exportName 13.0.13
 cloudformation.output.name 11.0.0
@@ -12,6 +17,7 @@ cloudformation.parameter 13.0.13
 cloudformation.parameter.allowedPattern 13.0.13
 cloudformation.parameter.allowedValues 13.0.13
 cloudformation.parameter.constraintDescription 13.0.13
+cloudformation.parameter.context 13.1.8
 cloudformation.parameter.default 13.0.13
 cloudformation.parameter.description 13.0.13
 cloudformation.parameter.maxLength 13.0.13
@@ -24,6 +30,7 @@ cloudformation.parameter.type 13.0.13
 cloudformation.resource 11.0.0
 cloudformation.resource.attributes 11.0.0
 cloudformation.resource.condition 11.0.0
+cloudformation.resource.context 13.1.8
 cloudformation.resource.creationPolicy 13.0.13
 cloudformation.resource.deletionPolicy 13.0.13
 cloudformation.resource.dependsOn 13.0.1

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"errors"
+
 	"github.com/aws-cloudformation/rain/cft"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -239,6 +241,11 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 			return nil, err
 		}
 
+		ctx, err := r.nodeContext(keyNode, valueNode)
+		if err != nil {
+			return nil, err
+		}
+
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.resource", map[string]*llx.RawData{
 			"name":                llx.StringData(keyNode.Value),
 			"type":                llx.StringData(resourceType),
@@ -252,6 +259,7 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 			"creationPolicy":      llx.DictData(creationPolicy),
 			"updatePolicy":        llx.DictData(updatePolicy),
 			"resourceMetadata":    llx.DictData(resourceMetadata),
+			"context":             llx.ResourceData(ctx, "cloudformation.context"),
 		})
 		if err != nil {
 			return nil, err
@@ -270,6 +278,81 @@ func (x *mqlCloudformationOutput) id() (string, error) {
 
 func (x *mqlCloudformationParameter) id() (string, error) {
 	return x.Name.Data, nil
+}
+
+// nodeEndLine returns the last source line spanned by a YAML node, computed as
+// the maximum start line over the node and all of its descendants. yaml.v3
+// records only the start position of each node, so this approximates the end
+// of a multi-line block from its deepest child.
+func nodeEndLine(n *yaml.Node) int {
+	if n == nil {
+		return 0
+	}
+	end := n.Line
+	for _, c := range n.Content {
+		if e := nodeEndLine(c); e > end {
+			end = e
+		}
+	}
+	return end
+}
+
+// nodeContext builds a cloudformation.context spanning the source lines a
+// template block occupies. keyNode is the block's logical-name key (its start
+// line); valueNode is the block body (its end line is the deepest child).
+func (r *mqlCloudformationTemplate) nodeContext(keyNode, valueNode *yaml.Node) (*mqlCloudformationContext, error) {
+	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
+
+	start := uint32(keyNode.Line)
+	end := uint32(nodeEndLine(valueNode))
+	if end < start {
+		end = start
+	}
+	rnge := llx.NewRange().AddLineRange(start, end)
+	content := rnge.ExtractString(string(conn.Content()), llx.DefaultExtractConfig)
+
+	cobj, err := CreateResource(r.MqlRuntime, "cloudformation.context", map[string]*llx.RawData{
+		"path":    llx.StringData(conn.Path()),
+		"range":   llx.RangeData(rnge),
+		"content": llx.StringData(content),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cobj.(*mqlCloudformationContext), nil
+}
+
+func (r *mqlCloudformationContext) id() (string, error) {
+	if r.Path.Data == "" {
+		return "", errors.New("need path to exist for cloudformation.context ID")
+	}
+	return r.Path.Data + ":" + r.Range.Data.String(), nil
+}
+
+func (r *mqlCloudformationContext) content(path string, rnge llx.Range) (string, error) {
+	if path == "" {
+		return "", errors.New("no path information for cloudformation.context")
+	}
+	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
+	src := conn.Content()
+	if src == nil {
+		return "", errors.New("missing cloudformation template source in cache")
+	}
+	return rnge.ExtractString(string(src), llx.DefaultExtractConfig), nil
+}
+
+// context is populated at creation for each block, so these fallback resolvers
+// only run if a resource was built without one.
+func (x *mqlCloudformationResource) context() (*mqlCloudformationContext, error) {
+	return nil, errors.New("context was not provided for cloudformation.resource")
+}
+
+func (x *mqlCloudformationOutput) context() (*mqlCloudformationContext, error) {
+	return nil, errors.New("context was not provided for cloudformation.output")
+}
+
+func (x *mqlCloudformationParameter) context() (*mqlCloudformationContext, error) {
+	return nil, errors.New("context was not provided for cloudformation.parameter")
 }
 
 func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
@@ -321,6 +404,11 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 			}
 		}
 
+		ctx, err := r.nodeContext(keyNode, valueNode)
+		if err != nil {
+			return nil, err
+		}
+
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.output", map[string]*llx.RawData{
 			"name":        llx.StringData(keyNode.Value),
 			"properties":  llx.DictData(dict),
@@ -328,6 +416,7 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 			"description": llx.StringData(description),
 			"exportName":  llx.StringData(exportName),
 			"condition":   llx.StringData(condition),
+			"context":     llx.ResourceData(ctx, "cloudformation.context"),
 		})
 		if err != nil {
 			return nil, err
@@ -414,6 +503,11 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 			return nil, err
 		}
 
+		ctx, err := r.nodeContext(keyNode, valueNode)
+		if err != nil {
+			return nil, err
+		}
+
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.parameter", map[string]*llx.RawData{
 			"__id":                  llx.StringData(keyNode.Value),
 			"name":                  llx.StringData(keyNode.Value),
@@ -428,6 +522,7 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 			"minValue":              llx.IntData(minValue),
 			"maxValue":              llx.IntData(maxValue),
 			"constraintDescription": llx.StringData(constraintDescription),
+			"context":               llx.ResourceData(ctx, "cloudformation.context"),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -309,7 +309,7 @@ func (r *mqlCloudformationTemplate) nodeContext(keyNode, valueNode *yaml.Node) (
 		end = start
 	}
 	rnge := llx.NewRange().AddLineRange(start, end)
-	content := rnge.ExtractString(string(conn.Content()), llx.DefaultExtractConfig)
+	content := rnge.ExtractString(conn.Content(), llx.DefaultExtractConfig)
 
 	cobj, err := CreateResource(r.MqlRuntime, "cloudformation.context", map[string]*llx.RawData{
 		"path":    llx.StringData(conn.Path()),
@@ -334,11 +334,7 @@ func (r *mqlCloudformationContext) content(path string, rnge llx.Range) (string,
 		return "", errors.New("no path information for cloudformation.context")
 	}
 	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
-	src := conn.Content()
-	if src == nil {
-		return "", errors.New("missing cloudformation template source in cache")
-	}
-	return rnge.ExtractString(string(src), llx.DefaultExtractConfig), nil
+	return rnge.ExtractString(conn.Content(), llx.DefaultExtractConfig), nil
 }
 
 // context is populated at creation for each block, so these fallback resolvers


### PR DESCRIPTION
Exposes a `context` accessor on `cloudformation.resource`, `cloudformation.output`, and `cloudformation.parameter`, mirroring the `terraform.block` file context from #8703 and the Dockerfile instructions from #8884. Each surfaces the template path, the line range it spans, and the raw source text within that range, so a reviewer (and SARIF output) can be pointed at the exact lines a policy flagged.

## Example

```
mql run cloudformation template.yaml -c 'cloudformation.template.resources { name context.range context.content }'
```

```
resources: [
  0: {
    name: "MyBucket"
    context.range:   7-11
    context.content: " 7:    MyBucket:
 8:      Type: AWS::S3::Bucket
 9:      Properties:
10:        BucketName: my-insecure-bucket
11:        AccessControl: PublicRead
"
  }
]
```

## What changed

- New `private cloudformation.context` resource (`path` / `range` / `content`), with `@context("cloudformation.context")` on `cloudformation.resource`, `cloudformation.output`, and `cloudformation.parameter`.
- The connection now retains the raw template bytes it already reads (previously discarded), so `content` can extract the source range.
- Line ranges are built at the 3 CreateResource sites from the rain/`yaml.v3` node positions: the logical-name key's start line through the deepest descendant line of the block body. JSON and YAML templates share the same parse path, so both work.

## Why a provider-specific context resource (not the generic `file.context`)

The generic `file.context` requires a resource backed by an os `file` (how the Dockerfile change works, since `docker.file` embeds `file`). The cloudformation provider is standalone with no `file` backing, so it follows terraform's model: a small provider-owned context resource that reads bytes from the connection cache.

## Notes / limitations

- `yaml.v3` records only node start positions, so the end line is derived from the deepest child. Ranges are line-only (no columns), which SARIF handles.
- Minified single-line JSON collapses every node to line 1; ranges are only meaningful for multi-line templates. This is inherent to any line-based approach.

## Testing

- `go test ./...` passes for the provider.
- Verified interactively that resources, outputs, and parameters report accurate line ranges and source snippets for both a YAML and a JSON template.