### PR TITLE
✨ providers: log each deleted provider at info with name and path

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -76,10 +76,10 @@ func deleteProvider(provider *Provider) error {
 	if provider.Path == "" {
 		return errors.Newf("provider %q is builtin and cannot be removed", provider.Name)
 	}
-	log.Debug().Str("path", provider.Path).Msg("removing installed provider")
 	if err := os.RemoveAll(provider.Path); err != nil {
 		return errors.Wrapf(err, "failed to remove provider %q", provider.Name)
 	}
+	log.Info().Str("provider", provider.Name).Str("path", provider.Path).Msg("deleted installed provider")
 	return nil
 }
 


### PR DESCRIPTION
## What

When deleting providers via `mql providers delete <name>` / `delete all`, log each removed provider at **info** level with both its **name** and **path**, so the user sees exactly what was removed.

## How

In `providers.deleteProvider`, the log moves from `debug` to `info`, now includes the provider name alongside the path, and fires *after* the removal succeeds:

```go
log.Info().Str("provider", provider.Name).Str("path", provider.Path).Msg("deleted installed provider")
```

Since `DeleteAll` delegates to `deleteProvider` per provider, `delete all` now emits one info line per removed provider.

## Test

`go test ./providers/ -run TestDelete` passes; sample output:

```
{"level":"info","provider":"aws","path":".../aws","message":"deleted installed provider"}
{"level":"info","provider":"os","path":".../os","message":"deleted installed provider"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)