### PR TITLE
⭐ aws: add aws.dynamodb.table.autoScalingEnabled

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -11236,6 +11236,8 @@ private aws.dynamodb.table @defaults("name region") {
   ttlDescription() dict
   // Global secondary indexes on the table
   globalSecondaryIndexes() []dict
+  // Whether Application Auto Scaling is configured for the table's read or write capacity
+  autoScalingEnabled() bool
 }
 
 // Amazon Simple Queue Service (SQS)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -16927,6 +16927,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.dynamodb.table.globalSecondaryIndexes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetGlobalSecondaryIndexes()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.dynamodb.table.autoScalingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetAutoScalingEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.sqs.queues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSqs).GetQueues()).ToDataRes(types.Array(types.Resource("aws.sqs.queue")))
 	},
@@ -50922,6 +50925,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.dynamodb.table.globalSecondaryIndexes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbTable).GlobalSecondaryIndexes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.dynamodb.table.autoScalingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).AutoScalingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.sqs.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -122519,6 +122526,7 @@ type mqlAwsDynamodbTable struct {
 	ReplicaRegions            plugin.TValue[[]any]
 	TtlDescription            plugin.TValue[any]
 	GlobalSecondaryIndexes    plugin.TValue[[]any]
+	AutoScalingEnabled        plugin.TValue[bool]
 }
 
 // createAwsDynamodbTable creates a new instance of this resource
@@ -122719,6 +122727,12 @@ func (c *mqlAwsDynamodbTable) GetTtlDescription() *plugin.TValue[any] {
 func (c *mqlAwsDynamodbTable) GetGlobalSecondaryIndexes() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.GlobalSecondaryIndexes, func() ([]any, error) {
 		return c.globalSecondaryIndexes()
+	})
+}
+
+func (c *mqlAwsDynamodbTable) GetAutoScalingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AutoScalingEnabled, func() (bool, error) {
+		return c.autoScalingEnabled()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2783,6 +2783,7 @@ aws.dynamodb.limit.tableMaxWrite 11.15.2
 aws.dynamodb.limits 11.15.2
 aws.dynamodb.table 11.15.2
 aws.dynamodb.table.arn 11.15.2
+aws.dynamodb.table.autoScalingEnabled 13.37.1
 aws.dynamodb.table.backups 11.15.2
 aws.dynamodb.table.billingMode 11.16.1
 aws.dynamodb.table.continuousBackups 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.37.0",
-  "generated_at": "2026-06-18T22:07:05-06:00",
+  "generated_at": "2026-06-22T22:15:48+03:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -994,6 +994,12 @@
       "service": "application-autoscaling",
       "action": "DescribeScalableTargets",
       "source_file": "aws_applicationautoscaling.go"
+    },
+    {
+      "permission": "application-autoscaling:DescribeScalableTargets",
+      "service": "application-autoscaling",
+      "action": "DescribeScalableTargets",
+      "source_file": "aws_dynamodb.go"
     },
     {
       "permission": "application-autoscaling:DescribeScalingPolicies",

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
+	aastypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/cockroachdb/errors"
@@ -667,6 +669,29 @@ func (a *mqlAwsDynamodbTable) kmsMasterKeyId() (string, error) {
 
 func (a *mqlAwsDynamodbTable) provisionedThroughput() (any, error) {
 	return nil, a.fetchDetail()
+}
+
+func (a *mqlAwsDynamodbTable) autoScalingEnabled() (bool, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	svc := conn.ApplicationAutoscaling(region)
+	ctx := context.Background()
+
+	paginator := applicationautoscaling.NewDescribeScalableTargetsPaginator(svc, &applicationautoscaling.DescribeScalableTargetsInput{
+		ServiceNamespace: aastypes.ServiceNamespaceDynamodb,
+		ResourceIds:      []string{"table/" + a.Name.Data},
+	})
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return false, errors.Wrap(err, "could not describe dynamodb scalable targets")
+		}
+		if len(resp.ScalableTargets) > 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (a *mqlAwsDynamodbTable) createdAt() (*time.Time, error) {


### PR DESCRIPTION
## What

Adds an `autoScalingEnabled` boolean field to the `aws.dynamodb.table` resource, indicating whether AWS Application Auto Scaling is configured for the table's read or write capacity.

## Why

The cnspec-enterprise-policies check `aws-dynamodb-autoscaling-enabled` (in `aws-operational-best-practices`) references `aws.dynamodb.table.autoScalingEnabled`:

```mql
aws.dynamodb.table.billingMode == "PAY_PER_REQUEST" || aws.dynamodb.table.autoScalingEnabled
```

That field never existed on the resource, so the policy bundle fails to compile (`cannot find field 'autoScalingEnabled' in aws.dynamodb.table`). This adds the missing field so the intended semantic works: **pass if the table is on-demand (`PAY_PER_REQUEST`) OR provisioned with auto scaling configured.**

## How

- **Schema** (`aws.lr`): `autoScalingEnabled() bool` on `aws.dynamodb.table`; regenerated `aws.lr.go` / `aws.lr.versions`.
- **Resolver** (`aws_dynamodb.go`): calls `application-autoscaling:DescribeScalableTargets` with `ServiceNamespace = dynamodb` and `ResourceIds = ["table/<name>"]`. Returns `true` when the table has at least one registered scalable target (read or write capacity). The `applicationautoscaling` SDK module and the `ApplicationAutoscaling(region)` connection client already existed.
- **Permissions** (`aws.permissions.json`): regenerated — now includes `application-autoscaling:DescribeScalableTargets` (source `aws_dynamodb.go`).

No provider version bump here — per repo convention that happens in the dedicated release commit.

## Verification

- `go build ./...` (aws provider) — clean.
- `go vet ./resources/` — clean.
- Field wired end-to-end through generated code (`GetAutoScalingEnabled`, plugin registration).