### PR TITLE
⭐ azure: bump armnetwork to v10 and add unlocked network fields

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights v0.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -132,8 +132,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:d
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0 h1:iyx6jFFyRo8/9FQiyHRTjoUluopwt+9lvOtRBhfB7Y8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0/go.mod h1:LSdxfHhUzKllvM+sYDf1wrcQrbInrF4iXJ/NMk7fK90=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0 h1:CbHDMVJhcJSmXenq+UDWyIjumzVkZIb5pVUGzsCok5M=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0/go.mod h1:raqbEXrok4aycS74XoU6p9Hne1dliAFpHLizlp+qJoM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0 h1:DI6sDa/IfWSjPCo6G7CuO9sekRNajIfg134SP1C13js=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0/go.mod h1:oSXzE/x+1AxZplJylWMM4BCq+RkQ3XM2uc9IkIgcBKk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0 h1:PQCYE8OR+vgoTJ1Vq6EutuoMN8n6LgJygxMSHNTsuYY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0/go.mod h1:s9hOdyntXLv/Y+IzJ6+O021/eAo7omS8Y6KwwICcG58=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights v0.10.0 h1:AzaqGJAacR0jIOJ8MQy3VZ1IHv00DW7bneMA7hx6PXk=

--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	apim "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v3"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1646,6 +1646,8 @@ azure.subscription.networkService.firewall @defaults("id name location") {
   skuTier string
   // Firewall threat intel mode
   threatIntelMode string
+  // Endpoint URL of the Azure Firewall control plane (AFC), empty when not configured
+  afcServiceEndpoint string
   // Policy associated with this firewall
   policy() azure.subscription.networkService.firewallPolicy
   // List of IP configurations for the firewall
@@ -1931,6 +1933,8 @@ private azure.subscription.networkService.virtualNetworkGateway.connection @defa
   dpdTimeoutSeconds int
   // Routing weight applied to this connection
   routingWeight int
+  // Associated and propagated route tables governing routing for this connection
+  routingConfiguration dict
   // Total ingress bytes transferred over this connection
   ingressBytesTransferred int
   // Total egress bytes transferred over this connection
@@ -2065,6 +2069,8 @@ azure.subscription.networkService.natGateway @defaults("id name location") {
   properties dict
   // NAT Gateway availability zones
   zones []string
+  // Whether NAT64 translation is enabled for the NAT Gateway
+  nat64Enabled bool
   // List of public IP addresses the NAT Gateway is associated with
   publicIpAddresses() []azure.subscription.networkService.ipAddress
   // List of subnets the NAT Gateway is associated with
@@ -2369,6 +2375,8 @@ private azure.subscription.networkService.frontendIpConfig @defaults("id name") 
   publicIpAddressId string
   // Private IP address (empty if public)
   privateIpAddress string
+  // Resource ID of the DDoS custom policy bound to this frontend IP configuration (empty when none)
+  ddosCustomPolicyId string
 }
 
 // Azure Load Balancer rule
@@ -2924,15 +2932,22 @@ private azure.subscription.networkService.applicationGateway.listener @defaults(
 // a Key Vault secret (the recommended path); when empty, the
 // certificate data was uploaded directly to the gateway. `publicCertData`
 // holds the base64-encoded public certificate (no private key).
-private azure.subscription.networkService.applicationGateway.sslCertificate @defaults("name keyVaultSecretId") {
+private azure.subscription.networkService.applicationGateway.sslCertificate @defaults("name") {
   // ARM resource ID
   id string
   // Certificate name
   name string
-  // Key Vault secret URI when the certificate is referenced from Key Vault; empty when the cert was uploaded directly
-  keyVaultSecretId string
+  // Key Vault secret URI backing the certificate
+  //
+  // Deprecated in favor of keyVaultSecret, which resolves the typed Key
+  // Vault secret. Empty when the certificate was uploaded directly.
+  keyVaultSecretId @maturity("deprecated") string
+  // Key Vault secret backing the certificate (null when the cert was uploaded directly)
+  keyVaultSecret() azure.subscription.keyVaultService.secret
   // Base64-encoded public certificate data
   publicCertData string
+  // Managed HSM key backing this certificate (null when Key Vault- or PFX-backed)
+  hsmKey() azure.subscription.keyVaultService.key
   // Provisioning state of the certificate resource
   provisioningState string
 }
@@ -2983,8 +2998,12 @@ azure.subscription.networkService.applicationFirewallPolicy @defaults("id name l
   properties dict
   // Policy enforcement mode ("Prevention" blocks matching requests; "Detection" only logs them)
   mode string
-  // Whether the policy is enabled ("Enabled" or "Disabled")
-  enabledState string
+  // Policy enabled state
+  //
+  // Deprecated in favor of enabled, which exposes this as a boolean.
+  enabledState @maturity("deprecated") string
+  // Whether the policy is enabled
+  enabled bool
   // Whether the request body is inspected by the WAF
   requestBodyCheck bool
   // Maximum inspected request body size, in kilobytes
@@ -3022,6 +3041,8 @@ private azure.subscription.networkService.privateEndpoint @defaults("id name loc
   subnetId string
   // Custom name of the network interface attached to the private endpoint
   customNetworkInterfaceName string
+  // Billing SKU of the private endpoint ("Fixed" or "PayAsYouGo")
+  billingSku string
   // Private link service connections
   privateLinkServiceConnections []azure.subscription.networkService.privateEndpoint.serviceconnection
   // Manually approved private link service connections
@@ -3154,6 +3175,8 @@ private azure.subscription.networkService.route @defaults("name addressPrefix ne
   nextHopType string
   // IP address packets should be forwarded to (only for VirtualAppliance)
   nextHopIpAddress string
+  // ECMP next-hop IP addresses (set only when nextHopType is "VirtualApplianceEcmp")
+  ecmpNextHopIpAddresses []string
   // Whether this route overrides overlapping BGP routes
   hasBgpOverride bool
   // Provisioning state of the route
@@ -3166,13 +3189,13 @@ private azure.subscription.networkService.route @defaults("name addressPrefix ne
 // balancer that resolves a single hostname to one of many backends
 // based on a routing method. Surfaces the `trafficRoutingMethod`
 // (Performance, Weighted, Priority, Geographic, MultiValue, Subnet),
-// the `profileStatus` (Enabled/Disabled), the `dnsConfig`
+// the `status` of the profile, the `dnsConfig`
 // (relativeName, ttl, fqdn) that controls the resolver-facing record,
 // the `monitorConfig` (protocol, port, path, intervals, expected
 // status codes, custom headers) that governs endpoint probing, and
 // the per-endpoint configuration through
 // [[azure.subscription.networkService.trafficManagerProfile.endpoint]].
-azure.subscription.networkService.trafficManagerProfile @defaults("id name location trafficRoutingMethod profileStatus") {
+azure.subscription.networkService.trafficManagerProfile @defaults("id name location trafficRoutingMethod status") {
   // Traffic Manager profile ID
   id string
   // Traffic Manager profile name
@@ -3185,8 +3208,12 @@ azure.subscription.networkService.trafficManagerProfile @defaults("id name locat
   type string
   // Traffic Manager profile properties
   properties dict
-  // Profile status ("Enabled" or "Disabled")
-  profileStatus string
+  // Profile status
+  //
+  // Deprecated in favor of status, which exposes this as a boolean.
+  profileStatus @maturity("deprecated") string
+  // Whether the profile is enabled
+  status bool
   // Traffic routing method ("Performance", "Weighted", "Priority", "Geographic", "MultiValue", "Subnet")
   trafficRoutingMethod string
   // Traffic View enrollment status ("Enabled" or "Disabled")
@@ -3208,8 +3235,8 @@ azure.subscription.networkService.trafficManagerProfile @defaults("id name locat
 // Examine a single endpoint inside a Traffic Manager profile —
 // either an Azure resource (`AzureEndpoints`), an external FQDN/IP
 // (`ExternalEndpoints`), or a child profile (`NestedEndpoints`).
-// Surfaces the `target` or `targetResourceId`, `endpointStatus`
-// (Enabled/Disabled), `endpointMonitorStatus` (the most recent probe
+// Surfaces the `target` or `targetResourceId`, the `status` of the
+// endpoint, `endpointMonitorStatus` (the most recent probe
 // result), `weight` (for Weighted routing), `priority` (for Priority
 // routing), `geoMapping` (for Geographic routing), `subnets` (for
 // Subnet routing), `customHeaders` overrides, `endpointLocation`
@@ -3218,7 +3245,7 @@ azure.subscription.networkService.trafficManagerProfile @defaults("id name locat
 // `minChildEndpointsIPv6`). The `alwaysServe` flag indicates that
 // the endpoint should remain in the routing decision even when
 // probes fail.
-private azure.subscription.networkService.trafficManagerProfile.endpoint @defaults("name type endpointStatus") {
+private azure.subscription.networkService.trafficManagerProfile.endpoint @defaults("name type status") {
   // Endpoint ID
   id string
   // Endpoint name
@@ -3227,8 +3254,12 @@ private azure.subscription.networkService.trafficManagerProfile.endpoint @defaul
   type string
   // Endpoint properties
   properties dict
-  // Endpoint status ("Enabled" or "Disabled")
-  endpointStatus string
+  // Endpoint status
+  //
+  // Deprecated in favor of status, which exposes this as a boolean.
+  endpointStatus @maturity("deprecated") string
+  // Whether the endpoint is enabled
+  status bool
   // Most recent monitor probe result ("CheckingEndpoint", "Online", "Degraded", "Disabled", "Inactive", "Stopped")
   endpointMonitorStatus string
   // "Enabled" keeps the endpoint in the routing decision even when probes fail

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3997,6 +3997,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.firewall.threatIntelMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewall).GetThreatIntelMode()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.firewall.afcServiceEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceFirewall).GetAfcServiceEndpoint()).ToDataRes(types.String)
+	},
 	"azure.subscription.networkService.firewall.policy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewall).GetPolicy()).ToDataRes(types.Resource("azure.subscription.networkService.firewallPolicy"))
 	},
@@ -4321,6 +4324,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualNetworkGateway.connection.routingWeight": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetRoutingWeight()).ToDataRes(types.Int)
 	},
+	"azure.subscription.networkService.virtualNetworkGateway.connection.routingConfiguration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetRoutingConfiguration()).ToDataRes(types.Dict)
+	},
 	"azure.subscription.networkService.virtualNetworkGateway.connection.ingressBytesTransferred": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetIngressBytesTransferred()).ToDataRes(types.Int)
 	},
@@ -4452,6 +4458,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.natGateway.zones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNatGateway).GetZones()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.networkService.natGateway.nat64Enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNatGateway).GetNat64Enabled()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.natGateway.publicIpAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNatGateway).GetPublicIpAddresses()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.ipAddress")))
@@ -4764,6 +4773,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.frontendIpConfig.privateIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPrivateIpAddress()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetDdosCustomPolicyId()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.loadBalancerRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceLoadBalancerRule).GetId()).ToDataRes(types.String)
@@ -5362,8 +5374,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecretId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetKeyVaultSecretId()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetKeyVaultSecret()).ToDataRes(types.Resource("azure.subscription.keyVaultService.secret"))
+	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.publicCertData": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetPublicCertData()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.applicationGateway.sslCertificate.hsmKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetHsmKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
 	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetProvisioningState()).ToDataRes(types.String)
@@ -5410,6 +5428,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.applicationFirewallPolicy.enabledState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetEnabledState()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.applicationFirewallPolicy.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetEnabled()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.networkService.applicationFirewallPolicy.requestBodyCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetRequestBodyCheck()).ToDataRes(types.Bool)
 	},
@@ -5451,6 +5472,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetCustomNetworkInterfaceName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.privateEndpoint.billingSku": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetBillingSku()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.privateEndpoint.privateLinkServiceConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetPrivateLinkServiceConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.privateEndpoint.serviceconnection")))
@@ -5614,6 +5638,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.route.nextHopIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceRoute).GetNextHopIpAddress()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.route.ecmpNextHopIpAddresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceRoute).GetEcmpNextHopIpAddresses()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.networkService.route.hasBgpOverride": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceRoute).GetHasBgpOverride()).ToDataRes(types.Bool)
 	},
@@ -5640,6 +5667,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.profileStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetProfileStatus()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.trafficManagerProfile.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetStatus()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.trafficManagerProfile.trafficRoutingMethod": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetTrafficRoutingMethod()).ToDataRes(types.String)
@@ -5676,6 +5706,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetEndpointStatus()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.trafficManagerProfile.endpoint.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetStatus()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointMonitorStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetEndpointMonitorStatus()).ToDataRes(types.String)
@@ -18842,6 +18875,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFirewall).ThreatIntelMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.firewall.afcServiceEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceFirewall).AfcServiceEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.firewall.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewall).Policy, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceFirewallPolicy](v.Value, v.Error)
 		return
@@ -19318,6 +19355,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).RoutingWeight, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.virtualNetworkGateway.connection.routingConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).RoutingConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.virtualNetworkGateway.connection.ingressBytesTransferred": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).IngressBytesTransferred, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -19512,6 +19553,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.natGateway.zones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceNatGateway).Zones, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.natGateway.nat64Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNatGateway).Nat64Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.natGateway.publicIpAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19976,6 +20021,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.frontendIpConfig.privateIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PrivateIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).DdosCustomPolicyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.loadBalancerRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20842,8 +20891,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).KeyVaultSecretId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).KeyVaultSecret, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceSecret](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.publicCertData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).PublicCertData, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.sslCertificate.hsmKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).HsmKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20914,6 +20971,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).EnabledState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.applicationFirewallPolicy.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.applicationFirewallPolicy.requestBodyCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).RequestBodyCheck, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -20972,6 +21033,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).CustomNetworkInterfaceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.privateEndpoint.billingSku": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).BillingSku, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.privateEndpoint.privateLinkServiceConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21210,6 +21275,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceRoute).NextHopIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.route.ecmpNextHopIpAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceRoute).EcmpNextHopIpAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.route.hasBgpOverride": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceRoute).HasBgpOverride, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -21248,6 +21317,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.profileStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).ProfileStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.trafficManagerProfile.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).Status, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.trafficManagerProfile.trafficRoutingMethod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21300,6 +21373,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).EndpointStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.trafficManagerProfile.endpoint.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).Status, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointMonitorStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -42748,6 +42825,7 @@ type mqlAzureSubscriptionNetworkServiceFirewall struct {
 	SkuName                   plugin.TValue[string]
 	SkuTier                   plugin.TValue[string]
 	ThreatIntelMode           plugin.TValue[string]
+	AfcServiceEndpoint        plugin.TValue[string]
 	Policy                    plugin.TValue[*mqlAzureSubscriptionNetworkServiceFirewallPolicy]
 	IpConfigurations          plugin.TValue[[]any]
 	ManagementIpConfiguration plugin.TValue[*mqlAzureSubscriptionNetworkServiceFirewallIpConfig]
@@ -42835,6 +42913,10 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewall) GetSkuTier() *plugin.TValue
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewall) GetThreatIntelMode() *plugin.TValue[string] {
 	return &c.ThreatIntelMode
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceFirewall) GetAfcServiceEndpoint() *plugin.TValue[string] {
+	return &c.AfcServiceEndpoint
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewall) GetPolicy() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceFirewallPolicy] {
@@ -43950,6 +44032,7 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection struct {
 	UseLocalAzureIpAddress         plugin.TValue[bool]
 	DpdTimeoutSeconds              plugin.TValue[int64]
 	RoutingWeight                  plugin.TValue[int64]
+	RoutingConfiguration           plugin.TValue[any]
 	IngressBytesTransferred        plugin.TValue[int64]
 	EgressBytesTransferred         plugin.TValue[int64]
 	LocalNetworkGateway2           plugin.TValue[*mqlAzureSubscriptionNetworkServiceLocalNetworkGateway]
@@ -44056,6 +44139,10 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetD
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetRoutingWeight() *plugin.TValue[int64] {
 	return &c.RoutingWeight
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetRoutingConfiguration() *plugin.TValue[any] {
+	return &c.RoutingConfiguration
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetIngressBytesTransferred() *plugin.TValue[int64] {
@@ -44470,6 +44557,7 @@ type mqlAzureSubscriptionNetworkServiceNatGateway struct {
 	Etag              plugin.TValue[string]
 	Properties        plugin.TValue[any]
 	Zones             plugin.TValue[[]any]
+	Nat64Enabled      plugin.TValue[bool]
 	PublicIpAddresses plugin.TValue[[]any]
 	Subnets           plugin.TValue[[]any]
 }
@@ -44541,6 +44629,10 @@ func (c *mqlAzureSubscriptionNetworkServiceNatGateway) GetProperties() *plugin.T
 
 func (c *mqlAzureSubscriptionNetworkServiceNatGateway) GetZones() *plugin.TValue[[]any] {
 	return &c.Zones
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNatGateway) GetNat64Enabled() *plugin.TValue[bool] {
+	return &c.Nat64Enabled
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceNatGateway) GetPublicIpAddresses() *plugin.TValue[[]any] {
@@ -45699,15 +45791,16 @@ type mqlAzureSubscriptionNetworkServiceFrontendIpConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceFrontendIpConfigInternal it will be used here
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Type              plugin.TValue[string]
-	Etag              plugin.TValue[string]
-	Properties        plugin.TValue[any]
-	Zones             plugin.TValue[[]any]
-	IsPublic          plugin.TValue[bool]
-	PublicIpAddressId plugin.TValue[string]
-	PrivateIpAddress  plugin.TValue[string]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Type               plugin.TValue[string]
+	Etag               plugin.TValue[string]
+	Properties         plugin.TValue[any]
+	Zones              plugin.TValue[[]any]
+	IsPublic           plugin.TValue[bool]
+	PublicIpAddressId  plugin.TValue[string]
+	PrivateIpAddress   plugin.TValue[string]
+	DdosCustomPolicyId plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServiceFrontendIpConfig creates a new instance of this resource
@@ -45781,6 +45874,10 @@ func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPublicIpAddressI
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPrivateIpAddress() *plugin.TValue[string] {
 	return &c.PrivateIpAddress
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetDdosCustomPolicyId() *plugin.TValue[string] {
+	return &c.DdosCustomPolicyId
 }
 
 // mqlAzureSubscriptionNetworkServiceLoadBalancerRule for the azure.subscription.networkService.loadBalancerRule resource
@@ -47686,11 +47783,13 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewayListener) GetProvis
 type mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificateInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificateInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	KeyVaultSecretId  plugin.TValue[string]
+	KeyVaultSecret    plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret]
 	PublicCertData    plugin.TValue[string]
+	HsmKey            plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	ProvisioningState plugin.TValue[string]
 }
 
@@ -47743,8 +47842,40 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) Get
 	return &c.KeyVaultSecretId
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetKeyVaultSecret() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceSecret](&c.KeyVaultSecret, func() (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway.sslCertificate", c.__id, "keyVaultSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceSecret), nil
+			}
+		}
+
+		return c.keyVaultSecret()
+	})
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetPublicCertData() *plugin.TValue[string] {
 	return &c.PublicCertData
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetHsmKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceKey](&c.HsmKey, func() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.applicationGateway.sslCertificate", c.__id, "hsmKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
+			}
+		}
+
+		return c.hsmKey()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetProvisioningState() *plugin.TValue[string] {
@@ -47834,6 +47965,7 @@ type mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy struct {
 	Properties             plugin.TValue[any]
 	Mode                   plugin.TValue[string]
 	EnabledState           plugin.TValue[string]
+	Enabled                plugin.TValue[bool]
 	RequestBodyCheck       plugin.TValue[bool]
 	MaxRequestBodySizeInKb plugin.TValue[int64]
 	FileUploadLimitInMb    plugin.TValue[int64]
@@ -47915,6 +48047,10 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetEnabled
 	return &c.EnabledState
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetRequestBodyCheck() *plugin.TValue[bool] {
 	return &c.RequestBodyCheck
 }
@@ -47964,6 +48100,7 @@ type mqlAzureSubscriptionNetworkServicePrivateEndpoint struct {
 	ProvisioningState                   plugin.TValue[string]
 	SubnetId                            plugin.TValue[string]
 	CustomNetworkInterfaceName          plugin.TValue[string]
+	BillingSku                          plugin.TValue[string]
 	PrivateLinkServiceConnections       plugin.TValue[[]any]
 	ManualPrivateLinkServiceConnections plugin.TValue[[]any]
 	PrivateDnsZoneGroups                plugin.TValue[[]any]
@@ -48031,6 +48168,10 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnetId() *plugi
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetCustomNetworkInterfaceName() *plugin.TValue[string] {
 	return &c.CustomNetworkInterfaceName
+}
+
+func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetBillingSku() *plugin.TValue[string] {
+	return &c.BillingSku
 }
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetPrivateLinkServiceConnections() *plugin.TValue[[]any] {
@@ -48484,13 +48625,14 @@ type mqlAzureSubscriptionNetworkServiceRoute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceRouteInternal it will be used here
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	AddressPrefix     plugin.TValue[string]
-	NextHopType       plugin.TValue[string]
-	NextHopIpAddress  plugin.TValue[string]
-	HasBgpOverride    plugin.TValue[bool]
-	ProvisioningState plugin.TValue[string]
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	AddressPrefix          plugin.TValue[string]
+	NextHopType            plugin.TValue[string]
+	NextHopIpAddress       plugin.TValue[string]
+	EcmpNextHopIpAddresses plugin.TValue[[]any]
+	HasBgpOverride         plugin.TValue[bool]
+	ProvisioningState      plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServiceRoute creates a new instance of this resource
@@ -48545,6 +48687,10 @@ func (c *mqlAzureSubscriptionNetworkServiceRoute) GetNextHopIpAddress() *plugin.
 	return &c.NextHopIpAddress
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceRoute) GetEcmpNextHopIpAddresses() *plugin.TValue[[]any] {
+	return &c.EcmpNextHopIpAddresses
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceRoute) GetHasBgpOverride() *plugin.TValue[bool] {
 	return &c.HasBgpOverride
 }
@@ -48565,6 +48711,7 @@ type mqlAzureSubscriptionNetworkServiceTrafficManagerProfile struct {
 	Type                        plugin.TValue[string]
 	Properties                  plugin.TValue[any]
 	ProfileStatus               plugin.TValue[string]
+	Status                      plugin.TValue[bool]
 	TrafficRoutingMethod        plugin.TValue[string]
 	TrafficViewEnrollmentStatus plugin.TValue[string]
 	MaxReturn                   plugin.TValue[int64]
@@ -48639,6 +48786,10 @@ func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetProfileStat
 	return &c.ProfileStatus
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetStatus() *plugin.TValue[bool] {
+	return &c.Status
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetTrafficRoutingMethod() *plugin.TValue[string] {
 	return &c.TrafficRoutingMethod
 }
@@ -48677,6 +48828,7 @@ type mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint struct {
 	Type                  plugin.TValue[string]
 	Properties            plugin.TValue[any]
 	EndpointStatus        plugin.TValue[string]
+	Status                plugin.TValue[bool]
 	EndpointMonitorStatus plugin.TValue[string]
 	AlwaysServe           plugin.TValue[string]
 	Target                plugin.TValue[string]
@@ -48747,6 +48899,10 @@ func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetPro
 
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetEndpointStatus() *plugin.TValue[string] {
 	return &c.EndpointStatus
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetStatus() *plugin.TValue[bool] {
+	return &c.Status
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetEndpointMonitorStatus() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2922,6 +2922,7 @@ azure.subscription.networkService.appSecurityGroup.type 9.0.8
 azure.subscription.networkService.applicationFirewallPolicies 9.0.1
 azure.subscription.networkService.applicationFirewallPolicy 9.0.13
 azure.subscription.networkService.applicationFirewallPolicy.customRulesCount 13.16.2
+azure.subscription.networkService.applicationFirewallPolicy.enabled 13.25.1
 azure.subscription.networkService.applicationFirewallPolicy.enabledState 13.16.2
 azure.subscription.networkService.applicationFirewallPolicy.etag 9.0.13
 azure.subscription.networkService.applicationFirewallPolicy.fileUploadLimitInMb 13.16.2
@@ -2974,7 +2975,9 @@ azure.subscription.networkService.applicationGateway.policy 9.0.13
 azure.subscription.networkService.applicationGateway.principalId 13.23.1
 azure.subscription.networkService.applicationGateway.properties 9.0.13
 azure.subscription.networkService.applicationGateway.sslCertificate 13.12.2
+azure.subscription.networkService.applicationGateway.sslCertificate.hsmKey 13.25.1
 azure.subscription.networkService.applicationGateway.sslCertificate.id 13.12.2
+azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret 13.25.1
 azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecretId 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.name 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.provisioningState 13.12.2
@@ -3101,6 +3104,7 @@ azure.subscription.networkService.expressRouteCircuit.tags 13.12.2
 azure.subscription.networkService.expressRouteCircuit.type 13.12.2
 azure.subscription.networkService.expressRouteCircuits 13.12.2
 azure.subscription.networkService.firewall 9.0.8
+azure.subscription.networkService.firewall.afcServiceEndpoint 13.25.1
 azure.subscription.networkService.firewall.applicationRule 9.0.8
 azure.subscription.networkService.firewall.applicationRule.action 13.16.2
 azure.subscription.networkService.firewall.applicationRule.etag 9.0.8
@@ -3179,6 +3183,7 @@ azure.subscription.networkService.firewallPolicy.tags 9.0.8
 azure.subscription.networkService.firewallPolicy.type 9.0.8
 azure.subscription.networkService.firewalls 9.0.8
 azure.subscription.networkService.frontendIpConfig 9.0.8
+azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId 13.25.1
 azure.subscription.networkService.frontendIpConfig.etag 9.0.8
 azure.subscription.networkService.frontendIpConfig.id 9.0.8
 azure.subscription.networkService.frontendIpConfig.isPublic 9.0.8
@@ -3275,6 +3280,7 @@ azure.subscription.networkService.natGateway.etag 9.0.8
 azure.subscription.networkService.natGateway.id 9.0.8
 azure.subscription.networkService.natGateway.location 9.0.8
 azure.subscription.networkService.natGateway.name 9.0.8
+azure.subscription.networkService.natGateway.nat64Enabled 13.25.1
 azure.subscription.networkService.natGateway.properties 9.0.8
 azure.subscription.networkService.natGateway.publicIpAddresses 9.0.8
 azure.subscription.networkService.natGateway.subnets 9.0.8
@@ -3289,6 +3295,7 @@ azure.subscription.networkService.outboundRule.name 9.0.8
 azure.subscription.networkService.outboundRule.properties 9.0.8
 azure.subscription.networkService.outboundRule.type 9.0.8
 azure.subscription.networkService.privateEndpoint 11.4.28
+azure.subscription.networkService.privateEndpoint.billingSku 13.25.1
 azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName 11.4.28
 azure.subscription.networkService.privateEndpoint.id 11.4.28
 azure.subscription.networkService.privateEndpoint.location 11.4.28
@@ -3351,6 +3358,7 @@ azure.subscription.networkService.probe.type 9.0.8
 azure.subscription.networkService.publicIpAddresses 9.0.1
 azure.subscription.networkService.route 11.4.28
 azure.subscription.networkService.route.addressPrefix 11.4.28
+azure.subscription.networkService.route.ecmpNextHopIpAddresses 13.25.1
 azure.subscription.networkService.route.hasBgpOverride 11.4.28
 azure.subscription.networkService.route.id 11.4.28
 azure.subscription.networkService.route.name 11.4.28
@@ -3469,6 +3477,7 @@ azure.subscription.networkService.trafficManagerProfile.endpoint.minChildEndpoin
 azure.subscription.networkService.trafficManagerProfile.endpoint.name 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.priority 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.properties 13.12.2
+azure.subscription.networkService.trafficManagerProfile.endpoint.status 13.25.1
 azure.subscription.networkService.trafficManagerProfile.endpoint.subnets 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.target 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.targetResourceId 13.12.2
@@ -3482,6 +3491,7 @@ azure.subscription.networkService.trafficManagerProfile.monitorConfig 13.12.2
 azure.subscription.networkService.trafficManagerProfile.name 13.12.2
 azure.subscription.networkService.trafficManagerProfile.profileStatus 13.12.2
 azure.subscription.networkService.trafficManagerProfile.properties 13.12.2
+azure.subscription.networkService.trafficManagerProfile.status 13.25.1
 azure.subscription.networkService.trafficManagerProfile.tags 13.12.2
 azure.subscription.networkService.trafficManagerProfile.trafficRoutingMethod 13.12.2
 azure.subscription.networkService.trafficManagerProfile.trafficViewEnrollmentStatus 13.12.2
@@ -3599,6 +3609,7 @@ azure.subscription.networkService.virtualNetworkGateway.connection.location 13.1
 azure.subscription.networkService.virtualNetworkGateway.connection.name 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.connection.properties 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.connection.provisioningState 13.10.2
+azure.subscription.networkService.virtualNetworkGateway.connection.routingConfiguration 13.25.1
 azure.subscription.networkService.virtualNetworkGateway.connection.routingWeight 13.10.2
 azure.subscription.networkService.virtualNetworkGateway.connection.type 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.connection.useLocalAzureIpAddress 13.10.2

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -26,7 +26,7 @@ import (
 	"go.mondoo.com/mql/v13/utils/stringx"
 	"golang.org/x/sync/errgroup"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 )
 
 func (a *mqlAzureSubscriptionNetworkService) id() (string, error) {
@@ -337,9 +337,11 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 		return nil, err
 	}
 
-	// armnetwork v9 misshapes EffectiveNetworkSecurityGroup.TagMap (declared *string,
-	// API returns object), so SDK unmarshalling fails. Use REST directly and pluck
-	// the effectiveSecurityRules out as raw JSON.
+	// armnetwork v9 misshaped EffectiveNetworkSecurityGroup.TagMap (declared *string
+	// while the API returns an object), so SDK unmarshalling failed and we fetch via
+	// REST, plucking effectiveSecurityRules out as raw JSON. armnetwork v10 corrected
+	// TagMap to map[string][]*string, so this could be switched back to the SDK client
+	// (BeginGetEffectiveNetworkSecurityGroups) in a follow-up once verified live.
 	tok, err := conn.Token().GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},
 	})
@@ -672,6 +674,7 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 		isPublic := false
 		var publicIpAddressId string
 		var privateIpAddress string
+		var ddosCustomPolicyId string
 		if ipConfig.Properties != nil {
 			if ipConfig.Properties.PublicIPAddress != nil && ipConfig.Properties.PublicIPAddress.ID != nil {
 				isPublic = true
@@ -680,19 +683,23 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 			if ipConfig.Properties.PrivateIPAddress != nil {
 				privateIpAddress = *ipConfig.Properties.PrivateIPAddress
 			}
+			if ds := ipConfig.Properties.DdosSettings; ds != nil && ds.DdosCustomPolicy != nil {
+				ddosCustomPolicyId = convert.ToValue(ds.DdosCustomPolicy.ID)
+			}
 		}
 
 		mqlIpConfig, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.frontendIpConfig",
 			map[string]*llx.RawData{
-				"id":                llx.StringDataPtr(ipConfig.ID),
-				"type":              llx.StringDataPtr(ipConfig.Type),
-				"name":              llx.StringDataPtr(ipConfig.Name),
-				"etag":              llx.StringDataPtr(ipConfig.Etag),
-				"zones":             llx.ArrayData(convert.SliceStrPtrToInterface(ipConfig.Zones), types.String),
-				"properties":        llx.DictData(props),
-				"isPublic":          llx.BoolData(isPublic),
-				"publicIpAddressId": llx.StringData(publicIpAddressId),
-				"privateIpAddress":  llx.StringData(privateIpAddress),
+				"id":                 llx.StringDataPtr(ipConfig.ID),
+				"type":               llx.StringDataPtr(ipConfig.Type),
+				"name":               llx.StringDataPtr(ipConfig.Name),
+				"etag":               llx.StringDataPtr(ipConfig.Etag),
+				"zones":              llx.ArrayData(convert.SliceStrPtrToInterface(ipConfig.Zones), types.String),
+				"properties":         llx.DictData(props),
+				"isPublic":           llx.BoolData(isPublic),
+				"publicIpAddressId":  llx.StringData(publicIpAddressId),
+				"privateIpAddress":   llx.StringData(privateIpAddress),
+				"ddosCustomPolicyId": llx.StringData(ddosCustomPolicyId),
 			})
 		if err != nil {
 			return nil, err
@@ -1840,7 +1847,7 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 		return nil, nil
 	}
 
-	var provisioningState, subnetId, customNicName string
+	var provisioningState, subnetId, customNicName, billingSku string
 	var plsConns, manualPlsConns []any
 
 	if pe.Properties != nil {
@@ -1851,6 +1858,9 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 			subnetId = convert.ToValue(pe.Properties.Subnet.ID)
 		}
 		customNicName = convert.ToValue(pe.Properties.CustomNetworkInterfaceName)
+		if pe.Properties.BillingSKU != nil {
+			billingSku = string(*pe.Properties.BillingSKU)
+		}
 
 		for _, c := range pe.Properties.PrivateLinkServiceConnections {
 			mqlConn, err := privateLinkServiceConnectionToMql(runtime, c)
@@ -1878,6 +1888,7 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 			"provisioningState":                   llx.StringData(provisioningState),
 			"subnetId":                            llx.StringData(subnetId),
 			"customNetworkInterfaceName":          llx.StringData(customNicName),
+			"billingSku":                          llx.StringData(billingSku),
 			"privateLinkServiceConnections":       llx.ArrayData(plsConns, types.ResourceLike),
 			"manualPrivateLinkServiceConnections": llx.ArrayData(manualPlsConns, types.ResourceLike),
 		})
@@ -2422,6 +2433,7 @@ func (a *mqlAzureSubscriptionNetworkService) routeTables() ([]any, error) {
 func azureRouteToMql(runtime *plugin.Runtime, route *network.Route) (*mqlAzureSubscriptionNetworkServiceRoute, error) {
 	var addressPrefix, nextHopType, nextHopIpAddress, provisioningState string
 	var hasBgpOverride bool
+	ecmpNextHopIpAddresses := []any{}
 
 	if route.Properties != nil {
 		addressPrefix = convert.ToValue(route.Properties.AddressPrefix)
@@ -2433,17 +2445,21 @@ func azureRouteToMql(runtime *plugin.Runtime, route *network.Route) (*mqlAzureSu
 		if route.Properties.ProvisioningState != nil {
 			provisioningState = string(*route.Properties.ProvisioningState)
 		}
+		if route.Properties.NextHop != nil {
+			ecmpNextHopIpAddresses = convert.SliceStrPtrToInterface(route.Properties.NextHop.NextHopIPAddresses)
+		}
 	}
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.route",
 		map[string]*llx.RawData{
-			"id":                llx.StringDataPtr(route.ID),
-			"name":              llx.StringDataPtr(route.Name),
-			"addressPrefix":     llx.StringData(addressPrefix),
-			"nextHopType":       llx.StringData(nextHopType),
-			"nextHopIpAddress":  llx.StringData(nextHopIpAddress),
-			"hasBgpOverride":    llx.BoolData(hasBgpOverride),
-			"provisioningState": llx.StringData(provisioningState),
+			"id":                     llx.StringDataPtr(route.ID),
+			"name":                   llx.StringDataPtr(route.Name),
+			"addressPrefix":          llx.StringData(addressPrefix),
+			"nextHopType":            llx.StringData(nextHopType),
+			"nextHopIpAddress":       llx.StringData(nextHopIpAddress),
+			"ecmpNextHopIpAddresses": llx.ArrayData(ecmpNextHopIpAddresses, types.String),
+			"hasBgpOverride":         llx.BoolData(hasBgpOverride),
+			"provisioningState":      llx.StringData(provisioningState),
 		})
 	if err != nil {
 		return nil, err
@@ -2713,6 +2729,11 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) connections() 
 				args["routingWeight"] = llx.IntDataDefault(cn.Properties.RoutingWeight, 0)
 				args["ingressBytesTransferred"] = llx.IntDataDefault(cn.Properties.IngressBytesTransferred, 0)
 				args["egressBytesTransferred"] = llx.IntDataDefault(cn.Properties.EgressBytesTransferred, 0)
+				routingConfig, err := convert.JsonToDict(cn.Properties.RoutingConfiguration)
+				if err != nil {
+					return nil, err
+				}
+				args["routingConfiguration"] = llx.DictData(routingConfig)
 			}
 			mqlConnection, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetworkGateway.connection", args)
 			if err != nil {
@@ -3138,17 +3159,27 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) id() (stri
 	return a.Id.Data, nil
 }
 
+// wafPolicyEnabled reports whether the WAF policy is enabled. The SDK models
+// this as an Enabled/Disabled enum; we collapse it to a bool where only the
+// explicit Enabled state (and, matching Azure's default for an unset value)
+// is true.
+func wafPolicyEnabled(ps *network.PolicySettings) bool {
+	return ps == nil || ps.State == nil || *ps.State == network.WebApplicationFirewallEnabledStateEnabled
+}
+
 func azureAppFirewallPolicyToMql(runtime *plugin.Runtime, waf network.WebApplicationFirewallPolicy) (*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy, error) {
 	props, err := convert.JsonToDict(waf.Properties)
 	if err != nil {
 		return nil, err
 	}
 	var mode, enabledState string
+	enabled := true
 	var requestBodyCheck *bool
 	var maxRequestBodySizeInKb, fileUploadLimitInMb *int64
 	customRulesCount := int64(0)
 	managedRuleSets := []any{}
 	if p := waf.Properties; p != nil {
+		enabled = wafPolicyEnabled(p.PolicySettings)
 		if ps := p.PolicySettings; ps != nil {
 			if ps.Mode != nil {
 				mode = string(*ps.Mode)
@@ -3193,6 +3224,7 @@ func azureAppFirewallPolicyToMql(runtime *plugin.Runtime, waf network.WebApplica
 		"properties":             llx.DictData(props),
 		"mode":                   llx.StringData(mode),
 		"enabledState":           llx.StringData(enabledState),
+		"enabled":                llx.BoolData(enabled),
 		"requestBodyCheck":       llx.BoolDataPtr(requestBodyCheck),
 		"maxRequestBodySizeInKb": llx.IntDataPtr(maxRequestBodySizeInKb),
 		"fileUploadLimitInMb":    llx.IntDataPtr(fileUploadLimitInMb),
@@ -3481,6 +3513,7 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 	keyVaultSecretId := ""
 	publicCertData := ""
 	provisioningState := ""
+	hsmKeyId := ""
 	if c.Properties != nil {
 		if c.Properties.KeyVaultSecretID != nil {
 			keyVaultSecretId = *c.Properties.KeyVaultSecretID
@@ -3490,6 +3523,9 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 		}
 		if c.Properties.ProvisioningState != nil {
 			provisioningState = string(*c.Properties.ProvisioningState)
+		}
+		if c.Properties.Hsm != nil {
+			hsmKeyId = convert.ToValue(c.Properties.Hsm.KeyID)
 		}
 	}
 	res, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway.sslCertificate", map[string]*llx.RawData{
@@ -3502,7 +3538,33 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate), nil
+	sslCert := res.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate)
+	sslCert.cacheHsmKeyId = hsmKeyId
+	return sslCert, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificateInternal struct {
+	cacheHsmKeyId string
+}
+
+// keyVaultSecret resolves the typed Key Vault secret backing this certificate
+// from its secret URI. Returns null for certificates uploaded directly.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) keyVaultSecret() (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
+	if a.KeyVaultSecretId.Data == "" {
+		a.KeyVaultSecret.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return newKeyVaultSecretResource(a.MqlRuntime, a.KeyVaultSecretId.Data)
+}
+
+// hsmKey resolves the typed Managed HSM key backing this certificate from its
+// key identifier. Returns null for Key Vault- or PFX-backed certificates.
+func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) hsmKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
+	if a.cacheHsmKeyId == "" {
+		a.HsmKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return newKeyVaultKeyResource(a.MqlRuntime, a.cacheHsmKeyId)
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayListener) id() (string, error) {
@@ -3620,7 +3682,7 @@ func azureFirewallToMql(runtime *plugin.Runtime, fw network.AzureFirewall) (*mql
 	if err != nil {
 		return nil, err
 	}
-	var fwSkuTier, fwSkuName, fwProvisioningState, fwThreatIntelMode *string
+	var fwSkuTier, fwSkuName, fwProvisioningState, fwThreatIntelMode, fwAfcServiceEndpoint *string
 	if fw.Properties != nil {
 		fwProvisioningState = (*string)(fw.Properties.ProvisioningState)
 		fwThreatIntelMode = (*string)(fw.Properties.ThreatIntelMode)
@@ -3628,19 +3690,23 @@ func azureFirewallToMql(runtime *plugin.Runtime, fw network.AzureFirewall) (*mql
 			fwSkuTier = (*string)(fw.Properties.SKU.Tier)
 			fwSkuName = (*string)(fw.Properties.SKU.Name)
 		}
+		if fw.Properties.AfcConfiguration != nil {
+			fwAfcServiceEndpoint = fw.Properties.AfcConfiguration.ServiceEndpoint
+		}
 	}
 	args := map[string]*llx.RawData{
-		"id":                llx.StringDataPtr(fw.ID),
-		"name":              llx.StringDataPtr(fw.Name),
-		"type":              llx.StringDataPtr(fw.Type),
-		"location":          llx.StringDataPtr(fw.Location),
-		"tags":              llx.MapData(convert.PtrMapStrToInterface(fw.Tags), types.String),
-		"etag":              llx.StringDataPtr(fw.Etag),
-		"properties":        llx.DictData(props),
-		"skuTier":           llx.StringDataPtr(fwSkuTier),
-		"skuName":           llx.StringDataPtr(fwSkuName),
-		"provisioningState": llx.StringDataPtr(fwProvisioningState),
-		"threatIntelMode":   llx.StringDataPtr(fwThreatIntelMode),
+		"id":                 llx.StringDataPtr(fw.ID),
+		"name":               llx.StringDataPtr(fw.Name),
+		"type":               llx.StringDataPtr(fw.Type),
+		"location":           llx.StringDataPtr(fw.Location),
+		"tags":               llx.MapData(convert.PtrMapStrToInterface(fw.Tags), types.String),
+		"etag":               llx.StringDataPtr(fw.Etag),
+		"properties":         llx.DictData(props),
+		"skuTier":            llx.StringDataPtr(fwSkuTier),
+		"skuName":            llx.StringDataPtr(fwSkuName),
+		"provisioningState":  llx.StringDataPtr(fwProvisioningState),
+		"threatIntelMode":    llx.StringDataPtr(fwThreatIntelMode),
+		"afcServiceEndpoint": llx.StringDataPtr(fwAfcServiceEndpoint),
 	}
 	mqlFw, err := CreateResource(runtime, "azure.subscription.networkService.firewall", args)
 	if err != nil {
@@ -3913,21 +3979,31 @@ func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzur
 	return mqlAzure.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
 }
 
+// natGatewayNat64Enabled reports whether NAT64 translation is switched on for
+// the NAT gateway. The SDK models this as a tri-state (Enabled/Disabled/None);
+// we collapse it to a bool where only the explicit Enabled state is true, so an
+// unset ("None") or nil value reads as "not enabled".
+func natGatewayNat64Enabled(props *network.NatGatewayPropertiesFormat) bool {
+	return props != nil && props.Nat64 != nil && *props.Nat64 == network.Nat64StateEnabled
+}
+
 func azureNatGatewayToMql(runtime *plugin.Runtime, ng network.NatGateway) (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
 	props, err := convert.JsonToDict(ng.Properties)
 	if err != nil {
 		return nil, err
 	}
+	nat64Enabled := natGatewayNat64Enabled(ng.Properties)
 	mqlNg, err := CreateResource(runtime, "azure.subscription.networkService.natGateway",
 		map[string]*llx.RawData{
-			"id":         llx.StringDataPtr(ng.ID),
-			"name":       llx.StringDataPtr(ng.Name),
-			"type":       llx.StringDataPtr(ng.Type),
-			"location":   llx.StringDataPtr(ng.Location),
-			"tags":       llx.MapData(convert.PtrMapStrToInterface(ng.Tags), types.String),
-			"etag":       llx.StringDataPtr(ng.Etag),
-			"zones":      llx.ArrayData(convert.SliceStrPtrToInterface(ng.Zones), types.String),
-			"properties": llx.DictData(props),
+			"id":           llx.StringDataPtr(ng.ID),
+			"name":         llx.StringDataPtr(ng.Name),
+			"type":         llx.StringDataPtr(ng.Type),
+			"location":     llx.StringDataPtr(ng.Location),
+			"tags":         llx.MapData(convert.PtrMapStrToInterface(ng.Tags), types.String),
+			"etag":         llx.StringDataPtr(ng.Etag),
+			"zones":        llx.ArrayData(convert.SliceStrPtrToInterface(ng.Zones), types.String),
+			"nat64Enabled": llx.BoolData(nat64Enabled),
+			"properties":   llx.DictData(props),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 	trafficmanager "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -128,6 +128,20 @@ func (a *mqlAzureSubscriptionNetworkService) trafficManagerProfiles() ([]any, er
 	return res, nil
 }
 
+// trafficManagerProfileEnabled reports whether the Traffic Manager profile is
+// enabled. The SDK models this as an Enabled/Disabled enum; we collapse it to a
+// bool where only the explicit Enabled state is true.
+func trafficManagerProfileEnabled(props *trafficmanager.ProfileProperties) bool {
+	return props != nil && props.ProfileStatus != nil && *props.ProfileStatus == trafficmanager.ProfileStatusEnabled
+}
+
+// trafficManagerEndpointEnabled reports whether the Traffic Manager endpoint is
+// enabled. The SDK models this as an Enabled/Disabled enum; we collapse it to a
+// bool where only the explicit Enabled state is true.
+func trafficManagerEndpointEnabled(props *trafficmanager.EndpointProperties) bool {
+	return props != nil && props.EndpointStatus != nil && *props.EndpointStatus == trafficmanager.EndpointStatusEnabled
+}
+
 func azureTrafficManagerProfileToMql(runtime *plugin.Runtime, p *trafficmanager.Profile) (plugin.Resource, error) {
 	if p == nil {
 		return nil, nil
@@ -145,6 +159,7 @@ func azureTrafficManagerProfileToMql(runtime *plugin.Runtime, p *trafficmanager.
 		"type":                        llx.StringDataPtr(p.Type),
 		"properties":                  llx.DictData(properties),
 		"profileStatus":               llx.StringDataPtr(nil),
+		"status":                      llx.BoolData(false),
 		"trafficRoutingMethod":        llx.StringDataPtr(nil),
 		"trafficViewEnrollmentStatus": llx.StringDataPtr(nil),
 		"maxReturn":                   llx.IntDataDefault[int64](nil, 0),
@@ -163,6 +178,7 @@ func azureTrafficManagerProfileToMql(runtime *plugin.Runtime, p *trafficmanager.
 		s := string(*props.ProfileStatus)
 		args["profileStatus"] = llx.StringData(s)
 	}
+	args["status"] = llx.BoolData(trafficManagerProfileEnabled(props))
 	if props.TrafficRoutingMethod != nil {
 		s := string(*props.TrafficRoutingMethod)
 		args["trafficRoutingMethod"] = llx.StringData(s)
@@ -224,6 +240,7 @@ func azureTrafficManagerEndpointToMql(runtime *plugin.Runtime, ep *trafficmanage
 		"properties":            llx.DictData(properties),
 		"alwaysServe":           llx.StringDataPtr(nil),
 		"endpointStatus":        llx.StringDataPtr(nil),
+		"status":                llx.BoolData(false),
 		"endpointMonitorStatus": llx.StringDataPtr(nil),
 		"target":                llx.StringDataPtr(nil),
 		"targetResourceId":      llx.StringDataPtr(nil),
@@ -251,6 +268,7 @@ func azureTrafficManagerEndpointToMql(runtime *plugin.Runtime, ep *trafficmanage
 		s := string(*props.EndpointStatus)
 		args["endpointStatus"] = llx.StringData(s)
 	}
+	args["status"] = llx.BoolData(trafficManagerEndpointEnabled(props))
 	if props.EndpointMonitorStatus != nil {
 		s := string(*props.EndpointMonitorStatus)
 		args["endpointMonitorStatus"] = llx.StringData(s)

--- a/providers/azure/resources/network_test.go
+++ b/providers/azure/resources/network_test.go
@@ -6,7 +6,8 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	trafficmanager "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +48,92 @@ func TestFrontendIpConfigFields(t *testing.T) {
 		assert.Empty(t, gotSubnet)
 		assert.Equal(t, "/publicIPAddresses/pip", gotPublic)
 	})
+}
+
+func TestNatGatewayNat64Enabled(t *testing.T) {
+	enabled := network.Nat64StateEnabled
+	disabled := network.Nat64StateDisabled
+	none := network.Nat64StateNone
+
+	tests := []struct {
+		name  string
+		props *network.NatGatewayPropertiesFormat
+		want  bool
+	}{
+		{"nil properties", nil, false},
+		{"unset nat64 field", &network.NatGatewayPropertiesFormat{}, false},
+		{"enabled", &network.NatGatewayPropertiesFormat{Nat64: &enabled}, true},
+		{"disabled", &network.NatGatewayPropertiesFormat{Nat64: &disabled}, false},
+		{"none collapses to false", &network.NatGatewayPropertiesFormat{Nat64: &none}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, natGatewayNat64Enabled(tc.props))
+		})
+	}
+}
+
+func TestWafPolicyEnabled(t *testing.T) {
+	enabled := network.WebApplicationFirewallEnabledStateEnabled
+	disabled := network.WebApplicationFirewallEnabledStateDisabled
+
+	tests := []struct {
+		name     string
+		settings *network.PolicySettings
+		want     bool
+	}{
+		{"nil settings defaults to enabled", nil, true},
+		{"unset state defaults to enabled", &network.PolicySettings{}, true},
+		{"enabled", &network.PolicySettings{State: &enabled}, true},
+		{"disabled", &network.PolicySettings{State: &disabled}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, wafPolicyEnabled(tc.settings))
+		})
+	}
+}
+
+func TestTrafficManagerProfileEnabled(t *testing.T) {
+	enabled := trafficmanager.ProfileStatusEnabled
+	disabled := trafficmanager.ProfileStatusDisabled
+
+	tests := []struct {
+		name  string
+		props *trafficmanager.ProfileProperties
+		want  bool
+	}{
+		{"nil properties", nil, false},
+		{"unset status", &trafficmanager.ProfileProperties{}, false},
+		{"enabled", &trafficmanager.ProfileProperties{ProfileStatus: &enabled}, true},
+		{"disabled", &trafficmanager.ProfileProperties{ProfileStatus: &disabled}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, trafficManagerProfileEnabled(tc.props))
+		})
+	}
+}
+
+func TestTrafficManagerEndpointEnabled(t *testing.T) {
+	enabled := trafficmanager.EndpointStatusEnabled
+	disabled := trafficmanager.EndpointStatusDisabled
+
+	tests := []struct {
+		name  string
+		props *trafficmanager.EndpointProperties
+		want  bool
+	}{
+		{"nil properties", nil, false},
+		{"unset status", &trafficmanager.EndpointProperties{}, false},
+		{"enabled", &trafficmanager.EndpointProperties{EndpointStatus: &enabled}, true},
+		{"disabled", &trafficmanager.EndpointProperties{EndpointStatus: &disabled}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, trafficManagerEndpointEnabled(tc.props))
+		})
+	}
 }
 
 func TestParseAzurePortRange(t *testing.T) {

--- a/providers/azure/resources/security_helpers.go
+++ b/providers/azure/resources/security_helpers.go
@@ -30,3 +30,25 @@ func newKeyVaultKeyResource(runtime *plugin.Runtime, keyURI string) (*mqlAzureSu
 	}
 	return mqlKey.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
 }
+
+// newKeyVaultSecretResource creates a typed azure.subscription.keyVaultService.secret
+// reference from a Key Vault secret URI (e.g. https://myvault.vault.azure.net/secrets/mysecret/version).
+// Returns nil resource if secretURI is empty.
+func newKeyVaultSecretResource(runtime *plugin.Runtime, secretURI string) (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
+	if secretURI == "" {
+		return nil, nil
+	}
+
+	// Use NewResource so that if the secret is already cached it gets reused.
+	// The id field (the secret URI) is the canonical identifier for key vault secrets.
+	mqlSecret, err := NewResource(runtime, "azure.subscription.keyVaultService.secret",
+		map[string]*llx.RawData{
+			"id":      llx.StringData(secretURI),
+			"managed": llx.BoolData(false),
+			"tags":    llx.MapData(map[string]interface{}{}, types.String),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlSecret.(*mqlAzureSubscriptionKeyVaultServiceSecret), nil
+}


### PR DESCRIPTION
## What

Bumps the Azure SDK's `armnetwork` module **v9 → v10** — the only `github.com/Azure/...` module with a stable major upgrade available (everything else was already on latest stable or only offered beta/pseudo-version majors) — and surfaces the network fields the new major unlocks. Also folds in a few `Enabled`/`Disabled`-string → `bool` cleanups on the same network resources.

## Dependency bump

`armnetwork/v9 v9.0.0` → `armnetwork/v10 v10.0.0`. Import paths rewritten in the 5 files that use it; `go.mod`/`go.sum` updated and `go mod tidy`-clean.

The v10 CHANGELOG breaking changes were audited against our call sites — none affect us:
- `EffectiveNetworkSecurityGroup.TagMap` is read via raw REST (not the SDK type); v10 actually *fixes* that field's shape, so the existing REST workaround comment was updated to note it can be reverted to the SDK client in a follow-up.
- `*SecurityPerimeter*.SystemData` type rename — we read `SystemData` only through `convert.JsonToDict`, which is type-agnostic.
- `VirtualNetworkAppliance.BandwidthInGbps` (`*string`→`*float64`) — we only use `ExpressRouteCircuit.BandwidthInGbps`, unaffected.
- Removed structs/enums (connection-monitor, error types, `PatchRouteFilter`, `VPNSiteID`) — unreferenced.

## New fields

| Resource | Field | Notes |
|---|---|---|
| `natGateway` | `nat64Enabled` (bool) | SDK `Nat64` tri-state collapsed (`Enabled`→true) |
| `route` | `ecmpNextHopIpAddresses` (`[]string`) | ECMP next-hops for `VirtualApplianceEcmp` routes |
| `frontendIpConfig` | `ddosCustomPolicyId` | per-frontend DDoS custom-policy binding |
| `privateEndpoint` | `billingSku` | `Fixed` / `PayAsYouGo` |
| `virtualNetworkGateway.connection` | `routingConfiguration` (dict) | associated/propagated route tables |
| `firewall` | `afcServiceEndpoint` | Azure Firewall control-plane endpoint |
| `applicationGateway.sslCertificate` | `hsmKey()` → `keyVaultService.key` | typed ref to the Managed HSM key backing the cert |
| `applicationGateway.sslCertificate` | `keyVaultSecret()` → `keyVaultService.secret` | typed ref (new shared `newKeyVaultSecretResource` helper, mirroring the existing key helper) |

## Deprecations

Legacy fields are **kept and still populated** for back-compat, marked `@maturity("deprecated")`, and superseded by cleaner typed/bool fields. Their original `.lr.versions` entries are unchanged (deprecation doesn't bump the version):

- `sslCertificate.keyVaultSecretId` → `keyVaultSecret()`
- `applicationFirewallPolicy.enabledState` → `enabled` (bool)
- `trafficManagerProfile.profileStatus` → `status` (bool)
- `trafficManagerProfile.endpoint.endpointStatus` → `status` (bool)

## Tests

Each enum→bool conversion is extracted into a pure helper (`natGatewayNat64Enabled`, `wafPolicyEnabled`, `trafficManagerProfileEnabled`, `trafficManagerEndpointEnabled`) with a table-driven test covering nil-props, unset-field, `Enabled`, and `Disabled`. `wafPolicyEnabled` treats unset as enabled (Azure's WAF default); the others treat only an explicit `Enabled` as true.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./resources/...` all pass.
- `gofmt` clean; `go mod tidy` clean; `permissions.json` unchanged (no new API calls — the key/secret refs reuse existing lazy clients).
- New `.lr.versions` entries at `13.25.1`; `config.go` `Version` untouched (release flow).
