### PR TITLE
🎉 aws-13.43.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.42.0",
+	Version:         "13.43.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.43.0)
- ⭐ aws: add FSx filesystem cross-references (#8925)
- ⭐ aws: add EC2 image and volume cross-references (#8926)
- ⭐ aws: add kmsKeys cross-reference on secret versions (#8927)
- ⭐ aws: add ECS EFS volume filesystem cross-reference (#8928)