### PR TITLE
🐛 nextdns: remove non-existent settings.blockBypassMethods field

### DIFF
--- a/providers/nextdns/resources/nextdns.lr
+++ b/providers/nextdns/resources/nextdns.lr
@@ -139,14 +139,14 @@ private nextdns.profileBlocklist @defaults("id name entries") {
 //
 // Examine the parental-control posture of a profile: blocked `services` and
 // `categories`, the SafeSearch and YouTube Restricted Mode toggles, whether
-// users may bypass blocks, and the recreation-time schedule during which
+// bypass methods are blocked, and the recreation-time schedule during which
 // recreation-flagged services and categories are allowed.
 private nextdns.profileParentalControl @defaults("safeSearch youtubeRestrictedMode blockBypass") {
   // Whether SafeSearch is enforced for supported search engines
   safeSearch bool
   // Whether YouTube Restricted Mode is enforced
   youtubeRestrictedMode bool
-  // Whether end users are allowed to bypass blocks
+  // Whether methods used to circumvent parental controls (VPNs, proxies, Tor, and public DNS resolvers) are blocked
   blockBypass bool
   // Timezone the recreation schedule is evaluated in (for example "America/New_York")
   recreationTimezone string
@@ -212,8 +212,6 @@ private nextdns.profileSettings @defaults("logsEnabled logsLocation web3") {
   cacheBoost bool
   // Whether CNAME flattening is enabled
   cnameFlattening bool
-  // Whether block-bypass methods (VPNs, proxies, Tor, and public resolvers used to circumvent NextDNS) are blocked
-  blockBypassMethods bool
   // Whether Web3 name resolution is enabled
   web3 bool
 }

--- a/providers/nextdns/resources/nextdns.lr.go
+++ b/providers/nextdns/resources/nextdns.lr.go
@@ -343,9 +343,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nextdns.profileSettings.cnameFlattening": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNextdnsProfileSettings).GetCnameFlattening()).ToDataRes(types.Bool)
 	},
-	"nextdns.profileSettings.blockBypassMethods": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlNextdnsProfileSettings).GetBlockBypassMethods()).ToDataRes(types.Bool)
-	},
 	"nextdns.profileSettings.web3": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNextdnsProfileSettings).GetWeb3()).ToDataRes(types.Bool)
 	},
@@ -681,10 +678,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nextdns.profileSettings.cnameFlattening": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNextdnsProfileSettings).CnameFlattening, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"nextdns.profileSettings.blockBypassMethods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlNextdnsProfileSettings).BlockBypassMethods, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"nextdns.profileSettings.web3": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1557,17 +1550,16 @@ type mqlNextdnsProfileSettings struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlNextdnsProfileSettingsInternal it will be used here
-	LogsEnabled        plugin.TValue[bool]
-	LogsDropIp         plugin.TValue[bool]
-	LogsDropDomain     plugin.TValue[bool]
-	LogsRetention      plugin.TValue[int64]
-	LogsLocation       plugin.TValue[string]
-	BlockPageEnabled   plugin.TValue[bool]
-	Ecs                plugin.TValue[bool]
-	CacheBoost         plugin.TValue[bool]
-	CnameFlattening    plugin.TValue[bool]
-	BlockBypassMethods plugin.TValue[bool]
-	Web3               plugin.TValue[bool]
+	LogsEnabled      plugin.TValue[bool]
+	LogsDropIp       plugin.TValue[bool]
+	LogsDropDomain   plugin.TValue[bool]
+	LogsRetention    plugin.TValue[int64]
+	LogsLocation     plugin.TValue[string]
+	BlockPageEnabled plugin.TValue[bool]
+	Ecs              plugin.TValue[bool]
+	CacheBoost       plugin.TValue[bool]
+	CnameFlattening  plugin.TValue[bool]
+	Web3             plugin.TValue[bool]
 }
 
 // createNextdnsProfileSettings creates a new instance of this resource
@@ -1636,10 +1628,6 @@ func (c *mqlNextdnsProfileSettings) GetCacheBoost() *plugin.TValue[bool] {
 
 func (c *mqlNextdnsProfileSettings) GetCnameFlattening() *plugin.TValue[bool] {
 	return &c.CnameFlattening
-}
-
-func (c *mqlNextdnsProfileSettings) GetBlockBypassMethods() *plugin.TValue[bool] {
-	return &c.BlockBypassMethods
 }
 
 func (c *mqlNextdnsProfileSettings) GetWeb3() *plugin.TValue[bool] {

--- a/providers/nextdns/resources/nextdns.lr.versions
+++ b/providers/nextdns/resources/nextdns.lr.versions
@@ -71,7 +71,6 @@ nextdns.profileSecurity.threatIntelligenceFeeds 13.0.2
 nextdns.profileSecurity.tlds 13.0.2
 nextdns.profileSecurity.typosquatting 13.0.2
 nextdns.profileSettings 13.0.2
-nextdns.profileSettings.blockBypassMethods 13.0.2
 nextdns.profileSettings.blockPageEnabled 13.0.2
 nextdns.profileSettings.cacheBoost 13.0.2
 nextdns.profileSettings.cnameFlattening 13.0.2

--- a/providers/nextdns/resources/profile.go
+++ b/providers/nextdns/resources/profile.go
@@ -134,7 +134,6 @@ type settingsData struct {
 	Logs        logsData        `json:"logs"`
 	BlockPage   blockPageData   `json:"blockPage"`
 	Performance performanceData `json:"performance"`
-	Bav         bool            `json:"bav"`
 	Web3        bool            `json:"web3"`
 }
 
@@ -343,18 +342,17 @@ func (r *mqlNextdnsProfile) settings() (*mqlNextdnsProfileSettings, error) {
 	}
 	s := d.Settings
 	res, err := CreateResource(r.MqlRuntime, "nextdns.profileSettings", map[string]*llx.RawData{
-		"__id":               llx.StringData(r.Id.Data + "/settings"),
-		"logsEnabled":        llx.BoolData(s.Logs.Enabled),
-		"logsDropIp":         llx.BoolData(s.Logs.Drop.IP),
-		"logsDropDomain":     llx.BoolData(s.Logs.Drop.Domain),
-		"logsRetention":      llx.IntData(s.Logs.Retention),
-		"logsLocation":       llx.StringData(s.Logs.Location),
-		"blockPageEnabled":   llx.BoolData(s.BlockPage.Enabled),
-		"ecs":                llx.BoolData(s.Performance.Ecs),
-		"cacheBoost":         llx.BoolData(s.Performance.CacheBoost),
-		"cnameFlattening":    llx.BoolData(s.Performance.CnameFlattening),
-		"blockBypassMethods": llx.BoolData(s.Bav),
-		"web3":               llx.BoolData(s.Web3),
+		"__id":             llx.StringData(r.Id.Data + "/settings"),
+		"logsEnabled":      llx.BoolData(s.Logs.Enabled),
+		"logsDropIp":       llx.BoolData(s.Logs.Drop.IP),
+		"logsDropDomain":   llx.BoolData(s.Logs.Drop.Domain),
+		"logsRetention":    llx.IntData(s.Logs.Retention),
+		"logsLocation":     llx.StringData(s.Logs.Location),
+		"blockPageEnabled": llx.BoolData(s.BlockPage.Enabled),
+		"ecs":              llx.BoolData(s.Performance.Ecs),
+		"cacheBoost":       llx.BoolData(s.Performance.CacheBoost),
+		"cnameFlattening":  llx.BoolData(s.Performance.CnameFlattening),
+		"web3":             llx.BoolData(s.Web3),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Removes the `nextdns.profileSettings.blockBypassMethods` field, which modeled a NextDNS API option that does not exist under profile *settings*. "Block Bypass Methods" is part of **Parental Control** in NextDNS, where it is already correctly modeled as `nextdns.profileParentalControl.blockBypass`.

## Why

The removed field mapped from a `settings.bav` JSON key that the `/profiles/:id` response never returns. Go's JSON decoder therefore left it at the zero value `false` on every profile — so any audit asserting `profileSettings.blockBypassMethods == true` would always fail, reporting bypass protection as disabled even when it was enabled under Parental Control. That is a false negative baked into the schema, worse than not modeling the field at all.

## Changes

- **`nextdns.lr`** — drop `blockBypassMethods` from `nextdns.profileSettings`; rewrite the `nextdns.profileParentalControl.blockBypass` doc-comment, which was semantically backwards ("whether users are *allowed* to bypass" — but `blockBypass == true` means bypass methods **are blocked**).
- **`profile.go`** — remove the `Bav bool` struct member and its `CreateResource` mapping.
- **`nextdns.lr.versions`** — drop the `nextdns.profileSettings.blockBypassMethods` entry.
- **`nextdns.lr.go`** — regenerated.

## Compatibility

`blockBypassMethods` shipped at `13.0.2`, so this is technically a breaking schema removal. Since the field never returned meaningful data, straight removal is preferred over deprecation.

## Verification

- `go build ./...`, `go vet`, and `gofmt` all clean
- codegen regenerated and consistent (`git diff --exit-code` on generated files after re-run)
- no remaining references to `blockBypassMethods` anywhere in the repo

Not live-tested: no NextDNS credentials in the dev environment. The real toggle remains queryable via `nextdns.profile.parentalControl.blockBypass`.
