### PR TITLE
⭐ gitlab: add CI job-token scope and protected tags resources

### DIFF
--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -708,6 +708,39 @@ gitlab.project @defaults("fullName visibility webURL") {
   packageProtectionRules() []gitlab.project.packageProtectionRule
   // Audit events recorded for the project (Premium/Ultimate)
   auditEvents() []gitlab.project.auditEvent
+  // CI/CD job-token access scope for the project
+  jobTokenScope() gitlab.project.jobTokenScope
+  // Protected tags and who may create them
+  protectedTags() []gitlab.project.protectedTag
+}
+
+// CI/CD job-token access scope
+//
+// Examine how the project restricts inbound CI/CD job-token access. When
+// `inboundEnabled` is true, only the projects in `inboundAllowlistProjects`
+// and groups in `allowlistGroups` may use their job tokens to access this
+// project; when false, any project's job token may reach it (a lateral-
+// movement risk).
+private gitlab.project.jobTokenScope @defaults("inboundEnabled") {
+  // Whether inbound job-token access is limited to the allowlist
+  inboundEnabled bool
+  // Projects whose CI job tokens are allowed to access this project
+  inboundAllowlistProjects() []gitlab.project
+  // Groups whose CI job tokens are allowed to access this project
+  allowlistGroups() []gitlab.group
+}
+
+// GitLab protected tag
+//
+// Examine a protected tag rule and the access levels permitted to create
+// tags matching it. The `name` is the tag name or wildcard pattern (for
+// example `v*`). `createAccessLevels` lists each role, user, group, or deploy
+// key allowed to create the tag.
+private gitlab.project.protectedTag @defaults("name") {
+  // Tag name or wildcard pattern
+  name string
+  // Access levels permitted to create the protected tag
+  createAccessLevels []gitlab.protectedBranch.accessLevel
 }
 
 // GitLab project approval rule

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -28,6 +28,8 @@ const (
 	ResourceGitlabGroupAuditEvent                        string = "gitlab.group.auditEvent"
 	ResourceGitlabProjectAuditEvent                      string = "gitlab.project.auditEvent"
 	ResourceGitlabProject                                string = "gitlab.project"
+	ResourceGitlabProjectJobTokenScope                   string = "gitlab.project.jobTokenScope"
+	ResourceGitlabProjectProtectedTag                    string = "gitlab.project.protectedTag"
 	ResourceGitlabProjectApprovalRule                    string = "gitlab.project.approvalRule"
 	ResourceGitlabProjectCodeowners                      string = "gitlab.project.codeowners"
 	ResourceGitlabProjectCodeownersRule                  string = "gitlab.project.codeowners.rule"
@@ -116,6 +118,14 @@ func init() {
 		"gitlab.project": {
 			Init:   initGitlabProject,
 			Create: createGitlabProject,
+		},
+		"gitlab.project.jobTokenScope": {
+			// to override args, implement: initGitlabProjectJobTokenScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGitlabProjectJobTokenScope,
+		},
+		"gitlab.project.protectedTag": {
+			// to override args, implement: initGitlabProjectProtectedTag(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGitlabProjectProtectedTag,
 		},
 		"gitlab.project.approvalRule": {
 			// to override args, implement: initGitlabProjectApprovalRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1161,6 +1171,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.auditEvents": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetAuditEvents()).ToDataRes(types.Array(types.Resource("gitlab.project.auditEvent")))
+	},
+	"gitlab.project.jobTokenScope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetJobTokenScope()).ToDataRes(types.Resource("gitlab.project.jobTokenScope"))
+	},
+	"gitlab.project.protectedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetProtectedTags()).ToDataRes(types.Array(types.Resource("gitlab.project.protectedTag")))
+	},
+	"gitlab.project.jobTokenScope.inboundEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectJobTokenScope).GetInboundEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.jobTokenScope.inboundAllowlistProjects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectJobTokenScope).GetInboundAllowlistProjects()).ToDataRes(types.Array(types.Resource("gitlab.project")))
+	},
+	"gitlab.project.jobTokenScope.allowlistGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectJobTokenScope).GetAllowlistGroups()).ToDataRes(types.Array(types.Resource("gitlab.group")))
+	},
+	"gitlab.project.protectedTag.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectProtectedTag).GetName()).ToDataRes(types.String)
+	},
+	"gitlab.project.protectedTag.createAccessLevels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectProtectedTag).GetCreateAccessLevels()).ToDataRes(types.Array(types.Resource("gitlab.protectedBranch.accessLevel")))
 	},
 	"gitlab.project.approvalRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectApprovalRule).GetId()).ToDataRes(types.Int)
@@ -3430,6 +3461,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.project.auditEvents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).AuditEvents, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.jobTokenScope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).JobTokenScope, ok = plugin.RawToTValue[*mqlGitlabProjectJobTokenScope](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.protectedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ProtectedTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.jobTokenScope.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectJobTokenScope).__id, ok = v.Value.(string)
+		return
+	},
+	"gitlab.project.jobTokenScope.inboundEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectJobTokenScope).InboundEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.jobTokenScope.inboundAllowlistProjects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectJobTokenScope).InboundAllowlistProjects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.jobTokenScope.allowlistGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectJobTokenScope).AllowlistGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.protectedTag.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedTag).__id, ok = v.Value.(string)
+		return
+	},
+	"gitlab.project.protectedTag.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedTag).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.protectedTag.createAccessLevels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectProtectedTag).CreateAccessLevels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.approvalRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7009,6 +7076,8 @@ type mqlGitlabProject struct {
 	Packages                                  plugin.TValue[[]any]
 	PackageProtectionRules                    plugin.TValue[[]any]
 	AuditEvents                               plugin.TValue[[]any]
+	JobTokenScope                             plugin.TValue[*mqlGitlabProjectJobTokenScope]
+	ProtectedTags                             plugin.TValue[[]any]
 }
 
 // createGitlabProject creates a new instance of this resource
@@ -7702,6 +7771,165 @@ func (c *mqlGitlabProject) GetAuditEvents() *plugin.TValue[[]any] {
 
 		return c.auditEvents()
 	})
+}
+
+func (c *mqlGitlabProject) GetJobTokenScope() *plugin.TValue[*mqlGitlabProjectJobTokenScope] {
+	return plugin.GetOrCompute[*mqlGitlabProjectJobTokenScope](&c.JobTokenScope, func() (*mqlGitlabProjectJobTokenScope, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.project", c.__id, "jobTokenScope")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGitlabProjectJobTokenScope), nil
+			}
+		}
+
+		return c.jobTokenScope()
+	})
+}
+
+func (c *mqlGitlabProject) GetProtectedTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ProtectedTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.project", c.__id, "protectedTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.protectedTags()
+	})
+}
+
+// mqlGitlabProjectJobTokenScope for the gitlab.project.jobTokenScope resource
+type mqlGitlabProjectJobTokenScope struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlGitlabProjectJobTokenScopeInternal
+	InboundEnabled           plugin.TValue[bool]
+	InboundAllowlistProjects plugin.TValue[[]any]
+	AllowlistGroups          plugin.TValue[[]any]
+}
+
+// createGitlabProjectJobTokenScope creates a new instance of this resource
+func createGitlabProjectJobTokenScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGitlabProjectJobTokenScope{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gitlab.project.jobTokenScope", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGitlabProjectJobTokenScope) MqlName() string {
+	return "gitlab.project.jobTokenScope"
+}
+
+func (c *mqlGitlabProjectJobTokenScope) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGitlabProjectJobTokenScope) GetInboundEnabled() *plugin.TValue[bool] {
+	return &c.InboundEnabled
+}
+
+func (c *mqlGitlabProjectJobTokenScope) GetInboundAllowlistProjects() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InboundAllowlistProjects, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.project.jobTokenScope", c.__id, "inboundAllowlistProjects")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.inboundAllowlistProjects()
+	})
+}
+
+func (c *mqlGitlabProjectJobTokenScope) GetAllowlistGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AllowlistGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gitlab.project.jobTokenScope", c.__id, "allowlistGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.allowlistGroups()
+	})
+}
+
+// mqlGitlabProjectProtectedTag for the gitlab.project.protectedTag resource
+type mqlGitlabProjectProtectedTag struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGitlabProjectProtectedTagInternal it will be used here
+	Name               plugin.TValue[string]
+	CreateAccessLevels plugin.TValue[[]any]
+}
+
+// createGitlabProjectProtectedTag creates a new instance of this resource
+func createGitlabProjectProtectedTag(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGitlabProjectProtectedTag{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gitlab.project.protectedTag", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGitlabProjectProtectedTag) MqlName() string {
+	return "gitlab.project.protectedTag"
+}
+
+func (c *mqlGitlabProjectProtectedTag) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGitlabProjectProtectedTag) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlGitlabProjectProtectedTag) GetCreateAccessLevels() *plugin.TValue[[]any] {
+	return &c.CreateAccessLevels
 }
 
 // mqlGitlabProjectApprovalRule for the gitlab.project.approvalRule resource

--- a/providers/gitlab/resources/gitlab.lr.versions
+++ b/providers/gitlab/resources/gitlab.lr.versions
@@ -354,6 +354,10 @@ gitlab.project.issue.webURL 11.1.129
 gitlab.project.issues 11.1.129
 gitlab.project.issuesAccessLevel 13.3.9
 gitlab.project.issuesEnabled 9.0.1
+gitlab.project.jobTokenScope 13.3.9
+gitlab.project.jobTokenScope.allowlistGroups 13.3.9
+gitlab.project.jobTokenScope.inboundAllowlistProjects 13.3.9
+gitlab.project.jobTokenScope.inboundEnabled 13.3.9
 gitlab.project.jobsEnabled 11.1.36
 gitlab.project.label 11.1.129
 gitlab.project.label.closedIssuesCount 11.1.129
@@ -477,6 +481,10 @@ gitlab.project.protectedBranch.name 11.1.12
 gitlab.project.protectedBranch.pushAccessLevels 13.3.9
 gitlab.project.protectedBranch.unprotectAccessLevels 13.3.9
 gitlab.project.protectedBranches 11.1.12
+gitlab.project.protectedTag 13.3.9
+gitlab.project.protectedTag.createAccessLevels 13.3.9
+gitlab.project.protectedTag.name 13.3.9
+gitlab.project.protectedTags 13.3.9
 gitlab.project.publicJobs 13.3.9
 gitlab.project.pushRule 11.1.138
 gitlab.project.pushRule.authorEmailRegex 11.1.138

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -522,6 +522,153 @@ func projectBranchAccessLevels(runtime *plugin.Runtime, idPrefix string, descs [
 	return out, nil
 }
 
+// projectTagAccessLevels reuses the shared protectedBranch.accessLevel row for
+// protected-tag create-access grants (TagAccessDescription is structurally
+// identical to BranchAccessDescription).
+func projectTagAccessLevels(runtime *plugin.Runtime, idPrefix string, descs []*gitlab.TagAccessDescription) ([]any, error) {
+	out := make([]any, 0, len(descs))
+	for _, d := range descs {
+		if d == nil {
+			continue
+		}
+		al, err := newMqlProtectedBranchAccessLevel(runtime, idPrefix, d.ID, int64(d.AccessLevel), d.UserID, d.GroupID, d.DeployKeyID, d.AccessLevelDescription)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, al)
+	}
+	return out, nil
+}
+
+// protectedTags lists the project's protected tags and who may create them.
+func (p *mqlGitlabProject) protectedTags() ([]any, error) {
+	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)
+	projectID := int(p.Id.Data)
+
+	perPage := int64(50)
+	page := int64(1)
+	var all []*gitlab.ProtectedTag
+	for {
+		tags, resp, err := conn.Client().ProtectedTags.ListProtectedTags(projectID, &gitlab.ListProtectedTagsOptions{ListOptions: gitlab.ListOptions{Page: page, PerPage: perPage}})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, tags...)
+		if resp.NextPage == 0 {
+			break
+		}
+		page = resp.NextPage
+	}
+
+	out := make([]any, 0, len(all))
+	for _, tag := range all {
+		prefix := fmt.Sprintf("gitlab.project.protectedTag/%d/%s", p.Id.Data, tag.Name)
+		levels, err := projectTagAccessLevels(p.MqlRuntime, prefix+"/create", tag.CreateAccessLevels)
+		if err != nil {
+			return nil, err
+		}
+		res, err := CreateResource(p.MqlRuntime, "gitlab.project.protectedTag", map[string]*llx.RawData{
+			"__id":               llx.StringData(prefix),
+			"name":               llx.StringData(tag.Name),
+			"createAccessLevels": llx.ArrayData(levels, types.Resource("gitlab.protectedBranch.accessLevel")),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// mqlGitlabProjectJobTokenScopeInternal caches the project id so the lazy
+// allowlist accessors can page their respective endpoints.
+type mqlGitlabProjectJobTokenScopeInternal struct {
+	projectID int64
+}
+
+// jobTokenScope returns the project's CI/CD job-token access scope, or null
+// when the setting is unavailable (permissions/tier).
+func (p *mqlGitlabProject) jobTokenScope() (*mqlGitlabProjectJobTokenScope, error) {
+	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)
+	settings, resp, err := conn.Client().JobTokenScope.GetProjectJobTokenAccessSettings(int(p.Id.Data))
+	if err != nil {
+		if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
+			p.JobTokenScope.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	res, err := CreateResource(p.MqlRuntime, "gitlab.project.jobTokenScope", map[string]*llx.RawData{
+		"__id":           llx.StringData(fmt.Sprintf("gitlab.project.jobTokenScope/%d", p.Id.Data)),
+		"inboundEnabled": llx.BoolData(settings.InboundEnabled),
+	})
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlGitlabProjectJobTokenScope).projectID = p.Id.Data
+	return res.(*mqlGitlabProjectJobTokenScope), nil
+}
+
+func (j *mqlGitlabProjectJobTokenScope) inboundAllowlistProjects() ([]any, error) {
+	conn := j.MqlRuntime.Connection.(*connection.GitLabConnection)
+	pid := int(j.projectID)
+
+	perPage := int64(50)
+	page := int64(1)
+	var out []any
+	for {
+		projects, resp, err := conn.Client().JobTokenScope.GetProjectJobTokenInboundAllowList(pid, &gitlab.GetJobTokenInboundAllowListOptions{ListOptions: gitlab.ListOptions{Page: page, PerPage: perPage}})
+		if err != nil {
+			if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for _, pr := range projects {
+			mqlPr, err := NewResource(j.MqlRuntime, "gitlab.project", map[string]*llx.RawData{"id": llx.IntData(int64(pr.ID))})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mqlPr)
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		page = resp.NextPage
+	}
+	return out, nil
+}
+
+func (j *mqlGitlabProjectJobTokenScope) allowlistGroups() ([]any, error) {
+	conn := j.MqlRuntime.Connection.(*connection.GitLabConnection)
+	pid := int(j.projectID)
+
+	perPage := int64(50)
+	page := int64(1)
+	var out []any
+	for {
+		groups, resp, err := conn.Client().JobTokenScope.GetJobTokenAllowlistGroups(pid, &gitlab.GetJobTokenAllowlistGroupsOptions{ListOptions: gitlab.ListOptions{Page: page, PerPage: perPage}})
+		if err != nil {
+			if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		for _, g := range groups {
+			mqlGrp, err := NewResource(j.MqlRuntime, "gitlab.group", map[string]*llx.RawData{"id": llx.IntData(int64(g.ID))})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mqlGrp)
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		page = resp.NextPage
+	}
+	return out, nil
+}
+
 // projectMembers fetches the list of members in the project with their roles
 func (p *mqlGitlabProject) projectMembers() ([]any, error) {
 	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)


### PR DESCRIPTION
## What

First PR of the new-resource (breadth) track — two supply-chain / access controls the provider didn't model at all.

### `gitlab.project.jobTokenScope` (new)
The CI/CD job-token access scope — a top hardening control:
- `inboundEnabled` — whether inbound job-token access is limited to an allowlist. When `false`, **any** project's CI job token may reach this project (a lateral-movement risk).
- `inboundAllowlistProjects()` / `allowlistGroups()` — typed `gitlab.project` / `gitlab.group` references for the projects and groups whose job tokens are allowed to access this project (fetched on demand, paged).

Exposed as a singular `gitlab.project.jobTokenScope()` accessor.

### `gitlab.project.protectedTag` (new)
- `name` (tag name or wildcard pattern) + `createAccessLevels` — who may create tags matching it. Reuses the shared `gitlab.protectedBranch.accessLevel` row (the SDK's `TagAccessDescription` is structurally identical to `BranchAccessDescription`), so each grant resolves to a typed `user()`/`group()` or a `deployKeyId` — the same shape shipped for protected branches in #8895.

Exposed as `gitlab.project.protectedTags()`.

## Example queries
```
# projects that accept job tokens from anywhere
gitlab.projects.where(jobTokenScope.inboundEnabled == false) { fullPath }

gitlab.project.jobTokenScope {
  inboundEnabled
  inboundAllowlistProjects { fullPath }
  allowlistGroups { fullPath }
}

# tags anyone below Maintainer can create
gitlab.project.protectedTags.where(createAccessLevels.any(accessLevel < 40)) { name }
```

## Notes
- Both new resources are additive; new `.lr.versions` entries at `13.3.9`.
- Premium/permission-gated calls return null (`jobTokenScope`) or an empty list on `403/404` rather than failing the resource graph.
- `jobTokenScope` synthetic `__id` is project-namespaced; the allowlist accessors page their endpoints on demand and cache nothing beyond the project id.

## Test
- `go build ./...` (gitlab module) — clean
- `go vet ./resources/` — clean
- `go test ./resources/` — pass
