### PR TITLE
🐛 azure: capture permissions from client-factory-created clients

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1508,6 +1508,12 @@ func extractAzurePermissions(root string) []PermissionDetail {
 
 			// Track client variables: varName -> (ARM provider, resource type)
 			clientVars := map[string]*azureClientInfo{}
+			// Track client-factory variables: varName -> ARM provider. Many azure
+			// SDKs (e.g. armsecurity) create clients via
+			// `f := pkg.NewClientFactory(...)` then `f.NewXxxClient()` rather than
+			// a package-qualified `pkg.NewXxxClient(...)`, so we resolve the ARM
+			// provider through the factory var.
+			factoryVars := map[string]string{}
 
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
 				assignStmt, ok := n.(*ast.AssignStmt)
@@ -1526,22 +1532,38 @@ func extractAzurePermissions(root string) []PermissionDetail {
 					}
 					methodName := sel.Sel.Name
 
-					// Pattern: pkg.NewXxxClient(...)
+					pkgIdent, isIdentReceiver := sel.X.(*ast.Ident)
+
+					// Pattern: f := pkg.NewClientFactory(...) — remember the
+					// factory var so its clients resolve to this ARM provider.
+					if methodName == "NewClientFactory" {
+						if isIdentReceiver {
+							if imp, isAzureImport := azureImports[pkgIdent.Name]; isAzureImport && i < len(assignStmt.Lhs) {
+								if ident, ok := assignStmt.Lhs[i].(*ast.Ident); ok {
+									factoryVars[ident.Name] = imp.armProvider
+								}
+							}
+						}
+						continue
+					}
+
+					// Pattern: pkg.NewXxxClient(...) or factoryVar.NewXxxClient(...)
 					if !strings.HasPrefix(methodName, "New") || !strings.HasSuffix(methodName, "Client") {
 						continue
 					}
-					// Skip NewClientFactory
-					if methodName == "NewClientFactory" {
+					if !isIdentReceiver {
 						continue
 					}
 
-					pkgIdent, ok := sel.X.(*ast.Ident)
-					if !ok {
-						continue
-					}
-
+					// Resolve the ARM provider: either the receiver is a tracked
+					// azure package import, or a tracked client-factory var.
 					imp, isAzureImport := azureImports[pkgIdent.Name]
-					if !isAzureImport {
+					armProvider := ""
+					if isAzureImport {
+						armProvider = imp.armProvider
+					} else if prov, isFactory := factoryVars[pkgIdent.Name]; isFactory {
+						armProvider = prov
+					} else {
 						continue
 					}
 
@@ -1551,15 +1573,19 @@ func extractAzurePermissions(root string) []PermissionDetail {
 					resourceType := strings.TrimPrefix(methodName, "New")
 					resourceType = strings.TrimSuffix(resourceType, "Client")
 
-					// For generic NewClient (no resource type), use package info
+					// A generic NewClient carries no resource type; only a
+					// package import can map it via its package name.
 					if resourceType == "" {
+						if !isAzureImport {
+							continue
+						}
 						resourceType = azureResourceFromPackage(imp.pkgName)
 					}
 
 					if i < len(assignStmt.Lhs) {
 						if ident, ok := assignStmt.Lhs[i].(*ast.Ident); ok {
 							clientVars[ident.Name] = &azureClientInfo{
-								armProvider:  imp.armProvider,
+								armProvider:  armProvider,
 								resourceType: resourceType,
 							}
 						}
@@ -1567,6 +1593,21 @@ func extractAzurePermissions(root string) []PermissionDetail {
 				}
 				return true
 			})
+
+			emitReadPerm := func(armProvider, resourceType, methodName string) {
+				perm := azurePermission(armProvider, resourceType)
+				// A client serving multiple read methods may need per-method
+				// permissions that the client-level derivation can't express.
+				if o, ok := azureMethodPermissionOverrides[resourceType+"."+methodName]; ok {
+					perm = o
+				}
+				details = append(details, PermissionDetail{
+					Permission: perm,
+					Service:    armProvider,
+					Action:     methodName,
+					SourceFile: fileName,
+				})
+			}
 
 			// Find pager/method calls on client variables
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -1579,31 +1620,38 @@ func extractAzurePermissions(root string) []PermissionDetail {
 					return true
 				}
 				methodName := sel.Sel.Name
-
-				ident, ok := sel.X.(*ast.Ident)
-				if !ok {
+				if !isAzureReadMethod(methodName) {
 					return true
 				}
 
-				info, ok := clientVars[ident.Name]
-				if !ok {
-					return true
-				}
-
-				// Only care about read operations
-				if isAzureReadMethod(methodName) {
-					perm := azurePermission(info.armProvider, info.resourceType)
-					// A client serving multiple read methods may need per-method
-					// permissions that the client-level derivation can't express.
-					if o, ok := azureMethodPermissionOverrides[info.resourceType+"."+methodName]; ok {
-						perm = o
+				switch recv := sel.X.(type) {
+				case *ast.Ident:
+					// Read method on a tracked client var: client.NewListPager(...)
+					if info, ok := clientVars[recv.Name]; ok {
+						emitReadPerm(info.armProvider, info.resourceType, methodName)
 					}
-					details = append(details, PermissionDetail{
-						Permission: perm,
-						Service:    info.armProvider,
-						Action:     methodName,
-						SourceFile: fileName,
-					})
+				case *ast.CallExpr:
+					// Inline factory chain: factoryVar.NewXxxClient().NewListPager(...)
+					innerSel, ok := recv.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					facIdent, ok := innerSel.X.(*ast.Ident)
+					if !ok {
+						return true
+					}
+					prov, isFactory := factoryVars[facIdent.Name]
+					if !isFactory {
+						return true
+					}
+					ctor := innerSel.Sel.Name
+					if !strings.HasPrefix(ctor, "New") || !strings.HasSuffix(ctor, "Client") {
+						return true
+					}
+					resourceType := strings.TrimSuffix(strings.TrimPrefix(ctor, "New"), "Client")
+					if resourceType != "" {
+						emitReadPerm(prov, resourceType, methodName)
+					}
 				}
 
 				return true

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1649,6 +1649,10 @@ func extractAzurePermissions(root string) []PermissionDetail {
 						return true
 					}
 					resourceType := strings.TrimSuffix(strings.TrimPrefix(ctor, "New"), "Client")
+					// A generic NewClient() on a factory has no resource type in
+					// its name and no package to derive one from (the receiver is
+					// a factory var, not an import), so skip it — same as the
+					// stored-variable path, which also can't map a factory generic.
 					if resourceType != "" {
 						emitReadPerm(prov, resourceType, methodName)
 					}

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.25.0",
-  "generated_at": "2026-07-05T11:39:56-07:00",
+  "generated_at": "2026-07-05T21:49:40-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -64,6 +64,7 @@
     "Microsoft.ContainerRegistry/registries/cacheRules/read",
     "Microsoft.ContainerRegistry/registries/connectedRegistries/read",
     "Microsoft.ContainerRegistry/registries/credentialSets/read",
+    "Microsoft.ContainerRegistry/registries/read",
     "Microsoft.ContainerRegistry/registries/replications/read",
     "Microsoft.ContainerRegistry/registries/scopeMaps/read",
     "Microsoft.ContainerRegistry/registries/tokens/read",
@@ -92,6 +93,7 @@
     "Microsoft.DataFactory/factories/read",
     "Microsoft.Databricks/workspaces/read",
     "Microsoft.DesktopVirtualization/hostPools/read",
+    "Microsoft.Devices/resource/read",
     "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
     "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/read",
@@ -209,8 +211,19 @@
     "Microsoft.Resources/subscriptions/read",
     "Microsoft.Resources/subscriptions/resourceGroups/read",
     "Microsoft.Search/searchServices/read",
+    "Microsoft.Security/alerts/read",
+    "Microsoft.Security/assessments/read",
     "Microsoft.Security/autoProvisioningSettings/read",
+    "Microsoft.Security/contacts/read",
     "Microsoft.Security/defenderForStorageSettings/read",
+    "Microsoft.Security/jitNetworkAccessPolicies/read",
+    "Microsoft.Security/pricings/read",
+    "Microsoft.Security/regulatoryComplianceControls/read",
+    "Microsoft.Security/regulatoryComplianceStandards/read",
+    "Microsoft.Security/secureScoreControls/read",
+    "Microsoft.Security/secureScores/read",
+    "Microsoft.Security/settings/read",
+    "Microsoft.Security/subAssessments/read",
     "Microsoft.Securityinsights/alertRules/read",
     "Microsoft.Securityinsights/dataConnectors/read",
     "Microsoft.ServiceBus/namespaces/queues/read",
@@ -639,6 +652,12 @@
       "source_file": "containerregistry.go"
     },
     {
+      "permission": "Microsoft.ContainerRegistry/registries/read",
+      "service": "Microsoft.ContainerRegistry",
+      "action": "NewListPager",
+      "source_file": "containerregistry.go"
+    },
+    {
       "permission": "Microsoft.ContainerRegistry/registries/replications/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
@@ -805,6 +824,12 @@
       "service": "Microsoft.DesktopVirtualization",
       "action": "NewListPager",
       "source_file": "desktopvirtualization.go"
+    },
+    {
+      "permission": "Microsoft.Devices/resource/read",
+      "service": "Microsoft.Devices",
+      "action": "NewListBySubscriptionPager",
+      "source_file": "iot.go"
     },
     {
       "permission": "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections/read",
@@ -1569,9 +1594,27 @@
       "source_file": "search.go"
     },
     {
+      "permission": "Microsoft.Security/alerts/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/assessments/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
       "permission": "Microsoft.Security/autoProvisioningSettings/read",
       "service": "Microsoft.Security",
       "action": "Get",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/contacts/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
       "source_file": "cloud_defender.go"
     },
     {
@@ -1579,6 +1622,54 @@
       "service": "Microsoft.Security",
       "action": "Get",
       "source_file": "storage_extras.go"
+    },
+    {
+      "permission": "Microsoft.Security/jitNetworkAccessPolicies/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/pricings/read",
+      "service": "Microsoft.Security",
+      "action": "Get",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/regulatoryComplianceControls/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/regulatoryComplianceStandards/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/secureScoreControls/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/secureScores/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/settings/read",
+      "service": "Microsoft.Security",
+      "action": "Get",
+      "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.Security/subAssessments/read",
+      "service": "Microsoft.Security",
+      "action": "NewListPager",
+      "source_file": "cloud_defender.go"
     },
     {
       "permission": "Microsoft.Securityinsights/alertRules/read",


### PR DESCRIPTION
## What

Fixes a systemic gap in the azure permissions extractor: it only recognized package-qualified client constructors (`pkg.NewXxxClient(...)`) and missed clients created through a **client factory** — `f := pkg.NewClientFactory(...)` then `f.NewXxxClient()`. The entire Microsoft Defender for Cloud surface (`armsecurity`) uses the factory pattern, so **none** of its read permissions were reaching `azure.permissions.json` — meaning anyone using the manifest to scope a least-privilege scanning identity would have been told they need zero `Microsoft.Security/*` reads, then hit 403s across the whole Defender service.

## How
`extractAzurePermissions` now:
- Tracks client-factory variables and the ARM provider each belongs to (previously `NewClientFactory` was skipped entirely).
- Resolves clients created from a factory var — both when assigned (`c := f.NewXxxClient()`) and inline-chained (`f.NewXxxClient().NewListPager(...)`).

The client-name → resource-type derivation and read-method detection are unchanged, so factory clients now flow through exactly the same logic as package-qualified ones.

## Result
Regenerating the manifest is **adds-only** (nothing removed) and surfaces **13 previously-missing read permissions**:
- 11 across `Microsoft.Security`: `assessments`, `alerts`, `pricings`, `secureScores`, `secureScoreControls`, `regulatoryComplianceStandards`, `regulatoryComplianceControls`, `subAssessments`, `settings`, `contacts`, `jitNetworkAccessPolicies`
- plus a container-registry and an IoT factory client that were also missed

So the Defender resources shipped over the last few PRs (sub-assessments #8956, JIT #8957, and the pre-existing assessments/secure-scores/alerts/pricings) now have accurate IAM in the manifest.

## Testing
- `go vet` + `gofmt` clean.
- **Verified end-to-end against the real manifest**: rebuilding the azure provider regenerates `azure.permissions.json` deterministically with the 13 additions and no removals; a re-run reproduces it (the committed manifest acts as the golden file — a future regression in the extractor would show up as these permissions vanishing from the generated diff).
- Note: as with all extractor-derived azure permissions, the resource name comes from the client name (e.g. the IoT `NewResourceClient` yields `Microsoft.Devices/resource/read`) — approximate but present, consistent with the existing heuristic; better than missing.
