### PR TITLE
⭐ gitlab: add project & group governance scalars; migrate deprecated *Enabled

### DIFF
--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -307,7 +307,11 @@ gitlab.group @defaults("name visibility webURL") {
   // Whether forking projects outside this group is forbidden
   preventForkingOutsideGroup bool
   // Whether group email notifications are disabled
-  emailsDisabled bool
+  //
+  // Deprecated in favor of emailsEnabled.
+  emailsDisabled @maturity("deprecated") bool
+  // Whether group email notifications are enabled
+  emailsEnabled bool
   // Whether group mentions within issues and merge requests are disabled
   mentionsDisabled bool
   // Whether users can request membership to the group
@@ -322,6 +326,38 @@ gitlab.group @defaults("name visibility webURL") {
   allowedEmailDomainsList string
   // Whether the group has Large File Storage (LFS) enabled
   lfsEnabled bool
+  // Allowed IP address ranges (CIDR) for accessing the group; empty when unrestricted
+  ipRestrictionRanges string
+  // Groups this group is shared with and their access levels
+  //
+  // Each entry is a dict with groupId, groupName, groupFullPath, and
+  // groupAccessLevel keys.
+  sharedWithGroups []dict
+  // Whether sharing this group's projects with other groups is locked
+  shareWithGroupLock bool
+  // Shared-runner policy for the group (enabled, disabled_and_overridable, disabled_and_unoverridable)
+  sharedRunnersSetting string
+  // Minimum role that can create projects in the group (noone, maintainer, developer)
+  projectCreationLevel string
+  // Minimum role that can create subgroups in the group (owner, maintainer)
+  subGroupCreationLevel string
+  // Whether Auto DevOps is enabled by default for projects in the group
+  autoDevopsEnabled bool
+  // Visibility of the group wiki (disabled, private, enabled)
+  wikiAccessLevel string
+  // Default branch-protection policy inherited by new projects
+  //
+  // A dict with allowForcePush, developerCanInitialPush,
+  // codeOwnerApprovalRequired, allowedToPush, and allowedToMerge keys.
+  defaultBranchProtection dict
+  // Common Name of the LDAP group synced to this group; empty when none
+  ldapCn string
+  // Access level granted to members synced from the LDAP group
+  ldapAccess int
+  // LDAP group links mapping directory groups to access levels
+  //
+  // Each entry is a dict with cn, filter, provider, and groupAccess keys.
+  ldapGroupLinks []dict
   // List of members in the group with their roles
   members() []gitlab.member
   // Custom member roles defined in the group
@@ -500,7 +536,11 @@ gitlab.project @defaults("fullName visibility webURL") {
   // URL of the project
   webURL string
   // Whether project email notifications are disabled
-  emailsDisabled bool
+  //
+  // Deprecated in favor of emailsEnabled.
+  emailsDisabled @maturity("deprecated") bool
+  // Whether project email notifications are enabled
+  emailsEnabled bool
   // Whether merging merge requests is allowed when a pipeline is skipped
   allowMergeOnSkippedPipeline bool
   // Whether merging merge requests is allowed only if the pipelines succeed
@@ -508,15 +548,35 @@ gitlab.project @defaults("fullName visibility webURL") {
   // Whether merging merge requests is allowed only if all discussions are resolved
   onlyAllowMergeIfAllDiscussionsAreResolved bool
   // Whether the issues feature is enabled
-  issuesEnabled bool
+  //
+  // Deprecated in favor of issuesAccessLevel.
+  issuesEnabled @maturity("deprecated") bool
+  // Visibility of the issues feature (disabled, private, enabled)
+  issuesAccessLevel string
   // Whether the merge request feature is enabled
-  mergeRequestsEnabled bool
+  //
+  // Deprecated in favor of mergeRequestsAccessLevel.
+  mergeRequestsEnabled @maturity("deprecated") bool
+  // Visibility of the merge requests feature (disabled, private, enabled)
+  mergeRequestsAccessLevel string
   // Whether the wiki feature is enabled
-  wikiEnabled bool
+  //
+  // Deprecated in favor of wikiAccessLevel.
+  wikiEnabled @maturity("deprecated") bool
+  // Visibility of the wiki feature (disabled, private, enabled)
+  wikiAccessLevel string
   // Whether the snippets feature is enabled
-  snippetsEnabled bool
+  //
+  // Deprecated in favor of snippetsAccessLevel.
+  snippetsEnabled @maturity("deprecated") bool
+  // Visibility of the snippets feature (disabled, private, enabled)
+  snippetsAccessLevel string
   // Whether the container registry feature is enabled
-  containerRegistryEnabled bool
+  //
+  // Deprecated in favor of containerRegistryAccessLevel.
+  containerRegistryEnabled @maturity("deprecated") bool
+  // Visibility of the container registry feature (disabled, private, enabled)
+  containerRegistryAccessLevel string
   // Whether the Service Desk feature is enabled
   serviceDeskEnabled bool
   // Whether the packages feature is enabled
@@ -525,6 +585,31 @@ gitlab.project @defaults("fullName visibility webURL") {
   autoDevopsEnabled bool
   // Whether the requirements feature is enabled
   requirementsEnabled bool
+  // Visibility of the repository (disabled, private, enabled)
+  repositoryAccessLevel string
+  // Who can fork the project (disabled, private, enabled)
+  forkingAccessLevel string
+  // Whether the Security & Compliance feature is enabled
+  securityAndComplianceEnabled bool
+  // Visibility of the Security & Compliance feature (disabled, private, enabled)
+  securityAndComplianceAccessLevel string
+  // Whether CI job tokens are scoped to an allowlist of projects
+  ciJobTokenScopeEnabled bool
+  // Whether job logs and artifacts are visible to non-members
+  publicJobs bool
+  // Whether server-side secret push protection is enabled
+  preReceiveSecretDetectionEnabled bool
+  // Compliance frameworks applied to the project
+  complianceFrameworks []string
+  // Groups the project is shared with and their access levels
+  //
+  // Each entry is a dict with groupId, groupName, groupFullPath, and
+  // groupAccessLevel keys.
+  sharedWithGroups []dict
+  // Whether mirrored branches trigger CI pipelines
+  mirrorTriggerBuilds bool
+  // Whether mirroring is limited to protected branches
+  onlyMirrorProtectedBranches bool
   // Approval rules for the project
   approvalRules() []gitlab.project.approvalRule
   // Merge methods for the project
@@ -540,7 +625,11 @@ gitlab.project @defaults("fullName visibility webURL") {
   // List of webhooks for the project
   webhooks() []gitlab.project.webhook
   // Whether CI jobs are enabled
-  jobsEnabled bool
+  //
+  // Deprecated in favor of buildsAccessLevel.
+  jobsEnabled @maturity("deprecated") bool
+  // Visibility of the CI/CD builds feature (disabled, private, enabled)
+  buildsAccessLevel string
   // Whether the repo is empty
   emptyRepo bool
   // Whether the project is enabled for shared runners

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -664,6 +664,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.group.emailsDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetEmailsDisabled()).ToDataRes(types.Bool)
 	},
+	"gitlab.group.emailsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetEmailsEnabled()).ToDataRes(types.Bool)
+	},
 	"gitlab.group.mentionsDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetMentionsDisabled()).ToDataRes(types.Bool)
 	},
@@ -684,6 +687,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.group.lfsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetLfsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.ipRestrictionRanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetIpRestrictionRanges()).ToDataRes(types.String)
+	},
+	"gitlab.group.sharedWithGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetSharedWithGroups()).ToDataRes(types.Array(types.Dict))
+	},
+	"gitlab.group.shareWithGroupLock": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetShareWithGroupLock()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.sharedRunnersSetting": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetSharedRunnersSetting()).ToDataRes(types.String)
+	},
+	"gitlab.group.projectCreationLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetProjectCreationLevel()).ToDataRes(types.String)
+	},
+	"gitlab.group.subGroupCreationLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetSubGroupCreationLevel()).ToDataRes(types.String)
+	},
+	"gitlab.group.autoDevopsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetAutoDevopsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.wikiAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetWikiAccessLevel()).ToDataRes(types.String)
+	},
+	"gitlab.group.defaultBranchProtection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetDefaultBranchProtection()).ToDataRes(types.Dict)
+	},
+	"gitlab.group.ldapCn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetLdapCn()).ToDataRes(types.String)
+	},
+	"gitlab.group.ldapAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetLdapAccess()).ToDataRes(types.Int)
+	},
+	"gitlab.group.ldapGroupLinks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetLdapGroupLinks()).ToDataRes(types.Array(types.Dict))
 	},
 	"gitlab.group.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetMembers()).ToDataRes(types.Array(types.Resource("gitlab.member")))
@@ -895,6 +934,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.emailsDisabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetEmailsDisabled()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.emailsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetEmailsEnabled()).ToDataRes(types.Bool)
+	},
 	"gitlab.project.allowMergeOnSkippedPipeline": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetAllowMergeOnSkippedPipeline()).ToDataRes(types.Bool)
 	},
@@ -907,17 +949,32 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.issuesEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetIssuesEnabled()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.issuesAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetIssuesAccessLevel()).ToDataRes(types.String)
+	},
 	"gitlab.project.mergeRequestsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetMergeRequestsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.mergeRequestsAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetMergeRequestsAccessLevel()).ToDataRes(types.String)
 	},
 	"gitlab.project.wikiEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetWikiEnabled()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.wikiAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetWikiAccessLevel()).ToDataRes(types.String)
+	},
 	"gitlab.project.snippetsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetSnippetsEnabled()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.snippetsAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSnippetsAccessLevel()).ToDataRes(types.String)
+	},
 	"gitlab.project.containerRegistryEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetContainerRegistryEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.containerRegistryAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetContainerRegistryAccessLevel()).ToDataRes(types.String)
 	},
 	"gitlab.project.serviceDeskEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetServiceDeskEnabled()).ToDataRes(types.Bool)
@@ -930,6 +987,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.requirementsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetRequirementsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.repositoryAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetRepositoryAccessLevel()).ToDataRes(types.String)
+	},
+	"gitlab.project.forkingAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetForkingAccessLevel()).ToDataRes(types.String)
+	},
+	"gitlab.project.securityAndComplianceEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSecurityAndComplianceEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.securityAndComplianceAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSecurityAndComplianceAccessLevel()).ToDataRes(types.String)
+	},
+	"gitlab.project.ciJobTokenScopeEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetCiJobTokenScopeEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.publicJobs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetPublicJobs()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.preReceiveSecretDetectionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetPreReceiveSecretDetectionEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.complianceFrameworks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetComplianceFrameworks()).ToDataRes(types.Array(types.String))
+	},
+	"gitlab.project.sharedWithGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSharedWithGroups()).ToDataRes(types.Array(types.Dict))
+	},
+	"gitlab.project.mirrorTriggerBuilds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetMirrorTriggerBuilds()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.onlyMirrorProtectedBranches": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetOnlyMirrorProtectedBranches()).ToDataRes(types.Bool)
 	},
 	"gitlab.project.approvalRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetApprovalRules()).ToDataRes(types.Array(types.Resource("gitlab.project.approvalRule")))
@@ -954,6 +1044,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.jobsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetJobsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.buildsAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetBuildsAccessLevel()).ToDataRes(types.String)
 	},
 	"gitlab.project.emptyRepo": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetEmptyRepo()).ToDataRes(types.Bool)
@@ -2623,6 +2716,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGitlabGroup).EmailsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.group.emailsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).EmailsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gitlab.group.mentionsDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroup).MentionsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -2649,6 +2746,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.group.lfsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroup).LfsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.ipRestrictionRanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).IpRestrictionRanges, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.sharedWithGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).SharedWithGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.shareWithGroupLock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).ShareWithGroupLock, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.sharedRunnersSetting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).SharedRunnersSetting, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.projectCreationLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).ProjectCreationLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.subGroupCreationLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).SubGroupCreationLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.autoDevopsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).AutoDevopsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.wikiAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).WikiAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.defaultBranchProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).DefaultBranchProtection, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.ldapCn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).LdapCn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.ldapAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).LdapAccess, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.ldapGroupLinks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).LdapGroupLinks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gitlab.group.members": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2947,6 +3092,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGitlabProject).EmailsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.emailsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).EmailsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.allowMergeOnSkippedPipeline": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).AllowMergeOnSkippedPipeline, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -2963,20 +3112,40 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGitlabProject).IssuesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.issuesAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).IssuesAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.mergeRequestsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).MergeRequestsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.mergeRequestsAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).MergeRequestsAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.wikiEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).WikiEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.wikiAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).WikiAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.snippetsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).SnippetsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.snippetsAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SnippetsAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.containerRegistryEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).ContainerRegistryEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.containerRegistryAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ContainerRegistryAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.serviceDeskEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2993,6 +3162,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.project.requirementsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).RequirementsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.repositoryAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).RepositoryAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.forkingAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ForkingAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.securityAndComplianceEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SecurityAndComplianceEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.securityAndComplianceAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SecurityAndComplianceAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.ciJobTokenScopeEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).CiJobTokenScopeEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.publicJobs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).PublicJobs, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.preReceiveSecretDetectionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).PreReceiveSecretDetectionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.complianceFrameworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ComplianceFrameworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.sharedWithGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SharedWithGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.mirrorTriggerBuilds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).MirrorTriggerBuilds, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.onlyMirrorProtectedBranches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).OnlyMirrorProtectedBranches, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.approvalRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3025,6 +3238,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.project.jobsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).JobsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.buildsAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).BuildsAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.emptyRepo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5674,6 +5891,7 @@ type mqlGitlabGroup struct {
 	MembershipLock                 plugin.TValue[bool]
 	PreventForkingOutsideGroup     plugin.TValue[bool]
 	EmailsDisabled                 plugin.TValue[bool]
+	EmailsEnabled                  plugin.TValue[bool]
 	MentionsDisabled               plugin.TValue[bool]
 	RequestAccessEnabled           plugin.TValue[bool]
 	MarkedForDeletionOn            plugin.TValue[*time.Time]
@@ -5681,6 +5899,18 @@ type mqlGitlabGroup struct {
 	Projects                       plugin.TValue[[]any]
 	AllowedEmailDomainsList        plugin.TValue[string]
 	LfsEnabled                     plugin.TValue[bool]
+	IpRestrictionRanges            plugin.TValue[string]
+	SharedWithGroups               plugin.TValue[[]any]
+	ShareWithGroupLock             plugin.TValue[bool]
+	SharedRunnersSetting           plugin.TValue[string]
+	ProjectCreationLevel           plugin.TValue[string]
+	SubGroupCreationLevel          plugin.TValue[string]
+	AutoDevopsEnabled              plugin.TValue[bool]
+	WikiAccessLevel                plugin.TValue[string]
+	DefaultBranchProtection        plugin.TValue[any]
+	LdapCn                         plugin.TValue[string]
+	LdapAccess                     plugin.TValue[int64]
+	LdapGroupLinks                 plugin.TValue[[]any]
 	Members                        plugin.TValue[[]any]
 	MemberRoles                    plugin.TValue[[]any]
 	Subgroups                      plugin.TValue[[]any]
@@ -5789,6 +6019,10 @@ func (c *mqlGitlabGroup) GetEmailsDisabled() *plugin.TValue[bool] {
 	return &c.EmailsDisabled
 }
 
+func (c *mqlGitlabGroup) GetEmailsEnabled() *plugin.TValue[bool] {
+	return &c.EmailsEnabled
+}
+
 func (c *mqlGitlabGroup) GetMentionsDisabled() *plugin.TValue[bool] {
 	return &c.MentionsDisabled
 }
@@ -5839,6 +6073,54 @@ func (c *mqlGitlabGroup) GetAllowedEmailDomainsList() *plugin.TValue[string] {
 
 func (c *mqlGitlabGroup) GetLfsEnabled() *plugin.TValue[bool] {
 	return &c.LfsEnabled
+}
+
+func (c *mqlGitlabGroup) GetIpRestrictionRanges() *plugin.TValue[string] {
+	return &c.IpRestrictionRanges
+}
+
+func (c *mqlGitlabGroup) GetSharedWithGroups() *plugin.TValue[[]any] {
+	return &c.SharedWithGroups
+}
+
+func (c *mqlGitlabGroup) GetShareWithGroupLock() *plugin.TValue[bool] {
+	return &c.ShareWithGroupLock
+}
+
+func (c *mqlGitlabGroup) GetSharedRunnersSetting() *plugin.TValue[string] {
+	return &c.SharedRunnersSetting
+}
+
+func (c *mqlGitlabGroup) GetProjectCreationLevel() *plugin.TValue[string] {
+	return &c.ProjectCreationLevel
+}
+
+func (c *mqlGitlabGroup) GetSubGroupCreationLevel() *plugin.TValue[string] {
+	return &c.SubGroupCreationLevel
+}
+
+func (c *mqlGitlabGroup) GetAutoDevopsEnabled() *plugin.TValue[bool] {
+	return &c.AutoDevopsEnabled
+}
+
+func (c *mqlGitlabGroup) GetWikiAccessLevel() *plugin.TValue[string] {
+	return &c.WikiAccessLevel
+}
+
+func (c *mqlGitlabGroup) GetDefaultBranchProtection() *plugin.TValue[any] {
+	return &c.DefaultBranchProtection
+}
+
+func (c *mqlGitlabGroup) GetLdapCn() *plugin.TValue[string] {
+	return &c.LdapCn
+}
+
+func (c *mqlGitlabGroup) GetLdapAccess() *plugin.TValue[int64] {
+	return &c.LdapAccess
+}
+
+func (c *mqlGitlabGroup) GetLdapGroupLinks() *plugin.TValue[[]any] {
+	return &c.LdapGroupLinks
 }
 
 func (c *mqlGitlabGroup) GetMembers() *plugin.TValue[[]any] {
@@ -6515,18 +6797,35 @@ type mqlGitlabProject struct {
 	Mirror                                    plugin.TValue[bool]
 	WebURL                                    plugin.TValue[string]
 	EmailsDisabled                            plugin.TValue[bool]
+	EmailsEnabled                             plugin.TValue[bool]
 	AllowMergeOnSkippedPipeline               plugin.TValue[bool]
 	OnlyAllowMergeIfPipelineSucceeds          plugin.TValue[bool]
 	OnlyAllowMergeIfAllDiscussionsAreResolved plugin.TValue[bool]
 	IssuesEnabled                             plugin.TValue[bool]
+	IssuesAccessLevel                         plugin.TValue[string]
 	MergeRequestsEnabled                      plugin.TValue[bool]
+	MergeRequestsAccessLevel                  plugin.TValue[string]
 	WikiEnabled                               plugin.TValue[bool]
+	WikiAccessLevel                           plugin.TValue[string]
 	SnippetsEnabled                           plugin.TValue[bool]
+	SnippetsAccessLevel                       plugin.TValue[string]
 	ContainerRegistryEnabled                  plugin.TValue[bool]
+	ContainerRegistryAccessLevel              plugin.TValue[string]
 	ServiceDeskEnabled                        plugin.TValue[bool]
 	PackagesEnabled                           plugin.TValue[bool]
 	AutoDevopsEnabled                         plugin.TValue[bool]
 	RequirementsEnabled                       plugin.TValue[bool]
+	RepositoryAccessLevel                     plugin.TValue[string]
+	ForkingAccessLevel                        plugin.TValue[string]
+	SecurityAndComplianceEnabled              plugin.TValue[bool]
+	SecurityAndComplianceAccessLevel          plugin.TValue[string]
+	CiJobTokenScopeEnabled                    plugin.TValue[bool]
+	PublicJobs                                plugin.TValue[bool]
+	PreReceiveSecretDetectionEnabled          plugin.TValue[bool]
+	ComplianceFrameworks                      plugin.TValue[[]any]
+	SharedWithGroups                          plugin.TValue[[]any]
+	MirrorTriggerBuilds                       plugin.TValue[bool]
+	OnlyMirrorProtectedBranches               plugin.TValue[bool]
 	ApprovalRules                             plugin.TValue[[]any]
 	MergeMethod                               plugin.TValue[string]
 	ApprovalSettings                          plugin.TValue[*mqlGitlabProjectApprovalSetting]
@@ -6535,6 +6834,7 @@ type mqlGitlabProject struct {
 	ProjectFiles                              plugin.TValue[[]any]
 	Webhooks                                  plugin.TValue[[]any]
 	JobsEnabled                               plugin.TValue[bool]
+	BuildsAccessLevel                         plugin.TValue[string]
 	EmptyRepo                                 plugin.TValue[bool]
 	SharedRunnersEnabled                      plugin.TValue[bool]
 	GroupRunnersEnabled                       plugin.TValue[bool]
@@ -6657,6 +6957,10 @@ func (c *mqlGitlabProject) GetEmailsDisabled() *plugin.TValue[bool] {
 	return &c.EmailsDisabled
 }
 
+func (c *mqlGitlabProject) GetEmailsEnabled() *plugin.TValue[bool] {
+	return &c.EmailsEnabled
+}
+
 func (c *mqlGitlabProject) GetAllowMergeOnSkippedPipeline() *plugin.TValue[bool] {
 	return &c.AllowMergeOnSkippedPipeline
 }
@@ -6673,20 +6977,40 @@ func (c *mqlGitlabProject) GetIssuesEnabled() *plugin.TValue[bool] {
 	return &c.IssuesEnabled
 }
 
+func (c *mqlGitlabProject) GetIssuesAccessLevel() *plugin.TValue[string] {
+	return &c.IssuesAccessLevel
+}
+
 func (c *mqlGitlabProject) GetMergeRequestsEnabled() *plugin.TValue[bool] {
 	return &c.MergeRequestsEnabled
+}
+
+func (c *mqlGitlabProject) GetMergeRequestsAccessLevel() *plugin.TValue[string] {
+	return &c.MergeRequestsAccessLevel
 }
 
 func (c *mqlGitlabProject) GetWikiEnabled() *plugin.TValue[bool] {
 	return &c.WikiEnabled
 }
 
+func (c *mqlGitlabProject) GetWikiAccessLevel() *plugin.TValue[string] {
+	return &c.WikiAccessLevel
+}
+
 func (c *mqlGitlabProject) GetSnippetsEnabled() *plugin.TValue[bool] {
 	return &c.SnippetsEnabled
 }
 
+func (c *mqlGitlabProject) GetSnippetsAccessLevel() *plugin.TValue[string] {
+	return &c.SnippetsAccessLevel
+}
+
 func (c *mqlGitlabProject) GetContainerRegistryEnabled() *plugin.TValue[bool] {
 	return &c.ContainerRegistryEnabled
+}
+
+func (c *mqlGitlabProject) GetContainerRegistryAccessLevel() *plugin.TValue[string] {
+	return &c.ContainerRegistryAccessLevel
 }
 
 func (c *mqlGitlabProject) GetServiceDeskEnabled() *plugin.TValue[bool] {
@@ -6703,6 +7027,50 @@ func (c *mqlGitlabProject) GetAutoDevopsEnabled() *plugin.TValue[bool] {
 
 func (c *mqlGitlabProject) GetRequirementsEnabled() *plugin.TValue[bool] {
 	return &c.RequirementsEnabled
+}
+
+func (c *mqlGitlabProject) GetRepositoryAccessLevel() *plugin.TValue[string] {
+	return &c.RepositoryAccessLevel
+}
+
+func (c *mqlGitlabProject) GetForkingAccessLevel() *plugin.TValue[string] {
+	return &c.ForkingAccessLevel
+}
+
+func (c *mqlGitlabProject) GetSecurityAndComplianceEnabled() *plugin.TValue[bool] {
+	return &c.SecurityAndComplianceEnabled
+}
+
+func (c *mqlGitlabProject) GetSecurityAndComplianceAccessLevel() *plugin.TValue[string] {
+	return &c.SecurityAndComplianceAccessLevel
+}
+
+func (c *mqlGitlabProject) GetCiJobTokenScopeEnabled() *plugin.TValue[bool] {
+	return &c.CiJobTokenScopeEnabled
+}
+
+func (c *mqlGitlabProject) GetPublicJobs() *plugin.TValue[bool] {
+	return &c.PublicJobs
+}
+
+func (c *mqlGitlabProject) GetPreReceiveSecretDetectionEnabled() *plugin.TValue[bool] {
+	return &c.PreReceiveSecretDetectionEnabled
+}
+
+func (c *mqlGitlabProject) GetComplianceFrameworks() *plugin.TValue[[]any] {
+	return &c.ComplianceFrameworks
+}
+
+func (c *mqlGitlabProject) GetSharedWithGroups() *plugin.TValue[[]any] {
+	return &c.SharedWithGroups
+}
+
+func (c *mqlGitlabProject) GetMirrorTriggerBuilds() *plugin.TValue[bool] {
+	return &c.MirrorTriggerBuilds
+}
+
+func (c *mqlGitlabProject) GetOnlyMirrorProtectedBranches() *plugin.TValue[bool] {
+	return &c.OnlyMirrorProtectedBranches
 }
 
 func (c *mqlGitlabProject) GetApprovalRules() *plugin.TValue[[]any] {
@@ -6809,6 +7177,10 @@ func (c *mqlGitlabProject) GetWebhooks() *plugin.TValue[[]any] {
 
 func (c *mqlGitlabProject) GetJobsEnabled() *plugin.TValue[bool] {
 	return &c.JobsEnabled
+}
+
+func (c *mqlGitlabProject) GetBuildsAccessLevel() *plugin.TValue[string] {
+	return &c.BuildsAccessLevel
 }
 
 func (c *mqlGitlabProject) GetEmptyRepo() *plugin.TValue[bool] {

--- a/providers/gitlab/resources/gitlab.lr.versions
+++ b/providers/gitlab/resources/gitlab.lr.versions
@@ -37,8 +37,10 @@ gitlab.group.auditEvent.ipAddress 13.0.8
 gitlab.group.auditEvent.targetDetails 13.0.8
 gitlab.group.auditEvent.targetType 13.0.8
 gitlab.group.auditEvents 13.0.8
+gitlab.group.autoDevopsEnabled 13.3.9
 gitlab.group.containerRegistryRepositories 13.3.1
 gitlab.group.createdAt 9.0.1
+gitlab.group.defaultBranchProtection 13.3.9
 gitlab.group.deployToken 11.1.138
 gitlab.group.deployToken.expired 11.1.138
 gitlab.group.deployToken.expiresAt 11.1.138
@@ -50,9 +52,11 @@ gitlab.group.deployToken.username 11.1.138
 gitlab.group.deployTokens 11.1.138
 gitlab.group.description 9.0.0
 gitlab.group.emailsDisabled 9.0.1
+gitlab.group.emailsEnabled 13.3.9
 gitlab.group.fullName 11.1.129
 gitlab.group.fullPath 11.1.129
 gitlab.group.id 9.0.0
+gitlab.group.ipRestrictionRanges 13.3.9
 gitlab.group.label 11.1.129
 gitlab.group.label.closedIssuesCount 11.1.129
 gitlab.group.label.color 11.1.129
@@ -67,6 +71,9 @@ gitlab.group.label.priority 11.1.129
 gitlab.group.label.subscribed 11.1.129
 gitlab.group.label.textColor 11.1.129
 gitlab.group.labels 11.1.129
+gitlab.group.ldapAccess 13.3.9
+gitlab.group.ldapCn 13.3.9
+gitlab.group.ldapGroupLinks 13.3.9
 gitlab.group.lfsEnabled 11.1.129
 gitlab.group.markedForDeletionOn 11.1.129
 gitlab.group.memberRoles 13.3.9
@@ -78,6 +85,7 @@ gitlab.group.namespace 11.2.1
 gitlab.group.packages 13.3.1
 gitlab.group.path 9.0.0
 gitlab.group.preventForkingOutsideGroup 9.0.1
+gitlab.group.projectCreationLevel 13.3.9
 gitlab.group.projects 9.0.0
 gitlab.group.protectedBranch 11.1.138
 gitlab.group.protectedBranch.allowForcePush 11.1.138
@@ -113,11 +121,16 @@ gitlab.group.samlGroupLink.memberRoleId 13.0.8
 gitlab.group.samlGroupLink.name 13.0.8
 gitlab.group.samlGroupLink.provider 13.0.8
 gitlab.group.samlGroupLinks 13.0.8
+gitlab.group.shareWithGroupLock 13.3.9
+gitlab.group.sharedRunnersSetting 13.3.9
+gitlab.group.sharedWithGroups 13.3.9
+gitlab.group.subGroupCreationLevel 13.3.9
 gitlab.group.subgroups 11.1.129
 gitlab.group.twoFactorGracePeriod 13.0.8
 gitlab.group.visibility 9.0.0
 gitlab.group.vulnerabilities 13.3.1
 gitlab.group.webURL 9.0.1
+gitlab.group.wikiAccessLevel 13.3.9
 gitlab.member 11.1.129
 gitlab.member.accessLevel 13.3.9
 gitlab.member.createdAt 13.3.9
@@ -232,6 +245,8 @@ gitlab.project.auditEvent.targetType 13.3.9
 gitlab.project.auditEvents 13.3.9
 gitlab.project.autoDevopsEnabled 9.0.1
 gitlab.project.autocloseReferencedIssues 11.1.107
+gitlab.project.buildsAccessLevel 13.3.9
+gitlab.project.ciJobTokenScopeEnabled 13.3.9
 gitlab.project.codeowners 13.2.3
 gitlab.project.codeowners.content 13.2.3
 gitlab.project.codeowners.path 13.2.3
@@ -245,6 +260,7 @@ gitlab.project.codeowners.rule.pattern 13.2.3
 gitlab.project.codeowners.rule.required 13.2.3
 gitlab.project.codeowners.rule.section 13.2.3
 gitlab.project.codeowners.rules 13.2.3
+gitlab.project.complianceFrameworks 13.3.9
 gitlab.project.containerExpirationPolicy 13.3.1
 gitlab.project.containerExpirationPolicy.cadence 13.3.1
 gitlab.project.containerExpirationPolicy.enabled 13.3.1
@@ -253,6 +269,7 @@ gitlab.project.containerExpirationPolicy.nameRegexDelete 13.3.1
 gitlab.project.containerExpirationPolicy.nameRegexKeep 13.3.1
 gitlab.project.containerExpirationPolicy.nextRunAt 13.3.1
 gitlab.project.containerExpirationPolicy.olderThan 13.3.1
+gitlab.project.containerRegistryAccessLevel 13.3.9
 gitlab.project.containerRegistryEnabled 9.0.1
 gitlab.project.containerRegistryProtectionRule 13.3.1
 gitlab.project.containerRegistryProtectionRule.id 13.3.1
@@ -306,12 +323,14 @@ gitlab.project.deployToken.username 11.1.138
 gitlab.project.deployTokens 11.1.138
 gitlab.project.description 9.0.0
 gitlab.project.emailsDisabled 9.0.1
+gitlab.project.emailsEnabled 13.3.9
 gitlab.project.emptyRepo 11.1.36
 gitlab.project.file 11.1.13
 gitlab.project.file.content 11.1.13
 gitlab.project.file.name 11.1.13
 gitlab.project.file.path 11.1.13
 gitlab.project.file.type 11.1.13
+gitlab.project.forkingAccessLevel 13.3.9
 gitlab.project.forksCount 11.1.129
 gitlab.project.fullName 9.0.1
 gitlab.project.fullPath 13.3.1
@@ -333,6 +352,7 @@ gitlab.project.issue.title 11.1.129
 gitlab.project.issue.updatedAt 11.1.129
 gitlab.project.issue.webURL 11.1.129
 gitlab.project.issues 11.1.129
+gitlab.project.issuesAccessLevel 13.3.9
 gitlab.project.issuesEnabled 9.0.1
 gitlab.project.jobsEnabled 11.1.36
 gitlab.project.label 11.1.129
@@ -369,6 +389,7 @@ gitlab.project.mergeRequest.title 11.1.129
 gitlab.project.mergeRequest.updatedAt 11.1.129
 gitlab.project.mergeRequest.webURL 11.1.129
 gitlab.project.mergeRequests 11.1.129
+gitlab.project.mergeRequestsAccessLevel 13.3.9
 gitlab.project.mergeRequestsEnabled 9.0.1
 gitlab.project.milestone 11.1.129
 gitlab.project.milestone.createdAt 11.1.129
@@ -384,9 +405,11 @@ gitlab.project.milestone.title 11.1.129
 gitlab.project.milestone.updatedAt 11.1.129
 gitlab.project.milestones 11.1.129
 gitlab.project.mirror 9.0.1
+gitlab.project.mirrorTriggerBuilds 13.3.9
 gitlab.project.name 9.0.0
 gitlab.project.onlyAllowMergeIfAllDiscussionsAreResolved 9.0.1
 gitlab.project.onlyAllowMergeIfPipelineSucceeds 9.0.1
+gitlab.project.onlyMirrorProtectedBranches 13.3.9
 gitlab.project.package 13.3.1
 gitlab.project.package.createdAt 13.3.1
 gitlab.project.package.file 13.3.1
@@ -442,6 +465,7 @@ gitlab.project.pipeline.user 13.3.9
 gitlab.project.pipeline.webURL 11.1.130
 gitlab.project.pipeline.yamlErrors 13.3.9
 gitlab.project.pipelines 11.1.130
+gitlab.project.preReceiveSecretDetectionEnabled 13.3.9
 gitlab.project.projectFiles 11.1.13
 gitlab.project.projectMembers 11.1.129
 gitlab.project.protectedBranch 11.1.12
@@ -453,6 +477,7 @@ gitlab.project.protectedBranch.name 11.1.12
 gitlab.project.protectedBranch.pushAccessLevels 13.3.9
 gitlab.project.protectedBranch.unprotectAccessLevels 13.3.9
 gitlab.project.protectedBranches 11.1.12
+gitlab.project.publicJobs 13.3.9
 gitlab.project.pushRule 11.1.138
 gitlab.project.pushRule.authorEmailRegex 11.1.138
 gitlab.project.pushRule.branchNameRegex 11.1.138
@@ -479,6 +504,7 @@ gitlab.project.release.releasedAt 11.1.129
 gitlab.project.release.tagName 11.1.129
 gitlab.project.releases 11.1.129
 gitlab.project.removeSourceBranchAfterMerge 11.1.107
+gitlab.project.repositoryAccessLevel 13.3.9
 gitlab.project.requirementsEnabled 9.0.1
 gitlab.project.runner 11.1.130
 gitlab.project.runner.accessLevel 13.2.3
@@ -500,6 +526,8 @@ gitlab.project.runner.status 11.1.130
 gitlab.project.runner.tagList 13.2.3
 gitlab.project.runner.tokenExpiresAt 13.3.9
 gitlab.project.runners 11.1.130
+gitlab.project.securityAndComplianceAccessLevel 13.3.9
+gitlab.project.securityAndComplianceEnabled 13.3.9
 gitlab.project.securitySetting 11.1.138
 gitlab.project.securitySetting.autoFixContainerScanning 11.1.138
 gitlab.project.securitySetting.autoFixDAST 11.1.138
@@ -511,6 +539,8 @@ gitlab.project.securitySetting.secretPushProtectionEnabled 11.1.138
 gitlab.project.securitySettings 11.1.138
 gitlab.project.serviceDeskEnabled 9.0.1
 gitlab.project.sharedRunnersEnabled 11.1.36
+gitlab.project.sharedWithGroups 13.3.9
+gitlab.project.snippetsAccessLevel 13.3.9
 gitlab.project.snippetsEnabled 9.0.1
 gitlab.project.starCount 11.1.129
 gitlab.project.variable 11.1.129
@@ -585,6 +615,7 @@ gitlab.project.webhook.url 11.1.13
 gitlab.project.webhook.vulnerabilityEvents 13.0.8
 gitlab.project.webhook.wikiPageEvents 13.0.8
 gitlab.project.webhooks 11.1.13
+gitlab.project.wikiAccessLevel 13.3.9
 gitlab.project.wikiEnabled 9.0.1
 gitlab.protectedBranch.accessLevel 13.3.9
 gitlab.protectedBranch.accessLevel.accessLevel 13.3.9

--- a/providers/gitlab/resources/gitlab_group.go
+++ b/providers/gitlab/resources/gitlab_group.go
@@ -191,6 +191,77 @@ func populateGroupArgs(args map[string]*llx.RawData, grp *gitlab.Group) {
 	args["markedForDeletionOn"] = llx.TimeDataPtr(markedForDeletionOn)
 	args["allowedEmailDomainsList"] = llx.StringData(grp.AllowedEmailDomainsList)
 	args["lfsEnabled"] = llx.BoolData(grp.LFSEnabled)
+	args["emailsEnabled"] = llx.BoolData(grp.EmailsEnabled)
+	args["ipRestrictionRanges"] = llx.StringData(grp.IPRestrictionRanges)
+	args["shareWithGroupLock"] = llx.BoolData(grp.ShareWithGroupLock)
+	args["sharedRunnersSetting"] = llx.StringData(string(grp.SharedRunnersSetting))
+	args["projectCreationLevel"] = llx.StringData(string(grp.ProjectCreationLevel))
+	args["subGroupCreationLevel"] = llx.StringData(string(grp.SubGroupCreationLevel))
+	args["autoDevopsEnabled"] = llx.BoolData(grp.AutoDevopsEnabled)
+	args["wikiAccessLevel"] = llx.StringData(string(grp.WikiAccessLevel))
+	args["ldapCn"] = llx.StringData(grp.LDAPCN)
+	args["ldapAccess"] = llx.IntData(int64(grp.LDAPAccess))
+	args["sharedWithGroups"] = llx.ArrayData(groupSharedGroupsToDicts(grp.SharedWithGroups), types.Dict)
+	args["ldapGroupLinks"] = llx.ArrayData(ldapGroupLinksToDicts(grp.LDAPGroupLinks), types.Dict)
+	args["defaultBranchProtection"] = llx.DictData(branchProtectionDefaultsToDict(grp.DefaultBranchProtectionDefaults))
+}
+
+// groupSharedGroupsToDicts flattens the groups a group is shared with into
+// queryable dicts (group identity + the access level granted).
+func groupSharedGroupsToDicts(groups []gitlab.SharedWithGroup) []any {
+	out := make([]any, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, map[string]any{
+			"groupId":          int64(g.GroupID),
+			"groupName":        g.GroupName,
+			"groupFullPath":    g.GroupFullPath,
+			"groupAccessLevel": int64(g.GroupAccessLevel),
+		})
+	}
+	return out
+}
+
+// ldapGroupLinksToDicts flattens LDAP group links into queryable dicts mapping
+// a directory group (cn/filter/provider) to the access level it grants.
+func ldapGroupLinksToDicts(links []*gitlab.LDAPGroupLink) []any {
+	out := make([]any, 0, len(links))
+	for _, l := range links {
+		if l == nil {
+			continue
+		}
+		out = append(out, map[string]any{
+			"cn":          l.CN,
+			"filter":      l.Filter,
+			"provider":    l.Provider,
+			"groupAccess": int64(l.GroupAccess),
+		})
+	}
+	return out
+}
+
+// branchProtectionDefaultsToDict summarizes the group's default branch-
+// protection policy; returns nil (MQL null) when the group has none.
+func branchProtectionDefaultsToDict(d *gitlab.BranchProtectionDefaults) any {
+	if d == nil {
+		return nil
+	}
+	accessLevels := func(levels []*gitlab.GroupAccessLevel) []any {
+		out := make([]any, 0, len(levels))
+		for _, l := range levels {
+			if l == nil || l.AccessLevel == nil {
+				continue
+			}
+			out = append(out, int64(*l.AccessLevel))
+		}
+		return out
+	}
+	return map[string]any{
+		"allowForcePush":            d.AllowForcePush,
+		"developerCanInitialPush":   d.DeveloperCanInitialPush,
+		"codeOwnerApprovalRequired": d.CodeOwnerApprovalRequired,
+		"allowedToPush":             accessLevels(d.AllowedToPush),
+		"allowedToMerge":            accessLevels(d.AllowedToMerge),
+	}
 }
 
 // projects lists all projects that belong to a group
@@ -350,34 +421,10 @@ func (g *mqlGitlabGroup) subgroups() ([]any, error) {
 
 	var mqlSubgroups []any
 	for _, subgroup := range allSubgroups {
-		// Convert ISOTime to time.Time for markedForDeletionOn
-		var markedForDeletionOn *time.Time
-		if subgroup.MarkedForDeletionOn != nil {
-			t := time.Time(*subgroup.MarkedForDeletionOn)
-			markedForDeletionOn = &t
-		}
-
-		subgroupArgs := map[string]*llx.RawData{
-			"id":                             llx.IntData(int64(subgroup.ID)),
-			"name":                           llx.StringData(subgroup.Name),
-			"path":                           llx.StringData(subgroup.Path),
-			"fullName":                       llx.StringData(subgroup.FullName),
-			"fullPath":                       llx.StringData(subgroup.FullPath),
-			"description":                    llx.StringData(subgroup.Description),
-			"createdAt":                      llx.TimeDataPtr(subgroup.CreatedAt),
-			"webURL":                         llx.StringData(string(subgroup.WebURL)),
-			"visibility":                     llx.StringData(string(subgroup.Visibility)),
-			"requireTwoFactorAuthentication": llx.BoolData(subgroup.RequireTwoFactorAuth),
-			"twoFactorGracePeriod":           llx.IntData(subgroup.TwoFactorGracePeriod),
-			"membershipLock":                 llx.BoolData(subgroup.MembershipLock),
-			"preventForkingOutsideGroup":     llx.BoolData(subgroup.PreventForkingOutsideGroup),
-			"mentionsDisabled":               llx.BoolData(subgroup.MentionsDisabled),
-			"emailsDisabled":                 llx.BoolData(!subgroup.EmailsEnabled),
-			"requestAccessEnabled":           llx.BoolData(subgroup.RequestAccessEnabled),
-			"markedForDeletionOn":            llx.TimeDataPtr(markedForDeletionOn),
-			"allowedEmailDomainsList":        llx.StringData(subgroup.AllowedEmailDomainsList),
-			"lfsEnabled":                     llx.BoolData(subgroup.LFSEnabled),
-		}
+		// Reuse populateGroupArgs so subgroups expose the same field set as
+		// top-level groups (and inherit new fields automatically).
+		subgroupArgs := map[string]*llx.RawData{}
+		populateGroupArgs(subgroupArgs, subgroup)
 
 		mqlSubgroup, err := CreateResource(g.MqlRuntime, "gitlab.group", subgroupArgs)
 		if err != nil {

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -89,7 +89,40 @@ func getGitlabProjectArgs(prj *gitlab.Project) map[string]*llx.RawData {
 		"forksCount":                                llx.IntData(prj.ForksCount),
 		"starCount":                                 llx.IntData(prj.StarCount),
 		"lastActivityAt":                            llx.TimeDataPtr(prj.LastActivityAt),
+		"emailsEnabled":                             llx.BoolData(prj.EmailsEnabled),
+		"issuesAccessLevel":                         llx.StringData(string(prj.IssuesAccessLevel)),
+		"mergeRequestsAccessLevel":                  llx.StringData(string(prj.MergeRequestsAccessLevel)),
+		"wikiAccessLevel":                           llx.StringData(string(prj.WikiAccessLevel)),
+		"snippetsAccessLevel":                       llx.StringData(string(prj.SnippetsAccessLevel)),
+		"containerRegistryAccessLevel":              llx.StringData(string(prj.ContainerRegistryAccessLevel)),
+		"buildsAccessLevel":                         llx.StringData(string(prj.BuildsAccessLevel)),
+		"repositoryAccessLevel":                     llx.StringData(string(prj.RepositoryAccessLevel)),
+		"forkingAccessLevel":                        llx.StringData(string(prj.ForkingAccessLevel)),
+		"securityAndComplianceAccessLevel":          llx.StringData(string(prj.SecurityAndComplianceAccessLevel)),
+		"securityAndComplianceEnabled":              llx.BoolData(prj.SecurityAndComplianceEnabled),
+		"ciJobTokenScopeEnabled":                    llx.BoolData(prj.CIJobTokenScopeEnabled),
+		"publicJobs":                                llx.BoolData(prj.PublicJobs),
+		"preReceiveSecretDetectionEnabled":          llx.BoolData(prj.PreReceiveSecretDetectionEnabled),
+		"complianceFrameworks":                      llx.ArrayData(convert.SliceAnyToInterface(prj.ComplianceFrameworks), types.String),
+		"sharedWithGroups":                          llx.ArrayData(projectSharedGroupsToDicts(prj.SharedWithGroups), types.Dict),
+		"mirrorTriggerBuilds":                       llx.BoolData(prj.MirrorTriggerBuilds),
+		"onlyMirrorProtectedBranches":               llx.BoolData(prj.OnlyMirrorProtectedBranches),
 	}
+}
+
+// projectSharedGroupsToDicts flattens the groups a project is shared with into
+// queryable dicts (group identity + the access level granted to that group).
+func projectSharedGroupsToDicts(groups []gitlab.ProjectSharedWithGroup) []any {
+	out := make([]any, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, map[string]any{
+			"groupId":          int64(g.GroupID),
+			"groupName":        g.GroupName,
+			"groupFullPath":    g.GroupFullPath,
+			"groupAccessLevel": int64(g.GroupAccessLevel),
+		})
+	}
+	return out
 }
 
 func (g *mqlGitlabProject) id() (string, error) {


### PR DESCRIPTION
## What

Second half of the depth-audit **Tier 1** (part 1 was #8895, protected-branch access levels). This adds governance/compliance visibility to `gitlab.project` and `gitlab.group`, and migrates the SDK-deprecated feature toggles.

### `gitlab.project`
- **Deprecated-field migration:** adds the modern `*AccessLevel` fields — `issuesAccessLevel`, `mergeRequestsAccessLevel`, `wikiAccessLevel`, `snippetsAccessLevel`, `containerRegistryAccessLevel`, `buildsAccessLevel`, `repositoryAccessLevel`, `forkingAccessLevel`, `securityAndComplianceAccessLevel` — and marks the matching `*Enabled` bools `@maturity("deprecated")`. The SDK deprecated those bools; they can return stale/`false` values on modern instances because the data moved to the access-level fields. Old fields are kept for back-compat (versions unchanged).
- `emailsEnabled` (deprecates `emailsDisabled`).
- `complianceFrameworks`, `sharedWithGroups`, `ciJobTokenScopeEnabled`, `publicJobs`, `preReceiveSecretDetectionEnabled`, `securityAndComplianceEnabled`, and the mirror security posture (`mirrorTriggerBuilds`, `onlyMirrorProtectedBranches`).

### `gitlab.group`
- `ipRestrictionRanges` (network perimeter), `sharedWithGroups`, `shareWithGroupLock`, `sharedRunnersSetting`, `projectCreationLevel`, `subGroupCreationLevel`, `autoDevopsEnabled`, `wikiAccessLevel`, `defaultBranchProtection` (dict), and LDAP governance (`ldapCn`, `ldapAccess`, `ldapGroupLinks`).
- `emailsEnabled` (deprecates `emailsDisabled`).
- **Cleanup:** `subgroups()` now reuses `populateGroupArgs` instead of a duplicated inline field map, so subgroups expose the same field set as top-level groups and inherit these new fields automatically.

## Example queries
```
gitlab.projects.where(issuesAccessLevel == "enabled" && repositoryAccessLevel == "private")
gitlab.projects.where(complianceFrameworks.length == 0)
gitlab.projects.where(ciJobTokenScopeEnabled == false)   # unscoped CI tokens
gitlab.groups.where(ipRestrictionRanges == "")           # no IP allowlist
gitlab.groups { fullPath sharedRunnersSetting projectCreationLevel ldapGroupLinks }
```

## Notes
- All additions are additive and non-breaking; new `.lr.versions` entries at `13.3.9`. Deprecations do **not** bump versions.
- `sharedWithGroups`, `ldapGroupLinks`, and `defaultBranchProtection` are modeled as `dict`/`[]dict` (following the existing `approvalRule.groups` precedent) rather than new sub-resources, since they're data containers without a standalone identity.

## Test
- `go build ./...` (gitlab module) — clean
- `go vet ./resources/` — clean
- `go test ./resources/` — pass
