### PR TITLE
⭐ gitlab: expose protected-branch push/merge/unprotect access levels

### DIFF
--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -741,6 +741,32 @@ private gitlab.project.protectedBranch @defaults("name allowForcePush") {
   defaultBranch bool
   // Whether code owner approval is required
   codeOwnerApproval bool
+  // Access levels permitted to push directly to the branch
+  pushAccessLevels []gitlab.protectedBranch.accessLevel
+  // Access levels permitted to merge into the branch
+  mergeAccessLevels []gitlab.protectedBranch.accessLevel
+  // Access levels permitted to remove protection from the branch
+  unprotectAccessLevels []gitlab.protectedBranch.accessLevel
+}
+
+// GitLab protected-branch access level
+//
+// A single access grant on a protected branch, describing who may perform the
+// push, merge, or unprotect action. Each entry grants access either to a role
+// (via `accessLevel`), a specific `user`, a specific `group`, or a deploy key
+// (via `deployKeyId`). Read these from a protected branch's `pushAccessLevels`,
+// `mergeAccessLevels`, or `unprotectAccessLevels`.
+private gitlab.protectedBranch.accessLevel @defaults("accessLevel accessLevelDescription") {
+  // Numeric access level (0 No access, 30 Developer, 40 Maintainer, 60 Admin)
+  accessLevel int
+  // Human-readable description of the access level
+  accessLevelDescription string
+  // ID of the deploy key granted access, or 0 when the grant does not target a deploy key
+  deployKeyId int
+  // User granted access, when the grant targets a specific user (null otherwise)
+  user() gitlab.user
+  // Group granted access, when the grant targets a specific group (null otherwise)
+  group() gitlab.group
 }
 
 // GitLab project file
@@ -1300,6 +1326,12 @@ private gitlab.group.protectedBranch @defaults("name allowForcePush") {
   allowForcePush bool
   // Whether code owner approval is required
   codeOwnerApprovalRequired bool
+  // Access levels permitted to push directly to the branch
+  pushAccessLevels []gitlab.protectedBranch.accessLevel
+  // Access levels permitted to merge into the branch
+  mergeAccessLevels []gitlab.protectedBranch.accessLevel
+  // Access levels permitted to remove protection from the branch
+  unprotectAccessLevels []gitlab.protectedBranch.accessLevel
 }
 
 // GitLab project security settings

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -33,6 +33,7 @@ const (
 	ResourceGitlabProjectCodeownersRule                  string = "gitlab.project.codeowners.rule"
 	ResourceGitlabProjectApprovalSetting                 string = "gitlab.project.approvalSetting"
 	ResourceGitlabProjectProtectedBranch                 string = "gitlab.project.protectedBranch"
+	ResourceGitlabProtectedBranchAccessLevel             string = "gitlab.protectedBranch.accessLevel"
 	ResourceGitlabProjectFile                            string = "gitlab.project.file"
 	ResourceGitlabProjectWebhook                         string = "gitlab.project.webhook"
 	ResourceGitlabProjectMergeRequest                    string = "gitlab.project.mergeRequest"
@@ -135,6 +136,10 @@ func init() {
 		"gitlab.project.protectedBranch": {
 			// to override args, implement: initGitlabProjectProtectedBranch(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGitlabProjectProtectedBranch,
+		},
+		"gitlab.protectedBranch.accessLevel": {
+			// to override args, implement: initGitlabProtectedBranchAccessLevel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGitlabProtectedBranchAccessLevel,
 		},
 		"gitlab.project.file": {
 			// to override args, implement: initGitlabProjectFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1148,6 +1153,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.protectedBranch.codeOwnerApproval": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectProtectedBranch).GetCodeOwnerApproval()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.protectedBranch.pushAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectProtectedBranch).GetPushAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
+	},
+	"gitlab.project.protectedBranch.mergeAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectProtectedBranch).GetMergeAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
+	},
+	"gitlab.project.protectedBranch.unprotectAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectProtectedBranch).GetUnprotectAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
+	},
+	"gitlab.protectedBranch.accessLevel.accessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProtectedBranchAccessLevel).GetAccessLevel()).ToDataRes(types.Int)
+	},
+	"gitlab.protectedBranch.accessLevel.accessLevelDescription": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProtectedBranchAccessLevel).GetAccessLevelDescription()).ToDataRes(types.String)
+	},
+	"gitlab.protectedBranch.accessLevel.deployKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProtectedBranchAccessLevel).GetDeployKeyId()).ToDataRes(types.Int)
+	},
+	"gitlab.protectedBranch.accessLevel.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProtectedBranchAccessLevel).GetUser()).ToDataRes(types.Resource("gitlab.user"))
+	},
+	"gitlab.protectedBranch.accessLevel.group": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProtectedBranchAccessLevel).GetGroup()).ToDataRes(types.Resource("gitlab.group"))
+	},
 	"gitlab.project.file.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectFile).GetPath()).ToDataRes(types.String)
 	},
@@ -1837,6 +1866,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.group.protectedBranch.codeOwnerApprovalRequired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroupProtectedBranch).GetCodeOwnerApprovalRequired()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.protectedBranch.pushAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroupProtectedBranch).GetPushAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
+	},
+	"gitlab.group.protectedBranch.mergeAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroupProtectedBranch).GetMergeAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
+	},
+	"gitlab.group.protectedBranch.unprotectAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroupProtectedBranch).GetUnprotectAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
 	},
 	"gitlab.project.securitySetting.autoFixContainerScanning": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectSecuritySetting).GetAutoFixContainerScanning()).ToDataRes(types.Bool)
@@ -3273,6 +3311,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGitlabProjectProtectedBranch).CodeOwnerApproval, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.protectedBranch.pushAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedBranch).PushAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.protectedBranch.mergeAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedBranch).MergeAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.protectedBranch.unprotectAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedBranch).UnprotectAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).__id, ok = v.Value.(string)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.accessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).AccessLevel, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.accessLevelDescription": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).AccessLevelDescription, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.deployKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).DeployKeyId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).User, ok = plugin.RawToTValue[*mqlGitlabUser](v.Value, v.Error)
+		return
+	},
+	"gitlab.protectedBranch.accessLevel.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProtectedBranchAccessLevel).Group, ok = plugin.RawToTValue[*mqlGitlabGroup](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.file.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProjectFile).__id, ok = v.Value.(string)
 		return
@@ -4267,6 +4341,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.group.protectedBranch.codeOwnerApprovalRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroupProtectedBranch).CodeOwnerApprovalRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.protectedBranch.pushAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroupProtectedBranch).PushAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.protectedBranch.mergeAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroupProtectedBranch).MergeAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.protectedBranch.unprotectAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroupProtectedBranch).UnprotectAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.securitySetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7434,10 +7520,13 @@ type mqlGitlabProjectProtectedBranch struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGitlabProjectProtectedBranchInternal it will be used here
-	Name              plugin.TValue[string]
-	AllowForcePush    plugin.TValue[bool]
-	DefaultBranch     plugin.TValue[bool]
-	CodeOwnerApproval plugin.TValue[bool]
+	Name                  plugin.TValue[string]
+	AllowForcePush        plugin.TValue[bool]
+	DefaultBranch         plugin.TValue[bool]
+	CodeOwnerApproval     plugin.TValue[bool]
+	PushAccessLevels      plugin.TValue[[]any]
+	MergeAccessLevels     plugin.TValue[[]any]
+	UnprotectAccessLevels plugin.TValue[[]any]
 }
 
 // createGitlabProjectProtectedBranch creates a new instance of this resource
@@ -7491,6 +7580,106 @@ func (c *mqlGitlabProjectProtectedBranch) GetDefaultBranch() *plugin.TValue[bool
 
 func (c *mqlGitlabProjectProtectedBranch) GetCodeOwnerApproval() *plugin.TValue[bool] {
 	return &c.CodeOwnerApproval
+}
+
+func (c *mqlGitlabProjectProtectedBranch) GetPushAccessLevels() *plugin.TValue[[]any] {
+	return &c.PushAccessLevels
+}
+
+func (c *mqlGitlabProjectProtectedBranch) GetMergeAccessLevels() *plugin.TValue[[]any] {
+	return &c.MergeAccessLevels
+}
+
+func (c *mqlGitlabProjectProtectedBranch) GetUnprotectAccessLevels() *plugin.TValue[[]any] {
+	return &c.UnprotectAccessLevels
+}
+
+// mqlGitlabProtectedBranchAccessLevel for the gitlab.protectedBranch.accessLevel resource
+type mqlGitlabProtectedBranchAccessLevel struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlGitlabProtectedBranchAccessLevelInternal
+	AccessLevel            plugin.TValue[int64]
+	AccessLevelDescription plugin.TValue[string]
+	DeployKeyId            plugin.TValue[int64]
+	User                   plugin.TValue[*mqlGitlabUser]
+	Group                  plugin.TValue[*mqlGitlabGroup]
+}
+
+// createGitlabProtectedBranchAccessLevel creates a new instance of this resource
+func createGitlabProtectedBranchAccessLevel(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGitlabProtectedBranchAccessLevel{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gitlab.protectedBranch.accessLevel", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) MqlName() string {
+	return "gitlab.protectedBranch.accessLevel"
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) GetAccessLevel() *plugin.TValue[int64] {
+	return &c.AccessLevel
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) GetAccessLevelDescription() *plugin.TValue[string] {
+	return &c.AccessLevelDescription
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) GetDeployKeyId() *plugin.TValue[int64] {
+	return &c.DeployKeyId
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) GetUser() *plugin.TValue[*mqlGitlabUser] {
+	return plugin.GetOrCompute[*mqlGitlabUser](&c.User, func() (*mqlGitlabUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.protectedBranch.accessLevel", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGitlabUser), nil
+			}
+		}
+
+		return c.user()
+	})
+}
+
+func (c *mqlGitlabProtectedBranchAccessLevel) GetGroup() *plugin.TValue[*mqlGitlabGroup] {
+	return plugin.GetOrCompute[*mqlGitlabGroup](&c.Group, func() (*mqlGitlabGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.protectedBranch.accessLevel", c.__id, "group")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGitlabGroup), nil
+			}
+		}
+
+		return c.group()
+	})
 }
 
 // mqlGitlabProjectFile for the gitlab.project.file resource
@@ -9550,6 +9739,9 @@ type mqlGitlabGroupProtectedBranch struct {
 	Name                      plugin.TValue[string]
 	AllowForcePush            plugin.TValue[bool]
 	CodeOwnerApprovalRequired plugin.TValue[bool]
+	PushAccessLevels          plugin.TValue[[]any]
+	MergeAccessLevels         plugin.TValue[[]any]
+	UnprotectAccessLevels     plugin.TValue[[]any]
 }
 
 // createGitlabGroupProtectedBranch creates a new instance of this resource
@@ -9603,6 +9795,18 @@ func (c *mqlGitlabGroupProtectedBranch) GetAllowForcePush() *plugin.TValue[bool]
 
 func (c *mqlGitlabGroupProtectedBranch) GetCodeOwnerApprovalRequired() *plugin.TValue[bool] {
 	return &c.CodeOwnerApprovalRequired
+}
+
+func (c *mqlGitlabGroupProtectedBranch) GetPushAccessLevels() *plugin.TValue[[]any] {
+	return &c.PushAccessLevels
+}
+
+func (c *mqlGitlabGroupProtectedBranch) GetMergeAccessLevels() *plugin.TValue[[]any] {
+	return &c.MergeAccessLevels
+}
+
+func (c *mqlGitlabGroupProtectedBranch) GetUnprotectAccessLevels() *plugin.TValue[[]any] {
+	return &c.UnprotectAccessLevels
 }
 
 // mqlGitlabProjectSecuritySetting for the gitlab.project.securitySetting resource

--- a/providers/gitlab/resources/gitlab.lr.versions
+++ b/providers/gitlab/resources/gitlab.lr.versions
@@ -83,7 +83,10 @@ gitlab.group.protectedBranch 11.1.138
 gitlab.group.protectedBranch.allowForcePush 11.1.138
 gitlab.group.protectedBranch.codeOwnerApprovalRequired 11.1.138
 gitlab.group.protectedBranch.id 11.1.138
+gitlab.group.protectedBranch.mergeAccessLevels 13.3.9
 gitlab.group.protectedBranch.name 11.1.138
+gitlab.group.protectedBranch.pushAccessLevels 13.3.9
+gitlab.group.protectedBranch.unprotectAccessLevels 13.3.9
 gitlab.group.protectedBranches 11.1.138
 gitlab.group.pushRule 11.1.138
 gitlab.group.pushRule.authorEmailRegex 11.1.138
@@ -445,7 +448,10 @@ gitlab.project.protectedBranch 11.1.12
 gitlab.project.protectedBranch.allowForcePush 11.1.12
 gitlab.project.protectedBranch.codeOwnerApproval 11.1.12
 gitlab.project.protectedBranch.defaultBranch 11.1.12
+gitlab.project.protectedBranch.mergeAccessLevels 13.3.9
 gitlab.project.protectedBranch.name 11.1.12
+gitlab.project.protectedBranch.pushAccessLevels 13.3.9
+gitlab.project.protectedBranch.unprotectAccessLevels 13.3.9
 gitlab.project.protectedBranches 11.1.12
 gitlab.project.pushRule 11.1.138
 gitlab.project.pushRule.authorEmailRegex 11.1.138
@@ -580,6 +586,12 @@ gitlab.project.webhook.vulnerabilityEvents 13.0.8
 gitlab.project.webhook.wikiPageEvents 13.0.8
 gitlab.project.webhooks 11.1.13
 gitlab.project.wikiEnabled 9.0.1
+gitlab.protectedBranch.accessLevel 13.3.9
+gitlab.protectedBranch.accessLevel.accessLevel 13.3.9
+gitlab.protectedBranch.accessLevel.accessLevelDescription 13.3.9
+gitlab.protectedBranch.accessLevel.deployKeyId 13.3.9
+gitlab.protectedBranch.accessLevel.group 13.3.9
+gitlab.protectedBranch.accessLevel.user 13.3.9
 gitlab.settings 13.0.3
 gitlab.settings.defaultGroupVisibility 13.0.3
 gitlab.settings.defaultProjectVisibility 13.0.3

--- a/providers/gitlab/resources/gitlab_group.go
+++ b/providers/gitlab/resources/gitlab_group.go
@@ -881,11 +881,28 @@ func (g *mqlGitlabGroup) protectedBranches() ([]any, error) {
 
 	var mqlBranches []any
 	for _, branch := range allBranches {
+		prefix := "gitlab.group.protectedBranch/" + strconv.FormatInt(branch.ID, 10)
+		push, err := groupBranchAccessLevels(g.MqlRuntime, prefix+"/push", branch.PushAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+		merge, err := groupBranchAccessLevels(g.MqlRuntime, prefix+"/merge", branch.MergeAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+		unprotect, err := groupBranchAccessLevels(g.MqlRuntime, prefix+"/unprotect", branch.UnprotectAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+
 		branchInfo := map[string]*llx.RawData{
 			"id":                        llx.IntData(branch.ID),
 			"name":                      llx.StringData(branch.Name),
 			"allowForcePush":            llx.BoolData(branch.AllowForcePush),
 			"codeOwnerApprovalRequired": llx.BoolData(branch.CodeOwnerApprovalRequired),
+			"pushAccessLevels":          llx.ArrayData(push, types.Resource("gitlab.protectedBranch.accessLevel")),
+			"mergeAccessLevels":         llx.ArrayData(merge, types.Resource("gitlab.protectedBranch.accessLevel")),
+			"unprotectAccessLevels":     llx.ArrayData(unprotect, types.Resource("gitlab.protectedBranch.accessLevel")),
 		}
 
 		mqlBranch, err := CreateResource(g.MqlRuntime, "gitlab.group.protectedBranch", branchInfo)
@@ -897,4 +914,19 @@ func (g *mqlGitlabGroup) protectedBranches() ([]any, error) {
 	}
 
 	return mqlBranches, nil
+}
+
+func groupBranchAccessLevels(runtime *plugin.Runtime, idPrefix string, descs []*gitlab.GroupBranchAccessDescription) ([]any, error) {
+	out := make([]any, 0, len(descs))
+	for _, d := range descs {
+		if d == nil {
+			continue
+		}
+		al, err := newMqlProtectedBranchAccessLevel(runtime, idPrefix, d.ID, int64(d.AccessLevel), d.UserID, d.GroupID, d.DeployKeyID, d.AccessLevelDescription)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, al)
+	}
+	return out, nil
 }

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -384,11 +384,28 @@ func (p *mqlGitlabProject) protectedBranches() ([]any, error) {
 	for _, branch := range protectedBranches {
 		isDefaultBranch := branch.Name == defaultBranch
 
+		prefix := "gitlab.project.protectedBranch/" + branch.Name
+		push, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/push", branch.PushAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+		merge, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/merge", branch.MergeAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+		unprotect, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/unprotect", branch.UnprotectAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+
 		branchSettings := map[string]*llx.RawData{
-			"name":              llx.StringData(branch.Name),
-			"allowForcePush":    llx.BoolData(branch.AllowForcePush),
-			"defaultBranch":     llx.BoolData(isDefaultBranch),
-			"codeOwnerApproval": llx.BoolData(branch.CodeOwnerApprovalRequired),
+			"name":                  llx.StringData(branch.Name),
+			"allowForcePush":        llx.BoolData(branch.AllowForcePush),
+			"defaultBranch":         llx.BoolData(isDefaultBranch),
+			"codeOwnerApproval":     llx.BoolData(branch.CodeOwnerApprovalRequired),
+			"pushAccessLevels":      llx.ArrayData(push, types.Resource("gitlab.protectedBranch.accessLevel")),
+			"mergeAccessLevels":     llx.ArrayData(merge, types.Resource("gitlab.protectedBranch.accessLevel")),
+			"unprotectAccessLevels": llx.ArrayData(unprotect, types.Resource("gitlab.protectedBranch.accessLevel")),
 		}
 
 		mqlProtectedBranch, err := CreateResource(p.MqlRuntime, "gitlab.project.protectedBranch", branchSettings)
@@ -400,6 +417,76 @@ func (p *mqlGitlabProject) protectedBranches() ([]any, error) {
 	}
 
 	return mqlProtectedBranches, nil
+}
+
+// mqlGitlabProtectedBranchAccessLevelInternal caches the user/group id so the
+// typed user()/group() accessors resolve lazily. Exactly one of accessLevel,
+// user, group, or deployKeyId is meaningful per row.
+type mqlGitlabProtectedBranchAccessLevelInternal struct {
+	cacheUserID  int64
+	cacheGroupID int64
+}
+
+func (a *mqlGitlabProtectedBranchAccessLevel) user() (*mqlGitlabUser, error) {
+	if a.cacheUserID <= 0 {
+		a.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "gitlab.user", map[string]*llx.RawData{
+		"id": llx.IntData(a.cacheUserID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGitlabUser), nil
+}
+
+func (a *mqlGitlabProtectedBranchAccessLevel) group() (*mqlGitlabGroup, error) {
+	if a.cacheGroupID <= 0 {
+		a.Group.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "gitlab.group", map[string]*llx.RawData{
+		"id": llx.IntData(a.cacheGroupID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGitlabGroup), nil
+}
+
+// newMqlProtectedBranchAccessLevel builds one access-level row. idPrefix
+// (parent protected-branch + action) namespaces the synthetic __id so rows
+// from different branches or scopes don't collide in the resource cache.
+func newMqlProtectedBranchAccessLevel(runtime *plugin.Runtime, idPrefix string, id, accessLevel, userID, groupID, deployKeyID int64, desc string) (*mqlGitlabProtectedBranchAccessLevel, error) {
+	res, err := CreateResource(runtime, "gitlab.protectedBranch.accessLevel", map[string]*llx.RawData{
+		"__id":                   llx.StringData(fmt.Sprintf("%s/%d", idPrefix, id)),
+		"accessLevel":            llx.IntData(accessLevel),
+		"accessLevelDescription": llx.StringData(desc),
+		"deployKeyId":            llx.IntData(deployKeyID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	al := res.(*mqlGitlabProtectedBranchAccessLevel)
+	al.cacheUserID = userID
+	al.cacheGroupID = groupID
+	return al, nil
+}
+
+func projectBranchAccessLevels(runtime *plugin.Runtime, idPrefix string, descs []*gitlab.BranchAccessDescription) ([]any, error) {
+	out := make([]any, 0, len(descs))
+	for _, d := range descs {
+		if d == nil {
+			continue
+		}
+		al, err := newMqlProtectedBranchAccessLevel(runtime, idPrefix, d.ID, int64(d.AccessLevel), d.UserID, d.GroupID, d.DeployKeyID, d.AccessLevelDescription)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, al)
+	}
+	return out, nil
 }
 
 // projectMembers fetches the list of members in the project with their roles


### PR DESCRIPTION
## What

Protected branches previously exposed only `name`, `allowForcePush`, and `codeOwnerApproval` — so MQL **could not answer "who can push to (or merge into, or unprotect) this branch?"**, which is the core branch-protection audit. This adds that access-control surface.

- **New `gitlab.protectedBranch.accessLevel`** sub-resource — one access grant, carrying the numeric `accessLevel` (0 No access, 30 Developer, 40 Maintainer, 60 Admin) + `accessLevelDescription`, and resolving to a typed `user()` or `group()` reference (or a `deployKeyId`) depending on which the grant targets.
- **`pushAccessLevels`, `mergeAccessLevels`, `unprotectAccessLevels`** added to both `gitlab.project.protectedBranch` and `gitlab.group.protectedBranch`, built eagerly from the list payload (no extra API calls).

The two GitLab SDK access-description types (`BranchAccessDescription` for projects, `GroupBranchAccessDescription` for groups) are structurally identical, so both scopes share one sub-resource type and one builder. The synthetic `__id` is namespaced by parent branch + action (`<scope>.protectedBranch/<branch>/push/<id>`) so rows never collide in the resource cache.

## Example queries
```
# branches where a plain Developer (or below) can push directly
gitlab.project.protectedBranches.where(
  pushAccessLevels.any(accessLevel <= 30)
) { name }

# who can merge / unprotect, by user or group
gitlab.project.protectedBranches {
  name
  mergeAccessLevels { accessLevel user { username } group { fullPath } }
  unprotectAccessLevels { accessLevel accessLevelDescription }
}
```

## Notes
- Additive and non-breaking; new `.lr.versions` entries at `13.3.9`.
- `user()` / `group()` resolve lazily and return null (a bare resource on 403/404) when the grant is a role-based level rather than a specific principal.
- This is the first of two PRs from the depth-audit "Tier 1". The next covers project & group governance/compliance scalars plus the deprecated `*Enabled`→`*AccessLevel` migration.

## Test
- `go build ./...` (gitlab module) — clean
- `go vet ./resources/` — clean
- `go test ./resources/` — pass
