### PR TITLE
🎉 aws-13.42.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.41.0",
+	Version:         "13.42.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Bumps the aws provider a minor version: `13.41.0` → `13.42.0`.

### Changes included since `13.41.0`

- ⭐ aws: add cross-references for IAM role, S3, snapshot, subnet, and hosted zone (#8922)
- ⭐ aws: add EFS filesystem cross-references (#8921)
- ⭐ aws: add `networkInterface()` cross-references (#8918)
- ⭐ aws: add ACM certificate cross-references (#8919)
- ⭐ aws: add discovery for memorydb, codebuild, cognito, and transfer (#8915)
