### PR TITLE
⭐ azure: traverse resource identities to their role assignments (attack path)

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -453,6 +453,13 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   identity dict
   // Principal ID of the VM's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
+  // System-assigned managed identity of the VM; null when no system-assigned identity is enabled
+  //
+  // Exposes the system-assigned identity as a managed identity so its role
+  // assignments, and their role definitions and permissions, can be traversed.
+  // This completes the resource-to-privilege leg of an attack path from an
+  // internet-reachable VM to what its identity is authorized to do.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the VM
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Internet-exposure summary combining public IPs and NSG ingress rules
@@ -929,6 +936,13 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
   identity dict
   // Principal ID of the scale set's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
+  // System-assigned managed identity of the scale set; null when no system-assigned identity is enabled
+  //
+  // Exposes the system-assigned identity as a managed identity so its role
+  // assignments, and their role definitions and permissions, can be traversed.
+  // This completes the resource-to-privilege leg of an attack path from an
+  // internet-reachable scale set to what its identity is authorized to do.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the scale set
   userAssignedIdentities() []azure.subscription.managedIdentity
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2834,6 +2834,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.computeService.vm.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.computeService.vm.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
@@ -3361,6 +3364,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.vmScaleSet.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetPrincipalId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vmScaleSet.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
 	},
 	"azure.subscription.computeService.vmScaleSet.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
@@ -18378,6 +18384,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vm.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vm.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -19112,6 +19122,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.vmScaleSet.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vmScaleSet.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.vmScaleSet.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -41625,6 +41639,7 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	VmScaleSet                    plugin.TValue[*mqlAzureSubscriptionComputeServiceVmScaleSet]
 	Identity                      plugin.TValue[any]
 	PrincipalId                   plugin.TValue[string]
+	SystemAssignedIdentity        plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities        plugin.TValue[[]any]
 	Exposure                      plugin.TValue[*mqlAzureSubscriptionNetworkServiceExposure]
 }
@@ -41956,6 +41971,22 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetIdentity() *plugin.TValue[any]
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vm", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetUserAssignedIdentities() *plugin.TValue[[]any] {
@@ -43164,6 +43195,7 @@ type mqlAzureSubscriptionComputeServiceVmScaleSet struct {
 	Extensions                        plugin.TValue[[]any]
 	Identity                          plugin.TValue[any]
 	PrincipalId                       plugin.TValue[string]
+	SystemAssignedIdentity            plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities            plugin.TValue[[]any]
 }
 
@@ -43364,6 +43396,22 @@ func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetIdentity() *plugin.TVa
 
 func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.vmScaleSet", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetUserAssignedIdentities() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1260,6 +1260,7 @@ azure.subscription.computeService.vm.secureBootEnabled 11.4.28
 azure.subscription.computeService.vm.securityType 11.4.28
 azure.subscription.computeService.vm.sshPublicKeys 13.5.1
 azure.subscription.computeService.vm.state 9.0.1
+azure.subscription.computeService.vm.systemAssignedIdentity 13.26.1
 azure.subscription.computeService.vm.systemData 13.8.2
 azure.subscription.computeService.vm.systemMetadata 13.19.2
 azure.subscription.computeService.vm.tags 9.0.1
@@ -1311,6 +1312,7 @@ azure.subscription.computeService.vmScaleSet.singlePlacementGroup 13.7.1
 azure.subscription.computeService.vmScaleSet.sku 13.7.1
 azure.subscription.computeService.vmScaleSet.skuProfile 13.8.2
 azure.subscription.computeService.vmScaleSet.spotRestorePolicy 13.8.2
+azure.subscription.computeService.vmScaleSet.systemAssignedIdentity 13.26.1
 azure.subscription.computeService.vmScaleSet.systemData 13.8.2
 azure.subscription.computeService.vmScaleSet.systemMetadata 13.19.2
 azure.subscription.computeService.vmScaleSet.tags 13.7.1

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -307,18 +307,13 @@ func (a *mqlAzureSubscriptionComputeServiceVm) userAssignedIdentities() ([]any, 
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	principalID := a.PrincipalId.Data
-	if principalID == "" {
-		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
 	tenantID := ""
 	if id, ok := a.Identity.Data.(map[string]any); ok {
 		if t, ok := id["tenantId"].(string); ok {
 			tenantID = t
 		}
 	}
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantID, &a.SystemAssignedIdentity)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -306,6 +306,28 @@ func (a *mqlAzureSubscriptionComputeServiceVm) userAssignedIdentities() ([]any, 
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionComputeServiceVm) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	principalID := a.PrincipalId.Data
+	if principalID == "" {
+		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	tenantID := ""
+	if id, ok := a.Identity.Data.(map[string]any); ok {
+		if t, ok := id["tenantId"].(string); ok {
+			tenantID = t
+		}
+	}
+	identity, err := newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	if identity == nil {
+		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return identity, nil
+}
+
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	// id is a Azure resource ID

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -318,14 +318,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) systemAssignedIdentity() (*mqlAzu
 			tenantID = t
 		}
 	}
-	identity, err := newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
-	if err != nil {
-		return nil, err
-	}
-	if identity == nil {
-		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
-	}
-	return identity, nil
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -253,14 +253,7 @@ func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) systemAssignedIdentity() 
 			tenantID = t
 		}
 	}
-	identity, err := newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
-	if err != nil {
-		return nil, err
-	}
-	if identity == nil {
-		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
-	}
-	return identity, nil
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) instances() ([]any, error) {

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -242,18 +242,13 @@ func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) userAssignedIdentities() 
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	principalID := a.PrincipalId.Data
-	if principalID == "" {
-		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
 	tenantID := ""
 	if id, ok := a.Identity.Data.(map[string]any); ok {
 		if t, ok := id["tenantId"].(string); ok {
 			tenantID = t
 		}
 	}
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantID, &a.SystemAssignedIdentity)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) instances() ([]any, error) {

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -241,6 +241,28 @@ func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) userAssignedIdentities() 
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	principalID := a.PrincipalId.Data
+	if principalID == "" {
+		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	tenantID := ""
+	if id, ok := a.Identity.Data.(map[string]any); ok {
+		if t, ok := id["tenantId"].(string); ok {
+			tenantID = t
+		}
+	}
+	identity, err := newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, principalID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	if identity == nil {
+		a.SystemAssignedIdentity.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return identity, nil
+}
+
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) instances() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -71,6 +71,30 @@ func resolveUserAssignedIdentities(runtime *plugin.Runtime, ids []string) ([]any
 	return res, nil
 }
 
+// newSystemAssignedManagedIdentity represents a resource's system-assigned
+// managed identity as a managed-identity resource keyed on its principal ID.
+// Unlike a user-assigned identity it has no standalone ARM resource, so it is
+// synthesized from the owning resource's ID and the identity's principal (and
+// tenant) so the same roleAssignments -> role -> permissions chain can be
+// traversed. Returns nil when no principal is set.
+func newSystemAssignedManagedIdentity(runtime *plugin.Runtime, ownerID, principalID, tenantID string) (*mqlAzureSubscriptionManagedIdentity, error) {
+	if principalID == "" {
+		return nil, nil
+	}
+	r, err := CreateResource(runtime, "azure.subscription.managedIdentity",
+		map[string]*llx.RawData{
+			"__id":        llx.StringData(ownerID + "/systemAssignedIdentity"),
+			"name":        llx.StringData(""),
+			"clientId":    llx.StringData(""),
+			"principalId": llx.StringData(principalID),
+			"tenantId":    llx.StringData(tenantID),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzureSubscriptionManagedIdentity), nil
+}
+
 func (a *mqlAzureSubscription) iam() (*mqlAzureSubscriptionAuthorizationService, error) {
 	svc, err := NewResource(a.MqlRuntime, "azure.subscription.authorizationService", map[string]*llx.RawData{
 		"subscriptionId": llx.StringData(a.SubscriptionId.Data),
@@ -338,10 +362,9 @@ func (a *mqlAzureSubscriptionAuthorizationService) managedIdentities() ([]any, e
 
 	ctx := context.Background()
 
-	// list all role assignments since we need to attach them to the managed identities
-	roleAssignments := a.GetRoleAssignments().Data
-
-	// list user assigned identities
+	// list user assigned identities; each identity's roleAssignments accessor
+	// resolves its granted roles on demand by filtering the subscription's
+	// (cached) role-assignment list by principal ID.
 	pager := client.NewListBySubscriptionPager(nil)
 	res := []any{}
 	for pager.More() {
@@ -354,25 +377,6 @@ func (a *mqlAzureSubscriptionAuthorizationService) managedIdentities() ([]any, e
 			if err != nil {
 				return nil, err
 			}
-
-			// set assigned roles to nil
-			mqlManagedIdentity.RoleAssignments = plugin.TValue[[]any]{Error: nil, State: plugin.StateIsSet | plugin.StateIsNull}
-
-			assignedRoles := []any{}
-			for i := range roleAssignments {
-				roleAssignment := roleAssignments[i].(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment)
-				// Compare the principal ID values, not the whole TValue structs
-				// (which also carry State/Error and would only match when those
-				// happen to be identical too).
-				if roleAssignment.PrincipalId.Data == mqlManagedIdentity.PrincipalId.Data {
-					assignedRoles = append(assignedRoles, roleAssignment)
-				}
-			}
-
-			if len(assignedRoles) > 0 {
-				mqlManagedIdentity.RoleAssignments = plugin.TValue[[]any]{Error: nil, Data: assignedRoles, State: plugin.StateIsSet}
-			}
-
 			res = append(res, mqlManagedIdentity)
 		}
 	}
@@ -472,8 +476,55 @@ func (a *mqlAzureSubscriptionManagedIdentity) systemMetadata() (*mqlAzureSubscri
 }
 
 func (a *mqlAzureSubscriptionManagedIdentity) roleAssignments() ([]any, error) {
-	// NOTE: this should never be called since we assign roles during the managed identities query
-	return nil, errors.New("could not fetch role assignments for managed identities")
+	return roleAssignmentsForPrincipal(a.MqlRuntime, a.PrincipalId.Data)
+}
+
+// roleAssignmentsForPrincipal returns the subscription role assignments granted
+// directly to a principal, identified by its object/principal ID. It filters
+// the subscription's role-assignment list (which the runtime caches), so every
+// caller shares a single API fetch rather than issuing a per-principal query.
+// An empty principalId yields no assignments.
+//
+// This is the identity-to-privilege edge of a resource's attack path: a managed
+// identity (system- or user-assigned) resolves to the roles it holds, and each
+// role assignment resolves further to its role definition and permissions.
+func roleAssignmentsForPrincipal(runtime *plugin.Runtime, principalId string) ([]any, error) {
+	if principalId == "" {
+		return []any{}, nil
+	}
+	conn := runtime.Connection.(*connection.AzureConnection)
+	r, err := CreateResource(runtime, "azure.subscription", map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	sub := r.(*mqlAzureSubscription)
+	iam := sub.GetIam().Data
+	if iam == nil {
+		return []any{}, nil
+	}
+	all := iam.GetRoleAssignments()
+	if all.Error != nil {
+		return nil, all.Error
+	}
+	return filterRoleAssignmentsByPrincipal(all.Data, principalId), nil
+}
+
+// filterRoleAssignmentsByPrincipal returns the role assignments whose principal
+// ID matches the given principal.
+func filterRoleAssignmentsByPrincipal(assignments []any, principalId string) []any {
+	res := []any{}
+	for _, ra := range assignments {
+		assignment, ok := ra.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment)
+		if !ok {
+			continue
+		}
+		if assignment.PrincipalId.Data == principalId {
+			res = append(res, assignment)
+		}
+	}
+	return res
 }
 
 func (a *mqlAzureSubscriptionManagedIdentity) federatedIdentityCredentials() ([]any, error) {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -76,9 +76,14 @@ func resolveUserAssignedIdentities(runtime *plugin.Runtime, ids []string) ([]any
 // Unlike a user-assigned identity it has no standalone ARM resource, so it is
 // synthesized from the owning resource's ID and the identity's principal (and
 // tenant) so the same roleAssignments -> role -> permissions chain can be
-// traversed. Returns nil when no principal is set.
-func newSystemAssignedManagedIdentity(runtime *plugin.Runtime, ownerID, principalID, tenantID string) (*mqlAzureSubscriptionManagedIdentity, error) {
+// traversed.
+//
+// When principalID is empty (no system-assigned identity) it marks the caller's
+// field null and returns nil, so callers pass their field pointer and do not
+// guard separately. This mirrors resolveRoleDefinition.
+func newSystemAssignedManagedIdentity(runtime *plugin.Runtime, ownerID, principalID, tenantID string, field *plugin.TValue[*mqlAzureSubscriptionManagedIdentity]) (*mqlAzureSubscriptionManagedIdentity, error) {
 	if principalID == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := CreateResource(runtime, "azure.subscription.managedIdentity",

--- a/providers/azure/resources/iam_test.go
+++ b/providers/azure/resources/iam_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func roleAssignmentFor(principalID string) *mqlAzureSubscriptionAuthorizationServiceRoleAssignment {
+	return &mqlAzureSubscriptionAuthorizationServiceRoleAssignment{
+		PrincipalId: plugin.TValue[string]{Data: principalID, State: plugin.StateIsSet},
+	}
+}
+
+func TestFilterRoleAssignmentsByPrincipal(t *testing.T) {
+	assignments := []any{
+		roleAssignmentFor("aaa"),
+		roleAssignmentFor("bbb"),
+		roleAssignmentFor("aaa"),
+		roleAssignmentFor("ccc"),
+	}
+
+	t.Run("returns every assignment for the principal", func(t *testing.T) {
+		got := filterRoleAssignmentsByPrincipal(assignments, "aaa")
+		assert.Len(t, got, 2)
+		for _, ra := range got {
+			assert.Equal(t, "aaa", ra.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).PrincipalId.Data)
+		}
+	})
+	t.Run("single match", func(t *testing.T) {
+		assert.Len(t, filterRoleAssignmentsByPrincipal(assignments, "bbb"), 1)
+	})
+	t.Run("no match yields empty, non-nil slice", func(t *testing.T) {
+		got := filterRoleAssignmentsByPrincipal(assignments, "zzz")
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("empty input yields empty slice", func(t *testing.T) {
+		assert.Empty(t, filterRoleAssignmentsByPrincipal(nil, "aaa"))
+	})
+	t.Run("skips entries of the wrong type", func(t *testing.T) {
+		mixed := []any{roleAssignmentFor("aaa"), "not-a-role-assignment", 42}
+		assert.Len(t, filterRoleAssignmentsByPrincipal(mixed, "aaa"), 1)
+	})
+}


### PR DESCRIPTION
## What

Makes the **network → identity → privilege** leg of an Azure attack path traversable in a single MQL query. Building on the exposure work in #8968, you can now walk from an internet-reachable resource straight to what its managed identity is authorized to do:

```
azure.subscription.computeService.vms.where(exposure.internetReachable) {
  name
  systemAssignedIdentity { roleAssignments { role.name scope } }
  userAssignedIdentities  { roleAssignments { role.name scope } }
}
```

## Why

Two gaps blocked this today:

1. **`managedIdentity.roleAssignments()` was a stub that errored.** Role assignments were only ever pre-filled by `authorizationService.managedIdentities()` (which filters the subscription's assignment list by principal ID). Any identity reached via a *reference* — e.g. `vm.userAssignedIdentities()`, which resolves through `init` — hit the stub and errored instead of resolving its roles. So the user-assigned attack path was effectively broken from the resource side.
2. **System-assigned identities had no typed edge at all** — only a raw `principalId string` on the resource, with no way to traverse to the roles it holds.

## How

- **`managedIdentity.roleAssignments()` now resolves on demand** by filtering the subscription's role-assignment list (already cached by the runtime) by principal ID, via a shared `roleAssignmentsForPrincipal` helper. The two divergent code paths are unified on this one accessor — `managedIdentities()` no longer pre-fills, so behavior is identical regardless of how an identity was reached.
- **Added `systemAssignedIdentity()` to the compute VM and scale set.** A system-assigned identity has no standalone ARM resource, so it is represented as a `managed identity` keyed on its principal ID (synthesized from the owning resource's ID + principal/tenant). It reuses the exact same `roleAssignments → role → permissions` chain as user-assigned identities, so both paths look identical in a query. Returns `null` when the resource has no system-assigned identity.

`systemAssignedIdentity` is the only schema addition (two `.lr.versions` entries at `13.26.1`); the `roleAssignments()` fix is behavior-only. **No new IAM permission** — it reuses the existing subscription role-assignment list, so `permissions.json` is unchanged.

## Tests

- Unit tests (`iam_test.go`) cover the principal-ID filter: multiple matches, single match, no match (empty non-nil slice), empty input, and skipping wrong-typed entries.
- **Live-verified** on a real subscription (`--auto-update=false`): VMs with a system-assigned identity resolve it and its (empty, for that principal) role assignments; VMs without one return `null`; the user-assigned accessor resolves without the old error; and the composite `exposure + systemAssignedIdentity + roleAssignments` query composes end-to-end. No managed identity in the test subscription happens to hold a role assignment, so the non-empty match path is covered by the unit test rather than live.

## Follow-ups (queued)

- Extend `systemAssignedIdentity()` to other identity-bearing resources (storage, web apps, AKS, etc.) as needed — the `managedIdentity.roleAssignments()` fix already benefits every resource that exposes `userAssignedIdentities()`.
- PR3: private-link reachability edges.
- AVNM security-admin overrides in exposure (from the #8968 follow-up).
