### PR TITLE
⭐ aws: add ECS EFS volume filesystem cross-reference

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7798,7 +7798,11 @@ private aws.ecs.taskDefinition.volume {
 // Amazon ECS Task Definition Volume EFS Configuration
 private aws.ecs.taskDefinition.volume.efsVolumeConfiguration {
   // ID of the EFS file system
-  fileSystemId string
+  //
+  // Deprecated in favor of `fileSystem`.
+  fileSystemId @maturity("deprecated") string
+  // EFS file system this volume mounts
+  fileSystem() aws.efs.filesystem
   // Directory within the EFS file system to mount
   rootDirectory string
   // Whether to enable encryption in transit (ENABLED, DISABLED)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -13485,6 +13485,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).GetFileSystemId()).ToDataRes(types.String)
 	},
+	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).GetFileSystem()).ToDataRes(types.Resource("aws.efs.filesystem"))
+	},
 	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.rootDirectory": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).GetRootDirectory()).ToDataRes(types.String)
 	},
@@ -46783,6 +46786,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).FileSystem, ok = plugin.RawToTValue[*mqlAwsEfsFilesystem](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.taskDefinition.volume.efsVolumeConfiguration.rootDirectory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -110540,8 +110547,9 @@ func (c *mqlAwsEcsTaskDefinitionVolume) GetS3filesVolumeConfiguration() *plugin.
 type mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfigurationInternal it will be used here
+	mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfigurationInternal
 	FileSystemId          plugin.TValue[string]
+	FileSystem            plugin.TValue[*mqlAwsEfsFilesystem]
 	RootDirectory         plugin.TValue[string]
 	TransitEncryption     plugin.TValue[string]
 	TransitEncryptionPort plugin.TValue[int64]
@@ -110587,6 +110595,22 @@ func (c *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) MqlID() string {
 
 func (c *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
+}
+
+func (c *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) GetFileSystem() *plugin.TValue[*mqlAwsEfsFilesystem] {
+	return plugin.GetOrCompute[*mqlAwsEfsFilesystem](&c.FileSystem, func() (*mqlAwsEfsFilesystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.taskDefinition.volume.efsVolumeConfiguration", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEfsFilesystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
 }
 
 func (c *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) GetRootDirectory() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3921,6 +3921,7 @@ aws.ecs.taskDefinition.volume.efsVolumeConfiguration 11.15.2
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig 11.15.2
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig.accessPointId 11.15.2
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig.iam 11.15.2
+aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystem 13.41.1
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystemId 11.15.2
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.rootDirectory 11.15.2
 aws.ecs.taskDefinition.volume.efsVolumeConfiguration.transitEncryption 11.15.2

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -922,7 +922,7 @@ func createTaskDefinitionResource(runtime *plugin.Runtime, region string, td *ec
 	// Create volumes
 	volumes := []any{}
 	for i := range td.Volumes {
-		mqlVolume, err := createVolumeResource(runtime, &td.Volumes[i])
+		mqlVolume, err := createVolumeResource(runtime, region, &td.Volumes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -1218,7 +1218,7 @@ func createContainerDefinitionResource(runtime *plugin.Runtime, taskDefArn strin
 		})
 }
 
-func createVolumeResource(runtime *plugin.Runtime, vol *ecstypes.Volume) (any, error) {
+func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.Volume) (any, error) {
 	volName := ""
 	if vol.Name != nil {
 		volName = *vol.Name
@@ -1291,6 +1291,7 @@ func createVolumeResource(runtime *plugin.Runtime, vol *ecstypes.Volume) (any, e
 		if err != nil {
 			return nil, err
 		}
+		mqlEfsConfig.(*mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration).region = region
 		efsVolConfig = mqlEfsConfig
 	} else {
 		// Create empty EFS config
@@ -1781,7 +1782,7 @@ func (a *mqlAwsEcsTaskDefinition) volumes() ([]any, error) {
 	}
 	volumes := []any{}
 	for i := range td.Volumes {
-		mqlVolume, err := createVolumeResource(a.MqlRuntime, &td.Volumes[i])
+		mqlVolume, err := createVolumeResource(a.MqlRuntime, a.Region.Data, &td.Volumes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -1936,8 +1937,28 @@ func (a *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) authorizationConfi
 	return a.AuthorizationConfig.Data, nil
 }
 
+type mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfigurationInternal struct {
+	region string
+}
+
 func (a *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) id() (string, error) {
 	return a.__id, nil
+}
+
+func (a *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfiguration) fileSystem() (*mqlAwsEfsFilesystem, error) {
+	fsID := a.FileSystemId.Data
+	if fsID == "" {
+		a.FileSystem.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	arnStr := fmt.Sprintf(efsFilesystemArnPattern, a.region, conn.AccountId(), fsID)
+	res, err := NewResource(a.MqlRuntime, "aws.efs.filesystem",
+		map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEfsFilesystem), nil
 }
 
 func (a *mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfigurationAuthorizationConfig) id() (string, error) {


### PR DESCRIPTION
## What

Adds `aws.ecs.taskDefinition.volume.efsVolumeConfiguration.fileSystem`, resolving the raw `fileSystemId` to the modeled `aws.efs.filesystem` so audits can check the mounted filesystem's encryption, backup policy, access points, etc. directly from a task definition.

The EFS volume config sub-resource carries no region of its own, so the task definition's region is threaded through `createVolumeResource` (both call sites already have it) onto a new `mqlAwsEcsTaskDefinitionVolumeEfsVolumeConfigurationInternal{region}` field, and the EFS ARN is built from region + account. The raw `fileSystemId` is kept but marked `@maturity("deprecated")`. No new IAM permissions (`aws.permissions.json` unchanged at 930).

## Example

```mql
aws.ecs.taskDefinitions {
  volumes { efsVolumeConfiguration { fileSystem { encrypted kmsKey { arn } } } }
}
```

## Testing

`make providers/build/aws` passes; generated code regenerated (new entry at 13.41.1). The query compiles and runs cleanly against a live account (4 task definitions), but none mount EFS volumes, so the accessor wasn't exercised against live infra — it uses the same EFS-ARN resolution verified end-to-end in #8921, with region threading identical to #8924/#8927.

## Deferred

`aws.sagemaker.trainingjob.channel.fileSystemId` is the other cross-service filesystem reference, but a training channel's file system is **either** EFS or FSx (per its `FileSystemType`), so it needs a discriminator and two separate typed accessors rather than one; left as a follow-up.
