### PR TITLE
⭐ aws: add ACM certificate cross-references

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4911,7 +4911,11 @@ private aws.es.domain @defaults("arn name") {
   // Custom endpoint hostname for the domain
   customEndpoint string
   // ACM certificate ARN for the custom endpoint
-  customEndpointCertificateArn string
+  //
+  // Deprecated in favor of `customEndpointCertificate`.
+  customEndpointCertificateArn @maturity("deprecated") string
+  // ACM certificate for the custom endpoint
+  customEndpointCertificate() aws.acm.certificate
   // VPC the domain is deployed into
   vpc() aws.vpc
   // Subnets the domain is deployed into
@@ -15688,7 +15692,11 @@ private aws.ec2.clientVpnEndpoint @defaults("id status region") {
   // VPC associated with the Client VPN endpoint
   vpc() aws.vpc
   // ARN of the server certificate
-  serverCertificateArn string
+  //
+  // Deprecated in favor of `serverCertificate`.
+  serverCertificateArn @maturity("deprecated") string
+  // Server certificate presented by the endpoint
+  serverCertificate() aws.acm.certificate
   // Transport protocol: tcp or udp
   transportProtocol string
   // VPN protocol: openvpn
@@ -15740,7 +15748,11 @@ private aws.ec2.customerGateway @defaults("id state type") {
   // Public IP address of the customer gateway device
   ipAddress string
   // ARN of the certificate for the customer gateway
-  certificateArn string
+  //
+  // Deprecated in favor of `certificate`.
+  certificateArn @maturity("deprecated") string
+  // Certificate associated with the customer gateway device
+  certificate() aws.acm.certificate
   // Name of the customer gateway device
   deviceName string
   // Tags on the customer gateway
@@ -16164,7 +16176,11 @@ private aws.signer.signingProfile @defaults("profileName platformId status") {
   // Status of the signing profile: Active, Canceled, or Revoked
   status string
   // Certificate ARN of the signing material used to sign artifacts
-  signingMaterialCertificateArn string
+  //
+  // Deprecated in favor of `signingMaterialCertificate`.
+  signingMaterialCertificateArn @maturity("deprecated") string
+  // Certificate of the signing material used to sign artifacts
+  signingMaterialCertificate() aws.acm.certificate
   // Validity period unit applied to generated signatures: DAYS, MONTHS, or YEARS
   signatureValidityType string
   // Number of validity-period units applied to generated signatures
@@ -24815,7 +24831,11 @@ private aws.verifiedaccess.endpoint @defaults("verifiedAccessEndpointId applicat
   // Attachment type
   attachmentType string
   // Domain certificate ARN
-  domainCertificateArn string
+  //
+  // Deprecated in favor of `domainCertificate`.
+  domainCertificateArn @maturity("deprecated") string
+  // Domain certificate presented by the endpoint
+  domainCertificate() aws.acm.certificate
   // Status of the endpoint
   status dict
   // Security groups associated with the endpoint

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10236,6 +10236,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.es.domain.customEndpointCertificateArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetCustomEndpointCertificateArn()).ToDataRes(types.String)
 	},
+	"aws.es.domain.customEndpointCertificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetCustomEndpointCertificate()).ToDataRes(types.Resource("aws.acm.certificate"))
+	},
 	"aws.es.domain.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
 	},
@@ -21993,6 +21996,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.clientVpnEndpoint.serverCertificateArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ClientVpnEndpoint).GetServerCertificateArn()).ToDataRes(types.String)
 	},
+	"aws.ec2.clientVpnEndpoint.serverCertificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2ClientVpnEndpoint).GetServerCertificate()).ToDataRes(types.Resource("aws.acm.certificate"))
+	},
 	"aws.ec2.clientVpnEndpoint.transportProtocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ClientVpnEndpoint).GetTransportProtocol()).ToDataRes(types.String)
 	},
@@ -22064,6 +22070,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.customerGateway.certificateArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2CustomerGateway).GetCertificateArn()).ToDataRes(types.String)
+	},
+	"aws.ec2.customerGateway.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2CustomerGateway).GetCertificate()).ToDataRes(types.Resource("aws.acm.certificate"))
 	},
 	"aws.ec2.customerGateway.deviceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2CustomerGateway).GetDeviceName()).ToDataRes(types.String)
@@ -22574,6 +22583,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.signer.signingProfile.signingMaterialCertificateArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSignerSigningProfile).GetSigningMaterialCertificateArn()).ToDataRes(types.String)
+	},
+	"aws.signer.signingProfile.signingMaterialCertificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSignerSigningProfile).GetSigningMaterialCertificate()).ToDataRes(types.Resource("aws.acm.certificate"))
 	},
 	"aws.signer.signingProfile.signatureValidityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSignerSigningProfile).GetSignatureValidityType()).ToDataRes(types.String)
@@ -32322,6 +32334,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.verifiedaccess.endpoint.domainCertificateArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVerifiedaccessEndpoint).GetDomainCertificateArn()).ToDataRes(types.String)
 	},
+	"aws.verifiedaccess.endpoint.domainCertificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVerifiedaccessEndpoint).GetDomainCertificate()).ToDataRes(types.Resource("aws.acm.certificate"))
+	},
 	"aws.verifiedaccess.endpoint.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVerifiedaccessEndpoint).GetStatus()).ToDataRes(types.Dict)
 	},
@@ -42012,6 +42027,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.es.domain.customEndpointCertificateArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEsDomain).CustomEndpointCertificateArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.es.domain.customEndpointCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).CustomEndpointCertificate, ok = plugin.RawToTValue[*mqlAwsAcmCertificate](v.Value, v.Error)
 		return
 	},
 	"aws.es.domain.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59146,6 +59165,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2ClientVpnEndpoint).ServerCertificateArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.clientVpnEndpoint.serverCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2ClientVpnEndpoint).ServerCertificate, ok = plugin.RawToTValue[*mqlAwsAcmCertificate](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.clientVpnEndpoint.transportProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2ClientVpnEndpoint).TransportProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -59244,6 +59267,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.customerGateway.certificateArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2CustomerGateway).CertificateArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.customerGateway.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2CustomerGateway).Certificate, ok = plugin.RawToTValue[*mqlAwsAcmCertificate](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.customerGateway.deviceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59980,6 +60007,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.signer.signingProfile.signingMaterialCertificateArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSignerSigningProfile).SigningMaterialCertificateArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.signer.signingProfile.signingMaterialCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSignerSigningProfile).SigningMaterialCertificate, ok = plugin.RawToTValue[*mqlAwsAcmCertificate](v.Value, v.Error)
 		return
 	},
 	"aws.signer.signingProfile.signatureValidityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -74112,6 +74143,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.verifiedaccess.endpoint.domainCertificateArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVerifiedaccessEndpoint).DomainCertificateArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.verifiedaccess.endpoint.domainCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVerifiedaccessEndpoint).DomainCertificate, ok = plugin.RawToTValue[*mqlAwsAcmCertificate](v.Value, v.Error)
 		return
 	},
 	"aws.verifiedaccess.endpoint.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -98620,6 +98655,7 @@ type mqlAwsEsDomain struct {
 	CustomEndpointEnabled              plugin.TValue[bool]
 	CustomEndpoint                     plugin.TValue[string]
 	CustomEndpointCertificateArn       plugin.TValue[string]
+	CustomEndpointCertificate          plugin.TValue[*mqlAwsAcmCertificate]
 	Vpc                                plugin.TValue[*mqlAwsVpc]
 	Subnets                            plugin.TValue[[]any]
 	SecurityGroups                     plugin.TValue[[]any]
@@ -98857,6 +98893,22 @@ func (c *mqlAwsEsDomain) GetCustomEndpoint() *plugin.TValue[string] {
 
 func (c *mqlAwsEsDomain) GetCustomEndpointCertificateArn() *plugin.TValue[string] {
 	return &c.CustomEndpointCertificateArn
+}
+
+func (c *mqlAwsEsDomain) GetCustomEndpointCertificate() *plugin.TValue[*mqlAwsAcmCertificate] {
+	return plugin.GetOrCompute[*mqlAwsAcmCertificate](&c.CustomEndpointCertificate, func() (*mqlAwsAcmCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.es.domain", c.__id, "customEndpointCertificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAcmCertificate), nil
+			}
+		}
+
+		return c.customEndpointCertificate()
+	})
 }
 
 func (c *mqlAwsEsDomain) GetVpc() *plugin.TValue[*mqlAwsVpc] {
@@ -142533,6 +142585,7 @@ type mqlAwsEc2ClientVpnEndpoint struct {
 	CreatedAt                       plugin.TValue[*time.Time]
 	Vpc                             plugin.TValue[*mqlAwsVpc]
 	ServerCertificateArn            plugin.TValue[string]
+	ServerCertificate               plugin.TValue[*mqlAwsAcmCertificate]
 	TransportProtocol               plugin.TValue[string]
 	VpnProtocol                     plugin.TValue[string]
 	SplitTunnel                     plugin.TValue[bool]
@@ -142629,6 +142682,22 @@ func (c *mqlAwsEc2ClientVpnEndpoint) GetVpc() *plugin.TValue[*mqlAwsVpc] {
 
 func (c *mqlAwsEc2ClientVpnEndpoint) GetServerCertificateArn() *plugin.TValue[string] {
 	return &c.ServerCertificateArn
+}
+
+func (c *mqlAwsEc2ClientVpnEndpoint) GetServerCertificate() *plugin.TValue[*mqlAwsAcmCertificate] {
+	return plugin.GetOrCompute[*mqlAwsAcmCertificate](&c.ServerCertificate, func() (*mqlAwsAcmCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.clientVpnEndpoint", c.__id, "serverCertificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAcmCertificate), nil
+			}
+		}
+
+		return c.serverCertificate()
+	})
 }
 
 func (c *mqlAwsEc2ClientVpnEndpoint) GetTransportProtocol() *plugin.TValue[string] {
@@ -142729,6 +142798,7 @@ type mqlAwsEc2CustomerGateway struct {
 	BgpAsnExtended plugin.TValue[string]
 	IpAddress      plugin.TValue[string]
 	CertificateArn plugin.TValue[string]
+	Certificate    plugin.TValue[*mqlAwsAcmCertificate]
 	DeviceName     plugin.TValue[string]
 	Tags           plugin.TValue[map[string]any]
 }
@@ -142804,6 +142874,22 @@ func (c *mqlAwsEc2CustomerGateway) GetIpAddress() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2CustomerGateway) GetCertificateArn() *plugin.TValue[string] {
 	return &c.CertificateArn
+}
+
+func (c *mqlAwsEc2CustomerGateway) GetCertificate() *plugin.TValue[*mqlAwsAcmCertificate] {
+	return plugin.GetOrCompute[*mqlAwsAcmCertificate](&c.Certificate, func() (*mqlAwsAcmCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.customerGateway", c.__id, "certificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAcmCertificate), nil
+			}
+		}
+
+		return c.certificate()
+	})
 }
 
 func (c *mqlAwsEc2CustomerGateway) GetDeviceName() *plugin.TValue[string] {
@@ -144407,6 +144493,7 @@ type mqlAwsSignerSigningProfile struct {
 	PlatformDisplayName           plugin.TValue[string]
 	Status                        plugin.TValue[string]
 	SigningMaterialCertificateArn plugin.TValue[string]
+	SigningMaterialCertificate    plugin.TValue[*mqlAwsAcmCertificate]
 	SignatureValidityType         plugin.TValue[string]
 	SignatureValidityValue        plugin.TValue[int64]
 	SigningParameters             plugin.TValue[map[string]any]
@@ -144476,6 +144563,22 @@ func (c *mqlAwsSignerSigningProfile) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsSignerSigningProfile) GetSigningMaterialCertificateArn() *plugin.TValue[string] {
 	return &c.SigningMaterialCertificateArn
+}
+
+func (c *mqlAwsSignerSigningProfile) GetSigningMaterialCertificate() *plugin.TValue[*mqlAwsAcmCertificate] {
+	return plugin.GetOrCompute[*mqlAwsAcmCertificate](&c.SigningMaterialCertificate, func() (*mqlAwsAcmCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.signer.signingProfile", c.__id, "signingMaterialCertificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAcmCertificate), nil
+			}
+		}
+
+		return c.signingMaterialCertificate()
+	})
 }
 
 func (c *mqlAwsSignerSigningProfile) GetSignatureValidityType() *plugin.TValue[string] {
@@ -179672,6 +179775,7 @@ type mqlAwsVerifiedaccessEndpoint struct {
 	EndpointType             plugin.TValue[string]
 	AttachmentType           plugin.TValue[string]
 	DomainCertificateArn     plugin.TValue[string]
+	DomainCertificate        plugin.TValue[*mqlAwsAcmCertificate]
 	Status                   plugin.TValue[any]
 	SecurityGroups           plugin.TValue[[]any]
 	SseSpecification         plugin.TValue[any]
@@ -179749,6 +179853,22 @@ func (c *mqlAwsVerifiedaccessEndpoint) GetAttachmentType() *plugin.TValue[string
 
 func (c *mqlAwsVerifiedaccessEndpoint) GetDomainCertificateArn() *plugin.TValue[string] {
 	return &c.DomainCertificateArn
+}
+
+func (c *mqlAwsVerifiedaccessEndpoint) GetDomainCertificate() *plugin.TValue[*mqlAwsAcmCertificate] {
+	return plugin.GetOrCompute[*mqlAwsAcmCertificate](&c.DomainCertificate, func() (*mqlAwsAcmCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.verifiedaccess.endpoint", c.__id, "domainCertificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsAcmCertificate), nil
+			}
+		}
+
+		return c.domainCertificate()
+	})
 }
 
 func (c *mqlAwsVerifiedaccessEndpoint) GetStatus() *plugin.TValue[any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2954,6 +2954,7 @@ aws.ec2.clientVpnEndpoint.id 13.6.3
 aws.ec2.clientVpnEndpoint.region 13.6.3
 aws.ec2.clientVpnEndpoint.securityGroups 13.6.3
 aws.ec2.clientVpnEndpoint.selfServicePortalUrl 13.6.3
+aws.ec2.clientVpnEndpoint.serverCertificate 13.41.1
 aws.ec2.clientVpnEndpoint.serverCertificateArn 13.6.3
 aws.ec2.clientVpnEndpoint.sessionTimeoutHours 13.6.3
 aws.ec2.clientVpnEndpoint.splitTunnel 13.6.3
@@ -2970,6 +2971,7 @@ aws.ec2.customerGateway 13.6.3
 aws.ec2.customerGateway.arn 13.6.3
 aws.ec2.customerGateway.bgpAsn 13.6.3
 aws.ec2.customerGateway.bgpAsnExtended 13.6.3
+aws.ec2.customerGateway.certificate 13.41.1
 aws.ec2.customerGateway.certificateArn 13.6.3
 aws.ec2.customerGateway.deviceName 13.6.3
 aws.ec2.customerGateway.id 13.6.3
@@ -4606,6 +4608,7 @@ aws.es.domain.cognitoUserPoolId 13.21.4
 aws.es.domain.coldStorageEnabled 13.21.4
 aws.es.domain.created 13.21.4
 aws.es.domain.customEndpoint 13.21.4
+aws.es.domain.customEndpointCertificate 13.41.1
 aws.es.domain.customEndpointCertificateArn 13.21.4
 aws.es.domain.customEndpointEnabled 13.21.4
 aws.es.domain.dedicatedMasterCount 13.21.4
@@ -9434,6 +9437,7 @@ aws.signer.signingProfile.profileVersionArn 13.35.2
 aws.signer.signingProfile.region 13.35.2
 aws.signer.signingProfile.signatureValidityType 13.35.2
 aws.signer.signingProfile.signatureValidityValue 13.35.2
+aws.signer.signingProfile.signingMaterialCertificate 13.41.1
 aws.signer.signingProfile.signingMaterialCertificateArn 13.35.2
 aws.signer.signingProfile.signingParameters 13.35.2
 aws.signer.signingProfile.status 13.35.2
@@ -9876,6 +9880,7 @@ aws.verifiedaccess 13.10.0
 aws.verifiedaccess.endpoint 13.10.0
 aws.verifiedaccess.endpoint.applicationDomain 13.10.0
 aws.verifiedaccess.endpoint.attachmentType 13.10.0
+aws.verifiedaccess.endpoint.domainCertificate 13.41.1
 aws.verifiedaccess.endpoint.domainCertificateArn 13.10.0
 aws.verifiedaccess.endpoint.endpointDomain 13.10.0
 aws.verifiedaccess.endpoint.endpointType 13.10.0

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3373,6 +3373,20 @@ func (a *mqlAwsEc2CustomerGateway) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsEc2CustomerGateway) certificate() (*mqlAwsAcmCertificate, error) {
+	arnVal := a.CertificateArn.Data
+	if arnVal == "" {
+		a.Certificate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsAcmCertificate,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAcmCertificate), nil
+}
+
 func initAwsEc2CustomerGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil

--- a/providers/aws/resources/aws_ec2_clientvpn.go
+++ b/providers/aws/resources/aws_ec2_clientvpn.go
@@ -190,6 +190,20 @@ func (a *mqlAwsEc2ClientVpnEndpoint) vpc() (*mqlAwsVpc, error) {
 	return mqlVpc.(*mqlAwsVpc), nil
 }
 
+func (a *mqlAwsEc2ClientVpnEndpoint) serverCertificate() (*mqlAwsAcmCertificate, error) {
+	arnVal := a.ServerCertificateArn.Data
+	if arnVal == "" {
+		a.ServerCertificate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsAcmCertificate,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAcmCertificate), nil
+}
+
 func (a *mqlAwsEc2ClientVpnEndpoint) transitGateway() (*mqlAwsEc2Transitgateway, error) {
 	if a.cacheTransitGatewayId == nil || *a.cacheTransitGatewayId == "" {
 		a.TransitGateway.State = plugin.StateIsNull | plugin.StateIsSet

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -510,6 +510,20 @@ func (a *mqlAwsEsDomain) vpc() (*mqlAwsVpc, error) {
 	return mqlVpc.(*mqlAwsVpc), nil
 }
 
+func (a *mqlAwsEsDomain) customEndpointCertificate() (*mqlAwsAcmCertificate, error) {
+	arnVal := a.CustomEndpointCertificateArn.Data
+	if arnVal == "" {
+		a.CustomEndpointCertificate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsAcmCertificate,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAcmCertificate), nil
+}
+
 func (a *mqlAwsEsDomain) subnets() ([]any, error) {
 	res := []any{}
 	for _, subnetId := range a.cacheSubnetIds {

--- a/providers/aws/resources/aws_signer.go
+++ b/providers/aws/resources/aws_signer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/signer"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
@@ -103,4 +104,18 @@ func (a *mqlAwsSigner) getSigningProfiles(conn *connection.AwsConnection) []*job
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+func (a *mqlAwsSignerSigningProfile) signingMaterialCertificate() (*mqlAwsAcmCertificate, error) {
+	arnVal := a.SigningMaterialCertificateArn.Data
+	if arnVal == "" {
+		a.SigningMaterialCertificate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsAcmCertificate,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAcmCertificate), nil
 }

--- a/providers/aws/resources/aws_verifiedaccess.go
+++ b/providers/aws/resources/aws_verifiedaccess.go
@@ -429,6 +429,20 @@ func (a *mqlAwsVerifiedaccessEndpoint) id() (string, error) {
 	return "aws.verifiedaccess.endpoint/" + a.Region.Data + "/" + a.VerifiedAccessEndpointId.Data, nil
 }
 
+func (a *mqlAwsVerifiedaccessEndpoint) domainCertificate() (*mqlAwsAcmCertificate, error) {
+	arnVal := a.DomainCertificateArn.Data
+	if arnVal == "" {
+		a.DomainCertificate.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsAcmCertificate,
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsAcmCertificate), nil
+}
+
 func (a *mqlAwsVerifiedaccessEndpoint) securityGroups() ([]any, error) {
 	return a.securityGroupIdHandler.newSecurityGroupResources(a.MqlRuntime)
 }


### PR DESCRIPTION
## What

Adds typed `aws.acm.certificate` accessors to five resources that previously exposed only a raw certificate ARN string, so audits can traverse from the referencing resource to the certificate's domain name, validity window, key algorithm, issuer, in-use-by list, etc.

| Resource | Was (raw) | Now (typed) |
|---|---|---|
| `aws.es.domain` | `customEndpointCertificateArn` | `customEndpointCertificate` |
| `aws.ec2.clientVpnEndpoint` | `serverCertificateArn` | `serverCertificate` |
| `aws.ec2.customerGateway` | `certificateArn` | `certificate` |
| `aws.signer.signingProfile` | `signingMaterialCertificateArn` | `signingMaterialCertificate` |
| `aws.verifiedaccess.endpoint` | `domainCertificateArn` | `domainCertificate` |

The raw `*Arn` fields are kept but marked `@maturity("deprecated")` in favor of the typed accessors, matching the existing `customEndpointCertificate()` pattern on `aws.opensearch.domain`. Accessors reuse the existing `aws.acm.certificate` init (by ARN), so no new IAM permissions are required (`aws.permissions.json` unchanged).

## Example

```mql
aws.ec2.clientVpnEndpoints {
  serverCertificate { domainName notAfter keyAlgorithm }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account:
- `aws.ec2.clientVpnEndpoint.serverCertificate` resolved the ACM certificate and returned its real `domainName`.
- A `customerGateway` with no certificate correctly returns `certificate: null` (null guard).

`make providers/build/aws` passes; generated `.lr.go` / `.lr.versions` regenerated (new entries at 13.41.1).
