### PR TITLE
⭐ bicep: add file context to declarations

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -106,7 +106,7 @@ bicep.paramFile @defaults("path") {
 // @allowed values, and the full raw decorator list — used to flag
 // missing @secure on credential-shaped parameters or unbounded @allowed
 // sets.
-bicep.parameter @defaults("name type") {
+bicep.parameter @defaults("name type") @context("bicep.context") {
   // Parameter name
   name string
   // Type (string, int, bool, object, array, or user-defined)
@@ -157,7 +157,7 @@ bicep.parameter @defaults("name type") {
 // Examine the variable name, the raw value expression, and any
 // @description decorator — useful for tracking how derived values flow
 // into resource bodies.
-bicep.variable @defaults("name") {
+bicep.variable @defaults("name") @context("bicep.context") {
   // Variable name
   name string
   // Value expression (raw Bicep expression)
@@ -189,7 +189,7 @@ bicep.variable @defaults("name") {
 // existing-resource flag, conditional-deployment expression, parent /
 // dependsOn relationships, and decorators — the surface IaC policies
 // match against to enforce Azure resource-shape rules.
-bicep.resource @defaults("type symbolicName") {
+bicep.resource @defaults("type symbolicName") @context("bicep.context") {
   // Symbolic name in the Bicep file
   symbolicName string
   // Azure resource type (e.g., "Microsoft.Storage/storageAccounts")
@@ -290,7 +290,7 @@ bicep.resource @defaults("type symbolicName") {
 // reference (br: / ts: flags break the source out by kind), scope, the
 // parameter values passed in, conditional-deployment expression,
 // description and decorators — the unit of cross-file Bicep composition.
-bicep.module @defaults("name source") {
+bicep.module @defaults("name source") @context("bicep.context") {
   // Symbolic name
   name string
   // Module source path or registry reference
@@ -363,7 +363,7 @@ bicep.module @defaults("name source") {
 // Examine an `output` statement: name, type, value expression, and
 // @description — useful for spotting outputs that leak secrets or
 // expose resource IDs unintentionally.
-bicep.output @defaults("name type") {
+bicep.output @defaults("name type") @context("bicep.context") {
   // Output name
   name string
   // Output type
@@ -753,4 +753,19 @@ bicep.template.resource @defaults("type name") {
   linkedTemplate() bicep.template
   // Full manifest
   manifest dict
+}
+
+// Bicep declaration source context
+//
+// Source location and raw text of a declaration in a Bicep file: the file
+// path, the line range it spans, and the Bicep text within that range. Points
+// a reviewer at the exact source of a flagged resource, module, parameter,
+// variable, or output.
+private bicep.context @defaults("path range content") {
+  // Path of the Bicep file this declaration is in
+  path string
+  // Line range the declaration spans in the file
+  range range
+  // Bicep text within the range, shown as an excerpt
+  content(path, range) string
 }

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -34,6 +34,7 @@ const (
 	ResourceBicepTemplateVariable   string = "bicep.template.variable"
 	ResourceBicepTemplateOutput     string = "bicep.template.output"
 	ResourceBicepTemplateResource   string = "bicep.template.resource"
+	ResourceBicepContext            string = "bicep.context"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -115,6 +116,10 @@ func init() {
 		"bicep.template.resource": {
 			// to override args, implement: initBicepTemplateResource(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createBicepTemplateResource,
+		},
+		"bicep.context": {
+			// to override args, implement: initBicepContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createBicepContext,
 		},
 	}
 }
@@ -283,6 +288,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.parameter.decorators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepParameter).GetDecorators()).ToDataRes(types.Array(types.String))
 	},
+	"bicep.parameter.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepParameter).GetContext()).ToDataRes(types.Resource("bicep.context"))
+	},
 	"bicep.variable.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepVariable).GetName()).ToDataRes(types.String)
 	},
@@ -306,6 +314,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.variable.loopExpression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepVariable).GetLoopExpression()).ToDataRes(types.String)
+	},
+	"bicep.variable.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetContext()).ToDataRes(types.Resource("bicep.context"))
 	},
 	"bicep.resource.symbolicName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetSymbolicName()).ToDataRes(types.String)
@@ -376,6 +387,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.resource.loopExpression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepResource).GetLoopExpression()).ToDataRes(types.String)
 	},
+	"bicep.resource.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepResource).GetContext()).ToDataRes(types.Resource("bicep.context"))
+	},
 	"bicep.module.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetName()).ToDataRes(types.String)
 	},
@@ -427,6 +441,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.module.loopExpression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepModule).GetLoopExpression()).ToDataRes(types.String)
 	},
+	"bicep.module.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepModule).GetContext()).ToDataRes(types.Resource("bicep.context"))
+	},
 	"bicep.output.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetName()).ToDataRes(types.String)
 	},
@@ -456,6 +473,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.output.loopExpression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetLoopExpression()).ToDataRes(types.String)
+	},
+	"bicep.output.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetContext()).ToDataRes(types.Resource("bicep.context"))
 	},
 	"bicep.expression.kind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepExpression).GetKind()).ToDataRes(types.String)
@@ -664,6 +684,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.template.resource.manifest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetManifest()).ToDataRes(types.Dict)
 	},
+	"bicep.context.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepContext).GetPath()).ToDataRes(types.String)
+	},
+	"bicep.context.range": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepContext).GetRange()).ToDataRes(types.Range)
+	},
+	"bicep.context.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepContext).GetContent()).ToDataRes(types.String)
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -820,6 +849,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepParameter).Decorators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"bicep.parameter.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepParameter).Context, ok = plugin.RawToTValue[*mqlBicepContext](v.Value, v.Error)
+		return
+	},
 	"bicep.variable.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepVariable).__id, ok = v.Value.(string)
 		return
@@ -854,6 +887,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.variable.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepVariable).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.variable.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).Context, ok = plugin.RawToTValue[*mqlBicepContext](v.Value, v.Error)
 		return
 	},
 	"bicep.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -952,6 +989,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepResource).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.resource.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepResource).Context, ok = plugin.RawToTValue[*mqlBicepContext](v.Value, v.Error)
+		return
+	},
 	"bicep.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepModule).__id, ok = v.Value.(string)
 		return
@@ -1024,6 +1065,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepModule).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.module.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepModule).Context, ok = plugin.RawToTValue[*mqlBicepContext](v.Value, v.Error)
+		return
+	},
 	"bicep.output.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).__id, ok = v.Value.(string)
 		return
@@ -1066,6 +1111,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.output.loopExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).LoopExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.output.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).Context, ok = plugin.RawToTValue[*mqlBicepContext](v.Value, v.Error)
 		return
 	},
 	"bicep.expression.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1386,6 +1435,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.template.resource.manifest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepTemplateResource).Manifest, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"bicep.context.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepContext).__id, ok = v.Value.(string)
+		return
+	},
+	"bicep.context.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepContext).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.context.range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepContext).Range, ok = plugin.RawToTValue[llx.Range](v.Value, v.Error)
+		return
+	},
+	"bicep.context.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepContext).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -1800,6 +1865,7 @@ type mqlBicepParameter struct {
 	MinValue     plugin.TValue[int64]
 	MaxValue     plugin.TValue[int64]
 	Decorators   plugin.TValue[[]any]
+	Context      plugin.TValue[*mqlBicepContext]
 }
 
 // createBicepParameter creates a new instance of this resource
@@ -1894,6 +1960,22 @@ func (c *mqlBicepParameter) GetDecorators() *plugin.TValue[[]any] {
 	return &c.Decorators
 }
 
+func (c *mqlBicepParameter) GetContext() *plugin.TValue[*mqlBicepContext] {
+	return plugin.GetOrCompute[*mqlBicepContext](&c.Context, func() (*mqlBicepContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.parameter", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlBicepVariable for the bicep.variable resource
 type mqlBicepVariable struct {
 	MqlRuntime *plugin.Runtime
@@ -1907,6 +1989,7 @@ type mqlBicepVariable struct {
 	LoopIterator   plugin.TValue[string]
 	LoopIndexVar   plugin.TValue[string]
 	LoopExpression plugin.TValue[string]
+	Context        plugin.TValue[*mqlBicepContext]
 }
 
 // createBicepVariable creates a new instance of this resource
@@ -1985,6 +2068,22 @@ func (c *mqlBicepVariable) GetLoopExpression() *plugin.TValue[string] {
 	return &c.LoopExpression
 }
 
+func (c *mqlBicepVariable) GetContext() *plugin.TValue[*mqlBicepContext] {
+	return plugin.GetOrCompute[*mqlBicepContext](&c.Context, func() (*mqlBicepContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.variable", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlBicepResource for the bicep.resource resource
 type mqlBicepResource struct {
 	MqlRuntime *plugin.Runtime
@@ -2013,6 +2112,7 @@ type mqlBicepResource struct {
 	LoopIterator        plugin.TValue[string]
 	LoopIndexVar        plugin.TValue[string]
 	LoopExpression      plugin.TValue[string]
+	Context             plugin.TValue[*mqlBicepContext]
 }
 
 // createBicepResource creates a new instance of this resource
@@ -2199,6 +2299,22 @@ func (c *mqlBicepResource) GetLoopExpression() *plugin.TValue[string] {
 	return &c.LoopExpression
 }
 
+func (c *mqlBicepResource) GetContext() *plugin.TValue[*mqlBicepContext] {
+	return plugin.GetOrCompute[*mqlBicepContext](&c.Context, func() (*mqlBicepContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.resource", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlBicepModule for the bicep.module resource
 type mqlBicepModule struct {
 	MqlRuntime *plugin.Runtime
@@ -2221,6 +2337,7 @@ type mqlBicepModule struct {
 	LoopIterator     plugin.TValue[string]
 	LoopIndexVar     plugin.TValue[string]
 	LoopExpression   plugin.TValue[string]
+	Context          plugin.TValue[*mqlBicepContext]
 }
 
 // createBicepModule creates a new instance of this resource
@@ -2371,6 +2488,22 @@ func (c *mqlBicepModule) GetLoopExpression() *plugin.TValue[string] {
 	return &c.LoopExpression
 }
 
+func (c *mqlBicepModule) GetContext() *plugin.TValue[*mqlBicepContext] {
+	return plugin.GetOrCompute[*mqlBicepContext](&c.Context, func() (*mqlBicepContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.module", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
 // mqlBicepOutput for the bicep.output resource
 type mqlBicepOutput struct {
 	MqlRuntime *plugin.Runtime
@@ -2386,6 +2519,7 @@ type mqlBicepOutput struct {
 	LoopIterator   plugin.TValue[string]
 	LoopIndexVar   plugin.TValue[string]
 	LoopExpression plugin.TValue[string]
+	Context        plugin.TValue[*mqlBicepContext]
 }
 
 // createBicepOutput creates a new instance of this resource
@@ -2482,6 +2616,22 @@ func (c *mqlBicepOutput) GetLoopIndexVar() *plugin.TValue[string] {
 
 func (c *mqlBicepOutput) GetLoopExpression() *plugin.TValue[string] {
 	return &c.LoopExpression
+}
+
+func (c *mqlBicepOutput) GetContext() *plugin.TValue[*mqlBicepContext] {
+	return plugin.GetOrCompute[*mqlBicepContext](&c.Context, func() (*mqlBicepContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.output", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepContext), nil
+			}
+		}
+
+		return c.context()
+	})
 }
 
 // mqlBicepExpression for the bicep.expression resource
@@ -3471,4 +3621,75 @@ func (c *mqlBicepTemplateResource) GetLinkedTemplate() *plugin.TValue[*mqlBicepT
 
 func (c *mqlBicepTemplateResource) GetManifest() *plugin.TValue[any] {
 	return &c.Manifest
+}
+
+// mqlBicepContext for the bicep.context resource
+type mqlBicepContext struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlBicepContextInternal it will be used here
+	Path    plugin.TValue[string]
+	Range   plugin.TValue[llx.Range]
+	Content plugin.TValue[string]
+}
+
+// createBicepContext creates a new instance of this resource
+func createBicepContext(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlBicepContext{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("bicep.context", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlBicepContext) MqlName() string {
+	return "bicep.context"
+}
+
+func (c *mqlBicepContext) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlBicepContext) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlBicepContext) GetRange() *plugin.TValue[llx.Range] {
+	return &c.Range
+}
+
+func (c *mqlBicepContext) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		vargPath := c.GetPath()
+		if vargPath.Error != nil {
+			return "", vargPath.Error
+		}
+
+		vargRange := c.GetRange()
+		if vargRange.Error != nil {
+			return "", vargRange.Error
+		}
+
+		return c.content(vargPath.Data, vargRange.Data)
+	})
 }

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 bicep 13.0.0
+bicep.context 13.3.6
+bicep.context.content 13.3.6
+bicep.context.path 13.3.6
+bicep.context.range 13.3.6
 bicep.expression 13.1.2
 bicep.expression.args 13.1.2
 bicep.expression.functionName 13.1.2
@@ -48,6 +52,7 @@ bicep.import.wildcard 13.1.2
 bicep.module 13.0.0
 bicep.module.condition 13.0.0
 bicep.module.conditionTree 13.1.2
+bicep.module.context 13.3.6
 bicep.module.decorators 13.0.1
 bicep.module.description 13.0.1
 bicep.module.isLoop 13.1.2
@@ -64,6 +69,7 @@ bicep.module.scopeTree 13.1.2
 bicep.module.source 13.0.0
 bicep.module.target 13.1.2
 bicep.output 13.0.0
+bicep.output.context 13.3.6
 bicep.output.description 13.0.0
 bicep.output.expression 13.0.0
 bicep.output.expressionTree 13.1.2
@@ -82,6 +88,7 @@ bicep.paramFile.using 13.1.2
 bicep.paramFiles 13.1.2
 bicep.parameter 13.0.0
 bicep.parameter.allowed 13.0.0
+bicep.parameter.context 13.3.6
 bicep.parameter.decorators 13.0.0
 bicep.parameter.defaultValue 13.0.0
 bicep.parameter.description 13.0.0
@@ -101,6 +108,7 @@ bicep.resource.apiVersion 13.0.0
 bicep.resource.body 13.2.2
 bicep.resource.condition 13.0.0
 bicep.resource.conditionTree 13.1.2
+bicep.resource.context 13.3.6
 bicep.resource.decorators 13.0.0
 bicep.resource.dependsOn 13.0.0
 bicep.resource.existing 13.0.0
@@ -170,6 +178,7 @@ bicep.type.property.name 13.1.2
 bicep.type.property.type 13.1.2
 bicep.type.unionMembers 13.1.2
 bicep.variable 13.0.0
+bicep.variable.context 13.3.6
 bicep.variable.description 13.0.0
 bicep.variable.expression 13.0.0
 bicep.variable.expressionTree 13.1.2

--- a/providers/bicep/resources/context.go
+++ b/providers/bicep/resources/context.go
@@ -82,23 +82,30 @@ func (r *mqlBicepContext) content(path string, rnge llx.Range) (string, error) {
 
 // context is populated at creation for each declaration, so these fallback
 // resolvers only run if a resource was built without one (e.g. a nested
-// resource, whose source position is not tracked).
+// resource, whose source position is not tracked). Mark the field null rather
+// than erroring so a query touching .context resolves to null instead of
+// failing.
 func (x *mqlBicepParameter) context() (*mqlBicepContext, error) {
-	return nil, errors.New("context was not provided for bicep.parameter")
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlBicepVariable) context() (*mqlBicepContext, error) {
-	return nil, errors.New("context was not provided for bicep.variable")
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlBicepResource) context() (*mqlBicepContext, error) {
-	return nil, errors.New("context was not provided for bicep.resource")
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlBicepModule) context() (*mqlBicepContext, error) {
-	return nil, errors.New("context was not provided for bicep.module")
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (x *mqlBicepOutput) context() (*mqlBicepContext, error) {
-	return nil, errors.New("context was not provided for bicep.output")
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }

--- a/providers/bicep/resources/context.go
+++ b/providers/bicep/resources/context.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/bicep/connection"
+)
+
+// bicepFileContent returns the raw text of the Bicep file at path, using the
+// files already loaded by the connection. It never reads from disk, so a
+// declaration can only ever reference the source it was parsed from.
+func bicepFileContent(runtime *plugin.Runtime, path string) (string, bool) {
+	conn, ok := runtime.Connection.(*connection.BicepConnection)
+	if !ok {
+		return "", false
+	}
+	for _, f := range conn.BicepFiles() {
+		if f.Path == path {
+			return f.Content, true
+		}
+	}
+	return "", false
+}
+
+// newBicepContext builds a bicep.context spanning [startLine, endLine] in the
+// file at path. It returns nil when no position is available (startLine <= 0),
+// e.g. for nested resources re-parsed from a parent's body.
+func newBicepContext(runtime *plugin.Runtime, path string, startLine, endLine int) (*mqlBicepContext, error) {
+	if startLine <= 0 {
+		return nil, nil
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+	rnge := llx.NewRange().AddLineRange(uint32(startLine), uint32(endLine))
+
+	content := ""
+	if src, ok := bicepFileContent(runtime, path); ok {
+		content = rnge.ExtractString(src, llx.DefaultExtractConfig)
+	}
+
+	cobj, err := CreateResource(runtime, "bicep.context", map[string]*llx.RawData{
+		"path":    llx.StringData(path),
+		"range":   llx.RangeData(rnge),
+		"content": llx.StringData(content),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cobj.(*mqlBicepContext), nil
+}
+
+// contextArg adds a built context to a resource's creation args when non-nil.
+func contextArg(args map[string]*llx.RawData, ctx *mqlBicepContext) {
+	if ctx != nil {
+		args["context"] = llx.ResourceData(ctx, "bicep.context")
+	}
+}
+
+func (r *mqlBicepContext) id() (string, error) {
+	if r.Path.Data == "" {
+		return "", errors.New("need path to exist for bicep.context ID")
+	}
+	return r.Path.Data + ":" + r.Range.Data.String(), nil
+}
+
+func (r *mqlBicepContext) content(path string, rnge llx.Range) (string, error) {
+	if path == "" {
+		return "", errors.New("no path information for bicep.context")
+	}
+	src, ok := bicepFileContent(r.MqlRuntime, path)
+	if !ok {
+		return "", errors.New("missing bicep file content for '" + path + "'")
+	}
+	return rnge.ExtractString(src, llx.DefaultExtractConfig), nil
+}
+
+// context is populated at creation for each declaration, so these fallback
+// resolvers only run if a resource was built without one (e.g. a nested
+// resource, whose source position is not tracked).
+func (x *mqlBicepParameter) context() (*mqlBicepContext, error) {
+	return nil, errors.New("context was not provided for bicep.parameter")
+}
+
+func (x *mqlBicepVariable) context() (*mqlBicepContext, error) {
+	return nil, errors.New("context was not provided for bicep.variable")
+}
+
+func (x *mqlBicepResource) context() (*mqlBicepContext, error) {
+	return nil, errors.New("context was not provided for bicep.resource")
+}
+
+func (x *mqlBicepModule) context() (*mqlBicepContext, error) {
+	return nil, errors.New("context was not provided for bicep.module")
+}
+
+func (x *mqlBicepOutput) context() (*mqlBicepContext, error) {
+	return nil, errors.New("context was not provided for bicep.output")
+}

--- a/providers/bicep/resources/ergonomics_test.go
+++ b/providers/bicep/resources/ergonomics_test.go
@@ -96,7 +96,7 @@ resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
 	resolver := newSymbolResolver("inline.bicep", parsed)
 	runtime := testRuntime()
 
-	pricing, err := newMqlBicepResource(runtime, "bicep.resource:inline:pricing", findResource(parsed, "pricing"), resolver)
+	pricing, err := newMqlBicepResource(runtime, "bicep.resource:inline:pricing", findResource(parsed, "pricing"), resolver, nil)
 	require.NoError(t, err)
 	// a literal name has its surrounding quotes stripped, so `name == "VirtualMachines"` matches
 	assert.Equal(t, "VirtualMachines", pricing.Name.Data)
@@ -105,7 +105,7 @@ resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
 	require.NoError(t, err)
 	assert.Equal(t, exprKindLiteral, nt.node.kind)
 
-	sa, err := newMqlBicepResource(runtime, "bicep.resource:inline:sa", findResource(parsed, "sa"), resolver)
+	sa, err := newMqlBicepResource(runtime, "bicep.resource:inline:sa", findResource(parsed, "sa"), resolver, nil)
 	require.NoError(t, err)
 	// an expression-valued name is left untouched
 	assert.Equal(t, "storageName", sa.Name.Data)

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -28,7 +28,11 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 		allowed := sliceToAny(p.allowed)
 		decorators := sliceToAny(p.decorators)
 
-		res, err := CreateResource(runtime, "bicep.parameter", map[string]*llx.RawData{
+		ctx, err := newBicepContext(runtime, filePath, p.startLine, p.endLine)
+		if err != nil {
+			return nil, err
+		}
+		args := map[string]*llx.RawData{
 			"__id":         llx.StringData("bicep.parameter:" + filePath + ":" + p.name),
 			"name":         llx.StringData(p.name),
 			"type":         llx.StringData(p.typ),
@@ -41,7 +45,9 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 			"minValue":     llx.IntDataPtr(p.minValue),
 			"maxValue":     llx.IntDataPtr(p.maxValue),
 			"decorators":   llx.ArrayData(decorators, types.String),
-		})
+		}
+		contextArg(args, ctx)
+		res, err := CreateResource(runtime, "bicep.parameter", args)
 		if err != nil {
 			return nil, err
 		}
@@ -76,6 +82,10 @@ type mqlBicepVariableInternal struct {
 func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedVariable, resolver *symbolResolver) ([]any, error) {
 	var mqlVars []any
 	for _, v := range vars {
+		ctx, err := newBicepContext(runtime, filePath, v.startLine, v.endLine)
+		if err != nil {
+			return nil, err
+		}
 		args := map[string]*llx.RawData{
 			"__id":        llx.StringData("bicep.variable:" + filePath + ":" + v.name),
 			"name":        llx.StringData(v.name),
@@ -83,6 +93,7 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 			"description": llx.StringData(v.description),
 		}
 		addLoopArgs(args, v.loop)
+		contextArg(args, ctx)
 		res, err := CreateResource(runtime, "bicep.variable", args)
 		if err != nil {
 			return nil, err
@@ -118,7 +129,11 @@ type mqlBicepResourceInternal struct {
 func createMqlResources(runtime *plugin.Runtime, filePath string, resources []parsedResource, resolver *symbolResolver) ([]any, error) {
 	var mqlResources []any
 	for _, r := range resources {
-		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r, resolver)
+		ctx, err := newBicepContext(runtime, filePath, r.startLine, r.endLine)
+		if err != nil {
+			return nil, err
+		}
+		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r, resolver, ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +165,7 @@ func resourceBodyInner(body string) string {
 // parent-qualified `<parentId>/<childSymbolicName>`. The parsed nested
 // declarations are cached on the Internal struct for the lazy `resources()`
 // accessor to materialize, recursively.
-func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, resolver *symbolResolver) (*mqlBicepResource, error) {
+func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, resolver *symbolResolver, ctx *mqlBicepContext) (*mqlBicepResource, error) {
 	dependsOn := sliceToAny(r.dependsOn)
 	decorators := sliceToAny(r.decorators)
 
@@ -209,6 +224,7 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 		args["tags"] = llx.MapData(tags, types.String)
 	}
 	addLoopArgs(args, r.loop)
+	contextArg(args, ctx)
 
 	res, err := CreateResource(runtime, "bicep.resource", args)
 	if err != nil {
@@ -230,7 +246,9 @@ func (r *mqlBicepResource) resources() ([]any, error) {
 	out := make([]any, 0, len(r.nested))
 	for _, child := range r.nested {
 		childID := r.__id + "/" + child.symbolicName
-		mqlChild, err := newMqlBicepResource(r.MqlRuntime, childID, child, r.resolver)
+		// Nested resources are re-parsed from the parent body without absolute
+		// line offsets, so they carry no source context.
+		mqlChild, err := newMqlBicepResource(r.MqlRuntime, childID, child, r.resolver, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -269,6 +287,10 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 
 		decorators := sliceToAny(m.decorators)
 
+		ctx, err := newBicepContext(runtime, filePath, m.startLine, m.endLine)
+		if err != nil {
+			return nil, err
+		}
 		args := map[string]*llx.RawData{
 			"__id":           llx.StringData("bicep.module:" + filePath + ":" + m.name),
 			"name":           llx.StringData(m.name),
@@ -282,6 +304,7 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 			"decorators":     llx.ArrayData(decorators, types.String),
 		}
 		addLoopArgs(args, m.loop)
+		contextArg(args, ctx)
 		res, err := CreateResource(runtime, "bicep.module", args)
 		if err != nil {
 			return nil, err
@@ -671,6 +694,10 @@ type mqlBicepOutputInternal struct {
 func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput, resolver *symbolResolver) ([]any, error) {
 	var mqlOutputs []any
 	for _, o := range outputs {
+		ctx, err := newBicepContext(runtime, filePath, o.startLine, o.endLine)
+		if err != nil {
+			return nil, err
+		}
 		args := map[string]*llx.RawData{
 			"__id":        llx.StringData("bicep.output:" + filePath + ":" + o.name),
 			"name":        llx.StringData(o.name),
@@ -679,6 +706,7 @@ func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsed
 			"description": llx.StringData(o.description),
 		}
 		addLoopArgs(args, o.loop)
+		contextArg(args, ctx)
 		res, err := CreateResource(runtime, "bicep.output", args)
 		if err != nil {
 			return nil, err

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -35,6 +35,8 @@ type parsedParameter struct {
 	minValue     *int64
 	maxValue     *int64
 	decorators   []string
+	startLine    int
+	endLine      int
 }
 
 type parsedVariable struct {
@@ -42,6 +44,8 @@ type parsedVariable struct {
 	expression  string
 	description string
 	loop        loopInfo
+	startLine   int
+	endLine     int
 }
 
 type parsedResource struct {
@@ -60,6 +64,8 @@ type parsedResource struct {
 	decorators   []string
 	loop         loopInfo
 	nested       []parsedResource
+	startLine    int
+	endLine      int
 }
 
 type parsedModule struct {
@@ -73,6 +79,8 @@ type parsedModule struct {
 	isTemplateSpec bool
 	decorators     []string
 	loop           loopInfo
+	startLine      int
+	endLine        int
 }
 
 type parsedOutput struct {
@@ -81,6 +89,8 @@ type parsedOutput struct {
 	expression  string
 	description string
 	loop        loopInfo
+	startLine   int
+	endLine     int
 }
 
 // loopInfo captures a Bicep `for`-loop on a declaration. Bicep iterates
@@ -249,18 +259,29 @@ func parseBicep(content string) *parsedBicepFile {
 		stmtLines := strings.Split(stmt.text, "\n")
 		firstLine := strings.TrimSpace(stmtLines[0])
 
+		// startLine/endLine bound the statement's source span (1-based); the
+		// tokenizer records the start and stmt.text carries every line, so the
+		// end is the start plus the additional lines.
+		startLine := stmt.startLine
+		endLine := stmt.startLine + len(stmtLines) - 1
+
 		switch stmt.keyword {
 		case "param":
-			result.parameters = append(result.parameters, parseParameter(firstLine, stmt.decorators))
+			p := parseParameter(firstLine, stmt.decorators)
+			p.startLine, p.endLine = startLine, endLine
+			result.parameters = append(result.parameters, p)
 		case "var":
 			v, _ := parseVariableDecl(stmtLines, 0, stmt.decorators)
+			v.startLine, v.endLine = startLine, endLine
 			result.variables = append(result.variables, v)
 		case "resource":
 			if res, _ := parseResourceDecl(stmtLines, 0, stmt.decorators); res != nil {
+				res.startLine, res.endLine = startLine, endLine
 				result.resources = append(result.resources, *res)
 			}
 		case "module":
 			if mod, _ := parseModuleDecl(stmtLines, 0, stmt.decorators); mod != nil {
+				mod.startLine, mod.endLine = startLine, endLine
 				result.modules = append(result.modules, *mod)
 			}
 		case "output":
@@ -271,7 +292,9 @@ func parseBicep(content string) *parsedBicepFile {
 			if len(stmtLines) > 1 {
 				outLine = strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
 			}
-			result.outputs = append(result.outputs, parseOutput(outLine, stmt.decorators))
+			o := parseOutput(outLine, stmt.decorators)
+			o.startLine, o.endLine = startLine, endLine
+			result.outputs = append(result.outputs, o)
 		case "type":
 			if t, ok := parseTypeDecl(stmt.text, stmt.decorators); ok {
 				result.types = append(result.types, t)

--- a/providers/bicep/resources/propexpr_test.go
+++ b/providers/bicep/resources/propexpr_test.go
@@ -35,7 +35,7 @@ func TestPropertyExpressions(t *testing.T) {
 	saResource := findResource(parsed, "sa")
 	require.Equal(t, "sa", saResource.symbolicName)
 
-	sa, err := newMqlBicepResource(runtime, "bicep.resource:testdata/propexpr.bicep:sa", saResource, resolver)
+	sa, err := newMqlBicepResource(runtime, "bicep.resource:testdata/propexpr.bicep:sa", saResource, resolver, nil)
 	require.NoError(t, err)
 
 	list, err := sa.propertyExpressions()

--- a/providers/bicep/resources/resolver.go
+++ b/providers/bicep/resources/resolver.go
@@ -139,7 +139,11 @@ func (r *symbolResolver) resource(runtime *plugin.Runtime, target string) (*mqlB
 	if !ok {
 		return nil, nil
 	}
-	return newMqlBicepResource(runtime, "bicep.resource:"+r.filePath+":"+res.symbolicName, res, r)
+	ctx, err := newBicepContext(runtime, r.filePath, res.startLine, res.endLine)
+	if err != nil {
+		return nil, err
+	}
+	return newMqlBicepResource(runtime, "bicep.resource:"+r.filePath+":"+res.symbolicName, res, r, ctx)
 }
 
 // module builds (or returns the cached) bicep.module the target names, or nil


### PR DESCRIPTION
Exposes a `context` accessor on `bicep.resource`, `bicep.module`, `bicep.parameter`, `bicep.variable`, and `bicep.output`, mirroring the `terraform.block` file context from #8703 and CloudFormation from #8885. Each surfaces the Bicep file path, the line range the declaration spans, and the raw source text within that range, so a reviewer (and SARIF output) can be pointed at the exact lines a policy flagged.

## Example

```
mql run bicep main.bicep -c 'bicep.files.first.resources { symbolicName context.range context.content }'
```

```
resources: [
  0: {
    symbolicName: "sa"
    context.range:   3-9
    context.content: "3:  resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
4:    name: storageName
 ...
8:    }
9:  }
"
  }
]
```

## What changed

- New `private bicep.context` resource (`path` / `range` / `content`), with `@context("bicep.context")` on the five declaration resources.
- The tokenizer already records a per-statement start line; this threads that (plus a derived end line, from the statement's line count) through the parsed structs (`parsedParameter`/`parsedVariable`/`parsedResource`/`parsedModule`/`parsedOutput`) into each declaration at creation.
- `content` is read from the connection's already-loaded Bicep file map (`conn.BicepFiles()`), never from disk — consistent with the existing `resolveScannedBicepFile` safety note.

## Why a provider-specific context resource (not `file.context`)

Bicep is standalone with no os `file` backing and can load files in-memory, so it follows terraform's model: a small provider-owned context resource reading source by path from the connection.

## Notes / limitations

- Ranges are line-only (the tokenizer is line-oriented; no columns). SARIF handles line-only regions.
- Nested resources (`resource` declared inside another resource's body) are re-parsed from the parent body without absolute line offsets, so they intentionally carry no context. Top-level resources, modules, parameters, variables, and outputs all do.
- The compiled ARM view (`bicep.template.*`) is out of scope — it has no source positions.

## Testing

- `go test ./...` passes for the provider.
- Verified interactively that a resource (lines 3-9), parameter (line 1), and output (line 11) all report accurate ranges and source snippets.