### PR TITLE
⭐ aws: add route table cross-references (NAT gateway, instance, prefix list)

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -55,6 +55,7 @@ const (
 	transitGatewayArnPattern      = "arn:aws:ec2:%s:%s:transit-gateway/%s"
 	efsFilesystemArnPattern       = "arn:aws:elasticfilesystem:%s:%s:file-system/%s"
 	fsxFilesystemArnPattern       = "arn:aws:fsx:%s:%s:file-system/%s"
+	prefixListArnPattern          = "arn:aws:ec2:%s:%s:prefix-list/%s"
 )
 
 func NewSecurityGroupArn(region, accountID, sgID string) string {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -412,11 +412,19 @@ private aws.vpc.routetable.route @defaults("destinationCidrBlock state") {
   // IPv6 CIDR block used for the destination match
   destinationIpv6CidrBlock string
   // Prefix list ID for the destination match
-  destinationPrefixListId string
+  //
+  // Deprecated in favor of `managedPrefixList`.
+  destinationPrefixListId @maturity("deprecated") string
+  // Managed prefix list used for the destination match
+  managedPrefixList() aws.ec2.managedPrefixList
   // ID of a gateway attached to the VPC
   gatewayId string
   // ID of a NAT instance in the VPC
-  instanceId string
+  //
+  // Deprecated in favor of `instance`.
+  instanceId @maturity("deprecated") string
+  // NAT instance the route sends traffic to
+  instance() aws.ec2.instance
   // ID of the Amazon Web Services account that owns the instance
   instanceOwnerId string
   // ID of the network interface
@@ -426,7 +434,11 @@ private aws.vpc.routetable.route @defaults("destinationCidrBlock state") {
   // Network interface a route sends traffic to
   networkInterface() aws.ec2.networkinterface
   // ID of a NAT gateway
-  natGatewayId string
+  //
+  // Deprecated in favor of `natGateway`.
+  natGatewayId @maturity("deprecated") string
+  // NAT gateway the route sends traffic to
+  natGateway() aws.vpc.natgateway
   // ID of a transit gateway
   transitGatewayId string
   // ID of a VPC peering connection

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3083,7 +3083,7 @@ func init() {
 			Create: createAwsEc2Eip,
 		},
 		"aws.vpc.natgateway": {
-			// to override args, implement: initAwsVpcNatgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsVpcNatgateway,
 			Create: createAwsVpcNatgateway,
 		},
 		"aws.vpc.natgateway.address": {
@@ -5025,11 +5025,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.routetable.route.destinationPrefixListId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetDestinationPrefixListId()).ToDataRes(types.String)
 	},
+	"aws.vpc.routetable.route.managedPrefixList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetManagedPrefixList()).ToDataRes(types.Resource("aws.ec2.managedPrefixList"))
+	},
 	"aws.vpc.routetable.route.gatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetGatewayId()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.route.instanceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetInstanceId()).ToDataRes(types.String)
+	},
+	"aws.vpc.routetable.route.instance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetInstance()).ToDataRes(types.Resource("aws.ec2.instance"))
 	},
 	"aws.vpc.routetable.route.instanceOwnerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetInstanceOwnerId()).ToDataRes(types.String)
@@ -5042,6 +5048,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.routetable.route.natGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetNatGatewayId()).ToDataRes(types.String)
+	},
+	"aws.vpc.routetable.route.natGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetNatGateway()).ToDataRes(types.Resource("aws.vpc.natgateway"))
 	},
 	"aws.vpc.routetable.route.transitGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetTransitGatewayId()).ToDataRes(types.String)
@@ -34427,12 +34436,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcRoutetableRoute).DestinationPrefixListId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.routetable.route.managedPrefixList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).ManagedPrefixList, ok = plugin.RawToTValue[*mqlAwsEc2ManagedPrefixList](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.route.gatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).GatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.route.instanceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).InstanceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.routetable.route.instance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).Instance, ok = plugin.RawToTValue[*mqlAwsEc2Instance](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.route.instanceOwnerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34449,6 +34466,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.routetable.route.natGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).NatGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.routetable.route.natGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).NatGateway, ok = plugin.RawToTValue[*mqlAwsVpcNatgateway](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.route.transitGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -78061,12 +78082,15 @@ type mqlAwsVpcRoutetableRoute struct {
 	DestinationCidrBlock        plugin.TValue[string]
 	DestinationIpv6CidrBlock    plugin.TValue[string]
 	DestinationPrefixListId     plugin.TValue[string]
+	ManagedPrefixList           plugin.TValue[*mqlAwsEc2ManagedPrefixList]
 	GatewayId                   plugin.TValue[string]
 	InstanceId                  plugin.TValue[string]
+	Instance                    plugin.TValue[*mqlAwsEc2Instance]
 	InstanceOwnerId             plugin.TValue[string]
 	NetworkInterfaceId          plugin.TValue[string]
 	NetworkInterface            plugin.TValue[*mqlAwsEc2Networkinterface]
 	NatGatewayId                plugin.TValue[string]
+	NatGateway                  plugin.TValue[*mqlAwsVpcNatgateway]
 	TransitGatewayId            plugin.TValue[string]
 	VpcPeeringConnectionId      plugin.TValue[string]
 	EgressOnlyInternetGatewayId plugin.TValue[string]
@@ -78130,12 +78154,44 @@ func (c *mqlAwsVpcRoutetableRoute) GetDestinationPrefixListId() *plugin.TValue[s
 	return &c.DestinationPrefixListId
 }
 
+func (c *mqlAwsVpcRoutetableRoute) GetManagedPrefixList() *plugin.TValue[*mqlAwsEc2ManagedPrefixList] {
+	return plugin.GetOrCompute[*mqlAwsEc2ManagedPrefixList](&c.ManagedPrefixList, func() (*mqlAwsEc2ManagedPrefixList, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "managedPrefixList")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2ManagedPrefixList), nil
+			}
+		}
+
+		return c.managedPrefixList()
+	})
+}
+
 func (c *mqlAwsVpcRoutetableRoute) GetGatewayId() *plugin.TValue[string] {
 	return &c.GatewayId
 }
 
 func (c *mqlAwsVpcRoutetableRoute) GetInstanceId() *plugin.TValue[string] {
 	return &c.InstanceId
+}
+
+func (c *mqlAwsVpcRoutetableRoute) GetInstance() *plugin.TValue[*mqlAwsEc2Instance] {
+	return plugin.GetOrCompute[*mqlAwsEc2Instance](&c.Instance, func() (*mqlAwsEc2Instance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "instance")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Instance), nil
+			}
+		}
+
+		return c.instance()
+	})
 }
 
 func (c *mqlAwsVpcRoutetableRoute) GetInstanceOwnerId() *plugin.TValue[string] {
@@ -78164,6 +78220,22 @@ func (c *mqlAwsVpcRoutetableRoute) GetNetworkInterface() *plugin.TValue[*mqlAwsE
 
 func (c *mqlAwsVpcRoutetableRoute) GetNatGatewayId() *plugin.TValue[string] {
 	return &c.NatGatewayId
+}
+
+func (c *mqlAwsVpcRoutetableRoute) GetNatGateway() *plugin.TValue[*mqlAwsVpcNatgateway] {
+	return plugin.GetOrCompute[*mqlAwsVpcNatgateway](&c.NatGateway, func() (*mqlAwsVpcNatgateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "natGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcNatgateway), nil
+			}
+		}
+
+		return c.natGateway()
+	})
 }
 
 func (c *mqlAwsVpcRoutetableRoute) GetTransitGatewayId() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10070,9 +10070,12 @@ aws.vpc.routetable.route.destinationPrefixListId 11.15.2
 aws.vpc.routetable.route.egressOnlyInternetGatewayId 11.15.2
 aws.vpc.routetable.route.gatewayId 11.15.2
 aws.vpc.routetable.route.id 11.15.2
+aws.vpc.routetable.route.instance 13.41.1
 aws.vpc.routetable.route.instanceId 11.15.2
 aws.vpc.routetable.route.instanceOwnerId 11.15.2
 aws.vpc.routetable.route.localGatewayId 11.15.2
+aws.vpc.routetable.route.managedPrefixList 13.41.1
+aws.vpc.routetable.route.natGateway 13.41.1
 aws.vpc.routetable.route.natGatewayId 11.15.2
 aws.vpc.routetable.route.networkInterface 13.41.1
 aws.vpc.routetable.route.networkInterfaceId 11.15.2

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -249,43 +249,84 @@ func (a *mqlAwsVpc) natGateways() ([]any, error) {
 				continue
 			}
 
-			addresses := []any{}
-			for _, address := range gw.NatGatewayAddresses {
-				mqlNatGatewayAddress, err := CreateResource(a.MqlRuntime, ResourceAwsVpcNatgatewayAddress,
-					map[string]*llx.RawData{
-						"allocationId":       llx.StringDataPtr(address.AllocationId),
-						"networkInterfaceId": llx.StringDataPtr(address.NetworkInterfaceId),
-						"privateIp":          llx.StringDataPtr(address.PrivateIp),
-						"isPrimary":          llx.BoolDataPtr(address.IsPrimary),
-					})
-				if err == nil {
-					mqlNatGatewayAddress.(*mqlAwsVpcNatgatewayAddress).natGatewayAddressCache = address
-					mqlNatGatewayAddress.(*mqlAwsVpcNatgatewayAddress).region = a.Region.Data
-					addresses = append(addresses, mqlNatGatewayAddress)
-				} else {
-					log.Error().Err(err).Msg("cannot create vpc natgateway address resource")
-				}
-			}
-
-			args := map[string]*llx.RawData{
-				"createdAt":    llx.TimeDataPtr(gw.CreateTime),
-				"natGatewayId": llx.StringDataPtr(gw.NatGatewayId),
-				"state":        llx.StringData(string(gw.State)),
-				"tags":         llx.MapData(toInterfaceMap(ec2TagsToMap(gw.Tags)), types.String),
-				"addresses":    llx.ArrayData(addresses, types.Type(ResourceAwsVpcNatgatewayAddress)),
-			}
-
-			mqlNatGat, err := CreateResource(a.MqlRuntime, ResourceAwsVpcNatgateway, args)
+			mqlNatGat, err := newMqlAwsVpcNatgateway(a.MqlRuntime, a.Region.Data, gw)
 			if err != nil {
 				return nil, err
 			}
-			mqlNatGat.(*mqlAwsVpcNatgateway).natGatewayCache = gw
-			mqlNatGat.(*mqlAwsVpcNatgateway).region = a.Region.Data
-
 			endpoints = append(endpoints, mqlNatGat)
 		}
 	}
 	return endpoints, nil
+}
+
+// newMqlAwsVpcNatgateway builds an aws.vpc.natgateway resource (and its
+// address sub-resources) from a DescribeNatGateways result.
+func newMqlAwsVpcNatgateway(runtime *plugin.Runtime, region string, gw vpctypes.NatGateway) (*mqlAwsVpcNatgateway, error) {
+	addresses := []any{}
+	for _, address := range gw.NatGatewayAddresses {
+		mqlAddr, err := CreateResource(runtime, ResourceAwsVpcNatgatewayAddress,
+			map[string]*llx.RawData{
+				"allocationId":       llx.StringDataPtr(address.AllocationId),
+				"networkInterfaceId": llx.StringDataPtr(address.NetworkInterfaceId),
+				"privateIp":          llx.StringDataPtr(address.PrivateIp),
+				"isPrimary":          llx.BoolDataPtr(address.IsPrimary),
+			})
+		if err != nil {
+			log.Error().Err(err).Msg("cannot create vpc natgateway address resource")
+			continue
+		}
+		mqlAddr.(*mqlAwsVpcNatgatewayAddress).natGatewayAddressCache = address
+		mqlAddr.(*mqlAwsVpcNatgatewayAddress).region = region
+		addresses = append(addresses, mqlAddr)
+	}
+
+	mqlNat, err := CreateResource(runtime, ResourceAwsVpcNatgateway,
+		map[string]*llx.RawData{
+			"createdAt":    llx.TimeDataPtr(gw.CreateTime),
+			"natGatewayId": llx.StringDataPtr(gw.NatGatewayId),
+			"state":        llx.StringData(string(gw.State)),
+			"tags":         llx.MapData(toInterfaceMap(ec2TagsToMap(gw.Tags)), types.String),
+			"addresses":    llx.ArrayData(addresses, types.Type(ResourceAwsVpcNatgatewayAddress)),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlNat.(*mqlAwsVpcNatgateway).natGatewayCache = gw
+	mqlNat.(*mqlAwsVpcNatgateway).region = region
+	return mqlNat.(*mqlAwsVpcNatgateway), nil
+}
+
+func initAwsVpcNatgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	// A targeted lookup needs both the NAT gateway id and its region (the id
+	// does not encode a region). Without them, hand back a bare resource.
+	if args["natGatewayId"] == nil || args["region"] == nil {
+		return args, nil, nil
+	}
+	natID, _ := args["natGatewayId"].Value.(string)
+	region, _ := args["region"].Value.(string)
+	if natID == "" || region == "" {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeNatGateways(context.Background(), &ec2.DescribeNatGatewaysInput{
+		NatGatewayIds: []string{natID},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(resp.NatGateways) == 0 {
+		return args, nil, nil
+	}
+	mqlNat, err := newMqlAwsVpcNatgateway(runtime, region, resp.NatGateways[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlNat, nil
 }
 
 func (a *mqlAwsVpcEndpoint) id() (string, error) {
@@ -822,6 +863,52 @@ func (a *mqlAwsVpcRoutetableRoute) networkInterface() (*mqlAwsEc2Networkinterfac
 		return nil, err
 	}
 	return res.(*mqlAwsEc2Networkinterface), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) natGateway() (*mqlAwsVpcNatgateway, error) {
+	natID := a.NatGatewayId.Data
+	if natID == "" {
+		a.NatGateway.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsVpcNatgateway,
+		map[string]*llx.RawData{"natGatewayId": llx.StringData(natID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcNatgateway), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) instance() (*mqlAwsEc2Instance, error) {
+	instanceID := a.InstanceId.Data
+	if instanceID == "" {
+		a.Instance.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(ec2InstanceArnPattern, a.region, conn.AccountId(), instanceID)
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Instance,
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Instance), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) managedPrefixList() (*mqlAwsEc2ManagedPrefixList, error) {
+	plID := a.DestinationPrefixListId.Data
+	if plID == "" {
+		a.ManagedPrefixList.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(prefixListArnPattern, a.region, conn.AccountId(), plID)
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2ManagedPrefixList,
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2ManagedPrefixList), nil
 }
 
 func (a *mqlAwsVpcRoutetable) routeEntries() ([]any, error) {
@@ -1888,35 +1975,7 @@ func (a *mqlAwsVpcSubnet) natGateway() (*mqlAwsVpcNatgateway, error) {
 	// Find an active NAT gateway
 	for _, gw := range resp.NatGateways {
 		if gw.State == vpctypes.NatGatewayStateAvailable || gw.State == vpctypes.NatGatewayStatePending {
-			addresses := []any{}
-			for _, address := range gw.NatGatewayAddresses {
-				mqlAddr, err := CreateResource(a.MqlRuntime, ResourceAwsVpcNatgatewayAddress,
-					map[string]*llx.RawData{
-						"allocationId":       llx.StringDataPtr(address.AllocationId),
-						"networkInterfaceId": llx.StringDataPtr(address.NetworkInterfaceId),
-						"privateIp":          llx.StringDataPtr(address.PrivateIp),
-						"isPrimary":          llx.BoolDataPtr(address.IsPrimary),
-					})
-				if err == nil {
-					mqlAddr.(*mqlAwsVpcNatgatewayAddress).natGatewayAddressCache = address
-					mqlAddr.(*mqlAwsVpcNatgatewayAddress).region = a.Region.Data
-					addresses = append(addresses, mqlAddr)
-				}
-			}
-			mqlNatGw, err := CreateResource(a.MqlRuntime, ResourceAwsVpcNatgateway,
-				map[string]*llx.RawData{
-					"createdAt":    llx.TimeDataPtr(gw.CreateTime),
-					"natGatewayId": llx.StringDataPtr(gw.NatGatewayId),
-					"state":        llx.StringData(string(gw.State)),
-					"tags":         llx.MapData(toInterfaceMap(ec2TagsToMap(gw.Tags)), types.String),
-					"addresses":    llx.ArrayData(addresses, types.Type(ResourceAwsVpcNatgatewayAddress)),
-				})
-			if err != nil {
-				return nil, err
-			}
-			mqlNatGw.(*mqlAwsVpcNatgateway).natGatewayCache = gw
-			mqlNatGw.(*mqlAwsVpcNatgateway).region = a.Region.Data
-			return mqlNatGw.(*mqlAwsVpcNatgateway), nil
+			return newMqlAwsVpcNatgateway(a.MqlRuntime, a.Region.Data, gw)
 		}
 	}
 	a.NatGateway.State = plugin.StateIsNull | plugin.StateIsSet

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -297,17 +297,24 @@ func newMqlAwsVpcNatgateway(runtime *plugin.Runtime, region string, gw vpctypes.
 }
 
 func initAwsVpcNatgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// region is a lookup hint, not a schema field on aws.vpc.natgateway. Pull it
+	// out of args before any fallthrough so SetAllData never tries to apply it.
+	var region string
+	if r := args["region"]; r != nil {
+		region, _ = r.Value.(string)
+		delete(args, "region")
+	}
+
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 	// A targeted lookup needs both the NAT gateway id and its region (the id
 	// does not encode a region). Without them, hand back a bare resource.
-	if args["natGatewayId"] == nil || args["region"] == nil {
+	if args["natGatewayId"] == nil || region == "" {
 		return args, nil, nil
 	}
 	natID, _ := args["natGatewayId"].Value.(string)
-	region, _ := args["region"].Value.(string)
-	if natID == "" || region == "" {
+	if natID == "" {
 		return args, nil, nil
 	}
 


### PR DESCRIPTION
## What

The route table route resource is the most under-connected resource in the provider (12 raw id fields). This wires up the modeled targets so audits can traverse from a route to what it routes to.

| Field | Now (typed) | Target |
|---|---|---|
| `natGatewayId` | `natGateway` | `aws.vpc.natgateway` |
| `instanceId` | `instance` | `aws.ec2.instance` |
| `destinationPrefixListId` | `managedPrefixList` | `aws.ec2.managedPrefixList` |

`aws.vpc.natgateway` had **no `init`**, so it could not be resolved standalone via `NewResource`. This PR adds `initAwsVpcNatgateway` (targeted `DescribeNatGateways` by id + region) and extracts a shared `newMqlAwsVpcNatgateway` builder, reused by the two existing natgateway creation sites — so NAT gateways are now resolvable provider-wide, not just from routes. The instance / prefix-list ARNs are built from the route's region + account via `ec2InstanceArnPattern` and a new `prefixListArnPattern` (added to the central ARN list in `aws.go`).

Raw fields are kept but marked `@maturity("deprecated")`. No new IAM permissions (`DescribeNatGateways` was already used; `aws.permissions.json` unchanged at 930).

## Example

```mql
aws.vpcs {
  routeTables { routeEntries { natGateway { state subnet { id } } } }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account:
- `aws.vpcs.natGateways` still lists correctly after the builder refactor.
- `route.natGateway` resolved the NAT gateway (`state: available`) for routes carrying a `nat-…` id, and returned `null` for routes without one.

`make providers/build/aws` passes; generated code regenerated (new entries at 13.41.1).

## Deferred

`transitGatewayId` and `vpcPeeringConnectionId` route targets also lack `init` functions on `aws.ec2.transitgateway` / `aws.vpc.peeringConnection`; adding those inits is a follow-up (not verifiable against the current test account). The `gatewayId` field is value-polymorphic (internet/vpn/local gateway, and internet gateways aren't modeled) and is left as-is.
