### PR TITLE
⭐ aws: security-group exposure on VPC-only data stores

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11814,6 +11814,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   managedBy() string
   // Whether the cluster is encrypted
   storageEncrypted bool
+  // Whether client connections to the cluster are required to use TLS
+  transitEncryptionEnabled() bool
   // Type of encryption for data at rest: "none", "sse-rds", or "sse-kms"
   storageEncryptionType string
   // Amount of storage, in GiB, provisioned on the cluster
@@ -18055,6 +18057,8 @@ private aws.documentdb.cluster @defaults("arn name status") {
   status string
   // Whether the DB cluster is encrypted
   storageEncrypted bool
+  // Whether client connections to the cluster are required to use TLS
+  transitEncryptionEnabled() bool
   // Storage type
   storageType string
   // Tags for the cluster

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12360,6 +12360,8 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   region string
   // A list of VPC security groups associated with the cluster
   securityGroups() []aws.ec2.securitygroup
+  // Security group ingress exposure breakdown (VPC-only service without a public endpoint, so it is not internet-reachable)
+  exposure() aws.network.exposure
   // Number of days ElastiCache retains automatic cluster snapshots before deleting them
   snapshotRetentionLimit int
   // The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your shard.
@@ -12416,6 +12418,8 @@ private aws.elasticache.serverlessCache @defaults("name description status engin
   kmsKey() aws.kms.key
   // A list of VPC security groups associated with the cluster
   securityGroups() []aws.ec2.securitygroup
+  // Security group ingress exposure breakdown (VPC-only service without a public endpoint, so it is not internet-reachable)
+  exposure() aws.network.exposure
   // Number of days ElastiCache retains automatic cluster snapshots before deleting them
   snapshotRetentionLimit int
   // Time each day that a cache snapshot is created
@@ -17561,6 +17565,8 @@ private aws.neptune.cluster @defaults("arn name status") {
   networkType string
   // List of VPC security groups associated with the DB cluster
   securityGroups() []aws.ec2.securitygroup
+  // Security group ingress exposure breakdown (VPC-only service without a public endpoint, so it is not internet-reachable)
+  exposure() aws.network.exposure
   // IAM roles associated with the cluster
   iamRoles() []aws.iam.role
   // Tags for the cluster
@@ -18063,6 +18069,8 @@ private aws.documentdb.cluster @defaults("arn name status") {
   snapshots() []aws.documentdb.snapshot
   // List of VPC security groups associated with the DB cluster
   securityGroups() []aws.ec2.securitygroup
+  // Security group ingress exposure breakdown (VPC-only service without a public endpoint, so it is not internet-reachable)
+  exposure() aws.network.exposure
   // Network type for the cluster (IPV4 or DUAL)
   networkType string
   // Source DB cluster, when this cluster is a read replica (null otherwise)
@@ -20399,6 +20407,8 @@ private aws.memorydb.cluster @defaults("name status nodeType region") {
   tags() map[string]string
   // Security groups associated with the cluster
   securityGroups() []aws.ec2.securitygroup
+  // Security group ingress exposure breakdown (VPC-only service without a public endpoint, so it is not internet-reachable)
+  exposure() aws.network.exposure
 }
 
 // Amazon MemoryDB access control list

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -17607,6 +17607,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetStorageEncrypted()).ToDataRes(types.Bool)
 	},
+	"aws.rds.dbcluster.transitEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetTransitEncryptionEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.rds.dbcluster.storageEncryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetStorageEncryptionType()).ToDataRes(types.String)
 	},
@@ -24779,6 +24782,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.documentdb.cluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetStorageEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.documentdb.cluster.transitEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbCluster).GetTransitEncryptionEnabled()).ToDataRes(types.Bool)
 	},
 	"aws.documentdb.cluster.storageType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetStorageType()).ToDataRes(types.String)
@@ -52840,6 +52846,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.transitEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).TransitEncryptionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbcluster.storageEncryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).StorageEncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -63146,6 +63156,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.documentdb.cluster.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDocumentdbCluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.cluster.transitEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbCluster).TransitEncryptionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.documentdb.cluster.storageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -127201,6 +127215,7 @@ type mqlAwsRdsDbcluster struct {
 	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
 	ManagedBy                          plugin.TValue[string]
 	StorageEncrypted                   plugin.TValue[bool]
+	TransitEncryptionEnabled           plugin.TValue[bool]
 	StorageEncryptionType              plugin.TValue[string]
 	StorageAllocated                   plugin.TValue[int64]
 	StorageIops                        plugin.TValue[int64]
@@ -127358,6 +127373,12 @@ func (c *mqlAwsRdsDbcluster) GetManagedBy() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsDbcluster) GetStorageEncrypted() *plugin.TValue[bool] {
 	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsRdsDbcluster) GetTransitEncryptionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.TransitEncryptionEnabled, func() (bool, error) {
+		return c.transitEncryptionEnabled()
+	})
 }
 
 func (c *mqlAwsRdsDbcluster) GetStorageEncryptionType() *plugin.TValue[string] {
@@ -151961,6 +151982,7 @@ type mqlAwsDocumentdbCluster struct {
 	CloneGroupId                 plugin.TValue[string]
 	Status                       plugin.TValue[string]
 	StorageEncrypted             plugin.TValue[bool]
+	TransitEncryptionEnabled     plugin.TValue[bool]
 	StorageType                  plugin.TValue[string]
 	Tags                         plugin.TValue[map[string]any]
 	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
@@ -152189,6 +152211,12 @@ func (c *mqlAwsDocumentdbCluster) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsDocumentdbCluster) GetStorageEncrypted() *plugin.TValue[bool] {
 	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsDocumentdbCluster) GetTransitEncryptionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.TransitEncryptionEnabled, func() (bool, error) {
+		return c.transitEncryptionEnabled()
+	})
 }
 
 func (c *mqlAwsDocumentdbCluster) GetStorageType() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -18291,6 +18291,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elasticache.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.elasticache.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.elasticache.cluster.snapshotRetentionLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetSnapshotRetentionLimit()).ToDataRes(types.Int)
 	},
@@ -18362,6 +18365,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.serverlessCache.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheServerlessCache).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.elasticache.serverlessCache.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.elasticache.serverlessCache.snapshotRetentionLimit": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheServerlessCache).GetSnapshotRetentionLimit()).ToDataRes(types.Int)
@@ -24231,6 +24237,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.neptune.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.neptune.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.neptune.cluster.iamRoles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptuneCluster).GetIamRoles()).ToDataRes(types.Array(types.Resource("aws.iam.role")))
 	},
@@ -24788,6 +24797,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.documentdb.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.documentdb.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.documentdb.cluster.networkType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetNetworkType()).ToDataRes(types.String)
@@ -27404,6 +27416,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.memorydb.cluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMemorydbCluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.memorydb.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsMemorydbCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.memorydb.acl.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsMemorydbAcl).GetArn()).ToDataRes(types.String)
@@ -53773,6 +53788,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElasticacheCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elasticache.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.elasticache.cluster.snapshotRetentionLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).SnapshotRetentionLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -53871,6 +53890,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.serverlessCache.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheServerlessCache).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.serverlessCache.snapshotRetentionLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62361,6 +62384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsNeptuneCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.neptune.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.neptune.cluster.iamRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsNeptuneCluster).IamRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -63143,6 +63170,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.documentdb.cluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDocumentdbCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.documentdb.cluster.networkType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -66943,6 +66974,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.memorydb.cluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsMemorydbCluster).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.memorydb.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsMemorydbCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.memorydb.acl.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -129109,6 +129144,7 @@ type mqlAwsElasticacheCluster struct {
 	PreferredAvailabilityZone          plugin.TValue[string]
 	Region                             plugin.TValue[string]
 	SecurityGroups                     plugin.TValue[[]any]
+	Exposure                           plugin.TValue[*mqlAwsNetworkExposure]
 	SnapshotRetentionLimit             plugin.TValue[int64]
 	SnapshotWindow                     plugin.TValue[string]
 	TransitEncryptionEnabled           plugin.TValue[bool]
@@ -129298,6 +129334,22 @@ func (c *mqlAwsElasticacheCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsElasticacheCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
+	})
+}
+
 func (c *mqlAwsElasticacheCluster) GetSnapshotRetentionLimit() *plugin.TValue[int64] {
 	return &c.SnapshotRetentionLimit
 }
@@ -129412,6 +129464,7 @@ type mqlAwsElasticacheServerlessCache struct {
 	KmsKeyId               plugin.TValue[string]
 	KmsKey                 plugin.TValue[*mqlAwsKmsKey]
 	SecurityGroups         plugin.TValue[[]any]
+	Exposure               plugin.TValue[*mqlAwsNetworkExposure]
 	SnapshotRetentionLimit plugin.TValue[int64]
 	DailySnapshotTime      plugin.TValue[string]
 	Status                 plugin.TValue[string]
@@ -129509,6 +129562,22 @@ func (c *mqlAwsElasticacheServerlessCache) GetSecurityGroups() *plugin.TValue[[]
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.serverlessCache", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -150195,6 +150264,7 @@ type mqlAwsNeptuneCluster struct {
 	StorageType                      plugin.TValue[string]
 	NetworkType                      plugin.TValue[string]
 	SecurityGroups                   plugin.TValue[[]any]
+	Exposure                         plugin.TValue[*mqlAwsNetworkExposure]
 	IamRoles                         plugin.TValue[[]any]
 	Tags                             plugin.TValue[map[string]any]
 	CloudformationStack              plugin.TValue[*mqlAwsCloudformationStack]
@@ -150406,6 +150476,22 @@ func (c *mqlAwsNeptuneCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsNeptuneCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -151881,6 +151967,7 @@ type mqlAwsDocumentdbCluster struct {
 	ManagedBy                    plugin.TValue[string]
 	Snapshots                    plugin.TValue[[]any]
 	SecurityGroups               plugin.TValue[[]any]
+	Exposure                     plugin.TValue[*mqlAwsNetworkExposure]
 	NetworkType                  plugin.TValue[string]
 	ReplicationSource            plugin.TValue[*mqlAwsDocumentdbCluster]
 	ReadReplicas                 plugin.TValue[[]any]
@@ -152165,6 +152252,22 @@ func (c *mqlAwsDocumentdbCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsDocumentdbCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.documentdb.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -161704,6 +161807,7 @@ type mqlAwsMemorydbCluster struct {
 	Region                  plugin.TValue[string]
 	Tags                    plugin.TValue[map[string]any]
 	SecurityGroups          plugin.TValue[[]any]
+	Exposure                plugin.TValue[*mqlAwsNetworkExposure]
 }
 
 // createAwsMemorydbCluster creates a new instance of this resource
@@ -161845,6 +161949,22 @@ func (c *mqlAwsMemorydbCluster) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsMemorydbCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.memorydb.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2539,6 +2539,7 @@ aws.documentdb.cluster.storageType 11.16.1
 aws.documentdb.cluster.subnetGroup 11.16.1
 aws.documentdb.cluster.subnets 13.19.1
 aws.documentdb.cluster.tags 11.16.1
+aws.documentdb.cluster.transitEncryptionEnabled 13.40.2
 aws.documentdb.cluster.vpc 13.19.1
 aws.documentdb.cluster.writer 13.19.1
 aws.documentdb.clusterParameter 13.19.1
@@ -7385,6 +7386,7 @@ aws.rds.dbcluster.storageEncryptionType 13.3.1
 aws.rds.dbcluster.storageIops 11.15.2
 aws.rds.dbcluster.storageType 11.15.2
 aws.rds.dbcluster.tags 11.15.2
+aws.rds.dbcluster.transitEncryptionEnabled 13.40.2
 aws.rds.dbcluster.upgradeRolloutOrder 13.14.2
 aws.rds.dbinstance 11.15.2
 aws.rds.dbinstance.activityStreamKmsKey 11.16.1

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2508,6 +2508,7 @@ aws.documentdb.cluster.enabledCloudwatchLogsExports 11.16.1
 aws.documentdb.cluster.endpoint 11.16.1
 aws.documentdb.cluster.engine 11.16.1
 aws.documentdb.cluster.engineVersion 11.16.1
+aws.documentdb.cluster.exposure 13.40.2
 aws.documentdb.cluster.globalCluster 13.19.1
 aws.documentdb.cluster.globalClusterIdentifier 13.19.1
 aws.documentdb.cluster.hostedZoneId 13.19.1
@@ -4207,6 +4208,7 @@ aws.elasticache.cluster.configurationEndpointAddress 13.39.2
 aws.elasticache.cluster.configurationEndpointPort 13.39.2
 aws.elasticache.cluster.engine 11.15.2
 aws.elasticache.cluster.engineVersion 11.15.2
+aws.elasticache.cluster.exposure 13.40.2
 aws.elasticache.cluster.ipDiscovery 11.15.2
 aws.elasticache.cluster.kmsKey 13.3.1
 aws.elasticache.cluster.logDeliveryConfigurations 11.15.2
@@ -4244,6 +4246,7 @@ aws.elasticache.serverlessCache.dailySnapshotTime 11.15.2
 aws.elasticache.serverlessCache.description 11.15.2
 aws.elasticache.serverlessCache.engine 11.15.2
 aws.elasticache.serverlessCache.engineVersion 11.15.2
+aws.elasticache.serverlessCache.exposure 13.40.2
 aws.elasticache.serverlessCache.kmsKey 11.16.1
 aws.elasticache.serverlessCache.kmsKeyId 11.15.2
 aws.elasticache.serverlessCache.majorEngineVersion 11.15.2
@@ -6518,6 +6521,7 @@ aws.memorydb.cluster.description 11.16.1
 aws.memorydb.cluster.engine 11.16.1
 aws.memorydb.cluster.enginePatchVersion 11.16.1
 aws.memorydb.cluster.engineVersion 11.16.1
+aws.memorydb.cluster.exposure 13.40.2
 aws.memorydb.cluster.kmsKey 11.16.1
 aws.memorydb.cluster.maintenanceWindow 11.16.1
 aws.memorydb.cluster.name 11.16.1
@@ -6876,6 +6880,7 @@ aws.neptune.cluster.enabledCloudwatchLogsExports 11.15.2
 aws.neptune.cluster.endpoint 11.15.2
 aws.neptune.cluster.engine 11.15.2
 aws.neptune.cluster.engineVersion 11.15.2
+aws.neptune.cluster.exposure 13.40.2
 aws.neptune.cluster.globalClusterIdentifier 11.15.2
 aws.neptune.cluster.iamDatabaseAuthenticationEnabled 11.15.2
 aws.neptune.cluster.iamRoles 13.39.2

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -164,3 +164,38 @@ func (a *mqlAwsMskCluster) exposure() (*mqlAwsNetworkExposure, error) {
 	}
 	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess.Data, a.GetSecurityGroups())
 }
+
+// buildVpcOnlyExposure builds a network exposure for a service that has no
+// public endpoint (it is only reachable inside its VPC). publiclyAccessible and
+// internetReachable are therefore always false; the value is in surfacing any
+// attached security group that opens the resource to a public source.
+func buildVpcOnlyExposure(a interface {
+	GetArn() *plugin.TValue[string]
+	GetSecurityGroups() *plugin.TValue[[]any]
+}, runtime *plugin.Runtime) (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	return buildNetworkExposure(runtime, arn.Data+"/exposure", false, a.GetSecurityGroups())
+}
+
+func (a *mqlAwsDocumentdbCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}
+
+func (a *mqlAwsElasticacheCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}
+
+func (a *mqlAwsElasticacheServerlessCache) exposure() (*mqlAwsNetworkExposure, error) {
+	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}
+
+func (a *mqlAwsMemorydbCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}
+
+func (a *mqlAwsNeptuneCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}

--- a/providers/aws/resources/aws_transit_encryption.go
+++ b/providers/aws/resources/aws_transit_encryption.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// paramIndicatesTLS reports whether a parameter-group entry enforces TLS/SSL for
+// client connections. Different engines expose this through different parameter
+// names and truthy values, so all known variants are recognized:
+//   - require_secure_transport: Aurora MySQL / MySQL (ON or 1)
+//   - rds.force_ssl:            Aurora PostgreSQL / PostgreSQL (1 or ON)
+//   - tls:                      DocumentDB (enabled)
+func paramIndicatesTLS(name, value string) bool {
+	v := strings.ToLower(strings.TrimSpace(value))
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "require_secure_transport", "rds.force_ssl":
+		return v == "on" || v == "1"
+	case "tls":
+		return v == "enabled"
+	}
+	return false
+}
+
+// parameterGroupEnforcesTLS scans a resolved parameter group's parameters for an
+// enabled TLS/SSL enforcement setting. Each parameter is expected to expose a
+// name and value accessor.
+func parameterGroupEnforcesTLS(params *plugin.TValue[[]any]) (bool, error) {
+	if params == nil {
+		return false, nil
+	}
+	if params.Error != nil {
+		return false, params.Error
+	}
+	for _, p := range params.Data {
+		param, ok := p.(interface {
+			GetName() *plugin.TValue[string]
+			GetValue() *plugin.TValue[string]
+		})
+		if !ok {
+			continue
+		}
+		name := param.GetName()
+		if name.Error != nil {
+			return false, name.Error
+		}
+		value := param.GetValue()
+		if value.Error != nil {
+			return false, value.Error
+		}
+		if paramIndicatesTLS(name.Data, value.Data) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a *mqlAwsRdsDbcluster) transitEncryptionEnabled() (bool, error) {
+	pg := a.GetDbClusterParameterGroup()
+	if pg.Error != nil {
+		return false, pg.Error
+	}
+	if pg.Data == nil {
+		return false, nil
+	}
+	return parameterGroupEnforcesTLS(pg.Data.GetParameters())
+}
+
+func (a *mqlAwsDocumentdbCluster) transitEncryptionEnabled() (bool, error) {
+	pg := a.GetParameterGroup()
+	if pg.Error != nil {
+		return false, pg.Error
+	}
+	if pg.Data == nil {
+		return false, nil
+	}
+	return parameterGroupEnforcesTLS(pg.Data.GetParameters())
+}


### PR DESCRIPTION
Wire the shared `aws.network.exposure` breakdown to VPC-only cache and database clusters. These services never receive a public IP, so `publiclyAccessible` and `internetReachable` are always false; the value is in surfacing any attached security group that opens the service to a public source (`openIngressRules`), a real misconfiguration finding even without internet reachability.

- **aws.documentdb.cluster**
- **aws.elasticache.cluster**
- **aws.elasticache.serverlessCache**
- **aws.memorydb.cluster**
- **aws.neptune.cluster**

A shared `buildVpcOnlyExposure` helper pins `publiclyAccessible` to false for this class of resource.

**Deferred:** `emr.cluster` is not included — its `MasterPublicDnsName` is not a reliable public signal (it returns the private DNS for VPC clusters), and EMR retains terminated clusters whose subnet and security-group references dangle, so `exposure()` would error on them. Needs terminated-cluster-safe reference handling plus a reliable public-IP signal.

New fields versioned at `13.40.2`.

**Verification:** compile- and schema-verified; none of these resources exist in the test account.

---
Stacked PR 3/4. Base: `aws-security-context-b-exposure-public`. Review/merge after PR B.
