### PR TITLE
⭐ aws: add FSx filesystem cross-references

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -54,6 +54,7 @@ const (
 	apiVpcLinkArnPattern          = "arn:aws:apigateway:%s:%s::/vpclinks/%s"
 	transitGatewayArnPattern      = "arn:aws:ec2:%s:%s:transit-gateway/%s"
 	efsFilesystemArnPattern       = "arn:aws:elasticfilesystem:%s:%s:file-system/%s"
+	fsxFilesystemArnPattern       = "arn:aws:fsx:%s:%s:file-system/%s"
 )
 
 func NewSecurityGroupArn(region, accountID, sgID string) string {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1649,7 +1649,11 @@ private aws.fsx.backup @defaults("backupId type lifecycle") {
   // Lifecycle status
   lifecycle string
   // Associated file system ID
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // File system this backup was taken from
+  fileSystem() aws.fsx.filesystem
   // File system type
   fileSystemType string
   // KMS key ID used for encryption
@@ -1675,7 +1679,11 @@ private aws.fsx.volume @defaults("id name lifecycle region") {
   // Volume name
   name string
   // Associated file system ID
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // File system this volume belongs to
+  fileSystem() aws.fsx.filesystem
   // Volume type (ONTAP or OPENZFS)
   volumeType string
   // Lifecycle status (AVAILABLE, CREATING, DELETING, FAILED, MISCONFIGURED, PENDING)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6381,6 +6381,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.fsx.backup.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxBackup).GetFileSystemId()).ToDataRes(types.String)
 	},
+	"aws.fsx.backup.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsFsxBackup).GetFileSystem()).ToDataRes(types.Resource("aws.fsx.filesystem"))
+	},
 	"aws.fsx.backup.fileSystemType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxBackup).GetFileSystemType()).ToDataRes(types.String)
 	},
@@ -6410,6 +6413,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.fsx.volume.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxVolume).GetFileSystemId()).ToDataRes(types.String)
+	},
+	"aws.fsx.volume.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsFsxVolume).GetFileSystem()).ToDataRes(types.Resource("aws.fsx.filesystem"))
 	},
 	"aws.fsx.volume.volumeType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsFsxVolume).GetVolumeType()).ToDataRes(types.String)
@@ -36445,6 +36451,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsFsxBackup).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.fsx.backup.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsFsxBackup).FileSystem, ok = plugin.RawToTValue[*mqlAwsFsxFilesystem](v.Value, v.Error)
+		return
+	},
 	"aws.fsx.backup.fileSystemType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsFsxBackup).FileSystemType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -36487,6 +36497,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.fsx.volume.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsFsxVolume).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.fsx.volume.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsFsxVolume).FileSystem, ok = plugin.RawToTValue[*mqlAwsFsxFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.fsx.volume.volumeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83546,6 +83560,7 @@ type mqlAwsFsxBackup struct {
 	Type           plugin.TValue[string]
 	Lifecycle      plugin.TValue[string]
 	FileSystemId   plugin.TValue[string]
+	FileSystem     plugin.TValue[*mqlAwsFsxFilesystem]
 	FileSystemType plugin.TValue[string]
 	KmsKeyId       plugin.TValue[string]
 	KmsKey         plugin.TValue[*mqlAwsKmsKey]
@@ -83611,6 +83626,22 @@ func (c *mqlAwsFsxBackup) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
 }
 
+func (c *mqlAwsFsxBackup) GetFileSystem() *plugin.TValue[*mqlAwsFsxFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsFsxFilesystem](&c.FileSystem, func() (*mqlAwsFsxFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.fsx.backup", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsFsxFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
+}
+
 func (c *mqlAwsFsxBackup) GetFileSystemType() *plugin.TValue[string] {
 	return &c.FileSystemType
 }
@@ -83656,6 +83687,7 @@ type mqlAwsFsxVolume struct {
 	Arn                                  plugin.TValue[string]
 	Name                                 plugin.TValue[string]
 	FileSystemId                         plugin.TValue[string]
+	FileSystem                           plugin.TValue[*mqlAwsFsxFilesystem]
 	VolumeType                           plugin.TValue[string]
 	Lifecycle                            plugin.TValue[string]
 	StorageVirtualMachineId              plugin.TValue[string]
@@ -83730,6 +83762,22 @@ func (c *mqlAwsFsxVolume) GetName() *plugin.TValue[string] {
 
 func (c *mqlAwsFsxVolume) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
+}
+
+func (c *mqlAwsFsxVolume) GetFileSystem() *plugin.TValue[*mqlAwsFsxFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsFsxFilesystem](&c.FileSystem, func() (*mqlAwsFsxFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.fsx.volume", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsFsxFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
 }
 
 func (c *mqlAwsFsxVolume) GetVolumeType() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5097,6 +5097,7 @@ aws.fsx.backup 11.15.2
 aws.fsx.backup.arn 11.15.2
 aws.fsx.backup.backupId 11.15.2
 aws.fsx.backup.createdAt 11.15.2
+aws.fsx.backup.fileSystem 13.41.1
 aws.fsx.backup.fileSystemId 11.15.2
 aws.fsx.backup.fileSystemType 11.15.2
 aws.fsx.backup.kmsKey 11.16.1
@@ -5141,6 +5142,7 @@ aws.fsx.filesystem.vpcId 11.15.2
 aws.fsx.volume 11.15.2
 aws.fsx.volume.arn 11.15.2
 aws.fsx.volume.createdAt 11.15.2
+aws.fsx.volume.fileSystem 13.41.1
 aws.fsx.volume.fileSystemId 11.15.2
 aws.fsx.volume.id 11.15.2
 aws.fsx.volume.lifecycle 11.15.2

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -546,12 +546,44 @@ func (a *mqlAwsFsxBackup) kmsKey() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+func (a *mqlAwsFsxBackup) fileSystem() (*mqlAwsFsxFilesystem, error) {
+	fsID := a.FileSystemId.Data
+	if fsID == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(fsxFilesystemArnPattern, a.Region.Data, conn.AccountId(), fsID)
+	res, err := NewResource(a.MqlRuntime, "aws.fsx.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsFsxFilesystem), nil
+}
+
 // ========================
 // aws.fsx.volume
 // ========================
 
 func (a *mqlAwsFsxVolume) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsFsxVolume) fileSystem() (*mqlAwsFsxFilesystem, error) {
+	fsID := a.FileSystemId.Data
+	if fsID == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(fsxFilesystemArnPattern, a.Region.Data, conn.AccountId(), fsID)
+	res, err := NewResource(a.MqlRuntime, "aws.fsx.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsFsxFilesystem), nil
 }
 
 func (a *mqlAwsFsx) volumes() ([]any, error) {


### PR DESCRIPTION
## What

Adds typed `aws.fsx.filesystem` accessors to the FSx resources that previously exposed only a raw filesystem id.

| Resource | Was (raw) | Now (typed) |
|---|---|---|
| `aws.fsx.backup` | `fileSystemId` | `fileSystem` |
| `aws.fsx.volume` | `fileSystemId` | `fileSystem` |

Both build the filesystem ARN from their region + account via a new `fsxFilesystemArnPattern` (added to the central ARN list in `aws.go`) and reuse the existing `aws.fsx.filesystem` init (by ARN). The raw `fileSystemId` fields are kept but marked `@maturity("deprecated")`. No new IAM permissions (`aws.permissions.json` unchanged at 930).

## Example

```mql
aws.fsx.backups {
  fileSystem { fileSystemType storageCapacity kmsKey { arn } }
}
```

## Testing

`make providers/build/aws` passes; generated code regenerated (new entries at 13.41.1). The query compiles and runs cleanly, but the test account has no FSx file systems/backups/volumes, so the accessors weren't exercised against live infra — they are mechanically identical to the EFS filesystem accessors verified end-to-end in #8921 (same builder shape, only the ARN service prefix differs).

## Note

`aws.fsx.volume.openzfsParentVolumeId` → `aws.fsx.volume` is left as a follow-up: `aws.fsx.volume` has no `init`, so that self-reference can't resolve until one is added.
