### PR TITLE
⭐ aws: in-transit TLS enforcement for rds and documentdb clusters

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11814,6 +11814,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   managedBy() string
   // Whether the cluster is encrypted
   storageEncrypted bool
+  // Whether client connections to the cluster are required to use TLS
+  transitEncryptionEnabled() bool
   // Type of encryption for data at rest: "none", "sse-rds", or "sse-kms"
   storageEncryptionType string
   // Amount of storage, in GiB, provisioned on the cluster
@@ -18055,6 +18057,8 @@ private aws.documentdb.cluster @defaults("arn name status") {
   status string
   // Whether the DB cluster is encrypted
   storageEncrypted bool
+  // Whether client connections to the cluster are required to use TLS
+  transitEncryptionEnabled() bool
   // Storage type
   storageType string
   // Tags for the cluster

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -17607,6 +17607,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetStorageEncrypted()).ToDataRes(types.Bool)
 	},
+	"aws.rds.dbcluster.transitEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetTransitEncryptionEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.rds.dbcluster.storageEncryptionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetStorageEncryptionType()).ToDataRes(types.String)
 	},
@@ -24779,6 +24782,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.documentdb.cluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetStorageEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.documentdb.cluster.transitEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDocumentdbCluster).GetTransitEncryptionEnabled()).ToDataRes(types.Bool)
 	},
 	"aws.documentdb.cluster.storageType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDocumentdbCluster).GetStorageType()).ToDataRes(types.String)
@@ -52840,6 +52846,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.transitEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).TransitEncryptionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbcluster.storageEncryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).StorageEncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -63146,6 +63156,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.documentdb.cluster.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDocumentdbCluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.documentdb.cluster.transitEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDocumentdbCluster).TransitEncryptionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.documentdb.cluster.storageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -127201,6 +127215,7 @@ type mqlAwsRdsDbcluster struct {
 	CloudformationStack                plugin.TValue[*mqlAwsCloudformationStack]
 	ManagedBy                          plugin.TValue[string]
 	StorageEncrypted                   plugin.TValue[bool]
+	TransitEncryptionEnabled           plugin.TValue[bool]
 	StorageEncryptionType              plugin.TValue[string]
 	StorageAllocated                   plugin.TValue[int64]
 	StorageIops                        plugin.TValue[int64]
@@ -127358,6 +127373,12 @@ func (c *mqlAwsRdsDbcluster) GetManagedBy() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsDbcluster) GetStorageEncrypted() *plugin.TValue[bool] {
 	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsRdsDbcluster) GetTransitEncryptionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.TransitEncryptionEnabled, func() (bool, error) {
+		return c.transitEncryptionEnabled()
+	})
 }
 
 func (c *mqlAwsRdsDbcluster) GetStorageEncryptionType() *plugin.TValue[string] {
@@ -151961,6 +151982,7 @@ type mqlAwsDocumentdbCluster struct {
 	CloneGroupId                 plugin.TValue[string]
 	Status                       plugin.TValue[string]
 	StorageEncrypted             plugin.TValue[bool]
+	TransitEncryptionEnabled     plugin.TValue[bool]
 	StorageType                  plugin.TValue[string]
 	Tags                         plugin.TValue[map[string]any]
 	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
@@ -152189,6 +152211,12 @@ func (c *mqlAwsDocumentdbCluster) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsDocumentdbCluster) GetStorageEncrypted() *plugin.TValue[bool] {
 	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsDocumentdbCluster) GetTransitEncryptionEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.TransitEncryptionEnabled, func() (bool, error) {
+		return c.transitEncryptionEnabled()
+	})
 }
 
 func (c *mqlAwsDocumentdbCluster) GetStorageType() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2539,6 +2539,7 @@ aws.documentdb.cluster.storageType 11.16.1
 aws.documentdb.cluster.subnetGroup 11.16.1
 aws.documentdb.cluster.subnets 13.19.1
 aws.documentdb.cluster.tags 11.16.1
+aws.documentdb.cluster.transitEncryptionEnabled 13.40.2
 aws.documentdb.cluster.vpc 13.19.1
 aws.documentdb.cluster.writer 13.19.1
 aws.documentdb.clusterParameter 13.19.1
@@ -7385,6 +7386,7 @@ aws.rds.dbcluster.storageEncryptionType 13.3.1
 aws.rds.dbcluster.storageIops 11.15.2
 aws.rds.dbcluster.storageType 11.15.2
 aws.rds.dbcluster.tags 11.15.2
+aws.rds.dbcluster.transitEncryptionEnabled 13.40.2
 aws.rds.dbcluster.upgradeRolloutOrder 13.14.2
 aws.rds.dbinstance 11.15.2
 aws.rds.dbinstance.activityStreamKmsKey 11.16.1

--- a/providers/aws/resources/aws_transit_encryption.go
+++ b/providers/aws/resources/aws_transit_encryption.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// paramIndicatesTLS reports whether a parameter-group entry enforces TLS/SSL for
+// client connections. Different engines expose this through different parameter
+// names and truthy values, so all known variants are recognized:
+//   - require_secure_transport: Aurora MySQL / MySQL (ON or 1)
+//   - rds.force_ssl:            Aurora PostgreSQL / PostgreSQL (1 or ON)
+//   - tls:                      DocumentDB (enabled)
+func paramIndicatesTLS(name, value string) bool {
+	v := strings.ToLower(strings.TrimSpace(value))
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "require_secure_transport", "rds.force_ssl":
+		return v == "on" || v == "1"
+	case "tls":
+		return v == "enabled"
+	}
+	return false
+}
+
+// parameterGroupEnforcesTLS scans a resolved parameter group's parameters for an
+// enabled TLS/SSL enforcement setting. Each parameter is expected to expose a
+// name and value accessor.
+func parameterGroupEnforcesTLS(params *plugin.TValue[[]any]) (bool, error) {
+	if params == nil {
+		return false, nil
+	}
+	if params.Error != nil {
+		return false, params.Error
+	}
+	for _, p := range params.Data {
+		param, ok := p.(interface {
+			GetName() *plugin.TValue[string]
+			GetValue() *plugin.TValue[string]
+		})
+		if !ok {
+			continue
+		}
+		name := param.GetName()
+		if name.Error != nil {
+			return false, name.Error
+		}
+		value := param.GetValue()
+		if value.Error != nil {
+			return false, value.Error
+		}
+		if paramIndicatesTLS(name.Data, value.Data) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a *mqlAwsRdsDbcluster) transitEncryptionEnabled() (bool, error) {
+	pg := a.GetDbClusterParameterGroup()
+	if pg.Error != nil {
+		return false, pg.Error
+	}
+	if pg.Data == nil {
+		return false, nil
+	}
+	return parameterGroupEnforcesTLS(pg.Data.GetParameters())
+}
+
+func (a *mqlAwsDocumentdbCluster) transitEncryptionEnabled() (bool, error) {
+	pg := a.GetParameterGroup()
+	if pg.Error != nil {
+		return false, pg.Error
+	}
+	if pg.Data == nil {
+		return false, nil
+	}
+	return parameterGroupEnforcesTLS(pg.Data.GetParameters())
+}


### PR DESCRIPTION
Surface whether client connections are required to use TLS, derived from the cluster's associated parameter group. This is the in-transit companion to the existing at-rest `storageEncrypted` field.

- **aws.rds.dbcluster**: `transitEncryptionEnabled` (`require_secure_transport` for Aurora MySQL / MySQL, `rds.force_ssl` for Aurora PostgreSQL / PostgreSQL)
- **aws.documentdb.cluster**: `transitEncryptionEnabled` (`tls` parameter)

A shared `parameterGroupEnforcesTLS` helper recognizes the per-engine parameter names and truthy values.

**Deferred:** `neptune.cluster` and `redshift.cluster` are not included — neither exposes a typed parameter-group resource (only parameter-group name strings), so deriving the flag would require modeling a new resource plus additional API calls.

New fields versioned at `13.40.2`.

**Verification:** compile-verified; the `require_secure_transport` parameter name was confirmed present in a real default Aurora parameter group. No RDS/DocumentDB clusters exist in the test account for full end-to-end resolution.

---
Stacked PR 4/4 (top). Base: `aws-security-context-c-exposure-vpc`. Review/merge after PR C.
