### PR TITLE
🐛 oci: fix internet-exposure to weigh routes and security lists

### DIFF
--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -452,7 +452,12 @@ oci.compute {
 // compute, the subnet's internet-ingress policy) that admit traffic from any
 // address. Shared by compute instances and load balancers.
 private oci.network.exposure @defaults("internetReachable hasPublicIp") {
-  // Whether the resource is reachable from the internet (a public IP and ingress that admits any address)
+  // Whether the resource is reachable from the internet
+  //
+  // True when the resource has a public IP, sits on a subnet that permits
+  // internet ingress and routes a default route to an enabled internet gateway,
+  // and an ingress rule (in an attached network security group or the subnet's
+  // security list) admits traffic from any address.
   internetReachable bool
   // Whether the resource has a public IP
   hasPublicIp bool
@@ -462,7 +467,23 @@ private oci.network.exposure @defaults("internetReachable hasPublicIp") {
   // the subnet's internet-ingress policy is applied only to internetReachable,
   // not here.
   securityGroupAllowsIngress bool
-  // Ingress rules that admit traffic from any address (0.0.0.0/0 or ::/0); for a load balancer, the listeners reachable from the internet
+  // Whether the subnet's security list admits inbound traffic from any address
+  //
+  // True also when no security list is resolvable, matching the network
+  // security group default. OCI evaluates the union of security list and NSG
+  // rules, so either layer admitting any address opens ingress.
+  securityListAllowsIngress bool
+  // Whether the subnet routes a default route (0.0.0.0/0 or ::/0) to an enabled internet gateway
+  //
+  // A public IP alone does not make a resource internet-reachable in OCI; the
+  // subnet's route table must also forward internet-bound traffic to an internet
+  // gateway. False when the only default route targets a NAT gateway, a DRG, or
+  // nothing.
+  hasRouteToInternet bool
+  // Ingress rules that admit traffic from any address (0.0.0.0/0 or ::/0)
+  //
+  // Combines the matching network security group rules and subnet security list
+  // rules. For a load balancer, the listeners reachable from the internet.
   openIngressRules []dict
 }
 

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1400,6 +1400,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
 	},
+	"oci.network.exposure.securityListAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkExposure).GetSecurityListAllowsIngress()).ToDataRes(types.Bool)
+	},
+	"oci.network.exposure.hasRouteToInternet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkExposure).GetHasRouteToInternet()).ToDataRes(types.Bool)
+	},
 	"oci.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Dict))
 	},
@@ -7128,6 +7134,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkExposure).SecurityGroupAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.network.exposure.securityListAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkExposure).SecurityListAllowsIngress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.network.exposure.hasRouteToInternet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkExposure).HasRouteToInternet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"oci.network.exposure.openIngressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16428,6 +16442,8 @@ type mqlOciNetworkExposure struct {
 	InternetReachable          plugin.TValue[bool]
 	HasPublicIp                plugin.TValue[bool]
 	SecurityGroupAllowsIngress plugin.TValue[bool]
+	SecurityListAllowsIngress  plugin.TValue[bool]
+	HasRouteToInternet         plugin.TValue[bool]
 	OpenIngressRules           plugin.TValue[[]any]
 }
 
@@ -16473,6 +16489,14 @@ func (c *mqlOciNetworkExposure) GetHasPublicIp() *plugin.TValue[bool] {
 
 func (c *mqlOciNetworkExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {
 	return &c.SecurityGroupAllowsIngress
+}
+
+func (c *mqlOciNetworkExposure) GetSecurityListAllowsIngress() *plugin.TValue[bool] {
+	return &c.SecurityListAllowsIngress
+}
+
+func (c *mqlOciNetworkExposure) GetHasRouteToInternet() *plugin.TValue[bool] {
+	return &c.HasRouteToInternet
 }
 
 func (c *mqlOciNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -1350,9 +1350,11 @@ oci.network.drgAttachment.virtualCircuit 13.13.1
 oci.network.drgs 13.13.1
 oci.network.exposure 13.12.0
 oci.network.exposure.hasPublicIp 13.12.0
+oci.network.exposure.hasRouteToInternet 13.13.1
 oci.network.exposure.internetReachable 13.12.0
 oci.network.exposure.openIngressRules 13.12.0
 oci.network.exposure.securityGroupAllowsIngress 13.12.0
+oci.network.exposure.securityListAllowsIngress 13.13.1
 oci.network.internetGateway 13.1.1
 oci.network.internetGateway.compartment 13.12.2
 oci.network.internetGateway.compartmentID 13.1.1

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -187,6 +187,36 @@ func ociSubnetReachesInternet(subnet *mqlOciNetworkSubnet) (bool, error) {
 	return ociRouteTableReachesInternet(rt.Data)
 }
 
+// ociIngressOpen reports whether ingress from any address is admitted. OCI
+// evaluates the union of network security group and security-list rules, so the
+// path is open when either an actual NSG rule admits any address or the
+// security-list layer admits ingress.
+func ociIngressOpen(nsgOpenRuleCount int, securityListAllows bool) bool {
+	return nsgOpenRuleCount > 0 || securityListAllows
+}
+
+// ociSubnetGate captures the two subnet conditions that gate internet
+// reachability: whether the subnet prohibits internet ingress, and whether it
+// routes a default route to an enabled internet gateway.
+type ociSubnetGate struct {
+	prohibitsIngress bool
+	routesToInternet bool
+}
+
+// ociAnySubnetReachable reports whether any single subnet both permits internet
+// ingress and routes to an internet gateway. The conjunction is evaluated per
+// subnet: a subnet that permits ingress but has no internet route, combined with
+// a different subnet that routes out but prohibits ingress, does not make a
+// resource reachable.
+func ociAnySubnetReachable(gates []ociSubnetGate) bool {
+	for _, g := range gates {
+		if !g.prohibitsIngress && g.routesToInternet {
+			return true
+		}
+	}
+	return false
+}
+
 // ociWhitelistOpensInternet reports whether an Autonomous Database access-control
 // allow-list admits any address. Unlike a security-group rule set, an *empty*
 // ADB allow-list with access control enabled denies everyone, so only an entry
@@ -309,7 +339,7 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		// any address. Reachability additionally requires a public IP, a subnet
 		// that permits internet ingress, and a default route to an internet
 		// gateway.
-		ingressOpen := len(nsgOpenRules) > 0 || slAllows
+		ingressOpen := ociIngressOpen(len(nsgOpenRules), slAllows)
 		if vnicHasPublicIp && !subnetProhibits && vnicRoutesToInternet && ingressOpen {
 			internetReachable = true
 		}
@@ -385,7 +415,10 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	if subnets.Error != nil {
 		return nil, subnets.Error
 	}
-	subnetReachable := false
+	// A load balancer is reachable only via a subnet that both permits internet
+	// ingress and routes to an internet gateway, so the two conditions are
+	// captured per subnet rather than aggregated independently.
+	gates := make([]ociSubnetGate, 0, len(subnets.Data))
 	hasRouteToInternet := false
 	allSecurityLists := []any{}
 	for _, s := range subnets.Data {
@@ -404,13 +437,8 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 		if reaches {
 			hasRouteToInternet = true
 		}
-		// A load balancer is reachable only via a subnet that both permits
-		// internet ingress and routes to an internet gateway. Tracking the two
-		// conditions per subnet avoids falsely combining one subnet's ingress with
-		// another subnet's route.
-		if !prohibit.Data && reaches {
-			subnetReachable = true
-		}
+		gates = append(gates, ociSubnetGate{prohibitsIngress: prohibit.Data, routesToInternet: reaches})
+
 		sls := subnet.GetSecurityLists()
 		if sls.Error != nil {
 			return nil, sls.Error
@@ -427,8 +455,8 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	// Union of NSG and security-list rules admits ingress; reachability also
 	// requires a public IP, a listener, and a single subnet that both permits
 	// internet ingress and routes to an internet gateway.
-	ingressOpen := len(nsgOpenRules) > 0 || securityListAllowsIngress
-	internetReachable := hasPublicIp && hasListener && ingressOpen && subnetReachable
+	ingressOpen := ociIngressOpen(len(nsgOpenRules), securityListAllowsIngress)
+	internetReachable := hasPublicIp && hasListener && ingressOpen && ociAnySubnetReachable(gates)
 
 	res, err := CreateResource(l.MqlRuntime, "oci.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("oci.loadBalancer.loadBalancer/" + id.Data + "/exposure"),

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -385,7 +385,7 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	if subnets.Error != nil {
 		return nil, subnets.Error
 	}
-	subnetPermitsIngress := false
+	subnetReachable := false
 	hasRouteToInternet := false
 	allSecurityLists := []any{}
 	for _, s := range subnets.Data {
@@ -397,15 +397,19 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 		if prohibit.Error != nil {
 			return nil, prohibit.Error
 		}
-		if !prohibit.Data {
-			subnetPermitsIngress = true
-		}
 		reaches, err := ociSubnetReachesInternet(subnet)
 		if err != nil {
 			return nil, err
 		}
 		if reaches {
 			hasRouteToInternet = true
+		}
+		// A load balancer is reachable only via a subnet that both permits
+		// internet ingress and routes to an internet gateway. Tracking the two
+		// conditions per subnet avoids falsely combining one subnet's ingress with
+		// another subnet's route.
+		if !prohibit.Data && reaches {
+			subnetReachable = true
 		}
 		sls := subnet.GetSecurityLists()
 		if sls.Error != nil {
@@ -421,10 +425,10 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	openRules = append(openRules, slOpenRules...)
 
 	// Union of NSG and security-list rules admits ingress; reachability also
-	// requires a public IP, a listener, a subnet permitting ingress, and a route
-	// to an internet gateway.
+	// requires a public IP, a listener, and a single subnet that both permits
+	// internet ingress and routes to an internet gateway.
 	ingressOpen := len(nsgOpenRules) > 0 || securityListAllowsIngress
-	internetReachable := hasPublicIp && hasListener && ingressOpen && subnetPermitsIngress && hasRouteToInternet
+	internetReachable := hasPublicIp && hasListener && ingressOpen && subnetReachable
 
 	res, err := CreateResource(l.MqlRuntime, "oci.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("oci.loadBalancer.loadBalancer/" + id.Data + "/exposure"),

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -81,6 +81,112 @@ func ociNsgIngressVerdict(nsgRuleSets [][]map[string]any) ([]any, bool) {
 	return openRules, len(nsgRuleSets) == 0 || len(openRules) > 0
 }
 
+// ociSecurityListRuleOpensIngress reports whether a VCN security-list ingress
+// rule dict admits traffic from any address. Security-list ingress rules are
+// inherently inbound (no direction field), and their source keys are snake_case
+// (source, source_type) unlike NSG rules. NSG and SERVICE_CIDR_BLOCK sources
+// reference internal networks, so only a CIDR_BLOCK (or unset) source can be
+// public.
+func ociSecurityListRuleOpensIngress(rule map[string]any) bool {
+	if st, _ := rule["source_type"].(string); st != "" && !strings.EqualFold(st, "CIDR_BLOCK") {
+		return false
+	}
+	source, _ := rule["source"].(string)
+	return ociCidrIsAny(source)
+}
+
+// ociCollectOpenSecurityListRules inspects the ingress rules of the security
+// lists associated with a subnet and returns the ones admitting traffic from any
+// address, plus whether the security-list layer admits ingress. With no security
+// list resolvable the subnet falls back to OCI's default open posture, so an
+// empty set counts as admitting ingress (matching the "no firewall == open"
+// network security group convention).
+func ociCollectOpenSecurityListRules(securityLists []any) ([]any, bool, error) {
+	if len(securityLists) == 0 {
+		return nil, true, nil
+	}
+	openRules := []any{}
+	for _, s := range securityLists {
+		sl, ok := s.(*mqlOciNetworkSecurityList)
+		if !ok {
+			continue
+		}
+		rules := sl.GetIngressSecurityRules()
+		if rules.Error != nil {
+			return nil, false, rules.Error
+		}
+		for _, r := range rules.Data {
+			if rule, ok := r.(map[string]any); ok && ociSecurityListRuleOpensIngress(rule) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+	return openRules, len(openRules) > 0, nil
+}
+
+// ociRouteTableReachesInternet reports whether a route table forwards a default
+// route (0.0.0.0/0 or ::/0) to an enabled internet gateway. A default route to a
+// NAT gateway, DRG, or service gateway is outbound-only or internal and does not
+// make the subnet internet-reachable. When the target internet gateway cannot be
+// resolved (for example it lives in another compartment), the default route is
+// treated as internet-reaching rather than silently dropped.
+func ociRouteTableReachesInternet(rt *mqlOciNetworkRouteTable) (bool, error) {
+	if rt == nil {
+		return false, nil
+	}
+	routes := rt.GetRoutes()
+	if routes.Error != nil {
+		return false, routes.Error
+	}
+	for _, r := range routes.Data {
+		route, ok := r.(*mqlOciNetworkRouteTableRoute)
+		if !ok {
+			continue
+		}
+		dest := route.GetDestination()
+		if dest.Error != nil {
+			return false, dest.Error
+		}
+		if !ociCidrIsAny(dest.Data) {
+			continue
+		}
+		targetType := route.GetTargetType()
+		if targetType.Error != nil {
+			return false, targetType.Error
+		}
+		if !strings.EqualFold(targetType.Data, "INTERNET_GATEWAY") {
+			continue
+		}
+		igw := route.GetInternetGateway()
+		if igw.Error != nil || igw.Data == nil {
+			// Cannot confirm the gateway is disabled; a default route to an
+			// internet gateway is treated as internet-reaching.
+			return true, nil
+		}
+		enabled := igw.Data.GetIsEnabled()
+		if enabled.Error != nil {
+			return false, enabled.Error
+		}
+		if enabled.Data {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ociSubnetReachesInternet reports whether a subnet's route table forwards a
+// default route to an enabled internet gateway.
+func ociSubnetReachesInternet(subnet *mqlOciNetworkSubnet) (bool, error) {
+	if subnet == nil {
+		return false, nil
+	}
+	rt := subnet.GetRouteTable()
+	if rt.Error != nil {
+		return false, rt.Error
+	}
+	return ociRouteTableReachesInternet(rt.Data)
+}
+
 // ociWhitelistOpensInternet reports whether an Autonomous Database access-control
 // allow-list admits any address. Unlike a security-group rule set, an *empty*
 // ADB allow-list with access control enabled denies everyone, so only an entry
@@ -119,6 +225,8 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 
 	hasPublicIp := false
 	securityGroupAllowsIngress := false
+	securityListAllowsIngress := false
+	hasRouteToInternet := false
 	internetReachable := false
 	openRules := []any{}
 
@@ -137,9 +245,13 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 			hasPublicIp = true
 		}
 
-		// Subnet-level gate: a subnet that prohibits internet ingress blocks
-		// reachability regardless of the security groups.
+		// Subnet-level gates: a subnet that prohibits internet ingress blocks
+		// reachability, and the subnet's security lists and route table decide
+		// the security-list layer and whether internet traffic is routed at all.
 		subnetProhibits := false
+		vnicRoutesToInternet := false
+		var slOpenRules []any
+		slAllows := true
 		subnet := vnic.GetSubnet()
 		if subnet.Error != nil {
 			return nil, subnet.Error
@@ -150,6 +262,22 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 				return nil, p.Error
 			}
 			subnetProhibits = p.Data
+
+			sls := subnet.Data.GetSecurityLists()
+			if sls.Error != nil {
+				return nil, sls.Error
+			}
+			var err error
+			slOpenRules, slAllows, err = ociCollectOpenSecurityListRules(sls.Data)
+			if err != nil {
+				return nil, err
+			}
+
+			reaches, err := ociSubnetReachesInternet(subnet.Data)
+			if err != nil {
+				return nil, err
+			}
+			vnicRoutesToInternet = reaches
 		}
 
 		// Network security groups attached to this VNIC.
@@ -157,23 +285,33 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		if nsgs.Error != nil {
 			return nil, nsgs.Error
 		}
-		vnicOpenRules, nsgAllows, err := ociCollectOpenNsgRules(nsgs.Data)
+		nsgOpenRules, nsgAllows, err := ociCollectOpenNsgRules(nsgs.Data)
 		if err != nil {
 			return nil, err
 		}
-		openRules = append(openRules, vnicOpenRules...)
+		openRules = append(openRules, nsgOpenRules...)
+		openRules = append(openRules, slOpenRules...)
 
-		// securityGroupAllowsIngress reflects the NSG verdict alone, so it is not
-		// muddied by the subnet gate (a user seeing it false can conclude no NSG
-		// admits traffic). The subnet's internet-ingress policy is applied only to
-		// internetReachable.
+		// securityGroupAllowsIngress reflects the NSG verdict alone (no NSG counts
+		// as open) so a user seeing it false can conclude no NSG admits traffic.
 		if nsgAllows {
 			securityGroupAllowsIngress = true
 		}
-		if !subnetProhibits && nsgAllows {
-			if vnicHasPublicIp {
-				internetReachable = true
-			}
+		if slAllows {
+			securityListAllowsIngress = true
+		}
+		if vnicRoutesToInternet {
+			hasRouteToInternet = true
+		}
+
+		// OCI evaluates the union of NSG and security-list rules, so ingress is
+		// open when either an actual NSG rule or the subnet's security list admits
+		// any address. Reachability additionally requires a public IP, a subnet
+		// that permits internet ingress, and a default route to an internet
+		// gateway.
+		ingressOpen := len(nsgOpenRules) > 0 || slAllows
+		if vnicHasPublicIp && !subnetProhibits && vnicRoutesToInternet && ingressOpen {
+			internetReachable = true
 		}
 	}
 
@@ -182,6 +320,8 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		"internetReachable":          llx.BoolData(internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
 		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
+		"securityListAllowsIngress":  llx.BoolData(securityListAllowsIngress),
+		"hasRouteToInternet":         llx.BoolData(hasRouteToInternet),
 		"openIngressRules":           llx.ArrayData(openRules, types.Dict),
 	})
 	if err != nil {
@@ -233,18 +373,66 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	if nsgs.Error != nil {
 		return nil, nsgs.Error
 	}
-	openRules, securityGroupAllowsIngress, err := ociCollectOpenNsgRules(nsgs.Data)
+	nsgOpenRules, securityGroupAllowsIngress, err := ociCollectOpenNsgRules(nsgs.Data)
 	if err != nil {
 		return nil, err
 	}
+	openRules := append([]any{}, nsgOpenRules...)
 
-	internetReachable := hasPublicIp && hasListener && securityGroupAllowsIngress
+	// Subnet gates: aggregate the load balancer's subnets. It is reachable via a
+	// subnet that permits internet ingress and routes to an internet gateway.
+	subnets := l.GetSubnets()
+	if subnets.Error != nil {
+		return nil, subnets.Error
+	}
+	subnetPermitsIngress := false
+	hasRouteToInternet := false
+	allSecurityLists := []any{}
+	for _, s := range subnets.Data {
+		subnet, ok := s.(*mqlOciNetworkSubnet)
+		if !ok {
+			continue
+		}
+		prohibit := subnet.GetProhibitInternetIngress()
+		if prohibit.Error != nil {
+			return nil, prohibit.Error
+		}
+		if !prohibit.Data {
+			subnetPermitsIngress = true
+		}
+		reaches, err := ociSubnetReachesInternet(subnet)
+		if err != nil {
+			return nil, err
+		}
+		if reaches {
+			hasRouteToInternet = true
+		}
+		sls := subnet.GetSecurityLists()
+		if sls.Error != nil {
+			return nil, sls.Error
+		}
+		allSecurityLists = append(allSecurityLists, sls.Data...)
+	}
+
+	slOpenRules, securityListAllowsIngress, err := ociCollectOpenSecurityListRules(allSecurityLists)
+	if err != nil {
+		return nil, err
+	}
+	openRules = append(openRules, slOpenRules...)
+
+	// Union of NSG and security-list rules admits ingress; reachability also
+	// requires a public IP, a listener, a subnet permitting ingress, and a route
+	// to an internet gateway.
+	ingressOpen := len(nsgOpenRules) > 0 || securityListAllowsIngress
+	internetReachable := hasPublicIp && hasListener && ingressOpen && subnetPermitsIngress && hasRouteToInternet
 
 	res, err := CreateResource(l.MqlRuntime, "oci.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("oci.loadBalancer.loadBalancer/" + id.Data + "/exposure"),
 		"internetReachable":          llx.BoolData(internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
 		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
+		"securityListAllowsIngress":  llx.BoolData(securityListAllowsIngress),
+		"hasRouteToInternet":         llx.BoolData(hasRouteToInternet),
 		"openIngressRules":           llx.ArrayData(openRules, types.Dict),
 	})
 	if err != nil {

--- a/providers/oci/resources/oci_exposure_test.go
+++ b/providers/oci/resources/oci_exposure_test.go
@@ -75,6 +75,41 @@ func TestOciNsgIngressVerdict(t *testing.T) {
 	}
 }
 
+func TestOciSecurityListRuleOpensIngress(t *testing.T) {
+	cases := []struct {
+		name string
+		rule map[string]any
+		want bool
+	}{
+		{"any cidr", map[string]any{"source_type": "CIDR_BLOCK", "source": "0.0.0.0/0"}, true},
+		{"any cidr v6", map[string]any{"source_type": "CIDR_BLOCK", "source": "::/0"}, true},
+		{"specific cidr", map[string]any{"source_type": "CIDR_BLOCK", "source": "1.2.3.4/32"}, false},
+		{"service source", map[string]any{"source_type": "SERVICE_CIDR_BLOCK", "source": "all-services"}, false},
+		{"missing source_type but any cidr", map[string]any{"source": "0.0.0.0/0"}, true},
+		{"empty", map[string]any{}, false},
+	}
+	for _, c := range cases {
+		if got := ociSecurityListRuleOpensIngress(c.rule); got != c.want {
+			t.Errorf("ociSecurityListRuleOpensIngress(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOciCollectOpenSecurityListRulesEmptyIsOpen(t *testing.T) {
+	// No security list resolvable falls back to OCI's default open posture,
+	// mirroring the network security group "no firewall == open" convention.
+	openRules, allows, err := ociCollectOpenSecurityListRules(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allows {
+		t.Errorf("empty security list set should admit ingress (absent == open)")
+	}
+	if len(openRules) != 0 {
+		t.Errorf("empty security list set should surface no open rules, got %d", len(openRules))
+	}
+}
+
 func TestOciWhitelistOpensInternet(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/providers/oci/resources/oci_exposure_test.go
+++ b/providers/oci/resources/oci_exposure_test.go
@@ -110,6 +110,62 @@ func TestOciCollectOpenSecurityListRulesEmptyIsOpen(t *testing.T) {
 	}
 }
 
+func TestOciIngressOpen(t *testing.T) {
+	cases := []struct {
+		name           string
+		nsgOpenRules   int
+		securityListOK bool
+		want           bool
+	}{
+		{"nsg opens", 2, false, true},
+		{"security list opens", 0, true, true},
+		{"both open", 1, true, true},
+		{"neither opens", 0, false, false},
+	}
+	for _, c := range cases {
+		if got := ociIngressOpen(c.nsgOpenRules, c.securityListOK); got != c.want {
+			t.Errorf("ociIngressOpen(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOciAnySubnetReachable(t *testing.T) {
+	cases := []struct {
+		name  string
+		gates []ociSubnetGate
+		want  bool
+	}{
+		{"no subnets", nil, false},
+		{"single subnet permits and routes", []ociSubnetGate{{prohibitsIngress: false, routesToInternet: true}}, true},
+		{"single subnet permits but no route", []ociSubnetGate{{prohibitsIngress: false, routesToInternet: false}}, false},
+		{"single subnet routes but prohibits", []ociSubnetGate{{prohibitsIngress: true, routesToInternet: true}}, false},
+		// Regression: independent aggregation would have combined subnet A's
+		// ingress with subnet B's route into a false positive. The conjunction is
+		// per subnet, so neither subnet alone makes the resource reachable.
+		{
+			"permit-only subnet plus route-only subnet is not reachable",
+			[]ociSubnetGate{
+				{prohibitsIngress: false, routesToInternet: false},
+				{prohibitsIngress: true, routesToInternet: true},
+			},
+			false,
+		},
+		{
+			"one fully reachable subnet among others is reachable",
+			[]ociSubnetGate{
+				{prohibitsIngress: true, routesToInternet: true},
+				{prohibitsIngress: false, routesToInternet: true},
+			},
+			true,
+		},
+	}
+	for _, c := range cases {
+		if got := ociAnySubnetReachable(c.gates); got != c.want {
+			t.Errorf("ociAnySubnetReachable(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 func TestOciWhitelistOpensInternet(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
## What

Fixes `oci.network.exposure.internetReachable`, which produced **incorrect verdicts** because it ignored two of the three things that actually determine OCI reachability. **PR 3 of the OCI network attack-path stack** (PR 1 #8967, PR 2 #8969, both merged). Uses the typed route targets added in PR 1.

## Bugs fixed

1. **Security lists were never evaluated — only NSGs.** OCI subnets default to a *security list* (not an NSG), and OCI applies the **union** of NSG + security-list rules. A VNIC with a locked-down security list but no NSG was reported `internetReachable = true` because "no NSG attached == open" was the entire ingress story → **false positive**. Security lists are now folded in: either layer admitting `0.0.0.0/0`/`::/0` opens ingress.

2. **The route table was never consulted.** A public IP on a subnet whose route table has no default route to an internet gateway was still reported reachable → **false positive**. Reachability now requires a `0.0.0.0/0` (or `::/0`) route to an **enabled** internet gateway, resolved through PR 1's typed route targets. A default route to a NAT gateway or DRG no longer counts.

3. **Load balancer exposure lacked the subnet gates** the compute path had. It now applies the subnet ingress-permission and route-to-internet gates across all of the load balancer's subnets.

## Schema

Two new `oci.network.exposure` fields expose the added signals:
- `securityListAllowsIngress` — the subnet security-list layer verdict (absent list == open, matching the NSG convention)
- `hasRouteToInternet` — subnet routes a default route to an enabled internet gateway

`securityGroupAllowsIngress` keeps its NSG-only meaning (unchanged). `openIngressRules` now includes the matching security-list rules alongside NSG rules.

## Behavior change

`internetReachable` will flip to `false` for resources that have a public IP but are gated by a restrictive security list or a route table with no IGW default route — these were false positives before. It may flip to `true` where a restrictive NSG was masking an open default security list (a real exposure OCI's union semantics allow).

## Tests

Table tests for the security-list rule classifier and the absent-list default. Existing exposure tests unchanged and passing.

## Verification

Build + unit tests + codegen clean.
