### PR TITLE
⭐ aws: add EFS filesystem cross-references

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -53,6 +53,7 @@ const (
 	apiUsagePlanArnPattern        = "arn:aws:apigateway:%s:%s::/usageplans/%s"
 	apiVpcLinkArnPattern          = "arn:aws:apigateway:%s:%s::/vpclinks/%s"
 	transitGatewayArnPattern      = "arn:aws:ec2:%s:%s:transit-gateway/%s"
+	efsFilesystemArnPattern       = "arn:aws:elasticfilesystem:%s:%s:file-system/%s"
 )
 
 func NewSecurityGroupArn(region, accountID, sgID string) string {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1453,9 +1453,17 @@ private aws.efs.filesystem.replicationConfiguration @defaults("sourceFileSystemI
   // Source file system region
   sourceFileSystemRegion string
   // Source file system ARN
-  sourceFileSystemArn string
+  //
+  // Deprecated in favor of `sourceFileSystem`.
+  sourceFileSystemArn @maturity("deprecated") string
+  // Source file system being replicated
+  sourceFileSystem() aws.efs.filesystem
   // Original source file system ARN
-  originalSourceFileSystemArn string
+  //
+  // Deprecated in favor of `originalSourceFileSystem`.
+  originalSourceFileSystemArn @maturity("deprecated") string
+  // Original source file system in the replication chain
+  originalSourceFileSystem() aws.efs.filesystem
   // When replication was created
   creationTime time
   // Replication destinations
@@ -1465,7 +1473,11 @@ private aws.efs.filesystem.replicationConfiguration @defaults("sourceFileSystemI
 // AWS EFS replication destination
 private aws.efs.filesystem.replicationDestination @defaults("fileSystemId region status") {
   // Destination file system ID
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // Destination file system replicated to
+  fileSystem() aws.efs.filesystem
   // Destination region
   region string
   // Replication status: ENABLED, ENABLING, DELETING, ERROR, PAUSED, PAUSING
@@ -1479,7 +1491,11 @@ private aws.efs.mountTarget @defaults("mountTargetId subnetId") {
   // Mount target ID
   mountTargetId string
   // Associated file system ID
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // File system the mount target exposes
+  fileSystem() aws.efs.filesystem
   // Subnet ID where mount target resides
   //
   // Deprecated in favor of `subnet`.
@@ -1511,7 +1527,11 @@ private aws.efs.accessPoint @defaults("accessPointId name") {
   // Access point ARN
   arn string
   // Associated file system ID
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // File system the access point belongs to
+  fileSystem() aws.efs.filesystem
   // Access point name
   name string
   // POSIX user identity (uid, gid, secondaryGids)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6174,8 +6174,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.efs.filesystem.replicationConfiguration.sourceFileSystemArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystemReplicationConfiguration).GetSourceFileSystemArn()).ToDataRes(types.String)
 	},
+	"aws.efs.filesystem.replicationConfiguration.sourceFileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystemReplicationConfiguration).GetSourceFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
+	},
 	"aws.efs.filesystem.replicationConfiguration.originalSourceFileSystemArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystemReplicationConfiguration).GetOriginalSourceFileSystemArn()).ToDataRes(types.String)
+	},
+	"aws.efs.filesystem.replicationConfiguration.originalSourceFileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystemReplicationConfiguration).GetOriginalSourceFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
 	},
 	"aws.efs.filesystem.replicationConfiguration.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystemReplicationConfiguration).GetCreationTime()).ToDataRes(types.Time)
@@ -6185,6 +6191,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.efs.filesystem.replicationDestination.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystemReplicationDestination).GetFileSystemId()).ToDataRes(types.String)
+	},
+	"aws.efs.filesystem.replicationDestination.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsFilesystemReplicationDestination).GetFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
 	},
 	"aws.efs.filesystem.replicationDestination.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsFilesystemReplicationDestination).GetRegion()).ToDataRes(types.String)
@@ -6200,6 +6209,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.efs.mountTarget.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetFileSystemId()).ToDataRes(types.String)
+	},
+	"aws.efs.mountTarget.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsMountTarget).GetFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
 	},
 	"aws.efs.mountTarget.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsMountTarget).GetSubnetId()).ToDataRes(types.String)
@@ -6236,6 +6248,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.efs.accessPoint.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsAccessPoint).GetFileSystemId()).ToDataRes(types.String)
+	},
+	"aws.efs.accessPoint.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEfsAccessPoint).GetFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
 	},
 	"aws.efs.accessPoint.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfsAccessPoint).GetName()).ToDataRes(types.String)
@@ -36108,8 +36123,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEfsFilesystemReplicationConfiguration).SourceFileSystemArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.efs.filesystem.replicationConfiguration.sourceFileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystemReplicationConfiguration).SourceFileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
+		return
+	},
 	"aws.efs.filesystem.replicationConfiguration.originalSourceFileSystemArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystemReplicationConfiguration).OriginalSourceFileSystemArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.filesystem.replicationConfiguration.originalSourceFileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystemReplicationConfiguration).OriginalSourceFileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.efs.filesystem.replicationConfiguration.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36126,6 +36149,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.efs.filesystem.replicationDestination.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsFilesystemReplicationDestination).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.filesystem.replicationDestination.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsFilesystemReplicationDestination).FileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.efs.filesystem.replicationDestination.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36150,6 +36177,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.efs.mountTarget.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsMountTarget).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.mountTarget.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsMountTarget).FileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.efs.mountTarget.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36202,6 +36233,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.efs.accessPoint.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEfsAccessPoint).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.efs.accessPoint.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEfsAccessPoint).FileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.efs.accessPoint.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -82628,7 +82663,9 @@ type mqlAwsEfsFilesystemReplicationConfiguration struct {
 	SourceFileSystemId          plugin.TValue[string]
 	SourceFileSystemRegion      plugin.TValue[string]
 	SourceFileSystemArn         plugin.TValue[string]
+	SourceFileSystem            plugin.TValue[*mqlAwsEfsFilesystem]
 	OriginalSourceFileSystemArn plugin.TValue[string]
+	OriginalSourceFileSystem    plugin.TValue[*mqlAwsEfsFilesystem]
 	CreationTime                plugin.TValue[*time.Time]
 	Destinations                plugin.TValue[[]any]
 }
@@ -82682,8 +82719,40 @@ func (c *mqlAwsEfsFilesystemReplicationConfiguration) GetSourceFileSystemArn() *
 	return &c.SourceFileSystemArn
 }
 
+func (c *mqlAwsEfsFilesystemReplicationConfiguration) GetSourceFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.SourceFileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.filesystem.replicationConfiguration", c.__id, "sourceFileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.sourceFileSystem()
+	})
+}
+
 func (c *mqlAwsEfsFilesystemReplicationConfiguration) GetOriginalSourceFileSystemArn() *plugin.TValue[string] {
 	return &c.OriginalSourceFileSystemArn
+}
+
+func (c *mqlAwsEfsFilesystemReplicationConfiguration) GetOriginalSourceFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.OriginalSourceFileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.filesystem.replicationConfiguration", c.__id, "originalSourceFileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.originalSourceFileSystem()
+	})
 }
 
 func (c *mqlAwsEfsFilesystemReplicationConfiguration) GetCreationTime() *plugin.TValue[*time.Time] {
@@ -82700,6 +82769,7 @@ type mqlAwsEfsFilesystemReplicationDestination struct {
 	__id       string
 	// optional: if you define mqlAwsEfsFilesystemReplicationDestinationInternal it will be used here
 	FileSystemId            plugin.TValue[string]
+	FileSystem              plugin.TValue[*mqlAwsEfsFilesystem]
 	Region                  plugin.TValue[string]
 	Status                  plugin.TValue[string]
 	LastReplicatedTimestamp plugin.TValue[*time.Time]
@@ -82746,6 +82816,22 @@ func (c *mqlAwsEfsFilesystemReplicationDestination) GetFileSystemId() *plugin.TV
 	return &c.FileSystemId
 }
 
+func (c *mqlAwsEfsFilesystemReplicationDestination) GetFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.FileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.filesystem.replicationDestination", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
+}
+
 func (c *mqlAwsEfsFilesystemReplicationDestination) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -82765,6 +82851,7 @@ type mqlAwsEfsMountTarget struct {
 	mqlAwsEfsMountTargetInternal
 	MountTargetId      plugin.TValue[string]
 	FileSystemId       plugin.TValue[string]
+	FileSystem         plugin.TValue[*mqlAwsEfsFilesystem]
 	SubnetId           plugin.TValue[string]
 	Subnet             plugin.TValue[*mqlAwsVpcSubnet]
 	AvailabilityZone   plugin.TValue[string]
@@ -82814,6 +82901,22 @@ func (c *mqlAwsEfsMountTarget) GetMountTargetId() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsMountTarget) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
+}
+
+func (c *mqlAwsEfsMountTarget) GetFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.FileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.mountTarget", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
 }
 
 func (c *mqlAwsEfsMountTarget) GetSubnetId() *plugin.TValue[string] {
@@ -82896,6 +82999,7 @@ type mqlAwsEfsAccessPoint struct {
 	AccessPointId  plugin.TValue[string]
 	Arn            plugin.TValue[string]
 	FileSystemId   plugin.TValue[string]
+	FileSystem     plugin.TValue[*mqlAwsEfsFilesystem]
 	Name           plugin.TValue[string]
 	PosixUser      plugin.TValue[any]
 	RootDirectory  plugin.TValue[any]
@@ -82946,6 +83050,22 @@ func (c *mqlAwsEfsAccessPoint) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEfsAccessPoint) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
+}
+
+func (c *mqlAwsEfsAccessPoint) GetFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.FileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.efs.accessPoint", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
 }
 
 func (c *mqlAwsEfsAccessPoint) GetName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3961,6 +3961,7 @@ aws.efs 11.15.2
 aws.efs.accessPoint 11.15.2
 aws.efs.accessPoint.accessPointId 11.15.2
 aws.efs.accessPoint.arn 11.15.2
+aws.efs.accessPoint.fileSystem 13.41.1
 aws.efs.accessPoint.fileSystemId 11.15.2
 aws.efs.accessPoint.lifecycleState 11.15.2
 aws.efs.accessPoint.name 11.15.2
@@ -3999,11 +4000,14 @@ aws.efs.filesystem.region 11.15.2
 aws.efs.filesystem.replicationConfiguration 13.12.1
 aws.efs.filesystem.replicationConfiguration.creationTime 13.12.1
 aws.efs.filesystem.replicationConfiguration.destinations 13.12.1
+aws.efs.filesystem.replicationConfiguration.originalSourceFileSystem 13.41.1
 aws.efs.filesystem.replicationConfiguration.originalSourceFileSystemArn 13.12.1
+aws.efs.filesystem.replicationConfiguration.sourceFileSystem 13.41.1
 aws.efs.filesystem.replicationConfiguration.sourceFileSystemArn 13.12.1
 aws.efs.filesystem.replicationConfiguration.sourceFileSystemId 13.12.1
 aws.efs.filesystem.replicationConfiguration.sourceFileSystemRegion 13.12.1
 aws.efs.filesystem.replicationDestination 13.12.1
+aws.efs.filesystem.replicationDestination.fileSystem 13.41.1
 aws.efs.filesystem.replicationDestination.fileSystemId 13.12.1
 aws.efs.filesystem.replicationDestination.lastReplicatedTimestamp 13.12.1
 aws.efs.filesystem.replicationDestination.region 13.12.1
@@ -4014,6 +4018,7 @@ aws.efs.filesystem.throughputMode 13.12.1
 aws.efs.filesystems 11.15.2
 aws.efs.mountTarget 11.15.2
 aws.efs.mountTarget.availabilityZone 11.15.2
+aws.efs.mountTarget.fileSystem 13.41.1
 aws.efs.mountTarget.fileSystemId 11.15.2
 aws.efs.mountTarget.ipAddress 11.15.2
 aws.efs.mountTarget.lifecycleState 11.15.2

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -376,8 +376,52 @@ func (a *mqlAwsEfsFilesystemReplicationConfiguration) id() (string, error) {
 	return a.__id, nil
 }
 
+func (a *mqlAwsEfsFilesystemReplicationConfiguration) sourceFileSystem() (*mqlAwsEfsFilesystem, error) {
+	arnVal := a.SourceFileSystemArn.Data
+	if arnVal == "" {
+		a.SourceFileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
+}
+
+func (a *mqlAwsEfsFilesystemReplicationConfiguration) originalSourceFileSystem() (*mqlAwsEfsFilesystem, error) {
+	arnVal := a.OriginalSourceFileSystemArn.Data
+	if arnVal == "" {
+		a.OriginalSourceFileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
+}
+
 func (a *mqlAwsEfsFilesystemReplicationDestination) id() (string, error) {
 	return a.__id, nil
+}
+
+func (a *mqlAwsEfsFilesystemReplicationDestination) fileSystem() (*mqlAwsEfsFilesystem, error) {
+	fsId := a.FileSystemId.Data
+	if fsId == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(efsFilesystemArnPattern, a.Region.Data, conn.AccountId(), fsId)
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
 }
 
 func (a *mqlAwsEfsFilesystem) fileSystemProtection() (any, error) {
@@ -634,4 +678,36 @@ func (a *mqlAwsEfsMountTarget) networkInterface() (*mqlAwsEc2Networkinterface, e
 		return nil, err
 	}
 	return res.(*mqlAwsEc2Networkinterface), nil
+}
+
+func (a *mqlAwsEfsMountTarget) fileSystem() (*mqlAwsEfsFilesystem, error) {
+	fsId := a.FileSystemId.Data
+	if fsId == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(efsFilesystemArnPattern, a.Region.Data, conn.AccountId(), fsId)
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
+}
+
+func (a *mqlAwsEfsAccessPoint) fileSystem() (*mqlAwsEfsFilesystem, error) {
+	fsId := a.FileSystemId.Data
+	if fsId == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(efsFilesystemArnPattern, a.Region.Data, conn.AccountId(), fsId)
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
 }


### PR DESCRIPTION
## What

Adds typed `aws.efs.filesystem` accessors to EFS sub-resources that previously exposed only a raw filesystem id/ARN string, so audits can traverse to the filesystem's encryption state, KMS key, backup policy, size, lifecycle config, etc.

| Resource | Was (raw) | Now (typed) |
|---|---|---|
| `aws.efs.mountTarget` | `fileSystemId` | `fileSystem` |
| `aws.efs.accessPoint` | `fileSystemId` | `fileSystem` |
| `aws.efs.filesystem.replicationDestination` | `fileSystemId` | `fileSystem` |
| `aws.efs.filesystem.replicationConfiguration` | `sourceFileSystemArn` | `sourceFileSystem` |
| `aws.efs.filesystem.replicationConfiguration` | `originalSourceFileSystemArn` | `originalSourceFileSystem` |

Id-based resources build the filesystem ARN from their own region + account via a new `efsFilesystemArnPattern` added to the central ARN-pattern list in `aws.go`; the replication-config accessors resolve the ARN fields directly. The raw fields are kept but marked `@maturity("deprecated")`. Accessors reuse the existing `aws.efs.filesystem` init, so no new IAM permissions (`aws.permissions.json` unchanged).

## Example

```mql
aws.efs.filesystems {
  mountTargets { fileSystem { encrypted kmsKey { arn } backupPolicy } }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account: `aws.efs.mountTarget.fileSystem` resolved the filesystem and returned its real `encrypted: true`. `make providers/build/aws` passes; generated `.lr.go` / `.lr.versions` regenerated (new entries at 13.41.1).

## Deferred (follow-ups)

Cross-service filesystem refs where the target is ambiguous or needs its own handling: `aws.ecs.taskDefinition.volume.efsVolumeConfiguration`, `aws.sagemaker.trainingjob.channel` (EFS *or* FSx per `FileSystemType`), and the FSx-side refs (`aws.fsx.backup`, `aws.fsx.volume` → `aws.fsx.filesystem`).
