### PR TITLE
✨ azure: expose APIM gateway TLS/cipher policy as typed booleans

### DIFF
--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -24,6 +25,31 @@ import (
 type mqlAzureSubscriptionApiManagementServiceServiceInternal struct {
 	cachePublicIpAddressId string
 	cacheSystemData        any
+}
+
+// API Management encodes its gateway TLS protocol and cipher policy as
+// string "True"/"False" values under these custom-property keys.
+const (
+	apimTLS10Key        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"
+	apimTLS11Key        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11"
+	apimSSL30Key        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30"
+	apimBackendTLS10Key = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10"
+	apimBackendTLS11Key = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11"
+	apimBackendSSL30Key = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30"
+	apimTripleDesKey    = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168"
+	apimHTTP2Key        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2"
+)
+
+// apimBoolCustomProperty reads a "True"/"False" API Management custom property,
+// returning nil when the key is absent so the field surfaces as null rather
+// than a misleading false.
+func apimBoolCustomProperty(props map[string]*string, key string) *bool {
+	v, ok := props[key]
+	if !ok || v == nil {
+		return nil
+	}
+	b := strings.EqualFold(*v, "true")
+	return &b
 }
 
 func (a *mqlAzureSubscriptionApiManagementService) id() (string, error) {
@@ -111,6 +137,14 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 				legacyPortalStatus             string
 				platformVersion                string
 				customProperties               = map[string]any{}
+				tls10Enabled                   *bool
+				tls11Enabled                   *bool
+				ssl30Enabled                   *bool
+				backendTls10Enabled            *bool
+				backendTls11Enabled            *bool
+				backendSsl30Enabled            *bool
+				tripleDesEnabled               *bool
+				http2Enabled                   *bool
 				publicIpAddresses              = []any{}
 				privateIpAddresses             = []any{}
 				outboundPublicIpAddresses      = []any{}
@@ -177,6 +211,14 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 						customProperties[k] = *v
 					}
 				}
+				tls10Enabled = apimBoolCustomProperty(p.CustomProperties, apimTLS10Key)
+				tls11Enabled = apimBoolCustomProperty(p.CustomProperties, apimTLS11Key)
+				ssl30Enabled = apimBoolCustomProperty(p.CustomProperties, apimSSL30Key)
+				backendTls10Enabled = apimBoolCustomProperty(p.CustomProperties, apimBackendTLS10Key)
+				backendTls11Enabled = apimBoolCustomProperty(p.CustomProperties, apimBackendTLS11Key)
+				backendSsl30Enabled = apimBoolCustomProperty(p.CustomProperties, apimBackendSSL30Key)
+				tripleDesEnabled = apimBoolCustomProperty(p.CustomProperties, apimTripleDesKey)
+				http2Enabled = apimBoolCustomProperty(p.CustomProperties, apimHTTP2Key)
 				for _, ip := range p.PublicIPAddresses {
 					if ip != nil {
 						publicIpAddresses = append(publicIpAddresses, *ip)
@@ -234,6 +276,14 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 					"legacyPortalStatus":             llx.StringData(legacyPortalStatus),
 					"platformVersion":                llx.StringData(platformVersion),
 					"customProperties":               llx.MapData(customProperties, types.String),
+					"tls10Enabled":                   llx.BoolDataPtr(tls10Enabled),
+					"tls11Enabled":                   llx.BoolDataPtr(tls11Enabled),
+					"ssl30Enabled":                   llx.BoolDataPtr(ssl30Enabled),
+					"backendTls10Enabled":            llx.BoolDataPtr(backendTls10Enabled),
+					"backendTls11Enabled":            llx.BoolDataPtr(backendTls11Enabled),
+					"backendSsl30Enabled":            llx.BoolDataPtr(backendSsl30Enabled),
+					"tripleDesEnabled":               llx.BoolDataPtr(tripleDesEnabled),
+					"http2Enabled":                   llx.BoolDataPtr(http2Enabled),
 					"identityType":                   llx.StringData(identityType),
 					"publicIpAddresses":              llx.ArrayData(publicIpAddresses, types.String),
 					"privateIpAddresses":             llx.ArrayData(privateIpAddresses, types.String),

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -11005,6 +11005,22 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   //
   // Keys like `Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10` map to "True"/"False" string values.
   customProperties map[string]string
+  // Whether TLS 1.0 is enabled for client connections to the gateway (null when the service does not report the setting)
+  tls10Enabled bool
+  // Whether TLS 1.1 is enabled for client connections to the gateway (null when the service does not report the setting)
+  tls11Enabled bool
+  // Whether SSL 3.0 is enabled for client connections to the gateway (null when the service does not report the setting)
+  ssl30Enabled bool
+  // Whether TLS 1.0 is enabled for gateway connections to backend services (null when the service does not report the setting)
+  backendTls10Enabled bool
+  // Whether TLS 1.1 is enabled for gateway connections to backend services (null when the service does not report the setting)
+  backendTls11Enabled bool
+  // Whether SSL 3.0 is enabled for gateway connections to backend services (null when the service does not report the setting)
+  backendSsl30Enabled bool
+  // Whether the 3DES (TLS_RSA_WITH_3DES_EDE_CBC_SHA) cipher is enabled on the gateway (null when the service does not report the setting)
+  tripleDesEnabled bool
+  // Whether HTTP/2 is enabled on the gateway (null when the service does not report the setting)
+  http2Enabled bool
   // Identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned")
   identityType string
   // Public load-balanced IPv4 addresses of the service in its primary region (Basic / Standard / Premium / Isolated SKUs)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -14530,6 +14530,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.apiManagementService.service.customProperties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetCustomProperties()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"azure.subscription.apiManagementService.service.tls10Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetTls10Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.tls11Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetTls11Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.ssl30Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetSsl30Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.backendTls10Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetBackendTls10Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.backendTls11Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetBackendTls11Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.backendSsl30Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetBackendSsl30Enabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.tripleDesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetTripleDesEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.apiManagementService.service.http2Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetHttp2Enabled()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.apiManagementService.service.identityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetIdentityType()).ToDataRes(types.String)
 	},
@@ -34098,6 +34122,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.apiManagementService.service.customProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionApiManagementServiceService).CustomProperties, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.tls10Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).Tls10Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.tls11Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).Tls11Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.ssl30Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).Ssl30Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.backendTls10Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).BackendTls10Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.backendTls11Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).BackendTls11Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.backendSsl30Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).BackendSsl30Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.tripleDesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).TripleDesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.http2Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).Http2Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.apiManagementService.service.identityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -79601,6 +79657,14 @@ type mqlAzureSubscriptionApiManagementServiceService struct {
 	LegacyPortalStatus             plugin.TValue[string]
 	PlatformVersion                plugin.TValue[string]
 	CustomProperties               plugin.TValue[map[string]any]
+	Tls10Enabled                   plugin.TValue[bool]
+	Tls11Enabled                   plugin.TValue[bool]
+	Ssl30Enabled                   plugin.TValue[bool]
+	BackendTls10Enabled            plugin.TValue[bool]
+	BackendTls11Enabled            plugin.TValue[bool]
+	BackendSsl30Enabled            plugin.TValue[bool]
+	TripleDesEnabled               plugin.TValue[bool]
+	Http2Enabled                   plugin.TValue[bool]
 	IdentityType                   plugin.TValue[string]
 	PublicIpAddresses              plugin.TValue[[]any]
 	PrivateIpAddresses             plugin.TValue[[]any]
@@ -79751,6 +79815,38 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetPlatformVersion() *
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetCustomProperties() *plugin.TValue[map[string]any] {
 	return &c.CustomProperties
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetTls10Enabled() *plugin.TValue[bool] {
+	return &c.Tls10Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetTls11Enabled() *plugin.TValue[bool] {
+	return &c.Tls11Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetSsl30Enabled() *plugin.TValue[bool] {
+	return &c.Ssl30Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetBackendTls10Enabled() *plugin.TValue[bool] {
+	return &c.BackendTls10Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetBackendTls11Enabled() *plugin.TValue[bool] {
+	return &c.BackendTls11Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetBackendSsl30Enabled() *plugin.TValue[bool] {
+	return &c.BackendSsl30Enabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetTripleDesEnabled() *plugin.TValue[bool] {
+	return &c.TripleDesEnabled
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetHttp2Enabled() *plugin.TValue[bool] {
+	return &c.Http2Enabled
 }
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetIdentityType() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -172,6 +172,9 @@ azure.subscription.aksService.subscriptionId 9.0.1
 azure.subscription.apiManagement 13.10.2
 azure.subscription.apiManagementService 13.10.2
 azure.subscription.apiManagementService.service 13.10.2
+azure.subscription.apiManagementService.service.backendSsl30Enabled 13.24.1
+azure.subscription.apiManagementService.service.backendTls10Enabled 13.24.1
+azure.subscription.apiManagementService.service.backendTls11Enabled 13.24.1
 azure.subscription.apiManagementService.service.createdAt 13.10.2
 azure.subscription.apiManagementService.service.customProperties 13.10.2
 azure.subscription.apiManagementService.service.developerPortalStatus 13.10.2
@@ -180,6 +183,7 @@ azure.subscription.apiManagementService.service.disableGateway 13.10.2
 azure.subscription.apiManagementService.service.enableClientCertificate 13.10.2
 azure.subscription.apiManagementService.service.gatewayRegionalUrl 13.10.2
 azure.subscription.apiManagementService.service.gatewayUrl 13.10.2
+azure.subscription.apiManagementService.service.http2Enabled 13.24.1
 azure.subscription.apiManagementService.service.id 13.10.2
 azure.subscription.apiManagementService.service.identityType 13.10.2
 azure.subscription.apiManagementService.service.legacyPortalStatus 13.10.2
@@ -202,9 +206,13 @@ azure.subscription.apiManagementService.service.publisherName 13.10.2
 azure.subscription.apiManagementService.service.scmUrl 13.10.2
 azure.subscription.apiManagementService.service.skuCapacity 13.10.2
 azure.subscription.apiManagementService.service.skuName 13.10.2
+azure.subscription.apiManagementService.service.ssl30Enabled 13.24.1
 azure.subscription.apiManagementService.service.systemMetadata 13.22.1
 azure.subscription.apiManagementService.service.tags 13.10.2
 azure.subscription.apiManagementService.service.targetProvisioningState 13.10.2
+azure.subscription.apiManagementService.service.tls10Enabled 13.24.1
+azure.subscription.apiManagementService.service.tls11Enabled 13.24.1
+azure.subscription.apiManagementService.service.tripleDesEnabled 13.24.1
 azure.subscription.apiManagementService.service.virtualNetworkType 13.10.2
 azure.subscription.apiManagementService.service.zones 13.10.2
 azure.subscription.apiManagementService.services 13.10.2


### PR DESCRIPTION
## What

Adds eight typed boolean fields to `azure.subscription.apiManagementService.service` that expose the API Management gateway's TLS protocol and cipher policy for direct security auditing.

Azure APIM encodes this policy as `"True"`/`"False"` **string** values under `customProperties` keys like `Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10`. The raw map was already surfaced, but auditing it means knowing the exact key strings and string-matching the values. These fields lift the CIS-relevant controls into first-class booleans:

| Field | Custom-property key |
|---|---|
| `tls10Enabled` / `tls11Enabled` / `ssl30Enabled` | `...Gateway.Security.Protocols.{Tls10,Tls11,Ssl30}` (client-facing) |
| `backendTls10Enabled` / `backendTls11Enabled` / `backendSsl30Enabled` | `...Security.Backend.Protocols.{Tls10,Tls11,Ssl30}` |
| `tripleDesEnabled` | `...Security.Ciphers.TripleDes168` |
| `http2Enabled` | `...Gateway.Protocols.Server.Http2` |

## Why

"Is legacy TLS/SSL disabled on this API gateway?" is a standard compliance control. Before this, answering it required:

```mql
azure.subscription.apiManagementService.services {
  customProperties["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"] == "False"
}
```

Now:

```mql
azure.subscription.apiManagementService.services.all(tls10Enabled == false && ssl30Enabled == false)
```

## Notes

- **Nullable by design.** When a key is absent (e.g. Consumption SKU, or the service does not report it) the field surfaces as `null`, not `false` — a missing setting should not read as a false "this is disabled" assurance on a security field.
- **No new API call / permissions unchanged.** Values are read from the already-fetched `CustomProperties`; the generated `azure.permissions.json` is unchanged (242 permissions).
- The raw `customProperties` map is retained for the open-ended per-cipher-suite keys (e.g. the individual `TLS_RSA_WITH_AES_*` entries), which vary and aren't worth exploding into scalars.
- `.lr.versions` entries added at `13.24.1` (next patch after the current provider version).

## Verification

- `mqlr generate` and `make providers/build/azure` both clean; generated accessors/setters present.
- Live value-verification against a real APIM instance is pending — none exist in the available test subscription (APIM is slow/costly to provision). The parsing is a straightforward map-lookup + case-insensitive bool parse.
