### PR TITLE
⭐ aws: generalize network exposure to more public-signal resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11844,6 +11844,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   deletionProtection bool
   // List of VPC security group elements that the database cluster belongs to
   securityGroups() []aws.ec2.securitygroup
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // List of Availability Zones (AZs) where instances in the database cluster can be created
   availabilityZones []string
   // Port on which the database engine is listening
@@ -12625,9 +12627,10 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   publiclyAccessible bool
   // Whether the cluster is reachable from the internet
   //
-  // True when the cluster is configured for public access, which assigns it a
-  // publicly resolvable endpoint reachable from outside its VPC.
-  internetReachable() bool
+  // Deprecated in favor of exposure.internetReachable, which additionally
+  // accounts for whether an attached security group opens the cluster to the
+  // internet.
+  internetReachable() @maturity("deprecated") bool
   // Connection endpoint address for the cluster (empty when the cluster has no endpoint)
   endpointAddress string
   // Connection endpoint port for the cluster (0 when the cluster has no endpoint)
@@ -12702,6 +12705,8 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   snapshotScheduleState string
   // VPC security groups attached to the cluster
   securityGroups() []aws.ec2.securitygroup
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // Custom domain name configured for the cluster endpoint
   customDomainName string
   // ACM certificate backing the custom domain
@@ -13951,6 +13956,8 @@ private aws.dms.replicationInstance @defaults("arn replicationInstanceIdentifier
   kmsKey() aws.kms.key
   // VPC security groups attached to the replication instance
   securityGroups() []aws.ec2.securitygroup
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // Subnet group that scopes the replication instance to a VPC
   subnetGroup() aws.dms.replicationSubnetGroup
   // Pending modifications scheduled for the next maintenance window
@@ -21475,6 +21482,8 @@ private aws.msk.cluster @defaults("name state clusterType region") {
   subnets() []aws.vpc.subnet
   // Security groups attached to the cluster
   securityGroups() []aws.ec2.securitygroup
+  // Internet-exposure breakdown (public-access flag combined with security group ingress)
+  exposure() aws.network.exposure
   // Storage mode: LOCAL or TIERED (TIERED-storage bucket is AWS-managed and not customer-visible)
   storageMode() string
   // Network type of the cluster: IPv4 or DUAL
@@ -22034,6 +22043,8 @@ private aws.mq.broker @defaults("name engineType deploymentMode state region") {
   subnets() []aws.vpc.subnet
   // Security groups attached to the broker
   securityGroups() []aws.ec2.securitygroup
+  // Internet-exposure breakdown (publicly-accessible flag combined with security group ingress)
+  exposure() aws.network.exposure
   // Day of the week when the maintenance window begins: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
   maintenanceDayOfWeek() string
   // Time of day, in 24-hour format, when the maintenance window begins

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -10410,10 +10410,16 @@ private aws.s3.bucket @defaults("name location public") {
   defaultLock() string
   // Bucket cross-region replication configuration
   replication() dict
-  // Bucket encryption configuration
-  encryption() dict
+  // Bucket default encryption configuration
+  //
+  // Deprecated in favor of encryptionRules, encrypted, and kmsKey.
+  encryption() @maturity("deprecated") dict
   // Typed encryption rules for the bucket
   encryptionRules() []aws.s3.bucket.encryptionRule
+  // Whether default server-side encryption is configured on the bucket
+  encrypted() bool
+  // KMS key used for default server-side encryption when the SSE-KMS algorithm is configured
+  kmsKey() aws.kms.key
   // Typed replication rules for the bucket
   replicationRules() []aws.s3.bucket.replicationRule
   // Public access block configuration for the bucket
@@ -11421,6 +11427,8 @@ private aws.dynamodb.dax.cluster @defaults("arn clusterName") {
   region string
   // Whether server-side encryption (SSE) is enabled (ENABLING, ENABLED, DISABLING, DISABLED)
   sseStatus string
+  // Whether server-side encryption at rest is enabled
+  encrypted bool
   // Cluster endpoint encryption type (NONE or TLS)
   clusterEndpointEncryptionType string
   // Tags for the cluster
@@ -14145,6 +14153,8 @@ private aws.apigateway.stage @defaults("arn") {
   cacheClusterSize string
   // Status of the cache cluster
   cacheClusterStatus string
+  // Whether the stage response cache is encrypted, from the default method settings
+  cacheDataEncrypted bool
   // Client certificate ID for mutual TLS with backend
   clientCertificateId string
   // WAF web ACL associated with the stage
@@ -19425,8 +19435,22 @@ private aws.athena.workgroup @defaults("name state region") {
   requesterPaysEnabled() bool
   // Engine version information
   engineVersion() dict
-  // Result configuration (output location and encryption)
-  resultConfiguration() dict
+  // Query result configuration
+  //
+  // Deprecated in favor of resultOutputLocation, encrypted,
+  // resultEncryptionOption, and kmsKey.
+  resultConfiguration() @maturity("deprecated") dict
+  // Amazon S3 location where query and calculation results are stored
+  resultOutputLocation() string
+  // Whether query results are encrypted at rest in Amazon S3
+  encrypted() bool
+  // Query result encryption option
+  //
+  // One of SSE_S3, SSE_KMS, or CSE_KMS. Empty when query results are not
+  // encrypted.
+  resultEncryptionOption() string
+  // KMS key protecting query results when the SSE_KMS or CSE_KMS option is used
+  kmsKey() aws.kms.key
   // Region where the workgroup exists
   region string
   // Tags for the workgroup

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -17652,6 +17652,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.rds.dbcluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.rds.dbcluster.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
 	},
@@ -18725,6 +18728,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.redshift.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.redshift.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.redshift.cluster.customDomainName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftCluster).GetCustomDomainName()).ToDataRes(types.String)
@@ -20027,6 +20033,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.dms.replicationInstance.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDmsReplicationInstance).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.dms.replicationInstance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDmsReplicationInstance).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.dms.replicationInstance.subnetGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDmsReplicationInstance).GetSubnetGroup()).ToDataRes(types.Resource("aws.dms.replicationSubnetGroup"))
@@ -28587,6 +28596,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.msk.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMskCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.msk.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMskCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.msk.cluster.storageMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMskCluster).GetStorageMode()).ToDataRes(types.String)
 	},
@@ -29222,6 +29234,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.mq.broker.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMqBroker).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.mq.broker.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMqBroker).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.mq.broker.maintenanceDayOfWeek": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMqBroker).GetMaintenanceDayOfWeek()).ToDataRes(types.String)
@@ -52870,6 +52885,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbcluster.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).AvailabilityZones, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -54368,6 +54387,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.redshift.cluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.cluster.customDomainName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56252,6 +56275,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.dms.replicationInstance.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDmsReplicationInstance).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.dms.replicationInstance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDmsReplicationInstance).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.dms.replicationInstance.subnetGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -68634,6 +68661,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsMskCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.msk.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMskCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.msk.cluster.storageMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsMskCluster).StorageMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -69592,6 +69623,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.mq.broker.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsMqBroker).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.mq.broker.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMqBroker).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.mq.broker.maintenanceDayOfWeek": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -127146,6 +127181,7 @@ type mqlAwsRdsDbcluster struct {
 	MultiAZ                            plugin.TValue[bool]
 	DeletionProtection                 plugin.TValue[bool]
 	SecurityGroups                     plugin.TValue[[]any]
+	Exposure                           plugin.TValue[*mqlAwsNetworkExposure]
 	AvailabilityZones                  plugin.TValue[[]any]
 	Port                               plugin.TValue[int64]
 	Endpoint                           plugin.TValue[string]
@@ -127358,6 +127394,22 @@ func (c *mqlAwsRdsDbcluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsRdsDbcluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbcluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -130201,6 +130253,7 @@ type mqlAwsRedshiftCluster struct {
 	ExpectedNextSnapshotScheduleStatus plugin.TValue[string]
 	SnapshotScheduleState              plugin.TValue[string]
 	SecurityGroups                     plugin.TValue[[]any]
+	Exposure                           plugin.TValue[*mqlAwsNetworkExposure]
 	CustomDomainName                   plugin.TValue[string]
 	CustomDomainCertificate            plugin.TValue[*mqlAwsAcmCertificate]
 	CustomDomainCertificateExpiresAt   plugin.TValue[*time.Time]
@@ -130598,6 +130651,22 @@ func (c *mqlAwsRedshiftCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsRedshiftCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.redshift.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -135109,6 +135178,7 @@ type mqlAwsDmsReplicationInstance struct {
 	Region                                plugin.TValue[string]
 	KmsKey                                plugin.TValue[*mqlAwsKmsKey]
 	SecurityGroups                        plugin.TValue[[]any]
+	Exposure                              plugin.TValue[*mqlAwsNetworkExposure]
 	SubnetGroup                           plugin.TValue[*mqlAwsDmsReplicationSubnetGroup]
 	PendingModifiedValues                 plugin.TValue[any]
 }
@@ -135255,6 +135325,22 @@ func (c *mqlAwsDmsReplicationInstance) GetSecurityGroups() *plugin.TValue[[]any]
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsDmsReplicationInstance) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.dms.replicationInstance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -165537,6 +165623,7 @@ type mqlAwsMskCluster struct {
 	NodeExporterEnabled             plugin.TValue[bool]
 	Subnets                         plugin.TValue[[]any]
 	SecurityGroups                  plugin.TValue[[]any]
+	Exposure                        plugin.TValue[*mqlAwsNetworkExposure]
 	StorageMode                     plugin.TValue[string]
 	NetworkType                     plugin.TValue[string]
 	EbsVolumeSizeGiB                plugin.TValue[int64]
@@ -165777,6 +165864,22 @@ func (c *mqlAwsMskCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsMskCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.msk.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -168414,6 +168517,7 @@ type mqlAwsMqBroker struct {
 	StorageType                   plugin.TValue[string]
 	Subnets                       plugin.TValue[[]any]
 	SecurityGroups                plugin.TValue[[]any]
+	Exposure                      plugin.TValue[*mqlAwsNetworkExposure]
 	MaintenanceDayOfWeek          plugin.TValue[string]
 	MaintenanceTimeOfDay          plugin.TValue[string]
 	MaintenanceTimeZone           plugin.TValue[string]
@@ -168625,6 +168729,22 @@ func (c *mqlAwsMqBroker) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsMqBroker) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.mq.broker", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -16098,6 +16098,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.encryptionRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetEncryptionRules()).ToDataRes(types.Array(types.Resource("aws.s3.bucket.encryptionRule")))
 	},
+	"aws.s3.bucket.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.s3.bucket.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3Bucket).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.s3.bucket.replicationRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3Bucket).GetReplicationRules()).ToDataRes(types.Array(types.Resource("aws.s3.bucket.replicationRule")))
 	},
@@ -17177,6 +17183,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.dynamodb.dax.cluster.sseStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbDaxCluster).GetSseStatus()).ToDataRes(types.String)
+	},
+	"aws.dynamodb.dax.cluster.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbDaxCluster).GetEncrypted()).ToDataRes(types.Bool)
 	},
 	"aws.dynamodb.dax.cluster.clusterEndpointEncryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbDaxCluster).GetClusterEndpointEncryptionType()).ToDataRes(types.String)
@@ -20267,6 +20276,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.apigateway.stage.cacheClusterStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayStage).GetCacheClusterStatus()).ToDataRes(types.String)
+	},
+	"aws.apigateway.stage.cacheDataEncrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayStage).GetCacheDataEncrypted()).ToDataRes(types.Bool)
 	},
 	"aws.apigateway.stage.clientCertificateId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayStage).GetClientCertificateId()).ToDataRes(types.String)
@@ -26303,6 +26315,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.athena.workgroup.resultConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAthenaWorkgroup).GetResultConfiguration()).ToDataRes(types.Dict)
+	},
+	"aws.athena.workgroup.resultOutputLocation": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAthenaWorkgroup).GetResultOutputLocation()).ToDataRes(types.String)
+	},
+	"aws.athena.workgroup.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAthenaWorkgroup).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.athena.workgroup.resultEncryptionOption": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAthenaWorkgroup).GetResultEncryptionOption()).ToDataRes(types.String)
+	},
+	"aws.athena.workgroup.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAthenaWorkgroup).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
 	"aws.athena.workgroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAthenaWorkgroup).GetRegion()).ToDataRes(types.String)
@@ -50582,6 +50606,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsS3Bucket).EncryptionRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.s3.bucket.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3Bucket).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.replicationRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3Bucket).ReplicationRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -52168,6 +52200,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.dynamodb.dax.cluster.sseStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbDaxCluster).SseStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.dynamodb.dax.cluster.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbDaxCluster).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.dynamodb.dax.cluster.clusterEndpointEncryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56572,6 +56608,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apigateway.stage.cacheClusterStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayStage).CacheClusterStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.stage.cacheDataEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayStage).CacheDataEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.apigateway.stage.clientCertificateId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -65296,6 +65336,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.athena.workgroup.resultConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAthenaWorkgroup).ResultConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.athena.workgroup.resultOutputLocation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAthenaWorkgroup).ResultOutputLocation, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.athena.workgroup.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAthenaWorkgroup).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.athena.workgroup.resultEncryptionOption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAthenaWorkgroup).ResultEncryptionOption, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.athena.workgroup.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAthenaWorkgroup).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.athena.workgroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -121273,6 +121329,8 @@ type mqlAwsS3Bucket struct {
 	Replication                      plugin.TValue[any]
 	Encryption                       plugin.TValue[any]
 	EncryptionRules                  plugin.TValue[[]any]
+	Encrypted                        plugin.TValue[bool]
+	KmsKey                           plugin.TValue[*mqlAwsKmsKey]
 	ReplicationRules                 plugin.TValue[[]any]
 	PublicAccessBlock                plugin.TValue[any]
 	BlockPublicAcls                  plugin.TValue[bool]
@@ -121503,6 +121561,28 @@ func (c *mqlAwsS3Bucket) GetEncryptionRules() *plugin.TValue[[]any] {
 		}
 
 		return c.encryptionRules()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetEncrypted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Encrypted, func() (bool, error) {
+		return c.encrypted()
+	})
+}
+
+func (c *mqlAwsS3Bucket) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.s3.bucket", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
 	})
 }
 
@@ -125504,6 +125584,7 @@ type mqlAwsDynamodbDaxCluster struct {
 	ActiveNodes                   plugin.TValue[int64]
 	Region                        plugin.TValue[string]
 	SseStatus                     plugin.TValue[string]
+	Encrypted                     plugin.TValue[bool]
 	ClusterEndpointEncryptionType plugin.TValue[string]
 	Tags                          plugin.TValue[map[string]any]
 }
@@ -125579,6 +125660,10 @@ func (c *mqlAwsDynamodbDaxCluster) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsDynamodbDaxCluster) GetSseStatus() *plugin.TValue[string] {
 	return &c.SseStatus
+}
+
+func (c *mqlAwsDynamodbDaxCluster) GetEncrypted() *plugin.TValue[bool] {
+	return &c.Encrypted
 }
 
 func (c *mqlAwsDynamodbDaxCluster) GetClusterEndpointEncryptionType() *plugin.TValue[string] {
@@ -135993,6 +136078,7 @@ type mqlAwsApigatewayStage struct {
 	CacheClusterEnabled  plugin.TValue[bool]
 	CacheClusterSize     plugin.TValue[string]
 	CacheClusterStatus   plugin.TValue[string]
+	CacheDataEncrypted   plugin.TValue[bool]
 	ClientCertificateId  plugin.TValue[string]
 	WebAcl               plugin.TValue[*mqlAwsWafAcl]
 	WebAclArn            plugin.TValue[string]
@@ -136074,6 +136160,10 @@ func (c *mqlAwsApigatewayStage) GetCacheClusterSize() *plugin.TValue[string] {
 
 func (c *mqlAwsApigatewayStage) GetCacheClusterStatus() *plugin.TValue[string] {
 	return &c.CacheClusterStatus
+}
+
+func (c *mqlAwsApigatewayStage) GetCacheDataEncrypted() *plugin.TValue[bool] {
+	return &c.CacheDataEncrypted
 }
 
 func (c *mqlAwsApigatewayStage) GetClientCertificateId() *plugin.TValue[string] {
@@ -157448,6 +157538,10 @@ type mqlAwsAthenaWorkgroup struct {
 	RequesterPaysEnabled            plugin.TValue[bool]
 	EngineVersion                   plugin.TValue[any]
 	ResultConfiguration             plugin.TValue[any]
+	ResultOutputLocation            plugin.TValue[string]
+	Encrypted                       plugin.TValue[bool]
+	ResultEncryptionOption          plugin.TValue[string]
+	KmsKey                          plugin.TValue[*mqlAwsKmsKey]
 	Region                          plugin.TValue[string]
 	Tags                            plugin.TValue[map[string]any]
 }
@@ -157537,6 +157631,40 @@ func (c *mqlAwsAthenaWorkgroup) GetEngineVersion() *plugin.TValue[any] {
 func (c *mqlAwsAthenaWorkgroup) GetResultConfiguration() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.ResultConfiguration, func() (any, error) {
 		return c.resultConfiguration()
+	})
+}
+
+func (c *mqlAwsAthenaWorkgroup) GetResultOutputLocation() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ResultOutputLocation, func() (string, error) {
+		return c.resultOutputLocation()
+	})
+}
+
+func (c *mqlAwsAthenaWorkgroup) GetEncrypted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Encrypted, func() (bool, error) {
+		return c.encrypted()
+	})
+}
+
+func (c *mqlAwsAthenaWorkgroup) GetResultEncryptionOption() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ResultEncryptionOption, func() (string, error) {
+		return c.resultEncryptionOption()
+	})
+}
+
+func (c *mqlAwsAthenaWorkgroup) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.athena.workgroup", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2438,6 +2438,7 @@ aws.dms.replicationInstance.autoMinorVersionUpgrade 13.21.4
 aws.dms.replicationInstance.availabilityZone 13.21.4
 aws.dms.replicationInstance.dnsNameServers 13.21.4
 aws.dms.replicationInstance.engineVersion 13.21.4
+aws.dms.replicationInstance.exposure 13.40.2
 aws.dms.replicationInstance.instanceCreateTime 13.21.4
 aws.dms.replicationInstance.kmsKey 13.21.4
 aws.dms.replicationInstance.multiAZ 13.21.4
@@ -6580,6 +6581,7 @@ aws.mq.broker.dataReplicationRole 13.21.4
 aws.mq.broker.deploymentMode 11.16.1
 aws.mq.broker.engineType 11.16.1
 aws.mq.broker.engineVersion 11.16.1
+aws.mq.broker.exposure 13.40.2
 aws.mq.broker.generalLogGroup 13.21.4
 aws.mq.broker.generalLogsEnabled 11.16.1
 aws.mq.broker.hostInstanceType 11.16.1
@@ -6698,6 +6700,7 @@ aws.msk.cluster.encryptionInfo.inTransitClientBroker 13.14.2
 aws.msk.cluster.encryptionInfo.inTransitInCluster 13.14.2
 aws.msk.cluster.encryptionInfo.kmsKey 13.14.2
 aws.msk.cluster.enhancedMonitoring 11.16.1
+aws.msk.cluster.exposure 13.40.2
 aws.msk.cluster.firehoseLogsEnabled 11.16.1
 aws.msk.cluster.iamAuthEnabled 11.16.1
 aws.msk.cluster.jmxExporterEnabled 11.16.1
@@ -7339,6 +7342,7 @@ aws.rds.dbcluster.engine 11.15.2
 aws.rds.dbcluster.engineLifecycleSupport 11.15.2
 aws.rds.dbcluster.engineMode 11.15.2
 aws.rds.dbcluster.engineVersion 11.15.2
+aws.rds.dbcluster.exposure 13.40.2
 aws.rds.dbcluster.globalCluster 13.21.4
 aws.rds.dbcluster.globalClusterIdentifier 11.15.2
 aws.rds.dbcluster.globalWriteForwardingStatus 13.14.2
@@ -7609,6 +7613,7 @@ aws.redshift.cluster.endpointVpcEndpoints 13.15.2
 aws.redshift.cluster.enhancedVpcRouting 11.15.2
 aws.redshift.cluster.expectedNextSnapshotScheduleAt 13.39.2
 aws.redshift.cluster.expectedNextSnapshotScheduleStatus 13.39.2
+aws.redshift.cluster.exposure 13.40.2
 aws.redshift.cluster.hsmStatus 11.16.1
 aws.redshift.cluster.iamRoles 13.39.2
 aws.redshift.cluster.internetReachable 13.37.1

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -124,6 +124,7 @@ aws.apigateway.stage.arn 11.15.2
 aws.apigateway.stage.cacheClusterEnabled 11.15.2
 aws.apigateway.stage.cacheClusterSize 11.15.2
 aws.apigateway.stage.cacheClusterStatus 11.15.2
+aws.apigateway.stage.cacheDataEncrypted 13.40.2
 aws.apigateway.stage.clientCertificateId 11.15.2
 aws.apigateway.stage.createdAt 11.15.2
 aws.apigateway.stage.deploymentId 11.15.2
@@ -709,13 +710,17 @@ aws.athena.workgroup.arn 11.16.1
 aws.athena.workgroup.bytesScannedCutoffPerQuery 11.16.1
 aws.athena.workgroup.createdAt 11.16.1
 aws.athena.workgroup.description 11.16.1
+aws.athena.workgroup.encrypted 13.40.2
 aws.athena.workgroup.enforceWorkGroupConfiguration 11.16.1
 aws.athena.workgroup.engineVersion 11.16.1
+aws.athena.workgroup.kmsKey 13.40.2
 aws.athena.workgroup.name 11.16.1
 aws.athena.workgroup.publishCloudWatchMetricsEnabled 11.16.1
 aws.athena.workgroup.region 11.16.1
 aws.athena.workgroup.requesterPaysEnabled 11.16.1
 aws.athena.workgroup.resultConfiguration 11.16.1
+aws.athena.workgroup.resultEncryptionOption 13.40.2
+aws.athena.workgroup.resultOutputLocation 13.40.2
 aws.athena.workgroup.state 11.16.1
 aws.athena.workgroup.tags 11.16.1
 aws.athena.workgroups 11.16.1
@@ -2838,6 +2843,7 @@ aws.dynamodb.dax.cluster.arn 13.3.0
 aws.dynamodb.dax.cluster.clusterEndpointEncryptionType 13.3.0
 aws.dynamodb.dax.cluster.clusterName 13.3.0
 aws.dynamodb.dax.cluster.description 13.3.0
+aws.dynamodb.dax.cluster.encrypted 13.40.2
 aws.dynamodb.dax.cluster.nodeType 13.3.0
 aws.dynamodb.dax.cluster.region 13.3.0
 aws.dynamodb.dax.cluster.sseStatus 13.3.0
@@ -8036,6 +8042,7 @@ aws.s3.bucket.corsrule.maxAgeSeconds 11.15.2
 aws.s3.bucket.corsrule.name 11.15.2
 aws.s3.bucket.createdAt 11.15.2
 aws.s3.bucket.defaultLock 11.15.2
+aws.s3.bucket.encrypted 13.40.2
 aws.s3.bucket.encryption 11.15.2
 aws.s3.bucket.encryptionRule 11.15.2
 aws.s3.bucket.encryptionRule.bucketKeyEnabled 11.15.2
@@ -8063,6 +8070,7 @@ aws.s3.bucket.grant.permission 11.15.2
 aws.s3.bucket.ignorePublicAcls 13.32.2
 aws.s3.bucket.intelligentTieringConfigurations 13.29.1
 aws.s3.bucket.inventoryConfigurations 13.29.1
+aws.s3.bucket.kmsKey 13.40.2
 aws.s3.bucket.lifecycleRule 13.6.3
 aws.s3.bucket.lifecycleRule.abortIncompleteMultipartUploadDays 13.6.3
 aws.s3.bucket.lifecycleRule.expiration 13.6.3

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -184,6 +184,12 @@ func (a *mqlAwsApigatewayRestapi) stages() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// CacheDataEncrypted is configured per method; the "*/*" key holds the
+		// stage-wide default that applies unless a specific method overrides it.
+		cacheDataEncrypted := false
+		if ms, ok := stage.MethodSettings["*/*"]; ok {
+			cacheDataEncrypted = ms.CacheDataEncrypted
+		}
 		mqlStage, err := CreateResource(a.MqlRuntime, ResourceAwsApigatewayStage,
 			map[string]*llx.RawData{
 				"arn":                  llx.StringData(fmt.Sprintf(apiStageArnPattern, region, conn.AccountId(), restApiId, convert.ToValue(stage.StageName))),
@@ -195,6 +201,7 @@ func (a *mqlAwsApigatewayRestapi) stages() ([]any, error) {
 				"cacheClusterEnabled":  llx.BoolData(stage.CacheClusterEnabled),
 				"cacheClusterSize":     llx.StringData(string(stage.CacheClusterSize)),
 				"cacheClusterStatus":   llx.StringData(string(stage.CacheClusterStatus)),
+				"cacheDataEncrypted":   llx.BoolData(cacheDataEncrypted),
 				"clientCertificateId":  llx.StringData(convert.ToValue(stage.ClientCertificateId)),
 				"webAclArn":            llx.StringData(convert.ToValue(stage.WebAclArn)),
 				"createdAt":            llx.TimeDataPtr(stage.CreatedDate),

--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -110,6 +110,9 @@ type mqlAwsAthenaWorkgroupInternal struct {
 	cachedBytesCutoff int64
 	cachedEngineVer   any
 	cachedResultCfg   any
+	cachedEncOption   string
+	cachedKmsKeyRef   string
+	cachedOutputLoc   string
 	lock              sync.Mutex
 }
 
@@ -157,6 +160,17 @@ func (a *mqlAwsAthenaWorkgroup) fetchConfig() error {
 		if err2 != nil {
 			return err2
 		}
+		if rc := cfg.ResultConfiguration; rc != nil {
+			if rc.OutputLocation != nil {
+				a.cachedOutputLoc = *rc.OutputLocation
+			}
+			if rc.EncryptionConfiguration != nil {
+				a.cachedEncOption = string(rc.EncryptionConfiguration.EncryptionOption)
+				if rc.EncryptionConfiguration.KmsKey != nil {
+					a.cachedKmsKeyRef = *rc.EncryptionConfiguration.KmsKey
+				}
+			}
+		}
 	}
 	a.fetched = true
 	return nil
@@ -202,6 +216,46 @@ func (a *mqlAwsAthenaWorkgroup) resultConfiguration() (any, error) {
 		return nil, err
 	}
 	return a.cachedResultCfg, nil
+}
+
+func (a *mqlAwsAthenaWorkgroup) resultOutputLocation() (string, error) {
+	if err := a.fetchConfig(); err != nil {
+		return "", err
+	}
+	return a.cachedOutputLoc, nil
+}
+
+func (a *mqlAwsAthenaWorkgroup) resultEncryptionOption() (string, error) {
+	if err := a.fetchConfig(); err != nil {
+		return "", err
+	}
+	return a.cachedEncOption, nil
+}
+
+func (a *mqlAwsAthenaWorkgroup) encrypted() (bool, error) {
+	if err := a.fetchConfig(); err != nil {
+		return false, err
+	}
+	return a.cachedEncOption != "", nil
+}
+
+func (a *mqlAwsAthenaWorkgroup) kmsKey() (*mqlAwsKmsKey, error) {
+	if err := a.fetchConfig(); err != nil {
+		return nil, err
+	}
+	if a.cachedKmsKeyRef == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+		map[string]*llx.RawData{
+			"arn":    llx.StringData(a.cachedKmsKeyRef),
+			"region": llx.StringData(a.Region.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
 func (a *mqlAwsAthena) dataCatalogs() ([]any, error) {

--- a/providers/aws/resources/aws_dax.go
+++ b/providers/aws/resources/aws_dax.go
@@ -83,6 +83,7 @@ func (a *mqlAwsDynamodb) getDaxClusters(conn *connection.AwsConnection) []*jobpo
 							"activeNodes":                   llx.IntDataDefault(cluster.ActiveNodes, 0),
 							"region":                        llx.StringData(region),
 							"sseStatus":                     llx.StringData(sseStatus),
+							"encrypted":                     llx.BoolData(sseStatus == "ENABLED"),
 							"clusterEndpointEncryptionType": llx.StringData(string(cluster.ClusterEndpointEncryptionType)),
 						})
 					if err != nil {

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -104,3 +104,63 @@ func (a *mqlAwsElbLoadbalancer) exposure() (*mqlAwsNetworkExposure, error) {
 	}
 	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", scheme.Data == "internet-facing", a.GetSecurityGroups())
 }
+
+func (a *mqlAwsRdsDbcluster) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsRedshiftCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsMqBroker) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsDmsReplicationInstance) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsMskCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publicAccess := a.GetPublicAccess()
+	if publicAccess.Error != nil {
+		return nil, publicAccess.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess.Data, a.GetSecurityGroups())
+}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -1180,6 +1180,52 @@ func (a *mqlAwsS3BucketEncryptionRule) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+func (a *mqlAwsS3Bucket) encrypted() (bool, error) {
+	config, err := a.fetchEncryptionConfig()
+	if err != nil {
+		return false, err
+	}
+	if config == nil {
+		return false, nil
+	}
+	for _, rule := range config.Rules {
+		if rule.ApplyServerSideEncryptionByDefault != nil && rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a *mqlAwsS3Bucket) kmsKey() (*mqlAwsKmsKey, error) {
+	config, err := a.fetchEncryptionConfig()
+	if err != nil {
+		return nil, err
+	}
+	keyRef := ""
+	if config != nil {
+		for _, rule := range config.Rules {
+			d := rule.ApplyServerSideEncryptionByDefault
+			if d != nil && d.KMSMasterKeyID != nil && *d.KMSMasterKeyID != "" {
+				keyRef = *d.KMSMasterKeyID
+				break
+			}
+		}
+	}
+	if keyRef == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+		map[string]*llx.RawData{
+			"arn":    llx.StringData(keyRef),
+			"region": llx.StringData(a.Location.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
+}
+
 func (a *mqlAwsS3Bucket) encryptionRules() ([]any, error) {
 	bucketArn := a.Arn.Data
 


### PR DESCRIPTION
Wire the shared `aws.network.exposure` breakdown (`internetReachable`, `publiclyAccessible`, `securityGroupAllowsIngress`, `openIngressRules`) to data-store and messaging resources that carry a genuine public-access toggle plus queryable security groups, reusing the existing `buildNetworkExposure` helper.

- **aws.rds.dbcluster**: `exposure()` (cluster-level, complementing the instance)
- **aws.redshift.cluster**: `exposure()`; deprecate the scalar `internetReachable` in favor of `exposure.internetReachable`, which also accounts for whether a security group opens the cluster
- **aws.mq.broker**: `exposure()`
- **aws.dms.replicationInstance**: `exposure()`
- **aws.msk.cluster**: `exposure()` (from the `publicAccess` toggle)

New fields versioned at `13.40.2`; the deprecated Redshift field keeps its existing version entry.

**Verification:** compile- and schema-verified; none of these cluster types exist in the test account, so live resolution wasn't exercised. Implementations are identical in shape to the already-shipped `rds.dbinstance`/`documentdb`/`elb` exposure methods.

---
Stacked PR 2/4. Base: `aws-security-context-a-encryption`. Review/merge after PR A.
