### PR TITLE
⭐ k8s: add file context to manifest resources

### DIFF
--- a/providers/k8s/connection/manifest/connection.go
+++ b/providers/k8s/connection/manifest/connection.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -57,6 +58,13 @@ type Connection struct {
 	manifestFile    string
 	manifestContent []byte
 	closer          func()
+
+	// Raw manifest bytes retained for source context. Kept separate from
+	// manifestContent, which drives the stdin-vs-file platform-id hashing.
+	sourceRaw  []byte
+	posOnce    sync.Once
+	contentStr string
+	positions  map[string]shared.SourcePosition
 }
 
 func NewGitConnection(id uint32, asset *inventory.Asset, opts ...Option) (shared.Connection, error) {
@@ -115,12 +123,28 @@ func NewConnection(id uint32, asset *inventory.Asset, opts ...Option) (shared.Co
 		}
 		asset.Labels[plugin.GitUrlOptionKey] = trimGitPath(gitPath)
 	}
+	// Retain the raw manifest so we can extract the source text a resource
+	// spans for file-context. In the file case the bytes were only local.
+	c.sourceRaw = manifest
+
 	c.ManifestParser, err = shared.NewManifestParser(manifest, c.namespace, "")
 	if err != nil {
 		return nil, err
 	}
 
 	return c, nil
+}
+
+// ManifestSource returns the manifest text, the file path it was read from, and
+// a per-resource source-position index keyed by object id (kind:namespace:name).
+// The index is built lazily on first use. Resources not present in the manifest
+// (e.g. synthesized CRDs) simply have no entry.
+func (c *Connection) ManifestSource() (string, string, map[string]shared.SourcePosition) {
+	c.posOnce.Do(func() {
+		c.contentStr = string(c.sourceRaw)
+		c.positions = shared.BuildManifestPositionIndex(c.sourceRaw, c.manifestFile)
+	})
+	return c.contentStr, c.manifestFile, c.positions
 }
 
 func trimGitPath(gitPath string) string {

--- a/providers/k8s/connection/shared/source_position.go
+++ b/providers/k8s/connection/shared/source_position.go
@@ -114,6 +114,11 @@ func mappingScalar(node *yaml.Node, key string) string {
 // maximum start line over the node and all of its descendants. yaml.v3 records
 // only the start position of each node, so this approximates the block end from
 // its deepest child.
+//
+// Limitation: when the last descendant is a multi-line block scalar (a folded
+// `>` or literal `|` value), the reported end is that scalar's start line, so
+// the excerpt can stop a few lines short. Acceptable for a line-range v1;
+// revisit if end positions become available upstream.
 func nodeEndLine(n *yaml.Node) int {
 	if n == nil {
 		return 0

--- a/providers/k8s/connection/shared/source_position.go
+++ b/providers/k8s/connection/shared/source_position.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shared
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SourcePosition is the location of a single resource within a manifest file.
+type SourcePosition struct {
+	Path      string
+	StartLine int
+	EndLine   int
+}
+
+// ObjectID builds the identity key used to correlate a manifest document with
+// the modeled resource. It mirrors objIdFromFields in the resources package so
+// a lookup by a resource's id succeeds.
+func ObjectID(kind, namespace, name string) string {
+	kind = strings.ToLower(kind)
+	if namespace == "" {
+		return kind + ":" + name
+	}
+	return kind + ":" + namespace + ":" + name
+}
+
+// BuildManifestPositionIndex parses a (possibly multi-document) manifest and
+// returns a map from object identity to its source position. `kind: *List`
+// wrapper documents are expanded to their items, each of which carries its own
+// kind/metadata. Documents without an identifiable kind and name are skipped.
+func BuildManifestPositionIndex(content []byte, path string) map[string]SourcePosition {
+	index := map[string]SourcePosition{}
+	if len(content) == 0 {
+		return index
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(content))
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			// EOF or a malformed document: stop and keep what we have. A parse
+			// failure here only means no source context, not a scan failure.
+			break
+		}
+		root := &doc
+		if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+			root = doc.Content[0]
+		}
+		addNodePositions(root, path, index)
+	}
+	return index
+}
+
+// addNodePositions records the position of a single resource mapping, or
+// recurses into the items of a List wrapper.
+func addNodePositions(root *yaml.Node, path string, index map[string]SourcePosition) {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return
+	}
+
+	kind := mappingScalar(root, "kind")
+	if strings.HasSuffix(kind, "List") {
+		if items := mappingValueNode(root, "items"); items != nil && items.Kind == yaml.SequenceNode {
+			for _, item := range items.Content {
+				addNodePositions(item, path, index)
+			}
+			return
+		}
+	}
+	if kind == "" {
+		return
+	}
+
+	meta := mappingValueNode(root, "metadata")
+	name := mappingScalar(meta, "name")
+	if name == "" {
+		return
+	}
+	namespace := mappingScalar(meta, "namespace")
+
+	index[ObjectID(kind, namespace, name)] = SourcePosition{
+		Path:      path,
+		StartLine: root.Line,
+		EndLine:   nodeEndLine(root),
+	}
+}
+
+// mappingValueNode returns the value node for a key in a mapping node, or nil.
+func mappingValueNode(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mappingScalar returns the scalar value for a key in a mapping node.
+func mappingScalar(node *yaml.Node, key string) string {
+	if v := mappingValueNode(node, key); v != nil && v.Kind == yaml.ScalarNode {
+		return v.Value
+	}
+	return ""
+}
+
+// nodeEndLine returns the last source line spanned by a node, computed as the
+// maximum start line over the node and all of its descendants. yaml.v3 records
+// only the start position of each node, so this approximates the block end from
+// its deepest child.
+func nodeEndLine(n *yaml.Node) int {
+	if n == nil {
+		return 0
+	}
+	end := n.Line
+	for _, c := range n.Content {
+		if e := nodeEndLine(c); e > end {
+			end = e
+		}
+	}
+	return end
+}

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/smithy-go v1.27.3
 	github.com/distribution/reference v0.6.0
 	golang.org/x/oauth2 v0.36.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/kube-aggregator v0.36.2
 	sigs.k8s.io/gateway-api v1.6.0
 	sigs.k8s.io/yaml v1.6.0
@@ -259,7 +260,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.1 // indirect
 	k8s.io/component-base v0.36.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260624041617-8f3fa4921821 // indirect

--- a/providers/k8s/resources/common.go
+++ b/providers/k8s/resources/common.go
@@ -72,6 +72,12 @@ func k8sResourceToMql(r *plugin.Runtime, kind string, fn resourceConvertFn) ([]a
 			return nil, err
 		}
 
+		// Attach the manifest source location (no-op for non-manifest scans and
+		// for resources the manifest doesn't contain).
+		if err := setK8sSourceContext(r, kt, obj, objT, mqlK8sResource); err != nil {
+			return nil, err
+		}
+
 		resp = append(resp, mqlK8sResource)
 	}
 

--- a/providers/k8s/resources/context.go
+++ b/providers/k8s/resources/context.go
@@ -83,171 +83,212 @@ func setK8sSourceContext(runtime *plugin.Runtime, kt shared.Connection, obj meta
 	return nil
 }
 
-// errK8sContextNotProvided is returned by the fallback context() resolvers.
-// context is populated at resource creation for manifest scans, so these only
-// run when a resource was built without one (live cluster, admission review).
-var errK8sContextNotProvided = errors.New("context is only available for manifest-file scans")
+// The fallback context() resolvers below mark the field null rather than
+// erroring. context is populated at creation for manifest-file scans; for
+// live-cluster and admission connections it is legitimately absent, so a query
+// touching .context there returns null instead of failing.
 
 func (x *mqlK8sAdmissionMutatingwebhookconfiguration) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sAdmissionValidatingadmissionpolicy) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sAdmissionValidatingadmissionpolicybinding) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sAdmissionValidatingwebhookconfiguration) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sApiservice) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sCertificatesigningrequest) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sConfigmap) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sCronjob) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sCustomresource) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sDaemonset) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sDeployment) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sEndpointslice) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sGateway) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sGatewayclass) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sGrpcroute) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sHorizontalpodautoscaler) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sHttproute) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sIngress) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sIngressclass) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sJob) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sLease) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sLimitrange) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sNetworkpolicy) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sNode) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sPersistentvolume) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sPersistentvolumeclaim) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sPod) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sPoddisruptionbudget) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sPriorityclass) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sRbacClusterrole) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sRbacClusterrolebinding) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sRbacRole) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sRbacRolebinding) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sReferencegrant) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sReplicaset) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sResourcequota) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sSecret) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sService) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sServiceaccount) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sStatefulset) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlK8sStorageclass) context() (*mqlK8sContext, error) {
-	return nil, errK8sContextNotProvided
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }

--- a/providers/k8s/resources/context.go
+++ b/providers/k8s/resources/context.go
@@ -1,0 +1,253 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"reflect"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/shared"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// manifestSourceProvider is implemented by the manifest connection. Live-cluster
+// and admission connections do not implement it, so resources scanned that way
+// carry no source context.
+type manifestSourceProvider interface {
+	ManifestSource() (content string, path string, positions map[string]shared.SourcePosition)
+}
+
+func (r *mqlK8sContext) id() (string, error) {
+	if r.Path.Data == "" {
+		return "", errors.New("need path to exist for k8s.context ID")
+	}
+	return r.Path.Data + ":" + r.Range.Data.String(), nil
+}
+
+func (r *mqlK8sContext) content(path string, rnge llx.Range) (string, error) {
+	if path == "" {
+		return "", errors.New("no path information for k8s.context")
+	}
+	ms, ok := r.MqlRuntime.Connection.(manifestSourceProvider)
+	if !ok {
+		return "", errors.New("k8s.context content is not available for this connection")
+	}
+	content, _, _ := ms.ManifestSource()
+	return rnge.ExtractString(content, llx.DefaultExtractConfig), nil
+}
+
+// setK8sSourceContext populates a resource's `context` field with the manifest
+// location it was declared at. It is a no-op for connections without a source
+// manifest, and for resources not found in the manifest (e.g. synthesized
+// CRDs). The field is set directly via reflection because the ~40 annotated
+// resource types share no common concrete type; every @context-annotated
+// resource has an exported `Context` field of the same type.
+func setK8sSourceContext(runtime *plugin.Runtime, kt shared.Connection, obj metav1.Object, objT metav1.Type, res any) error {
+	ms, ok := kt.(manifestSourceProvider)
+	if !ok {
+		return nil
+	}
+	content, path, positions := ms.ManifestSource()
+	if len(positions) == 0 {
+		return nil
+	}
+	pos, ok := positions[objIdFromFields(objT.GetKind(), obj.GetNamespace(), obj.GetName())]
+	if !ok {
+		return nil
+	}
+
+	rnge := llx.NewRange().AddLineRange(uint32(pos.StartLine), uint32(pos.EndLine))
+	ctxObj, err := CreateResource(runtime, "k8s.context", map[string]*llx.RawData{
+		"path":    llx.StringData(path),
+		"range":   llx.RangeData(rnge),
+		"content": llx.StringData(rnge.ExtractString(content, llx.DefaultExtractConfig)),
+	})
+	if err != nil {
+		return err
+	}
+
+	rv := reflect.ValueOf(res)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return nil
+	}
+	field := rv.Elem().FieldByName("Context")
+	if field.IsValid() && field.CanSet() {
+		field.Set(reflect.ValueOf(plugin.TValue[*mqlK8sContext]{
+			Data:  ctxObj.(*mqlK8sContext),
+			State: plugin.StateIsSet,
+		}))
+	}
+	return nil
+}
+
+// errK8sContextNotProvided is returned by the fallback context() resolvers.
+// context is populated at resource creation for manifest scans, so these only
+// run when a resource was built without one (live cluster, admission review).
+var errK8sContextNotProvided = errors.New("context is only available for manifest-file scans")
+
+func (x *mqlK8sAdmissionMutatingwebhookconfiguration) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sAdmissionValidatingadmissionpolicy) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sAdmissionValidatingadmissionpolicybinding) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sAdmissionValidatingwebhookconfiguration) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sApiservice) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sCertificatesigningrequest) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sConfigmap) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sCronjob) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sCustomresource) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sDaemonset) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sDeployment) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sEndpointslice) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sGateway) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sGatewayclass) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sGrpcroute) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sHorizontalpodautoscaler) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sHttproute) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sIngress) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sIngressclass) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sJob) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sLease) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sLimitrange) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sNetworkpolicy) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sNode) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sPersistentvolume) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sPersistentvolumeclaim) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sPod) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sPoddisruptionbudget) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sPriorityclass) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sRbacClusterrole) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sRbacClusterrolebinding) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sRbacRole) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sRbacRolebinding) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sReferencegrant) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sReplicaset) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sResourcequota) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sSecret) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sService) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sServiceaccount) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sStatefulset) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}
+
+func (x *mqlK8sStorageclass) context() (*mqlK8sContext, error) {
+	return nil, errK8sContextNotProvided
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -286,7 +286,7 @@ private k8s.namespace @defaults("name created") {
 // containerRuntimeVersion, operatingSystem, and architecture fields report the
 // node's software stack, and unschedulable reports whether the node is
 // cordoned.
-private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes.io/os'] ") {
+private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes.io/os'] ") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -397,7 +397,7 @@ private k8s.nodeAddress @defaults("type address") {
 // and runtime status by phase, qosClass, podIP, and conditions. The owning
 // controller is reached through replicaSet, statefulSet, daemonSet, job, and
 // deployment.
-private k8s.pod @defaults("namespace name created"){
+private k8s.pod @defaults("namespace name created") @context("k8s.context") {
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
   runsPrivileged() bool
   // Whether privilege escalation is possible for any container
@@ -645,7 +645,7 @@ private k8s.pod @defaults("namespace name created"){
 // the current rollout state is reported by replicas, readyReplicas,
 // availableReplicas, updatedReplicas, unavailableReplicas, and conditions. The
 // pods field returns the pods currently backing the deployment.
-private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas created") {
+private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -813,7 +813,7 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
 // desiredNumberScheduled, currentNumberScheduled, numberReady, numberAvailable,
 // numberMisscheduled, and updatedNumberScheduled. The pods field returns the
 // daemon pods currently running.
-private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberReady created") {
+private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberReady created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -980,7 +980,7 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
 // scale-down. Rollout state is reported by replicas, readyReplicas,
 // currentReplicas, updatedReplicas, currentRevision, updateRevision, and
 // conditions, and the pods field returns the backing pods.
-private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas created") {
+private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -1155,7 +1155,7 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
 // desiredReplicas and selector, and the observed state is reported by replicas,
 // readyReplicas, availableReplicas, fullyLabeledReplicas, and conditions. The
 // pods field returns the pods the ReplicaSet owns.
-private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas created") {
+private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -1310,7 +1310,7 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
 // backoffLimit, activeDeadlineSeconds, and suspend; and progress is reported by
 // active, succeeded, failed, ready, startTime, completionTime, and conditions.
 // The pods field returns the pods the job has created.
-private k8s.job @defaults("namespace name succeeded failed created") {
+private k8s.job @defaults("namespace name succeeded failed created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -1490,7 +1490,7 @@ private k8s.job @defaults("namespace name succeeded failed created") {
 // finished jobs are retained. The activeJobs field returns the jobs currently
 // running, jobs returns every job the CronJob still owns, and the shared pod
 // template is available through podSpec, containers, and initContainers.
-private k8s.cronjob @defaults("namespace name schedule suspend created") {
+private k8s.cronjob @defaults("namespace name schedule suspend created") @context("k8s.context") {
   // Whether an API token is automatically mounted for the ServiceAccount
   automountServiceAccountToken() bool
   // Whether the pod shares the host network namespace
@@ -1947,7 +1947,7 @@ private k8s.ephemeralContainer @defaults("name") {
 // certificates parses any X.509 certificates the secret carries, and usedBy
 // returns the pods that consume the secret through volumes, environment
 // variables, or image-pull references.
-private k8s.secret @defaults("namespace name created") {
+private k8s.secret @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2004,7 +2004,7 @@ private k8s.secret @defaults("namespace name created") {
 // selected by namespace and name. The data field exposes the stored
 // configuration entries, and usedBy returns the pods that consume the ConfigMap
 // through volumes, environment variables, or envFrom.
-private k8s.configmap @defaults("namespace name created") {
+private k8s.configmap @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2045,7 +2045,7 @@ private k8s.configmap @defaults("namespace name created") {
 // governed by externalTrafficPolicy, internalTrafficPolicy, and
 // sessionAffinity, and endpointSlices returns the slices listing the current
 // backing endpoints.
-private k8s.service @defaults("namespace name created") {
+private k8s.service @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2202,7 +2202,7 @@ private k8s.ingresstls {
 // terminated by the ingress, and ingressClass identifies the controller that
 // implements the rules. The loadBalancerIngress field reports the addresses the
 // controller has assigned.
-private k8s.ingress @defaults("namespace name created") {
+private k8s.ingress @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2250,7 +2250,7 @@ private k8s.ingress @defaults("namespace name created") {
 // and registry credentials associated with the account, and
 // automountServiceAccountToken reports whether its API token is mounted into
 // pods by default.
-private k8s.serviceaccount @defaults("namespace name created") {
+private k8s.serviceaccount @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2301,7 +2301,7 @@ private k8s.serviceaccount @defaults("namespace name created") {
 // the API groups, resources, and verbs the role grants, aggregationRule
 // describes how the role aggregates other ClusterRoles by label, and boundBy
 // returns the ClusterRoleBindings that grant this role to subjects.
-private k8s.rbac.clusterrole @defaults("name created") {
+private k8s.rbac.clusterrole @defaults("name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2372,7 +2372,7 @@ private k8s.rbac.policyRule @defaults("verbs apiGroups resources") {
 // name. The subjects field lists the users, groups, and service accounts the
 // role is granted to, serviceAccounts resolves the service-account subjects to
 // their objects, and clusterRole returns the ClusterRole named by roleRef.
-private k8s.rbac.clusterrolebinding @defaults("name created") {
+private k8s.rbac.clusterrolebinding @defaults("name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2419,7 +2419,7 @@ private k8s.rbac.clusterrolebinding @defaults("name created") {
 // field lists the API groups, resources, and verbs the role grants within its
 // namespace, and boundBy returns the RoleBindings that grant this role to
 // subjects.
-private k8s.rbac.role @defaults("name namespace") {
+private k8s.rbac.role @defaults("name namespace") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2473,7 +2473,7 @@ private k8s.rbac.role @defaults("name namespace") {
 // and service accounts the permissions are granted to, serviceAccounts resolves
 // the service-account subjects to their objects, and role or clusterRole
 // returns the object named by roleRef depending on its kind.
-private k8s.rbac.rolebinding @defaults("name namespace created") {
+private k8s.rbac.rolebinding @defaults("name namespace created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2590,7 +2590,7 @@ private k8s.rbac.whoCan @defaults("verb resource namespace") {
 // governs, policyTypes reports whether ingress, egress, or both are restricted,
 // and the ingress and egress fields list the permitted peers and ports. Pods
 // selected by a policy deny all traffic not explicitly allowed by these rules.
-private k8s.networkpolicy @defaults("namespace name created") {
+private k8s.networkpolicy @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2785,7 +2785,7 @@ private k8s.networkPolicyCoverage @defaults("namespace policyRef defaultDenyIngr
 // by namespace and name. The kind field reports the custom type and manifest
 // exposes the object's full content, so custom API extensions can be queried
 // alongside built-in Kubernetes objects.
-private k8s.customresource @defaults("name namespace created") {
+private k8s.customresource @defaults("name namespace created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2820,7 +2820,7 @@ private k8s.customresource @defaults("name namespace created") {
 // happens when its claim is released, and phase reports its lifecycle state
 // (Available, Bound, Released, or Failed). The claim field returns the
 // PersistentVolumeClaim currently bound to the volume.
-private k8s.persistentvolume @defaults("name capacity['storage'] phase storageClassName created") {
+private k8s.persistentvolume @defaults("name capacity['storage'] phase storageClassName created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2884,7 +2884,7 @@ private k8s.persistentvolume @defaults("name capacity['storage'] phase storageCl
 // carries the provisioner-specific settings, and reclaimPolicy,
 // volumeBindingMode, and allowVolumeExpansion govern reclamation, binding
 // timing, and whether bound volumes may grow.
-private k8s.storageclass @defaults("name provisioner") {
+private k8s.storageclass @defaults("name provisioner") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2928,7 +2928,7 @@ private k8s.storageclass @defaults("name provisioner") {
 // globalDefault marks the class applied to pods that request none, and
 // preemptionPolicy controls whether higher-priority pods may evict
 // lower-priority ones.
-private k8s.priorityclass @defaults("name value") {
+private k8s.priorityclass @defaults("name value") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -2970,7 +2970,7 @@ private k8s.priorityclass @defaults("name value") {
 // bound the replica count, and metrics and behavior define the targets and
 // scaling policies. Current state is reported by currentReplicas,
 // desiredReplicas, currentMetrics, lastScaleTime, and conditions.
-private k8s.horizontalpodautoscaler @defaults("namespace name minReplicas maxReplicas currentReplicas created") {
+private k8s.horizontalpodautoscaler @defaults("namespace name minReplicas maxReplicas currentReplicas created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3039,7 +3039,7 @@ private k8s.horizontalpodautoscaler @defaults("namespace name minReplicas maxRep
 // namespace and name. The hard field lists the enforced limits (such as CPU,
 // memory, and object counts) and used reports current consumption against them.
 // The scopes and scopeSelector fields narrow which objects the quota applies to.
-private k8s.resourcequota @defaults("namespace name created") {
+private k8s.resourcequota @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3085,7 +3085,7 @@ private k8s.resourcequota @defaults("namespace name created") {
 // default, minimum, and maximum values applied per object type (Container, Pod,
 // or PersistentVolumeClaim), supplying defaults to objects that omit them and
 // rejecting objects that fall outside the bounds.
-private k8s.limitrange @defaults("namespace name created") {
+private k8s.limitrange @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3123,7 +3123,7 @@ private k8s.limitrange @defaults("namespace name created") {
 // volume and volumeName identify the bound PersistentVolume, and phase reports
 // whether the claim is Pending, Bound, or Lost. The capacity and
 // boundAccessModes fields report what the bound volume actually provides.
-private k8s.persistentvolumeclaim @defaults("namespace name phase capacity['storage'] storageClassName created") {
+private k8s.persistentvolumeclaim @defaults("namespace name phase capacity['storage'] storageClassName created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3189,7 +3189,7 @@ private k8s.persistentvolumeclaim @defaults("namespace name phase capacity['stor
 // FQDN endpoints, endpoints lists the backing addresses and their readiness,
 // ports lists the ports they expose, and service returns the Service the slice
 // belongs to.
-private k8s.endpointslice @defaults("namespace name addressType") {
+private k8s.endpointslice @defaults("namespace name addressType") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3274,7 +3274,7 @@ private k8s.userinfo @defaults("username") {
 // endpoint, the resource rules and namespace and object selectors that decide
 // when it is called, its failure policy, and its admission side effects.
 // Validating webhooks may reject a request but cannot modify the object.
-private k8s.admission.validatingwebhookconfiguration @defaults("name") {
+private k8s.admission.validatingwebhookconfiguration @defaults("name") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3333,7 +3333,7 @@ private k8s.app {
 // Gateways of this class, parametersRef points to a controller-specific
 // configuration resource, and conditions reports whether the class has been
 // accepted.
-private k8s.gatewayclass @defaults("name controllerName created") {
+private k8s.gatewayclass @defaults("name controllerName created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3374,7 +3374,7 @@ private k8s.gatewayclass @defaults("name controllerName created") {
 // hostnames the Gateway accepts, and addresses requests specific entry
 // addresses. The statusAddresses and listenerStatus fields report the addresses
 // the controller assigned and the routes attached to each listener.
-private k8s.gateway @defaults("namespace name gatewayClassName created") {
+private k8s.gateway @defaults("namespace name gatewayClassName created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3429,7 +3429,7 @@ private k8s.gateway @defaults("namespace name gatewayClassName created") {
 // specific hosts, and rules describes the matches, filters, and backend
 // forwarding applied to requests. The parentStatus field reports whether each
 // parent accepted the route.
-private k8s.httproute @defaults("namespace name created") {
+private k8s.httproute @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3472,7 +3472,7 @@ private k8s.httproute @defaults("namespace name created") {
 // specific hosts, and rules describes the method matches, filters, and backend
 // forwarding applied to requests. The parentStatus field reports whether each
 // parent accepted the route.
-private k8s.grpcroute @defaults("namespace name created") {
+private k8s.grpcroute @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3641,7 +3641,7 @@ private k8s.udproute @defaults("namespace name created") {
 // namespaces allowed to make references, and the to field lists the resource
 // kinds in this namespace they may reference, letting routes and other objects
 // point at targets they would otherwise be denied.
-private k8s.referencegrant @defaults("namespace name created") {
+private k8s.referencegrant @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3680,7 +3680,7 @@ private k8s.referencegrant @defaults("namespace name created") {
 // when it is called, its reinvocation and failure policies, and its admission
 // side effects. Mutating webhooks run before validation and may patch the
 // incoming object.
-private k8s.admission.mutatingwebhookconfiguration @defaults("name") {
+private k8s.admission.mutatingwebhookconfiguration @defaults("name") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3720,7 +3720,7 @@ private k8s.admission.mutatingwebhookconfiguration @defaults("name") {
 // `k8s.admission.validatingadmissionpolicybinding` activates it; use
 // `bindings()` to reach the bindings that reference this policy by name and
 // the enforcement actions (Deny, Warn, Audit) they apply.
-private k8s.admission.validatingadmissionpolicy @defaults("name failurePolicy") {
+private k8s.admission.validatingadmissionpolicy @defaults("name failurePolicy") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3770,7 +3770,7 @@ private k8s.admission.validatingadmissionpolicy @defaults("name failurePolicy") 
 // request, `Warn` returns a client warning, and `Audit` records the failure in
 // the audit log. Use `matchResources()` to see how the binding narrows the
 // policy's scope and `paramRef()` for the parameter resource it supplies.
-private k8s.admission.validatingadmissionpolicybinding @defaults("name policyName") {
+private k8s.admission.validatingadmissionpolicybinding @defaults("name policyName") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3813,7 +3813,7 @@ private k8s.admission.validatingadmissionpolicybinding @defaults("name policyNam
 // unhealthyPodEvictionPolicy governs eviction of unhealthy pods. Current state
 // is reported by currentHealthy, desiredHealthy, expectedPods, and
 // disruptionsAllowed.
-private k8s.poddisruptionbudget @defaults("namespace name created") {
+private k8s.poddisruptionbudget @defaults("namespace name created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3867,7 +3867,7 @@ private k8s.poddisruptionbudget @defaults("namespace name created") {
 // leaseDurationSeconds and renewTime report how long the lease is held and when
 // it was last renewed, and acquireTime and leaseTransitions track when it was
 // acquired and how often it has changed hands.
-private k8s.lease @defaults("namespace name holderIdentity created") {
+private k8s.lease @defaults("namespace name holderIdentity created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3916,7 +3916,7 @@ private k8s.lease @defaults("namespace name holderIdentity created") {
 // expirationSeconds state the requested key usages and lifetime. The username,
 // groups, and requesterUid fields identify the requester, conditions reports
 // approval state, and certificate holds the issued certificate once signed.
-private k8s.certificatesigningrequest @defaults("name signerName username created") {
+private k8s.certificatesigningrequest @defaults("name signerName username created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -3968,7 +3968,7 @@ private k8s.certificatesigningrequest @defaults("name signerName username create
 // kube-apiserver itself), and caBundle and insecureSkipTLSVerify govern how the
 // API server trusts that backend. The conditions field reports whether the API
 // is available.
-private k8s.apiservice @defaults("name group version created") {
+private k8s.apiservice @defaults("name group version created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -4021,7 +4021,7 @@ private k8s.apiservice @defaults("name group version created") {
 // name. The controller field names the controller that handles ingresses of this
 // class, and parameters points to a controller-specific configuration resource
 // that tunes its behavior.
-private k8s.ingressclass @defaults("name controller created") {
+private k8s.ingressclass @defaults("name controller created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID
@@ -4125,4 +4125,19 @@ private k8s.accessReview @defaults("subject verb resource allowed") {
   allowed() bool
   // Authorizer's explanation for the decision
   reason() string
+}
+
+// Kubernetes manifest source context
+//
+// Source location and raw text of a resource declared in a manifest file: the
+// file path, the line range it spans, and the manifest text within that range.
+// Points a reviewer at the exact source of a flagged resource. Available only
+// for manifest-file scans; empty for live-cluster and admission connections.
+private k8s.context @defaults("path range content") {
+  // Path of the manifest file this resource is declared in
+  path string
+  // Line range the resource spans in the manifest
+  range range
+  // Manifest text within the range, shown as an excerpt
+  content(path, range) string
 }

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -90,6 +90,7 @@ const (
 	ResourceK8sOwnerReference                            string = "k8s.ownerReference"
 	ResourceK8sManagedField                              string = "k8s.managedField"
 	ResourceK8sAccessReview                              string = "k8s.accessReview"
+	ResourceK8sContext                                   string = "k8s.context"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -391,6 +392,10 @@ func init() {
 		"k8s.accessReview": {
 			Init:   initK8sAccessReview,
 			Create: createK8sAccessReview,
+		},
+		"k8s.context": {
+			// to override args, implement: initK8sContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createK8sContext,
 		},
 	}
 }
@@ -856,6 +861,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.node.volumesInUse": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNode).GetVolumesInUse()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.node.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.nodeTaint.key": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNodeTaint).GetKey()).ToDataRes(types.String)
 	},
@@ -1192,6 +1200,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.deployment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetDeployment()).ToDataRes(types.Resource("k8s.deployment"))
 	},
+	"k8s.pod.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.deployment.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
 	},
@@ -1390,6 +1401,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.deployment.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.daemonset.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
 	},
@@ -1584,6 +1598,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.daemonset.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.daemonset.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.statefulset.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
@@ -1795,6 +1812,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.statefulset.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.statefulset.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.replicaset.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
 	},
@@ -1974,6 +1994,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.replicaset.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.replicaset.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.job.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
@@ -2191,6 +2214,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.job.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.job.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.cronjob.automountServiceAccountToken": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetAutomountServiceAccountToken()).ToDataRes(types.Bool)
 	},
@@ -2376,6 +2402,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.jobs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetJobs()).ToDataRes(types.Array(types.Resource("k8s.job")))
+	},
+	"k8s.cronjob.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.container.uid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sContainer).GetUid()).ToDataRes(types.String)
@@ -2761,6 +2790,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.secret.certificateExpiry": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sSecret).GetCertificateExpiry()).ToDataRes(types.Time)
 	},
+	"k8s.secret.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sSecret).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.configmap.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sConfigmap).GetId()).ToDataRes(types.String)
 	},
@@ -2802,6 +2834,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.configmap.usedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sConfigmap).GetUsedBy()).ToDataRes(types.Array(types.Resource("k8s.pod")))
+	},
+	"k8s.configmap.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sConfigmap).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.service.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetId()).ToDataRes(types.String)
@@ -2916,6 +2951,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.service.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sService).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
+	},
+	"k8s.service.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sService).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.ingressresourceref.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngressresourceref).GetId()).ToDataRes(types.String)
@@ -3037,6 +3075,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.ingress.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngress).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
+	"k8s.ingress.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sIngress).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.serviceaccount.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sServiceaccount).GetId()).ToDataRes(types.String)
 	},
@@ -3100,6 +3141,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.serviceaccount.hasWildcardPermissions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sServiceaccount).GetHasWildcardPermissions()).ToDataRes(types.Bool)
 	},
+	"k8s.serviceaccount.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.rbac.clusterrole.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetId()).ToDataRes(types.String)
 	},
@@ -3156,6 +3200,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.clusterrole.boundBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetBoundBy()).ToDataRes(types.Array(types.Resource("k8s.rbac.clusterrolebinding")))
+	},
+	"k8s.rbac.clusterrole.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrole).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.rbac.policyRule.verbs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacPolicyRule).GetVerbs()).ToDataRes(types.Array(types.String))
@@ -3229,6 +3276,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.clusterrolebinding.clusterRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrolebinding).GetClusterRole()).ToDataRes(types.Resource("k8s.rbac.clusterrole"))
 	},
+	"k8s.rbac.clusterrolebinding.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.rbac.role.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetId()).ToDataRes(types.String)
 	},
@@ -3285,6 +3335,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.role.boundBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetBoundBy()).ToDataRes(types.Array(types.Resource("k8s.rbac.rolebinding")))
+	},
+	"k8s.rbac.role.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRole).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.rbac.rolebinding.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetId()).ToDataRes(types.String)
@@ -3348,6 +3401,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.rolebinding.clusterRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetClusterRole()).ToDataRes(types.Resource("k8s.rbac.clusterrole"))
+	},
+	"k8s.rbac.rolebinding.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.rbac.subject.kind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacSubject).GetKind()).ToDataRes(types.String)
@@ -3450,6 +3506,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.networkpolicy.coverage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNetworkpolicy).GetCoverage()).ToDataRes(types.Resource("k8s.networkPolicyCoverage"))
+	},
+	"k8s.networkpolicy.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNetworkpolicy).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.networkExposure.sourceKind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNetworkExposure).GetSourceKind()).ToDataRes(types.String)
@@ -3661,6 +3720,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.customresource.manifest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCustomresource).GetManifest()).ToDataRes(types.Dict)
 	},
+	"k8s.customresource.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCustomresource).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.persistentvolume.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolume).GetId()).ToDataRes(types.String)
 	},
@@ -3742,6 +3804,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.persistentvolume.message": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolume).GetMessage()).ToDataRes(types.String)
 	},
+	"k8s.persistentvolume.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPersistentvolume).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.storageclass.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStorageclass).GetId()).ToDataRes(types.String)
 	},
@@ -3793,6 +3858,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.storageclass.mountOptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStorageclass).GetMountOptions()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.storageclass.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStorageclass).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.priorityclass.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPriorityclass).GetId()).ToDataRes(types.String)
 	},
@@ -3837,6 +3905,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.priorityclass.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPriorityclass).GetDescription()).ToDataRes(types.String)
+	},
+	"k8s.priorityclass.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPriorityclass).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.horizontalpodautoscaler.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sHorizontalpodautoscaler).GetId()).ToDataRes(types.String)
@@ -3928,6 +3999,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.horizontalpodautoscaler.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sHorizontalpodautoscaler).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.horizontalpodautoscaler.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sHorizontalpodautoscaler).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.resourcequota.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sResourcequota).GetId()).ToDataRes(types.String)
 	},
@@ -3982,6 +4056,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.resourcequota.scopeSelector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sResourcequota).GetScopeSelector()).ToDataRes(types.Dict)
 	},
+	"k8s.resourcequota.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sResourcequota).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.limitrange.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLimitrange).GetId()).ToDataRes(types.String)
 	},
@@ -4023,6 +4100,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.limitrange.limits": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLimitrange).GetLimits()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.limitrange.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sLimitrange).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.persistentvolumeclaim.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolumeclaim).GetId()).ToDataRes(types.String)
@@ -4108,6 +4188,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.persistentvolumeclaim.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolumeclaim).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.persistentvolumeclaim.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPersistentvolumeclaim).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.endpointslice.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEndpointslice).GetId()).ToDataRes(types.String)
 	},
@@ -4158,6 +4241,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.endpointslice.externalAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEndpointslice).GetExternalAddresses()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.endpointslice.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEndpointslice).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.admissionreview.request": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionreview).GetRequest()).ToDataRes(types.Resource("k8s.admissionrequest"))
@@ -4225,6 +4311,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.admission.validatingwebhookconfiguration.failsOpen": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingwebhookconfiguration).GetFailsOpen()).ToDataRes(types.Bool)
 	},
+	"k8s.admission.validatingwebhookconfiguration.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionValidatingwebhookconfiguration).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.app.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sApp).GetName()).ToDataRes(types.String)
 	},
@@ -4287,6 +4376,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.gatewayclass.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGatewayclass).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.gatewayclass.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sGatewayclass).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.gateway.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGateway).GetId()).ToDataRes(types.String)
@@ -4354,6 +4446,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.gateway.networkExposures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGateway).GetNetworkExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
+	"k8s.gateway.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sGateway).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.httproute.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sHttproute).GetId()).ToDataRes(types.String)
 	},
@@ -4402,6 +4497,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.httproute.parentStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sHttproute).GetParentStatus()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.httproute.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sHttproute).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.grpcroute.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGrpcroute).GetId()).ToDataRes(types.String)
 	},
@@ -4449,6 +4547,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.grpcroute.parentStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sGrpcroute).GetParentStatus()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.grpcroute.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sGrpcroute).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.tlsroute.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sTlsroute).GetId()).ToDataRes(types.String)
@@ -4636,6 +4737,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.referencegrant.to": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReferencegrant).GetTo()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.referencegrant.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReferencegrant).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.admission.mutatingwebhookconfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionMutatingwebhookconfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -4674,6 +4778,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.admission.mutatingwebhookconfiguration.failsOpen": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionMutatingwebhookconfiguration).GetFailsOpen()).ToDataRes(types.Bool)
+	},
+	"k8s.admission.mutatingwebhookconfiguration.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionMutatingwebhookconfiguration).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.admission.validatingadmissionpolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingadmissionpolicy).GetId()).ToDataRes(types.String)
@@ -4732,6 +4839,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.admission.validatingadmissionpolicy.bindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingadmissionpolicy).GetBindings()).ToDataRes(types.Array(types.Resource("k8s.admission.validatingadmissionpolicybinding")))
 	},
+	"k8s.admission.validatingadmissionpolicy.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionValidatingadmissionpolicy).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.admission.validatingadmissionpolicybinding.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).GetId()).ToDataRes(types.String)
 	},
@@ -4779,6 +4889,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.admission.validatingadmissionpolicybinding.matchResources": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).GetMatchResources()).ToDataRes(types.Dict)
+	},
+	"k8s.admission.validatingadmissionpolicybinding.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.poddisruptionbudget.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPoddisruptionbudget).GetId()).ToDataRes(types.String)
@@ -4846,6 +4959,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.poddisruptionbudget.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPoddisruptionbudget).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.poddisruptionbudget.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPoddisruptionbudget).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.lease.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLease).GetId()).ToDataRes(types.String)
 	},
@@ -4902,6 +5018,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.lease.preferredHolder": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLease).GetPreferredHolder()).ToDataRes(types.String)
+	},
+	"k8s.lease.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sLease).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.certificatesigningrequest.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCertificatesigningrequest).GetId()).ToDataRes(types.String)
@@ -4962,6 +5081,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.certificatesigningrequest.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCertificatesigningrequest).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.certificatesigningrequest.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCertificatesigningrequest).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.apiservice.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sApiservice).GetId()).ToDataRes(types.String)
@@ -5029,6 +5151,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.apiservice.conditions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sApiservice).GetConditions()).ToDataRes(types.Array(types.Dict))
 	},
+	"k8s.apiservice.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sApiservice).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
 	"k8s.ingressclass.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngressclass).GetId()).ToDataRes(types.String)
 	},
@@ -5067,6 +5192,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.ingressclass.parameters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sIngressclass).GetParameters()).ToDataRes(types.Dict)
+	},
+	"k8s.ingressclass.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sIngressclass).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
 	"k8s.ownerReference.apiVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sOwnerReference).GetApiVersion()).ToDataRes(types.String)
@@ -5130,6 +5258,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.accessReview.reason": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAccessReview).GetReason()).ToDataRes(types.String)
+	},
+	"k8s.context.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContext).GetPath()).ToDataRes(types.String)
+	},
+	"k8s.context.range": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContext).GetRange()).ToDataRes(types.Range)
+	},
+	"k8s.context.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContext).GetContent()).ToDataRes(types.String)
 	},
 }
 
@@ -5683,6 +5820,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sNode).VolumesInUse, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.node.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.nodeTaint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNodeTaint).__id, ok = v.Value.(string)
 		return
@@ -6147,6 +6288,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).Deployment, ok = plugin.RawToTValue[*mqlK8sDeployment](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).__id, ok = v.Value.(string)
 		return
@@ -6415,6 +6560,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).__id, ok = v.Value.(string)
 		return
@@ -6677,6 +6826,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.daemonset.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6963,6 +7116,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sStatefulset).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.statefulset.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).__id, ok = v.Value.(string)
 		return
@@ -7205,6 +7362,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.replicaset.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.job.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7499,6 +7660,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sJob).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.job.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.cronjob.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).__id, ok = v.Value.(string)
 		return
@@ -7749,6 +7914,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.jobs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).Jobs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.container.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8283,6 +8452,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sSecret).CertificateExpiry, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"k8s.secret.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sSecret).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.configmap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sConfigmap).__id, ok = v.Value.(string)
 		return
@@ -8341,6 +8514,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.configmap.usedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sConfigmap).UsedBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.configmap.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sConfigmap).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8497,6 +8674,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.service.networkExposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sService).NetworkExposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.service.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sService).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.ingressresourceref.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8687,6 +8868,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sIngress).NetworkExposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.ingress.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sIngress).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.serviceaccount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sServiceaccount).__id, ok = v.Value.(string)
 		return
@@ -8775,6 +8960,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sServiceaccount).HasWildcardPermissions, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.serviceaccount.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.clusterrole.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacClusterrole).__id, ok = v.Value.(string)
 		return
@@ -8853,6 +9042,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.clusterrole.boundBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacClusterrole).BoundBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.clusterrole.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrole).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.policyRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8959,6 +9152,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacClusterrolebinding).ClusterRole, ok = plugin.RawToTValue[*mqlK8sRbacClusterrole](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.clusterrolebinding.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRole).__id, ok = v.Value.(string)
 		return
@@ -9037,6 +9234,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.role.boundBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRole).BoundBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.role.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRole).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.rolebinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9125,6 +9326,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.rolebinding.clusterRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRolebinding).ClusterRole, ok = plugin.RawToTValue[*mqlK8sRbacClusterrole](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.subject.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9273,6 +9478,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.networkpolicy.coverage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNetworkpolicy).Coverage, ok = plugin.RawToTValue[*mqlK8sNetworkPolicyCoverage](v.Value, v.Error)
+		return
+	},
+	"k8s.networkpolicy.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNetworkpolicy).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.networkExposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9575,6 +9784,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sCustomresource).Manifest, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"k8s.customresource.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCustomresource).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.persistentvolume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPersistentvolume).__id, ok = v.Value.(string)
 		return
@@ -9687,6 +9900,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPersistentvolume).Message, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"k8s.persistentvolume.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPersistentvolume).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.storageclass.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStorageclass).__id, ok = v.Value.(string)
 		return
@@ -9759,6 +9976,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sStorageclass).MountOptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.storageclass.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStorageclass).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.priorityclass.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPriorityclass).__id, ok = v.Value.(string)
 		return
@@ -9821,6 +10042,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.priorityclass.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPriorityclass).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.priorityclass.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPriorityclass).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.horizontalpodautoscaler.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9947,6 +10172,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sHorizontalpodautoscaler).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.horizontalpodautoscaler.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sHorizontalpodautoscaler).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.resourcequota.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sResourcequota).__id, ok = v.Value.(string)
 		return
@@ -10023,6 +10252,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sResourcequota).ScopeSelector, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"k8s.resourcequota.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sResourcequota).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.limitrange.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLimitrange).__id, ok = v.Value.(string)
 		return
@@ -10081,6 +10314,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.limitrange.limits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLimitrange).Limits, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.limitrange.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sLimitrange).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.persistentvolumeclaim.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10199,6 +10436,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPersistentvolumeclaim).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.persistentvolumeclaim.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPersistentvolumeclaim).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.endpointslice.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sEndpointslice).__id, ok = v.Value.(string)
 		return
@@ -10269,6 +10510,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.endpointslice.externalAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sEndpointslice).ExternalAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.endpointslice.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEndpointslice).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.admissionreview.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10375,6 +10620,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sAdmissionValidatingwebhookconfiguration).FailsOpen, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.admission.validatingwebhookconfiguration.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionValidatingwebhookconfiguration).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.app.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sApp).__id, ok = v.Value.(string)
 		return
@@ -10465,6 +10714,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.gatewayclass.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sGatewayclass).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.gatewayclass.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sGatewayclass).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.gateway.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10559,6 +10812,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sGateway).NetworkExposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.gateway.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sGateway).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.httproute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sHttproute).__id, ok = v.Value.(string)
 		return
@@ -10627,6 +10884,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sHttproute).ParentStatus, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.httproute.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sHttproute).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.grpcroute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sGrpcroute).__id, ok = v.Value.(string)
 		return
@@ -10693,6 +10954,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.grpcroute.parentStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sGrpcroute).ParentStatus, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.grpcroute.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sGrpcroute).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.tlsroute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10959,6 +11224,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReferencegrant).To, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.referencegrant.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReferencegrant).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.admission.mutatingwebhookconfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAdmissionMutatingwebhookconfiguration).__id, ok = v.Value.(string)
 		return
@@ -11013,6 +11282,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.admission.mutatingwebhookconfiguration.failsOpen": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAdmissionMutatingwebhookconfiguration).FailsOpen, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.admission.mutatingwebhookconfiguration.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionMutatingwebhookconfiguration).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.admission.validatingadmissionpolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11095,6 +11368,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sAdmissionValidatingadmissionpolicy).Bindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.admission.validatingadmissionpolicy.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionValidatingadmissionpolicy).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.admission.validatingadmissionpolicybinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).__id, ok = v.Value.(string)
 		return
@@ -11161,6 +11438,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.admission.validatingadmissionpolicybinding.matchResources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).MatchResources, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.admission.validatingadmissionpolicybinding.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sAdmissionValidatingadmissionpolicybinding).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.poddisruptionbudget.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11255,6 +11536,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPoddisruptionbudget).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.poddisruptionbudget.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPoddisruptionbudget).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.lease.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLease).__id, ok = v.Value.(string)
 		return
@@ -11333,6 +11618,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.lease.preferredHolder": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLease).PreferredHolder, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.lease.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sLease).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.certificatesigningrequest.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11417,6 +11706,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.certificatesigningrequest.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCertificatesigningrequest).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.certificatesigningrequest.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCertificatesigningrequest).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.apiservice.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11511,6 +11804,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sApiservice).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.apiservice.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sApiservice).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
 	"k8s.ingressclass.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sIngressclass).__id, ok = v.Value.(string)
 		return
@@ -11565,6 +11862,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.ingressclass.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sIngressclass).Parameters, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.ingressclass.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sIngressclass).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
 	},
 	"k8s.ownerReference.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11661,6 +11962,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.accessReview.reason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sAccessReview).Reason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.context.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContext).__id, ok = v.Value.(string)
+		return
+	},
+	"k8s.context.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContext).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.context.range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContext).Range, ok = plugin.RawToTValue[llx.Range](v.Value, v.Error)
+		return
+	},
+	"k8s.context.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContext).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -13300,6 +13617,7 @@ type mqlK8sNode struct {
 	Images                  plugin.TValue[[]any]
 	VolumesAttached         plugin.TValue[[]any]
 	VolumesInUse            plugin.TValue[[]any]
+	Context                 plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sNode creates a new instance of this resource
@@ -13552,6 +13870,22 @@ func (c *mqlK8sNode) GetVolumesAttached() *plugin.TValue[[]any] {
 func (c *mqlK8sNode) GetVolumesInUse() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.VolumesInUse, func() ([]any, error) {
 		return c.volumesInUse()
+	})
+}
+
+func (c *mqlK8sNode) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.node", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -13837,6 +14171,7 @@ type mqlK8sPod struct {
 	DaemonSet                     plugin.TValue[*mqlK8sDaemonset]
 	Job                           plugin.TValue[*mqlK8sJob]
 	Deployment                    plugin.TValue[*mqlK8sDeployment]
+	Context                       plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sPod creates a new instance of this resource
@@ -14620,6 +14955,22 @@ func (c *mqlK8sPod) GetDeployment() *plugin.TValue[*mqlK8sDeployment] {
 	})
 }
 
+func (c *mqlK8sPod) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.pod", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sDeployment for the k8s.deployment resource
 type mqlK8sDeployment struct {
 	MqlRuntime *plugin.Runtime
@@ -14691,6 +15042,7 @@ type mqlK8sDeployment struct {
 	ObservedGeneration           plugin.TValue[int64]
 	CollisionCount               plugin.TValue[int64]
 	Conditions                   plugin.TValue[[]any]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sDeployment creates a new instance of this resource
@@ -15162,6 +15514,22 @@ func (c *mqlK8sDeployment) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sDeployment) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.deployment", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sDaemonset for the k8s.daemonset resource
 type mqlK8sDaemonset struct {
 	MqlRuntime *plugin.Runtime
@@ -15232,6 +15600,7 @@ type mqlK8sDaemonset struct {
 	ObservedGeneration           plugin.TValue[int64]
 	CollisionCount               plugin.TValue[int64]
 	Conditions                   plugin.TValue[[]any]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sDaemonset creates a new instance of this resource
@@ -15697,6 +16066,22 @@ func (c *mqlK8sDaemonset) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sDaemonset) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.daemonset", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sStatefulset for the k8s.statefulset resource
 type mqlK8sStatefulset struct {
 	MqlRuntime *plugin.Runtime
@@ -15772,6 +16157,7 @@ type mqlK8sStatefulset struct {
 	UpdateRevision                       plugin.TValue[string]
 	CollisionCount                       plugin.TValue[int64]
 	Conditions                           plugin.TValue[[]any]
+	Context                              plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sStatefulset creates a new instance of this resource
@@ -16267,6 +16653,22 @@ func (c *mqlK8sStatefulset) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sStatefulset) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.statefulset", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sReplicaset for the k8s.replicaset resource
 type mqlK8sReplicaset struct {
 	MqlRuntime *plugin.Runtime
@@ -16332,6 +16734,7 @@ type mqlK8sReplicaset struct {
 	AvailableReplicas            plugin.TValue[int64]
 	ObservedGeneration           plugin.TValue[int64]
 	Conditions                   plugin.TValue[[]any]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sReplicaset creates a new instance of this resource
@@ -16767,6 +17170,22 @@ func (c *mqlK8sReplicaset) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sReplicaset) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.replicaset", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sJob for the k8s.job resource
 type mqlK8sJob struct {
 	MqlRuntime *plugin.Runtime
@@ -16844,6 +17263,7 @@ type mqlK8sJob struct {
 	StartTime                    plugin.TValue[*time.Time]
 	CompletionTime               plugin.TValue[*time.Time]
 	Conditions                   plugin.TValue[[]any]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sJob creates a new instance of this resource
@@ -17351,6 +17771,22 @@ func (c *mqlK8sJob) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sJob) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.job", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sCronjob for the k8s.cronjob resource
 type mqlK8sCronjob struct {
 	MqlRuntime *plugin.Runtime
@@ -17418,6 +17854,7 @@ type mqlK8sCronjob struct {
 	LastSuccessfulTime           plugin.TValue[*time.Time]
 	ActiveJobs                   plugin.TValue[[]any]
 	Jobs                         plugin.TValue[[]any]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sCronjob creates a new instance of this resource
@@ -17872,6 +18309,22 @@ func (c *mqlK8sCronjob) GetJobs() *plugin.TValue[[]any] {
 		}
 
 		return c.jobs()
+	})
+}
+
+func (c *mqlK8sCronjob) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.cronjob", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -18647,6 +19100,7 @@ type mqlK8sSecret struct {
 	IsUnused              plugin.TValue[bool]
 	HasExpiredCertificate plugin.TValue[bool]
 	CertificateExpiry     plugin.TValue[*time.Time]
+	Context               plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sSecret creates a new instance of this resource
@@ -18830,6 +19284,22 @@ func (c *mqlK8sSecret) GetCertificateExpiry() *plugin.TValue[*time.Time] {
 	})
 }
 
+func (c *mqlK8sSecret) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.secret", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sConfigmap for the k8s.configmap resource
 type mqlK8sConfigmap struct {
 	MqlRuntime *plugin.Runtime
@@ -18849,6 +19319,7 @@ type mqlK8sConfigmap struct {
 	Manifest        plugin.TValue[any]
 	Data            plugin.TValue[map[string]any]
 	UsedBy          plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sConfigmap creates a new instance of this resource
@@ -18986,6 +19457,22 @@ func (c *mqlK8sConfigmap) GetUsedBy() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sConfigmap) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.configmap", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sService for the k8s.service resource
 type mqlK8sService struct {
 	MqlRuntime *plugin.Runtime
@@ -19029,6 +19516,7 @@ type mqlK8sService struct {
 	ExternalEndpoints             plugin.TValue[[]any]
 	RoutesToPublicEndpoint        plugin.TValue[bool]
 	NetworkExposures              plugin.TValue[[]any]
+	Context                       plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sService creates a new instance of this resource
@@ -19329,6 +19817,22 @@ func (c *mqlK8sService) GetNetworkExposures() *plugin.TValue[[]any] {
 		}
 
 		return c.networkExposures()
+	})
+}
+
+func (c *mqlK8sService) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.service", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -19725,6 +20229,7 @@ type mqlK8sIngress struct {
 	LoadBalancerIngress plugin.TValue[[]any]
 	Pods                plugin.TValue[[]any]
 	NetworkExposures    plugin.TValue[[]any]
+	Context             plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sIngress creates a new instance of this resource
@@ -19922,6 +20427,22 @@ func (c *mqlK8sIngress) GetNetworkExposures() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sIngress) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.ingress", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sServiceaccount for the k8s.serviceaccount resource
 type mqlK8sServiceaccount struct {
 	MqlRuntime *plugin.Runtime
@@ -19948,6 +20469,7 @@ type mqlK8sServiceaccount struct {
 	CanEscalatePrivileges        plugin.TValue[bool]
 	CanReadSecrets               plugin.TValue[bool]
 	HasWildcardPermissions       plugin.TValue[bool]
+	Context                      plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sServiceaccount creates a new instance of this resource
@@ -20133,6 +20655,22 @@ func (c *mqlK8sServiceaccount) GetHasWildcardPermissions() *plugin.TValue[bool] 
 	})
 }
 
+func (c *mqlK8sServiceaccount) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.serviceaccount", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sRbacClusterrole for the k8s.rbac.clusterrole resource
 type mqlK8sRbacClusterrole struct {
 	MqlRuntime *plugin.Runtime
@@ -20157,6 +20695,7 @@ type mqlK8sRbacClusterrole struct {
 	GrantsClusterAdmin        plugin.TValue[bool]
 	AggregationRule           plugin.TValue[any]
 	BoundBy                   plugin.TValue[[]any]
+	Context                   plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sRbacClusterrole creates a new instance of this resource
@@ -20334,6 +20873,22 @@ func (c *mqlK8sRbacClusterrole) GetBoundBy() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sRbacClusterrole) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.clusterrole", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sRbacPolicyRule for the k8s.rbac.policyRule resource
 type mqlK8sRbacPolicyRule struct {
 	MqlRuntime *plugin.Runtime
@@ -20422,6 +20977,7 @@ type mqlK8sRbacClusterrolebinding struct {
 	AllowsPrivilegeEscalation plugin.TValue[bool]
 	CanReadSecrets            plugin.TValue[bool]
 	ClusterRole               plugin.TValue[*mqlK8sRbacClusterrole]
+	Context                   plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sRbacClusterrolebinding creates a new instance of this resource
@@ -20599,6 +21155,22 @@ func (c *mqlK8sRbacClusterrolebinding) GetClusterRole() *plugin.TValue[*mqlK8sRb
 	})
 }
 
+func (c *mqlK8sRbacClusterrolebinding) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.clusterrolebinding", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sRbacRole for the k8s.rbac.role resource
 type mqlK8sRbacRole struct {
 	MqlRuntime *plugin.Runtime
@@ -20623,6 +21195,7 @@ type mqlK8sRbacRole struct {
 	CanReadSecrets            plugin.TValue[bool]
 	GrantsClusterAdmin        plugin.TValue[bool]
 	BoundBy                   plugin.TValue[[]any]
+	Context                   plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sRbacRole creates a new instance of this resource
@@ -20800,6 +21373,22 @@ func (c *mqlK8sRbacRole) GetBoundBy() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sRbacRole) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.role", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sRbacRolebinding for the k8s.rbac.rolebinding resource
 type mqlK8sRbacRolebinding struct {
 	MqlRuntime *plugin.Runtime
@@ -20826,6 +21415,7 @@ type mqlK8sRbacRolebinding struct {
 	CanReadSecrets            plugin.TValue[bool]
 	Role                      plugin.TValue[*mqlK8sRbacRole]
 	ClusterRole               plugin.TValue[*mqlK8sRbacClusterrole]
+	Context                   plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sRbacRolebinding creates a new instance of this resource
@@ -21020,6 +21610,22 @@ func (c *mqlK8sRbacRolebinding) GetClusterRole() *plugin.TValue[*mqlK8sRbacClust
 		}
 
 		return c.clusterRole()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.rolebinding", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -21260,6 +21866,7 @@ type mqlK8sNetworkpolicy struct {
 	Ingress         plugin.TValue[[]any]
 	Egress          plugin.TValue[[]any]
 	Coverage        plugin.TValue[*mqlK8sNetworkPolicyCoverage]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sNetworkpolicy creates a new instance of this resource
@@ -21420,6 +22027,22 @@ func (c *mqlK8sNetworkpolicy) GetCoverage() *plugin.TValue[*mqlK8sNetworkPolicyC
 		}
 
 		return c.coverage()
+	})
+}
+
+func (c *mqlK8sNetworkpolicy) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.networkpolicy", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -21918,6 +22541,7 @@ type mqlK8sCustomresource struct {
 	Kind            plugin.TValue[string]
 	Created         plugin.TValue[*time.Time]
 	Manifest        plugin.TValue[any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sCustomresource creates a new instance of this resource
@@ -22035,6 +22659,22 @@ func (c *mqlK8sCustomresource) GetManifest() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlK8sCustomresource) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.customresource", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sPersistentvolume for the k8s.persistentvolume resource
 type mqlK8sPersistentvolume struct {
 	MqlRuntime *plugin.Runtime
@@ -22067,6 +22707,7 @@ type mqlK8sPersistentvolume struct {
 	Phase                         plugin.TValue[string]
 	Reason                        plugin.TValue[string]
 	Message                       plugin.TValue[string]
+	Context                       plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sPersistentvolume creates a new instance of this resource
@@ -22296,6 +22937,22 @@ func (c *mqlK8sPersistentvolume) GetMessage() *plugin.TValue[string] {
 	})
 }
 
+func (c *mqlK8sPersistentvolume) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.persistentvolume", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sStorageclass for the k8s.storageclass resource
 type mqlK8sStorageclass struct {
 	MqlRuntime *plugin.Runtime
@@ -22318,6 +22975,7 @@ type mqlK8sStorageclass struct {
 	AllowVolumeExpansion plugin.TValue[bool]
 	Parameters           plugin.TValue[map[string]any]
 	MountOptions         plugin.TValue[[]any]
+	Context              plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sStorageclass creates a new instance of this resource
@@ -22459,6 +23117,22 @@ func (c *mqlK8sStorageclass) GetMountOptions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sStorageclass) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.storageclass", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sPriorityclass for the k8s.priorityclass resource
 type mqlK8sPriorityclass struct {
 	MqlRuntime *plugin.Runtime
@@ -22479,6 +23153,7 @@ type mqlK8sPriorityclass struct {
 	GlobalDefault    plugin.TValue[bool]
 	PreemptionPolicy plugin.TValue[string]
 	Description      plugin.TValue[string]
+	Context          plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sPriorityclass creates a new instance of this resource
@@ -22608,6 +23283,22 @@ func (c *mqlK8sPriorityclass) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
 
+func (c *mqlK8sPriorityclass) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.priorityclass", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sHorizontalpodautoscaler for the k8s.horizontalpodautoscaler resource
 type mqlK8sHorizontalpodautoscaler struct {
 	MqlRuntime *plugin.Runtime
@@ -22643,6 +23334,7 @@ type mqlK8sHorizontalpodautoscaler struct {
 	DesiredReplicas        plugin.TValue[int64]
 	CurrentMetrics         plugin.TValue[[]any]
 	Conditions             plugin.TValue[[]any]
+	Context                plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sHorizontalpodautoscaler creates a new instance of this resource
@@ -22898,6 +23590,22 @@ func (c *mqlK8sHorizontalpodautoscaler) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sHorizontalpodautoscaler) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.horizontalpodautoscaler", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sResourcequota for the k8s.resourcequota resource
 type mqlK8sResourcequota struct {
 	MqlRuntime *plugin.Runtime
@@ -22921,6 +23629,7 @@ type mqlK8sResourcequota struct {
 	Used            plugin.TValue[map[string]any]
 	Scopes          plugin.TValue[[]any]
 	ScopeSelector   plugin.TValue[any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sResourcequota creates a new instance of this resource
@@ -23074,6 +23783,22 @@ func (c *mqlK8sResourcequota) GetScopeSelector() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlK8sResourcequota) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.resourcequota", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sLimitrange for the k8s.limitrange resource
 type mqlK8sLimitrange struct {
 	MqlRuntime *plugin.Runtime
@@ -23093,6 +23818,7 @@ type mqlK8sLimitrange struct {
 	Manifest        plugin.TValue[any]
 	Spec            plugin.TValue[any]
 	Limits          plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sLimitrange creates a new instance of this resource
@@ -23222,6 +23948,22 @@ func (c *mqlK8sLimitrange) GetLimits() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sLimitrange) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.limitrange", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sPersistentvolumeclaim for the k8s.persistentvolumeclaim resource
 type mqlK8sPersistentvolumeclaim struct {
 	MqlRuntime *plugin.Runtime
@@ -23255,6 +23997,7 @@ type mqlK8sPersistentvolumeclaim struct {
 	Capacity         plugin.TValue[map[string]any]
 	BoundAccessModes plugin.TValue[[]any]
 	Conditions       plugin.TValue[[]any]
+	Context          plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sPersistentvolumeclaim creates a new instance of this resource
@@ -23488,6 +24231,22 @@ func (c *mqlK8sPersistentvolumeclaim) GetConditions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sPersistentvolumeclaim) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.persistentvolumeclaim", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sEndpointslice for the k8s.endpointslice resource
 type mqlK8sEndpointslice struct {
 	MqlRuntime *plugin.Runtime
@@ -23510,6 +24269,7 @@ type mqlK8sEndpointslice struct {
 	Ports             plugin.TValue[[]any]
 	Service           plugin.TValue[*mqlK8sService]
 	ExternalAddresses plugin.TValue[[]any]
+	Context           plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sEndpointslice creates a new instance of this resource
@@ -23662,6 +24422,22 @@ func (c *mqlK8sEndpointslice) GetService() *plugin.TValue[*mqlK8sService] {
 func (c *mqlK8sEndpointslice) GetExternalAddresses() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ExternalAddresses, func() ([]any, error) {
 		return c.externalAddresses()
+	})
+}
+
+func (c *mqlK8sEndpointslice) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.endpointslice", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
 	})
 }
 
@@ -23879,6 +24655,7 @@ type mqlK8sAdmissionValidatingwebhookconfiguration struct {
 	Manifest        plugin.TValue[any]
 	Webhooks        plugin.TValue[[]any]
 	FailsOpen       plugin.TValue[bool]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sAdmissionValidatingwebhookconfiguration creates a new instance of this resource
@@ -24004,6 +24781,22 @@ func (c *mqlK8sAdmissionValidatingwebhookconfiguration) GetFailsOpen() *plugin.T
 	})
 }
 
+func (c *mqlK8sAdmissionValidatingwebhookconfiguration) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.admission.validatingwebhookconfiguration", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sApp for the k8s.app resource
 type mqlK8sApp struct {
 	MqlRuntime *plugin.Runtime
@@ -24093,6 +24886,7 @@ type mqlK8sGatewayclass struct {
 	Description     plugin.TValue[string]
 	ParametersRef   plugin.TValue[any]
 	Conditions      plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sGatewayclass creates a new instance of this resource
@@ -24222,6 +25016,22 @@ func (c *mqlK8sGatewayclass) GetConditions() *plugin.TValue[[]any] {
 	return &c.Conditions
 }
 
+func (c *mqlK8sGatewayclass) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.gatewayclass", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sGateway for the k8s.gateway resource
 type mqlK8sGateway struct {
 	MqlRuntime *plugin.Runtime
@@ -24249,6 +25059,7 @@ type mqlK8sGateway struct {
 	Conditions       plugin.TValue[[]any]
 	Pods             plugin.TValue[[]any]
 	NetworkExposures plugin.TValue[[]any]
+	Context          plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sGateway creates a new instance of this resource
@@ -24442,6 +25253,22 @@ func (c *mqlK8sGateway) GetNetworkExposures() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sGateway) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.gateway", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sHttproute for the k8s.httproute resource
 type mqlK8sHttproute struct {
 	MqlRuntime *plugin.Runtime
@@ -24463,6 +25290,7 @@ type mqlK8sHttproute struct {
 	Hostnames       plugin.TValue[[]any]
 	Rules           plugin.TValue[[]any]
 	ParentStatus    plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sHttproute creates a new instance of this resource
@@ -24596,6 +25424,22 @@ func (c *mqlK8sHttproute) GetParentStatus() *plugin.TValue[[]any] {
 	return &c.ParentStatus
 }
 
+func (c *mqlK8sHttproute) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.httproute", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sGrpcroute for the k8s.grpcroute resource
 type mqlK8sGrpcroute struct {
 	MqlRuntime *plugin.Runtime
@@ -24617,6 +25461,7 @@ type mqlK8sGrpcroute struct {
 	Hostnames       plugin.TValue[[]any]
 	Rules           plugin.TValue[[]any]
 	ParentStatus    plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sGrpcroute creates a new instance of this resource
@@ -24748,6 +25593,22 @@ func (c *mqlK8sGrpcroute) GetRules() *plugin.TValue[[]any] {
 
 func (c *mqlK8sGrpcroute) GetParentStatus() *plugin.TValue[[]any] {
 	return &c.ParentStatus
+}
+
+func (c *mqlK8sGrpcroute) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.grpcroute", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
 }
 
 // mqlK8sTlsroute for the k8s.tlsroute resource
@@ -25231,6 +26092,7 @@ type mqlK8sReferencegrant struct {
 	Manifest        plugin.TValue[any]
 	From            plugin.TValue[[]any]
 	To              plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sReferencegrant creates a new instance of this resource
@@ -25356,6 +26218,22 @@ func (c *mqlK8sReferencegrant) GetTo() *plugin.TValue[[]any] {
 	return &c.To
 }
 
+func (c *mqlK8sReferencegrant) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.referencegrant", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sAdmissionMutatingwebhookconfiguration for the k8s.admission.mutatingwebhookconfiguration resource
 type mqlK8sAdmissionMutatingwebhookconfiguration struct {
 	MqlRuntime *plugin.Runtime
@@ -25374,6 +26252,7 @@ type mqlK8sAdmissionMutatingwebhookconfiguration struct {
 	Manifest        plugin.TValue[any]
 	Webhooks        plugin.TValue[[]any]
 	FailsOpen       plugin.TValue[bool]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sAdmissionMutatingwebhookconfiguration creates a new instance of this resource
@@ -25499,6 +26378,22 @@ func (c *mqlK8sAdmissionMutatingwebhookconfiguration) GetFailsOpen() *plugin.TVa
 	})
 }
 
+func (c *mqlK8sAdmissionMutatingwebhookconfiguration) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.admission.mutatingwebhookconfiguration", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sAdmissionValidatingadmissionpolicy for the k8s.admission.validatingadmissionpolicy resource
 type mqlK8sAdmissionValidatingadmissionpolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -25523,6 +26418,7 @@ type mqlK8sAdmissionValidatingadmissionpolicy struct {
 	AuditAnnotations plugin.TValue[[]any]
 	ParamKind        plugin.TValue[any]
 	Bindings         plugin.TValue[[]any]
+	Context          plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sAdmissionValidatingadmissionpolicy creates a new instance of this resource
@@ -25692,6 +26588,22 @@ func (c *mqlK8sAdmissionValidatingadmissionpolicy) GetBindings() *plugin.TValue[
 	})
 }
 
+func (c *mqlK8sAdmissionValidatingadmissionpolicy) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.admission.validatingadmissionpolicy", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sAdmissionValidatingadmissionpolicybinding for the k8s.admission.validatingadmissionpolicybinding resource
 type mqlK8sAdmissionValidatingadmissionpolicybinding struct {
 	MqlRuntime *plugin.Runtime
@@ -25713,6 +26625,7 @@ type mqlK8sAdmissionValidatingadmissionpolicybinding struct {
 	ValidationActions plugin.TValue[[]any]
 	ParamRef          plugin.TValue[any]
 	MatchResources    plugin.TValue[any]
+	Context           plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sAdmissionValidatingadmissionpolicybinding creates a new instance of this resource
@@ -25862,6 +26775,22 @@ func (c *mqlK8sAdmissionValidatingadmissionpolicybinding) GetMatchResources() *p
 	})
 }
 
+func (c *mqlK8sAdmissionValidatingadmissionpolicybinding) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.admission.validatingadmissionpolicybinding", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sPoddisruptionbudget for the k8s.poddisruptionbudget resource
 type mqlK8sPoddisruptionbudget struct {
 	MqlRuntime *plugin.Runtime
@@ -25889,6 +26818,7 @@ type mqlK8sPoddisruptionbudget struct {
 	DisruptionsAllowed         plugin.TValue[int64]
 	ObservedGeneration         plugin.TValue[int64]
 	Conditions                 plugin.TValue[[]any]
+	Context                    plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sPoddisruptionbudget creates a new instance of this resource
@@ -26046,6 +26976,22 @@ func (c *mqlK8sPoddisruptionbudget) GetConditions() *plugin.TValue[[]any] {
 	return &c.Conditions
 }
 
+func (c *mqlK8sPoddisruptionbudget) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.poddisruptionbudget", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sLease for the k8s.lease resource
 type mqlK8sLease struct {
 	MqlRuntime *plugin.Runtime
@@ -26070,6 +27016,7 @@ type mqlK8sLease struct {
 	LeaseTransitions     plugin.TValue[int64]
 	Strategy             plugin.TValue[string]
 	PreferredHolder      plugin.TValue[string]
+	Context              plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sLease creates a new instance of this resource
@@ -26215,6 +27162,22 @@ func (c *mqlK8sLease) GetPreferredHolder() *plugin.TValue[string] {
 	return &c.PreferredHolder
 }
 
+func (c *mqlK8sLease) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.lease", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sCertificatesigningrequest for the k8s.certificatesigningrequest resource
 type mqlK8sCertificatesigningrequest struct {
 	MqlRuntime *plugin.Runtime
@@ -26240,6 +27203,7 @@ type mqlK8sCertificatesigningrequest struct {
 	Groups            plugin.TValue[[]any]
 	Certificate       plugin.TValue[string]
 	Conditions        plugin.TValue[[]any]
+	Context           plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sCertificatesigningrequest creates a new instance of this resource
@@ -26389,6 +27353,22 @@ func (c *mqlK8sCertificatesigningrequest) GetConditions() *plugin.TValue[[]any] 
 	return &c.Conditions
 }
 
+func (c *mqlK8sCertificatesigningrequest) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.certificatesigningrequest", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sApiservice for the k8s.apiservice resource
 type mqlK8sApiservice struct {
 	MqlRuntime *plugin.Runtime
@@ -26416,6 +27396,7 @@ type mqlK8sApiservice struct {
 	ServicePort           plugin.TValue[int64]
 	Service               plugin.TValue[*mqlK8sService]
 	Conditions            plugin.TValue[[]any]
+	Context               plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sApiservice creates a new instance of this resource
@@ -26585,6 +27566,22 @@ func (c *mqlK8sApiservice) GetConditions() *plugin.TValue[[]any] {
 	return &c.Conditions
 }
 
+func (c *mqlK8sApiservice) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.apiservice", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlK8sIngressclass for the k8s.ingressclass resource
 type mqlK8sIngressclass struct {
 	MqlRuntime *plugin.Runtime
@@ -26603,6 +27600,7 @@ type mqlK8sIngressclass struct {
 	Manifest        plugin.TValue[any]
 	Controller      plugin.TValue[string]
 	Parameters      plugin.TValue[any]
+	Context         plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sIngressclass creates a new instance of this resource
@@ -26722,6 +27720,22 @@ func (c *mqlK8sIngressclass) GetController() *plugin.TValue[string] {
 
 func (c *mqlK8sIngressclass) GetParameters() *plugin.TValue[any] {
 	return &c.Parameters
+}
+
+func (c *mqlK8sIngressclass) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.ingressclass", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
 }
 
 // mqlK8sOwnerReference for the k8s.ownerReference resource
@@ -26947,5 +27961,76 @@ func (c *mqlK8sAccessReview) GetAllowed() *plugin.TValue[bool] {
 func (c *mqlK8sAccessReview) GetReason() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Reason, func() (string, error) {
 		return c.reason()
+	})
+}
+
+// mqlK8sContext for the k8s.context resource
+type mqlK8sContext struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlK8sContextInternal it will be used here
+	Path    plugin.TValue[string]
+	Range   plugin.TValue[llx.Range]
+	Content plugin.TValue[string]
+}
+
+// createK8sContext creates a new instance of this resource
+func createK8sContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlK8sContext{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("k8s.context", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlK8sContext) MqlName() string {
+	return "k8s.context"
+}
+
+func (c *mqlK8sContext) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlK8sContext) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlK8sContext) GetRange() *plugin.TValue[llx.Range] {
+	return &c.Range
+}
+
+func (c *mqlK8sContext) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		vargPath := c.GetPath()
+		if vargPath.Error != nil {
+			return "", vargPath.Error
+		}
+
+		vargRange := c.GetRange()
+		if vargRange.Error != nil {
+			return "", vargRange.Error
+		}
+
+		return c.content(vargPath.Data, vargRange.Data)
 	})
 }

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -13,6 +13,7 @@ k8s.accessReview.subject 13.3.1
 k8s.accessReview.verb 13.3.1
 k8s.admission.mutatingwebhookconfiguration 13.0.16
 k8s.admission.mutatingwebhookconfiguration.annotations 13.0.16
+k8s.admission.mutatingwebhookconfiguration.context 13.6.1
 k8s.admission.mutatingwebhookconfiguration.created 13.0.16
 k8s.admission.mutatingwebhookconfiguration.failsOpen 13.3.1
 k8s.admission.mutatingwebhookconfiguration.id 13.0.16
@@ -29,6 +30,7 @@ k8s.admission.validatingadmissionpolicy 13.2.2
 k8s.admission.validatingadmissionpolicy.annotations 13.2.2
 k8s.admission.validatingadmissionpolicy.auditAnnotations 13.2.2
 k8s.admission.validatingadmissionpolicy.bindings 13.2.2
+k8s.admission.validatingadmissionpolicy.context 13.6.1
 k8s.admission.validatingadmissionpolicy.created 13.2.2
 k8s.admission.validatingadmissionpolicy.failurePolicy 13.2.2
 k8s.admission.validatingadmissionpolicy.id 13.2.2
@@ -47,6 +49,7 @@ k8s.admission.validatingadmissionpolicy.validations 13.2.2
 k8s.admission.validatingadmissionpolicy.variables 13.2.2
 k8s.admission.validatingadmissionpolicybinding 13.2.2
 k8s.admission.validatingadmissionpolicybinding.annotations 13.2.2
+k8s.admission.validatingadmissionpolicybinding.context 13.6.1
 k8s.admission.validatingadmissionpolicybinding.created 13.2.2
 k8s.admission.validatingadmissionpolicybinding.id 13.2.2
 k8s.admission.validatingadmissionpolicybinding.kind 13.2.2
@@ -64,6 +67,7 @@ k8s.admission.validatingadmissionpolicybinding.uid 13.2.2
 k8s.admission.validatingadmissionpolicybinding.validationActions 13.2.2
 k8s.admission.validatingwebhookconfiguration 11.1.63
 k8s.admission.validatingwebhookconfiguration.annotations 11.1.63
+k8s.admission.validatingwebhookconfiguration.context 13.6.1
 k8s.admission.validatingwebhookconfiguration.created 11.1.63
 k8s.admission.validatingwebhookconfiguration.failsOpen 13.3.1
 k8s.admission.validatingwebhookconfiguration.id 11.1.63
@@ -100,6 +104,7 @@ k8s.apiservice 13.0.16
 k8s.apiservice.annotations 13.0.16
 k8s.apiservice.caBundle 13.0.16
 k8s.apiservice.conditions 13.0.16
+k8s.apiservice.context 13.6.1
 k8s.apiservice.created 13.0.16
 k8s.apiservice.group 13.0.16
 k8s.apiservice.groupPriorityMinimum 13.0.16
@@ -132,6 +137,7 @@ k8s.certificatesigningrequest 13.0.16
 k8s.certificatesigningrequest.annotations 13.0.16
 k8s.certificatesigningrequest.certificate 13.0.16
 k8s.certificatesigningrequest.conditions 13.0.16
+k8s.certificatesigningrequest.context 13.6.1
 k8s.certificatesigningrequest.created 13.0.16
 k8s.certificatesigningrequest.expirationSeconds 13.0.16
 k8s.certificatesigningrequest.groups 13.0.16
@@ -153,6 +159,7 @@ k8s.clusterrolebindings 9.0.0
 k8s.clusterroles 9.0.0
 k8s.configmap 9.0.0
 k8s.configmap.annotations 9.0.0
+k8s.configmap.context 13.6.1
 k8s.configmap.created 9.0.0
 k8s.configmap.data 9.0.0
 k8s.configmap.id 9.0.0
@@ -214,6 +221,10 @@ k8s.containerStatus.resources 13.0.16
 k8s.containerStatus.restartCount 11.1.110
 k8s.containerStatus.started 13.0.16
 k8s.containerStatus.state 13.0.16
+k8s.context 13.6.1
+k8s.context.content 13.6.1
+k8s.context.path 13.6.1
+k8s.context.range 13.6.1
 k8s.cronjob 9.0.0
 k8s.cronjob.active 13.0.16
 k8s.cronjob.activeJobs 13.0.16
@@ -225,6 +236,7 @@ k8s.cronjob.concurrencyPolicy 13.0.16
 k8s.cronjob.consumedSecrets 13.3.1
 k8s.cronjob.containerImages 13.3.1
 k8s.cronjob.containers 9.0.0
+k8s.cronjob.context 13.6.1
 k8s.cronjob.created 9.0.0
 k8s.cronjob.dropsAllCapabilities 13.2.2
 k8s.cronjob.failedJobsHistoryLimit 13.0.16
@@ -280,6 +292,7 @@ k8s.cronjob.usesUnmaskedProcMount 13.4.1
 k8s.cronjobs 9.0.0
 k8s.customresource 9.0.0
 k8s.customresource.annotations 9.0.0
+k8s.customresource.context 13.6.1
 k8s.customresource.created 9.0.0
 k8s.customresource.id 9.0.0
 k8s.customresource.kind 9.0.0
@@ -302,6 +315,7 @@ k8s.daemonset.conditions 13.0.16
 k8s.daemonset.consumedSecrets 13.3.1
 k8s.daemonset.containerImages 13.3.1
 k8s.daemonset.containers 9.0.0
+k8s.daemonset.context 13.6.1
 k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
 k8s.daemonset.desiredNumberScheduled 13.0.16
@@ -370,6 +384,7 @@ k8s.deployment.conditions 13.0.16
 k8s.deployment.consumedSecrets 13.3.1
 k8s.deployment.containerImages 13.3.1
 k8s.deployment.containers 9.0.0
+k8s.deployment.context 13.6.1
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
 k8s.deployment.dropsAllCapabilities 13.2.2
@@ -458,6 +473,7 @@ k8s.endpointSlices 11.1.139
 k8s.endpointslice 11.1.139
 k8s.endpointslice.addressType 11.1.139
 k8s.endpointslice.annotations 11.1.139
+k8s.endpointslice.context 13.6.1
 k8s.endpointslice.created 11.1.139
 k8s.endpointslice.endpoints 11.1.139
 k8s.endpointslice.externalAddresses 13.4.1
@@ -506,6 +522,7 @@ k8s.gateway 13.0.16
 k8s.gateway.addresses 13.0.16
 k8s.gateway.annotations 13.0.16
 k8s.gateway.conditions 13.0.16
+k8s.gateway.context 13.6.1
 k8s.gateway.created 13.0.16
 k8s.gateway.gatewayClass 13.0.16
 k8s.gateway.gatewayClassName 13.0.16
@@ -529,6 +546,7 @@ k8s.gatewayClasses 13.0.16
 k8s.gatewayclass 13.0.16
 k8s.gatewayclass.annotations 13.0.16
 k8s.gatewayclass.conditions 13.0.16
+k8s.gatewayclass.context 13.6.1
 k8s.gatewayclass.controllerName 13.0.16
 k8s.gatewayclass.created 13.0.16
 k8s.gatewayclass.description 13.0.16
@@ -546,6 +564,7 @@ k8s.gateways 13.0.16
 k8s.grpcRoutes 13.0.16
 k8s.grpcroute 13.0.16
 k8s.grpcroute.annotations 13.0.16
+k8s.grpcroute.context 13.6.1
 k8s.grpcroute.created 13.0.16
 k8s.grpcroute.hostnames 13.0.16
 k8s.grpcroute.id 13.0.16
@@ -566,6 +585,7 @@ k8s.horizontalpodautoscaler 11.1.139
 k8s.horizontalpodautoscaler.annotations 11.1.139
 k8s.horizontalpodautoscaler.behavior 13.0.16
 k8s.horizontalpodautoscaler.conditions 13.0.16
+k8s.horizontalpodautoscaler.context 13.6.1
 k8s.horizontalpodautoscaler.created 11.1.139
 k8s.horizontalpodautoscaler.currentMetrics 13.0.16
 k8s.horizontalpodautoscaler.currentReplicas 13.0.16
@@ -596,6 +616,7 @@ k8s.horizontalpodautoscaler.uid 11.1.139
 k8s.httpRoutes 13.0.16
 k8s.httproute 13.0.16
 k8s.httproute.annotations 13.0.16
+k8s.httproute.context 13.6.1
 k8s.httproute.created 13.0.16
 k8s.httproute.hostnames 13.0.16
 k8s.httproute.id 13.0.16
@@ -613,6 +634,7 @@ k8s.httproute.rules 13.0.16
 k8s.httproute.uid 13.0.16
 k8s.ingress 9.0.0
 k8s.ingress.annotations 9.0.0
+k8s.ingress.context 13.6.1
 k8s.ingress.created 9.0.0
 k8s.ingress.id 9.0.0
 k8s.ingress.ingressClass 13.0.16
@@ -638,6 +660,7 @@ k8s.ingressbackend.resourceRef 9.0.0
 k8s.ingressbackend.service 9.0.0
 k8s.ingressclass 13.0.16
 k8s.ingressclass.annotations 13.0.16
+k8s.ingressclass.context 13.6.1
 k8s.ingressclass.controller 13.0.16
 k8s.ingressclass.created 13.0.16
 k8s.ingressclass.id 13.0.16
@@ -727,6 +750,7 @@ k8s.job.conditions 13.0.16
 k8s.job.consumedSecrets 13.3.1
 k8s.job.containerImages 13.3.1
 k8s.job.containers 9.0.0
+k8s.job.context 13.6.1
 k8s.job.created 9.0.0
 k8s.job.dropsAllCapabilities 13.2.2
 k8s.job.failed 13.0.16
@@ -787,6 +811,7 @@ k8s.jobs 9.0.0
 k8s.lease 13.0.16
 k8s.lease.acquireTime 13.0.16
 k8s.lease.annotations 13.0.16
+k8s.lease.context 13.6.1
 k8s.lease.created 13.0.16
 k8s.lease.holderIdentity 13.0.16
 k8s.lease.id 13.0.16
@@ -808,6 +833,7 @@ k8s.leases 13.0.16
 k8s.limitRanges 11.1.139
 k8s.limitrange 11.1.139
 k8s.limitrange.annotations 11.1.139
+k8s.limitrange.context 13.6.1
 k8s.limitrange.created 11.1.139
 k8s.limitrange.id 11.1.139
 k8s.limitrange.kind 11.1.139
@@ -914,6 +940,7 @@ k8s.networkPolicyCoverage.workloadRef 13.3.2
 k8s.networkPolicyCoverages 13.3.2
 k8s.networkpolicy 9.0.0
 k8s.networkpolicy.annotations 9.0.0
+k8s.networkpolicy.context 13.6.1
 k8s.networkpolicy.coverage 13.3.2
 k8s.networkpolicy.created 9.0.0
 k8s.networkpolicy.egress 13.0.16
@@ -939,6 +966,7 @@ k8s.node.architecture 13.0.16
 k8s.node.capacity 11.1.138
 k8s.node.conditions 11.1.138
 k8s.node.containerRuntimeVersion 13.0.16
+k8s.node.context 13.6.1
 k8s.node.created 11.1.42
 k8s.node.id 9.0.0
 k8s.node.images 13.0.16
@@ -994,6 +1022,7 @@ k8s.persistentvolume.capacity 13.0.16
 k8s.persistentvolume.claim 13.0.16
 k8s.persistentvolume.claimName 13.0.16
 k8s.persistentvolume.claimNamespace 13.0.16
+k8s.persistentvolume.context 13.6.1
 k8s.persistentvolume.created 11.1.139
 k8s.persistentvolume.id 11.1.139
 k8s.persistentvolume.kind 11.1.139
@@ -1021,6 +1050,7 @@ k8s.persistentvolumeclaim.annotations 11.1.139
 k8s.persistentvolumeclaim.boundAccessModes 13.0.16
 k8s.persistentvolumeclaim.capacity 13.0.16
 k8s.persistentvolumeclaim.conditions 13.0.16
+k8s.persistentvolumeclaim.context 13.6.1
 k8s.persistentvolumeclaim.created 11.1.139
 k8s.persistentvolumeclaim.dataSource 13.0.16
 k8s.persistentvolumeclaim.dataSourceRef 13.0.16
@@ -1057,6 +1087,7 @@ k8s.pod.consumedSecrets 13.3.1
 k8s.pod.containerImages 13.3.1
 k8s.pod.containerStatuses 11.1.110
 k8s.pod.containers 9.0.0
+k8s.pod.context 13.6.1
 k8s.pod.created 9.0.0
 k8s.pod.daemonSet 13.0.16
 k8s.pod.deployment 13.0.16
@@ -1149,6 +1180,7 @@ k8s.podDisruptionBudgets 13.0.16
 k8s.poddisruptionbudget 13.0.16
 k8s.poddisruptionbudget.annotations 13.0.16
 k8s.poddisruptionbudget.conditions 13.0.16
+k8s.poddisruptionbudget.context 13.6.1
 k8s.poddisruptionbudget.created 13.0.16
 k8s.poddisruptionbudget.currentHealthy 13.0.16
 k8s.poddisruptionbudget.desiredHealthy 13.0.16
@@ -1173,6 +1205,7 @@ k8s.pods 9.0.0
 k8s.priorityClasses 11.1.139
 k8s.priorityclass 11.1.139
 k8s.priorityclass.annotations 11.1.139
+k8s.priorityclass.context 13.6.1
 k8s.priorityclass.created 11.1.139
 k8s.priorityclass.description 11.1.139
 k8s.priorityclass.globalDefault 11.1.139
@@ -1193,6 +1226,7 @@ k8s.rbac.clusterrole.allowsPrivilegeEscalation 13.2.2
 k8s.rbac.clusterrole.annotations 9.0.0
 k8s.rbac.clusterrole.boundBy 13.0.16
 k8s.rbac.clusterrole.canReadSecrets 13.2.2
+k8s.rbac.clusterrole.context 13.6.1
 k8s.rbac.clusterrole.created 9.0.0
 k8s.rbac.clusterrole.grantsClusterAdmin 13.3.1
 k8s.rbac.clusterrole.hasWildcardRule 13.2.2
@@ -1212,6 +1246,7 @@ k8s.rbac.clusterrolebinding.allowsPrivilegeEscalation 13.3.1
 k8s.rbac.clusterrolebinding.annotations 9.0.0
 k8s.rbac.clusterrolebinding.canReadSecrets 13.3.1
 k8s.rbac.clusterrolebinding.clusterRole 13.0.16
+k8s.rbac.clusterrolebinding.context 13.6.1
 k8s.rbac.clusterrolebinding.created 9.0.0
 k8s.rbac.clusterrolebinding.grantsClusterAdmin 13.3.1
 k8s.rbac.clusterrolebinding.hasWildcardRule 13.3.1
@@ -1238,6 +1273,7 @@ k8s.rbac.role.allowsPrivilegeEscalation 13.2.2
 k8s.rbac.role.annotations 9.0.0
 k8s.rbac.role.boundBy 13.0.16
 k8s.rbac.role.canReadSecrets 13.2.2
+k8s.rbac.role.context 13.6.1
 k8s.rbac.role.created 9.0.0
 k8s.rbac.role.grantsClusterAdmin 13.3.1
 k8s.rbac.role.hasWildcardRule 13.2.2
@@ -1258,6 +1294,7 @@ k8s.rbac.rolebinding.allowsPrivilegeEscalation 13.3.1
 k8s.rbac.rolebinding.annotations 9.0.0
 k8s.rbac.rolebinding.canReadSecrets 13.3.1
 k8s.rbac.rolebinding.clusterRole 13.0.16
+k8s.rbac.rolebinding.context 13.6.1
 k8s.rbac.rolebinding.created 9.0.0
 k8s.rbac.rolebinding.grantsClusterAdmin 13.3.1
 k8s.rbac.rolebinding.hasWildcardRule 13.3.1
@@ -1297,6 +1334,7 @@ k8s.rbacSubjects 13.3.1
 k8s.referenceGrants 13.0.16
 k8s.referencegrant 13.0.16
 k8s.referencegrant.annotations 13.0.16
+k8s.referencegrant.context 13.6.1
 k8s.referencegrant.created 13.0.16
 k8s.referencegrant.from 13.0.16
 k8s.referencegrant.id 13.0.16
@@ -1320,6 +1358,7 @@ k8s.replicaset.conditions 13.0.16
 k8s.replicaset.consumedSecrets 13.3.1
 k8s.replicaset.containerImages 13.3.1
 k8s.replicaset.containers 9.0.0
+k8s.replicaset.context 13.6.1
 k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
 k8s.replicaset.dropsAllCapabilities 13.2.2
@@ -1375,6 +1414,7 @@ k8s.replicasets 9.0.0
 k8s.resourceQuotas 11.1.139
 k8s.resourcequota 11.1.139
 k8s.resourcequota.annotations 11.1.139
+k8s.resourcequota.context 13.6.1
 k8s.resourcequota.created 11.1.139
 k8s.resourcequota.hard 13.0.16
 k8s.resourcequota.id 11.1.139
@@ -1398,6 +1438,7 @@ k8s.secret 9.0.0
 k8s.secret.annotations 9.0.0
 k8s.secret.certificateExpiry 13.3.4
 k8s.secret.certificates 9.0.2
+k8s.secret.context 13.6.1
 k8s.secret.created 9.0.0
 k8s.secret.hasExpiredCertificate 13.3.4
 k8s.secret.id 9.0.0
@@ -1422,6 +1463,7 @@ k8s.service.allocateLoadBalancerNodePorts 13.0.16
 k8s.service.annotations 9.0.0
 k8s.service.clusterIP 13.0.16
 k8s.service.clusterIPs 13.0.16
+k8s.service.context 13.6.1
 k8s.service.created 9.0.0
 k8s.service.endpointSlices 13.0.16
 k8s.service.externalEndpoints 13.4.1
@@ -1462,6 +1504,7 @@ k8s.serviceaccount.automountServiceAccountToken 9.0.0
 k8s.serviceaccount.canEscalatePrivileges 13.3.1
 k8s.serviceaccount.canReadSecrets 13.3.1
 k8s.serviceaccount.clusterRoleBindings 13.3.1
+k8s.serviceaccount.context 13.6.1
 k8s.serviceaccount.created 9.0.0
 k8s.serviceaccount.hasWildcardPermissions 13.3.1
 k8s.serviceaccount.id 9.0.0
@@ -1491,6 +1534,7 @@ k8s.statefulset.conditions 13.0.16
 k8s.statefulset.consumedSecrets 13.3.1
 k8s.statefulset.containerImages 13.3.1
 k8s.statefulset.containers 9.0.0
+k8s.statefulset.context 13.6.1
 k8s.statefulset.created 9.0.0
 k8s.statefulset.currentReplicas 13.0.16
 k8s.statefulset.currentRevision 13.0.16
@@ -1556,6 +1600,7 @@ k8s.storageClasses 11.1.139
 k8s.storageclass 11.1.139
 k8s.storageclass.allowVolumeExpansion 11.1.139
 k8s.storageclass.annotations 11.1.139
+k8s.storageclass.context 13.6.1
 k8s.storageclass.created 11.1.139
 k8s.storageclass.id 11.1.139
 k8s.storageclass.kind 11.1.139


### PR DESCRIPTION
Exposes a `context` accessor on the 41 manifest-backed Kubernetes resources (deployment, pod, daemonset, statefulset, job, cronjob, replicaset, service, ingress, configmap, secret, RBAC roles/bindings, serviceaccount, networkpolicy, gateway/httproute/grpcroute, HPA, PDB, PV/PVC, and more), mirroring the `terraform.block` file context from #8703, the Dockerfile instructions from #8884, and CloudFormation from #8885.

Each resource surfaces the manifest path, the line range it spans, and the raw source text within that range, so a reviewer (and SARIF output) can be pointed at the exact lines a policy flagged. This is the highest-value IaC target for source locations — k8s manifests are the most common thing scanned.

## Example

```
mql run k8s manifest.yaml -c 'k8s.deployments { name context.range context.content }'
```

```
k8s.deployments: [
  0: {
    name: "web"
    context.range:   1-12
    context.content: " 1:  apiVersion: apps/v1
 2:  kind: Deployment
 ...
11:          - name: app
12:            image: nginx:latest
"
  }
]
```

## Scope

Only **manifest-file** scans carry source context. Live-cluster and admission connections have no source file, so the `context` field resolves to null there (the connection type gates it). Covers every resource that flows through the shared `k8sResourceToMql` funnel; the two admission-only funnel resources (`k8s.admissionrequest`, `k8s.userinfo`) are intentionally excluded.

## How it works

- New provider-specific `private k8s.context` resource (`path` / `range` / `content`) reading from the manifest bytes — k8s isn't backed by an os `file` resource, so it follows the terraform/cloudformation model rather than reusing `file.context`.
- The manifest connection now **retains the raw bytes** (previously dropped in the file case) in a dedicated `sourceRaw` field — kept separate from `manifestContent` so the stdin-vs-file platform-id hashing is unchanged (verified: the existing platform-id tests still pass).
- The apimachinery decoder discards positions, so a **supplementary `yaml.v3` pass** builds a per-resource position index keyed by object id (`kind:namespace:name`), handling multi-document manifests (`---`) and `kind: *List` wrappers. Synthesized CRDs (not in the source) simply get no context.
- Context is injected once in the shared `k8sResourceToMql` funnel, covering all 41 types. The field is set directly (the 41 resource types share no common concrete type), and populated at creation so the per-type resolvers are fallbacks.

## Notes / limitations

- Ranges are line-only (`yaml.v3` records start positions; the end line is derived from the deepest child node). SARIF handles line-only regions.
- Rendered/generated manifests (e.g. Helm output) are out of scope — this is for manifests that are real source files.

## Testing

- `go test ./...` passes for the provider (including the platform-id tests that guard asset identity).
- Verified interactively against a multi-document manifest that deployment and service report accurate, distinct line ranges and source snippets.