### PR TITLE
⭐ azure: typed subnet/public-IP refs on LB frontends and Bastion IP configs

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2666,8 +2666,15 @@ private azure.subscription.networkService.frontendIpConfig @defaults("id name") 
   zones []string
   // Whether this frontend IP configuration uses a public IP address
   isPublic bool
-  // Resource ID of the associated public IP address (empty if private)
-  publicIpAddressId string
+  // Resource ID of the associated public IP address
+  //
+  // Deprecated in favor of publicIpAddress, which resolves to the typed public
+  // IP address resource.
+  publicIpAddressId @maturity("deprecated") string
+  // Public IP address bound to this frontend (internet-facing); null for an internal frontend
+  publicIpAddress() azure.subscription.networkService.ipAddress
+  // Subnet the frontend is bound to (internal load balancer); null for a public frontend
+  subnet() azure.subscription.networkService.subnet
   // Private IP address (empty if public)
   privateIpAddress string
   // Resource ID of the DDoS custom policy bound to this frontend IP configuration (empty when none)
@@ -2863,6 +2870,31 @@ private azure.subscription.networkService.bastionHost @defaults("id name locatio
   scaleUnits int
   // Source IP address ranges (CIDRs) permitted to reach the Bastion host; empty means no IP restriction is applied
   allowedIpRules []string
+  // IP configurations binding the Bastion host to its subnet and public IP
+  ipConfigurations() []azure.subscription.networkService.bastionHost.ipConfiguration
+}
+
+// Azure Bastion host IP configuration
+//
+// An IP configuration binding a Bastion host to the AzureBastionSubnet it runs
+// in and, for a public Bastion, to its public IP address. Surfaces the private
+// IP allocation method and typed references to the subnet and public IP.
+// Select by the configuration's Azure resource ID.
+private azure.subscription.networkService.bastionHost.ipConfiguration @defaults("id name") {
+  // IP configuration ID
+  id string
+  // IP configuration name
+  name string
+  // IP configuration etag
+  etag string
+  // Provisioning state of the IP configuration
+  provisioningState string
+  // Private IP allocation method (Static, Dynamic)
+  privateIpAllocationMethod string
+  // Subnet the Bastion host runs in (AzureBastionSubnet)
+  subnet() azure.subscription.networkService.subnet
+  // Public IP address of the Bastion host; null for a private-only Bastion
+  publicIpAddress() azure.subscription.networkService.ipAddress
 }
 
 // Azure network security group

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -92,6 +92,7 @@ const (
 	ResourceAzureSubscriptionNetworkServiceInterfaceIpConfiguration                                   string = "azure.subscription.networkService.interface.ipConfiguration"
 	ResourceAzureSubscriptionNetworkServiceIpAddress                                                  string = "azure.subscription.networkService.ipAddress"
 	ResourceAzureSubscriptionNetworkServiceBastionHost                                                string = "azure.subscription.networkService.bastionHost"
+	ResourceAzureSubscriptionNetworkServiceBastionHostIpConfiguration                                 string = "azure.subscription.networkService.bastionHost.ipConfiguration"
 	ResourceAzureSubscriptionNetworkServiceSecurityGroup                                              string = "azure.subscription.networkService.securityGroup"
 	ResourceAzureSubscriptionNetworkServiceSecurityrule                                               string = "azure.subscription.networkService.securityrule"
 	ResourceAzureSubscriptionNetworkServiceExposure                                                   string = "azure.subscription.networkService.exposure"
@@ -762,6 +763,10 @@ func init() {
 		"azure.subscription.networkService.bastionHost": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceBastionHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionNetworkServiceBastionHost,
+		},
+		"azure.subscription.networkService.bastionHost.ipConfiguration": {
+			// to override args, implement: initAzureSubscriptionNetworkServiceBastionHostIpConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionNetworkServiceBastionHostIpConfiguration,
 		},
 		"azure.subscription.networkService.securityGroup": {
 			Init:   initAzureSubscriptionNetworkServiceSecurityGroup,
@@ -5209,6 +5214,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.frontendIpConfig.publicIpAddressId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPublicIpAddressId()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.frontendIpConfig.publicIpAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPublicIpAddress()).ToDataRes(types.Resource("azure.subscription.networkService.ipAddress"))
+	},
+	"azure.subscription.networkService.frontendIpConfig.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
 	"azure.subscription.networkService.frontendIpConfig.privateIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPrivateIpAddress()).ToDataRes(types.String)
 	},
@@ -5427,6 +5438,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.bastionHost.allowedIpRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHost).GetAllowedIpRules()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.networkService.bastionHost.ipConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHost).GetIpConfigurations()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.bastionHost.ipConfiguration")))
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.etag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetEtag()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.provisioningState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.privateIpAllocationMethod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetPrivateIpAllocationMethod()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.publicIpAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).GetPublicIpAddress()).ToDataRes(types.Resource("azure.subscription.networkService.ipAddress"))
 	},
 	"azure.subscription.networkService.securityGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetId()).ToDataRes(types.String)
@@ -21541,6 +21576,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PublicIpAddressId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.frontendIpConfig.publicIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PublicIpAddress, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceIpAddress](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.frontendIpConfig.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.frontendIpConfig.privateIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PrivateIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -21855,6 +21898,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.bastionHost.allowedIpRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceBastionHost).AllowedIpRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHost).IpConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.etag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.privateIpAllocationMethod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).PrivateIpAllocationMethod, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.bastionHost.ipConfiguration.publicIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration).PublicIpAddress, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceIpAddress](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.securityGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49457,7 +49536,7 @@ func (c *mqlAzureSubscriptionNetworkServiceInboundNatRule) GetProperties() *plug
 type mqlAzureSubscriptionNetworkServiceFrontendIpConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceFrontendIpConfigInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceFrontendIpConfigInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	Type               plugin.TValue[string]
@@ -49466,6 +49545,8 @@ type mqlAzureSubscriptionNetworkServiceFrontendIpConfig struct {
 	Zones              plugin.TValue[[]any]
 	IsPublic           plugin.TValue[bool]
 	PublicIpAddressId  plugin.TValue[string]
+	PublicIpAddress    plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
+	Subnet             plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	PrivateIpAddress   plugin.TValue[string]
 	DdosCustomPolicyId plugin.TValue[string]
 }
@@ -49537,6 +49618,38 @@ func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetIsPublic() *plug
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPublicIpAddressId() *plugin.TValue[string] {
 	return &c.PublicIpAddressId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPublicIpAddress() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceIpAddress](&c.PublicIpAddress, func() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.frontendIpConfig", c.__id, "publicIpAddress")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
+			}
+		}
+
+		return c.publicIpAddress()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.frontendIpConfig", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPrivateIpAddress() *plugin.TValue[string] {
@@ -50124,7 +50237,7 @@ func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetPublicIpPrefix() *plugi
 type mqlAzureSubscriptionNetworkServiceBastionHost struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceBastionHostInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceBastionHostInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Location                 plugin.TValue[string]
@@ -50143,6 +50256,7 @@ type mqlAzureSubscriptionNetworkServiceBastionHost struct {
 	EnableTunneling          plugin.TValue[bool]
 	ScaleUnits               plugin.TValue[int64]
 	AllowedIpRules           plugin.TValue[[]any]
+	IpConfigurations         plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceBastionHost creates a new instance of this resource
@@ -50252,6 +50366,125 @@ func (c *mqlAzureSubscriptionNetworkServiceBastionHost) GetScaleUnits() *plugin.
 
 func (c *mqlAzureSubscriptionNetworkServiceBastionHost) GetAllowedIpRules() *plugin.TValue[[]any] {
 	return &c.AllowedIpRules
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHost) GetIpConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IpConfigurations, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.bastionHost", c.__id, "ipConfigurations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ipConfigurations()
+	})
+}
+
+// mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration for the azure.subscription.networkService.bastionHost.ipConfiguration resource
+type mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureSubscriptionNetworkServiceBastionHostIpConfigurationInternal
+	Id                        plugin.TValue[string]
+	Name                      plugin.TValue[string]
+	Etag                      plugin.TValue[string]
+	ProvisioningState         plugin.TValue[string]
+	PrivateIpAllocationMethod plugin.TValue[string]
+	Subnet                    plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
+	PublicIpAddress           plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
+}
+
+// createAzureSubscriptionNetworkServiceBastionHostIpConfiguration creates a new instance of this resource
+func createAzureSubscriptionNetworkServiceBastionHostIpConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.bastionHost.ipConfiguration", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) MqlName() string {
+	return "azure.subscription.networkService.bastionHost.ipConfiguration"
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetEtag() *plugin.TValue[string] {
+	return &c.Etag
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetProvisioningState() *plugin.TValue[string] {
+	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetPrivateIpAllocationMethod() *plugin.TValue[string] {
+	return &c.PrivateIpAllocationMethod
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.bastionHost.ipConfiguration", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) GetPublicIpAddress() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceIpAddress](&c.PublicIpAddress, func() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.bastionHost.ipConfiguration", c.__id, "publicIpAddress")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
+			}
+		}
+
+		return c.publicIpAddress()
+	})
 }
 
 // mqlAzureSubscriptionNetworkServiceSecurityGroup for the azure.subscription.networkService.securityGroup resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3010,6 +3010,15 @@ azure.subscription.networkService.bastionHost.enableSessionRecording 13.16.2
 azure.subscription.networkService.bastionHost.enableShareableLink 13.16.2
 azure.subscription.networkService.bastionHost.enableTunneling 13.16.2
 azure.subscription.networkService.bastionHost.id 9.0.1
+azure.subscription.networkService.bastionHost.ipConfiguration 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.etag 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.id 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.name 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.privateIpAllocationMethod 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.provisioningState 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.publicIpAddress 13.25.1
+azure.subscription.networkService.bastionHost.ipConfiguration.subnet 13.25.1
+azure.subscription.networkService.bastionHost.ipConfigurations 13.25.1
 azure.subscription.networkService.bastionHost.location 9.0.1
 azure.subscription.networkService.bastionHost.name 9.0.1
 azure.subscription.networkService.bastionHost.properties 9.0.1
@@ -3262,7 +3271,9 @@ azure.subscription.networkService.frontendIpConfig.isPublic 9.0.8
 azure.subscription.networkService.frontendIpConfig.name 9.0.8
 azure.subscription.networkService.frontendIpConfig.privateIpAddress 9.0.8
 azure.subscription.networkService.frontendIpConfig.properties 9.0.8
+azure.subscription.networkService.frontendIpConfig.publicIpAddress 13.25.1
 azure.subscription.networkService.frontendIpConfig.publicIpAddressId 9.0.8
+azure.subscription.networkService.frontendIpConfig.subnet 13.25.1
 azure.subscription.networkService.frontendIpConfig.type 9.0.8
 azure.subscription.networkService.frontendIpConfig.zones 9.0.8
 azure.subscription.networkService.inboundNatPool 9.0.8

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -273,6 +273,9 @@ func (a *mqlAzureSubscriptionNetworkService) bastionHosts() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			if bh.Properties != nil {
+				mqlAzure.(*mqlAzureSubscriptionNetworkServiceBastionHost).cacheIPConfigurations = bh.Properties.IPConfigurations
+			}
 			res = append(res, mqlAzure)
 		}
 	}
@@ -675,10 +678,15 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 		var publicIpAddressId string
 		var privateIpAddress string
 		var ddosCustomPolicyId string
+		var publicIpAddressIDPtr, subnetIDPtr *string
 		if ipConfig.Properties != nil {
 			if ipConfig.Properties.PublicIPAddress != nil && ipConfig.Properties.PublicIPAddress.ID != nil {
 				isPublic = true
 				publicIpAddressId = *ipConfig.Properties.PublicIPAddress.ID
+				publicIpAddressIDPtr = ipConfig.Properties.PublicIPAddress.ID
+			}
+			if ipConfig.Properties.Subnet != nil {
+				subnetIDPtr = ipConfig.Properties.Subnet.ID
 			}
 			if ipConfig.Properties.PrivateIPAddress != nil {
 				privateIpAddress = *ipConfig.Properties.PrivateIPAddress
@@ -704,6 +712,9 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 		if err != nil {
 			return nil, err
 		}
+		fic := mqlIpConfig.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig)
+		fic.cachePublicIpAddressID = publicIpAddressIDPtr
+		fic.cacheSubnetID = subnetIDPtr
 		res = append(res, mqlIpConfig)
 	}
 	return res, nil

--- a/providers/azure/resources/network_lb_bastion_ipconfig.go
+++ b/providers/azure/resources/network_lb_bastion_ipconfig.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// -----------------------------------------------------------------------------
+// Load balancer frontend IP configuration typed references
+// -----------------------------------------------------------------------------
+
+type mqlAzureSubscriptionNetworkServiceFrontendIpConfigInternal struct {
+	cachePublicIpAddressID *string
+	cacheSubnetID          *string
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) publicIpAddress() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+	if a.cachePublicIpAddressID == nil || *a.cachePublicIpAddressID == "" {
+		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.ipAddress", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(a.cachePublicIpAddressID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.cacheSubnetID == nil || *a.cacheSubnetID == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(a.cacheSubnetID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
+// -----------------------------------------------------------------------------
+// Bastion host IP configurations
+// -----------------------------------------------------------------------------
+
+type mqlAzureSubscriptionNetworkServiceBastionHostInternal struct {
+	cacheIPConfigurations []*network.BastionHostIPConfiguration
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceBastionHost) ipConfigurations() ([]any, error) {
+	res := []any{}
+	for _, ipConfig := range a.cacheIPConfigurations {
+		if ipConfig == nil {
+			continue
+		}
+		var provisioningState, privateIpAllocationMethod string
+		var subnetId, publicIpAddressId *string
+		if p := ipConfig.Properties; p != nil {
+			if p.ProvisioningState != nil {
+				provisioningState = string(*p.ProvisioningState)
+			}
+			if p.PrivateIPAllocationMethod != nil {
+				privateIpAllocationMethod = string(*p.PrivateIPAllocationMethod)
+			}
+			if p.Subnet != nil {
+				subnetId = p.Subnet.ID
+			}
+			if p.PublicIPAddress != nil {
+				publicIpAddressId = p.PublicIPAddress.ID
+			}
+		}
+		mqlConfig, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.bastionHost.ipConfiguration",
+			map[string]*llx.RawData{
+				"id":                        llx.StringDataPtr(ipConfig.ID),
+				"name":                      llx.StringDataPtr(ipConfig.Name),
+				"etag":                      llx.StringDataPtr(ipConfig.Etag),
+				"provisioningState":         llx.StringData(provisioningState),
+				"privateIpAllocationMethod": llx.StringData(privateIpAllocationMethod),
+			})
+		if err != nil {
+			return nil, err
+		}
+		c := mqlConfig.(*mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration)
+		c.cacheSubnetID = subnetId
+		c.cachePublicIpAddressID = publicIpAddressId
+		res = append(res, mqlConfig)
+	}
+	return res, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceBastionHostIpConfigurationInternal struct {
+	cacheSubnetID          *string
+	cachePublicIpAddressID *string
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.cacheSubnetID == nil || *a.cacheSubnetID == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(a.cacheSubnetID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceBastionHostIpConfiguration) publicIpAddress() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
+	if a.cachePublicIpAddressID == nil || *a.cachePublicIpAddressID == "" {
+		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.ipAddress", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(a.cachePublicIpAddressID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
+}


### PR DESCRIPTION
## What

Continues the depth expansion of existing network resources with typed subnet/public-IP references on load balancer frontends and Bastion hosts.

### Load balancer `frontendIpConfig`
- Added typed **`publicIpAddress()`** and **`subnet()`** references.
- The released `publicIpAddressId string` (v9.0.8) is **deprecated** in favor of `publicIpAddress()` (kept at its version — retyping would break).
- `subnet()` is net-new: an internal (private) load balancer's frontend binds to a subnet, which was previously unmodeled.

### Bastion host
- Added **`ipConfigurations()`** and a new **`bastionHost.ipConfiguration`** sub-resource: private IP allocation method plus typed `subnet()` (the AzureBastionSubnet it runs in) and `publicIpAddress()`.

Both reuse the existing `ipAddress` and `subnet` inits (from earlier depth PRs) for resolution.

## Testing
- `go build ./...`, `go vet`, `gofmt`, `go test ./resources/ ./provider/` all pass; `go.mod` clean; no new IAM permissions (the `ipAddress`/`subnet`/`bastionHosts` reads already existed).
- Live smoke against a real subscription: accessors execute cleanly, but the dev subscription has no load balancers or Bastion hosts provisioned, so field values weren't exercised here. The refs use the identical `NewResource` + `ipAddress`/`subnet` init mechanism that was **live-verified** in #8950 (NIC IP configs) against real subnets and public IPs.
- No new unit test: pure ID-extraction + ref resolution reusing already-covered mechanisms; no new fragile helper or dict-serialization assumption.

## Series
Depth PRs: #8950 (NIC IP configs), #8951 (Tier 3 cross-refs), and this. Remaining: NIC `effectiveRouteTable()`; minor `ipAddress` fields (sku, idleTimeout, ipTags, natGateway).
