### PR TITLE
⭐ azure: roll out private endpoint connections, identity, and provenance

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -561,6 +561,38 @@ func (a *mqlAzureSubscriptionAksServiceClusterIdentityBinding) id() (string, err
 	return a.Id.Data, nil
 }
 
+func (a *mqlAzureSubscriptionAksServiceCluster) privateEndpointConnections() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clusters.NewPrivateEndpointConnectionsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.List(ctx, resourceID.ResourceGroup, a.Name.Data, nil)
+	if err != nil {
+		// Private endpoint connections are absent on clusters without private
+		// networking, and the endpoint returns 403 when the caller lacks
+		// access. Treat both as "no connections" rather than failing.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, resp.Value)
+}
+
 func (a *mqlAzureSubscriptionAksServiceCluster) identityBindings() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()

--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -23,8 +23,18 @@ import (
 )
 
 type mqlAzureSubscriptionApiManagementServiceServiceInternal struct {
-	cachePublicIpAddressId string
-	cacheSystemData        any
+	cachePublicIpAddressId          string
+	cacheSystemData                 any
+	cacheUserAssignedIdentityIds    []string
+	cachePrivateEndpointConnections []*apim.RemotePrivateEndpointConnectionWrapper
+}
+
+func (a *mqlAzureSubscriptionApiManagementServiceService) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionApiManagementServiceService) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 // API Management encodes its gateway TLS protocol and cipher policy as
@@ -112,8 +122,15 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 			}
 
 			var identityType string
-			if svc.Identity != nil && svc.Identity.Type != nil {
-				identityType = string(*svc.Identity.Type)
+			var identityPrincipalId, identityTenantId *string
+			var userAssignedIdentityIds []string
+			if svc.Identity != nil {
+				if svc.Identity.Type != nil {
+					identityType = string(*svc.Identity.Type)
+				}
+				identityPrincipalId = svc.Identity.PrincipalID
+				identityTenantId = svc.Identity.TenantID
+				userAssignedIdentityIds = sortedUserAssignedIdentityIDs(svc.Identity.UserAssignedIdentities)
 			}
 
 			var (
@@ -285,6 +302,8 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 					"tripleDesEnabled":               llx.BoolDataPtr(tripleDesEnabled),
 					"http2Enabled":                   llx.BoolDataPtr(http2Enabled),
 					"identityType":                   llx.StringData(identityType),
+					"principalId":                    llx.StringDataPtr(identityPrincipalId),
+					"tenantId":                       llx.StringDataPtr(identityTenantId),
 					"publicIpAddresses":              llx.ArrayData(publicIpAddresses, types.String),
 					"privateIpAddresses":             llx.ArrayData(privateIpAddresses, types.String),
 					"outboundPublicIpAddresses":      llx.ArrayData(outboundPublicIpAddresses, types.String),
@@ -297,6 +316,10 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 			}
 			svcRes := mqlSvc.(*mqlAzureSubscriptionApiManagementServiceService)
 			svcRes.cachePublicIpAddressId = publicIpAddressId
+			svcRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			if p := svc.Properties; p != nil {
+				svcRes.cachePrivateEndpointConnections = p.PrivateEndpointConnections
+			}
 			sysData, err := convert.JsonToDict(svc.SystemData)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/appconfiguration.go
+++ b/providers/azure/resources/appconfiguration.go
@@ -163,9 +163,17 @@ func configurationStoreToMql(runtime *plugin.Runtime, store *armappconfiguration
 		return nil, err
 	}
 	mqlStore.cacheSystemData = sysData
+	if store.Properties != nil {
+		mqlStore.cachePrivateEndpointConnections = store.Properties.PrivateEndpointConnections
+	}
 	return mqlStore, nil
 }
 
 type mqlAzureSubscriptionAppConfigurationServiceConfigurationStoreInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armappconfiguration.PrivateEndpointConnectionReference
+}
+
+func (a *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7816,6 +7816,8 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   kubeletIdentity() azure.subscription.managedIdentity
   // Client ID of the legacy service principal used by the cluster; empty when the cluster uses a managed identity
   servicePrincipalClientId string
+  // Private endpoint connections to the cluster API server
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // Whether the AKS API server is reachable from the public internet
@@ -8246,6 +8248,16 @@ private azure.subscription.iotService.iotHub @defaults("id name location") {
   enableDataResidency bool
   // Network rule set: defaultAction, applyToBuiltInEventHubEndpoint, ipRules
   networkRuleSet dict
+  // Managed identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned")
+  identityType string
+  // Principal ID of the system-assigned managed identity
+  principalId string
+  // Tenant ID of the system-assigned managed identity
+  tenantId string
+  // User-assigned managed identities associated with the IoT hub
+  userAssignedIdentities() []azure.subscription.managedIdentity
+  // Private endpoint connections to the IoT hub
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Diagnostic settings configured on the IoT hub (forwarding logs and metrics to Log Analytics, storage, or Event Hub)
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
   // Creation and last-modification provenance recorded by Azure Resource Manager
@@ -8628,6 +8640,8 @@ azure.subscription.synapseService.workspace @defaults("name location") {
   cmkKey() azure.subscription.keyVaultService.key
   // User-assigned managed identities associated with the workspace
   userAssignedIdentities() []azure.subscription.managedIdentity
+  // Private endpoint connections to the workspace
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
 }
 
 // Azure Container Registry service
@@ -9595,6 +9609,8 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   queues() []azure.subscription.serviceBusService.namespace.queue
   // Topics in this namespace
   topics() []azure.subscription.serviceBusService.namespace.topic
+  // Private endpoint connections to the namespace
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // When the namespace was created
   creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
@@ -9783,6 +9799,8 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   networkRules() azure.subscription.eventHubService.namespace.networkRules
   // Event Hubs in this namespace
   eventHubs() []azure.subscription.eventHubService.namespace.eventHub
+  // Private endpoint connections to the namespace
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // When the namespace was created
   creationTime time
   // Creation and last-modification provenance recorded by Azure Resource Manager
@@ -11023,6 +11041,12 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   http2Enabled bool
   // Identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned")
   identityType string
+  // Principal ID of the system-assigned managed identity
+  principalId string
+  // Tenant ID of the system-assigned managed identity
+  tenantId string
+  // User-assigned managed identities associated with the service
+  userAssignedIdentities() []azure.subscription.managedIdentity
   // Public load-balanced IPv4 addresses of the service in its primary region (Basic / Standard / Premium / Isolated SKUs)
   publicIpAddresses []string
   // Private load-balanced IPv4 addresses of the service in its primary region when deployed in an Internal VNet
@@ -11030,7 +11054,11 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   // Outbound public IPv4 prefixes associated with NAT Gateway-deployed services (Premium SKU on stv2)
   outboundPublicIpAddresses []string
   // Number of private endpoint connections to the service
-  privateEndpointConnectionCount int
+  //
+  // Deprecated in favor of `privateEndpointConnections`.
+  privateEndpointConnectionCount @maturity("deprecated") int
+  // Private endpoint connections to the service
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Availability zones the service is spread across
   zones []string
   // Public IP address attached to the service (null when not configured)
@@ -11106,6 +11134,8 @@ private azure.subscription.purviewService.account @defaults("name location publi
   createdBy string
   // Unmodeled raw properties returned by the Azure API
   properties dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure AI Search
@@ -11652,6 +11682,8 @@ azure.subscription.appConfigurationService.configurationStore @defaults("id name
   defaultKeyValueRevisionRetentionPeriodInSeconds int
   // When the configuration store was created
   creationTime time
+  // Private endpoint connections to the configuration store
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -11741,6 +11773,8 @@ azure.subscription.cognitiveServicesService.account @defaults("id name location 
   projects() []azure.subscription.cognitiveServicesService.account.project
   // Account-scoped connections to external resources, model providers, data sources, and tool servers
   connections() []azure.subscription.cognitiveServicesService.account.connection
+  // Private endpoint connections to the account
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -12163,6 +12197,8 @@ azure.subscription.signalRService.signalR @defaults("id name location publicNetw
   networkAclsDefaultAction string
   // Provisioning state
   provisioningState string
+  // Private endpoint connections to the instance
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -12222,6 +12258,8 @@ azure.subscription.webPubSubService.webPubSub @defaults("id name location public
   networkAclsDefaultAction string
   // Provisioning state
   provisioningState string
+  // Private endpoint connections to the instance
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -11011,6 +11011,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.servicePrincipalClientId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetServicePrincipalClientId()).ToDataRes(types.String)
 	},
+	"azure.subscription.aksService.cluster.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -11521,6 +11524,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.iotService.iotHub.networkRuleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetNetworkRuleSet()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.iotService.iotHub.identityType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetIdentityType()).ToDataRes(types.String)
+	},
+	"azure.subscription.iotService.iotHub.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.iotService.iotHub.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.iotService.iotHub.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
+	"azure.subscription.iotService.iotHub.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotServiceIotHub).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
 	},
@@ -11919,6 +11937,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.synapseService.workspace.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
+	"azure.subscription.synapseService.workspace.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSynapseServiceWorkspace).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
 	"azure.subscription.containerRegistryService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryService).GetSubscriptionId()).ToDataRes(types.String)
@@ -12994,6 +13015,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetTopics()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.topic")))
 	},
+	"azure.subscription.serviceBusService.namespace.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.serviceBusService.namespace.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetCreationTime()).ToDataRes(types.Time)
 	},
@@ -13194,6 +13218,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventHubService.namespace.eventHubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetEventHubs()).ToDataRes(types.Array(types.Resource("azure.subscription.eventHubService.namespace.eventHub")))
+	},
+	"azure.subscription.eventHubService.namespace.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
 	"azure.subscription.eventHubService.namespace.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetCreationTime()).ToDataRes(types.Time)
@@ -14557,6 +14584,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.apiManagementService.service.identityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetIdentityType()).ToDataRes(types.String)
 	},
+	"azure.subscription.apiManagementService.service.principalId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.apiManagementService.service.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.apiManagementService.service.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
+	},
 	"azure.subscription.apiManagementService.service.publicIpAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPublicIpAddresses()).ToDataRes(types.Array(types.String))
 	},
@@ -14568,6 +14604,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.apiManagementService.service.privateEndpointConnectionCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPrivateEndpointConnectionCount()).ToDataRes(types.Int)
+	},
+	"azure.subscription.apiManagementService.service.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
 	"azure.subscription.apiManagementService.service.zones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetZones()).ToDataRes(types.Array(types.String))
@@ -14643,6 +14682,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.purviewService.account.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPurviewServiceAccount).GetProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.purviewService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPurviewServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.searchService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSearchService).GetSubscriptionId()).ToDataRes(types.String)
@@ -15157,6 +15199,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.appConfigurationService.configurationStore.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetCreationTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.appConfigurationService.configurationStore.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.appConfigurationService.configurationStore.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -15246,6 +15291,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.connections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.cognitiveServicesService.account.connection")))
+	},
+	"azure.subscription.cognitiveServicesService.account.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
 	"azure.subscription.cognitiveServicesService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -15625,6 +15673,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.signalRService.signalR.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSignalRServiceSignalR).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.signalRService.signalR.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSignalRServiceSignalR).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.signalRService.signalR.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSignalRServiceSignalR).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -15681,6 +15732,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webPubSubService.webPubSub.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.webPubSubService.webPubSub.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
 	"azure.subscription.webPubSubService.webPubSub.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -28964,6 +29018,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAksServiceCluster).ServicePrincipalClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.aksService.cluster.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.aksService.cluster.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -29716,6 +29774,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionIotServiceIotHub).NetworkRuleSet, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.iotService.iotHub.identityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.iotService.iotHub.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.iotService.iotHub.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.iotService.iotHub.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.iotService.iotHub.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionIotServiceIotHub).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.iotService.iotHub.diagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionIotServiceIotHub).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -30298,6 +30376,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.synapseService.workspace.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.synapseService.workspace.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSynapseServiceWorkspace).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31888,6 +31970,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).Topics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -32182,6 +32268,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventHubService.namespace.eventHubs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespace).EventHubs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventHubService.namespace.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespace).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventHubService.namespace.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34160,6 +34250,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionApiManagementServiceService).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.apiManagementService.service.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.apiManagementService.service.publicIpAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionApiManagementServiceService).PublicIpAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -34174,6 +34276,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.apiManagementService.service.privateEndpointConnectionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionApiManagementServiceService).PrivateEndpointConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.apiManagementService.service.zones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34282,6 +34388,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.purviewService.account.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPurviewServiceAccount).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.purviewService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPurviewServiceAccount).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.searchService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35028,6 +35138,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.appConfigurationService.configurationStore.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.appConfigurationService.configurationStore.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAppConfigurationServiceConfigurationStore).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -35154,6 +35268,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.connections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).Connections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35712,6 +35830,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSignalRServiceSignalR).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.signalRService.signalR.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSignalRServiceSignalR).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.signalRService.signalR.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSignalRServiceSignalR).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -35794,6 +35916,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webPubSubService.webPubSub.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webPubSubService.webPubSub.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webPubSubService.webPubSub.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -66540,6 +66666,7 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	DiskEncryptionSet                 plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
 	KubeletIdentity                   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	ServicePrincipalClientId          plugin.TValue[string]
+	PrivateEndpointConnections        plugin.TValue[[]any]
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
 	InternetReachable                 plugin.TValue[bool]
 }
@@ -66903,6 +67030,22 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetKubeletIdentity() *plugin.TVa
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetServicePrincipalClientId() *plugin.TValue[string] {
 	return &c.ServicePrincipalClientId
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -68590,6 +68733,11 @@ type mqlAzureSubscriptionIotServiceIotHub struct {
 	AllowedFqdnList               plugin.TValue[[]any]
 	EnableDataResidency           plugin.TValue[bool]
 	NetworkRuleSet                plugin.TValue[any]
+	IdentityType                  plugin.TValue[string]
+	PrincipalId                   plugin.TValue[string]
+	TenantId                      plugin.TValue[string]
+	UserAssignedIdentities        plugin.TValue[[]any]
+	PrivateEndpointConnections    plugin.TValue[[]any]
 	DiagnosticSettings            plugin.TValue[[]any]
 	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
@@ -68701,6 +68849,50 @@ func (c *mqlAzureSubscriptionIotServiceIotHub) GetEnableDataResidency() *plugin.
 
 func (c *mqlAzureSubscriptionIotServiceIotHub) GetNetworkRuleSet() *plugin.TValue[any] {
 	return &c.NetworkRuleSet
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetIdentityType() *plugin.TValue[string] {
+	return &c.IdentityType
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.iotService.iotHub", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
+func (c *mqlAzureSubscriptionIotServiceIotHub) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.iotService.iotHub", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionIotServiceIotHub) GetDiagnosticSettings() *plugin.TValue[[]any] {
@@ -70063,6 +70255,7 @@ type mqlAzureSubscriptionSynapseServiceWorkspace struct {
 	DefaultStorage              plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount]
 	CmkKey                      plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	UserAssignedIdentities      plugin.TValue[[]any]
+	PrivateEndpointConnections  plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionSynapseServiceWorkspace creates a new instance of this resource
@@ -70211,6 +70404,22 @@ func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetUserAssignedIdentities(
 		}
 
 		return c.userAssignedIdentities()
+	})
+}
+
+func (c *mqlAzureSubscriptionSynapseServiceWorkspace) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.synapseService.workspace", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
 	})
 }
 
@@ -74241,6 +74450,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespace struct {
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules]
 	Queues                          plugin.TValue[[]any]
 	Topics                          plugin.TValue[[]any]
+	PrivateEndpointConnections      plugin.TValue[[]any]
 	CreationTime                    plugin.TValue[*time.Time]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
@@ -74385,6 +74595,22 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetTopics() *plugin.TVa
 		}
 
 		return c.topics()
+	})
+}
+
+func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.serviceBusService.namespace", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
 	})
 }
 
@@ -74988,6 +75214,7 @@ type mqlAzureSubscriptionEventHubServiceNamespace struct {
 	NetworkRuleSet                  plugin.TValue[any]
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules]
 	EventHubs                       plugin.TValue[[]any]
+	PrivateEndpointConnections      plugin.TValue[[]any]
 	CreationTime                    plugin.TValue[*time.Time]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
@@ -75128,6 +75355,22 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetEventHubs() *plugin.TV
 		}
 
 		return c.eventHubs()
+	})
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.eventHubService.namespace", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
 	})
 }
 
@@ -79666,10 +79909,14 @@ type mqlAzureSubscriptionApiManagementServiceService struct {
 	TripleDesEnabled               plugin.TValue[bool]
 	Http2Enabled                   plugin.TValue[bool]
 	IdentityType                   plugin.TValue[string]
+	PrincipalId                    plugin.TValue[string]
+	TenantId                       plugin.TValue[string]
+	UserAssignedIdentities         plugin.TValue[[]any]
 	PublicIpAddresses              plugin.TValue[[]any]
 	PrivateIpAddresses             plugin.TValue[[]any]
 	OutboundPublicIpAddresses      plugin.TValue[[]any]
 	PrivateEndpointConnectionCount plugin.TValue[int64]
+	PrivateEndpointConnections     plugin.TValue[[]any]
 	Zones                          plugin.TValue[[]any]
 	PublicIpAddress                plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
 	CreatedAt                      plugin.TValue[*time.Time]
@@ -79853,6 +80100,30 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetIdentityType() *plu
 	return &c.IdentityType
 }
 
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrincipalId() *plugin.TValue[string] {
+	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetUserAssignedIdentities() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UserAssignedIdentities, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.apiManagementService.service", c.__id, "userAssignedIdentities")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.userAssignedIdentities()
+	})
+}
+
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetPublicIpAddresses() *plugin.TValue[[]any] {
 	return &c.PublicIpAddresses
 }
@@ -79867,6 +80138,22 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetOutboundPublicIpAdd
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrivateEndpointConnectionCount() *plugin.TValue[int64] {
 	return &c.PrivateEndpointConnectionCount
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.apiManagementService.service", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetZones() *plugin.TValue[[]any] {
@@ -79979,7 +80266,7 @@ func (c *mqlAzureSubscriptionPurviewService) GetAccounts() *plugin.TValue[[]any]
 type mqlAzureSubscriptionPurviewServiceAccount struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionPurviewServiceAccountInternal it will be used here
+	mqlAzureSubscriptionPurviewServiceAccountInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Location                   plugin.TValue[string]
@@ -79999,6 +80286,7 @@ type mqlAzureSubscriptionPurviewServiceAccount struct {
 	CreatedByObjectId          plugin.TValue[string]
 	CreatedBy                  plugin.TValue[string]
 	Properties                 plugin.TValue[any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionPurviewServiceAccount creates a new instance of this resource
@@ -80112,6 +80400,22 @@ func (c *mqlAzureSubscriptionPurviewServiceAccount) GetCreatedBy() *plugin.TValu
 
 func (c *mqlAzureSubscriptionPurviewServiceAccount) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionPurviewServiceAccount) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.purviewService.account", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSearchService for the azure.subscription.searchService resource
@@ -81841,6 +82145,7 @@ type mqlAzureSubscriptionAppConfigurationServiceConfigurationStore struct {
 	CreateMode                                      plugin.TValue[string]
 	DefaultKeyValueRevisionRetentionPeriodInSeconds plugin.TValue[int64]
 	CreationTime                                    plugin.TValue[*time.Time]
+	PrivateEndpointConnections                      plugin.TValue[[]any]
 	SystemMetadata                                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -81947,6 +82252,22 @@ func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetDefau
 
 func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetCreationTime() *plugin.TValue[*time.Time] {
 	return &c.CreationTime
+}
+
+func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.appConfigurationService.configurationStore", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionAppConfigurationServiceConfigurationStore) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -82063,6 +82384,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccount struct {
 	Deployments                   plugin.TValue[[]any]
 	Projects                      plugin.TValue[[]any]
 	Connections                   plugin.TValue[[]any]
+	PrivateEndpointConnections    plugin.TValue[[]any]
 	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -82270,6 +82592,22 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetConnections() *
 		}
 
 		return c.connections()
+	})
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
 	})
 }
 
@@ -83527,23 +83865,24 @@ type mqlAzureSubscriptionSignalRServiceSignalR struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionSignalRServiceSignalRInternal
-	Id                       plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Location                 plugin.TValue[string]
-	Tags                     plugin.TValue[map[string]any]
-	Kind                     plugin.TValue[string]
-	Sku                      plugin.TValue[any]
-	Identity                 plugin.TValue[any]
-	HostName                 plugin.TValue[string]
-	ExternalIp               plugin.TValue[string]
-	Version                  plugin.TValue[string]
-	PublicNetworkAccess      plugin.TValue[string]
-	DisableLocalAuth         plugin.TValue[bool]
-	DisableAadAuth           plugin.TValue[bool]
-	ClientCertEnabled        plugin.TValue[bool]
-	NetworkAclsDefaultAction plugin.TValue[string]
-	ProvisioningState        plugin.TValue[string]
-	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
+	Id                         plugin.TValue[string]
+	Name                       plugin.TValue[string]
+	Location                   plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
+	Kind                       plugin.TValue[string]
+	Sku                        plugin.TValue[any]
+	Identity                   plugin.TValue[any]
+	HostName                   plugin.TValue[string]
+	ExternalIp                 plugin.TValue[string]
+	Version                    plugin.TValue[string]
+	PublicNetworkAccess        plugin.TValue[string]
+	DisableLocalAuth           plugin.TValue[bool]
+	DisableAadAuth             plugin.TValue[bool]
+	ClientCertEnabled          plugin.TValue[bool]
+	NetworkAclsDefaultAction   plugin.TValue[string]
+	ProvisioningState          plugin.TValue[string]
+	PrivateEndpointConnections plugin.TValue[[]any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSignalRServiceSignalR creates a new instance of this resource
@@ -83647,6 +83986,22 @@ func (c *mqlAzureSubscriptionSignalRServiceSignalR) GetProvisioningState() *plug
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionSignalRServiceSignalR) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.signalRService.signalR", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
+}
+
 func (c *mqlAzureSubscriptionSignalRServiceSignalR) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -83734,23 +84089,24 @@ type mqlAzureSubscriptionWebPubSubServiceWebPubSub struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionWebPubSubServiceWebPubSubInternal
-	Id                       plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Location                 plugin.TValue[string]
-	Tags                     plugin.TValue[map[string]any]
-	Kind                     plugin.TValue[string]
-	Sku                      plugin.TValue[any]
-	Identity                 plugin.TValue[any]
-	HostName                 plugin.TValue[string]
-	ExternalIp               plugin.TValue[string]
-	Version                  plugin.TValue[string]
-	PublicNetworkAccess      plugin.TValue[string]
-	DisableLocalAuth         plugin.TValue[bool]
-	DisableAadAuth           plugin.TValue[bool]
-	ClientCertEnabled        plugin.TValue[bool]
-	NetworkAclsDefaultAction plugin.TValue[string]
-	ProvisioningState        plugin.TValue[string]
-	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
+	Id                         plugin.TValue[string]
+	Name                       plugin.TValue[string]
+	Location                   plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
+	Kind                       plugin.TValue[string]
+	Sku                        plugin.TValue[any]
+	Identity                   plugin.TValue[any]
+	HostName                   plugin.TValue[string]
+	ExternalIp                 plugin.TValue[string]
+	Version                    plugin.TValue[string]
+	PublicNetworkAccess        plugin.TValue[string]
+	DisableLocalAuth           plugin.TValue[bool]
+	DisableAadAuth             plugin.TValue[bool]
+	ClientCertEnabled          plugin.TValue[bool]
+	NetworkAclsDefaultAction   plugin.TValue[string]
+	ProvisioningState          plugin.TValue[string]
+	PrivateEndpointConnections plugin.TValue[[]any]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebPubSubServiceWebPubSub creates a new instance of this resource
@@ -83852,6 +84208,22 @@ func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetNetworkAclsDefaultAct
 
 func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webPubSubService.webPubSub", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionWebPubSubServiceWebPubSub) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -152,6 +152,7 @@ azure.subscription.aksService.cluster.podIdentityProfile 9.0.1
 azure.subscription.aksService.cluster.powerState 9.0.1
 azure.subscription.aksService.cluster.principalId 13.22.1
 azure.subscription.aksService.cluster.privateDnsZone 11.4.28
+azure.subscription.aksService.cluster.privateEndpointConnections 13.24.1
 azure.subscription.aksService.cluster.privateFqdn 13.1.8
 azure.subscription.aksService.cluster.provisioningState 9.0.1
 azure.subscription.aksService.cluster.publicNetworkAccess 11.4.28
@@ -195,7 +196,9 @@ azure.subscription.apiManagementService.service.notificationSenderEmail 13.10.2
 azure.subscription.apiManagementService.service.outboundPublicIpAddresses 13.10.2
 azure.subscription.apiManagementService.service.platformVersion 13.10.2
 azure.subscription.apiManagementService.service.portalUrl 13.10.2
+azure.subscription.apiManagementService.service.principalId 13.24.1
 azure.subscription.apiManagementService.service.privateEndpointConnectionCount 13.10.2
+azure.subscription.apiManagementService.service.privateEndpointConnections 13.24.1
 azure.subscription.apiManagementService.service.privateIpAddresses 13.10.2
 azure.subscription.apiManagementService.service.provisioningState 13.10.2
 azure.subscription.apiManagementService.service.publicIpAddress 13.10.2
@@ -210,9 +213,11 @@ azure.subscription.apiManagementService.service.ssl30Enabled 13.24.1
 azure.subscription.apiManagementService.service.systemMetadata 13.22.1
 azure.subscription.apiManagementService.service.tags 13.10.2
 azure.subscription.apiManagementService.service.targetProvisioningState 13.10.2
+azure.subscription.apiManagementService.service.tenantId 13.24.1
 azure.subscription.apiManagementService.service.tls10Enabled 13.24.1
 azure.subscription.apiManagementService.service.tls11Enabled 13.24.1
 azure.subscription.apiManagementService.service.tripleDesEnabled 13.24.1
+azure.subscription.apiManagementService.service.userAssignedIdentities 13.24.1
 azure.subscription.apiManagementService.service.virtualNetworkType 13.10.2
 azure.subscription.apiManagementService.service.zones 13.10.2
 azure.subscription.apiManagementService.services 13.10.2
@@ -232,6 +237,7 @@ azure.subscription.appConfigurationService.configurationStore.id 13.11.3
 azure.subscription.appConfigurationService.configurationStore.identity 13.11.3
 azure.subscription.appConfigurationService.configurationStore.location 13.11.3
 azure.subscription.appConfigurationService.configurationStore.name 13.11.3
+azure.subscription.appConfigurationService.configurationStore.privateEndpointConnections 13.24.1
 azure.subscription.appConfigurationService.configurationStore.provisioningState 13.11.3
 azure.subscription.appConfigurationService.configurationStore.publicNetworkAccess 13.11.3
 azure.subscription.appConfigurationService.configurationStore.sku 13.11.3
@@ -794,6 +800,7 @@ azure.subscription.cognitiveServicesService.account.name 13.11.3
 azure.subscription.cognitiveServicesService.account.networkAcls 13.11.3
 azure.subscription.cognitiveServicesService.account.networkAclsBypass 13.16.2
 azure.subscription.cognitiveServicesService.account.networkAclsDefaultAction 13.16.2
+azure.subscription.cognitiveServicesService.account.privateEndpointConnections 13.24.1
 azure.subscription.cognitiveServicesService.account.project 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connection 13.15.2
 azure.subscription.cognitiveServicesService.account.project.connection.authType 13.15.2
@@ -2029,6 +2036,7 @@ azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule 13.
 azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule.ignoreMissingVnetServiceEndpoint 13.12.2
 azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule.subnet 13.12.2
 azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRules 13.12.2
+azure.subscription.eventHubService.namespace.privateEndpointConnections 13.24.1
 azure.subscription.eventHubService.namespace.publicNetworkAccess 13.4.3
 azure.subscription.eventHubService.namespace.requireInfrastructureEncryption 13.5.1
 azure.subscription.eventHubService.namespace.sku 13.3.3
@@ -2173,10 +2181,13 @@ azure.subscription.iotService.iotHub.disableModuleSAS 13.5.1
 azure.subscription.iotService.iotHub.enableDataResidency 13.5.1
 azure.subscription.iotService.iotHub.hostName 13.5.1
 azure.subscription.iotService.iotHub.id 13.5.1
+azure.subscription.iotService.iotHub.identityType 13.24.1
 azure.subscription.iotService.iotHub.location 13.5.1
 azure.subscription.iotService.iotHub.minTlsVersion 13.5.1
 azure.subscription.iotService.iotHub.name 13.5.1
 azure.subscription.iotService.iotHub.networkRuleSet 13.5.1
+azure.subscription.iotService.iotHub.principalId 13.24.1
+azure.subscription.iotService.iotHub.privateEndpointConnections 13.24.1
 azure.subscription.iotService.iotHub.provisioningState 13.5.1
 azure.subscription.iotService.iotHub.publicNetworkAccess 13.5.1
 azure.subscription.iotService.iotHub.restrictOutboundNetworkAccess 13.5.1
@@ -2184,7 +2195,9 @@ azure.subscription.iotService.iotHub.sku 13.5.1
 azure.subscription.iotService.iotHub.state 13.5.1
 azure.subscription.iotService.iotHub.systemMetadata 13.22.1
 azure.subscription.iotService.iotHub.tags 13.5.1
+azure.subscription.iotService.iotHub.tenantId 13.24.1
 azure.subscription.iotService.iotHub.type 13.5.1
+azure.subscription.iotService.iotHub.userAssignedIdentities 13.24.1
 azure.subscription.iotService.iotHubs 13.5.1
 azure.subscription.iotService.subscriptionId 11.3.0
 azure.subscription.keyVault 9.0.0
@@ -3885,6 +3898,7 @@ azure.subscription.purviewService.account.properties 13.11.2
 azure.subscription.purviewService.account.provisioningState 13.11.2
 azure.subscription.purviewService.account.publicNetworkAccess 13.11.2
 azure.subscription.purviewService.account.sku 13.11.2
+azure.subscription.purviewService.account.systemMetadata 13.24.1
 azure.subscription.purviewService.account.tags 13.11.2
 azure.subscription.purviewService.account.type 13.11.2
 azure.subscription.purviewService.accounts 13.11.2
@@ -4045,6 +4059,7 @@ azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRule 1
 azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRule.ignoreMissingVnetServiceEndpoint 13.12.2
 azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRule.subnet 13.12.2
 azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRules 13.12.2
+azure.subscription.serviceBusService.namespace.privateEndpointConnections 13.24.1
 azure.subscription.serviceBusService.namespace.provisioningState 13.5.1
 azure.subscription.serviceBusService.namespace.queue 13.3.3
 azure.subscription.serviceBusService.namespace.queue.creationTime 13.22.1
@@ -4112,6 +4127,7 @@ azure.subscription.signalRService.signalR.kind 13.16.2
 azure.subscription.signalRService.signalR.location 13.16.2
 azure.subscription.signalRService.signalR.name 13.16.2
 azure.subscription.signalRService.signalR.networkAclsDefaultAction 13.16.2
+azure.subscription.signalRService.signalR.privateEndpointConnections 13.24.1
 azure.subscription.signalRService.signalR.provisioningState 13.16.2
 azure.subscription.signalRService.signalR.publicNetworkAccess 13.16.2
 azure.subscription.signalRService.signalR.sku 13.16.2
@@ -4749,6 +4765,7 @@ azure.subscription.synapseService.workspace.location 13.3.0
 azure.subscription.synapseService.workspace.managedResourceGroupName 13.3.0
 azure.subscription.synapseService.workspace.managedVirtualNetwork 13.3.0
 azure.subscription.synapseService.workspace.name 13.3.0
+azure.subscription.synapseService.workspace.privateEndpointConnections 13.24.1
 azure.subscription.synapseService.workspace.properties 13.3.0
 azure.subscription.synapseService.workspace.provisioningState 13.3.0
 azure.subscription.synapseService.workspace.publicNetworkAccess 13.3.0
@@ -4784,6 +4801,7 @@ azure.subscription.webPubSubService.webPubSub.kind 13.16.2
 azure.subscription.webPubSubService.webPubSub.location 13.16.2
 azure.subscription.webPubSubService.webPubSub.name 13.16.2
 azure.subscription.webPubSubService.webPubSub.networkAclsDefaultAction 13.16.2
+azure.subscription.webPubSubService.webPubSub.privateEndpointConnections 13.24.1
 azure.subscription.webPubSubService.webPubSub.provisioningState 13.16.2
 azure.subscription.webPubSubService.webPubSub.publicNetworkAccess 13.16.2
 azure.subscription.webPubSubService.webPubSub.sku 13.16.2

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -186,11 +186,19 @@ func cognitiveServicesAccountToMql(runtime *plugin.Runtime, account *armcognitiv
 		return nil, err
 	}
 	mqlAccount.cacheSystemData = sysData
+	if account.Properties != nil {
+		mqlAccount.cachePrivateEndpointConnections = account.Properties.PrivateEndpointConnections
+	}
 	return mqlAccount, nil
 }
 
 type mqlAzureSubscriptionCognitiveServicesServiceAccountInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armcognitiveservices.PrivateEndpointConnection
+}
+
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiPolicy) id() (string, error) {

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -21,10 +21,15 @@ import (
 )
 
 type mqlAzureSubscriptionEventHubServiceNamespaceInternal struct {
-	networkRuleSetFetched bool
-	networkRuleSetProps   *armeventhub.NetworkRuleSetProperties
-	networkRuleSetLock    sync.Mutex
-	cacheSystemData       any
+	networkRuleSetFetched           bool
+	networkRuleSetProps             *armeventhub.NetworkRuleSetProperties
+	networkRuleSetLock              sync.Mutex
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armeventhub.PrivateEndpointConnection
+}
+
+func (a *mqlAzureSubscriptionEventHubServiceNamespace) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 type mqlAzureSubscriptionEventHubServiceNamespaceEventHubInternal struct {
@@ -173,7 +178,11 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlNs.(*mqlAzureSubscriptionEventHubServiceNamespace).cacheSystemData = sysData
+			mqlNsRes := mqlNs.(*mqlAzureSubscriptionEventHubServiceNamespace)
+			mqlNsRes.cacheSystemData = sysData
+			if ns.Properties != nil {
+				mqlNsRes.cachePrivateEndpointConnections = ns.Properties.PrivateEndpointConnections
+			}
 			res = append(res, mqlNs)
 		}
 	}

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -17,7 +17,17 @@ import (
 )
 
 type mqlAzureSubscriptionIotServiceIotHubInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cacheUserAssignedIdentityIds    []string
+	cachePrivateEndpointConnections []*armiothub.PrivateEndpointConnection
+}
+
+func (a *mqlAzureSubscriptionIotServiceIotHub) userAssignedIdentities() ([]any, error) {
+	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
+}
+
+func (a *mqlAzureSubscriptionIotServiceIotHub) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 func (a *mqlAzureSubscriptionIotServiceIotHub) id() (string, error) {
@@ -151,6 +161,18 @@ func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 				}
 			}
 
+			var identityType, identityPrincipalId, identityTenantId *string
+			var userAssignedIdentityIds []string
+			if hub.Identity != nil {
+				if hub.Identity.Type != nil {
+					s := string(*hub.Identity.Type)
+					identityType = &s
+				}
+				identityPrincipalId = hub.Identity.PrincipalID
+				identityTenantId = hub.Identity.TenantID
+				userAssignedIdentityIds = sortedUserAssignedIdentityIDs(hub.Identity.UserAssignedIdentities)
+			}
+
 			mqlHub, err := CreateResource(a.MqlRuntime, "azure.subscription.iotService.iotHub", map[string]*llx.RawData{
 				"id":                            llx.StringDataPtr(hub.ID),
 				"name":                          llx.StringDataPtr(hub.Name),
@@ -170,6 +192,9 @@ func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 				"allowedFqdnList":               llx.ArrayData(allowedFqdns, types.String),
 				"enableDataResidency":           llx.BoolDataPtr(enableDataResidency),
 				"networkRuleSet":                llx.DictData(nrs),
+				"identityType":                  llx.StringDataPtr(identityType),
+				"principalId":                   llx.StringDataPtr(identityPrincipalId),
+				"tenantId":                      llx.StringDataPtr(identityTenantId),
 			})
 			if err != nil {
 				return nil, err
@@ -178,7 +203,12 @@ func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlHub.(*mqlAzureSubscriptionIotServiceIotHub).cacheSystemData = sysData
+			mqlHubRes := mqlHub.(*mqlAzureSubscriptionIotServiceIotHub)
+			mqlHubRes.cacheSystemData = sysData
+			mqlHubRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			if hub.Properties != nil {
+				mqlHubRes.cachePrivateEndpointConnections = hub.Properties.PrivateEndpointConnections
+			}
 			res = append(res, mqlHub)
 		}
 	}

--- a/providers/azure/resources/private_endpoint_connections.go
+++ b/providers/azure/resources/private_endpoint_connections.go
@@ -46,7 +46,13 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 		return nil, nil
 	}
 
+	// A connection with no ID has no stable cache key, and everything useful
+	// about it (name, navigation) derives from that ID. Skip it rather than
+	// letting multiple ID-less entries collide on an empty __id.
 	id, _ := dict["id"].(string)
+	if id == "" {
+		return nil, nil
+	}
 	args := map[string]*llx.RawData{
 		"__id": llx.StringData(id),
 		"id":   llx.StringData(id),

--- a/providers/azure/resources/private_endpoint_connections.go
+++ b/providers/azure/resources/private_endpoint_connections.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+// azurePrivateEndpointConnectionsToMql converts a slice of Azure SDK private
+// endpoint connection values into shared azure.subscription.privateEndpointConnection
+// resources. Every Azure SDK models private endpoint connections with the same
+// JSON shape (id, name, type, properties.privateEndpoint.id,
+// properties.privateLinkServiceConnectionState, properties.provisioningState),
+// so the values are normalized through a dict rather than accessed per SDK type.
+// This lets one helper serve resources whose SDK connection type differs
+// (armservicebus.PrivateEndpointConnection, armappconfiguration.PrivateEndpointConnectionReference,
+// armapimanagement.RemotePrivateEndpointConnectionWrapper, and so on).
+func azurePrivateEndpointConnectionsToMql[T any](runtime *plugin.Runtime, entries []T) ([]any, error) {
+	res := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		mqlConn, err := azurePrivateEndpointConnectionToMql(runtime, entry)
+		if err != nil {
+			return nil, err
+		}
+		if mqlConn != nil {
+			res = append(res, mqlConn)
+		}
+	}
+	return res, nil
+}
+
+// azurePrivateEndpointConnectionToMql builds a single shared private endpoint
+// connection resource from any Azure SDK connection value. It returns nil when
+// the value carries no usable data (e.g. a nil pointer in the slice).
+func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (plugin.Resource, error) {
+	dict, err := convert.JsonToDict(entry)
+	if err != nil {
+		return nil, err
+	}
+	if len(dict) == 0 {
+		return nil, nil
+	}
+
+	id, _ := dict["id"].(string)
+	args := map[string]*llx.RawData{
+		"__id": llx.StringData(id),
+		"id":   llx.StringData(id),
+	}
+
+	// Prefer the SDK-provided name; most connection types leave it empty on
+	// read, so fall back to deriving it from the resource ID.
+	name, _ := dict["name"].(string)
+	if name == "" && id != "" {
+		if rid, err := ParseResourceID(id); err == nil {
+			if comp, err := rid.Component("privateEndpointConnections"); err == nil {
+				name = comp
+			}
+		}
+		if name == "" {
+			parts := strings.Split(id, "/")
+			name = parts[len(parts)-1]
+		}
+	}
+	if name != "" {
+		args["name"] = llx.StringData(name)
+	}
+	if typ, _ := dict["type"].(string); typ != "" {
+		args["type"] = llx.StringData(typ)
+	}
+
+	if props, ok := dict["properties"].(map[string]any); ok && props != nil {
+		args["properties"] = llx.DictData(props)
+
+		if pe, ok := props["privateEndpoint"].(map[string]any); ok {
+			if peID, _ := pe["id"].(string); peID != "" {
+				args["privateEndpointId"] = llx.StringData(peID)
+			}
+		}
+		if provState, _ := props["provisioningState"].(string); provState != "" {
+			args["provisioningState"] = llx.StringData(provState)
+		}
+		if cs, ok := props["privateLinkServiceConnectionState"].(map[string]any); ok && cs != nil {
+			// Derive a unique cache key from the parent connection so multiple
+			// connection states never collide on an empty __id.
+			stateArgs := map[string]*llx.RawData{
+				"__id": llx.StringData(id + "/privateLinkServiceConnectionState"),
+			}
+			if v, _ := cs["actionsRequired"].(string); v != "" {
+				stateArgs["actionsRequired"] = llx.StringData(v)
+			}
+			if v, _ := cs["description"].(string); v != "" {
+				stateArgs["description"] = llx.StringData(v)
+			}
+			if v, _ := cs["status"].(string); v != "" {
+				stateArgs["status"] = llx.StringData(v)
+			}
+			stateRes, err := CreateResource(runtime, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState, stateArgs)
+			if err != nil {
+				return nil, err
+			}
+			args["privateLinkServiceConnectionState"] = llx.ResourceData(stateRes, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState)
+		}
+	}
+
+	return CreateResource(runtime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
+}

--- a/providers/azure/resources/purview.go
+++ b/providers/azure/resources/purview.go
@@ -196,5 +196,19 @@ func purviewAccountToMql(runtime *plugin.Runtime, account *armpurview.Account) (
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionPurviewServiceAccount), nil
+	mqlAccount := res.(*mqlAzureSubscriptionPurviewServiceAccount)
+	sysData, err := convert.JsonToDict(account.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlAccount.cacheSystemData = sysData
+	return mqlAccount, nil
+}
+
+type mqlAzureSubscriptionPurviewServiceAccountInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionPurviewServiceAccount) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/servicebus.go
+++ b/providers/azure/resources/servicebus.go
@@ -21,10 +21,15 @@ import (
 )
 
 type mqlAzureSubscriptionServiceBusServiceNamespaceInternal struct {
-	networkRuleSetFetched bool
-	networkRuleSetProps   *armservicebus.NetworkRuleSetProperties
-	networkRuleSetLock    sync.Mutex
-	cacheSystemData       any
+	networkRuleSetFetched           bool
+	networkRuleSetProps             *armservicebus.NetworkRuleSetProperties
+	networkRuleSetLock              sync.Mutex
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armservicebus.PrivateEndpointConnection
+}
+
+func (a *mqlAzureSubscriptionServiceBusServiceNamespace) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 type mqlAzureSubscriptionServiceBusServiceNamespaceQueueInternal struct {
@@ -179,7 +184,11 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlNs.(*mqlAzureSubscriptionServiceBusServiceNamespace).cacheSystemData = sysData
+			mqlNsRes := mqlNs.(*mqlAzureSubscriptionServiceBusServiceNamespace)
+			mqlNsRes.cacheSystemData = sysData
+			if ns.Properties != nil {
+				mqlNsRes.cachePrivateEndpointConnections = ns.Properties.PrivateEndpointConnections
+			}
 			res = append(res, mqlNs)
 		}
 	}

--- a/providers/azure/resources/signalr.go
+++ b/providers/azure/resources/signalr.go
@@ -136,15 +136,23 @@ func signalRToMql(runtime *plugin.Runtime, sr *armsignalr.ResourceInfo) (*mqlAzu
 	}
 	mqlSr := res.(*mqlAzureSubscriptionSignalRServiceSignalR)
 	mqlSr.cacheSystemData = sysData
+	if sr.Properties != nil {
+		mqlSr.cachePrivateEndpointConnections = sr.Properties.PrivateEndpointConnections
+	}
 	return mqlSr, nil
 }
 
 type mqlAzureSubscriptionSignalRServiceSignalRInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armsignalr.PrivateEndpointConnection
 }
 
 func (a *mqlAzureSubscriptionSignalRServiceSignalR) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionSignalRServiceSignalR) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 func initAzureSubscriptionWebPubSubService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -262,13 +270,21 @@ func webPubSubToMql(runtime *plugin.Runtime, wps *armwebpubsub.ResourceInfo) (*m
 	}
 	mqlWps := res.(*mqlAzureSubscriptionWebPubSubServiceWebPubSub)
 	mqlWps.cacheSystemData = sysData
+	if wps.Properties != nil {
+		mqlWps.cachePrivateEndpointConnections = wps.Properties.PrivateEndpointConnections
+	}
 	return mqlWps, nil
 }
 
 type mqlAzureSubscriptionWebPubSubServiceWebPubSubInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armwebpubsub.PrivateEndpointConnection
 }
 
 func (a *mqlAzureSubscriptionWebPubSubServiceWebPubSub) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionWebPubSubServiceWebPubSub) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }

--- a/providers/azure/resources/synapse.go
+++ b/providers/azure/resources/synapse.go
@@ -21,9 +21,14 @@ import (
 )
 
 type mqlAzureSubscriptionSynapseServiceWorkspaceInternal struct {
-	cacheDefaultStorageId        string
-	cacheCmkKeyURI               string
-	cacheUserAssignedIdentityIds []string
+	cacheDefaultStorageId           string
+	cacheCmkKeyURI                  string
+	cacheUserAssignedIdentityIds    []string
+	cachePrivateEndpointConnections []*armsynapse.PrivateEndpointConnection
+}
+
+func (a *mqlAzureSubscriptionSynapseServiceWorkspace) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 func (a *mqlAzureSubscriptionSynapseService) id() (string, error) {
@@ -163,6 +168,9 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 			workspaceRes.cacheDefaultStorageId = defaultStorageId
 			workspaceRes.cacheCmkKeyURI = cmkKeyURI
 			workspaceRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			if ws.Properties != nil {
+				workspaceRes.cachePrivateEndpointConnections = ws.Properties.PrivateEndpointConnections
+			}
 			res = append(res, workspaceRes)
 		}
 	}


### PR DESCRIPTION
## What

Expands security context across several Azure resources with three verified additions. Every candidate was checked against its vendored SDK **before** any code was written, so resources whose SDK cannot populate a field were deliberately skipped rather than shipped with dead schema.

### 1. Private endpoint connections

Adds a typed `privateEndpointConnections() []azure.subscription.privateEndpointConnection` accessor to resources that lacked one:

| Resource | How |
|---|---|
| Service Bus, Event Hubs, IoT Hub, Cognitive Services, App Configuration, SignalR, Web PubSub, Synapse | Read connections already embedded in the parent's properties — **no extra API call** |
| AKS cluster | Dedicated `PrivateEndpointConnectionsClient`, tolerating 404/403 as "no connections" |
| API Management | Full typed list; the pre-existing `privateEndpointConnectionCount` is deprecated in favor of it |

A shared helper (`private_endpoint_connections.go`) normalizes any SDK connection type through `convert.JsonToDict` — every Azure SDK models these with the same JSON shape, so one helper serves them all, including App Configuration's `PrivateEndpointConnectionReference` and API Management's `RemotePrivateEndpointConnectionWrapper`. The nested connection-state resource is given a derived `__id` to avoid empty-key cache collisions.

**Skipped (SDK verified):** Log Analytics workspace (no PEC type — only `PrivateLinkScopedResources`, already exposed); Machine Learning workspace and Purview account (already expose PE connections).

### 2. Managed identity

- **IoT Hub:** adds `identityType`, `principalId`, `tenantId`, `userAssignedIdentities` (previously modeled no identity at all).
- **API Management:** adds `principalId`, `tenantId`, `userAssignedIdentities` (`identityType` already present).

**Skipped:** customer-managed-key encryption — neither the IoT Hub nor the API Management SDK exposes it.

### 3. Provenance

- **Purview account:** adds `systemMetadata()`, surfacing the ARM last-modified provenance that its bespoke `createdAt`/`createdBy` fields don't carry.

## Why

These are standard compliance controls — "is this resource reachable only through a private endpoint?", "what identity does it run as?", "who last modified it?" — that previously couldn't be queried on these services.

## Notes

- **No new provider permissions** (`azure.permissions.json` unchanged at 242). Shape-A accessors read already-fetched properties; the AKS List call did not alter the extracted permission set.
- New `.lr.versions` entries at `13.24.1` (next patch after the current provider version).

## Verification

- `make providers/build/azure` compiles the full module cleanly; codegen (`mqlr generate`) is consistent and generated accessors/setters are present.
- Live value-verification is pending: none of these resource types exist in the available test subscription, so there was nothing to query against. The private-endpoint helper is a faithful generalization of the shipped Key Vault builder, and all field paths were verified against the vendored SDK structs.
