### PR TITLE
🐛 azure: evaluate NSG priority and full NSG chain in VM exposure

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -458,8 +458,11 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   // Internet-exposure summary combining public IPs and NSG ingress rules
   //
   // Reports whether the VM is reachable from the public internet by checking for
-  // an assigned public IP and an attached network security group rule that
-  // allows inbound traffic from any source.
+  // an assigned public IP and whether the effective network security group
+  // chain admits inbound traffic from any source. Inbound traffic must be
+  // admitted by every NSG in the chain (subnet-level and NIC-level), and rule
+  // priority is honored so a higher-priority Deny that shadows an Allow closes
+  // the exposure.
   exposure() azure.subscription.networkService.exposure
 }
 
@@ -2994,25 +2997,31 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
 //
 // Combines whether the resource has a public IP with whether its effective
 // network security rules permit inbound traffic from the internet. A resource
-// is considered internet-reachable only when it has a public IP AND an
-// effective rule allows ingress from any source (0.0.0.0/0, ::/0, *, or the
-// "Internet" service tag). The effective rules merge the NSG on the NIC, the
-// NSG on its subnet, and application security groups.
+// is considered internet-reachable only when it has a public IP AND its
+// effective network security group chain admits ingress from any source
+// (0.0.0.0/0, ::/0, *, or the "Internet" service tag). The effective rules
+// merge the NSG on the NIC, the NSG on its subnet, and application security
+// groups. Inbound traffic must be admitted by every NSG in the chain, and rule
+// priority is honored so a higher-priority Deny that shadows an Allow closes
+// the exposure.
 private azure.subscription.networkService.exposure {
   // Whether the resource is reachable from the public internet
   //
-  // True when the resource has a public IP AND an attached security group
-  // allows inbound traffic from any source. False when either signal is absent.
+  // True when the resource has a public IP AND the effective NSG chain admits
+  // inbound traffic from any source. False when either signal is absent.
   internetReachable bool
   // Whether the resource has at least one public IP address assigned
   hasPublicIp bool
-  // Whether an effective NSG rule (NIC, subnet, or ASG) has an inbound Allow rule open to any source
+  // Whether the effective NSG chain (NIC and subnet NSGs, resolved by priority) admits inbound traffic from any internet source
   securityGroupAllowsIngress bool
-  // Effective inbound security rules that allow traffic from any internet source
+  // Effective inbound rules that admit traffic from any internet source
   //
-  // Sourced from the NIC's effective security rules, which merge the NSG
-  // attached to the NIC, the NSG attached to its subnet, and any application
-  // security group rules. Each entry is the raw Azure effective-rule object.
+  // The priority-resolved inbound Allow rules that survive shadowing by any
+  // higher-priority Deny and are admitted by every NSG in the chain. Sourced
+  // from the effective rules on the resource's NICs, which merge the NSG on the
+  // NIC, the NSG on its subnet, and any application security group rules. Each
+  // entry is the raw Azure effective-rule object. Empty when a higher-priority
+  // Deny or another NSG in the chain blocks the traffic.
   openIngressRules []dict
 }
 

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.25.0",
-  "generated_at": "2026-07-05T22:13:17-07:00",
+  "version": "13.26.0",
+  "generated_at": "2026-07-06T12:03:49-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"sort"
+	"strconv"
 	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -112,42 +114,247 @@ func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAcces
 
 // --- Resolvers ---
 
-// effectiveRuleAllowsInternetIngress reports whether a single Azure
-// effective-security-rule object (the raw dict returned by a NIC's
-// effectiveSecurityRules) is an inbound Allow rule open to any internet source.
-// It reads the camelCase keys of the Azure effective-NSG payload and reuses
-// securityRuleAllowsInternetIngress for the direction/access/source matching.
-func effectiveRuleAllowsInternetIngress(rule map[string]any) bool {
-	direction, _ := rule["direction"].(string)
-	access, _ := rule["access"].(string)
-	sourcePrefix, _ := rule["sourceAddressPrefix"].(string)
-	sourcePrefixes := []string{}
-	// The effective rule lists sources both as the configured prefixes and the
-	// expanded set (service tags resolved to CIDRs); check both.
+// ruleSourceIsInternet reports whether an Azure effective-security-rule object
+// has a source that covers the public internet. It reads the source both as the
+// configured prefix(es) and as the expanded set (service tags resolved to
+// CIDRs), matching any internet-open source.
+func ruleSourceIsInternet(rule map[string]any) bool {
+	if sp, ok := rule["sourceAddressPrefix"].(string); ok && isInternetOpenSourcePrefix(sp) {
+		return true
+	}
 	for _, key := range []string{"sourceAddressPrefixes", "expandedSourceAddressPrefix"} {
 		if arr, ok := rule[key].([]any); ok {
 			for _, p := range arr {
-				if s, ok := p.(string); ok {
-					sourcePrefixes = append(sourcePrefixes, s)
+				if s, ok := p.(string); ok && isInternetOpenSourcePrefix(s) {
+					return true
 				}
 			}
 		}
 	}
-	return securityRuleAllowsInternetIngress(direction, access, sourcePrefix, sourcePrefixes)
+	return false
+}
+
+// effectiveRuleAllowsInternetIngress reports whether a single Azure
+// effective-security-rule object (the raw dict returned by a NIC's
+// effectiveSecurityRules) is an inbound Allow rule open to any internet source.
+func effectiveRuleAllowsInternetIngress(rule map[string]any) bool {
+	direction, _ := rule["direction"].(string)
+	if !strings.EqualFold(strings.TrimSpace(direction), "Inbound") {
+		return false
+	}
+	access, _ := rule["access"].(string)
+	if !strings.EqualFold(strings.TrimSpace(access), "Allow") {
+		return false
+	}
+	return ruleSourceIsInternet(rule)
+}
+
+// ruleInt extracts an integer field from an effective-rule dict. JSON numbers
+// decode as float64 through encoding/json, so both float64 and integer forms
+// are accepted.
+func ruleInt(rule map[string]any, key string) (int, bool) {
+	switch v := rule[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	}
+	return 0, false
+}
+
+// portInterval is an inclusive [lo, hi] port range.
+type portInterval struct{ lo, hi int }
+
+// rulePortIntervals reads a rule's destination port range(s) into intervals.
+// "*", an empty value, or an absent value means all ports (0-65535). Both the
+// single destinationPortRange and the destinationPortRanges list are read.
+func rulePortIntervals(rule map[string]any) []portInterval {
+	var out []portInterval
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" || s == "*" {
+			out = append(out, portInterval{0, 65535})
+			return
+		}
+		if i := strings.IndexByte(s, '-'); i >= 0 {
+			lo, err1 := strconv.Atoi(strings.TrimSpace(s[:i]))
+			hi, err2 := strconv.Atoi(strings.TrimSpace(s[i+1:]))
+			if err1 == nil && err2 == nil {
+				out = append(out, portInterval{lo, hi})
+			}
+			return
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			out = append(out, portInterval{n, n})
+		}
+	}
+	if sp, ok := rule["destinationPortRange"].(string); ok {
+		add(sp)
+	}
+	if arr, ok := rule["destinationPortRanges"].([]any); ok {
+		for _, p := range arr {
+			if s, ok := p.(string); ok {
+				add(s)
+			}
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, portInterval{0, 65535})
+	}
+	return out
+}
+
+// portsCover reports whether the deny intervals fully contain every allow
+// interval (each allow interval must fall within a single deny interval).
+func portsCover(deny, allow []portInterval) bool {
+	for _, a := range allow {
+		covered := false
+		for _, d := range deny {
+			if d.lo <= a.lo && a.hi <= d.hi {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			return false
+		}
+	}
+	return true
+}
+
+// protocolCovers reports whether a deny rule's protocol covers an allow rule's
+// protocol. "*"/"Any"/empty on the deny side covers every protocol.
+func protocolCovers(deny, allow string) bool {
+	deny = strings.TrimSpace(deny)
+	if deny == "" || deny == "*" || strings.EqualFold(deny, "Any") {
+		return true
+	}
+	return strings.EqualFold(deny, strings.TrimSpace(allow))
+}
+
+// destAddressIsBroad reports whether a destination prefix covers all addresses.
+func destAddressIsBroad(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return s == "*" || s == "0.0.0.0/0" || s == "::/0"
+}
+
+// destCovers reports whether a deny rule's destination covers an allow rule's
+// destination: the deny destination is all-addresses, or it equals the allow
+// destination. When neither holds we conservatively report false, leaving the
+// allow rule un-shadowed (a security audit should err toward reporting exposure
+// rather than hiding it).
+func destCovers(deny, allow map[string]any) bool {
+	allowDest, _ := allow["destinationAddressPrefix"].(string)
+	check := func(s string) bool {
+		return destAddressIsBroad(s) || (allowDest != "" && strings.EqualFold(s, allowDest))
+	}
+	if dp, ok := deny["destinationAddressPrefix"].(string); ok && check(dp) {
+		return true
+	}
+	if arr, ok := deny["destinationAddressPrefixes"].([]any); ok {
+		for _, p := range arr {
+			if s, ok := p.(string); ok && check(s) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// denyDominatesAllow reports whether a higher-priority Deny rule fully shadows
+// an Allow rule for internet ingress: it must cover the Allow's protocol,
+// destination ports, and destination address.
+func denyDominatesAllow(deny, allow map[string]any) bool {
+	dproto, _ := deny["protocol"].(string)
+	aproto, _ := allow["protocol"].(string)
+	if !protocolCovers(dproto, aproto) {
+		return false
+	}
+	if !portsCover(rulePortIntervals(deny), rulePortIntervals(allow)) {
+		return false
+	}
+	return destCovers(deny, allow)
+}
+
+// nsgAllowsInternetIngress reports whether a single NSG's effective rules admit
+// inbound traffic from the internet, honoring rule priority, and returns the
+// surviving internet-open Allow rules. An inbound internet Allow rule survives
+// when no higher-priority (lower-numbered) inbound internet Deny rule dominates
+// it (same protocol, destination ports, and destination). When no internet
+// source rule allows ingress the group admits nothing (Azure's default
+// DenyAllInbound applies).
+func nsgAllowsInternetIngress(rules []map[string]any) (bool, []map[string]any) {
+	type prioritized struct {
+		rule  map[string]any
+		prio  int
+		allow bool
+	}
+	var internetRules []prioritized
+	for _, r := range rules {
+		dir, _ := r["direction"].(string)
+		if !strings.EqualFold(strings.TrimSpace(dir), "Inbound") {
+			continue
+		}
+		if !ruleSourceIsInternet(r) {
+			continue
+		}
+		prio, ok := ruleInt(r, "priority")
+		if !ok {
+			prio = int(^uint(0) >> 1) // unknown priority sorts last
+		}
+		access, _ := r["access"].(string)
+		internetRules = append(internetRules, prioritized{
+			rule:  r,
+			prio:  prio,
+			allow: strings.EqualFold(strings.TrimSpace(access), "Allow"),
+		})
+	}
+	sort.SliceStable(internetRules, func(i, j int) bool {
+		return internetRules[i].prio < internetRules[j].prio
+	})
+
+	var open []map[string]any
+	for i, a := range internetRules {
+		if !a.allow {
+			continue
+		}
+		shadowed := false
+		for j := 0; j < i; j++ {
+			d := internetRules[j]
+			if d.allow {
+				continue
+			}
+			if denyDominatesAllow(d.rule, a.rule) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			open = append(open, a.rule)
+		}
+	}
+	return len(open) > 0, open
 }
 
 // exposure builds the network-exposure summary for a VM from its already-cached
-// public IPs and the effective security rules of its NICs. The effective rules
-// (via the NIC's effectiveSecurityRules accessor) merge the NSG attached to the
-// NIC, the NSG attached to its subnet, and application security group rules, so
-// a subnet-level NSG that opens the VM is accounted for. Resolving effective
-// rules is a live Azure call per NIC; it is only paid when exposure is queried.
+// public IPs and the effective security rules of its NICs.
 //
-// Limitation: NSG rule priorities are not evaluated. Azure applies rules in
-// priority order (lowest number wins), so a higher-priority Deny rule can
-// shadow a lower-priority Allow-from-internet rule. This breakdown flags any
-// matching Allow rule as opening ingress, so securityGroupAllowsIngress may
-// report true even when a higher-priority Deny actually blocks the traffic.
+// Inbound internet traffic must be admitted by every NSG in a NIC's effective
+// chain (the subnet-level NSG and the NIC-level NSG are evaluated in sequence),
+// so each NIC is evaluated per-NSG: the NIC admits internet ingress only when
+// all of its effective NSGs do. The VM is exposed when any NIC admits it. NICs
+// with no effective NSG (stopped/detached, or the API could not compute rules)
+// contribute nothing. Resolving effective rules is a live Azure call per NIC;
+// it is only paid when exposure is queried.
+//
+// Rule priority is honored: within an NSG a higher-priority (lower-numbered)
+// Deny rule shadows a lower-priority Allow-from-internet rule when it covers the
+// same protocol, destination ports, and destination (see nsgAllowsInternetIngress).
+//
+// Limitation: AVNM security-admin rules, which override NSGs tenant-wide, are
+// not folded into this evaluation.
 func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscriptionNetworkServiceExposure, error) {
 	publicIps := a.GetPublicIpAddresses()
 	if publicIps.Error != nil {
@@ -155,36 +362,43 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 	}
 	hasPublicIp := len(publicIps.Data) > 0
 
-	openRules := []any{}
 	nics := a.GetNetworkInterfaces()
 	if nics.Error != nil {
 		return nil, nics.Error
 	}
+
+	securityGroupAllowsIngress := false
+	openRules := []any{}
 	for _, n := range nics.Data {
 		nic, ok := n.(*mqlAzureSubscriptionNetworkServiceInterface)
 		if !ok {
 			continue
 		}
-		// effectiveSecurityRules merges NIC-level NSG, subnet-level NSG, and ASG
-		// rules. It propagates real errors but returns an empty set for
-		// stopped/detached NICs (the Azure API can't compute effective rules
-		// there), so those simply contribute no open rules.
-		eff := nic.GetEffectiveSecurityRules()
-		if eff.Error != nil {
-			return nil, eff.Error
+		groups, err := nic.effectiveNsgGroupsCached()
+		if err != nil {
+			return nil, err
 		}
-		for _, r := range eff.Data {
-			rule, ok := r.(map[string]any)
-			if !ok {
-				continue
+		if len(groups) == 0 {
+			continue
+		}
+		nicAdmits := true
+		var nicRules []map[string]any
+		for _, g := range groups {
+			allows, surviving := nsgAllowsInternetIngress(g.rules)
+			if !allows {
+				nicAdmits = false
+				break
 			}
-			if effectiveRuleAllowsInternetIngress(rule) {
-				openRules = append(openRules, rule)
+			nicRules = append(nicRules, surviving...)
+		}
+		if nicAdmits {
+			securityGroupAllowsIngress = true
+			for _, r := range nicRules {
+				openRules = append(openRules, r)
 			}
 		}
 	}
 
-	securityGroupAllowsIngress := len(openRules) > 0
 	internetReachable := hasPublicIp && securityGroupAllowsIngress
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.exposure", map[string]*llx.RawData{

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -240,27 +240,50 @@ func destAddressIsBroad(s string) bool {
 	return s == "*" || s == "0.0.0.0/0" || s == "::/0"
 }
 
-// destCovers reports whether a deny rule's destination covers an allow rule's
-// destination: the deny destination is all-addresses, or it equals the allow
-// destination. When neither holds we conservatively report false, leaving the
-// allow rule un-shadowed (a security audit should err toward reporting exposure
-// rather than hiding it).
-func destCovers(deny, allow map[string]any) bool {
-	allowDest, _ := allow["destinationAddressPrefix"].(string)
-	check := func(s string) bool {
-		return destAddressIsBroad(s) || (allowDest != "" && strings.EqualFold(s, allowDest))
+// ruleDestPrefixes reads a rule's destination address prefix(es), reading both
+// the single destinationAddressPrefix and the destinationAddressPrefixes list.
+// An absent/empty destination means all addresses, represented as "*".
+func ruleDestPrefixes(rule map[string]any) []string {
+	var out []string
+	if s, ok := rule["destinationAddressPrefix"].(string); ok && strings.TrimSpace(s) != "" {
+		out = append(out, s)
 	}
-	if dp, ok := deny["destinationAddressPrefix"].(string); ok && check(dp) {
-		return true
-	}
-	if arr, ok := deny["destinationAddressPrefixes"].([]any); ok {
+	if arr, ok := rule["destinationAddressPrefixes"].([]any); ok {
 		for _, p := range arr {
-			if s, ok := p.(string); ok && check(s) {
-				return true
+			if s, ok := p.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, s)
 			}
 		}
 	}
-	return false
+	if len(out) == 0 {
+		out = []string{"*"}
+	}
+	return out
+}
+
+// destCovers reports whether a deny rule's destination covers an allow rule's
+// destination: every one of the allow rule's destinations must be an
+// all-addresses prefix on the deny side or equal to one of the deny rule's
+// destinations. Both the single and plural forms are read on each side. When a
+// destination is not covered we conservatively report false, leaving the allow
+// rule un-shadowed (a security audit should err toward reporting exposure
+// rather than hiding it).
+func destCovers(deny, allow map[string]any) bool {
+	denyDests := ruleDestPrefixes(deny)
+	covers := func(target string) bool {
+		for _, d := range denyDests {
+			if destAddressIsBroad(d) || strings.EqualFold(d, target) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, a := range ruleDestPrefixes(allow) {
+		if !covers(a) {
+			return false
+		}
+	}
+	return true
 }
 
 // denyDominatesAllow reports whether a higher-priority Deny rule fully shadows
@@ -285,6 +308,11 @@ func denyDominatesAllow(deny, allow map[string]any) bool {
 // it (same protocol, destination ports, and destination). When no internet
 // source rule allows ingress the group admits nothing (Azure's default
 // DenyAllInbound applies).
+//
+// Only rules whose source covers the internet are considered — for both Allow
+// and Deny. A Deny whose source is a non-internet tag (VirtualNetwork,
+// AzureLoadBalancer, a private CIDR) does not block internet-sourced traffic,
+// so it correctly never shadows an internet Allow here.
 func nsgAllowsInternetIngress(rules []map[string]any) (bool, []map[string]any) {
 	type prioritized struct {
 		rule  map[string]any

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -227,6 +227,13 @@ func TestDestCovers(t *testing.T) {
 	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.4"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
 	assert.True(t, destCovers(map[string]any{"destinationAddressPrefixes": []any{"10.0.0.4"}}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
 	assert.False(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.5"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+	// allow rule using the plural destination form is read on the allow side too
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.4"}, map[string]any{"destinationAddressPrefixes": []any{"10.0.0.4"}}))
+	// every allow destination must be covered; a deny covering only one is not enough
+	assert.False(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.4"}, map[string]any{"destinationAddressPrefixes": []any{"10.0.0.4", "10.0.0.5"}}))
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "*"}, map[string]any{"destinationAddressPrefixes": []any{"10.0.0.4", "10.0.0.5"}}))
+	// a narrow deny cannot cover an allow that targets all addresses
+	assert.False(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.4"}, map[string]any{"destinationAddressPrefix": "*"}))
 }
 
 func TestDenyDominatesAllow(t *testing.T) {

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -171,3 +171,146 @@ func TestStorageAccountIsPublic(t *testing.T) {
 		assert.False(t, storageAccountIsPublic("Enabled", "", true))
 	})
 }
+
+func TestRuleSourceIsInternet(t *testing.T) {
+	assert.True(t, ruleSourceIsInternet(map[string]any{"sourceAddressPrefix": "*"}))
+	assert.True(t, ruleSourceIsInternet(map[string]any{"sourceAddressPrefix": "Internet"}))
+	assert.True(t, ruleSourceIsInternet(map[string]any{"sourceAddressPrefixes": []any{"10.0.0.0/8", "0.0.0.0/0"}}))
+	assert.True(t, ruleSourceIsInternet(map[string]any{"expandedSourceAddressPrefix": []any{"*"}}))
+	assert.False(t, ruleSourceIsInternet(map[string]any{"sourceAddressPrefix": "VirtualNetwork"}))
+	assert.False(t, ruleSourceIsInternet(map[string]any{"sourceAddressPrefixes": []any{"10.0.0.0/8"}}))
+	assert.False(t, ruleSourceIsInternet(map[string]any{}))
+}
+
+func TestRuleInt(t *testing.T) {
+	v, ok := ruleInt(map[string]any{"priority": float64(100)}, "priority")
+	assert.True(t, ok)
+	assert.Equal(t, 100, v)
+	v, ok = ruleInt(map[string]any{"priority": 200}, "priority")
+	assert.True(t, ok)
+	assert.Equal(t, 200, v)
+	_, ok = ruleInt(map[string]any{"priority": "300"}, "priority")
+	assert.False(t, ok, "string priority is not accepted")
+	_, ok = ruleInt(map[string]any{}, "priority")
+	assert.False(t, ok)
+}
+
+func TestRulePortIntervals(t *testing.T) {
+	assert.Equal(t, []portInterval{{0, 65535}}, rulePortIntervals(map[string]any{"destinationPortRange": "*"}))
+	assert.Equal(t, []portInterval{{22, 22}}, rulePortIntervals(map[string]any{"destinationPortRange": "22"}))
+	assert.Equal(t, []portInterval{{80, 443}}, rulePortIntervals(map[string]any{"destinationPortRange": "80-443"}))
+	assert.Equal(t, []portInterval{{22, 22}, {443, 443}}, rulePortIntervals(map[string]any{"destinationPortRanges": []any{"22", "443"}}))
+	assert.Equal(t, []portInterval{{0, 65535}}, rulePortIntervals(map[string]any{}), "absent ports means all ports")
+}
+
+func TestPortsCover(t *testing.T) {
+	all := []portInterval{{0, 65535}}
+	assert.True(t, portsCover(all, []portInterval{{22, 22}}))
+	assert.True(t, portsCover([]portInterval{{20, 30}}, []portInterval{{22, 25}}))
+	assert.False(t, portsCover([]portInterval{{20, 30}}, []portInterval{{22, 40}}))
+	assert.False(t, portsCover([]portInterval{{80, 80}}, []portInterval{{22, 22}}))
+	// allow spanning two deny intervals is not covered (must fall within one)
+	assert.False(t, portsCover([]portInterval{{20, 25}, {26, 30}}, []portInterval{{22, 28}}))
+}
+
+func TestProtocolCovers(t *testing.T) {
+	assert.True(t, protocolCovers("*", "Tcp"))
+	assert.True(t, protocolCovers("Any", "Tcp"))
+	assert.True(t, protocolCovers("", "Tcp"))
+	assert.True(t, protocolCovers("Tcp", "tcp"))
+	assert.False(t, protocolCovers("Udp", "Tcp"))
+}
+
+func TestDestCovers(t *testing.T) {
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "*"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "0.0.0.0/0"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.4"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+	assert.True(t, destCovers(map[string]any{"destinationAddressPrefixes": []any{"10.0.0.4"}}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+	assert.False(t, destCovers(map[string]any{"destinationAddressPrefix": "10.0.0.5"}, map[string]any{"destinationAddressPrefix": "10.0.0.4"}))
+}
+
+func TestDenyDominatesAllow(t *testing.T) {
+	denyAll := map[string]any{"protocol": "*", "destinationPortRange": "*", "destinationAddressPrefix": "*"}
+	allowSsh := map[string]any{"protocol": "Tcp", "destinationPortRange": "22", "destinationAddressPrefix": "*"}
+	assert.True(t, denyDominatesAllow(denyAll, allowSsh))
+
+	denyOtherPort := map[string]any{"protocol": "*", "destinationPortRange": "80", "destinationAddressPrefix": "*"}
+	assert.False(t, denyDominatesAllow(denyOtherPort, allowSsh), "deny on a different port does not shadow")
+
+	denyOtherProto := map[string]any{"protocol": "Udp", "destinationPortRange": "*", "destinationAddressPrefix": "*"}
+	assert.False(t, denyDominatesAllow(denyOtherProto, allowSsh), "deny on a different protocol does not shadow")
+
+	denyOtherDest := map[string]any{"protocol": "*", "destinationPortRange": "*", "destinationAddressPrefix": "10.0.0.5"}
+	assert.False(t, denyDominatesAllow(denyOtherDest, allowSsh), "deny on a different destination does not shadow")
+}
+
+func TestNsgAllowsInternetIngress(t *testing.T) {
+	allowSsh := map[string]any{
+		"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "*",
+		"protocol": "Tcp", "destinationPortRange": "22", "priority": float64(300),
+		"destinationAddressPrefix": "*",
+	}
+	denyAllHigh := map[string]any{
+		"direction": "Inbound", "access": "Deny", "sourceAddressPrefix": "*",
+		"protocol": "*", "destinationPortRange": "*", "priority": float64(100),
+		"destinationAddressPrefix": "*",
+	}
+	denyAllLow := map[string]any{
+		"direction": "Inbound", "access": "Deny", "sourceAddressPrefix": "*",
+		"protocol": "*", "destinationPortRange": "*", "priority": float64(4000),
+		"destinationAddressPrefix": "*",
+	}
+
+	t.Run("allow with no deny is open", func(t *testing.T) {
+		open, surviving := nsgAllowsInternetIngress([]map[string]any{allowSsh})
+		assert.True(t, open)
+		assert.Len(t, surviving, 1)
+	})
+	t.Run("higher-priority deny-all shadows the allow", func(t *testing.T) {
+		open, surviving := nsgAllowsInternetIngress([]map[string]any{allowSsh, denyAllHigh})
+		assert.False(t, open)
+		assert.Empty(t, surviving)
+	})
+	t.Run("lower-priority deny-all does not shadow the allow", func(t *testing.T) {
+		open, surviving := nsgAllowsInternetIngress([]map[string]any{allowSsh, denyAllLow})
+		assert.True(t, open)
+		assert.Len(t, surviving, 1)
+	})
+	t.Run("deny on a different port leaves the allow open", func(t *testing.T) {
+		denyHttp := map[string]any{
+			"direction": "Inbound", "access": "Deny", "sourceAddressPrefix": "*",
+			"protocol": "Tcp", "destinationPortRange": "80", "priority": float64(100),
+			"destinationAddressPrefix": "*",
+		}
+		open, _ := nsgAllowsInternetIngress([]map[string]any{allowSsh, denyHttp})
+		assert.True(t, open)
+	})
+	t.Run("no internet-source rule admits nothing", func(t *testing.T) {
+		vnetAllow := map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "VirtualNetwork",
+			"protocol": "*", "destinationPortRange": "*", "priority": float64(100),
+		}
+		open, surviving := nsgAllowsInternetIngress([]map[string]any{vnetAllow})
+		assert.False(t, open)
+		assert.Empty(t, surviving)
+	})
+	t.Run("deny-internet only admits nothing", func(t *testing.T) {
+		open, _ := nsgAllowsInternetIngress([]map[string]any{denyAllHigh})
+		assert.False(t, open)
+	})
+	t.Run("one allow shadowed, another open", func(t *testing.T) {
+		allowHttp := map[string]any{
+			"direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "*",
+			"protocol": "Tcp", "destinationPortRange": "443", "priority": float64(200),
+			"destinationAddressPrefix": "*",
+		}
+		denySshHigh := map[string]any{
+			"direction": "Inbound", "access": "Deny", "sourceAddressPrefix": "*",
+			"protocol": "Tcp", "destinationPortRange": "22", "priority": float64(150),
+			"destinationAddressPrefix": "*",
+		}
+		open, surviving := nsgAllowsInternetIngress([]map[string]any{allowSsh, allowHttp, denySshHigh})
+		assert.True(t, open)
+		assert.Len(t, surviving, 1, "only the HTTPS allow survives")
+	})
+}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -327,14 +327,24 @@ type effectiveNsgGroup struct {
 	rules []map[string]any
 }
 
-// effectiveNsgGroupsCached fetches the NIC's effective NSGs at most once,
-// caching the result (and any error) for reuse by both the effectiveSecurityRules
-// field and the VM exposure computation.
+// effectiveNsgGroupsCached fetches the NIC's effective NSGs, memoizing the
+// result for reuse by both the effectiveSecurityRules field and the VM exposure
+// computation. Only successful fetches are cached: the effective-NSG call is a
+// bounded Azure long-poll that can fail transiently (timeout), so an error is
+// returned without being memoized, letting a later caller retry.
 func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveNsgGroupsCached() ([]effectiveNsgGroup, error) {
-	a.effNsgOnce.Do(func() {
-		a.effNsgGroups, a.effNsgErr = a.fetchEffectiveNsgGroups()
-	})
-	return a.effNsgGroups, a.effNsgErr
+	a.effNsgMu.Lock()
+	defer a.effNsgMu.Unlock()
+	if a.effNsgLoaded {
+		return a.effNsgGroups, nil
+	}
+	groups, err := a.fetchEffectiveNsgGroups()
+	if err != nil {
+		return nil, err
+	}
+	a.effNsgGroups = groups
+	a.effNsgLoaded = true
+	return a.effNsgGroups, nil
 }
 
 // effectiveSecurityRules computes the merged NSG rules effective on this NIC
@@ -4537,12 +4547,13 @@ type mqlAzureSubscriptionNetworkServiceInterfaceInternal struct {
 	cacheNetworkSecurityGroupID string
 	cacheIPConfigurations       []*network.InterfaceIPConfiguration
 
-	// effNsgOnce guards a single fetch of the NIC's effective NSGs, shared by
+	// effNsgMu guards a memoized fetch of the NIC's effective NSGs, shared by
 	// the effectiveSecurityRules field and the VM exposure computation so the
-	// live Azure call is paid at most once per interface.
-	effNsgOnce   sync.Once
+	// live Azure call is paid at most once per interface. Only a successful
+	// fetch is memoized (effNsgLoaded), so a transient error can be retried.
+	effNsgMu     sync.Mutex
+	effNsgLoaded bool
 	effNsgGroups []effectiveNsgGroup
-	effNsgErr    error
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceInterface) networkSecurityGroup() (*mqlAzureSubscriptionNetworkServiceSecurityGroup, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -317,14 +317,49 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) vm() (*mqlAzureSubscriptio
 	return res.(*mqlAzureSubscriptionComputeServiceVm), nil
 }
 
+// effectiveNsgGroup is one network security group in a NIC's effective-NSG
+// chain, paired with the effective rules Azure computed for it. Inbound traffic
+// must be admitted by every group in the chain (subnet-level NSG then NIC-level
+// NSG) to reach the interface, so exposure evaluation is per-group rather than
+// over a flattened rule set.
+type effectiveNsgGroup struct {
+	nsgID string
+	rules []map[string]any
+}
+
+// effectiveNsgGroupsCached fetches the NIC's effective NSGs at most once,
+// caching the result (and any error) for reuse by both the effectiveSecurityRules
+// field and the VM exposure computation.
+func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveNsgGroupsCached() ([]effectiveNsgGroup, error) {
+	a.effNsgOnce.Do(func() {
+		a.effNsgGroups, a.effNsgErr = a.fetchEffectiveNsgGroups()
+	})
+	return a.effNsgGroups, a.effNsgErr
+}
+
 // effectiveSecurityRules computes the merged NSG rules effective on this NIC
-// (NSG attached to NIC + ASG + NSG attached to subnet). Lazily called per NIC.
-//
-// Azure only computes effective rules for NICs attached to a running VM; for
-// detached or stopped NICs the API returns NicNotAssociatedWithVm or similar
-// 400/404 errors. We treat those as "no effective rules" rather than failing
-// the whole interfaces query.
+// (NSG attached to NIC + ASG + NSG attached to subnet), flattened across the
+// effective-NSG chain. Lazily called per NIC.
 func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() ([]any, error) {
+	groups, err := a.effectiveNsgGroupsCached()
+	if err != nil {
+		return nil, err
+	}
+	var res []any
+	for _, g := range groups {
+		for _, rule := range g.rules {
+			res = append(res, rule)
+		}
+	}
+	return res, nil
+}
+
+// fetchEffectiveNsgGroups computes the effective NSGs on this NIC, one group per
+// NSG in the effective chain. Azure only computes effective rules for NICs
+// attached to a running VM; for detached or stopped NICs the API returns
+// NicNotAssociatedWithVm or similar 400/404 errors. We treat those as "no
+// effective NSGs" rather than failing the whole interfaces query.
+func (a *mqlAzureSubscriptionNetworkServiceInterface) fetchEffectiveNsgGroups() ([]effectiveNsgGroup, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	// Bound the long-poll so a stuck operation doesn't hang the interfaces query.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -404,7 +439,7 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 		httpResp.StatusCode == http.StatusNotFound ||
 		httpResp.StatusCode == http.StatusForbidden {
 		log.Warn().Str("nic", nicName).Int("status", httpResp.StatusCode).Msg("effective security rules unavailable for NIC")
-		return []any{}, nil
+		return []effectiveNsgGroup{}, nil
 	}
 	if httpResp.StatusCode >= 400 {
 		body, _ := io.ReadAll(httpResp.Body)
@@ -413,23 +448,28 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 
 	var payload struct {
 		Value []struct {
-			EffectiveSecurityRules []any `json:"effectiveSecurityRules"`
+			NetworkSecurityGroup struct {
+				ID string `json:"id"`
+			} `json:"networkSecurityGroup"`
+			EffectiveSecurityRules []map[string]any `json:"effectiveSecurityRules"`
 		} `json:"value"`
 	}
 	if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
 		return nil, err
 	}
 
-	var res []any
+	groups := make([]effectiveNsgGroup, 0, len(payload.Value))
 	for _, ensg := range payload.Value {
+		rules := make([]map[string]any, 0, len(ensg.EffectiveSecurityRules))
 		for _, rule := range ensg.EffectiveSecurityRules {
 			if rule == nil {
 				continue
 			}
-			res = append(res, rule)
+			rules = append(rules, rule)
 		}
+		groups = append(groups, effectiveNsgGroup{nsgID: ensg.NetworkSecurityGroup.ID, rules: rules})
 	}
-	return res, nil
+	return groups, nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {
@@ -4496,6 +4536,13 @@ func azureInterfaceToMql(runtime *plugin.Runtime, iface network.Interface) (*mql
 type mqlAzureSubscriptionNetworkServiceInterfaceInternal struct {
 	cacheNetworkSecurityGroupID string
 	cacheIPConfigurations       []*network.InterfaceIPConfiguration
+
+	// effNsgOnce guards a single fetch of the NIC's effective NSGs, shared by
+	// the effectiveSecurityRules field and the VM exposure computation so the
+	// live Azure call is paid at most once per interface.
+	effNsgOnce   sync.Once
+	effNsgGroups []effectiveNsgGroup
+	effNsgErr    error
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceInterface) networkSecurityGroup() (*mqlAzureSubscriptionNetworkServiceSecurityGroup, error) {


### PR DESCRIPTION
## What

Improves the fidelity of `azure.subscription.computeService.vm.exposure()` so `internetReachable` / `securityGroupAllowsIngress` stop producing **false positives**.

Previously exposure flagged a VM as internet-reachable when *any* effective NSG rule was an internet-open inbound Allow. That ignored two things Azure actually enforces:

1. **Rule priority** — Azure evaluates NSG rules in priority order (lowest number wins), so a higher-priority Deny can shadow a lower-priority Allow-from-internet. The old code counted the Allow regardless.
2. **The full NSG chain** — inbound traffic must be admitted by *every* NSG in the effective chain (the subnet-level NSG **and** the NIC-level NSG). The old code treated a single open NSG as sufficient.

## How

- Exposure is now computed **per-NSG** with priority honored. An internet-open inbound Allow survives only when no higher-priority (lower-numbered) inbound internet Deny **dominates** it — i.e. covers the same protocol, destination ports, and destination. A NIC admits internet ingress only when **all** of its effective NSGs do; the VM is exposed when any NIC admits it.
- **Conservative shadow resolution:** an Allow is discounted only when a single Deny clearly dominates it. This removes false positives without introducing false negatives that would hide real exposure (the right bias for a security signal).
- The effective-NSG fetch is refactored into a grouped, `sync.Once`-cached helper shared by the `effectiveSecurityRules` field and the exposure computation, so the live Azure call is paid at most once per interface.
- `openIngressRules` now reports the surviving, priority-resolved rules (empty when a higher-priority Deny or another NSG in the chain blocks the traffic).

Schema change is **comment-only** — no new fields, so no `.lr.versions` entries. The `permissions.json` diff is a version/timestamp regen only (no permission added; the effective-NSG call already existed).

## Tests

New table tests in `azure_exposure_test.go` cover:
- priority shadowing (higher-priority Deny-all closes an Allow; lower-priority Deny does not),
- per-port / per-protocol / per-destination shadowing (a Deny on a different port/protocol/dest leaves the Allow open),
- "all NSGs in the chain must allow",
- the `rulePortIntervals` / `portsCover` / `protocolCovers` / `destCovers` / `ruleSourceIsInternet` / `ruleInt` helpers.

## Verification

Built + installed the provider and ran `exposure` against a live subscription (with `--auto-update=false`). Confirmed a VM with a public IP but an NSG that only allows a scoped source IP correctly reports `internetReachable: false`, and that stopped/detached NICs (effective-rules API returns 400) contribute nothing. Priority-shadowing and multi-NSG-chain cases aren't present in the test subscription, so those paths are covered by unit tests.

## Follow-up

Folding **AVNM security-admin rules** (which override NSGs tenant-wide) into effective exposure is deliberately **not** in this PR — it needs Azure's per-VNet `listNetworkManagerEffectiveSecurityAdminRules` API and can't be live-verified without a configured AVNM deployment. Tracked as a follow-up.
