### PR TITLE
⭐ aws: add kmsKeys cross-reference on secret versions

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7123,6 +7123,8 @@ private aws.secretsmanager.secret.version @defaults("versionId versionStages") {
   lastAccessedDate time
   // KMS key IDs used to encrypt this version
   kmsKeyIds []string
+  // KMS keys used to encrypt this version
+  kmsKeys() []aws.kms.key
 }
 
 // AWS Secrets Manager secret rotation rules configuration

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12696,6 +12696,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.secretsmanager.secret.version.kmsKeyIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecretVersion).GetKmsKeyIds()).ToDataRes(types.Array(types.String))
 	},
+	"aws.secretsmanager.secret.version.kmsKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecretVersion).GetKmsKeys()).ToDataRes(types.Array(types.Resource("aws.kms.key")))
+	},
 	"aws.secretsmanager.secret.rotationRules.automaticallyAfterDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecretRotationRules).GetAutomaticallyAfterDays()).ToDataRes(types.Int)
 	},
@@ -45635,6 +45638,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.secretsmanager.secret.version.kmsKeyIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecretVersion).KmsKeyIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.secretsmanager.secret.version.kmsKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecretVersion).KmsKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.secretsmanager.secret.rotationRules.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -107604,12 +107611,13 @@ func (c *mqlAwsSecretsmanagerSecretReplicaRegion) GetLastAccessedDate() *plugin.
 type mqlAwsSecretsmanagerSecretVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsSecretsmanagerSecretVersionInternal it will be used here
+	mqlAwsSecretsmanagerSecretVersionInternal
 	VersionId        plugin.TValue[string]
 	VersionStages    plugin.TValue[[]any]
 	CreatedDate      plugin.TValue[*time.Time]
 	LastAccessedDate plugin.TValue[*time.Time]
 	KmsKeyIds        plugin.TValue[[]any]
+	KmsKeys          plugin.TValue[[]any]
 }
 
 // createAwsSecretsmanagerSecretVersion creates a new instance of this resource
@@ -107662,6 +107670,22 @@ func (c *mqlAwsSecretsmanagerSecretVersion) GetLastAccessedDate() *plugin.TValue
 
 func (c *mqlAwsSecretsmanagerSecretVersion) GetKmsKeyIds() *plugin.TValue[[]any] {
 	return &c.KmsKeyIds
+}
+
+func (c *mqlAwsSecretsmanagerSecretVersion) GetKmsKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.KmsKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.secretsmanager.secret.version", c.__id, "kmsKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.kmsKeys()
+	})
 }
 
 // mqlAwsSecretsmanagerSecretRotationRules for the aws.secretsmanager.secret.rotationRules resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -9213,6 +9213,7 @@ aws.secretsmanager.secret.type 13.12.1
 aws.secretsmanager.secret.version 13.12.1
 aws.secretsmanager.secret.version.createdDate 13.12.1
 aws.secretsmanager.secret.version.kmsKeyIds 13.12.1
+aws.secretsmanager.secret.version.kmsKeys 13.41.1
 aws.secretsmanager.secret.version.lastAccessedDate 13.12.1
 aws.secretsmanager.secret.version.versionId 13.12.1
 aws.secretsmanager.secret.version.versionStages 13.12.1

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -402,8 +403,43 @@ func (a *mqlAwsSecretsmanagerSecret) versions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlVersion.(*mqlAwsSecretsmanagerSecretVersion).region = region
+			mqlVersion.(*mqlAwsSecretsmanagerSecretVersion).accountID = conn.AccountId()
 			res = append(res, mqlVersion)
 		}
+	}
+	return res, nil
+}
+
+type mqlAwsSecretsmanagerSecretVersionInternal struct {
+	region    string
+	accountID string
+}
+
+func (a *mqlAwsSecretsmanagerSecretVersion) kmsKeys() ([]any, error) {
+	res := []any{}
+	for _, idAny := range a.KmsKeyIds.Data {
+		keyID, ok := idAny.(string)
+		if !ok || keyID == "" {
+			continue
+		}
+		// Versions encrypted with the AWS-managed secrets manager key report the
+		// literal "DefaultEncryptionKey" sentinel rather than a resolvable key id.
+		if keyID == "DefaultEncryptionKey" {
+			continue
+		}
+		// KmsKeyIds may already be full ARNs or bare key ids; build an ARN from
+		// the version's region + account only when it isn't one already.
+		arnStr := keyID
+		if !strings.HasPrefix(keyID, "arn:") {
+			arnStr = fmt.Sprintf(kmsKeyArnPattern, a.region, a.accountID, keyID)
+		}
+		mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+			map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlKey)
 	}
 	return res, nil
 }


### PR DESCRIPTION
## What

Adds `aws.secretsmanager.secret.version.kmsKeys`, resolving the raw `kmsKeyIds` list to `[]aws.kms.key` so audits can inspect the encrypting keys' rotation status, key policy, manager, etc.

The raw `kmsKeyIds` list is **kept** (it carries the ids and their order) alongside the new typed accessor, per the list-field convention. Each id builds a KMS key ARN from the version's region + account — threaded from the parent secret via a new `mqlAwsSecretsmanagerSecretVersionInternal` struct — unless the entry is already an ARN.

Versions encrypted with the AWS-managed secrets manager key report the literal `"DefaultEncryptionKey"` sentinel rather than a resolvable key id; that value is skipped instead of being attempted (which would 400 on `kms:DescribeKey`). No new IAM permissions (`aws.permissions.json` unchanged at 930).

## Example

```mql
aws.secretsmanager.secrets {
  versions { kmsKeys { keyRotationEnabled keyManager } }
}
```

## Testing

Built and installed the provider, verified end-to-end against a live account: for a secret whose version reports `kmsKeyIds: ["DefaultEncryptionKey"]`, `kmsKeys` correctly resolves to `[]` (the sentinel is skipped) and the query runs without error. A customer-managed key id/ARN would resolve to the corresponding `aws.kms.key`. `make providers/build/aws` passes; generated code regenerated (new entry at 13.41.1).
