### PR TITLE
🐛 nutanix: pin v4 client require lines to v4.0.x so weekly mod-update can't advance them

### DIFF
--- a/providers/nutanix/go.mod
+++ b/providers/nutanix/go.mod
@@ -5,9 +5,12 @@ replace go.mondoo.com/mql/v13 => ../..
 // Nutanix serves the v4 REST APIs only at v4.0 on GA Prism Central. The v4.1+
 // SDKs request URL paths (e.g. /api/clustermgmt/v4.2/...) that GA PCs return 404
 // for, breaking every non-IAM resource (customer issue #222, PR #8917). These
-// replace directives pin the four clients to v4.0.x so a `go get -u` cannot pull
-// them forward. Do NOT bump without confirming the minimum supported Prism
-// Central serves the newer path version.
+// replace directives force the build onto v4.0.x regardless of the require
+// versions below. The `// pin v4.0.x` comments in the require block keep the
+// weekly `version mod-update` job (.github/workflows/update-deps.yaml) from
+// advancing those require lines, so replace and require stay consistent. Do NOT
+// bump either without confirming the minimum supported Prism Central serves the
+// newer path version.
 replace (
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 => github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.0.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 => github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.0.1
@@ -18,10 +21,15 @@ replace (
 go 1.26.4
 
 require (
+	// pin v4.0.2
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.0.2
+	// pin v4.0.1
 	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.0.1
+	// pin v4.0.1
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.0.1
+	// pin v4.0.1
 	github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.0.1
+	// pin v4.0.1
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.0.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.26.0


### PR DESCRIPTION
## What

Add `// pin v4.0.x` comments above the five Nutanix v4 client `require` lines in `providers/nutanix/go.mod` so the weekly dependency-update job keeps them on v4.0.x instead of advancing them to v4.2.x/v4.3.1.

## Why

PR #8917 added `replace` directives pinning the four non-IAM v4 clients to v4.0.x, because GA Prism Central serves the v4 REST APIs only at the `v4.0` URL path and 404s the `v4.1+` paths (customer issue #222). Those `replace` directives correctly govern the **build**.

However, the weekly `version mod-update providers/*/ --latest` job (`.github/workflows/update-deps.yaml`, Monday cron) runs `go get -u <pkg>@latest` on every direct dependency. `replace` does not stop that from advancing the `require` **minimum**, so the require lines drifted up to `v4.2.2`/`v4.3.1` while `replace` silently held the build at v4.0.x. That left `require` and `replace` inconsistent and one deleted `replace` block away from reintroducing issue #222.

## What changed

- Added `// pin v4.0.x` comments above all five Nutanix v4 client requires (including `iam`, so the whole client set is locked consistently). The `mod-update` tool honors this convention (`providers-sdk/v1/util/version/version.go`) and runs `go get -u <pkg>@<pinned>` instead of `@latest`.
- Rewrote the `replace`-block comment to explain the split: `replace` forces the build onto v4.0.x; the `// pin` comments keep the require lines from drifting.

Both mechanisms are kept intentionally — `replace` is the hard build-time guarantee, `// pin` keeps the file self-consistent and stops the weekly churn.

## Verification

- Built the version tool and ran `mod-update providers/nutanix/ --latest`: it detected each pin comment and re-pinned to v4.0.x rather than bumping to `@latest`; the five clients stayed on v4.0.x through the full run.
- `go list -m` confirms the effective versions are still v4.0.x; `go build ./...` passes.
- Diff is limited to the two comment blocks; `go.sum` untouched.
