### PR TITLE
⭐ azure: enrich public IP address (sku, idle timeout, ip tags, NAT gateway ref)

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2763,6 +2763,12 @@ azure.subscription.networkService.interface @defaults("name location properties.
   vm() azure.subscription.computeService.vm
   // Effective NSG rules merged across NSG-on-NIC, ASGs, and NSG-on-subnet (computed via BeginGetEffectiveNetworkSecurityGroup)
   effectiveSecurityRules() []dict
+  // Effective routes applied to the NIC
+  //
+  // Merges system, user-defined, and BGP-learned routes into the route table
+  // actually applied to the interface. Each entry carries name, source, state,
+  // addressPrefix, nextHopType, and nextHopIpAddress.
+  effectiveRouteTable() []dict
 }
 
 // Azure network interface IP configuration

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2836,6 +2836,16 @@ private azure.subscription.networkService.ipAddress @defaults("name location ipA
   associatedResourceId string
   // Public IP prefix this address was allocated from; null when the address is not drawn from a prefix
   publicIpPrefix() azure.subscription.networkService.publicIpPrefix
+  // Public IP SKU name (Basic, Standard)
+  skuName string
+  // Public IP SKU tier (Regional, Global)
+  skuTier string
+  // Idle timeout in minutes for the public IP
+  idleTimeoutInMinutes int
+  // IP tags applied to the address; each entry carries ipTagType and tag
+  ipTags []dict
+  // NAT gateway using this public IP; null when the address is not used by a NAT gateway
+  natGateway() azure.subscription.networkService.natGateway
 }
 
 // Azure Network Bastion host

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -689,7 +689,7 @@ func init() {
 			Create: createAzureSubscriptionNetworkServiceBgpSettingsIpConfigurationBgpPeeringAddress,
 		},
 		"azure.subscription.networkService.natGateway": {
-			// to override args, implement: initAzureSubscriptionNetworkServiceNatGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionNetworkServiceNatGateway,
 			Create: createAzureSubscriptionNetworkServiceNatGateway,
 		},
 		"azure.subscription.networkService.subnet": {
@@ -5387,6 +5387,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.ipAddress.publicIpPrefix": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetPublicIpPrefix()).ToDataRes(types.Resource("azure.subscription.networkService.publicIpPrefix"))
+	},
+	"azure.subscription.networkService.ipAddress.skuName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetSkuName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.ipAddress.skuTier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetSkuTier()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.ipAddress.idleTimeoutInMinutes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetIdleTimeoutInMinutes()).ToDataRes(types.Int)
+	},
+	"azure.subscription.networkService.ipAddress.ipTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetIpTags()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.networkService.ipAddress.natGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetNatGateway()).ToDataRes(types.Resource("azure.subscription.networkService.natGateway"))
 	},
 	"azure.subscription.networkService.bastionHost.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHost).GetId()).ToDataRes(types.String)
@@ -21829,6 +21844,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.ipAddress.publicIpPrefix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).PublicIpPrefix, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServicePublicIpPrefix](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.skuName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).SkuName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.skuTier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).SkuTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.idleTimeoutInMinutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).IdleTimeoutInMinutes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.ipTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).IpTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.natGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).NatGateway, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceNatGateway](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.bastionHost.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50148,6 +50183,11 @@ type mqlAzureSubscriptionNetworkServiceIpAddress struct {
 	DdosProtectionMode   plugin.TValue[string]
 	AssociatedResourceId plugin.TValue[string]
 	PublicIpPrefix       plugin.TValue[*mqlAzureSubscriptionNetworkServicePublicIpPrefix]
+	SkuName              plugin.TValue[string]
+	SkuTier              plugin.TValue[string]
+	IdleTimeoutInMinutes plugin.TValue[int64]
+	IpTags               plugin.TValue[[]any]
+	NatGateway           plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway]
 }
 
 // createAzureSubscriptionNetworkServiceIpAddress creates a new instance of this resource
@@ -50244,6 +50284,38 @@ func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetPublicIpPrefix() *plugi
 		}
 
 		return c.publicIpPrefix()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetSkuName() *plugin.TValue[string] {
+	return &c.SkuName
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetSkuTier() *plugin.TValue[string] {
+	return &c.SkuTier
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetIdleTimeoutInMinutes() *plugin.TValue[int64] {
+	return &c.IdleTimeoutInMinutes
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetIpTags() *plugin.TValue[[]any] {
+	return &c.IpTags
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetNatGateway() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceNatGateway](&c.NatGateway, func() (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.ipAddress", c.__id, "natGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
+			}
+		}
+
+		return c.natGateway()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5313,6 +5313,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.interface.effectiveSecurityRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetEffectiveSecurityRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.networkService.interface.effectiveRouteTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetEffectiveRouteTable()).ToDataRes(types.Array(types.Dict))
+	},
 	"azure.subscription.networkService.interface.ipConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterfaceIpConfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -21718,6 +21721,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.interface.effectiveSecurityRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceInterface).EffectiveSecurityRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.interface.effectiveRouteTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceInterface).EffectiveRouteTable, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.interface.ipConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49812,6 +49819,7 @@ type mqlAzureSubscriptionNetworkServiceInterface struct {
 	IpConfigs                   plugin.TValue[[]any]
 	Vm                          plugin.TValue[*mqlAzureSubscriptionComputeServiceVm]
 	EffectiveSecurityRules      plugin.TValue[[]any]
+	EffectiveRouteTable         plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceInterface creates a new instance of this resource
@@ -49962,6 +49970,12 @@ func (c *mqlAzureSubscriptionNetworkServiceInterface) GetVm() *plugin.TValue[*mq
 func (c *mqlAzureSubscriptionNetworkServiceInterface) GetEffectiveSecurityRules() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.EffectiveSecurityRules, func() ([]any, error) {
 		return c.effectiveSecurityRules()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceInterface) GetEffectiveRouteTable() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveRouteTable, func() ([]any, error) {
+		return c.effectiveRouteTable()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3327,12 +3327,17 @@ azure.subscription.networkService.ipAddress 9.0.1
 azure.subscription.networkService.ipAddress.associatedResourceId 13.16.2
 azure.subscription.networkService.ipAddress.ddosProtectionMode 13.1.8
 azure.subscription.networkService.ipAddress.id 9.0.1
+azure.subscription.networkService.ipAddress.idleTimeoutInMinutes 13.25.1
 azure.subscription.networkService.ipAddress.ipAddress 9.0.1
 azure.subscription.networkService.ipAddress.ipAllocationMethod 11.6.1
+azure.subscription.networkService.ipAddress.ipTags 13.25.1
 azure.subscription.networkService.ipAddress.ipVersion 11.6.1
 azure.subscription.networkService.ipAddress.location 9.0.1
 azure.subscription.networkService.ipAddress.name 9.0.1
+azure.subscription.networkService.ipAddress.natGateway 13.25.1
 azure.subscription.networkService.ipAddress.publicIpPrefix 13.25.1
+azure.subscription.networkService.ipAddress.skuName 13.25.1
+azure.subscription.networkService.ipAddress.skuTier 13.25.1
 azure.subscription.networkService.ipAddress.tags 9.0.1
 azure.subscription.networkService.ipAddress.type 9.0.1
 azure.subscription.networkService.ipAddress.zones 13.1.8

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3291,6 +3291,7 @@ azure.subscription.networkService.inboundNatRule.type 9.0.8
 azure.subscription.networkService.interface 9.0.1
 azure.subscription.networkService.interface.appliedDnsServers 13.12.2
 azure.subscription.networkService.interface.dnsServers 13.12.2
+azure.subscription.networkService.interface.effectiveRouteTable 13.25.1
 azure.subscription.networkService.interface.effectiveSecurityRules 13.5.1
 azure.subscription.networkService.interface.enableAcceleratedNetworking 11.4.28
 azure.subscription.networkService.interface.enableIPForwarding 11.4.28

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -3954,7 +3954,9 @@ func azureFirewallPolicyToMql(runtime *plugin.Runtime, fwp network.FirewallPolic
 
 func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
 	var ipAllocationMethod, ipVersion, ddosProtectionMode, associatedResourceId string
-	var ipAddr, publicIpPrefixId *string
+	var ipAddr, publicIpPrefixId, natGatewayId *string
+	var idleTimeoutInMinutes int64
+	ipTags := []any{}
 	if ip.Properties != nil {
 		ipAddr = ip.Properties.IPAddress
 		if ip.Properties.PublicIPAllocationMethod != nil {
@@ -3971,6 +3973,26 @@ func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzur
 		}
 		if ip.Properties.PublicIPPrefix != nil {
 			publicIpPrefixId = ip.Properties.PublicIPPrefix.ID
+		}
+		if ip.Properties.NatGateway != nil {
+			natGatewayId = ip.Properties.NatGateway.ID
+		}
+		if ip.Properties.IdleTimeoutInMinutes != nil {
+			idleTimeoutInMinutes = int64(*ip.Properties.IdleTimeoutInMinutes)
+		}
+		tags, err := convert.JsonToDictSlice(ip.Properties.IPTags)
+		if err != nil {
+			return nil, err
+		}
+		ipTags = tags
+	}
+	var skuName, skuTier string
+	if ip.SKU != nil {
+		if ip.SKU.Name != nil {
+			skuName = string(*ip.SKU.Name)
+		}
+		if ip.SKU.Tier != nil {
+			skuTier = string(*ip.SKU.Tier)
 		}
 	}
 	zones := []any{}
@@ -3992,17 +4014,37 @@ func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzur
 			"zones":                llx.ArrayData(zones, types.String),
 			"ddosProtectionMode":   llx.StringData(ddosProtectionMode),
 			"associatedResourceId": llx.StringData(associatedResourceId),
+			"skuName":              llx.StringData(skuName),
+			"skuTier":              llx.StringData(skuTier),
+			"idleTimeoutInMinutes": llx.IntData(idleTimeoutInMinutes),
+			"ipTags":               llx.ArrayData(ipTags, types.Dict),
 		})
 	if err != nil {
 		return nil, err
 	}
 	mqlIp := mqlAzure.(*mqlAzureSubscriptionNetworkServiceIpAddress)
 	mqlIp.cachePublicIpPrefixID = publicIpPrefixId
+	mqlIp.cacheNatGatewayID = natGatewayId
 	return mqlIp, nil
 }
 
 type mqlAzureSubscriptionNetworkServiceIpAddressInternal struct {
 	cachePublicIpPrefixID *string
+	cacheNatGatewayID     *string
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceIpAddress) natGateway() (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
+	if a.cacheNatGatewayID == nil || *a.cacheNatGatewayID == "" {
+		a.NatGateway.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.natGateway", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(a.cacheNatGatewayID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceIpAddress) publicIpPrefix() (*mqlAzureSubscriptionNetworkServicePublicIpPrefix, error) {
@@ -4025,6 +4067,49 @@ func (a *mqlAzureSubscriptionNetworkServiceIpAddress) publicIpPrefix() (*mqlAzur
 // unset ("None") or nil value reads as "not enabled".
 func natGatewayNat64Enabled(props *network.NatGatewayPropertiesFormat) bool {
 	return props != nil && props.Nat64 != nil && *props.Nat64 == network.Nat64StateEnabled
+}
+
+// initAzureSubscriptionNetworkServiceNatGateway resolves a NAT gateway by its
+// ARM ID so typed references to it (e.g. from a public IP address) populate
+// fully.
+func initAzureSubscriptionNetworkServiceNatGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+	azureId, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	name, err := azureId.Component("natGateways")
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := network.NewNatGatewaysClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), azureId.ResourceGroup, name, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	mql, err := azureNatGatewayToMql(runtime, resp.NatGateway)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mql, nil
 }
 
 func azureNatGatewayToMql(runtime *plugin.Runtime, ng network.NatGateway) (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {

--- a/providers/azure/resources/network_nic_effective_routes.go
+++ b/providers/azure/resources/network_nic_effective_routes.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// effectiveRouteTable resolves the routes actually applied to the network
+// interface, merging system, user-defined, and BGP-learned routes. This is a
+// long-running operation and is only available when the NIC is attached to a
+// running VM; when it is not, Azure returns a 4xx that we surface as an empty
+// list rather than an error.
+func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveRouteTable() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	// Bound the long-poll so a stuck operation doesn't hang the interfaces query.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	nicName, err := resourceID.Component("networkInterfaces")
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := network.NewInterfacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	poller, err := client.BeginGetEffectiveRouteTable(ctx, resourceID.ResourceGroup, nicName, nil)
+	if err != nil {
+		return effectiveRouteTableErr(err, nicName)
+	}
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return effectiveRouteTableErr(err, nicName)
+	}
+
+	res := []any{}
+	for _, route := range resp.Value {
+		if route == nil {
+			continue
+		}
+		dict, err := convert.JsonToDict(route)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, dict)
+	}
+	return res, nil
+}
+
+// effectiveRouteTableErr treats a 4xx (typically a NIC not attached to a
+// running VM, or missing permissions) as "no effective routes available"
+// rather than a hard error, so one such NIC doesn't fail the whole query.
+func effectiveRouteTableErr(err error, nicName string) ([]any, error) {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode >= 400 && respErr.StatusCode < 500 {
+		log.Warn().Str("nic", nicName).Int("status", respErr.StatusCode).Msg("effective route table unavailable for NIC")
+		return []any{}, nil
+	}
+	return nil, err
+}


### PR DESCRIPTION
## What

Rounds out the public IP address resource with the remaining commonly-audited fields:

- **`skuName` / `skuTier`** — Basic vs Standard is a security-relevant distinction (Basic has no zone redundancy and weaker defaults)
- **`idleTimeoutInMinutes`**
- **`ipTags`** — as dicts carrying `ipTagType` and `tag`
- **`natGateway()`** — typed reference to the NAT gateway using the address

Added a `natGateway` init so the reference resolves by ARM ID (`subnet.natGateway()` uses a direct `Get`, so there were no `NewResource` callers to affect).

## Testing
- **Verified live against a real subscription**: a public IP returned `skuName: "Basic"`, `skuTier: "Regional"`, `idleTimeoutInMinutes: 4`, `ipTags: []`, and `natGateway` null (correctly, since it's not on a NAT gateway).
- `go build ./...`, `go vet`, `gofmt`, `go test ./resources/ ./provider/` pass.

## Note
> **Stacked on #8953** (effective route table) — both touch `azure.lr`. The diff will show #8953's change until it merges, then this retargets to main. Review/merge #8953 first.

This is the "minor polish" tail of the azure network coverage work.
