### PR TITLE
⭐ aws: resolve Route 53 alias records to load balancer and CloudFront

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13181,6 +13181,20 @@ private aws.route53.record @defaults("name type") {
   aliasTargetDnsName string
   // Hosted zone ID of the alias target
   aliasTargetHostedZoneId string
+  // Load balancer this record's alias points to
+  //
+  // Resolves an A or AAAA alias record whose target is an Application, Network,
+  // or Classic Load Balancer, matched on the alias target DNS name. Null when
+  // the record is not an alias to a load balancer. Follows the DNS front door of
+  // an ingress path to the load balancer that fronts the workload.
+  aliasLoadBalancer() aws.elb.loadbalancer
+  // CloudFront distribution this record's alias points to
+  //
+  // Resolves an A or AAAA alias record whose target is a CloudFront distribution
+  // (identified by the fixed alias hosted zone Z2FDTNDATAQYW2), matched on the
+  // distribution domain name. Null when the record is not an alias to a
+  // distribution.
+  aliasCloudFrontDistribution() aws.cloudfront.distribution
   // Whether to evaluate target health for alias records
   aliasEvaluateTargetHealth bool
   // Routing policy identifier (for weighted, latency, failover, geolocation routing)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -19184,6 +19184,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.route53.record.aliasTargetHostedZoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53Record).GetAliasTargetHostedZoneId()).ToDataRes(types.String)
 	},
+	"aws.route53.record.aliasLoadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRoute53Record).GetAliasLoadBalancer()).ToDataRes(types.Resource("aws.elb.loadbalancer"))
+	},
+	"aws.route53.record.aliasCloudFrontDistribution": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRoute53Record).GetAliasCloudFrontDistribution()).ToDataRes(types.Resource("aws.cloudfront.distribution"))
+	},
 	"aws.route53.record.aliasEvaluateTargetHealth": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRoute53Record).GetAliasEvaluateTargetHealth()).ToDataRes(types.Bool)
 	},
@@ -55183,6 +55189,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.route53.record.aliasTargetHostedZoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRoute53Record).AliasTargetHostedZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.route53.record.aliasLoadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRoute53Record).AliasLoadBalancer, ok = plugin.RawToTValue[*mqlAwsElbLoadbalancer](v.Value, v.Error)
+		return
+	},
+	"aws.route53.record.aliasCloudFrontDistribution": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRoute53Record).AliasCloudFrontDistribution, ok = plugin.RawToTValue[*mqlAwsCloudfrontDistribution](v.Value, v.Error)
 		return
 	},
 	"aws.route53.record.aliasEvaluateTargetHealth": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -101066,7 +101080,7 @@ func (c *mqlAwsAutoscalingGroupTag) GetResourceType() *plugin.TValue[string] {
 type mqlAwsElb struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElbInternal it will be used here
+	mqlAwsElbInternal
 	ClassicLoadBalancers plugin.TValue[[]any]
 	LoadBalancers        plugin.TValue[[]any]
 }
@@ -118787,7 +118801,7 @@ func (c *mqlAwsCloudwatchLogAnomalyDetector) GetRegion() *plugin.TValue[string] 
 type mqlAwsCloudfront struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsCloudfrontInternal it will be used here
+	mqlAwsCloudfrontInternal
 	Distributions                plugin.TValue[[]any]
 	Functions                    plugin.TValue[[]any]
 	AnycastIpLists               plugin.TValue[[]any]
@@ -132805,28 +132819,30 @@ type mqlAwsRoute53Record struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsRoute53RecordInternal
-	HostedZoneId              plugin.TValue[string]
-	HostedZone                plugin.TValue[*mqlAwsRoute53HostedZone]
-	Name                      plugin.TValue[string]
-	Type                      plugin.TValue[string]
-	Ttl                       plugin.TValue[int64]
-	ResourceRecords           plugin.TValue[[]any]
-	AliasTarget               plugin.TValue[any]
-	IsAlias                   plugin.TValue[bool]
-	AliasTargetDnsName        plugin.TValue[string]
-	AliasTargetHostedZoneId   plugin.TValue[string]
-	AliasEvaluateTargetHealth plugin.TValue[bool]
-	SetIdentifier             plugin.TValue[string]
-	Weight                    plugin.TValue[int64]
-	Region                    plugin.TValue[string]
-	Failover                  plugin.TValue[string]
-	GeoLocation               plugin.TValue[any]
-	GeoProximityLocation      plugin.TValue[any]
-	MultiValueAnswer          plugin.TValue[bool]
-	HealthCheckId             plugin.TValue[string]
-	HealthCheck               plugin.TValue[*mqlAwsRoute53HealthCheck]
-	CidrRoutingConfig         plugin.TValue[any]
-	TrafficPolicyInstanceId   plugin.TValue[string]
+	HostedZoneId                plugin.TValue[string]
+	HostedZone                  plugin.TValue[*mqlAwsRoute53HostedZone]
+	Name                        plugin.TValue[string]
+	Type                        plugin.TValue[string]
+	Ttl                         plugin.TValue[int64]
+	ResourceRecords             plugin.TValue[[]any]
+	AliasTarget                 plugin.TValue[any]
+	IsAlias                     plugin.TValue[bool]
+	AliasTargetDnsName          plugin.TValue[string]
+	AliasTargetHostedZoneId     plugin.TValue[string]
+	AliasLoadBalancer           plugin.TValue[*mqlAwsElbLoadbalancer]
+	AliasCloudFrontDistribution plugin.TValue[*mqlAwsCloudfrontDistribution]
+	AliasEvaluateTargetHealth   plugin.TValue[bool]
+	SetIdentifier               plugin.TValue[string]
+	Weight                      plugin.TValue[int64]
+	Region                      plugin.TValue[string]
+	Failover                    plugin.TValue[string]
+	GeoLocation                 plugin.TValue[any]
+	GeoProximityLocation        plugin.TValue[any]
+	MultiValueAnswer            plugin.TValue[bool]
+	HealthCheckId               plugin.TValue[string]
+	HealthCheck                 plugin.TValue[*mqlAwsRoute53HealthCheck]
+	CidrRoutingConfig           plugin.TValue[any]
+	TrafficPolicyInstanceId     plugin.TValue[string]
 }
 
 // createAwsRoute53Record creates a new instance of this resource
@@ -132920,6 +132936,38 @@ func (c *mqlAwsRoute53Record) GetAliasTargetDnsName() *plugin.TValue[string] {
 
 func (c *mqlAwsRoute53Record) GetAliasTargetHostedZoneId() *plugin.TValue[string] {
 	return &c.AliasTargetHostedZoneId
+}
+
+func (c *mqlAwsRoute53Record) GetAliasLoadBalancer() *plugin.TValue[*mqlAwsElbLoadbalancer] {
+	return plugin.GetOrCompute[*mqlAwsElbLoadbalancer](&c.AliasLoadBalancer, func() (*mqlAwsElbLoadbalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.route53.record", c.__id, "aliasLoadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsElbLoadbalancer), nil
+			}
+		}
+
+		return c.aliasLoadBalancer()
+	})
+}
+
+func (c *mqlAwsRoute53Record) GetAliasCloudFrontDistribution() *plugin.TValue[*mqlAwsCloudfrontDistribution] {
+	return plugin.GetOrCompute[*mqlAwsCloudfrontDistribution](&c.AliasCloudFrontDistribution, func() (*mqlAwsCloudfrontDistribution, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.route53.record", c.__id, "aliasCloudFrontDistribution")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsCloudfrontDistribution), nil
+			}
+		}
+
+		return c.aliasCloudFrontDistribution()
+	})
 }
 
 func (c *mqlAwsRoute53Record) GetAliasEvaluateTargetHealth() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -7851,7 +7851,9 @@ aws.route53.queryLoggingConfig.id 11.15.3
 aws.route53.queryLoggingConfig.logGroup 13.12.1
 aws.route53.queryLoggingConfigs 11.15.3
 aws.route53.record 11.15.3
+aws.route53.record.aliasCloudFrontDistribution 13.43.1
 aws.route53.record.aliasEvaluateTargetHealth 11.15.3
+aws.route53.record.aliasLoadBalancer 13.43.1
 aws.route53.record.aliasTarget 11.15.3
 aws.route53.record.aliasTargetDnsName 11.15.3
 aws.route53.record.aliasTargetHostedZoneId 11.15.3

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -25,6 +25,47 @@ func (a *mqlAwsCloudfront) id() (string, error) {
 	return "aws.cloudfront", nil
 }
 
+type mqlAwsCloudfrontInternal struct {
+	domainIndexMu    sync.Mutex
+	domainIndexBuilt bool
+	domainIndex      map[string]*mqlAwsCloudfrontDistribution
+}
+
+// distributionByDomainName returns the distribution whose domain name matches
+// the given already-normalized DNS name, or nil when none matches. It builds a
+// normalized-domain-name index on first call and reuses it afterwards. The index
+// lives on the aws.cloudfront list resource, which the runtime caches, so many
+// callers (for example Route 53 alias records) share one index instead of each
+// rescanning every distribution.
+func (a *mqlAwsCloudfront) distributionByDomainName(normalized string) (*mqlAwsCloudfrontDistribution, error) {
+	a.domainIndexMu.Lock()
+	defer a.domainIndexMu.Unlock()
+
+	if !a.domainIndexBuilt {
+		dists := a.GetDistributions()
+		if dists.Error != nil {
+			return nil, dists.Error
+		}
+		idx := make(map[string]*mqlAwsCloudfrontDistribution, len(dists.Data))
+		for _, d := range dists.Data {
+			dist, ok := d.(*mqlAwsCloudfrontDistribution)
+			if !ok {
+				continue
+			}
+			domainName := dist.GetDomainName()
+			if domainName.Error != nil {
+				return nil, domainName.Error
+			}
+			if domainName.Data != "" {
+				idx[normalizeAliasDNSName(domainName.Data)] = dist
+			}
+		}
+		a.domainIndex = idx
+		a.domainIndexBuilt = true
+	}
+	return a.domainIndex[normalized], nil
+}
+
 func (a *mqlAwsCloudfrontDistribution) id() (string, error) {
 	return a.Arn.Data, nil
 }

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -46,12 +46,35 @@ func (a *mqlAwsElb) loadBalancerByDNSName(normalized string) (*mqlAwsElbLoadbala
 	defer a.dnsIndexMu.Unlock()
 
 	if !a.dnsIndexBuilt {
+		// Index both v2 (application/network/gateway) and classic load balancers:
+		// a Route 53 alias record can point at either, and each carries its own
+		// DNS name.
 		lbs := a.GetLoadBalancers()
 		if lbs.Error != nil {
 			return nil, lbs.Error
 		}
-		idx := make(map[string]*mqlAwsElbLoadbalancer, len(lbs.Data))
-		for _, l := range lbs.Data {
+		classic := a.GetClassicLoadBalancers()
+		if classic.Error != nil {
+			return nil, classic.Error
+		}
+		idx, err := buildLoadBalancerDNSIndex(lbs.Data, classic.Data)
+		if err != nil {
+			return nil, err
+		}
+		a.dnsIndex = idx
+		a.dnsIndexBuilt = true
+	}
+	return a.dnsIndex[normalized], nil
+}
+
+// buildLoadBalancerDNSIndex maps each load balancer's normalized DNS name to the
+// load balancer, across every provided list (v2 and classic). DNS names are
+// unique across load balancer types, so the lists share one index without
+// collision.
+func buildLoadBalancerDNSIndex(lbLists ...[]any) (map[string]*mqlAwsElbLoadbalancer, error) {
+	idx := map[string]*mqlAwsElbLoadbalancer{}
+	for _, lbs := range lbLists {
+		for _, l := range lbs {
 			lb, ok := l.(*mqlAwsElbLoadbalancer)
 			if !ok {
 				continue
@@ -64,10 +87,8 @@ func (a *mqlAwsElb) loadBalancerByDNSName(normalized string) (*mqlAwsElbLoadbala
 				idx[normalizeAliasDNSName(dnsName.Data)] = lb
 			}
 		}
-		a.dnsIndex = idx
-		a.dnsIndexBuilt = true
 	}
-	return a.dnsIndex[normalized], nil
+	return idx, nil
 }
 
 func (a *mqlAwsElb) classicLoadBalancers() ([]any, error) {

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -29,6 +29,47 @@ func (a *mqlAwsElb) id() (string, error) {
 	return ResourceAwsElb, nil
 }
 
+type mqlAwsElbInternal struct {
+	dnsIndexMu    sync.Mutex
+	dnsIndexBuilt bool
+	dnsIndex      map[string]*mqlAwsElbLoadbalancer
+}
+
+// loadBalancerByDNSName returns the load balancer whose DNS name matches the
+// given already-normalized DNS name, or nil when none matches. It builds a
+// normalized-DNS-name index across all load balancers on first call and reuses
+// it afterwards. The index lives on the aws.elb list resource, which the runtime
+// caches, so many callers (for example every Route 53 alias record resolving its
+// target) share one index instead of each rescanning every load balancer.
+func (a *mqlAwsElb) loadBalancerByDNSName(normalized string) (*mqlAwsElbLoadbalancer, error) {
+	a.dnsIndexMu.Lock()
+	defer a.dnsIndexMu.Unlock()
+
+	if !a.dnsIndexBuilt {
+		lbs := a.GetLoadBalancers()
+		if lbs.Error != nil {
+			return nil, lbs.Error
+		}
+		idx := make(map[string]*mqlAwsElbLoadbalancer, len(lbs.Data))
+		for _, l := range lbs.Data {
+			lb, ok := l.(*mqlAwsElbLoadbalancer)
+			if !ok {
+				continue
+			}
+			dnsName := lb.GetDnsName()
+			if dnsName.Error != nil {
+				return nil, dnsName.Error
+			}
+			if dnsName.Data != "" {
+				idx[normalizeAliasDNSName(dnsName.Data)] = lb
+			}
+		}
+		a.dnsIndex = idx
+		a.dnsIndexBuilt = true
+	}
+	return a.dnsIndex[normalized], nil
+}
+
 func (a *mqlAwsElb) classicLoadBalancers() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 

--- a/providers/aws/resources/aws_route53_targets.go
+++ b/providers/aws/resources/aws_route53_targets.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// cloudFrontAliasHostedZoneID is the fixed hosted zone AWS assigns to every
+// CloudFront distribution alias target, so an alias record pointing at a
+// distribution always carries this value in aliasTargetHostedZoneId.
+const cloudFrontAliasHostedZoneID = "Z2FDTNDATAQYW2"
+
+// normalizeAliasDNSName canonicalizes a Route 53 alias target DNS name for
+// comparison against a resource's own DNS name: it lowercases, drops the
+// trailing dot of the fully qualified name, and strips the "dualstack." prefix
+// that Route 53 prepends to load balancer alias targets.
+func normalizeAliasDNSName(name string) string {
+	n := strings.ToLower(strings.TrimSuffix(name, "."))
+	return strings.TrimPrefix(n, "dualstack.")
+}
+
+// aliasLoadBalancer resolves the load balancer an A/AAAA alias record points to
+// by matching the alias target DNS name against the load balancer DNS-name index
+// on the (runtime-cached) aws.elb list resource.
+func (a *mqlAwsRoute53Record) aliasLoadBalancer() (*mqlAwsElbLoadbalancer, error) {
+	target := normalizeAliasDNSName(a.AliasTargetDnsName.Data)
+	if target == "" {
+		a.AliasLoadBalancer.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	obj, err := CreateResource(a.MqlRuntime, ResourceAwsElb, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	lb, err := obj.(*mqlAwsElb).loadBalancerByDNSName(target)
+	if err != nil {
+		return nil, err
+	}
+	if lb == nil {
+		a.AliasLoadBalancer.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return lb, nil
+}
+
+// aliasCloudFrontDistribution resolves the CloudFront distribution an A/AAAA
+// alias record points to. A distribution alias always uses the fixed CloudFront
+// hosted zone, so records with any other alias zone short-circuit to null.
+func (a *mqlAwsRoute53Record) aliasCloudFrontDistribution() (*mqlAwsCloudfrontDistribution, error) {
+	if a.AliasTargetHostedZoneId.Data != cloudFrontAliasHostedZoneID {
+		a.AliasCloudFrontDistribution.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	target := normalizeAliasDNSName(a.AliasTargetDnsName.Data)
+	if target == "" {
+		a.AliasCloudFrontDistribution.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	obj, err := CreateResource(a.MqlRuntime, ResourceAwsCloudfront, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	dist, err := obj.(*mqlAwsCloudfront).distributionByDomainName(target)
+	if err != nil {
+		return nil, err
+	}
+	if dist == nil {
+		a.AliasCloudFrontDistribution.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return dist, nil
+}

--- a/providers/aws/resources/aws_route53_test.go
+++ b/providers/aws/resources/aws_route53_test.go
@@ -402,3 +402,56 @@ func TestNewMqlAwsRoute53HealthCheck(t *testing.T) {
 		assert.Empty(t, mqlHc.childHealthChecksCache)
 	})
 }
+
+func TestNormalizeAliasDNSName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"my-alb-123.us-east-1.elb.amazonaws.com.", "my-alb-123.us-east-1.elb.amazonaws.com"},
+		{"dualstack.my-alb-123.us-east-1.elb.amazonaws.com.", "my-alb-123.us-east-1.elb.amazonaws.com"},
+		{"MY-ALB-123.US-EAST-1.ELB.AMAZONAWS.COM", "my-alb-123.us-east-1.elb.amazonaws.com"},
+		{"d111111abcdef8.cloudfront.net", "d111111abcdef8.cloudfront.net"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, normalizeAliasDNSName(c.in), "normalizeAliasDNSName(%q)", c.in)
+	}
+}
+
+// TestRecordAliasTargetNullState covers the branches of the alias-target
+// resolvers that return before any resource enumeration: an empty alias target,
+// and a CloudFront resolver short-circuiting when the alias hosted zone is not
+// the fixed CloudFront zone. These are the branches reachable without a live
+// connection.
+func TestRecordAliasTargetNullState(t *testing.T) {
+	t.Run("aliasLoadBalancer is null when alias target DNS name is empty", func(t *testing.T) {
+		record := &mqlAwsRoute53Record{}
+		result, err := record.aliasLoadBalancer()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, record.AliasLoadBalancer.IsNull())
+		assert.True(t, record.AliasLoadBalancer.IsSet())
+	})
+
+	t.Run("aliasCloudFrontDistribution is null when alias hosted zone is not CloudFront", func(t *testing.T) {
+		record := &mqlAwsRoute53Record{}
+		record.AliasTargetHostedZoneId = plugin.TValue[string]{Data: "Z35SXDOTRQ7X7K", State: plugin.StateIsSet}
+		record.AliasTargetDnsName = plugin.TValue[string]{Data: "dualstack.my-alb.us-east-1.elb.amazonaws.com", State: plugin.StateIsSet}
+		result, err := record.aliasCloudFrontDistribution()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, record.AliasCloudFrontDistribution.IsNull())
+		assert.True(t, record.AliasCloudFrontDistribution.IsSet())
+	})
+
+	t.Run("aliasCloudFrontDistribution is null when CloudFront zone but no DNS name", func(t *testing.T) {
+		record := &mqlAwsRoute53Record{}
+		record.AliasTargetHostedZoneId = plugin.TValue[string]{Data: cloudFrontAliasHostedZoneID, State: plugin.StateIsSet}
+		result, err := record.aliasCloudFrontDistribution()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, record.AliasCloudFrontDistribution.IsNull())
+		assert.True(t, record.AliasCloudFrontDistribution.IsSet())
+	})
+}

--- a/providers/aws/resources/aws_route53_test.go
+++ b/providers/aws/resources/aws_route53_test.go
@@ -455,3 +455,32 @@ func TestRecordAliasTargetNullState(t *testing.T) {
 		assert.True(t, record.AliasCloudFrontDistribution.IsSet())
 	})
 }
+
+func lbWithDNSName(dnsName string) *mqlAwsElbLoadbalancer {
+	lb := &mqlAwsElbLoadbalancer{}
+	lb.DnsName = plugin.TValue[string]{Data: dnsName, State: plugin.StateIsSet}
+	return lb
+}
+
+// TestBuildLoadBalancerDNSIndex verifies the alias-target DNS index that backs
+// aws.route53.record.aliasLoadBalancer(): it must key every load balancer by its
+// normalized DNS name and include classic load balancers, not just v2 ones (a
+// Route 53 alias record can point at either).
+func TestBuildLoadBalancerDNSIndex(t *testing.T) {
+	v2 := lbWithDNSName("my-alb-123.us-east-1.elb.amazonaws.com")
+	classic := lbWithDNSName("my-classic-elb-456.us-east-1.elb.amazonaws.com")
+	blank := lbWithDNSName("")
+
+	idx, err := buildLoadBalancerDNSIndex([]any{v2, blank}, []any{classic})
+	require.NoError(t, err)
+
+	// A v2 load balancer alias target (Route 53 prepends "dualstack." and a
+	// trailing dot) resolves through the normalized key.
+	assert.Same(t, v2, idx[normalizeAliasDNSName("dualstack.my-alb-123.us-east-1.elb.amazonaws.com.")])
+	// The classic load balancer is indexed too — the regression this guards.
+	assert.Same(t, classic, idx[normalizeAliasDNSName("my-classic-elb-456.us-east-1.elb.amazonaws.com")])
+	// Load balancers with no DNS name are skipped rather than keyed under "".
+	_, hasBlank := idx[""]
+	assert.False(t, hasBlank)
+	assert.Len(t, idx, 2)
+}


### PR DESCRIPTION
## What

Adds typed accessors on `aws.route53.record` that resolve an alias record's target to the fronting resource:

| Accessor | Resolves to | Match |
|---|---|---|
| `aliasLoadBalancer()` | `aws.elb.loadbalancer` | alias target DNS name == load balancer DNS name |
| `aliasCloudFrontDistribution()` | `aws.cloudfront.distribution` | alias hosted zone == `Z2FDTNDATAQYW2` and DNS name == distribution domain name |

## Why

An A/AAAA alias record previously exposed only `aliasTargetDnsName` and `aliasTargetHostedZoneId` as raw strings, so "what does this DNS name point at" could not be followed to the actual resource. The entry point of most external attack paths is a DNS name — making the alias target a typed edge lets a query walk `record -> load balancer -> target group -> backend`, composing with the rest of the network graph:

```mql
// public DNS names and the internet-facing load balancer they front
aws.route53.hostedZones {
  records.where(isAlias) {
    name
    aliasLoadBalancer { dnsName scheme exposure { internetReachable } }
    aliasCloudFrontDistribution { domainName }
  }
}
```

## Notes

- DNS matching normalizes case, the trailing `.` of the FQDN, and the `dualstack.` prefix Route 53 prepends to load balancer alias targets.
- Resource enumeration reuses the cached-list pattern from `aws.ec2.instance.loadBalancers()`, so **no new IAM permissions** (`permissions.json` change is version/timestamp metadata only).
- Scope is the internet-facing ingress targets (ELB, CloudFront). S3 website endpoints and API Gateway aliases are natural follow-ups.

## Testing

- `TestNormalizeAliasDNSName` covers the DNS normalization (dualstack prefix, trailing dot, case).
- `TestRecordAliasTargetNullState` covers the null-dispatch branches (empty target, non-CloudFront hosted zone, CloudFront zone with no DNS name).
- Full `providers/aws/resources` test package passes.
- Note: the test account has no Route 53 hosted zones, so the positive resolution path was not exercised live; the enumeration logic is copied verbatim from the live-verified `instance.loadBalancers()` accessor.
