### PR TITLE
⭐ aws: typed route table next-hops for network path traversal

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -455,7 +455,21 @@ private aws.vpc.routetable.route @defaults("destinationCidrBlock state") {
   // Managed prefix list used for the destination match
   managedPrefixList() aws.ec2.managedPrefixList
   // ID of a gateway attached to the VPC
+  //
+  // Covers internet gateways (igw-), virtual private gateways (vgw-), VPC
+  // endpoints (vpce-), and the special `local` route. Use `internetGateway`
+  // or `vpnGateway` for the typed next-hop resource.
   gatewayId string
+  // Internet gateway the route sends traffic to
+  //
+  // Resolves the next hop when `gatewayId` names an internet gateway (igw-),
+  // the route that makes a subnet public. Null for any other gateway kind.
+  internetGateway() aws.ec2.internetgateway
+  // Virtual private gateway the route sends traffic to
+  //
+  // Resolves the next hop when `gatewayId` names a virtual private gateway
+  // (vgw-), the on-ramp for a Site-to-Site VPN. Null for any other gateway kind.
+  vpnGateway() aws.vpc.vpnGateway
   // ID of a NAT instance in the VPC
   //
   // Deprecated in favor of `instance`.
@@ -477,11 +491,33 @@ private aws.vpc.routetable.route @defaults("destinationCidrBlock state") {
   // NAT gateway the route sends traffic to
   natGateway() aws.vpc.natgateway
   // ID of a transit gateway
-  transitGatewayId string
+  //
+  // Deprecated in favor of `transitGateway`.
+  transitGatewayId @maturity("deprecated") string
+  // Transit gateway the route sends traffic to
+  //
+  // Resolves the next hop for traffic leaving the VPC across a transit gateway,
+  // the path to other VPCs, on-premises networks, and peered regions. Null when
+  // the route does not target a transit gateway.
+  transitGateway() aws.ec2.transitgateway
   // ID of a VPC peering connection
-  vpcPeeringConnectionId string
+  //
+  // Deprecated in favor of `peeringConnection`.
+  vpcPeeringConnectionId @maturity("deprecated") string
+  // VPC peering connection the route sends traffic to
+  //
+  // Resolves the next hop for traffic crossing into a peered VPC. Null when the
+  // route does not target a peering connection.
+  peeringConnection() aws.vpc.peeringConnection
   // ID of the egress-only internet gateway
-  egressOnlyInternetGatewayId string
+  //
+  // Deprecated in favor of `egressOnlyInternetGateway`.
+  egressOnlyInternetGatewayId @maturity("deprecated") string
+  // Egress-only internet gateway the route sends traffic to
+  //
+  // Resolves the next hop for IPv6 outbound-only internet access. Null when the
+  // route does not target an egress-only internet gateway.
+  egressOnlyInternetGateway() aws.ec2.egressOnlyInternetGateway
   // ID of the local gateway
   localGatewayId string
   // ID of the carrier gateway

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3100,7 +3100,7 @@ func init() {
 			Create: createAwsVpcServiceEndpoint,
 		},
 		"aws.vpc.peeringConnection": {
-			// to override args, implement: initAwsVpcPeeringConnection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsVpcPeeringConnection,
 			Create: createAwsVpcPeeringConnection,
 		},
 		"aws.vpc.peeringConnection.peeringVpc": {
@@ -3132,11 +3132,11 @@ func init() {
 			Create: createAwsEc2Vgwtelemetry,
 		},
 		"aws.ec2.internetgateway": {
-			// to override args, implement: initAwsEc2Internetgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2Internetgateway,
 			Create: createAwsEc2Internetgateway,
 		},
 		"aws.ec2.transitgateway": {
-			// to override args, implement: initAwsEc2Transitgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2Transitgateway,
 			Create: createAwsEc2Transitgateway,
 		},
 		"aws.ec2.transitgateway.attachment": {
@@ -3172,7 +3172,7 @@ func init() {
 			Create: createAwsEc2CustomerGateway,
 		},
 		"aws.ec2.egressOnlyInternetGateway": {
-			// to override args, implement: initAwsEc2EgressOnlyInternetGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2EgressOnlyInternetGateway,
 			Create: createAwsEc2EgressOnlyInternetGateway,
 		},
 		"aws.ec2.placementGroup": {
@@ -5057,6 +5057,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.routetable.route.gatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetGatewayId()).ToDataRes(types.String)
 	},
+	"aws.vpc.routetable.route.internetGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetInternetGateway()).ToDataRes(types.Resource("aws.ec2.internetgateway"))
+	},
+	"aws.vpc.routetable.route.vpnGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetVpnGateway()).ToDataRes(types.Resource("aws.vpc.vpnGateway"))
+	},
 	"aws.vpc.routetable.route.instanceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetInstanceId()).ToDataRes(types.String)
 	},
@@ -5081,11 +5087,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.routetable.route.transitGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetTransitGatewayId()).ToDataRes(types.String)
 	},
+	"aws.vpc.routetable.route.transitGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetTransitGateway()).ToDataRes(types.Resource("aws.ec2.transitgateway"))
+	},
 	"aws.vpc.routetable.route.vpcPeeringConnectionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetVpcPeeringConnectionId()).ToDataRes(types.String)
 	},
+	"aws.vpc.routetable.route.peeringConnection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetPeeringConnection()).ToDataRes(types.Resource("aws.vpc.peeringConnection"))
+	},
 	"aws.vpc.routetable.route.egressOnlyInternetGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetEgressOnlyInternetGatewayId()).ToDataRes(types.String)
+	},
+	"aws.vpc.routetable.route.egressOnlyInternetGateway": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableRoute).GetEgressOnlyInternetGateway()).ToDataRes(types.Resource("aws.ec2.egressOnlyInternetGateway"))
 	},
 	"aws.vpc.routetable.route.localGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableRoute).GetLocalGatewayId()).ToDataRes(types.String)
@@ -34502,6 +34517,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcRoutetableRoute).GatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.routetable.route.internetGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).InternetGateway, ok = plugin.RawToTValue[*mqlAwsEc2Internetgateway](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.routetable.route.vpnGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).VpnGateway, ok = plugin.RawToTValue[*mqlAwsVpcVpnGateway](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.route.instanceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).InstanceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -34534,12 +34557,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcRoutetableRoute).TransitGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.routetable.route.transitGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).TransitGateway, ok = plugin.RawToTValue[*mqlAwsEc2Transitgateway](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.route.vpcPeeringConnectionId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).VpcPeeringConnectionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.routetable.route.peeringConnection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).PeeringConnection, ok = plugin.RawToTValue[*mqlAwsVpcPeeringConnection](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.route.egressOnlyInternetGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetableRoute).EgressOnlyInternetGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.routetable.route.egressOnlyInternetGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableRoute).EgressOnlyInternetGateway, ok = plugin.RawToTValue[*mqlAwsEc2EgressOnlyInternetGateway](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.route.localGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -78228,6 +78263,8 @@ type mqlAwsVpcRoutetableRoute struct {
 	DestinationPrefixListId     plugin.TValue[string]
 	ManagedPrefixList           plugin.TValue[*mqlAwsEc2ManagedPrefixList]
 	GatewayId                   plugin.TValue[string]
+	InternetGateway             plugin.TValue[*mqlAwsEc2Internetgateway]
+	VpnGateway                  plugin.TValue[*mqlAwsVpcVpnGateway]
 	InstanceId                  plugin.TValue[string]
 	Instance                    plugin.TValue[*mqlAwsEc2Instance]
 	InstanceOwnerId             plugin.TValue[string]
@@ -78236,8 +78273,11 @@ type mqlAwsVpcRoutetableRoute struct {
 	NatGatewayId                plugin.TValue[string]
 	NatGateway                  plugin.TValue[*mqlAwsVpcNatgateway]
 	TransitGatewayId            plugin.TValue[string]
+	TransitGateway              plugin.TValue[*mqlAwsEc2Transitgateway]
 	VpcPeeringConnectionId      plugin.TValue[string]
+	PeeringConnection           plugin.TValue[*mqlAwsVpcPeeringConnection]
 	EgressOnlyInternetGatewayId plugin.TValue[string]
+	EgressOnlyInternetGateway   plugin.TValue[*mqlAwsEc2EgressOnlyInternetGateway]
 	LocalGatewayId              plugin.TValue[string]
 	CarrierGatewayId            plugin.TValue[string]
 	CoreNetworkArn              plugin.TValue[string]
@@ -78318,6 +78358,38 @@ func (c *mqlAwsVpcRoutetableRoute) GetGatewayId() *plugin.TValue[string] {
 	return &c.GatewayId
 }
 
+func (c *mqlAwsVpcRoutetableRoute) GetInternetGateway() *plugin.TValue[*mqlAwsEc2Internetgateway] {
+	return plugin.GetOrCompute[*mqlAwsEc2Internetgateway](&c.InternetGateway, func() (*mqlAwsEc2Internetgateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "internetGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Internetgateway), nil
+			}
+		}
+
+		return c.internetGateway()
+	})
+}
+
+func (c *mqlAwsVpcRoutetableRoute) GetVpnGateway() *plugin.TValue[*mqlAwsVpcVpnGateway] {
+	return plugin.GetOrCompute[*mqlAwsVpcVpnGateway](&c.VpnGateway, func() (*mqlAwsVpcVpnGateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "vpnGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcVpnGateway), nil
+			}
+		}
+
+		return c.vpnGateway()
+	})
+}
+
 func (c *mqlAwsVpcRoutetableRoute) GetInstanceId() *plugin.TValue[string] {
 	return &c.InstanceId
 }
@@ -78386,12 +78458,60 @@ func (c *mqlAwsVpcRoutetableRoute) GetTransitGatewayId() *plugin.TValue[string] 
 	return &c.TransitGatewayId
 }
 
+func (c *mqlAwsVpcRoutetableRoute) GetTransitGateway() *plugin.TValue[*mqlAwsEc2Transitgateway] {
+	return plugin.GetOrCompute[*mqlAwsEc2Transitgateway](&c.TransitGateway, func() (*mqlAwsEc2Transitgateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "transitGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Transitgateway), nil
+			}
+		}
+
+		return c.transitGateway()
+	})
+}
+
 func (c *mqlAwsVpcRoutetableRoute) GetVpcPeeringConnectionId() *plugin.TValue[string] {
 	return &c.VpcPeeringConnectionId
 }
 
+func (c *mqlAwsVpcRoutetableRoute) GetPeeringConnection() *plugin.TValue[*mqlAwsVpcPeeringConnection] {
+	return plugin.GetOrCompute[*mqlAwsVpcPeeringConnection](&c.PeeringConnection, func() (*mqlAwsVpcPeeringConnection, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "peeringConnection")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcPeeringConnection), nil
+			}
+		}
+
+		return c.peeringConnection()
+	})
+}
+
 func (c *mqlAwsVpcRoutetableRoute) GetEgressOnlyInternetGatewayId() *plugin.TValue[string] {
 	return &c.EgressOnlyInternetGatewayId
+}
+
+func (c *mqlAwsVpcRoutetableRoute) GetEgressOnlyInternetGateway() *plugin.TValue[*mqlAwsEc2EgressOnlyInternetGateway] {
+	return plugin.GetOrCompute[*mqlAwsEc2EgressOnlyInternetGateway](&c.EgressOnlyInternetGateway, func() (*mqlAwsEc2EgressOnlyInternetGateway, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.route", c.__id, "egressOnlyInternetGateway")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2EgressOnlyInternetGateway), nil
+			}
+		}
+
+		return c.egressOnlyInternetGateway()
+	})
 }
 
 func (c *mqlAwsVpcRoutetableRoute) GetLocalGatewayId() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10074,12 +10074,14 @@ aws.vpc.routetable.route.coreNetworkArn 11.15.2
 aws.vpc.routetable.route.destinationCidrBlock 11.15.2
 aws.vpc.routetable.route.destinationIpv6CidrBlock 11.15.2
 aws.vpc.routetable.route.destinationPrefixListId 11.15.2
+aws.vpc.routetable.route.egressOnlyInternetGateway 13.43.1
 aws.vpc.routetable.route.egressOnlyInternetGatewayId 11.15.2
 aws.vpc.routetable.route.gatewayId 11.15.2
 aws.vpc.routetable.route.id 11.15.2
 aws.vpc.routetable.route.instance 13.41.1
 aws.vpc.routetable.route.instanceId 11.15.2
 aws.vpc.routetable.route.instanceOwnerId 11.15.2
+aws.vpc.routetable.route.internetGateway 13.43.1
 aws.vpc.routetable.route.localGatewayId 11.15.2
 aws.vpc.routetable.route.managedPrefixList 13.41.1
 aws.vpc.routetable.route.natGateway 13.41.1
@@ -10087,9 +10089,12 @@ aws.vpc.routetable.route.natGatewayId 11.15.2
 aws.vpc.routetable.route.networkInterface 13.41.1
 aws.vpc.routetable.route.networkInterfaceId 11.15.2
 aws.vpc.routetable.route.origin 11.15.2
+aws.vpc.routetable.route.peeringConnection 13.43.1
 aws.vpc.routetable.route.state 11.15.2
+aws.vpc.routetable.route.transitGateway 13.43.1
 aws.vpc.routetable.route.transitGatewayId 11.15.2
 aws.vpc.routetable.route.vpcPeeringConnectionId 11.15.2
+aws.vpc.routetable.route.vpnGateway 13.43.1
 aws.vpc.routetable.routeEntries 11.15.2
 aws.vpc.routetable.routes 11.15.2
 aws.vpc.routetable.tags 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.42.0",
-  "generated_at": "2026-07-04T20:33:35-07:00",
+  "version": "13.43.0",
+  "generated_at": "2026-07-06T12:03:49-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3022,18 +3022,7 @@ func (a *mqlAwsEc2) getInternetGateways(conn *connection.AwsConnection) []*jobpo
 						log.Debug().Interface("igw", gateway.InternetGatewayId).Msg("excluding internet gateway due to filters")
 						continue
 					}
-					jsonAttachments, err := convert.JsonToDictSlice(gateway.Attachments)
-					if err != nil {
-						return nil, err
-					}
-					mqlInternetGw, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Internetgateway,
-						map[string]*llx.RawData{
-							"arn":         llx.StringData(fmt.Sprintf(internetGwArnPattern, region, conn.AccountId(), convert.ToValue(gateway.InternetGatewayId))),
-							"id":          llx.StringData(convert.ToValue(gateway.InternetGatewayId)),
-							"region":      llx.StringData(region),
-							"attachments": llx.ArrayData(jsonAttachments, types.Any),
-							"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(gateway.Tags)), types.String),
-						})
+					mqlInternetGw, err := newMqlAwsEc2Internetgateway(a.MqlRuntime, region, conn, gateway)
 					if err != nil {
 						return nil, err
 					}
@@ -3051,8 +3040,200 @@ func (a *mqlAwsEc2Internetgateway) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// newMqlAwsEc2Internetgateway builds an aws.ec2.internetgateway resource from an
+// SDK InternetGateway. Shared by the account-level list and the by-id init so
+// both paths produce an identically shaped resource.
+func newMqlAwsEc2Internetgateway(runtime *plugin.Runtime, region string, conn *connection.AwsConnection, gateway ec2types.InternetGateway) (plugin.Resource, error) {
+	jsonAttachments, err := convert.JsonToDictSlice(gateway.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	return CreateResource(runtime, ResourceAwsEc2Internetgateway,
+		map[string]*llx.RawData{
+			"arn":         llx.StringData(fmt.Sprintf(internetGwArnPattern, region, conn.AccountId(), convert.ToValue(gateway.InternetGatewayId))),
+			"id":          llx.StringData(convert.ToValue(gateway.InternetGatewayId)),
+			"region":      llx.StringData(region),
+			"attachments": llx.ArrayData(jsonAttachments, types.Any),
+			"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(gateway.Tags)), types.String),
+		})
+}
+
+func initAwsEc2Internetgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["arn"] == nil && args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	var igwID, region string
+	if args["id"] != nil {
+		igwID, _ = args["id"].Value.(string)
+	}
+	if args["region"] != nil {
+		region, _ = args["region"].Value.(string)
+	}
+	if args["arn"] != nil {
+		if parsed, err := arn.Parse(args["arn"].Value.(string)); err == nil {
+			region = parsed.Region
+			parts := strings.Split(parsed.Resource, "/")
+			if len(parts) == 2 {
+				igwID = parts[1]
+			}
+		}
+	}
+	// Without both id and region a targeted lookup is not possible; hand back a
+	// bare resource.
+	if igwID == "" || region == "" {
+		return args, nil, nil
+	}
+
+	// Reuse the internet gateway already materialized by aws.ec2.internetGateways()
+	// (routes commonly share one gateway) before spending a DescribeInternetGateways call.
+	cacheID := ResourceAwsEc2Internetgateway + "\x00" + fmt.Sprintf(internetGwArnPattern, region, conn.AccountId(), igwID)
+	if cached, ok := runtime.Resources.Get(cacheID); ok {
+		return args, cached, nil
+	}
+
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeInternetGateways(context.Background(), &ec2.DescribeInternetGatewaysInput{
+		InternetGatewayIds: []string{igwID},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.InternetGateways) == 0 {
+		return args, nil, nil
+	}
+	res, err := newMqlAwsEc2Internetgateway(runtime, region, conn, resp.InternetGateways[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (a *mqlAwsEc2Transitgateway) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// newMqlAwsEc2Transitgateway builds an aws.ec2.transitgateway from an SDK
+// TransitGateway, flattening its Options block. Shared by the account-level list
+// and the by-id init.
+func newMqlAwsEc2Transitgateway(runtime *plugin.Runtime, region string, tgw ec2types.TransitGateway) (plugin.Resource, error) {
+	tgwArn := convert.ToValue(tgw.TransitGatewayArn)
+	if tgwArn == "" {
+		tgwArn = fmt.Sprintf(transitGatewayArnPattern, region, convert.ToValue(tgw.OwnerId), convert.ToValue(tgw.TransitGatewayId))
+	}
+
+	// Flatten Options
+	var amazonSideAsn int64
+	var autoAcceptSharedAttachments, defaultRouteTableAssociation, defaultRouteTablePropagation bool
+	var dnsSupport, multicastSupport, vpnEcmpSupport bool
+	var transitGatewayCidrBlocks []string
+	var associationDefaultRouteTableId, propagationDefaultRouteTableId string
+	if opts := tgw.Options; opts != nil {
+		if opts.AmazonSideAsn != nil {
+			amazonSideAsn = *opts.AmazonSideAsn
+		}
+		autoAcceptSharedAttachments = string(opts.AutoAcceptSharedAttachments) == "enable"
+		defaultRouteTableAssociation = string(opts.DefaultRouteTableAssociation) == "enable"
+		defaultRouteTablePropagation = string(opts.DefaultRouteTablePropagation) == "enable"
+		dnsSupport = string(opts.DnsSupport) == "enable"
+		multicastSupport = string(opts.MulticastSupport) == "enable"
+		vpnEcmpSupport = string(opts.VpnEcmpSupport) == "enable"
+		transitGatewayCidrBlocks = opts.TransitGatewayCidrBlocks
+		associationDefaultRouteTableId = convert.ToValue(opts.AssociationDefaultRouteTableId)
+		propagationDefaultRouteTableId = convert.ToValue(opts.PropagationDefaultRouteTableId)
+	}
+
+	mqlTgw, err := CreateResource(runtime, ResourceAwsEc2Transitgateway,
+		map[string]*llx.RawData{
+			"__id":                           llx.StringData(tgwArn),
+			"arn":                            llx.StringData(tgwArn),
+			"id":                             llx.StringData(convert.ToValue(tgw.TransitGatewayId)),
+			"ownerId":                        llx.StringData(convert.ToValue(tgw.OwnerId)),
+			"state":                          llx.StringData(string(tgw.State)),
+			"description":                    llx.StringData(convert.ToValue(tgw.Description)),
+			"region":                         llx.StringData(region),
+			"createdAt":                      llx.TimeDataPtr(tgw.CreationTime),
+			"tags":                           llx.MapData(toInterfaceMap(ec2TagsToMap(tgw.Tags)), types.String),
+			"amazonSideAsn":                  llx.IntData(amazonSideAsn),
+			"autoAcceptSharedAttachments":    llx.BoolData(autoAcceptSharedAttachments),
+			"defaultRouteTableAssociation":   llx.BoolData(defaultRouteTableAssociation),
+			"defaultRouteTablePropagation":   llx.BoolData(defaultRouteTablePropagation),
+			"dnsSupport":                     llx.BoolData(dnsSupport),
+			"multicastSupport":               llx.BoolData(multicastSupport),
+			"vpnEcmpSupport":                 llx.BoolData(vpnEcmpSupport),
+			"transitGatewayCidrBlocks":       llx.ArrayData(convert.SliceAnyToInterface(transitGatewayCidrBlocks), types.String),
+			"associationDefaultRouteTableId": llx.StringData(associationDefaultRouteTableId),
+			"propagationDefaultRouteTableId": llx.StringData(propagationDefaultRouteTableId),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlTgw.(*mqlAwsEc2Transitgateway).region = region
+	return mqlTgw, nil
+}
+
+func initAwsEc2Transitgateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["arn"] == nil && args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	var tgwID, region string
+	if args["id"] != nil {
+		tgwID, _ = args["id"].Value.(string)
+	}
+	if args["region"] != nil {
+		region, _ = args["region"].Value.(string)
+	}
+	if args["arn"] != nil {
+		if parsed, err := arn.Parse(args["arn"].Value.(string)); err == nil {
+			region = parsed.Region
+			parts := strings.Split(parsed.Resource, "/")
+			if len(parts) == 2 {
+				tgwID = parts[1]
+			}
+		}
+	}
+	if tgwID == "" || region == "" {
+		return args, nil, nil
+	}
+
+	// Reuse a transit gateway already listed before spending an API call. The
+	// cache key uses the caller's account; a cross-account shared gateway misses
+	// here and is fetched below (still correct).
+	cacheID := ResourceAwsEc2Transitgateway + "\x00" + fmt.Sprintf(transitGatewayArnPattern, region, conn.AccountId(), tgwID)
+	if cached, ok := runtime.Resources.Get(cacheID); ok {
+		return args, cached, nil
+	}
+
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeTransitGateways(context.Background(), &ec2.DescribeTransitGatewaysInput{
+		TransitGatewayIds: []string{tgwID},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.TransitGateways) == 0 {
+		return args, nil, nil
+	}
+	res, err := newMqlAwsEc2Transitgateway(runtime, region, resp.TransitGateways[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
 }
 
 func (a *mqlAwsEc2) transitGateways() ([]any, error) {
@@ -3098,59 +3279,10 @@ func (a *mqlAwsEc2) getTransitGateways(conn *connection.AwsConnection) []*jobpoo
 						log.Debug().Interface("tgw", tgw.TransitGatewayId).Msg("excluding transit gateway due to filters")
 						continue
 					}
-
-					tgwArn := convert.ToValue(tgw.TransitGatewayArn)
-					if tgwArn == "" {
-						tgwArn = fmt.Sprintf(transitGatewayArnPattern, region, convert.ToValue(tgw.OwnerId), convert.ToValue(tgw.TransitGatewayId))
-					}
-
-					// Flatten Options
-					var amazonSideAsn int64
-					var autoAcceptSharedAttachments, defaultRouteTableAssociation, defaultRouteTablePropagation bool
-					var dnsSupport, multicastSupport, vpnEcmpSupport bool
-					var transitGatewayCidrBlocks []string
-					var associationDefaultRouteTableId, propagationDefaultRouteTableId string
-					if opts := tgw.Options; opts != nil {
-						if opts.AmazonSideAsn != nil {
-							amazonSideAsn = *opts.AmazonSideAsn
-						}
-						autoAcceptSharedAttachments = string(opts.AutoAcceptSharedAttachments) == "enable"
-						defaultRouteTableAssociation = string(opts.DefaultRouteTableAssociation) == "enable"
-						defaultRouteTablePropagation = string(opts.DefaultRouteTablePropagation) == "enable"
-						dnsSupport = string(opts.DnsSupport) == "enable"
-						multicastSupport = string(opts.MulticastSupport) == "enable"
-						vpnEcmpSupport = string(opts.VpnEcmpSupport) == "enable"
-						transitGatewayCidrBlocks = opts.TransitGatewayCidrBlocks
-						associationDefaultRouteTableId = convert.ToValue(opts.AssociationDefaultRouteTableId)
-						propagationDefaultRouteTableId = convert.ToValue(opts.PropagationDefaultRouteTableId)
-					}
-
-					mqlTgw, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Transitgateway,
-						map[string]*llx.RawData{
-							"__id":                           llx.StringData(tgwArn),
-							"arn":                            llx.StringData(tgwArn),
-							"id":                             llx.StringData(convert.ToValue(tgw.TransitGatewayId)),
-							"ownerId":                        llx.StringData(convert.ToValue(tgw.OwnerId)),
-							"state":                          llx.StringData(string(tgw.State)),
-							"description":                    llx.StringData(convert.ToValue(tgw.Description)),
-							"region":                         llx.StringData(region),
-							"createdAt":                      llx.TimeDataPtr(tgw.CreationTime),
-							"tags":                           llx.MapData(toInterfaceMap(ec2TagsToMap(tgw.Tags)), types.String),
-							"amazonSideAsn":                  llx.IntData(amazonSideAsn),
-							"autoAcceptSharedAttachments":    llx.BoolData(autoAcceptSharedAttachments),
-							"defaultRouteTableAssociation":   llx.BoolData(defaultRouteTableAssociation),
-							"defaultRouteTablePropagation":   llx.BoolData(defaultRouteTablePropagation),
-							"dnsSupport":                     llx.BoolData(dnsSupport),
-							"multicastSupport":               llx.BoolData(multicastSupport),
-							"vpnEcmpSupport":                 llx.BoolData(vpnEcmpSupport),
-							"transitGatewayCidrBlocks":       llx.ArrayData(convert.SliceAnyToInterface(transitGatewayCidrBlocks), types.String),
-							"associationDefaultRouteTableId": llx.StringData(associationDefaultRouteTableId),
-							"propagationDefaultRouteTableId": llx.StringData(propagationDefaultRouteTableId),
-						})
+					mqlTgw, err := newMqlAwsEc2Transitgateway(a.MqlRuntime, region, tgw)
 					if err != nil {
 						return nil, err
 					}
-					mqlTgw.(*mqlAwsEc2Transitgateway).region = region
 					res = append(res, mqlTgw)
 				}
 			}
@@ -3526,6 +3658,79 @@ func (a *mqlAwsEc2EgressOnlyInternetGateway) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// newMqlAwsEc2EgressOnlyInternetGateway builds an aws.ec2.egressOnlyInternetGateway
+// from an SDK EgressOnlyInternetGateway. Shared by the account-level list and the
+// by-id init.
+func newMqlAwsEc2EgressOnlyInternetGateway(runtime *plugin.Runtime, region string, conn *connection.AwsConnection, eigw ec2types.EgressOnlyInternetGateway) (plugin.Resource, error) {
+	attachments, err := convert.JsonToDictSlice(eigw.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	return CreateResource(runtime, ResourceAwsEc2EgressOnlyInternetGateway,
+		map[string]*llx.RawData{
+			"id":          llx.StringData(convert.ToValue(eigw.EgressOnlyInternetGatewayId)),
+			"arn":         llx.StringData(fmt.Sprintf(egressOnlyIgwArnPattern, region, conn.AccountId(), convert.ToValue(eigw.EgressOnlyInternetGatewayId))),
+			"region":      llx.StringData(region),
+			"attachments": llx.ArrayData(attachments, types.Any),
+			"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(eigw.Tags)), types.String),
+		})
+}
+
+func initAwsEc2EgressOnlyInternetGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["arn"] == nil && args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	var eigwID, region string
+	if args["id"] != nil {
+		eigwID, _ = args["id"].Value.(string)
+	}
+	if args["region"] != nil {
+		region, _ = args["region"].Value.(string)
+	}
+	if args["arn"] != nil {
+		if parsed, err := arn.Parse(args["arn"].Value.(string)); err == nil {
+			region = parsed.Region
+			parts := strings.Split(parsed.Resource, "/")
+			if len(parts) == 2 {
+				eigwID = parts[1]
+			}
+		}
+	}
+	if eigwID == "" || region == "" {
+		return args, nil, nil
+	}
+
+	// Reuse an egress-only gateway already listed before spending an API call.
+	cacheID := ResourceAwsEc2EgressOnlyInternetGateway + "\x00" + fmt.Sprintf(egressOnlyIgwArnPattern, region, conn.AccountId(), eigwID)
+	if cached, ok := runtime.Resources.Get(cacheID); ok {
+		return args, cached, nil
+	}
+
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeEgressOnlyInternetGateways(context.Background(), &ec2.DescribeEgressOnlyInternetGatewaysInput{
+		EgressOnlyInternetGatewayIds: []string{eigwID},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.EgressOnlyInternetGateways) == 0 {
+		return args, nil, nil
+	}
+	res, err := newMqlAwsEc2EgressOnlyInternetGateway(runtime, region, conn, resp.EgressOnlyInternetGateways[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (a *mqlAwsEc2) egressOnlyInternetGateways() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}
@@ -3568,15 +3773,7 @@ func (a *mqlAwsEc2) getEgressOnlyIGWs(conn *connection.AwsConnection) []*jobpool
 					if conn.Filters.General.MatchesExcludeTags(ec2TagsToMap(eigw.Tags)) {
 						continue
 					}
-					attachments, _ := convert.JsonToDictSlice(eigw.Attachments)
-					mqlEigw, err := CreateResource(a.MqlRuntime, ResourceAwsEc2EgressOnlyInternetGateway,
-						map[string]*llx.RawData{
-							"id":          llx.StringData(convert.ToValue(eigw.EgressOnlyInternetGatewayId)),
-							"arn":         llx.StringData(fmt.Sprintf(egressOnlyIgwArnPattern, region, conn.AccountId(), convert.ToValue(eigw.EgressOnlyInternetGatewayId))),
-							"region":      llx.StringData(region),
-							"attachments": llx.ArrayData(attachments, types.Any),
-							"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(eigw.Tags)), types.String),
-						})
+					mqlEigw, err := newMqlAwsEc2EgressOnlyInternetGateway(a.MqlRuntime, region, conn, eigw)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -676,45 +676,10 @@ func (a *mqlAwsVpc) peeringConnections() ([]any, error) {
 				}
 				seen[id] = struct{}{}
 
-				status := ""
-				if peerconn.Status != nil {
-					status = convert.ToValue(peerconn.Status.Message)
-				}
-				// Determine DNS resolution status from peering options
-				dnsResolution := false
-				if peerconn.RequesterVpcInfo != nil && peerconn.RequesterVpcInfo.PeeringOptions != nil &&
-					peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
-					dnsResolution = *peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
-				}
-				if !dnsResolution && peerconn.AccepterVpcInfo != nil && peerconn.AccepterVpcInfo.PeeringOptions != nil &&
-					peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
-					dnsResolution = *peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
-				}
-
-				var requesterAccountId, accepterAccountId string
-				if peerconn.RequesterVpcInfo != nil {
-					requesterAccountId = convert.ToValue(peerconn.RequesterVpcInfo.OwnerId)
-				}
-				if peerconn.AccepterVpcInfo != nil {
-					accepterAccountId = convert.ToValue(peerconn.AccepterVpcInfo.OwnerId)
-				}
-
-				mqlPeerConn, err := CreateResource(a.MqlRuntime, ResourceAwsVpcPeeringConnection,
-					map[string]*llx.RawData{
-						"expirationTime":       llx.TimeDataPtr(peerconn.ExpirationTime),
-						"id":                   llx.StringDataPtr(peerconn.VpcPeeringConnectionId),
-						"status":               llx.StringData(status),
-						"tags":                 llx.MapData(toInterfaceMap(ec2TagsToMap(peerconn.Tags)), types.String),
-						"requesterAccountId":   llx.StringData(requesterAccountId),
-						"accepterAccountId":    llx.StringData(accepterAccountId),
-						"dnsResolutionEnabled": llx.BoolData(dnsResolution),
-					},
-				)
+				mqlPeerConn, err := newMqlAwsVpcPeeringConnection(a.MqlRuntime, a.Region.Data, peerconn)
 				if err != nil {
 					return nil, err
 				}
-				mqlPeerConn.(*mqlAwsVpcPeeringConnection).peeringConnectionCache = peerconn
-				mqlPeerConn.(*mqlAwsVpcPeeringConnection).region = a.Region.Data
 				pcs = append(pcs, mqlPeerConn)
 			}
 		}
@@ -729,6 +694,99 @@ func (a *mqlAwsVpcPeeringConnectionPeeringVpc) id() (string, error) {
 type mqlAwsVpcPeeringConnectionInternal struct {
 	peeringConnectionCache vpctypes.VpcPeeringConnection
 	region                 string
+}
+
+// newMqlAwsVpcPeeringConnection builds an aws.vpc.peeringConnection from an SDK
+// VpcPeeringConnection. Shared by the per-VPC list and the by-id init. The
+// acceptor/requestor VPC sub-resources are resolved lazily from the cached SDK
+// struct by their own accessors, so only the scalar fields are set here.
+func newMqlAwsVpcPeeringConnection(runtime *plugin.Runtime, region string, peerconn vpctypes.VpcPeeringConnection) (plugin.Resource, error) {
+	status := ""
+	if peerconn.Status != nil {
+		status = convert.ToValue(peerconn.Status.Message)
+	}
+	// Determine DNS resolution status from peering options
+	dnsResolution := false
+	if peerconn.RequesterVpcInfo != nil && peerconn.RequesterVpcInfo.PeeringOptions != nil &&
+		peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
+		dnsResolution = *peerconn.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
+	}
+	if !dnsResolution && peerconn.AccepterVpcInfo != nil && peerconn.AccepterVpcInfo.PeeringOptions != nil &&
+		peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc != nil {
+		dnsResolution = *peerconn.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc
+	}
+
+	var requesterAccountId, accepterAccountId string
+	if peerconn.RequesterVpcInfo != nil {
+		requesterAccountId = convert.ToValue(peerconn.RequesterVpcInfo.OwnerId)
+	}
+	if peerconn.AccepterVpcInfo != nil {
+		accepterAccountId = convert.ToValue(peerconn.AccepterVpcInfo.OwnerId)
+	}
+
+	mqlPeerConn, err := CreateResource(runtime, ResourceAwsVpcPeeringConnection,
+		map[string]*llx.RawData{
+			"expirationTime":       llx.TimeDataPtr(peerconn.ExpirationTime),
+			"id":                   llx.StringDataPtr(peerconn.VpcPeeringConnectionId),
+			"status":               llx.StringData(status),
+			"tags":                 llx.MapData(toInterfaceMap(ec2TagsToMap(peerconn.Tags)), types.String),
+			"requesterAccountId":   llx.StringData(requesterAccountId),
+			"accepterAccountId":    llx.StringData(accepterAccountId),
+			"dnsResolutionEnabled": llx.BoolData(dnsResolution),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	mqlPeerConn.(*mqlAwsVpcPeeringConnection).peeringConnectionCache = peerconn
+	mqlPeerConn.(*mqlAwsVpcPeeringConnection).region = region
+	return mqlPeerConn, nil
+}
+
+func initAwsVpcPeeringConnection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// region is a lookup hint, not a schema field on aws.vpc.peeringConnection.
+	var region string
+	if r := args["region"]; r != nil {
+		region, _ = r.Value.(string)
+		delete(args, "region")
+	}
+
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["id"] == nil || region == "" {
+		return args, nil, nil
+	}
+	pcxID, _ := args["id"].Value.(string)
+	if pcxID == "" {
+		return args, nil, nil
+	}
+
+	// Reuse a peering connection already listed before spending an API call.
+	cacheID := ResourceAwsVpcPeeringConnection + "\x00" + pcxID
+	if cached, ok := runtime.Resources.Get(cacheID); ok {
+		return args, cached, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(region)
+	resp, err := svc.DescribeVpcPeeringConnections(context.Background(), &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{pcxID},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.VpcPeeringConnections) == 0 {
+		return args, nil, nil
+	}
+	res, err := newMqlAwsVpcPeeringConnection(runtime, region, resp.VpcPeeringConnections[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
 }
 
 func (a *mqlAwsVpcPeeringConnection) acceptorVpc() (*mqlAwsVpcPeeringConnectionPeeringVpc, error) {
@@ -964,6 +1022,76 @@ func (a *mqlAwsVpcRoutetableRoute) instance() (*mqlAwsEc2Instance, error) {
 		return nil, err
 	}
 	return res.(*mqlAwsEc2Instance), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) internetGateway() (*mqlAwsEc2Internetgateway, error) {
+	gwID := a.GatewayId.Data
+	if !strings.HasPrefix(gwID, "igw-") {
+		a.InternetGateway.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Internetgateway,
+		map[string]*llx.RawData{"id": llx.StringData(gwID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Internetgateway), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) vpnGateway() (*mqlAwsVpcVpnGateway, error) {
+	gwID := a.GatewayId.Data
+	if !strings.HasPrefix(gwID, "vgw-") {
+		a.VpnGateway.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsVpcVpnGateway,
+		map[string]*llx.RawData{"id": llx.StringData(gwID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcVpnGateway), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) transitGateway() (*mqlAwsEc2Transitgateway, error) {
+	tgwID := a.TransitGatewayId.Data
+	if tgwID == "" {
+		a.TransitGateway.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Transitgateway,
+		map[string]*llx.RawData{"id": llx.StringData(tgwID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Transitgateway), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) peeringConnection() (*mqlAwsVpcPeeringConnection, error) {
+	pcxID := a.VpcPeeringConnectionId.Data
+	if pcxID == "" {
+		a.PeeringConnection.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsVpcPeeringConnection,
+		map[string]*llx.RawData{"id": llx.StringData(pcxID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcPeeringConnection), nil
+}
+
+func (a *mqlAwsVpcRoutetableRoute) egressOnlyInternetGateway() (*mqlAwsEc2EgressOnlyInternetGateway, error) {
+	eigwID := a.EgressOnlyInternetGatewayId.Data
+	if eigwID == "" {
+		a.EgressOnlyInternetGateway.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2EgressOnlyInternetGateway,
+		map[string]*llx.RawData{"id": llx.StringData(eigwID), "region": llx.StringData(a.region)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2EgressOnlyInternetGateway), nil
 }
 
 func (a *mqlAwsVpcRoutetableRoute) managedPrefixList() (*mqlAwsEc2ManagedPrefixList, error) {

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -12,6 +12,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestEc2TagsToMap(t *testing.T) {
@@ -383,5 +384,77 @@ func TestVpnGatewayNullState(t *testing.T) {
 		require.Nil(t, result)
 		assert.True(t, vpn.CustomerGateway.IsNull())
 		assert.True(t, vpn.CustomerGateway.IsSet())
+	})
+}
+
+// TestRouteNextHopNullState covers how a route table route resolves its
+// polymorphic gatewayId into the correct typed next-hop. gatewayId can name an
+// internet gateway (igw-), a virtual private gateway (vgw-), a VPC endpoint, or
+// the local route, so internetGateway() and vpnGateway() must each resolve only
+// their own prefix and return a set-null value otherwise (never cross-resolve).
+func TestRouteNextHopNullState(t *testing.T) {
+	t.Run("internetGateway is null when gatewayId is empty", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		result, err := route.internetGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.InternetGateway.IsNull())
+		assert.True(t, route.InternetGateway.IsSet())
+	})
+
+	t.Run("internetGateway is null when gatewayId is a virtual private gateway", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		route.GatewayId = plugin.TValue[string]{Data: "vgw-0123456789abcdef0", State: plugin.StateIsSet}
+		result, err := route.internetGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.InternetGateway.IsNull())
+		assert.True(t, route.InternetGateway.IsSet())
+	})
+
+	t.Run("vpnGateway is null when gatewayId is empty", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		result, err := route.vpnGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.VpnGateway.IsNull())
+		assert.True(t, route.VpnGateway.IsSet())
+	})
+
+	t.Run("vpnGateway is null when gatewayId is an internet gateway", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		route.GatewayId = plugin.TValue[string]{Data: "igw-0123456789abcdef0", State: plugin.StateIsSet}
+		result, err := route.vpnGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.VpnGateway.IsNull())
+		assert.True(t, route.VpnGateway.IsSet())
+	})
+
+	t.Run("egressOnlyInternetGateway is null when id is empty", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		result, err := route.egressOnlyInternetGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.EgressOnlyInternetGateway.IsNull())
+		assert.True(t, route.EgressOnlyInternetGateway.IsSet())
+	})
+
+	t.Run("transitGateway is null when transitGatewayId is empty", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		result, err := route.transitGateway()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.TransitGateway.IsNull())
+		assert.True(t, route.TransitGateway.IsSet())
+	})
+
+	t.Run("peeringConnection is null when vpcPeeringConnectionId is empty", func(t *testing.T) {
+		route := &mqlAwsVpcRoutetableRoute{}
+		result, err := route.peeringConnection()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, route.PeeringConnection.IsNull())
+		assert.True(t, route.PeeringConnection.IsSet())
 	})
 }


### PR DESCRIPTION
## What

Adds typed next-hop accessors to `aws.vpc.routetable.route` so the VPC routing graph can be **traversed in MQL** instead of dead-ending at raw ID strings:

| Accessor | Resolves to | Source field |
|---|---|---|
| `internetGateway()` | `aws.ec2.internetgateway` | `gatewayId` (`igw-*`) |
| `vpnGateway()` | `aws.vpc.vpnGateway` | `gatewayId` (`vgw-*`) |
| `egressOnlyInternetGateway()` | `aws.ec2.egressOnlyInternetGateway` | `egressOnlyInternetGatewayId` |
| `transitGateway()` | `aws.ec2.transitgateway` | `transitGatewayId` |
| `peeringConnection()` | `aws.vpc.peeringConnection` | `vpcPeeringConnectionId` |

The raw `transitGatewayId`, `vpcPeeringConnectionId`, and `egressOnlyInternetGatewayId` fields are deprecated in favor of the typed accessors, matching the convention already used on this resource for `instanceId`/`natGatewayId`/`networkInterfaceId`.

## Why

Tracing how internet traffic reaches a resource means walking `route -> gateway` edges — a `0.0.0.0/0 -> igw-*` route is exactly what makes a subnet public. Previously that edge was a raw string, so only a hardcoded Go evaluator (`aws.ec2.instance.exposure`) could follow it. Now it is a first-class typed edge that composes with the existing subnet / ENI / security-group graph, e.g.:

```mql
// VPCs with a public default route, resolved to the actual gateway
aws.vpcs.where(
  routeTables.any(routeEntries.any(destinationCidrBlock == "0.0.0.0/0" && gatewayId.contains("igw-")))
) {
  id
  routeTables { routeEntries.where(_.gatewayId.contains("igw-")) { destinationCidrBlock internetGateway { id arn } } }
}
```

## Notes

- `gatewayId` is polymorphic (internet gateway / virtual private gateway / VPC endpoint / `local`), so `internetGateway()` and `vpnGateway()` each resolve only their own prefix and return a set-null value otherwise — they never cross-resolve.
- The list creators for internet / egress-only / transit gateways and peering connections were refactored into shared constructors, so the list path and the new by-id init path produce identically shaped resources.
- The by-id inits are **cache-aware**: they reuse a gateway already materialized by its account-level list before spending a `Describe*` call, avoiding an N+1 when many routes share one gateway.
- No new IAM permissions (`permissions.json` change is version/timestamp metadata only — the inits reuse `Describe*` calls the list functions already make).

## Testing

- Unit tests (`TestRouteNextHopNullState`) cover the null-dispatch logic for all five accessors, including that a `vgw-` never resolves an internet gateway and an `igw-` never resolves a VPN gateway.
- Full `providers/aws/resources` test package passes.
- Live-verified against a real account: a `0.0.0.0/0` route with an `igw-` gateway resolves `internetGateway` to the typed resource (id + arn) while `vpnGateway` returns null; the transit-gateway constructor was exercised via the account-level list.
