### PR TITLE
⭐ azure: add network interface effectiveRouteTable()

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2763,6 +2763,12 @@ azure.subscription.networkService.interface @defaults("name location properties.
   vm() azure.subscription.computeService.vm
   // Effective NSG rules merged across NSG-on-NIC, ASGs, and NSG-on-subnet (computed via BeginGetEffectiveNetworkSecurityGroup)
   effectiveSecurityRules() []dict
+  // Effective routes applied to the NIC
+  //
+  // Merges system, user-defined, and BGP-learned routes into the route table
+  // actually applied to the interface. Each entry carries name, source, state,
+  // addressPrefix, nextHopType, and nextHopIpAddress.
+  effectiveRouteTable() []dict
 }
 
 // Azure network interface IP configuration

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5313,6 +5313,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.interface.effectiveSecurityRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetEffectiveSecurityRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.networkService.interface.effectiveRouteTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetEffectiveRouteTable()).ToDataRes(types.Array(types.Dict))
+	},
 	"azure.subscription.networkService.interface.ipConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterfaceIpConfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -21718,6 +21721,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.interface.effectiveSecurityRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceInterface).EffectiveSecurityRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.interface.effectiveRouteTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceInterface).EffectiveRouteTable, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.interface.ipConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49812,6 +49819,7 @@ type mqlAzureSubscriptionNetworkServiceInterface struct {
 	IpConfigs                   plugin.TValue[[]any]
 	Vm                          plugin.TValue[*mqlAzureSubscriptionComputeServiceVm]
 	EffectiveSecurityRules      plugin.TValue[[]any]
+	EffectiveRouteTable         plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceInterface creates a new instance of this resource
@@ -49962,6 +49970,12 @@ func (c *mqlAzureSubscriptionNetworkServiceInterface) GetVm() *plugin.TValue[*mq
 func (c *mqlAzureSubscriptionNetworkServiceInterface) GetEffectiveSecurityRules() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.EffectiveSecurityRules, func() ([]any, error) {
 		return c.effectiveSecurityRules()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceInterface) GetEffectiveRouteTable() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveRouteTable, func() ([]any, error) {
+		return c.effectiveRouteTable()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3291,6 +3291,7 @@ azure.subscription.networkService.inboundNatRule.type 9.0.8
 azure.subscription.networkService.interface 9.0.1
 azure.subscription.networkService.interface.appliedDnsServers 13.12.2
 azure.subscription.networkService.interface.dnsServers 13.12.2
+azure.subscription.networkService.interface.effectiveRouteTable 13.25.1
 azure.subscription.networkService.interface.effectiveSecurityRules 13.5.1
 azure.subscription.networkService.interface.enableAcceleratedNetworking 11.4.28
 azure.subscription.networkService.interface.enableIPForwarding 11.4.28

--- a/providers/azure/resources/network_nic_effective_routes.go
+++ b/providers/azure/resources/network_nic_effective_routes.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// effectiveRouteTable resolves the routes actually applied to the network
+// interface, merging system, user-defined, and BGP-learned routes. This is a
+// long-running operation and is only available when the NIC is attached to a
+// running VM; when it is not, Azure returns a 4xx that we surface as an empty
+// list rather than an error.
+func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveRouteTable() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	// Bound the long-poll so a stuck operation doesn't hang the interfaces query.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	nicName, err := resourceID.Component("networkInterfaces")
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := network.NewInterfacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	poller, err := client.BeginGetEffectiveRouteTable(ctx, resourceID.ResourceGroup, nicName, nil)
+	if err != nil {
+		return effectiveRouteTableErr(err, nicName)
+	}
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return effectiveRouteTableErr(err, nicName)
+	}
+
+	res := []any{}
+	for _, route := range resp.Value {
+		if route == nil {
+			continue
+		}
+		dict, err := convert.JsonToDict(route)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, dict)
+	}
+	return res, nil
+}
+
+// effectiveRouteTableErr treats a 4xx (typically a NIC not attached to a
+// running VM, or missing permissions) as "no effective routes available"
+// rather than a hard error, so one such NIC doesn't fail the whole query.
+func effectiveRouteTableErr(err error, nicName string) ([]any, error) {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode >= 400 && respErr.StatusCode < 500 {
+		log.Warn().Str("nic", nicName).Int("status", respErr.StatusCode).Msg("effective route table unavailable for NIC")
+		return []any{}, nil
+	}
+	return nil, err
+}


### PR DESCRIPTION
## What

Adds **`interface.effectiveRouteTable()`** — the operational companion to the existing `effectiveSecurityRules()`. It answers "what routes actually apply to this NIC," merging system, user-defined (UDR), and BGP-learned routes. Each entry carries `name`, `source`, `state`, `addressPrefix`, `nextHopType`, `nextHopIpAddress`, and `disableBgpRoutePropagation`.

Uses the SDK's `BeginGetEffectiveRouteTable` long-running operation directly (cleaner than `effectiveSecurityRules()`, which needs raw REST to work around a v9 SDK field bug). The operation is only valid for a NIC attached to a running VM; a 4xx (unattached NIC or missing permission) is surfaced as an empty list rather than failing the whole interfaces query.

## Testing
- **Verified live against a real subscription**: a NIC on a running VM returned its full effective route table (23 routes with real prefixes, next-hop types, and sources).
- `go build ./...`, `go vet`, `gofmt`, `go test ./resources/ ./provider/` all pass; `go.mod` clean.
- **Permissions note**: the required `Microsoft.Network/networkInterfaces/effectiveRouteTable/action` is not auto-captured in `permissions.json` — the extractor doesn't model `BeginGet*` LRO `/action` permissions. This is consistent with the existing `effectiveSecurityRules()`, whose effective-NSG action isn't captured either. Left as-is rather than special-casing the extractor for one method.

## Context
This completes the substantive azure **network** coverage work — breadth (Tiers 1–3 + AVNM: #8941, #8946–8949) and depth (NIC configs, Tier 3 cross-refs, LB/bastion, and now effective routes: #8950–8952 + this). Remaining is minor polish (a few `ipAddress` scalar fields); the next high-leverage move would be a coverage audit of the non-network azure services.
