### PR TITLE
🎉 aws-13.43.0, azure-13.26.0, nutanix-13.2.1

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.42.0",
+	Version:         "13.43.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.25.0",
+	Version:   "13.26.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.2.0",
+	Version:         "13.2.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Version bump for three providers ahead of release.

| Provider | Bump | From → To |
|---|---|---|
| aws | minor | 13.42.0 → 13.43.0 |
| azure | minor | 13.25.0 → 13.26.0 |
| nutanix | patch | 13.2.0 → 13.2.1 |

### aws 13.43.0
- ⭐ add VPC encryption-in-transit control + bump aws SDK deps (#8939)
- ⭐ add route table cross-references (NAT gateway, instance, prefix list) (#8924)
- ⭐ add FSx filesystem cross-references (#8925)
- ⭐ add EC2 image and volume cross-references (#8926)
- ⭐ add kmsKeys cross-reference on secret versions (#8927)
- ⭐ add ECS EFS volume filesystem cross-reference (#8928)

### azure 13.26.0
- ⭐ add Defender for Cloud alert-suppression rules + workspace settings (#8959)
- 🐛 capture permissions from client-factory-created clients (#8958)
- ⭐ add Defender for Cloud JIT network access policies (#8957)
- ⭐ add Defender for Cloud sub-assessments (per-finding drill-down) (#8956)
- ⭐ add PIM role eligibility + assignment schedules (#8955)
- ⭐ enrich public IP address (sku, idle timeout, ip tags, NAT gateway ref) (#8954)
- ⭐ add network interface effectiveRouteTable() (#8953)
- ⭐ typed subnet/public-IP refs on LB frontends and Bastion IP configs (#8952)
- ⭐ wire IP-prefix/allocation/tap/private-endpoint refs into existing resources (#8951)
- ⭐ type network interface IP configurations (subnet/publicIP/ASG refs) (#8950)
- ⭐ add Azure Virtual Network Manager (AVNM) with security admin rules (#8949)
- ⭐ add NVAs, virtual routers, public/custom IP prefixes, VNet taps, IP allocations (#8948)
- ⭐ add Virtual WAN VPN/ExpressRoute gateways, ER ports, route filters (#8947)
- ⭐ add IP group resource + typed IP-group refs on IDPS bypass rules (#8946)
- ⭐ add network security perimeter + firewall policy rule collection groups (#8941)
- ⭐ bump armnetwork to v10 and add unlocked network fields (#8936)
- ✨ bump operationalinsights/privatedns SDKs and expose systemMetadata (#8920)

### nutanix 13.2.1
- 🐛 pin v4 client require lines to v4.0.x so weekly mod-update can't advance them (#8938)
- 🐛 pin v4 SDKs to v4.0.x for GA Prism Central compatibility (#8917)
- 🧹 Update deps for mql and providers 20260701 (#8862)
