### PR TITLE
🐛 terraform: serialize HCL cache build and block creation

### DIFF
--- a/providers/terraform/connection/connection.go
+++ b/providers/terraform/connection/connection.go
@@ -40,7 +40,23 @@ type Connection struct {
 	// built only once per connection. Guarded by varCtxOnce.
 	varCtx     *hcl.EvalContext
 	varCtxOnce sync.Once
+
+	// hclCache carries the resources package's one-time HCL block
+	// classification for this connection as an opaque handle — owned and
+	// synchronized entirely by that package. It lives on the connection so
+	// the state is built once per asset (resource instances may be
+	// duplicated by the runtime registry) and is released together with the
+	// connection on disconnect.
+	hclCache any
 }
+
+// HclCache returns the classification handle stored via SetHclCache, or nil.
+// Synchronization is the caller's responsibility.
+func (c *Connection) HclCache() any { return c.hclCache }
+
+// SetHclCache stores the resources package's HCL block classification.
+// Synchronization is the caller's responsibility.
+func (c *Connection) SetHclCache(cache any) { c.hclCache = cache }
 
 // SetFeatures stores the active MQL feature-flag bitset on the connection.
 func (c *Connection) SetFeatures(features []byte) {

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -30,9 +30,22 @@ type mqlTerraformInternal struct {
 	relatedBlocks map[string][]*mqlTerraformBlock
 	// these are blocks with the type set to "terraform", used for settings
 	terraformBlocks []*mqlTerraformBlock
-	lock            sync.Mutex
-	resources       []*mqlTerraformBlock
+	// resource-type blocks, handed to terraform.resources' init
+	resources []*mqlTerraformBlock
 }
+
+// hclStateLock serializes the cache builds in refreshCache and every
+// listHclBlocks call across the whole provider. It guards two things at
+// once: the mqlTerraformInternal fields above, and the terraform.block
+// instances themselves — blocks are deduped through the runtime's resource
+// registry with a non-atomic get-then-set and are initialized in place, so
+// concurrent listings would both duplicate registry entries and mutate
+// instances another goroutine is reading. A single process-wide mutex is
+// deliberately coarse but safe: builds are one-shot per asset and block
+// listings are cheap, static HCL walks. (It also covers the case where the
+// registry's get-then-set hands out two `terraform` instances — a
+// per-instance lock would then guard nothing.)
+var hclStateLock sync.Mutex
 
 func (t *mqlTerraform) files() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
@@ -95,71 +108,71 @@ func (t *mqlTerraform) modules() ([]any, error) {
 }
 
 func (t *mqlTerraform) blocks() ([]any, error) {
-	conn := t.MqlRuntime.Connection.(*connection.Connection)
-	parser := conn.Parser()
-	if parser == nil {
-		return []any{}, nil
-	}
-
-	files := parser.Files()
-	mqlHclBlocks := make([]any, 0)
-	for k := range files {
-		f := files[k]
-		blocks, err := listHclBlocks(t.MqlRuntime, f.Body, f)
-		if err != nil {
-			return nil, err
-		}
-		mqlHclBlocks = append(mqlHclBlocks, blocks...)
-	}
-
-	return mqlHclBlocks, t.refreshCache(mqlHclBlocks)
+	// The guarded build proactively sets Blocks (and the other collection
+	// fields), so the generated accessor picks the value up from the cache.
+	return nil, t.refreshCache()
 }
 
-func (t *mqlTerraform) refreshCache(blocks []any) error {
-	if blocks == nil {
-		raw := t.GetBlocks()
-		return raw.Error
-	}
-
-	t.lock.Lock()
-	defer t.lock.Unlock()
+// refreshCache parses the connection's HCL files and classifies every block
+// exactly once per asset. It is the single guarded builder behind all of the
+// generated collection accessors (blocks, providers, datasources, variables,
+// outputs) and terraform.resources' init: everything is assembled in locals
+// and only published — the collection fields proactively, the guard map last
+// — once the build fully succeeded. Concurrent callers serialize on the lock
+// and find the guard set, so blocks are created and initialized by exactly
+// one goroutine, and a failed build publishes nothing and is retried by the
+// next caller.
+func (t *mqlTerraform) refreshCache() error {
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
 	if t.blocksByName != nil {
 		return nil
 	}
 
-	t.blocksByName = map[string]*mqlTerraformBlock{}
-	t.relatedBlocks = map[string][]*mqlTerraformBlock{}
+	conn := t.MqlRuntime.Connection.(*connection.Connection)
 
-	t.Providers.State = plugin.StateIsSet
-	t.Providers.Data = []any{}
-	t.Datasources.State = plugin.StateIsSet
-	t.Datasources.Data = []any{}
-	t.mqlTerraformInternal.resources = []*mqlTerraformBlock{}
-	t.Variables.State = plugin.StateIsSet
-	t.Variables.Data = []any{}
-	t.Outputs.State = plugin.StateIsSet
-	t.Outputs.Data = []any{}
-	t.terraformBlocks = []*mqlTerraformBlock{}
+	// plan and state assets have no HCL parser; publish empty collections.
+	mqlHclBlocks := []any{}
+	if parser := conn.Parser(); parser != nil {
+		files := parser.Files()
+		for k := range files {
+			f := files[k]
+			blocks, err := listHclBlocks(t.MqlRuntime, f.Body, f)
+			if err != nil {
+				return err
+			}
+			mqlHclBlocks = append(mqlHclBlocks, blocks...)
+		}
+	}
 
-	for i := range blocks {
-		block := blocks[i].(*mqlTerraformBlock)
+	blocksByName := map[string]*mqlTerraformBlock{}
+	relatedBlocks := map[string][]*mqlTerraformBlock{}
+	providers := []any{}
+	datasources := []any{}
+	resources := []*mqlTerraformBlock{}
+	variables := []any{}
+	outputs := []any{}
+	terraformBlocks := []*mqlTerraformBlock{}
+
+	for i := range mqlHclBlocks {
+		block := mqlHclBlocks[i].(*mqlTerraformBlock)
 
 		// type must be pre-initialized
 		typ := block.Type.Data
 
 		switch typ {
 		case "provider":
-			t.Providers.Data = append(t.Providers.Data, block)
+			providers = append(providers, block)
 		case "data":
-			t.Datasources.Data = append(t.Datasources.Data, block)
+			datasources = append(datasources, block)
 		case "resource":
-			t.mqlTerraformInternal.resources = append(t.mqlTerraformInternal.resources, block)
+			resources = append(resources, block)
 		case "variable":
-			t.Variables.Data = append(t.Variables.Data, block)
+			variables = append(variables, block)
 		case "output":
-			t.Outputs.Data = append(t.Outputs.Data, block)
+			outputs = append(outputs, block)
 		case "terraform":
-			t.terraformBlocks = append(t.terraformBlocks, block)
+			terraformBlocks = append(terraformBlocks, block)
 		default:
 			// Note: we don't do anything with these blocks yet.
 			// They might be worth looking into.
@@ -167,33 +180,33 @@ func (t *mqlTerraform) refreshCache(blocks []any) error {
 
 		// labels must be pre-initialized
 		name := block.terraformID()
-		t.blocksByName[name] = block
+		blocksByName[name] = block
 	}
 
 	// We need blocks by name before we can jump into
 	// related blocks, because we need to access them
 	// via their name
-	for i := range blocks {
-		block := blocks[i].(*mqlTerraformBlock)
+	for i := range mqlHclBlocks {
+		block := mqlHclBlocks[i].(*mqlTerraformBlock)
 		name := block.terraformID()
 
-		rel, err := listRelatedBlocks(t, block.block.Data.Body)
+		rel, err := listRelatedBlocks(blocksByName, block.block.Data.Body)
 		if err != nil {
 			return err
 		}
 
 		// connect from this block to all related blocks...
-		t.relatedBlocks[name] = append(t.relatedBlocks[name], rel...)
+		relatedBlocks[name] = append(relatedBlocks[name], rel...)
 		// ... and also connect the inverse (related to this block)
 		for i := range rel {
 			relBlock := rel[i]
 			relName := relBlock.terraformID()
-			t.relatedBlocks[relName] = append(t.relatedBlocks[relName], block)
+			relatedBlocks[relName] = append(relatedBlocks[relName], block)
 		}
 	}
 
-	for k, v := range t.relatedBlocks {
-		block, ok := t.blocksByName[k]
+	for k, v := range relatedBlocks {
+		block, ok := blocksByName[k]
 		if !ok {
 			return errors.New("cannot find terraform block by name: " + k)
 		}
@@ -209,10 +222,23 @@ func (t *mqlTerraform) refreshCache(blocks []any) error {
 		}
 	}
 
+	// The build succeeded in full — publish it. The collection fields are
+	// set proactively (their compute methods return nil and the generated
+	// accessors read these cells); the guard map goes last.
+	t.Blocks = plugin.TValue[[]any]{Data: mqlHclBlocks, State: plugin.StateIsSet}
+	t.Providers = plugin.TValue[[]any]{Data: providers, State: plugin.StateIsSet}
+	t.Datasources = plugin.TValue[[]any]{Data: datasources, State: plugin.StateIsSet}
+	t.Variables = plugin.TValue[[]any]{Data: variables, State: plugin.StateIsSet}
+	t.Outputs = plugin.TValue[[]any]{Data: outputs, State: plugin.StateIsSet}
+	t.mqlTerraformInternal.resources = resources
+	t.terraformBlocks = terraformBlocks
+	t.relatedBlocks = relatedBlocks
+	t.blocksByName = blocksByName
+
 	return nil
 }
 
-func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, error) {
+func listRelatedBlocks(blocksByName map[string]*mqlTerraformBlock, rawBody any) ([]*mqlTerraformBlock, error) {
 	var res []*mqlTerraformBlock
 	switch body := rawBody.(type) {
 	case *hclsyntax.Body:
@@ -226,10 +252,10 @@ func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, erro
 			}
 
 			refName := strings.Join(refs[0:2], "\x00")
-			if t.blocksByName[refName] == nil { // do not add nil blocks
+			if blocksByName[refName] == nil { // do not add nil blocks
 				continue
 			}
-			res = append(res, t.blocksByName[refName])
+			res = append(res, blocksByName[refName])
 		}
 	case hcl.Body:
 		return nil, errors.New("cannot yet list related blocks for regular hcl Body")
@@ -238,23 +264,46 @@ func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, erro
 }
 
 func (t *mqlTerraform) providers() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	return nil, t.refreshCache()
 }
 
 func (t *mqlTerraform) datasources() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	return nil, t.refreshCache()
 }
 
 func (t *mqlTerraform) resources() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	return nil, t.refreshCache()
 }
 
 func (t *mqlTerraform) variables() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	return nil, t.refreshCache()
 }
 
 func (t *mqlTerraform) outputs() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	return nil, t.refreshCache()
+}
+
+// resourceBlocks returns the classified resource-type blocks, building the
+// cache if needed. The snapshot is taken under the lock so a caller never
+// observes a partially built list.
+func (t *mqlTerraform) resourceBlocks() ([]*mqlTerraformBlock, error) {
+	if err := t.refreshCache(); err != nil {
+		return nil, err
+	}
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
+	return t.mqlTerraformInternal.resources, nil
+}
+
+// settingsBlocks returns the `terraform { ... }` settings blocks, building
+// the cache if needed; same locking rationale as resourceBlocks.
+func (t *mqlTerraform) settingsBlocks() ([]*mqlTerraformBlock, error) {
+	if err := t.refreshCache(); err != nil {
+		return nil, err
+	}
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
+	return t.terraformBlocks, nil
 }
 
 func extractHclCodeSnippet(file *hcl.File, fileRange hcl.Range) string {
@@ -304,8 +353,14 @@ func newMqlHclBlock(runtime *plugin.Runtime, block *hcl.Block, file *hcl.File) (
 		return nil, err
 	}
 	r := res.(*mqlTerraformBlock)
-	r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
-	r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
+	// The instance is deduped by the resource registry, so a re-listing hands
+	// back a block that is already initialized — leave it untouched then.
+	// Every listHclBlocks call site holds hclStateLock, which is what makes
+	// this check-then-set safe.
+	if r.block.State&plugin.StateIsSet == 0 {
+		r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
+		r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
+	}
 	return r, err
 }
 
@@ -461,10 +516,10 @@ func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	tf := tfraw.(*mqlTerraform)
-	if err := tf.refreshCache(nil); err != nil {
+	resources, err := tf.resourceBlocks()
+	if err != nil {
 		return nil, nil, err
 	}
-	resources := tf.mqlTerraformInternal.resources
 
 	resourceArg := args["resource"]
 	nameArg := args["name"]
@@ -1004,6 +1059,8 @@ func (g *mqlTerraformBlock) blocks() ([]any, error) {
 		return nil, errors.New("cannot get hcl file")
 	}
 
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
 	return listHclBlocks(g.MqlRuntime, hclBlock.Body, hclFile)
 }
 
@@ -1045,7 +1102,7 @@ func (g *mqlTerraformBlock) related() ([]any, error) {
 	}
 
 	terraform := o.(*mqlTerraform)
-	return nil, terraform.refreshCache(nil)
+	return nil, terraform.refreshCache()
 }
 
 func newFilePosRange(runtime *plugin.Runtime, r hcl.Range) (plugin.Resource, plugin.Resource, error) {
@@ -1101,6 +1158,9 @@ func (t *mqlTerraformFile) blocks() ([]any, error) {
 		// or case mismatch); there are no blocks to list rather than a panic.
 		return []any{}, nil
 	}
+
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
 	return listHclBlocks(t.MqlRuntime, file.Body, file)
 }
 
@@ -1123,6 +1183,9 @@ func (t *mqlTerraformModule) block() (*mqlTerraformBlock, error) {
 	}
 
 	files := parser.Files()
+
+	hclStateLock.Lock()
+	defer hclStateLock.Unlock()
 
 	var mqlHclBlock *mqlTerraformBlock
 	for k := range files {
@@ -1158,11 +1221,10 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	terraform := o.(*mqlTerraform)
-	if err := terraform.refreshCache(nil); err != nil {
+	blocks, err := terraform.settingsBlocks()
+	if err != nil {
 		return nil, nil, err
 	}
-
-	blocks := terraform.terraformBlocks
 	if len(blocks) == 0 {
 		// no terraform settings block found, this is ok for terraform and not an error
 		// TODO: return modified arguments to load from recording

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -25,27 +25,60 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+// mqlTerraformInternal is embedded in mqlTerraform by the generated code.
+// The block classification itself lives in an hclCache on the connection,
+// not here: the runtime registry can hand out duplicate mqlTerraform
+// instances, so instance-local state would be built repeatedly and would
+// let readers of one instance race the build of another.
 type mqlTerraformInternal struct {
-	blocksByName  map[string]*mqlTerraformBlock
-	relatedBlocks map[string][]*mqlTerraformBlock
-	// these are blocks with the type set to "terraform", used for settings
-	terraformBlocks []*mqlTerraformBlock
-	// resource-type blocks, handed to terraform.resources' init
-	resources []*mqlTerraformBlock
+	// published tracks whether the cached collections were already copied to
+	// this instance's accessor cells, so the cells are written exactly once
+	// — republishing would race concurrent lock-free accessor reads.
+	// Guarded by hclStateLock.
+	published bool
 }
 
-// hclStateLock serializes the cache builds in refreshCache and every
+// hclCache is the one-time classification of an asset's HCL blocks — the
+// internal state behind every collection accessor. It is built exactly once
+// per connection (stored via connection.SetHclCache) and read-only
+// afterwards.
+type hclCache struct {
+	blocks          []any
+	providers       []any
+	datasources     []any
+	resources       []*mqlTerraformBlock
+	variables       []any
+	outputs         []any
+	terraformBlocks []*mqlTerraformBlock
+}
+
+// hclStateLock serializes the one-time hclCache build and every
 // listHclBlocks call across the whole provider. It guards two things at
-// once: the mqlTerraformInternal fields above, and the terraform.block
-// instances themselves — blocks are deduped through the runtime's resource
-// registry with a non-atomic get-then-set and are initialized in place, so
-// concurrent listings would both duplicate registry entries and mutate
-// instances another goroutine is reading. A single process-wide mutex is
-// deliberately coarse but safe: builds are one-shot per asset and block
-// listings are cheap, static HCL walks. (It also covers the case where the
-// registry's get-then-set hands out two `terraform` instances — a
-// per-instance lock would then guard nothing.)
+// once: the per-connection cache handle, and the terraform.block instances
+// themselves — blocks are deduped through the runtime's resource registry
+// with a non-atomic get-then-set and are initialized in place, so concurrent
+// listings would both duplicate registry entries and mutate instances
+// another goroutine is reading. A single process-wide mutex is deliberately
+// coarse but safe: builds are one-shot per asset and block listings are
+// cheap, static HCL walks. (It also covers the case where the registry's
+// get-then-set hands out two `terraform` instances — a per-instance lock
+// would then guard nothing.)
 var hclStateLock sync.Mutex
+
+// hclCacheLocked returns the connection's built HCL classification, building
+// and storing it on first use. Callers must hold hclStateLock.
+func hclCacheLocked(runtime *plugin.Runtime) (*hclCache, error) {
+	conn := runtime.Connection.(*connection.Connection)
+	if cache, ok := conn.HclCache().(*hclCache); ok {
+		return cache, nil
+	}
+	cache, err := buildHclCache(runtime, conn)
+	if err != nil {
+		return nil, err
+	}
+	conn.SetHclCache(cache)
+	return cache, nil
+}
 
 func (t *mqlTerraform) files() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
@@ -113,33 +146,60 @@ func (t *mqlTerraform) blocks() ([]any, error) {
 	return nil, t.refreshCache()
 }
 
-// refreshCache parses the connection's HCL files and classifies every block
-// exactly once per asset. It is the single guarded builder behind all of the
-// generated collection accessors (blocks, providers, datasources, variables,
-// outputs) and terraform.resources' init: everything is assembled in locals
-// and only published — the collection fields proactively, the guard map last
-// — once the build fully succeeded. Concurrent callers serialize on the lock
-// and find the guard set, so blocks are created and initialized by exactly
-// one goroutine, and a failed build publishes nothing and is retried by the
-// next caller.
-func (t *mqlTerraform) refreshCache() error {
+// cachedState returns the connection's HCL block classification — built
+// exactly once per connection, no matter how many `terraform` resource
+// instances the registry handed out — after publishing the cached
+// collections to this instance's accessor cells exactly once.
+func (t *mqlTerraform) cachedState() (*hclCache, error) {
 	hclStateLock.Lock()
 	defer hclStateLock.Unlock()
-	if t.blocksByName != nil {
-		return nil
+
+	cache, err := hclCacheLocked(t.MqlRuntime)
+	if err != nil {
+		return nil, err
 	}
 
-	conn := t.MqlRuntime.Connection.(*connection.Connection)
+	// Publish once per instance: a duplicate instance gets the same cached
+	// data as the one that triggered the build. Never republish — the
+	// generated accessors read these cells without a lock, so any later
+	// write would race them.
+	if !t.published {
+		t.Blocks = plugin.TValue[[]any]{Data: cache.blocks, State: plugin.StateIsSet}
+		t.Providers = plugin.TValue[[]any]{Data: cache.providers, State: plugin.StateIsSet}
+		t.Datasources = plugin.TValue[[]any]{Data: cache.datasources, State: plugin.StateIsSet}
+		t.Variables = plugin.TValue[[]any]{Data: cache.variables, State: plugin.StateIsSet}
+		t.Outputs = plugin.TValue[[]any]{Data: cache.outputs, State: plugin.StateIsSet}
+		t.published = true
+	}
+	return cache, nil
+}
 
-	// plan and state assets have no HCL parser; publish empty collections.
+// refreshCache ensures the classification exists and this instance's
+// accessor cells are published. The generated collection accessors (blocks,
+// providers, datasources, variables, outputs) all funnel through here;
+// their compute methods return nil and pick the published cells up.
+func (t *mqlTerraform) refreshCache() error {
+	_, err := t.cachedState()
+	return err
+}
+
+// buildHclCache parses the connection's HCL files, creates and initializes
+// the (registry-shared) block resources, and classifies them. Everything is
+// assembled in locals and returned as one immutable cache, so a failed
+// build stores nothing and is retried by the next caller. Callers must hold
+// hclStateLock — it makes this the only goroutine creating or touching
+// block instances.
+func buildHclCache(runtime *plugin.Runtime, conn *connection.Connection) (*hclCache, error) {
+
+	// plan and state assets have no HCL parser; the cache stays empty.
 	mqlHclBlocks := []any{}
 	if parser := conn.Parser(); parser != nil {
 		files := parser.Files()
 		for k := range files {
 			f := files[k]
-			blocks, err := listHclBlocks(t.MqlRuntime, f.Body, f)
+			blocks, err := listHclBlocks(runtime, f.Body, f)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			mqlHclBlocks = append(mqlHclBlocks, blocks...)
 		}
@@ -192,7 +252,7 @@ func (t *mqlTerraform) refreshCache() error {
 
 		rel, err := listRelatedBlocks(blocksByName, block.block.Data.Body)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// connect from this block to all related blocks...
@@ -208,7 +268,7 @@ func (t *mqlTerraform) refreshCache() error {
 	for k, v := range relatedBlocks {
 		block, ok := blocksByName[k]
 		if !ok {
-			return errors.New("cannot find terraform block by name: " + k)
+			return nil, errors.New("cannot find terraform block by name: " + k)
 		}
 
 		vi := make([]any, len(v))
@@ -222,20 +282,15 @@ func (t *mqlTerraform) refreshCache() error {
 		}
 	}
 
-	// The build succeeded in full — publish it. The collection fields are
-	// set proactively (their compute methods return nil and the generated
-	// accessors read these cells); the guard map goes last.
-	t.Blocks = plugin.TValue[[]any]{Data: mqlHclBlocks, State: plugin.StateIsSet}
-	t.Providers = plugin.TValue[[]any]{Data: providers, State: plugin.StateIsSet}
-	t.Datasources = plugin.TValue[[]any]{Data: datasources, State: plugin.StateIsSet}
-	t.Variables = plugin.TValue[[]any]{Data: variables, State: plugin.StateIsSet}
-	t.Outputs = plugin.TValue[[]any]{Data: outputs, State: plugin.StateIsSet}
-	t.mqlTerraformInternal.resources = resources
-	t.terraformBlocks = terraformBlocks
-	t.relatedBlocks = relatedBlocks
-	t.blocksByName = blocksByName
-
-	return nil
+	return &hclCache{
+		blocks:          mqlHclBlocks,
+		providers:       providers,
+		datasources:     datasources,
+		resources:       resources,
+		variables:       variables,
+		outputs:         outputs,
+		terraformBlocks: terraformBlocks,
+	}, nil
 }
 
 func listRelatedBlocks(blocksByName map[string]*mqlTerraformBlock, rawBody any) ([]*mqlTerraformBlock, error) {
@@ -283,27 +338,24 @@ func (t *mqlTerraform) outputs() ([]any, error) {
 	return nil, t.refreshCache()
 }
 
-// resourceBlocks returns the classified resource-type blocks, building the
-// cache if needed. The snapshot is taken under the lock so a caller never
-// observes a partially built list.
+// resourceBlocks returns the classified resource-type blocks from the
+// connection's cache, building it if needed.
 func (t *mqlTerraform) resourceBlocks() ([]*mqlTerraformBlock, error) {
-	if err := t.refreshCache(); err != nil {
+	cache, err := t.cachedState()
+	if err != nil {
 		return nil, err
 	}
-	hclStateLock.Lock()
-	defer hclStateLock.Unlock()
-	return t.mqlTerraformInternal.resources, nil
+	return cache.resources, nil
 }
 
-// settingsBlocks returns the `terraform { ... }` settings blocks, building
-// the cache if needed; same locking rationale as resourceBlocks.
+// settingsBlocks returns the `terraform { ... }` settings blocks from the
+// connection's cache, building it if needed.
 func (t *mqlTerraform) settingsBlocks() ([]*mqlTerraformBlock, error) {
-	if err := t.refreshCache(); err != nil {
+	cache, err := t.cachedState()
+	if err != nil {
 		return nil, err
 	}
-	hclStateLock.Lock()
-	defer hclStateLock.Unlock()
-	return t.terraformBlocks, nil
+	return cache.terraformBlocks, nil
 }
 
 func extractHclCodeSnippet(file *hcl.File, fileRange hcl.Range) string {

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -61,7 +61,7 @@ func writeLargeHclFixture(t *testing.T, resources, variables, outputs int) strin
 // Run with -race: on the unfixed code the detector flags the concurrent
 // (re-)initialization of registry-shared terraform.block instances
 // (newMqlHclBlock), refreshCache reading blocks another goroutine is still
-// writing, and the unsynchronized read of mqlTerraformInternal.resources in
+// writing, and the unsynchronized read of the internal resource list in
 // initTerraformResources.
 //
 // The accessor phase runs after the build fan-out completed: the very first

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -1,0 +1,142 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/terraform/connection"
+)
+
+// newHclTestRuntime stands up a plugin runtime over an HCL directory, wired
+// exactly like the provider service does (same create/new/get/set hooks), so
+// resource inits and generated Get* accessors behave as they do in a scan.
+func newHclTestRuntime(t *testing.T, path string) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{{
+			Options: map[string]string{"path": path},
+		}},
+	}
+	conn, err := connection.NewHclConnection(0, asset)
+	require.NoError(t, err)
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+}
+
+// writeLargeHclFixture generates a single-module config with enough blocks
+// that refreshCache's populate loop has a meaningful execution window.
+func writeLargeHclFixture(t *testing.T, resources, variables, outputs int) string {
+	t.Helper()
+	dir := t.TempDir()
+	var sb strings.Builder
+	sb.WriteString("provider \"google\" {\n  project = \"test\"\n}\n\n")
+	for i := 0; i < resources; i++ {
+		fmt.Fprintf(&sb, "resource \"google_storage_bucket\" \"b%d\" {\n  name = \"bucket-%d\"\n  location = \"EU\"\n}\n\n", i, i)
+	}
+	for i := 0; i < variables; i++ {
+		fmt.Fprintf(&sb, "variable \"v%d\" {\n  default = %d\n}\n\n", i, i)
+	}
+	for i := 0; i < outputs; i++ {
+		fmt.Fprintf(&sb, "output \"o%d\" {\n  value = var.v%d\n}\n\n", i, i)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(sb.String()), 0o644))
+	return dir
+}
+
+// TestConcurrentTerraformResources mimics what a policy scan does on first
+// touch of a terraform asset: many filter queries concurrently evaluating
+// terraform.resources against a cold cache, then reading the block
+// collections. Every worker must observe the same, complete collections.
+//
+// Run with -race: on the unfixed code the detector flags the concurrent
+// (re-)initialization of registry-shared terraform.block instances
+// (newMqlHclBlock), refreshCache reading blocks another goroutine is still
+// writing, and the unsynchronized read of mqlTerraformInternal.resources in
+// initTerraformResources.
+//
+// The accessor phase runs after the build fan-out completed: the very first
+// touch of a TValue cell under concurrency is unsynchronized in the SDK
+// itself (GetOrCompute's fast path reads, and the runtime registry's
+// get-then-set can hand out duplicate instances whose cells are published
+// while another goroutine cold-reads them). That hazard cannot be fixed from
+// provider code and is deliberately out of this test's scope.
+func TestConcurrentTerraformResources(t *testing.T) {
+	const (
+		nResources = 300
+		nVariables = 50
+		nOutputs   = 50
+		workers    = 64
+	)
+	dir := writeLargeHclFixture(t, nResources, nVariables, nOutputs)
+	runtime := newHclTestRuntime(t, dir)
+
+	type observation struct {
+		resources int
+		providers int
+		variables int
+	}
+	obs := make([]observation, workers)
+
+	// Phase 1: concurrent cold builds. This is the path every
+	// `terraform.resources...` filter query takes (snapshot at resource
+	// init); it parses, creates the shared block instances, and classifies
+	// them.
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+
+			args, _, err := initTerraformResources(runtime, map[string]*llx.RawData{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			obs[i].resources = len(args["list"].Value.([]any))
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	// Phase 2: concurrent collection reads via the generated accessors,
+	// against the now-built cache.
+	var readsDone sync.WaitGroup
+	readsDone.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer readsDone.Done()
+
+			tfraw, err := CreateResource(runtime, "terraform", map[string]*llx.RawData{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			tf := tfraw.(*mqlTerraform)
+			if p := tf.GetProviders(); p.Error == nil {
+				obs[i].providers = len(p.Data)
+			}
+			if v := tf.GetVariables(); v.Error == nil {
+				obs[i].variables = len(v.Data)
+			}
+		}(i)
+	}
+	readsDone.Wait()
+
+	for i := 0; i < workers; i++ {
+		require.Equalf(t, nResources, obs[i].resources, "worker %d saw a partial terraform.resources list", i)
+		require.Equalf(t, 1, obs[i].providers, "worker %d saw a partial terraform.providers list", i)
+		require.Equalf(t, nVariables, obs[i].variables, "worker %d saw a partial terraform.variables list", i)
+	}
+}


### PR DESCRIPTION
Fixes the nondeterministic `terraform.resources` results from #8780 (checks silently skipping under large-policy scans).

## The races (all confirmed by `-race`, see the new test)

A policy scan evaluates many queries against a cold terraform asset concurrently. On current `main` that races in four ways:

1. **Shared block re-initialization** — `terraform.block` instances are deduped through the runtime registry and initialized in place (`newMqlHclBlock`), so concurrent listings re-assigned `r.block`/`r.cachedFile` on instances other goroutines were reading (write↔write and read↔write).
2. **Mark-ready-then-fill** — `refreshCache` set `Providers/Datasources/Variables/Outputs` to `StateIsSet` with empty `Data` and then appended in a loop; a concurrent accessor read a legitimately-flagged, partially-filled list.
3. **Unlocked snapshot** — `initTerraformResources` read the internal resource list without the lock while the build was writing it. Each check's `terraform.resources` snapshots that list once at init, so one bad read pinned the check's filter false for the whole scan — the "0 or 1 instead of N" from the issue.
4. Same pattern for the `terraform` settings init reading `terraformBlocks`.

## The fix (terraform provider only): one internal state, built once, read-only after

- **`hclCache`** is the classification state — blocks, providers, datasources, resources, variables, outputs, settings blocks — assembled entirely in locals by **`buildHclCache`** and stored **once per connection** (as an opaque handle on `connection.Connection`, released with it on disconnect). It is immutable after the build; every reader gets the same data. Keying it to the connection rather than the resource instance matters because the registry's `Get`+`Set` dedup is not atomic and can hand out duplicate `terraform` instances — instance-local state was rebuilt per duplicate, letting readers of one instance race the build of another.
- **`hclStateLock`** (process-wide) serializes the one-time build, the cache handle, and every `listHclBlocks` call, so `terraform.block` instances are created and initialized by exactly one goroutine; `newMqlHclBlock` leaves already-initialized instances untouched when `terraform.file(...).blocks()` / module lookups re-list them.
- **All reads come from the cache**: the collection accessors funnel through `cachedState()`, which publishes the cached collections to an instance's accessor cells **exactly once** (per-instance `published` flag — republishing would race the generated accessors' lock-free reads); `terraform.resources`' init and the settings init read their slices straight from the cache.
- A failed build stores nothing and is retried by the next caller.

## Test

`TestConcurrentTerraformResources`: generates a 400-block module, fans out 64 goroutines through `initTerraformResources` (cold concurrent builds), then 64 concurrent accessor readers, and asserts every worker sees the complete collections. On unfixed `main` it fails immediately with 4 data-race reports; now `-race -count=20` and the full provider module under `-race` pass.

## Explicitly out of scope (SDK-level, follow-ups for #8780)

- `plugin.GetOrCompute`'s fast path reads/writes TValue cells with no synchronization — the very first concurrent touch of any cell remains a data race the provider cannot prevent (the test's accessor phase runs after the build barrier for this reason).
- The generated `CreateResource`/`NewResource` dedup is `Get`-then-`Set` (TOCTOU): concurrent registrations can hand out duplicate instances. The per-connection cache makes this harmless for this provider, but an atomic `GetOrSet` in the registry would fix the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)