### PR TITLE
🐛 mqlc: suppress where-clause advisory during interactive shell recompiles

### DIFF
--- a/cli/shell/completer.go
+++ b/cli/shell/completer.go
@@ -60,7 +60,9 @@ func (c *Completer) Complete(text string) []Suggestion {
 		}
 	}
 
-	bundle, _ := mqlc.Compile(text, nil, mqlc.NewConfig(c.schema, c.features))
+	cfg := mqlc.NewConfig(c.schema, c.features)
+	cfg.EditorMode = true
+	bundle, _ := mqlc.Compile(text, nil, cfg)
 	if bundle != nil && len(bundle.Suggestions) > 0 {
 		// reorder suggestions to put the ones from connected providers first
 		slices.SortFunc(bundle.Suggestions, c.sortFn)

--- a/cli/shell/model.go
+++ b/cli/shell/model.go
@@ -539,7 +539,9 @@ func (m *shellModel) executeQuery(input string) (tea.Model, tea.Cmd) {
 	m.query += " " + input
 
 	// Try to compile
-	code, err := mqlc.Compile(m.query, nil, mqlc.NewConfig(m.runtime.Schema(), m.features))
+	cfg := mqlc.NewConfig(m.runtime.Schema(), m.features)
+	cfg.EditorMode = true
+	code, err := mqlc.Compile(m.query, nil, cfg)
 	if err != nil {
 		if e, ok := err.(*parser.ErrIncomplete); ok {
 			// Incomplete query - enter multiline mode
@@ -802,7 +804,9 @@ func (m *shellModel) updateCompletions() {
 
 	// Check for compile errors (for inline feedback)
 	fullQuery := m.query + " " + input
-	_, err := mqlc.Compile(fullQuery, nil, mqlc.NewConfig(m.runtime.Schema(), m.features))
+	cfg := mqlc.NewConfig(m.runtime.Schema(), m.features)
+	cfg.EditorMode = true
+	_, err := mqlc.Compile(fullQuery, nil, cfg)
 	if err != nil {
 		// Ignore incomplete errors - those are expected for multi-line
 		if _, ok := err.(*parser.ErrIncomplete); !ok {
@@ -867,7 +871,9 @@ func (m *shellModel) recompileForErrors() {
 
 	// Check for compile errors
 	fullQuery := m.query + " " + input
-	_, err := mqlc.Compile(fullQuery, nil, mqlc.NewConfig(m.runtime.Schema(), m.features))
+	cfg := mqlc.NewConfig(m.runtime.Schema(), m.features)
+	cfg.EditorMode = true
+	_, err := mqlc.Compile(fullQuery, nil, cfg)
 	if err != nil {
 		// Ignore incomplete errors - those are expected for multi-line
 		if _, ok := err.(*parser.ErrIncomplete); !ok {

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -154,7 +154,7 @@ func compileResourceWhere(c *compiler, typ types.Type, ref uint64, id string, ca
 	if err != nil {
 		return types.Nil, err
 	}
-	if refs.isStandalone {
+	if refs.isStandalone && !c.EditorMode {
 		log.Warn().Str("resource", resource.Name).Msg("Detected a standalone function in a WHERE clause! This is probably unintended. Be sure to filter the list.")
 	}
 	if refs.block == 0 {

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -90,6 +90,9 @@ type CompilerConfig struct {
 	UseAssetContext bool
 	Stats           CompilerStats
 	Features        mql.Features
+	// EditorMode suppresses non-fatal interactive advisories, like standalone
+	// where warnings, that would otherwise spam terminals during live shell recompiles.
+	EditorMode bool
 }
 
 func (c *CompilerConfig) EnableStats() {

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -4,11 +4,14 @@
 package mqlc_test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13"
@@ -32,6 +35,30 @@ var (
 
 func init() {
 	logger.InitTestEnv()
+}
+
+func TestStandaloneWhereEditorMode(t *testing.T) {
+	var buf bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() {
+		log.Logger = oldLogger
+	}()
+
+	const query = `packages.where("foo")`
+	res, err := mqlc.Compile(query, nil, conf)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Contains(t, buf.String(), "standalone function in a WHERE clause")
+
+	buf.Reset()
+
+	editorConf := mqlc.NewConfig(conf.Schema, features)
+	editorConf.EditorMode = true
+	res, err = mqlc.Compile(query, nil, editorConf)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.NotContains(t, buf.String(), "standalone function in a WHERE clause")
 }
 
 func compileProps(t *testing.T, s string, props mqlc.PropsHandler, f func(res *llx.CodeBundle)) {


### PR DESCRIPTION
## Summary

The interactive shell no longer floods the terminal with the "Detected a standalone function in a WHERE clause!" advisory on every keystroke. The message now appears exactly once, when you actually run a query that has a standalone `where` body.

## Why this matters

Reported in #8436: typing a `where` clause with a standalone body (for example `services.where(name = "systemd-journald")`, where the user meant `==`) made the shell effectively unusable. The advisory is emitted as a global `log.Warn` side effect inside `compileResourceWhere`, and the shell recompiles the current input on every keystroke for autocomplete and inline error feedback. Every one of those recompiles re-fired the warning, so a single malformed `where` produced a stream of duplicated advisories interleaved with the prompt and the completion popup.

The advisory itself is useful, so the fix keeps it. It adds an `EditorMode bool` field to `mqlc.CompilerConfig` (default `false`, so every existing caller and the embedding API keep today's behavior) and gates the `log.Warn` behind `if !c.EditorMode`. The shell sets `EditorMode = true` on the three non-execution compiles (the completer autocomplete compile and the two live-feedback compiles) plus the incomplete-check compile in `executeQuery`, while the real execution compile and the non-interactive run path are left untouched. Result: the user still sees the advisory once when they run a standalone-`where` query, but the live editor stops spamming it.

## Testing

- Added `TestStandaloneWhereEditorMode` in `mqlc/mqlc_test.go`: it points the global zerolog logger at a `bytes.Buffer`, compiles `packages.where("foo")` with the default config and asserts the buffer contains "standalone function in a WHERE clause", then recompiles the same query with `EditorMode: true` and asserts the message is absent while compilation still succeeds and returns a non-nil `CodeBundle`.
- `go test ./mqlc/...`, `go vet ./mqlc/... ./cli/shell/...`, `gofmt -l`, and `go build ./mqlc/... ./cli/shell/...` all pass.

Fixes #8436
