### PR TITLE
⭐ aws: add EC2 image and volume cross-references

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -16012,7 +16012,11 @@ private aws.ec2.launchconfiguration @defaults("name region") {
   // Region for the launch configuration
   region string
   // AMI ID used by the launch configuration
-  imageId string
+  //
+  // Deprecated in favor of `image`.
+  imageId @maturity("deprecated") string
+  // AMI used by the launch configuration
+  image() aws.ec2.image
   // Instance type
   instanceType string
   // Name of the key pair
@@ -16856,7 +16860,11 @@ private aws.ec2.instance.device @defaults("deviceName volumeId status") {
   // Status of the device
   status string
   // Volume ID for the device
-  volumeId string
+  //
+  // Deprecated in favor of `volume`.
+  volumeId @maturity("deprecated") string
+  // EBS volume backing the device
+  volume() aws.ec2.volume
   // Name for the device
   deviceName string
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22374,6 +22374,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.launchconfiguration.imageId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Launchconfiguration).GetImageId()).ToDataRes(types.String)
 	},
+	"aws.ec2.launchconfiguration.image": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Launchconfiguration).GetImage()).ToDataRes(types.Resource("aws.ec2.image"))
+	},
 	"aws.ec2.launchconfiguration.instanceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Launchconfiguration).GetInstanceType()).ToDataRes(types.String)
 	},
@@ -23378,6 +23381,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.instance.device.volumeId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2InstanceDevice).GetVolumeId()).ToDataRes(types.String)
+	},
+	"aws.ec2.instance.device.volume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceDevice).GetVolume()).ToDataRes(types.Resource("aws.ec2.volume"))
 	},
 	"aws.ec2.instance.device.deviceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2InstanceDevice).GetDeviceName()).ToDataRes(types.String)
@@ -59749,6 +59755,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Launchconfiguration).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.launchconfiguration.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Launchconfiguration).Image, ok = plugin.RawToTValue[*mqlAwsEc2Image](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.launchconfiguration.instanceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Launchconfiguration).InstanceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -61199,6 +61209,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.device.volumeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2InstanceDevice).VolumeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.device.volume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceDevice).Volume, ok = plugin.RawToTValue[*mqlAwsEc2Volume](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.device.deviceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -143999,6 +144013,7 @@ type mqlAwsEc2Launchconfiguration struct {
 	Name                      plugin.TValue[string]
 	Region                    plugin.TValue[string]
 	ImageId                   plugin.TValue[string]
+	Image                     plugin.TValue[*mqlAwsEc2Image]
 	InstanceType              plugin.TValue[string]
 	KeyName                   plugin.TValue[string]
 	SecurityGroups            plugin.TValue[[]any]
@@ -144064,6 +144079,22 @@ func (c *mqlAwsEc2Launchconfiguration) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Launchconfiguration) GetImageId() *plugin.TValue[string] {
 	return &c.ImageId
+}
+
+func (c *mqlAwsEc2Launchconfiguration) GetImage() *plugin.TValue[*mqlAwsEc2Image] {
+	return plugin.GetOrCompute[*mqlAwsEc2Image](&c.Image, func() (*mqlAwsEc2Image, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.launchconfiguration", c.__id, "image")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Image), nil
+			}
+		}
+
+		return c.image()
+	})
 }
 
 func (c *mqlAwsEc2Launchconfiguration) GetInstanceType() *plugin.TValue[string] {
@@ -147405,10 +147436,11 @@ func (c *mqlAwsEc2InstanceExposure) GetInternetFacingLoadBalancers() *plugin.TVa
 type mqlAwsEc2InstanceDevice struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2InstanceDeviceInternal it will be used here
+	mqlAwsEc2InstanceDeviceInternal
 	DeleteOnTermination plugin.TValue[bool]
 	Status              plugin.TValue[string]
 	VolumeId            plugin.TValue[string]
+	Volume              plugin.TValue[*mqlAwsEc2Volume]
 	DeviceName          plugin.TValue[string]
 }
 
@@ -147459,6 +147491,22 @@ func (c *mqlAwsEc2InstanceDevice) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2InstanceDevice) GetVolumeId() *plugin.TValue[string] {
 	return &c.VolumeId
+}
+
+func (c *mqlAwsEc2InstanceDevice) GetVolume() *plugin.TValue[*mqlAwsEc2Volume] {
+	return plugin.GetOrCompute[*mqlAwsEc2Volume](&c.Volume, func() (*mqlAwsEc2Volume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.instance.device", c.__id, "volume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Volume), nil
+			}
+		}
+
+		return c.volume()
+	})
 }
 
 func (c *mqlAwsEc2InstanceDevice) GetDeviceName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3092,6 +3092,7 @@ aws.ec2.instance.device 11.15.2
 aws.ec2.instance.device.deleteOnTermination 11.15.2
 aws.ec2.instance.device.deviceName 11.15.2
 aws.ec2.instance.device.status 11.15.2
+aws.ec2.instance.device.volume 13.41.1
 aws.ec2.instance.device.volumeId 11.15.2
 aws.ec2.instance.deviceMappings 11.15.2
 aws.ec2.instance.disableApiTermination 11.15.2
@@ -3286,6 +3287,7 @@ aws.ec2.launchconfiguration.ebsBlockDevice.volumeSize 13.6.0
 aws.ec2.launchconfiguration.ebsBlockDevice.volumeType 13.6.0
 aws.ec2.launchconfiguration.ebsOptimized 13.6.0
 aws.ec2.launchconfiguration.iamInstanceProfile 13.6.0
+aws.ec2.launchconfiguration.image 13.41.1
 aws.ec2.launchconfiguration.imageId 13.6.0
 aws.ec2.launchconfiguration.instanceType 13.6.0
 aws.ec2.launchconfiguration.keyName 13.6.0

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1322,6 +1322,7 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			if err != nil {
 				return nil, err
 			}
+			mqlInstanceDevice.(*mqlAwsEc2InstanceDevice).region = regionVal
 			mqlDevices = append(mqlDevices, mqlInstanceDevice)
 		}
 
@@ -2222,8 +2223,28 @@ func anyStringEquals(list []any, target string) bool {
 	return false
 }
 
+type mqlAwsEc2InstanceDeviceInternal struct {
+	region string
+}
+
 func (a *mqlAwsEc2InstanceDevice) id() (string, error) {
 	return a.VolumeId.Data, nil
+}
+
+func (a *mqlAwsEc2InstanceDevice) volume() (*mqlAwsEc2Volume, error) {
+	volumeID := a.VolumeId.Data
+	if volumeID == "" {
+		a.Volume.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(volumeArnPattern, a.region, conn.AccountId(), volumeID)
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Volume,
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Volume), nil
 }
 
 func (a *mqlAwsEc2Instance) id() (string, error) {

--- a/providers/aws/resources/aws_ec2_launchconfiguration.go
+++ b/providers/aws/resources/aws_ec2_launchconfiguration.go
@@ -29,6 +29,22 @@ func (a *mqlAwsEc2Launchconfiguration) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsEc2Launchconfiguration) image() (*mqlAwsEc2Image, error) {
+	imageID := a.ImageId.Data
+	if imageID == "" {
+		a.Image.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(imageArnPattern, a.Region.Data, conn.AccountId(), imageID)
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Image,
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Image), nil
+}
+
 func (a *mqlAwsEc2LaunchconfigurationBlockDeviceMapping) id() (string, error) {
 	return a.DeviceName.Data, nil
 }


### PR DESCRIPTION
## What

Resolves raw AMI / volume id strings to their modeled resources.

| Resource | Was (raw) | Now (typed) | Target |
|---|---|---|---|
| `aws.ec2.instance.device` | `volumeId` | `volume` | `aws.ec2.volume` |
| `aws.ec2.launchconfiguration` | `imageId` | `image` | `aws.ec2.image` |

Both build the target ARN from region + account via the existing `volumeArnPattern` / `imageArnPattern` and reuse the target inits. The instance device sub-resource carries no region of its own, so the parent instance's region is threaded onto it via a new `mqlAwsEc2InstanceDeviceInternal{region}` field (set in `gatherInstanceInfo`). Raw id fields are kept but marked `@maturity("deprecated")`. No new IAM permissions (`aws.permissions.json` unchanged at 930).

## Example

```mql
aws.ec2.instances {
  deviceMappings { volume { size encrypted kmsKey { arn } } }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account: `aws.ec2.instance.device.volume` resolved each EBS volume and returned its real `size` (16/8/10 GiB). `make providers/build/aws` passes; generated code regenerated (new entries at 13.41.1). `launchconfiguration.image` uses the same shape but wasn't exercised live (no launch configurations in the account).

## Deferred

`aws.ec2.image.watermark.sourceImageId` → `aws.ec2.image` also fits here but the watermark sub-resource needs region threading and is rarely populated; left as a follow-up.
