### PR TITLE
🎉 os-13.31.0, cloudformation-13.2.0, bicep-13.4.0

### DIFF
--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.3.5",
+	Version:         "13.4.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.1.7",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.30.1",
+	Version: "13.31.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Minor release bumping the `os`, `cloudformation`, and `bicep` providers.

| Provider | Old | New |
|---|---|---|
| os | 13.30.1 | 13.31.0 |
| cloudformation | 13.1.7 | 13.2.0 |
| bicep | 13.3.5 | 13.4.0 |

Version bumps generated via `providers-sdk/v1/util/version`.