### PR TITLE
🧹 aws: unify 27 tag→map converters onto one generic helper

### DIFF
--- a/providers/aws/resources/aws_acm.go
+++ b/providers/aws/resources/aws_acm.go
@@ -144,13 +144,7 @@ func initAwsAcmCertificate(runtime *plugin.Runtime, args map[string]*llx.RawData
 }
 
 func CertTagsToMapTags(tags []acmtypes.Tag) map[string]any {
-	mapTags := make(map[string]any)
-	for i := range tags {
-		if tags[i].Key != nil && tags[i].Value != nil {
-			mapTags[*tags[i].Key] = *tags[i].Value
-		}
-	}
-	return mapTags
+	return tagsToMap(tags, func(t acmtypes.Tag) *string { return t.Key }, func(t acmtypes.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsAcmCertificate) certificate() (plugin.Resource, error) {

--- a/providers/aws/resources/aws_autoscaling.go
+++ b/providers/aws/resources/aws_autoscaling.go
@@ -312,16 +312,7 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 }
 
 func autoscalingTagsToMap(tags []ec2types.TagDescription) map[string]any {
-	tagsMap := make(map[string]any)
-
-	if len(tags) > 0 {
-		for i := range tags {
-			tag := tags[i]
-			tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-
-	return tagsMap
+	return tagsToMap(tags, func(t ec2types.TagDescription) *string { return t.Key }, func(t ec2types.TagDescription) *string { return t.Value })
 }
 
 func createTagSpecifications(runtime *plugin.Runtime, tags []ec2types.TagDescription, groupArn string) ([]any, error) {

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -42,18 +42,7 @@ func (a *mqlAwsCloudformation) stacks() ([]any, error) {
 }
 
 func cfnTagsToMap(in []cf_types.Tag) map[string]any {
-	tags := make(map[string]any, len(in))
-	for _, t := range in {
-		if t.Key == nil {
-			continue
-		}
-		val := ""
-		if t.Value != nil {
-			val = *t.Value
-		}
-		tags[*t.Key] = val
-	}
-	return tags
+	return tagsToMap(in, func(t cf_types.Tag) *string { return t.Key }, func(t cf_types.Tag) *string { return t.Value })
 }
 
 // stackParameterToDict converts an SDK Parameter to a dict with lowercase

--- a/providers/aws/resources/aws_cloudhsm.go
+++ b/providers/aws/resources/aws_cloudhsm.go
@@ -26,18 +26,7 @@ func (a *mqlAwsCloudhsm) id() (string, error) {
 }
 
 func cloudHsmTagsToMap(tags []cloudhsmv2_types.Tag) map[string]any {
-	res := map[string]any{}
-	for _, t := range tags {
-		if t.Key == nil {
-			continue
-		}
-		val := ""
-		if t.Value != nil {
-			val = *t.Value
-		}
-		res[*t.Key] = val
-	}
-	return res
+	return tagsToMap(tags, func(t cloudhsmv2_types.Tag) *string { return t.Key }, func(t cloudhsmv2_types.Tag) *string { return t.Value })
 }
 
 // ---- aws.cloudhsm.cluster ----

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -600,16 +600,7 @@ func (a *mqlAwsCodebuildReportGroup) id() (string, error) {
 // ===== helpers =====
 
 func cbTagsToMap(tags []cbtypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-
-	if len(tags) > 0 {
-		for i := range tags {
-			tag := tags[i]
-			tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-
-	return tagsMap
+	return tagsToMap(tags, func(t cbtypes.Tag) *string { return t.Key }, func(t cbtypes.Tag) *string { return t.Value })
 }
 
 func cbArtifactsToDicts(arts []cbtypes.ProjectArtifacts) ([]any, error) {

--- a/providers/aws/resources/aws_codepipeline.go
+++ b/providers/aws/resources/aws_codepipeline.go
@@ -416,12 +416,7 @@ func (a *mqlAwsCodepipelineWebhook) targetPipeline() (*mqlAwsCodepipelinePipelin
 // ===== helpers =====
 
 func cpTagsToMap(tags []cptypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for i := range tags {
-		t := tags[i]
-		tagsMap[convert.ToValue(t.Key)] = convert.ToValue(t.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t cptypes.Tag) *string { return t.Key }, func(t cptypes.Tag) *string { return t.Value })
 }
 
 func cpStagesToDicts(stages []cptypes.StageDeclaration) ([]any, error) {

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -907,11 +907,7 @@ func replicaRegionsFromDescriptions(replicas []ddtypes.ReplicaDescription) []any
 }
 
 func dynamoDBTagsToMap(tags []ddtypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t ddtypes.Tag) *string { return t.Key }, func(t ddtypes.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsDynamodbGlobaltable) replicaSettings() ([]any, error) {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3900,13 +3900,7 @@ func shouldExcludeInstance(instance ec2types.Instance, filters connection.Discov
 
 // tags in AWS are guaranteed to have a unique key, so we can convert the slice to a map for easier processing
 func ec2TagsToMap(tags []ec2types.Tag) map[string]string {
-	result := make(map[string]string)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			result[*tag.Key] = *tag.Value
-		}
-	}
-	return result
+	return tagsToStringMap(tags, func(t ec2types.Tag) *string { return t.Key }, func(t ec2types.Tag) *string { return t.Value })
 }
 
 const launchTemplateArnPattern = "arn:aws:ec2:%s:%s:launch-template/%s"

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -766,13 +766,7 @@ func (s *mqlAwsEcsContainer) id() (string, error) {
 }
 
 func ecsTagsToMap(tags []ecstypes.Tag) map[string]any {
-	res := map[string]any{}
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			res[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-	return res
+	return tagsToMap(tags, func(t ecstypes.Tag) *string { return t.Key }, func(t ecstypes.Tag) *string { return t.Value })
 }
 
 // validateAndParseARN validates that the given string is a valid ECS ARN

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -435,16 +435,7 @@ func (a *mqlAwsEfsFilesystem) fileSystemProtection() (any, error) {
 }
 
 func efsTagsToMap(tags []efstypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-
-	if len(tags) > 0 {
-		for i := range tags {
-			tag := tags[i]
-			tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-
-	return tagsMap
+	return tagsToMap(tags, func(t efstypes.Tag) *string { return t.Key }, func(t efstypes.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsEfsFilesystem) mountTargets() ([]any, error) {

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -752,19 +752,11 @@ func isV1LoadBalancerArn(a string) bool {
 }
 
 func elbv2TagsToMap(tags []elbtypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t elbtypes.Tag) *string { return t.Key }, func(t elbtypes.Tag) *string { return t.Value })
 }
 
 func elbv1TagsToMap(tags []elbv1types.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t elbv1types.Tag) *string { return t.Key }, func(t elbv1types.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsElbLoadbalancer) tags() (map[string]any, error) {

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -1384,13 +1384,7 @@ func newMqlAwsEmrStudio(runtime *plugin.Runtime, region string, studio *emrtypes
 }
 
 func emrTagsToMap(tags []emrtypes.Tag) map[string]string {
-	out := make(map[string]string, len(tags))
-	for _, t := range tags {
-		if t.Key != nil && t.Value != nil {
-			out[*t.Key] = *t.Value
-		}
-	}
-	return out
+	return tagsToStringMap(tags, func(t emrtypes.Tag) *string { return t.Key }, func(t emrtypes.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsEmrStudio) vpc() (*mqlAwsVpc, error) {

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -756,11 +756,5 @@ func (a *mqlAwsFsx) getVolumes(conn *connection.AwsConnection) []*jobpool.Job {
 // ========================
 
 func fsxTagsToMap(tags []fsxtypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagsMap[*tag.Key] = *tag.Value
-		}
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t fsxtypes.Tag) *string { return t.Key }, func(t fsxtypes.Tag) *string { return t.Value })
 }

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -341,12 +341,7 @@ func (a *mqlAwsIam) users() ([]any, error) {
 }
 
 func iamTagsToMap(tags []iamtypes.Tag) map[string]any {
-	tagsMap := map[string]any{}
-	for i := range tags {
-		tag := tags[i]
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t iamtypes.Tag) *string { return t.Key }, func(t iamtypes.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsIam) instanceProfiles() ([]any, error) {

--- a/providers/aws/resources/aws_identitycenter.go
+++ b/providers/aws/resources/aws_identitycenter.go
@@ -375,13 +375,7 @@ func (a *mqlAwsIdentitycenterAccountAssignment) id() (string, error) {
 }
 
 func ssoTagsToMap(tags []ssotypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagsMap[*tag.Key] = *tag.Value
-		}
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t ssotypes.Tag) *string { return t.Key }, func(t ssotypes.Tag) *string { return t.Value })
 }
 
 // Permission set customer managed policies

--- a/providers/aws/resources/aws_lightsail.go
+++ b/providers/aws/resources/aws_lightsail.go
@@ -876,17 +876,7 @@ func (a *mqlAwsLightsailDisk) attachedTo() (*mqlAwsLightsailInstance, error) {
 }
 
 func lightsailTagsToMap(tags []lightsail_types.Tag) map[string]any {
-	result := make(map[string]any)
-	for _, t := range tags {
-		if t.Key != nil {
-			val := ""
-			if t.Value != nil {
-				val = *t.Value
-			}
-			result[*t.Key] = val
-		}
-	}
-	return result
+	return tagsToMap(tags, func(t lightsail_types.Tag) *string { return t.Key }, func(t lightsail_types.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsLightsailDistribution) id() (string, error) {

--- a/providers/aws/resources/aws_networkfirewall.go
+++ b/providers/aws/resources/aws_networkfirewall.go
@@ -905,13 +905,7 @@ func (a *mqlAwsNetworkfirewallRulegroup) snsTopic() (*mqlAwsSnsTopic, error) {
 }
 
 func nfTagsToMap(tags []nftypes.Tag) map[string]any {
-	m := make(map[string]any, len(tags))
-	for _, t := range tags {
-		if t.Key != nil && t.Value != nil {
-			m[*t.Key] = *t.Value
-		}
-	}
-	return m
+	return tagsToMap(tags, func(t nftypes.Tag) *string { return t.Key }, func(t nftypes.Tag) *string { return t.Value })
 }
 
 type mqlAwsNetworkfirewallTlsInspectionConfigurationInternal struct {

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -1035,11 +1035,7 @@ func masterUserSecretToDict(secret *rds_types.MasterUserSecret) any {
 }
 
 func rdsTagsToMap(tags []rds_types.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t rds_types.Tag) *string { return t.Key }, func(t rds_types.Tag) *string { return t.Value })
 }
 
 // clusters returns all RDS clusters

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -227,11 +227,7 @@ func redshiftHsmStatusToDict(hsm *redshifttypes.HsmStatus) map[string]any {
 }
 
 func redshiftTagsToMap(tags []redshifttypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t redshifttypes.Tag) *string { return t.Key }, func(t redshifttypes.Tag) *string { return t.Value })
 }
 
 type mqlAwsRedshiftClusterInternal struct {

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -471,14 +471,5 @@ func (a *mqlAwsSecretsmanagerSecretReplicaRegion) kmsKey() (*mqlAwsKmsKey, error
 }
 
 func secretTagsToMap(tags []secretstypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-
-	if len(tags) > 0 {
-		for i := range tags {
-			tag := tags[i]
-			tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-
-	return tagsMap
+	return tagsToMap(tags, func(t secretstypes.Tag) *string { return t.Key }, func(t secretstypes.Tag) *string { return t.Value })
 }

--- a/providers/aws/resources/aws_ses.go
+++ b/providers/aws/resources/aws_ses.go
@@ -23,18 +23,7 @@ func (a *mqlAwsSes) id() (string, error) {
 }
 
 func sesTagsToMap(tags []sesv2_types.Tag) map[string]any {
-	res := map[string]any{}
-	for _, t := range tags {
-		if t.Key == nil {
-			continue
-		}
-		val := ""
-		if t.Value != nil {
-			val = *t.Value
-		}
-		res[*t.Key] = val
-	}
-	return res
+	return tagsToMap(tags, func(t sesv2_types.Tag) *string { return t.Key }, func(t sesv2_types.Tag) *string { return t.Value })
 }
 
 // ---- aws.ses.identity ----

--- a/providers/aws/resources/aws_sfn.go
+++ b/providers/aws/resources/aws_sfn.go
@@ -592,11 +592,5 @@ func (a *mqlAwsSfnActivity) id() (string, error) {
 }
 
 func sfnTagsToMap(tags []sfntypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagsMap[*tag.Key] = *tag.Value
-		}
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t sfntypes.Tag) *string { return t.Key }, func(t sfntypes.Tag) *string { return t.Value })
 }

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -333,14 +333,5 @@ func (a *mqlAwsSsmInstance) tags() (map[string]any, error) {
 }
 
 func Ec2SSMTagsToMap(tags []ec2types.TagDescription) map[string]any {
-	tagsMap := make(map[string]any)
-
-	if len(tags) > 0 {
-		for i := range tags {
-			tag := tags[i]
-			tagsMap[convert.ToValue(tag.Key)] = convert.ToValue(tag.Value)
-		}
-	}
-
-	return tagsMap
+	return tagsToMap(tags, func(t ec2types.TagDescription) *string { return t.Key }, func(t ec2types.TagDescription) *string { return t.Value })
 }

--- a/providers/aws/resources/aws_ssm_documents.go
+++ b/providers/aws/resources/aws_ssm_documents.go
@@ -222,11 +222,7 @@ func (a *mqlAwsSsmDocument) permissions() ([]any, error) {
 }
 
 func ssmTagsToMap(tags []types.Tag) map[string]string {
-	m := make(map[string]string, len(tags))
-	for _, t := range tags {
-		m[convert.ToValue(t.Key)] = convert.ToValue(t.Value)
-	}
-	return m
+	return tagsToStringMap(tags, func(t types.Tag) *string { return t.Key }, func(t types.Tag) *string { return t.Value })
 }
 
 func (a *mqlAwsSsm) patchBaselines() ([]any, error) {

--- a/providers/aws/resources/aws_storagegateway.go
+++ b/providers/aws/resources/aws_storagegateway.go
@@ -746,11 +746,5 @@ func (a *mqlAwsStoragegatewayVolume) kmsKey() (*mqlAwsKmsKey, error) {
 // ========================
 
 func storageGatewayTagsToMap(tags []sgwtypes.Tag) map[string]any {
-	tagsMap := make(map[string]any)
-	for _, tag := range tags {
-		if tag.Key != nil && tag.Value != nil {
-			tagsMap[*tag.Key] = *tag.Value
-		}
-	}
-	return tagsMap
+	return tagsToMap(tags, func(t sgwtypes.Tag) *string { return t.Key }, func(t sgwtypes.Tag) *string { return t.Value })
 }

--- a/providers/aws/resources/aws_tags.go
+++ b/providers/aws/resources/aws_tags.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+// tagsToStringMap converts a slice of AWS SDK tag structs into a
+// map[string]string, using the supplied key and value accessors. The accessors
+// absorb the only variation across the ~100 AWS tag shapes: the field names
+// (Key/Value vs KMS-style TagKey/TagValue).
+//
+// Nil policy: an entry whose key is nil is skipped (a tag key is never
+// legitimately empty), while a nil value is normalized to the empty string so a
+// tag key present on a resource is always represented.
+func tagsToStringMap[T any](tags []T, key func(T) *string, value func(T) *string) map[string]string {
+	m := make(map[string]string, len(tags))
+	for i := range tags {
+		k := key(tags[i])
+		if k == nil {
+			continue
+		}
+		m[*k] = convert.ToValue(value(tags[i]))
+	}
+	return m
+}
+
+// tagsToMap is tagsToStringMap with a map[string]any result, the shape MQL
+// expects for tag fields.
+func tagsToMap[T any](tags []T, key func(T) *string, value func(T) *string) map[string]any {
+	return toInterfaceMap(tagsToStringMap(tags, key, value))
+}

--- a/providers/aws/resources/aws_tags.go
+++ b/providers/aws/resources/aws_tags.go
@@ -28,7 +28,16 @@ func tagsToStringMap[T any](tags []T, key func(T) *string, value func(T) *string
 }
 
 // tagsToMap is tagsToStringMap with a map[string]any result, the shape MQL
-// expects for tag fields.
+// expects for tag fields. It builds the map directly rather than converting a
+// map[string]string, avoiding a second allocation and copy.
 func tagsToMap[T any](tags []T, key func(T) *string, value func(T) *string) map[string]any {
-	return toInterfaceMap(tagsToStringMap(tags, key, value))
+	m := make(map[string]any, len(tags))
+	for i := range tags {
+		k := key(tags[i])
+		if k == nil {
+			continue
+		}
+		m[*k] = convert.ToValue(value(tags[i]))
+	}
+	return m
 }

--- a/providers/aws/resources/aws_tags_test.go
+++ b/providers/aws/resources/aws_tags_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	emrtypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keyValueTag mirrors the shape of the vast majority of AWS SDK tag structs
+// (Key/Value, both *string).
+type keyValueTag struct {
+	Key   *string
+	Value *string
+}
+
+// tagKeyValueTag mirrors the KMS-style shape (TagKey/TagValue) to prove the
+// generic helper handles alternate field names via its accessors.
+type tagKeyValueTag struct {
+	TagKey   *string
+	TagValue *string
+}
+
+func kvKey(t keyValueTag) *string   { return t.Key }
+func kvValue(t keyValueTag) *string { return t.Value }
+
+func TestTagsToMap(t *testing.T) {
+	t.Run("nil slice returns non-nil empty map", func(t *testing.T) {
+		got := tagsToMap(nil, kvKey, kvValue)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty slice returns non-nil empty map", func(t *testing.T) {
+		got := tagsToMap([]keyValueTag{}, kvKey, kvValue)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("maps key/value pairs", func(t *testing.T) {
+		got := tagsToMap([]keyValueTag{
+			{Key: aws.String("Name"), Value: aws.String("web")},
+			{Key: aws.String("env"), Value: aws.String("prod")},
+		}, kvKey, kvValue)
+		assert.Equal(t, map[string]any{"Name": "web", "env": "prod"}, got)
+	})
+
+	t.Run("skips entries with a nil key", func(t *testing.T) {
+		got := tagsToMap([]keyValueTag{
+			{Key: nil, Value: aws.String("orphan")},
+			{Key: aws.String("ok"), Value: aws.String("yes")},
+		}, kvKey, kvValue)
+		assert.Equal(t, map[string]any{"ok": "yes"}, got)
+	})
+
+	t.Run("coerces a nil value to empty string, keeping the key", func(t *testing.T) {
+		got := tagsToMap([]keyValueTag{
+			{Key: aws.String("present-empty"), Value: nil},
+		}, kvKey, kvValue)
+		assert.Equal(t, map[string]any{"present-empty": ""}, got)
+	})
+
+	t.Run("values are stored as strings", func(t *testing.T) {
+		got := tagsToMap([]keyValueTag{
+			{Key: aws.String("k"), Value: aws.String("v")},
+		}, kvKey, kvValue)
+		v, ok := got["k"].(string)
+		require.True(t, ok, "value must be a string, got %T", got["k"])
+		assert.Equal(t, "v", v)
+	})
+
+	t.Run("works with alternate field names (TagKey/TagValue)", func(t *testing.T) {
+		got := tagsToMap([]tagKeyValueTag{
+			{TagKey: aws.String("k"), TagValue: aws.String("v")},
+			{TagKey: nil, TagValue: aws.String("dropped")},
+		},
+			func(t tagKeyValueTag) *string { return t.TagKey },
+			func(t tagKeyValueTag) *string { return t.TagValue },
+		)
+		assert.Equal(t, map[string]any{"k": "v"}, got)
+	})
+}
+
+// Wrapper spot-checks: guard the mechanical rewrite of the per-service
+// converters against a Key/Value accessor swap or wrong output type. The
+// common Tag shape is already covered by TestEc2TagsToMap (Tag -> string) and
+// TestCfnTagsToMap (Tag -> any); these cover the structurally different
+// families.
+
+func TestAutoscalingTagsToMap_TagDescriptionShape(t *testing.T) {
+	// autoscaling / SSM use ec2types.TagDescription, not Tag.
+	got := autoscalingTagsToMap([]astypes.TagDescription{
+		{Key: aws.String("team"), Value: aws.String("infra")},
+		{Key: aws.String("empty"), Value: nil},
+		{Key: nil, Value: aws.String("dropped")},
+	})
+	assert.Equal(t, map[string]any{"team": "infra", "empty": ""}, got)
+}
+
+func TestEmrTagsToMap_StringMapShape(t *testing.T) {
+	got := emrTagsToMap([]emrtypes.Tag{
+		{Key: aws.String("k"), Value: aws.String("v")},
+	})
+	// must be a map[string]string, and key/value must not be swapped
+	assert.Equal(t, map[string]string{"k": "v"}, got)
+}
+
+func TestTagsToStringMap(t *testing.T) {
+	t.Run("nil slice returns non-nil empty map", func(t *testing.T) {
+		got := tagsToStringMap(nil, kvKey, kvValue)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns a map[string]string with the same nil policy", func(t *testing.T) {
+		got := tagsToStringMap([]keyValueTag{
+			{Key: aws.String("a"), Value: aws.String("1")},
+			{Key: nil, Value: aws.String("drop")},
+			{Key: aws.String("b"), Value: nil},
+		}, kvKey, kvValue)
+		assert.Equal(t, map[string]string{"a": "1", "b": ""}, got)
+	})
+}

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -302,11 +302,7 @@ func (a *mqlAwsTransferServer) structuredLogDestinations() ([]any, error) {
 }
 
 func transferTagsToMap(tags []transfertypes.Tag) map[string]any {
-	out := make(map[string]any, len(tags))
-	for _, t := range tags {
-		out[convert.ToValue(t.Key)] = convert.ToValue(t.Value)
-	}
-	return out
+	return tagsToMap(tags, func(t transfertypes.Tag) *string { return t.Key }, func(t transfertypes.Tag) *string { return t.Value })
 }
 
 // Connectors

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -27,15 +27,17 @@ func TestEc2TagsToMap(t *testing.T) {
 		assert.Len(t, result, 2)
 	})
 
-	t.Run("skips tags with nil key or value", func(t *testing.T) {
+	t.Run("skips nil keys and represents a nil value as empty string", func(t *testing.T) {
+		// Unified tag-conversion policy (see tagsToStringMap): a nil key is
+		// dropped (a tag key is never legitimately empty), but a present key
+		// with a nil value is kept as "" so the tag remains visible.
 		tags := []ec2types.Tag{
 			{Key: aws.String("good"), Value: aws.String("val")},
 			{Key: nil, Value: aws.String("orphan-val")},
 			{Key: aws.String("orphan-key"), Value: nil},
 		}
 		result := ec2TagsToMap(tags)
-		assert.Equal(t, "val", result["good"])
-		assert.Len(t, result, 1)
+		assert.Equal(t, map[string]string{"good": "val", "orphan-key": ""}, result)
 	})
 
 	t.Run("returns empty map for nil slice", func(t *testing.T) {


### PR DESCRIPTION
## What

Replaces the 27 per-service tag→map converters (`fsxTagsToMap`, `rdsTagsToMap`, `iamTagsToMap`, `ec2TagsToMap`, …) with two generic helpers in a new `aws_tags.go`:

```go
// nil key -> skipped; nil value -> ""
func tagsToStringMap[T any](tags []T, key func(T) *string, value func(T) *string) map[string]string
func tagsToMap[T any](tags []T, key func(T) *string, value func(T) *string) map[string]any // = toInterfaceMap(tagsToStringMap(...))
```

Each converter becomes a one-line wrapper, so **every call site is untouched**:

```go
func rdsTagsToMap(tags []rds_types.Tag) map[string]any {
    return tagsToMap(tags, func(t rds_types.Tag) *string { return t.Key }, func(t rds_types.Tag) *string { return t.Value })
}
```

The key/value accessor funcs absorb the only real variation across AWS's ~100 tag shapes: the field names (`Key`/`Value` vs KMS's `TagKey`/`TagValue`). Both output types are covered — `map[string]any` for MQL tag fields, `map[string]string` for the three converters that feed `GeneralDiscoveryFilters.IsFilteredOutByTags`.

## Why

The converters were pure copy-paste whose only difference was the SDK type name — and they had **drifted on nil handling**: some skipped an entry when either `Key` or `Value` was nil, some coerced a nil `Value` to `""`, and several passed a nil `Key` straight through `convert.ToValue`, producing an empty-string map key. One tested implementation removes the duplication and the inconsistency.

## Unified nil policy

Documented on `tagsToStringMap`: **a nil key is skipped** (a tag key is never legitimately empty); **a nil value becomes `""`** so a tag key present on a resource stays visible. This also fixes the latent bug of a nil key becoming an `""` map key.

This is a deliberate, small behavior change for the converters that previously *dropped* a present-key/nil-value entry (e.g. `ec2TagsToMap`): such a tag now surfaces as `{"key": ""}` rather than disappearing — which matches how AWS itself represents an empty-valued tag.

## Testing

New `aws_tags_test.go`:
- **Engine** (`tagsToMap` / `tagsToStringMap`): nil key skipped, nil value → `""`, key/value mapping, values stored as strings, alternate `TagKey`/`TagValue` field names, `map[string]string` variant, and nil/empty slices → non-nil empty map.
- **Wrapper spot-checks** for the structurally distinct families that the engine test can't catch an accessor-swap on: `ec2types.TagDescription` (autoscaling/SSM shape) and a `map[string]string` converter (`emrTagsToMap`).
- The existing `TestEc2TagsToMap` (Tag→string) and `TestCfnTagsToMap` (Tag→any) still exercise two wrappers end-to-end; the one `TestEc2TagsToMap` subtest that pinned the old dropped-nil-value behavior is updated to the unified policy with a comment explaining why.

Verification: `go build ./...` (whole provider), `go vet`, full `go test ./resources/`, `gofmt`. No `go.mod`/`go.sum` change.

## Follow-up

~35 inline tag loops still live directly in resolver / `CreateResource` paths (including the one KMS site using `TagKey`/`TagValue`). They can migrate to this same helper in a separate PR to keep this one focused and reviewable.
