### PR TITLE
⭐ aws: add networkInterface() cross-references

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -420,7 +420,11 @@ private aws.vpc.routetable.route @defaults("destinationCidrBlock state") {
   // ID of the Amazon Web Services account that owns the instance
   instanceOwnerId string
   // ID of the network interface
-  networkInterfaceId string
+  //
+  // Deprecated in favor of `networkInterface`.
+  networkInterfaceId @maturity("deprecated") string
+  // Network interface a route sends traffic to
+  networkInterface() aws.ec2.networkinterface
   // ID of a NAT gateway
   natGatewayId string
   // ID of a transit gateway
@@ -1491,7 +1495,11 @@ private aws.efs.mountTarget @defaults("mountTargetId subnetId") {
   // Mount target state (creating, available, deleting)
   lifecycleState string
   // Network interface ID
-  networkInterfaceId string
+  //
+  // Deprecated in favor of `networkInterface`.
+  networkInterfaceId @maturity("deprecated") string
+  // Network interface the mount target uses
+  networkInterface() aws.ec2.networkinterface
   // Region where the mount target exists
   region string
 }
@@ -10051,7 +10059,11 @@ private aws.cloudhsm.hsm @defaults("hsmId state availabilityZone") {
   // HSM instance type
   hsmType string
   // ID of the elastic network interface attached to the HSM
-  eniId string
+  //
+  // Deprecated in favor of `networkInterface`.
+  eniId @maturity("deprecated") string
+  // Elastic network interface attached to the HSM
+  networkInterface() aws.ec2.networkinterface
   // Private IP address of the HSM's elastic network interface
   eniIp string
   // Subnet the HSM runs in
@@ -15299,7 +15311,11 @@ private aws.vpc.natgateway.address {
   // Allocation ID for the address
   allocationId string
   // Network interface ID for the address
-  networkInterfaceId string
+  //
+  // Deprecated in favor of `networkInterface`.
+  networkInterfaceId @maturity("deprecated") string
+  // Network interface associated with the address
+  networkInterface() aws.ec2.networkinterface
   // Private IP associated with the address
   privateIp string
   // EIP associated with the address
@@ -19026,7 +19042,11 @@ private aws.appstream.session @defaults("id userId state fleetName stackName") {
   // Time when the session is set to expire (per the fleet's max-user-duration)
   maxExpirationTime time
   // ENI ID for the session network access (VPC-enabled fleets only)
-  eniId string
+  //
+  // Deprecated in favor of `networkInterface`.
+  eniId @maturity("deprecated") string
+  // Network interface for the session network access (VPC-enabled fleets only)
+  networkInterface() aws.ec2.networkinterface
   // Private IP address attached to the session ENI (VPC-enabled fleets only)
   eniPrivateIpAddress string
   // Region where the session exists

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -77902,7 +77902,7 @@ func (c *mqlAwsVpcRoutetable) GetTags() *plugin.TValue[map[string]any] {
 type mqlAwsVpcRoutetableRoute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsVpcRoutetableRouteInternal it will be used here
+	mqlAwsVpcRoutetableRouteInternal
 	Id                          plugin.TValue[string]
 	DestinationCidrBlock        plugin.TValue[string]
 	DestinationIpv6CidrBlock    plugin.TValue[string]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5037,6 +5037,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.routetable.route.networkInterfaceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetNetworkInterfaceId()).ToDataRes(types.String)
 	},
+	"aws.vpc.routetable.route.networkInterface": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetNetworkInterface()).ToDataRes(types.Resource("aws.ec2.networkinterface"))
+	},
 	"aws.vpc.routetable.route.natGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetNatGatewayId()).ToDataRes(types.String)
 	},
@@ -6218,6 +6221,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.efs.mountTarget.networkInterfaceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetNetworkInterfaceId()).ToDataRes(types.String)
+	},
+	"aws.efs.mountTarget.networkInterface": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsMountTarget).GetNetworkInterface()).ToDataRes(types.Resource("aws.ec2.networkinterface"))
 	},
 	"aws.efs.mountTarget.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetRegion()).ToDataRes(types.String)
@@ -15726,6 +15732,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudhsm.hsm.eniId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudhsmHsm).GetEniId()).ToDataRes(types.String)
 	},
+	"aws.cloudhsm.hsm.networkInterface": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudhsmHsm).GetNetworkInterface()).ToDataRes(types.Resource("aws.ec2.networkinterface"))
+	},
 	"aws.cloudhsm.hsm.eniIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudhsmHsm).GetEniIp()).ToDataRes(types.String)
 	},
@@ -21534,6 +21543,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.natgateway.address.networkInterfaceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcNatgatewayAddress).GetNetworkInterfaceId()).ToDataRes(types.String)
 	},
+	"aws.vpc.natgateway.address.networkInterface": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcNatgatewayAddress).GetNetworkInterface()).ToDataRes(types.Resource("aws.ec2.networkinterface"))
+	},
 	"aws.vpc.natgateway.address.privateIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcNatgatewayAddress).GetPrivateIp()).ToDataRes(types.String)
 	},
@@ -25949,6 +25961,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.appstream.session.eniId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAppstreamSession).GetEniId()).ToDataRes(types.String)
+	},
+	"aws.appstream.session.networkInterface": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAppstreamSession).GetNetworkInterface()).ToDataRes(types.Resource("aws.ec2.networkinterface"))
 	},
 	"aws.appstream.session.eniPrivateIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAppstreamSession).GetEniPrivateIpAddress()).ToDataRes(types.String)
@@ -34362,6 +34377,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcRoutetableRoute).NetworkInterfaceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.routetable.route.networkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).NetworkInterface, ok = plugin.RawToTValue[*mqlAwsEc2Networkinterface](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.route.natGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).NatGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -36144,6 +36163,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.efs.mountTarget.networkInterfaceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsMountTarget).NetworkInterfaceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.mountTarget.networkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsMountTarget).NetworkInterface, ok = plugin.RawToTValue[*mqlAwsEc2Networkinterface](v.Value, v.Error)
 		return
 	},
 	"aws.efs.mountTarget.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50094,6 +50117,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudhsmHsm).EniId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.cloudhsm.hsm.networkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudhsmHsm).NetworkInterface, ok = plugin.RawToTValue[*mqlAwsEc2Networkinterface](v.Value, v.Error)
+		return
+	},
 	"aws.cloudhsm.hsm.eniIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudhsmHsm).EniIp, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -58462,6 +58489,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcNatgatewayAddress).NetworkInterfaceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.natgateway.address.networkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcNatgatewayAddress).NetworkInterface, ok = plugin.RawToTValue[*mqlAwsEc2Networkinterface](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.natgateway.address.privateIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcNatgatewayAddress).PrivateIp, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -64832,6 +64863,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.appstream.session.eniId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAppstreamSession).EniId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.appstream.session.networkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAppstreamSession).NetworkInterface, ok = plugin.RawToTValue[*mqlAwsEc2Networkinterface](v.Value, v.Error)
 		return
 	},
 	"aws.appstream.session.eniPrivateIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -77876,6 +77911,7 @@ type mqlAwsVpcRoutetableRoute struct {
 	InstanceId                  plugin.TValue[string]
 	InstanceOwnerId             plugin.TValue[string]
 	NetworkInterfaceId          plugin.TValue[string]
+	NetworkInterface            plugin.TValue[*mqlAwsEc2Networkinterface]
 	NatGatewayId                plugin.TValue[string]
 	TransitGatewayId            plugin.TValue[string]
 	VpcPeeringConnectionId      plugin.TValue[string]
@@ -77954,6 +77990,22 @@ func (c *mqlAwsVpcRoutetableRoute) GetInstanceOwnerId() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcRoutetableRoute) GetNetworkInterfaceId() *plugin.TValue[string] {
 	return &c.NetworkInterfaceId
+}
+
+func (c *mqlAwsVpcRoutetableRoute) GetNetworkInterface() *plugin.TValue[*mqlAwsEc2Networkinterface] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkinterface](&c.NetworkInterface, func() (*mqlAwsEc2Networkinterface, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "networkInterface")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkinterface), nil
+			}
+		}
+
+		return c.networkInterface()
+	})
 }
 
 func (c *mqlAwsVpcRoutetableRoute) GetNatGatewayId() *plugin.TValue[string] {
@@ -82685,6 +82737,7 @@ type mqlAwsEfsMountTarget struct {
 	SecurityGroups     plugin.TValue[[]any]
 	LifecycleState     plugin.TValue[string]
 	NetworkInterfaceId plugin.TValue[string]
+	NetworkInterface   plugin.TValue[*mqlAwsEc2Networkinterface]
 	Region             plugin.TValue[string]
 }
 
@@ -82778,6 +82831,22 @@ func (c *mqlAwsEfsMountTarget) GetLifecycleState() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsMountTarget) GetNetworkInterfaceId() *plugin.TValue[string] {
 	return &c.NetworkInterfaceId
+}
+
+func (c *mqlAwsEfsMountTarget) GetNetworkInterface() *plugin.TValue[*mqlAwsEc2Networkinterface] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkinterface](&c.NetworkInterface, func() (*mqlAwsEc2Networkinterface, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.mountTarget", c.__id, "networkInterface")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkinterface), nil
+			}
+		}
+
+		return c.networkInterface()
+	})
 }
 
 func (c *mqlAwsEfsMountTarget) GetRegion() *plugin.TValue[string] {
@@ -120001,6 +120070,7 @@ type mqlAwsCloudhsmHsm struct {
 	AvailabilityZone plugin.TValue[string]
 	HsmType          plugin.TValue[string]
 	EniId            plugin.TValue[string]
+	NetworkInterface plugin.TValue[*mqlAwsEc2Networkinterface]
 	EniIp            plugin.TValue[string]
 	Subnet           plugin.TValue[*mqlAwsVpcSubnet]
 }
@@ -120063,6 +120133,22 @@ func (c *mqlAwsCloudhsmHsm) GetHsmType() *plugin.TValue[string] {
 
 func (c *mqlAwsCloudhsmHsm) GetEniId() *plugin.TValue[string] {
 	return &c.EniId
+}
+
+func (c *mqlAwsCloudhsmHsm) GetNetworkInterface() *plugin.TValue[*mqlAwsEc2Networkinterface] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkinterface](&c.NetworkInterface, func() (*mqlAwsEc2Networkinterface, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.cloudhsm.hsm", c.__id, "networkInterface")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkinterface), nil
+			}
+		}
+
+		return c.networkInterface()
+	})
 }
 
 func (c *mqlAwsCloudhsmHsm) GetEniIp() *plugin.TValue[string] {
@@ -140821,6 +140907,7 @@ type mqlAwsVpcNatgatewayAddress struct {
 	mqlAwsVpcNatgatewayAddressInternal
 	AllocationId       plugin.TValue[string]
 	NetworkInterfaceId plugin.TValue[string]
+	NetworkInterface   plugin.TValue[*mqlAwsEc2Networkinterface]
 	PrivateIp          plugin.TValue[string]
 	PublicIp           plugin.TValue[*mqlAwsEc2Eip]
 	IsPrimary          plugin.TValue[bool]
@@ -140869,6 +140956,22 @@ func (c *mqlAwsVpcNatgatewayAddress) GetAllocationId() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcNatgatewayAddress) GetNetworkInterfaceId() *plugin.TValue[string] {
 	return &c.NetworkInterfaceId
+}
+
+func (c *mqlAwsVpcNatgatewayAddress) GetNetworkInterface() *plugin.TValue[*mqlAwsEc2Networkinterface] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkinterface](&c.NetworkInterface, func() (*mqlAwsEc2Networkinterface, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.natgateway.address", c.__id, "networkInterface")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkinterface), nil
+			}
+		}
+
+		return c.networkInterface()
+	})
 }
 
 func (c *mqlAwsVpcNatgatewayAddress) GetPrivateIp() *plugin.TValue[string] {
@@ -156170,6 +156273,7 @@ type mqlAwsAppstreamSession struct {
 	StartTime           plugin.TValue[*time.Time]
 	MaxExpirationTime   plugin.TValue[*time.Time]
 	EniId               plugin.TValue[string]
+	NetworkInterface    plugin.TValue[*mqlAwsEc2Networkinterface]
 	EniPrivateIpAddress plugin.TValue[string]
 	Region              plugin.TValue[string]
 }
@@ -156285,6 +156389,22 @@ func (c *mqlAwsAppstreamSession) GetMaxExpirationTime() *plugin.TValue[*time.Tim
 
 func (c *mqlAwsAppstreamSession) GetEniId() *plugin.TValue[string] {
 	return &c.EniId
+}
+
+func (c *mqlAwsAppstreamSession) GetNetworkInterface() *plugin.TValue[*mqlAwsEc2Networkinterface] {
+	return plugin.GetOrCompute[*mqlAwsEc2Networkinterface](&c.NetworkInterface, func() (*mqlAwsEc2Networkinterface, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.appstream.session", c.__id, "networkInterface")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Networkinterface), nil
+			}
+		}
+
+		return c.networkInterface()
+	})
 }
 
 func (c *mqlAwsAppstreamSession) GetEniPrivateIpAddress() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -614,6 +614,7 @@ aws.appstream.session.fleetName 13.20.1
 aws.appstream.session.id 13.20.1
 aws.appstream.session.instanceId 13.20.1
 aws.appstream.session.maxExpirationTime 13.20.1
+aws.appstream.session.networkInterface 13.41.1
 aws.appstream.session.region 13.20.1
 aws.appstream.session.stack 13.20.1
 aws.appstream.session.stackName 13.20.1
@@ -1668,6 +1669,7 @@ aws.cloudhsm.hsm.eniId 13.28.1
 aws.cloudhsm.hsm.eniIp 13.28.1
 aws.cloudhsm.hsm.hsmId 13.28.1
 aws.cloudhsm.hsm.hsmType 13.28.1
+aws.cloudhsm.hsm.networkInterface 13.41.1
 aws.cloudhsm.hsm.state 13.28.1
 aws.cloudhsm.hsm.stateMessage 13.28.1
 aws.cloudhsm.hsm.subnet 13.28.1
@@ -4014,6 +4016,7 @@ aws.efs.mountTarget.fileSystemId 11.15.2
 aws.efs.mountTarget.ipAddress 11.15.2
 aws.efs.mountTarget.lifecycleState 11.15.2
 aws.efs.mountTarget.mountTargetId 11.15.2
+aws.efs.mountTarget.networkInterface 13.41.1
 aws.efs.mountTarget.networkInterfaceId 11.15.2
 aws.efs.mountTarget.region 11.15.2
 aws.efs.mountTarget.securityGroups 11.15.2
@@ -9990,6 +9993,7 @@ aws.vpc.natgateway 11.15.2
 aws.vpc.natgateway.address 11.15.2
 aws.vpc.natgateway.address.allocationId 11.15.2
 aws.vpc.natgateway.address.isPrimary 11.15.2
+aws.vpc.natgateway.address.networkInterface 13.41.1
 aws.vpc.natgateway.address.networkInterfaceId 11.15.2
 aws.vpc.natgateway.address.privateIp 11.15.2
 aws.vpc.natgateway.address.publicIp 11.15.2
@@ -10048,6 +10052,7 @@ aws.vpc.routetable.route.instanceId 11.15.2
 aws.vpc.routetable.route.instanceOwnerId 11.15.2
 aws.vpc.routetable.route.localGatewayId 11.15.2
 aws.vpc.routetable.route.natGatewayId 11.15.2
+aws.vpc.routetable.route.networkInterface 13.41.1
 aws.vpc.routetable.route.networkInterfaceId 11.15.2
 aws.vpc.routetable.route.origin 11.15.2
 aws.vpc.routetable.route.state 11.15.2

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -1153,3 +1153,17 @@ func (a *mqlAwsAppstreamSession) stack() (*mqlAwsAppstreamStack, error) {
 	}
 	return res.(*mqlAwsAppstreamStack), nil
 }
+
+func (a *mqlAwsAppstreamSession) networkInterface() (*mqlAwsEc2Networkinterface, error) {
+	eniId := a.EniId.Data
+	if eniId == "" {
+		a.NetworkInterface.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
+		map[string]*llx.RawData{"id": llx.StringData(eniId), "region": llx.StringData(a.Region.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Networkinterface), nil
+}

--- a/providers/aws/resources/aws_cloudhsm.go
+++ b/providers/aws/resources/aws_cloudhsm.go
@@ -305,6 +305,20 @@ func (a *mqlAwsCloudhsmHsm) subnet() (*mqlAwsVpcSubnet, error) {
 	return mqlSubnet.(*mqlAwsVpcSubnet), nil
 }
 
+func (a *mqlAwsCloudhsmHsm) networkInterface() (*mqlAwsEc2Networkinterface, error) {
+	eniId := a.EniId.Data
+	if eniId == "" {
+		a.NetworkInterface.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
+		map[string]*llx.RawData{"id": llx.StringData(eniId), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Networkinterface), nil
+}
+
 // ---- aws.cloudhsm.backup ----
 
 func (a *mqlAwsCloudhsm) backups() ([]any, error) {

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -621,3 +621,17 @@ func (a *mqlAwsEfsMountTarget) subnet() (*mqlAwsVpcSubnet, error) {
 	}
 	return res.(*mqlAwsVpcSubnet), nil
 }
+
+func (a *mqlAwsEfsMountTarget) networkInterface() (*mqlAwsEc2Networkinterface, error) {
+	eniId := a.NetworkInterfaceId.Data
+	if eniId == "" {
+		a.NetworkInterface.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
+		map[string]*llx.RawData{"id": llx.StringData(eniId), "region": llx.StringData(a.Region.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Networkinterface), nil
+}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -210,6 +210,20 @@ func (a *mqlAwsVpcNatgatewayAddress) publicIp() (*mqlAwsEc2Eip, error) {
 	return nil, nil
 }
 
+func (a *mqlAwsVpcNatgatewayAddress) networkInterface() (*mqlAwsEc2Networkinterface, error) {
+	eniId := a.NetworkInterfaceId.Data
+	if eniId == "" {
+		a.NetworkInterface.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
+		map[string]*llx.RawData{"id": llx.StringData(eniId), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Networkinterface), nil
+}
+
 func (a *mqlAwsVpc) natGateways() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	vpcId := a.Id.Data
@@ -790,6 +804,20 @@ type mqlAwsVpcRoutetableInternal struct {
 
 func (a *mqlAwsVpcRoutetableRoute) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) networkInterface() (*mqlAwsEc2Networkinterface, error) {
+	eniId := a.NetworkInterfaceId.Data
+	if eniId == "" {
+		a.NetworkInterface.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
+		map[string]*llx.RawData{"id": llx.StringData(eniId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Networkinterface), nil
 }
 
 func (a *mqlAwsVpcRoutetable) routeEntries() ([]any, error) {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -802,6 +802,10 @@ type mqlAwsVpcRoutetableInternal struct {
 	cacheRoutes       []vpctypes.Route
 }
 
+type mqlAwsVpcRoutetableRouteInternal struct {
+	region string
+}
+
 func (a *mqlAwsVpcRoutetableRoute) id() (string, error) {
 	return a.Id.Data, nil
 }
@@ -813,7 +817,7 @@ func (a *mqlAwsVpcRoutetableRoute) networkInterface() (*mqlAwsEc2Networkinterfac
 		return nil, nil
 	}
 	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Networkinterface,
-		map[string]*llx.RawData{"id": llx.StringData(eniId)})
+		map[string]*llx.RawData{"id": llx.StringData(eniId), "region": llx.StringData(a.region)})
 	if err != nil {
 		return nil, err
 	}
@@ -865,6 +869,7 @@ func (a *mqlAwsVpcRoutetable) routeEntries() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRoute.(*mqlAwsVpcRoutetableRoute).region = a.Region.Data
 		res = append(res, mqlRoute)
 	}
 	return res, nil


### PR DESCRIPTION
## What

Adds typed `networkInterface() aws.ec2.networkinterface` accessors to five resources that previously exposed only a raw ENI id string. This lets audits traverse straight from a route / mount target / HSM / NAT gateway address / streaming session to the underlying elastic network interface and everything modeled on it (private IP, status, security groups, attachment, source/dest check, etc.).

| Resource | Was (raw) | Now (typed) |
|---|---|---|
| `aws.vpc.routetable.route` | `networkInterfaceId` | `networkInterface` |
| `aws.efs.mountTarget` | `networkInterfaceId` | `networkInterface` |
| `aws.cloudhsm.hsm` | `eniId` | `networkInterface` |
| `aws.vpc.natgateway.address` | `networkInterfaceId` | `networkInterface` |
| `aws.appstream.session` | `eniId` | `networkInterface` |

The raw id fields are kept but marked `@maturity("deprecated")` in favor of the typed accessor, matching the existing `vpc()` / `kmsKey()` deprecation pattern in this schema. Accessors reuse the existing `aws.ec2.networkinterface` init (by id), so no new IAM permissions are required (`aws.permissions.json` unchanged).

## Example

```mql
aws.efs.filesystems {
  mountTargets {
    networkInterface { id privateIpAddress securityGroups { id } }
  }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account:
- `aws.efs.mountTarget.networkInterface` resolved the ENI and returned its real `privateIpAddress`.
- `aws.vpc.natgateway.address.networkInterface` resolved the ENI and returned `status: in-use`.

The other three accessors are code-identical (same helper shape). `make providers/build/aws` passes; generated `.lr.go` / `.lr.versions` regenerated (new entries at 13.41.1).
