### PR TITLE
🐛 recover panics during query execution instead of crashing

### DIFF
--- a/exec/internal/execution_manager.go
+++ b/exec/internal/execution_manager.go
@@ -5,6 +5,8 @@ package internal
 
 import (
 	"errors"
+	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -59,17 +61,31 @@ func (em *executionManager) Start() {
 	go func() {
 		defer em.wg.Done()
 		// current is the code bundle being executed; the deferred panic
-		// reporter snapshots it at crash time so the report carries WHICH
+		// handler snapshots it at crash time so the report carries WHICH
 		// query was running, not just where the engine died. The recover
-		// stays at the goroutine top — recovering closer to the query and
-		// re-panicking would truncate the stacktrace.
+		// stays at the goroutine top so the stacktrace points at the
+		// panic site. Instead of crashing the process, the panic is
+		// reported upstream and surfaced as an unrecoverable execution
+		// error, mirroring the executeCodeBundle error path below.
 		var current *llx.CodeBundle
-		defer health.ReportPanicWithTags("mql", mql.Version, mql.Build, func() map[string]string {
-			if current == nil {
-				return nil
+		defer func() {
+			r := recover()
+			if r == nil {
+				return
 			}
-			return health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
-		})
+			var tags map[string]string
+			if current != nil {
+				tags = health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
+			}
+			health.ReportRecoveredPanic("mql", mql.Version, mql.Build, r, tags)
+			log.Error().
+				Str("stacktrace", string(debug.Stack())).
+				Msgf("recovered from panic during query execution: %v", r)
+			select {
+			case em.errChan <- fmt.Errorf("panic during query execution: %v", r):
+			default:
+			}
+		}()
 		for {
 			// Prioritize stopChan
 			select {

--- a/exec/internal/execution_manager.go
+++ b/exec/internal/execution_manager.go
@@ -77,9 +77,10 @@ func (em *executionManager) Start() {
 			if current != nil {
 				tags = health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
 			}
-			health.ReportRecoveredPanic("mql", mql.Version, mql.Build, r, tags)
+			stack := debug.Stack()
+			health.ReportRecoveredPanic("mql", mql.Version, mql.Build, r, stack, tags)
 			log.Error().
-				Str("stacktrace", string(debug.Stack())).
+				Str("stacktrace", string(stack)).
 				Msgf("recovered from panic during query execution: %v", r)
 			select {
 			case em.errChan <- fmt.Errorf("panic during query execution: %v", r):

--- a/exec/internal/execution_manager_test.go
+++ b/exec/internal/execution_manager_test.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestExecutionManagerRecoversPanic(t *testing.T) {
+	runQueue := make(chan runQueueItem, 1)
+	resultChan := make(chan *llx.RawResult, 1)
+	em := newExecutionManager(nil, nil, runQueue, resultChan, time.Second)
+	em.Start()
+
+	// A nil code bundle panics inside executeCodeBundle. The manager must
+	// recover and surface it as an unrecoverable error instead of crashing.
+	runQueue <- runQueueItem{}
+
+	select {
+	case err := <-em.Err():
+		require.ErrorContains(t, err, "panic during query execution")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the execution manager to report the panic as an error")
+	}
+
+	em.Stop()
+}

--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -126,19 +126,22 @@ func ReportPanicWithTags(product, version, build string, tagsFn PanicTagsFn, rep
 
 // ReportRecoveredPanic reports an already-recovered panic without
 // re-panicking. Use it when the caller recovers a panic itself and converts
-// it into an error instead of crashing the process. It must be called from
-// within the deferred function that recovered so the stacktrace still points
-// at the panic site.
-func ReportRecoveredPanic(product, version, build string, r any, tags map[string]string, reporters ...PanicReportFn) {
+// it into an error instead of crashing the process. The caller supplies the
+// stacktrace (it typically needs one for its own logging anyway) — capture
+// it via debug.Stack() inside the deferred function that recovered, so it
+// still points at the panic site.
+func ReportRecoveredPanic(product, version, build string, r any, stacktrace []byte, tags map[string]string, reporters ...PanicReportFn) {
 	if build == "" {
 		return // avoid reporting panics from environments that don't set this variable
 	}
-
-	handlePanic(product, version, build, r, tags, reporters)
+	handlePanicWithStack(product, version, build, r, stacktrace, tags, reporters)
 }
 
 func handlePanic(product, version, build string, r any, tags map[string]string, reporters []PanicReportFn) {
-	stack := debug.Stack()
+	handlePanicWithStack(product, version, build, r, debug.Stack(), tags, reporters)
+}
+
+func handlePanicWithStack(product, version, build string, r any, stack []byte, tags map[string]string, reporters []PanicReportFn) {
 	sendPanic(product, version, build, r, stack, tags)
 
 	// call additional reporters

--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -124,6 +124,19 @@ func ReportPanicWithTags(product, version, build string, tagsFn PanicTagsFn, rep
 	}
 }
 
+// ReportRecoveredPanic reports an already-recovered panic without
+// re-panicking. Use it when the caller recovers a panic itself and converts
+// it into an error instead of crashing the process. It must be called from
+// within the deferred function that recovered so the stacktrace still points
+// at the panic site.
+func ReportRecoveredPanic(product, version, build string, r any, tags map[string]string, reporters ...PanicReportFn) {
+	if build == "" {
+		return // avoid reporting panics from environments that don't set this variable
+	}
+
+	handlePanic(product, version, build, r, tags, reporters)
+}
+
 func handlePanic(product, version, build string, r any, tags map[string]string, reporters []PanicReportFn) {
 	stack := debug.Stack()
 	sendPanic(product, version, build, r, stack, tags)

--- a/providers-sdk/v1/upstream/health/errors_test.go
+++ b/providers-sdk/v1/upstream/health/errors_test.go
@@ -5,6 +5,7 @@ package health
 
 import (
 	"runtime"
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,7 @@ func TestReportRecoveredPanicSkipsWithoutBuild(t *testing.T) {
 	}()
 	defer func() {
 		if r := recover(); r != nil {
-			ReportRecoveredPanic("mql", "12.0.0", "", r, nil, reporter)
+			ReportRecoveredPanic("mql", "12.0.0", "", r, debug.Stack(), nil, reporter)
 		}
 	}()
 	panic("boom")

--- a/providers-sdk/v1/upstream/health/errors_test.go
+++ b/providers-sdk/v1/upstream/health/errors_test.go
@@ -46,6 +46,32 @@ func TestPanicEventPlatformTagsWin(t *testing.T) {
 	assert.Equal(t, runtime.GOARCH, event.Tags["arch"])
 }
 
+// ReportRecoveredPanic must return normally (never re-panic) so callers can
+// convert a recovered panic into an error, and it must honor the empty-build
+// guard that keeps dev environments from reporting.
+//
+// The build != "" reporting path is intentionally not exercised here: it
+// reads the local mondoo config and would send a real error report to the
+// platform on machines with a configured service account. It is covered
+// indirectly by TestPanicEvent* above and the exec manager's recovery test.
+func TestReportRecoveredPanicSkipsWithoutBuild(t *testing.T) {
+	reporterCalled := false
+	reporter := func(product, version, build string, r any, stacktrace []byte) {
+		reporterCalled = true
+	}
+
+	defer func() {
+		require.Nil(t, recover(), "ReportRecoveredPanic must not re-panic")
+		assert.False(t, reporterCalled, "empty build must skip all reporting")
+	}()
+	defer func() {
+		if r := recover(); r != nil {
+			ReportRecoveredPanic("mql", "12.0.0", "", r, nil, reporter)
+		}
+	}()
+	panic("boom")
+}
+
 func TestQueryPanicTags(t *testing.T) {
 	assert.Nil(t, QueryPanicTags("", ""))
 


### PR DESCRIPTION
## Problem

A panic during query execution was reported to the platform (via `health.ReportPanicWithTags`) but then **re-panicked**, killing the whole process. One bad query could take down an entire scan.

```
→ Connecting to your local system. To learn how to scan other platforms, use the --help flag.
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
→ connected to macOS

 _ __ ___   __ _| |
| '_ ` _ \ / _` | |
| | | | | | (_| | |
|_| |_| |_|\__, |_|
  mondoo™     |_|
 interactive shell

> [1,2].first                                                                                                                                                                    

x recovered from panic during query execution: boom stacktrace="goroutine 115 [running]:\nruntime/debug.Stack()\n\t/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/debug/stack.go:26 +0x64\ngo.mondoo.com/mql/v13/exec/internal.(*executionManager).Start.func1.1()\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/exec/internal/execution_manager.go:82 +0x238\npanic({0x1026dcb80?, 0x102a993d0?})\n\t/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/panic.go:860 +0x12c\ngo.mondoo.com/mql/v13/llx.arrayGetFirstIndexV2(0x1bcd0f0480ca?, 0x2?, 0x1bcd0f0480b0?, 0x5?)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/builtin_array.go:22 +0x2c\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).runBoundFunction(0x1bcd0f09b3b0, 0x1bcd0f050c30, 0x1bcd0f05a460, 0x100000002)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/builtin.go:917 +0x144\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).runFunction(0x1bcd0f09b3b0, 0x1bcd0f05a460, 0x100000002)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:812 +0x154\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).runChunk(0x1bcd0f09b3b0, 0x100df5b54?, 0x100000002)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:829 +0x204\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).runRef(0x1bcd0f046340?, 0x10059b62c?)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:854 +0xec\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).runChain(0x1bcd0f09b3b0, 0x1015dff00?)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:886 +0x88\ngo.mondoo.com/mql/v13/llx.(*blockExecutor).run(0x1bcd0f09b3b0)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:357 +0x294\ngo.mondoo.com/mql/v13/llx.(*MQLExecutorV2).Run(0x1bcd0ea14960?)\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/llx/llx.go:287 +0x5c\ngo.mondoo.com/mql/v13/exec/internal.(*executionManager).executeCodeBundle(0x1bcd0ea14a20, 0x1bcd0f022500, 0x1bcd0f0509f0, {0x0, 0x0})\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/exec/internal/execution_manager.go:202 +0x6bc\ngo.mondoo.com/mql/v13/exec/internal.(*executionManager).Start.func1()\n\t/Users/preslavgerchev/go/src/go.mondoo.com/mql/exec/internal/execution_manager.go:119 +0x1e0\ncreat> [1,2].first
failed to compile: panic during query execution: boom
```

<img width="1189" height="298" alt="image" src="https://github.com/user-attachments/assets/f434bcca-8045-441e-9edd-463dc12b2f90" />



## Change

- **`exec/internal/execution_manager.go`** — the executor goroutine now owns the `recover()`. On panic it:
  1. reports upstream with the crash-time query tags (code ID + source), same as before,
  2. logs the panic locally with its stacktrace,
  3. surfaces it as an unrecoverable execution error on `errChan`, mirroring the existing `executeCodeBundle` error path — `GraphExecutor.Execute()` returns the error and the process survives.
- **`providers-sdk/v1/upstream/health`** — adds `ReportRecoveredPanic`, a report-only variant of `ReportPanicWithTags` for callers that recover themselves and convert the panic into an error. Same `handlePanic` path, same empty-build guard, no re-panic.

`ReportPanicWithTags` is kept: cnspec's policy executor (`policy/executor/internal/execution_manager.go`) still uses it. Follow-ups: port the same recovery pattern to cnspec, then remove `ReportPanicWithTags`/`PanicTagsFn` in a breaking cleanup. The top-of-`main` `ReportPanic` keeps its report-then-crash contract by design.

Note: this covers panics on the execution manager's goroutine. Panics on goroutines spawned inside `llx`/providers still crash via the `main` handler — guarding those is a separate, larger change.

## Testing

- New `TestExecutionManagerRecoversPanic`: pushes a nil code bundle through the run queue (panics inside `executeCodeBundle`) and asserts the manager surfaces it on `Err()` instead of crashing; verified the reported stacktrace points at the real panic site.
- New `TestReportRecoveredPanicSkipsWithoutBuild`: no re-panic + empty-build guard (the live reporting path is deliberately untested to avoid sending real reports from dev machines).
- `go test ./exec/... ./providers-sdk/v1/upstream/health/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)