### PR TITLE
🐛 discovery: carry context mql features into asset connections

### DIFF
--- a/discovery/asset_explorer.go
+++ b/discovery/asset_explorer.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/cli/execruntime"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers"
@@ -72,6 +73,7 @@ type AssetExplorer struct {
 
 	upstream      *upstream.UpstreamConfig
 	recording     llx.Recording
+	features      []byte
 	runtimeLabels map[string]string
 	rootAssets    []*inventory.Asset // original root assets, for prepareAsset
 	errors        []*AssetWithError
@@ -100,8 +102,13 @@ func NewAssetExplorer(ctx context.Context, cfg AssetExplorerConfig) (*AssetExplo
 	}
 
 	e := &AssetExplorer{
-		upstream:      cfg.Upstream,
-		recording:     cfg.Recording,
+		upstream:  cfg.Upstream,
+		recording: cfg.Recording,
+		// Carry the context's mql features (which include platform/server-activated
+		// ones like TerraformResolveVars) into every asset connection, unioned with
+		// the local cli/config.Features global. Without this, connection-level
+		// features present only on the context never reach the provider.
+		features:      []byte(mql.GetFeatures(ctx)),
 		runtimeLabels: runtimeLabels,
 	}
 
@@ -111,7 +118,7 @@ func NewAssetExplorer(ctx context.Context, cfg AssetExplorerConfig) (*AssetExplo
 			return nil, err
 		}
 
-		awr, err := createRuntimeForAsset(resolvedRootAsset, cfg.Upstream, cfg.Recording)
+		awr, err := createRuntimeForAsset(resolvedRootAsset, cfg.Upstream, cfg.Recording, e.features)
 		if err != nil {
 			log.Error().Err(err).Str("asset", resolvedRootAsset.Name).Msg("unable to create runtime for asset")
 			e.errors = append(e.errors, &AssetWithError{Asset: resolvedRootAsset, Err: err})
@@ -194,7 +201,7 @@ func (e *AssetExplorer) Connect(asset *TrackedAsset) (*TrackedAsset, error) {
 		return nil, fmt.Errorf("asset %q has been closed and cannot be reconnected", asset.Asset.GetName())
 	}
 
-	awr, err := createRuntimeForAsset(asset.Asset, e.upstream, e.recording)
+	awr, err := createRuntimeForAsset(asset.Asset, e.upstream, e.recording, e.features)
 	if err != nil {
 		e.errors = append(e.errors, &AssetWithError{Asset: asset.Asset, Err: err})
 		return nil, err

--- a/discovery/asset_explorer_test.go
+++ b/discovery/asset_explorer_test.go
@@ -8,8 +8,34 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/cli/config"
 	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
+
+// TestMergeConnectionFeatures verifies that connection features are the union of
+// the local cli/config.Features global and caller-supplied (server-activated)
+// features — so a feature present only on the context (e.g. TerraformResolveVars
+// from GetScanParameters) still reaches the provider connection.
+func TestMergeConnectionFeatures(t *testing.T) {
+	saved := config.Features
+	t.Cleanup(func() { config.Features = saved })
+	config.Features = []byte{7, 9} // local config features
+
+	t.Run("adds server features on top of local ones", func(t *testing.T) {
+		got := mergeConnectionFeatures([]byte{17}) // TerraformResolveVars from server
+		assert.ElementsMatch(t, []byte{7, 9, 17}, got)
+	})
+
+	t.Run("deduplicates overlap", func(t *testing.T) {
+		got := mergeConnectionFeatures([]byte{9, 17})
+		assert.ElementsMatch(t, []byte{7, 9, 17}, got)
+	})
+
+	t.Run("nil extra returns just the local features", func(t *testing.T) {
+		got := mergeConnectionFeatures(nil)
+		assert.ElementsMatch(t, []byte{7, 9}, got)
+	})
+}
 
 func newTestExplorer(assets ...*TrackedAsset) *AssetExplorer {
 	return &AssetExplorer{

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -25,7 +25,31 @@ type AssetWithError struct {
 	Err   error
 }
 
-func createRuntimeForAsset(asset *inventory.Asset, upstream *upstream.UpstreamConfig, recording llx.Recording) (*AssetWithRuntime, error) {
+// mergeConnectionFeatures unions the process-global CLI features
+// (cli/config.Features, populated from local config/MONDOO_FEATURES) with any
+// caller-supplied features (e.g. platform/server-activated ones). Both must
+// reach the provider connection: connection-level features like
+// TerraformResolveVars are read at Connect time, and the global alone never
+// carries server-activated features.
+func mergeConnectionFeatures(extra []byte) []byte {
+	out := make([]byte, 0, len(config.Features)+len(extra))
+	seen := make(map[byte]bool, len(config.Features)+len(extra))
+	for _, f := range config.Features {
+		if !seen[f] {
+			seen[f] = true
+			out = append(out, f)
+		}
+	}
+	for _, f := range extra {
+		if !seen[f] {
+			seen[f] = true
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func createRuntimeForAsset(asset *inventory.Asset, upstream *upstream.UpstreamConfig, recording llx.Recording, features []byte) (*AssetWithRuntime, error) {
 	var runtime *providers.Runtime
 	var err error
 	// Close the runtime if an error occurred
@@ -50,7 +74,7 @@ func createRuntimeForAsset(asset *inventory.Asset, upstream *upstream.UpstreamCo
 	}
 
 	err = runtime.Connect(&plugin.ConnectReq{
-		Features: config.Features,
+		Features: mergeConnectionFeatures(features),
 		Asset:    asset,
 		Upstream: upstream,
 	})


### PR DESCRIPTION
## Problem

Asset discovery connects every asset with only the process-global `cli/config.Features` (populated from local config / `MONDOO_FEATURES`), ignoring the mql features already set on the **context**:

```go
// discovery.createRuntimeForAsset
runtime.Connect(&plugin.ConnectReq{ Features: config.Features, ... })
```

Connection-level features are read at provider **Connect** time. So a feature that's active on the context but not in the global — e.g. `TerraformResolveVars` activated server-side and layered onto the context via `GetScanParameters` — never reaches the connection.

Concretely: an authenticated (service-account) Terraform scan could not resolve `var.*`/`local.*` references even when the platform enabled `TerraformResolveVars`, so a bad value hidden behind a variable (with a `.tfvars` override) was silently missed. See mondoohq/mql#8753.

## Fix

`NewAssetExplorer` now carries `mql.GetFeatures(ctx)` onto each asset connection, unioned with `cli/config.Features` via a new `mergeConnectionFeatures` helper, so **both** locally-configured and server-activated features reach the provider. Applies to root and lazily-connected child assets.

No behavior change when the context carries no extra features (union with an empty set == the global, as before).

## Verified

Built cnspec against this branch and ran a bare authenticated Terraform scan: `GetScanParameters` returns `TerraformResolveVars`, and the feature now reaches the terraform connection (`merged` feature set includes it; previously the connection saw only the local global). Forced-mode scans (feature set locally) already resolved variables, confirming that once the feature reaches the connection, resolution works.

## Tests

`TestMergeConnectionFeatures` — union of local + server features, dedup, and nil-extra (global-only) cases.

Fixes the connection half of mondoohq/mql#8753.