### PR TITLE
⭐ aws: add IAM role, S3, snapshot, subnet, and hosted zone cross-references

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4987,7 +4987,11 @@ private aws.es.domain @defaults("arn name") {
   // Cognito identity pool ID for Kibana authentication
   cognitoIdentityPoolId string
   // ARN of the IAM role granting Elasticsearch access to Cognito resources
-  cognitoRoleArn string
+  //
+  // Deprecated in favor of `cognitoRole`.
+  cognitoRoleArn @maturity("deprecated") string
+  // IAM role granting Elasticsearch access to Cognito resources
+  cognitoRole() aws.iam.role
   // State of Auto-Tune for the domain
   autoTuneState string
   // Current service software version present on the domain
@@ -5936,7 +5940,11 @@ private aws.codeartifact.domain @defaults("arn name owner status region") {
   // Total size in bytes of all package assets in the domain
   assetSizeBytes int
   // ARN of the S3 bucket that stores package assets for the domain
-  s3BucketArn string
+  //
+  // Deprecated in favor of `s3Bucket`.
+  s3BucketArn @maturity("deprecated") string
+  // S3 bucket that stores package assets for the domain
+  s3Bucket() aws.s3.bucket
   // Resource policy attached to the domain
   //
   // Shape (when set): `{document: "<JSON policy>", resourceArn, revision}`. Null when no policy is attached or the caller is denied access.
@@ -11054,7 +11062,11 @@ private aws.drs.replicationConfiguration @defaults("sourceServerID") {
   // Associated source server ID
   sourceServerID string
   // Staging area subnet ID
-  stagingAreaSubnetId string
+  //
+  // Deprecated in favor of `stagingAreaSubnet`.
+  stagingAreaSubnetId @maturity("deprecated") string
+  // Subnet used for the replication staging area
+  stagingAreaSubnet() aws.vpc.subnet
   // Staging area tags
   stagingAreaTags map[string]string
   // Whether to use dedicated replication server
@@ -13029,7 +13041,11 @@ private aws.route53.hostedZone.dnssec @defaults("status") {
 // Route 53 DNS resource record set
 private aws.route53.record @defaults("name type") {
   // Hosted zone ID this record belongs to
-  hostedZoneId string
+  //
+  // Deprecated in favor of `hostedZone`.
+  hostedZoneId @maturity("deprecated") string
+  // Hosted zone this record belongs to
+  hostedZone() aws.route53.hostedZone
   // Fully qualified domain name (e.g., www.example.com.)
   name string
   // DNS record type (A, AAAA, CNAME, MX, TXT, SOA, NS, SRV, PTR, CAA, etc.)
@@ -16020,7 +16036,11 @@ private aws.ec2.launchconfiguration.ebsBlockDevice @defaults("volumeSize volumeT
   // Whether the volume is encrypted
   encrypted bool
   // ID of the snapshot used to create the volume
-  snapshotId string
+  //
+  // Deprecated in favor of `snapshot`.
+  snapshotId @maturity("deprecated") string
+  // Snapshot the volume is created from
+  snapshot() aws.ec2.snapshot
   // Size of the volume in GiB
   volumeSize int
   // Volume type (gp2, gp3, io1, io2, etc.)
@@ -20220,7 +20240,11 @@ private aws.kinesis.firehoseDeliveryStream.cloudWatchLogging @defaults("enabled 
 // Amazon Kinesis Firehose S3 (Extended) destination
 private aws.kinesis.firehoseDeliveryStream.destination.s3 @defaults("bucketArn compressionFormat") {
   // ARN of the S3 bucket
-  bucketArn string
+  //
+  // Deprecated in favor of `bucket`.
+  bucketArn @maturity("deprecated") string
+  // S3 bucket records are delivered to
+  bucket() aws.s3.bucket
   // IAM role for delivery
   iamRole() aws.iam.role
   // Compression format: UNCOMPRESSED, GZIP, ZIP, Snappy, HADOOP_SNAPPY

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10341,6 +10341,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.es.domain.cognitoRoleArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetCognitoRoleArn()).ToDataRes(types.String)
 	},
+	"aws.es.domain.cognitoRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEsDomain).GetCognitoRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
 	"aws.es.domain.autoTuneState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEsDomain).GetAutoTuneState()).ToDataRes(types.String)
 	},
@@ -11453,6 +11456,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.codeartifact.domain.s3BucketArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodeartifactDomain).GetS3BucketArn()).ToDataRes(types.String)
+	},
+	"aws.codeartifact.domain.s3Bucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCodeartifactDomain).GetS3Bucket()).ToDataRes(types.Resource("aws.s3.bucket"))
 	},
 	"aws.codeartifact.domain.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodeartifactDomain).GetPolicy()).ToDataRes(types.Dict)
@@ -16788,6 +16794,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.drs.replicationConfiguration.stagingAreaSubnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDrsReplicationConfiguration).GetStagingAreaSubnetId()).ToDataRes(types.String)
 	},
+	"aws.drs.replicationConfiguration.stagingAreaSubnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDrsReplicationConfiguration).GetStagingAreaSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
+	},
 	"aws.drs.replicationConfiguration.stagingAreaTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDrsReplicationConfiguration).GetStagingAreaTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -19070,6 +19079,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.route53.record.hostedZoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53Record).GetHostedZoneId()).ToDataRes(types.String)
+	},
+	"aws.route53.record.hostedZone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRoute53Record).GetHostedZone()).ToDataRes(types.Resource("aws.route53.hostedZone"))
 	},
 	"aws.route53.record.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53Record).GetName()).ToDataRes(types.String)
@@ -22400,6 +22412,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.launchconfiguration.ebsBlockDevice.snapshotId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2LaunchconfigurationEbsBlockDevice).GetSnapshotId()).ToDataRes(types.String)
+	},
+	"aws.ec2.launchconfiguration.ebsBlockDevice.snapshot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2LaunchconfigurationEbsBlockDevice).GetSnapshot()).ToDataRes(types.Resource("aws.ec2.snapshot"))
 	},
 	"aws.ec2.launchconfiguration.ebsBlockDevice.volumeSize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2LaunchconfigurationEbsBlockDevice).GetVolumeSize()).ToDataRes(types.Int)
@@ -27167,6 +27182,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.s3.bucketArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamDestinationS3).GetBucketArn()).ToDataRes(types.String)
+	},
+	"aws.kinesis.firehoseDeliveryStream.destination.s3.bucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamDestinationS3).GetBucket()).ToDataRes(types.Resource("aws.s3.bucket"))
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.s3.iamRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamDestinationS3).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
@@ -42184,6 +42202,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEsDomain).CognitoRoleArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.es.domain.cognitoRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEsDomain).CognitoRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
 	"aws.es.domain.autoTuneState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEsDomain).AutoTuneState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -43754,6 +43776,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.codeartifact.domain.s3BucketArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCodeartifactDomain).S3BucketArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.codeartifact.domain.s3Bucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCodeartifactDomain).S3Bucket, ok = plugin.RawToTValue[*mqlAwsS3Bucket](v.Value, v.Error)
 		return
 	},
 	"aws.codeartifact.domain.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51688,6 +51714,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsDrsReplicationConfiguration).StagingAreaSubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.drs.replicationConfiguration.stagingAreaSubnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDrsReplicationConfiguration).StagingAreaSubnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
+		return
+	},
 	"aws.drs.replicationConfiguration.stagingAreaTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDrsReplicationConfiguration).StagingAreaTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -54934,6 +54964,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.route53.record.hostedZoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRoute53Record).HostedZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.route53.record.hostedZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRoute53Record).HostedZone, ok = plugin.RawToTValue[*mqlAwsRoute53HostedZone](v.Value, v.Error)
 		return
 	},
 	"aws.route53.record.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59758,6 +59792,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.launchconfiguration.ebsBlockDevice.snapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2LaunchconfigurationEbsBlockDevice).SnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.launchconfiguration.ebsBlockDevice.snapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2LaunchconfigurationEbsBlockDevice).Snapshot, ok = plugin.RawToTValue[*mqlAwsEc2Snapshot](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.launchconfiguration.ebsBlockDevice.volumeSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -66650,6 +66688,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.s3.bucketArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKinesisFirehoseDeliveryStreamDestinationS3).BucketArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.destination.s3.bucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamDestinationS3).Bucket, ok = plugin.RawToTValue[*mqlAwsS3Bucket](v.Value, v.Error)
 		return
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.s3.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -98757,6 +98799,7 @@ type mqlAwsEsDomain struct {
 	CognitoUserPoolId                  plugin.TValue[string]
 	CognitoIdentityPoolId              plugin.TValue[string]
 	CognitoRoleArn                     plugin.TValue[string]
+	CognitoRole                        plugin.TValue[*mqlAwsIamRole]
 	AutoTuneState                      plugin.TValue[string]
 	ServiceSoftwareCurrentVersion      plugin.TValue[string]
 	ServiceSoftwareNewVersion          plugin.TValue[string]
@@ -99142,6 +99185,22 @@ func (c *mqlAwsEsDomain) GetCognitoIdentityPoolId() *plugin.TValue[string] {
 
 func (c *mqlAwsEsDomain) GetCognitoRoleArn() *plugin.TValue[string] {
 	return &c.CognitoRoleArn
+}
+
+func (c *mqlAwsEsDomain) GetCognitoRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.CognitoRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.es.domain", c.__id, "cognitoRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.cognitoRole()
+	})
 }
 
 func (c *mqlAwsEsDomain) GetAutoTuneState() *plugin.TValue[string] {
@@ -102456,6 +102515,7 @@ type mqlAwsCodeartifactDomain struct {
 	RepositoryCount plugin.TValue[int64]
 	AssetSizeBytes  plugin.TValue[int64]
 	S3BucketArn     plugin.TValue[string]
+	S3Bucket        plugin.TValue[*mqlAwsS3Bucket]
 	Policy          plugin.TValue[any]
 	Tags            plugin.TValue[map[string]any]
 }
@@ -102551,6 +102611,22 @@ func (c *mqlAwsCodeartifactDomain) GetAssetSizeBytes() *plugin.TValue[int64] {
 
 func (c *mqlAwsCodeartifactDomain) GetS3BucketArn() *plugin.TValue[string] {
 	return &c.S3BucketArn
+}
+
+func (c *mqlAwsCodeartifactDomain) GetS3Bucket() *plugin.TValue[*mqlAwsS3Bucket] {
+	return plugin.GetOrCompute[*mqlAwsS3Bucket](&c.S3Bucket, func() (*mqlAwsS3Bucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.codeartifact.domain", c.__id, "s3Bucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsS3Bucket), nil
+			}
+		}
+
+		return c.s3Bucket()
+	})
 }
 
 func (c *mqlAwsCodeartifactDomain) GetPolicy() *plugin.TValue[any] {
@@ -124291,6 +124367,7 @@ type mqlAwsDrsReplicationConfiguration struct {
 	// optional: if you define mqlAwsDrsReplicationConfigurationInternal it will be used here
 	SourceServerID                plugin.TValue[string]
 	StagingAreaSubnetId           plugin.TValue[string]
+	StagingAreaSubnet             plugin.TValue[*mqlAwsVpcSubnet]
 	StagingAreaTags               plugin.TValue[map[string]any]
 	UseDedicatedReplicationServer plugin.TValue[bool]
 	ReplicationServerInstanceType plugin.TValue[string]
@@ -124349,6 +124426,22 @@ func (c *mqlAwsDrsReplicationConfiguration) GetSourceServerID() *plugin.TValue[s
 
 func (c *mqlAwsDrsReplicationConfiguration) GetStagingAreaSubnetId() *plugin.TValue[string] {
 	return &c.StagingAreaSubnetId
+}
+
+func (c *mqlAwsDrsReplicationConfiguration) GetStagingAreaSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
+	return plugin.GetOrCompute[*mqlAwsVpcSubnet](&c.StagingAreaSubnet, func() (*mqlAwsVpcSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.drs.replicationConfiguration", c.__id, "stagingAreaSubnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcSubnet), nil
+			}
+		}
+
+		return c.stagingAreaSubnet()
+	})
 }
 
 func (c *mqlAwsDrsReplicationConfiguration) GetStagingAreaTags() *plugin.TValue[map[string]any] {
@@ -132147,6 +132240,7 @@ type mqlAwsRoute53Record struct {
 	__id       string
 	mqlAwsRoute53RecordInternal
 	HostedZoneId              plugin.TValue[string]
+	HostedZone                plugin.TValue[*mqlAwsRoute53HostedZone]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
 	Ttl                       plugin.TValue[int64]
@@ -132208,6 +132302,22 @@ func (c *mqlAwsRoute53Record) MqlID() string {
 
 func (c *mqlAwsRoute53Record) GetHostedZoneId() *plugin.TValue[string] {
 	return &c.HostedZoneId
+}
+
+func (c *mqlAwsRoute53Record) GetHostedZone() *plugin.TValue[*mqlAwsRoute53HostedZone] {
+	return plugin.GetOrCompute[*mqlAwsRoute53HostedZone](&c.HostedZone, func() (*mqlAwsRoute53HostedZone, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.route53.record", c.__id, "hostedZone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsRoute53HostedZone), nil
+			}
+		}
+
+		return c.hostedZone()
+	})
 }
 
 func (c *mqlAwsRoute53Record) GetName() *plugin.TValue[string] {
@@ -143967,6 +144077,7 @@ type mqlAwsEc2LaunchconfigurationEbsBlockDevice struct {
 	// optional: if you define mqlAwsEc2LaunchconfigurationEbsBlockDeviceInternal it will be used here
 	Encrypted           plugin.TValue[bool]
 	SnapshotId          plugin.TValue[string]
+	Snapshot            plugin.TValue[*mqlAwsEc2Snapshot]
 	VolumeSize          plugin.TValue[int64]
 	VolumeType          plugin.TValue[string]
 	Iops                plugin.TValue[int64]
@@ -144017,6 +144128,22 @@ func (c *mqlAwsEc2LaunchconfigurationEbsBlockDevice) GetEncrypted() *plugin.TVal
 
 func (c *mqlAwsEc2LaunchconfigurationEbsBlockDevice) GetSnapshotId() *plugin.TValue[string] {
 	return &c.SnapshotId
+}
+
+func (c *mqlAwsEc2LaunchconfigurationEbsBlockDevice) GetSnapshot() *plugin.TValue[*mqlAwsEc2Snapshot] {
+	return plugin.GetOrCompute[*mqlAwsEc2Snapshot](&c.Snapshot, func() (*mqlAwsEc2Snapshot, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.launchconfiguration.ebsBlockDevice", c.__id, "snapshot")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Snapshot), nil
+			}
+		}
+
+		return c.snapshot()
+	})
 }
 
 func (c *mqlAwsEc2LaunchconfigurationEbsBlockDevice) GetVolumeSize() *plugin.TValue[int64] {
@@ -161240,6 +161367,7 @@ type mqlAwsKinesisFirehoseDeliveryStreamDestinationS3 struct {
 	__id       string
 	mqlAwsKinesisFirehoseDeliveryStreamDestinationS3Internal
 	BucketArn                  plugin.TValue[string]
+	Bucket                     plugin.TValue[*mqlAwsS3Bucket]
 	IamRole                    plugin.TValue[*mqlAwsIamRole]
 	CompressionFormat          plugin.TValue[string]
 	Prefix                     plugin.TValue[string]
@@ -161294,6 +161422,22 @@ func (c *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) MqlID() string {
 
 func (c *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) GetBucketArn() *plugin.TValue[string] {
 	return &c.BucketArn
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) GetBucket() *plugin.TValue[*mqlAwsS3Bucket] {
+	return plugin.GetOrCompute[*mqlAwsS3Bucket](&c.Bucket, func() (*mqlAwsS3Bucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kinesis.firehoseDeliveryStream.destination.s3", c.__id, "bucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsS3Bucket), nil
+			}
+		}
+
+		return c.bucket()
+	})
 }
 
 func (c *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1923,6 +1923,7 @@ aws.codeartifact.domain.owner 13.26.3
 aws.codeartifact.domain.policy 13.26.3
 aws.codeartifact.domain.region 13.26.3
 aws.codeartifact.domain.repositoryCount 13.26.3
+aws.codeartifact.domain.s3Bucket 13.41.1
 aws.codeartifact.domain.s3BucketArn 13.26.3
 aws.codeartifact.domain.status 13.26.3
 aws.codeartifact.domain.tags 13.26.3
@@ -2747,6 +2748,7 @@ aws.drs.replicationConfiguration.internetProtocol 13.9.0
 aws.drs.replicationConfiguration.replicatedDisks 11.15.2
 aws.drs.replicationConfiguration.replicationServerInstanceType 11.15.2
 aws.drs.replicationConfiguration.sourceServerID 11.15.2
+aws.drs.replicationConfiguration.stagingAreaSubnet 13.41.1
 aws.drs.replicationConfiguration.stagingAreaSubnetId 11.15.2
 aws.drs.replicationConfiguration.stagingAreaTags 11.15.2
 aws.drs.replicationConfiguration.useDedicatedReplicationServer 11.15.2
@@ -3277,6 +3279,7 @@ aws.ec2.launchconfiguration.ebsBlockDevice 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.deleteOnTermination 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.encrypted 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.iops 13.6.0
+aws.ec2.launchconfiguration.ebsBlockDevice.snapshot 13.41.1
 aws.ec2.launchconfiguration.ebsBlockDevice.snapshotId 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.throughput 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.volumeSize 13.6.0
@@ -4606,6 +4609,7 @@ aws.es.domain.availabilityZones 13.21.4
 aws.es.domain.cloudformationStack 13.39.2
 aws.es.domain.cognitoEnabled 13.21.4
 aws.es.domain.cognitoIdentityPoolId 13.21.4
+aws.es.domain.cognitoRole 13.41.1
 aws.es.domain.cognitoRoleArn 13.21.4
 aws.es.domain.cognitoUserPoolId 13.21.4
 aws.es.domain.coldStorageEnabled 13.21.4
@@ -5865,6 +5869,7 @@ aws.kinesis.firehoseDeliveryStream.destination.redshift.s3BackupMode 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.redshift.username 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.region 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.s3 13.0.2
+aws.kinesis.firehoseDeliveryStream.destination.s3.bucket 13.41.1
 aws.kinesis.firehoseDeliveryStream.destination.s3.bucketArn 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.s3.bufferingIntervalInSeconds 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.s3.bufferingSizeInMBs 13.0.2
@@ -7846,6 +7851,7 @@ aws.route53.record.geoLocation 11.15.3
 aws.route53.record.geoProximityLocation 11.15.3
 aws.route53.record.healthCheck 11.15.3
 aws.route53.record.healthCheckId 11.15.3
+aws.route53.record.hostedZone 13.41.1
 aws.route53.record.hostedZoneId 11.15.3
 aws.route53.record.isAlias 11.15.3
 aws.route53.record.multiValueAnswer 11.15.3

--- a/providers/aws/resources/aws_codeartifact.go
+++ b/providers/aws/resources/aws_codeartifact.go
@@ -173,6 +173,20 @@ func newMqlAwsCodeartifactDomain(runtime *plugin.Runtime, region, name, owner st
 	return mqlDomain, nil
 }
 
+func (a *mqlAwsCodeartifactDomain) s3Bucket() (*mqlAwsS3Bucket, error) {
+	arnVal := a.S3BucketArn.Data
+	if arnVal == "" {
+		a.S3Bucket.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.s3.bucket",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsS3Bucket), nil
+}
+
 func (a *mqlAwsCodeartifactDomain) id() (string, error) {
 	return a.Arn.Data, nil
 }

--- a/providers/aws/resources/aws_drs.go
+++ b/providers/aws/resources/aws_drs.go
@@ -75,6 +75,20 @@ func (a *mqlAwsDrsReplicationConfiguration) ebsEncryptionKey() (*mqlAwsKmsKey, e
 	return res.(*mqlAwsKmsKey), nil
 }
 
+func (a *mqlAwsDrsReplicationConfiguration) stagingAreaSubnet() (*mqlAwsVpcSubnet, error) {
+	subnetID := a.StagingAreaSubnetId.Data
+	if subnetID == "" {
+		a.StagingAreaSubnet.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.vpc.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(subnetID)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcSubnet), nil
+}
+
 func (a *mqlAwsDrsLaunchConfiguration) id() (string, error) {
 	return "aws.drs.launchConfiguration/" + a.SourceServerID.Data, nil
 }

--- a/providers/aws/resources/aws_ec2_launchconfiguration.go
+++ b/providers/aws/resources/aws_ec2_launchconfiguration.go
@@ -37,6 +37,20 @@ func (a *mqlAwsEc2LaunchconfigurationEbsBlockDevice) id() (string, error) {
 	return a.__id, nil
 }
 
+func (a *mqlAwsEc2LaunchconfigurationEbsBlockDevice) snapshot() (*mqlAwsEc2Snapshot, error) {
+	snapshotId := a.SnapshotId.Data
+	if snapshotId == "" {
+		a.Snapshot.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.ec2.snapshot",
+		map[string]*llx.RawData{"id": llx.StringData(snapshotId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Snapshot), nil
+}
+
 func (a *mqlAwsEc2LaunchconfigurationMetadataOptions) id() (string, error) {
 	return a.__id, nil
 }

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -524,6 +524,20 @@ func (a *mqlAwsEsDomain) customEndpointCertificate() (*mqlAwsAcmCertificate, err
 	return res.(*mqlAwsAcmCertificate), nil
 }
 
+func (a *mqlAwsEsDomain) cognitoRole() (*mqlAwsIamRole, error) {
+	arnVal := a.CognitoRoleArn.Data
+	if arnVal == "" {
+		a.CognitoRole.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.iam.role",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsIamRole), nil
+}
+
 func (a *mqlAwsEsDomain) subnets() ([]any, error) {
 	res := []any{}
 	for _, subnetId := range a.cacheSubnetIds {

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -980,6 +980,20 @@ func (a *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) id() (string, error) 
 	return a.BucketArn.Data + "/" + a.Region.Data, nil
 }
 
+func (a *mqlAwsKinesisFirehoseDeliveryStreamDestinationS3) bucket() (*mqlAwsS3Bucket, error) {
+	arnVal := a.BucketArn.Data
+	if arnVal == "" {
+		a.Bucket.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.s3.bucket",
+		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsS3Bucket), nil
+}
+
 func (a *mqlAwsKinesisFirehoseDeliveryStreamDestination) redshift() (*mqlAwsKinesisFirehoseDeliveryStreamDestinationRedshift, error) {
 	if a.cacheDest == nil || a.cacheDest.RedshiftDestinationDescription == nil {
 		a.Redshift.State = plugin.StateIsNull | plugin.StateIsSet

--- a/providers/aws/resources/aws_route53.go
+++ b/providers/aws/resources/aws_route53.go
@@ -493,6 +493,20 @@ func (a *mqlAwsRoute53Record) id() (string, error) {
 	return fmt.Sprintf("%s//%s//%s//%s", a.HostedZoneId.Data, a.Name.Data, a.Type.Data, a.SetIdentifier.Data), nil
 }
 
+func (a *mqlAwsRoute53Record) hostedZone() (*mqlAwsRoute53HostedZone, error) {
+	zoneId := a.HostedZoneId.Data
+	if zoneId == "" {
+		a.HostedZone.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.route53.hostedZone",
+		map[string]*llx.RawData{"id": llx.StringData(zoneId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsRoute53HostedZone), nil
+}
+
 func (a *mqlAwsRoute53Record) resourceRecords() ([]any, error) {
 	return a.resourceRecordsCache, nil
 }


### PR DESCRIPTION
## What

Rounds out the cross-reference sweep with typed accessors that resolve raw ARN/id strings to their already-modeled resources.

| Resource | Was (raw) | Now (typed) | Target |
|---|---|---|---|
| `aws.es.domain` | `cognitoRoleArn` | `cognitoRole` | `aws.iam.role` |
| `aws.codeartifact.domain` | `s3BucketArn` | `s3Bucket` | `aws.s3.bucket` |
| `aws.kinesis.firehoseDeliveryStream.destination.s3` | `bucketArn` | `bucket` | `aws.s3.bucket` |
| `aws.ec2.launchconfiguration.ebsBlockDevice` | `snapshotId` | `snapshot` | `aws.ec2.snapshot` |
| `aws.route53.record` | `hostedZoneId` | `hostedZone` | `aws.route53.hostedZone` |
| `aws.drs.replicationConfiguration` | `stagingAreaSubnetId` | `stagingAreaSubnet` | `aws.vpc.subnet` |

The raw fields are kept but marked `@maturity("deprecated")`. The drs staging-subnet accessor mirrors the existing one on `aws.drs.replicationConfigurationTemplate`. All accessors reuse existing resource inits (by ARN or id), so no new IAM permissions are required (`aws.permissions.json` unchanged).

## Example

```mql
aws.route53.hostedZones {
  records { hostedZone { name isPrivate } }
}
```

## Testing

`make providers/build/aws` passes; generated `.lr.go` / `.lr.versions` regenerated (new entries at 13.41.1). The referencing resources (CodeArtifact domains, Firehose streams, ES domains, launch configs, Route 53 zones) are not present in the test account, so these specific accessors were not exercised live here — but each is mechanically identical to the by-ARN / by-id resolution patterns verified end-to-end in the sibling PRs (#8918 ENI-by-id, #8919 ACM-by-ARN, #8921 EFS-by-ARN), and the subnet accessor is a copy of the existing shipped drs-template accessor.
