### PR TITLE
⭐ aws: typed WAF web ACL association on load balancers (both directions)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -736,6 +736,13 @@ private aws.waf.acl @defaults("name") {
   loggingConfiguration() aws.waf.acl.loggingConfiguration
   // ARNs of resources associated with this web ACL
   associatedResources() []string
+  // Application Load Balancers protected by this web ACL
+  //
+  // The load balancers this regional web ACL is associated with, resolved to
+  // typed resources. Empty for CloudFront-scoped web ACLs (those attach through
+  // CloudFront distributions) and for regional web ACLs with no load balancer
+  // association.
+  associatedLoadBalancers() []aws.elb.loadbalancer
 }
 
 // Amazon WAF v2 RuleGroup
@@ -5602,6 +5609,14 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   securityGroups []aws.ec2.securitygroup
   // Internet-exposure breakdown (internet-facing scheme combined with security group ingress)
   exposure() aws.network.exposure
+  // WAFv2 web ACL protecting the load balancer
+  //
+  // The regional web ACL associated with an Application Load Balancer, or null
+  // when none is attached or the load balancer is not an Application Load
+  // Balancer (Network, Gateway, and Classic load balancers cannot have a WAFv2
+  // web ACL). Shows whether internet traffic reaching the load balancer passes
+  // through a web application firewall.
+  webAcl() aws.waf.acl
   // ID of the Amazon Route 53 hosted zone associated with the load balancer
   hostedZoneId string
   // Region where the load balancer exists

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5372,6 +5372,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.acl.associatedResources": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafAcl).GetAssociatedResources()).ToDataRes(types.Array(types.String))
 	},
+	"aws.waf.acl.associatedLoadBalancers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafAcl).GetAssociatedLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
+	},
 	"aws.waf.rulegroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRulegroup).GetArn()).ToDataRes(types.String)
 	},
@@ -11041,6 +11044,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.loadbalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
+	"aws.elb.loadbalancer.webAcl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetWebAcl()).ToDataRes(types.Resource("aws.waf.acl"))
 	},
 	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetHostedZoneId()).ToDataRes(types.String)
@@ -34965,6 +34971,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWafAcl).AssociatedResources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.waf.acl.associatedLoadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafAcl).AssociatedLoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.waf.rulegroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRulegroup).__id, ok = v.Value.(string)
 		return
@@ -43259,6 +43269,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.loadbalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.webAcl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).WebAcl, ok = plugin.RawToTValue[*mqlAwsWafAcl](v.Value, v.Error)
 		return
 	},
 	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -79410,6 +79424,7 @@ type mqlAwsWafAcl struct {
 	Scope                    plugin.TValue[string]
 	LoggingConfiguration     plugin.TValue[*mqlAwsWafAclLoggingConfiguration]
 	AssociatedResources      plugin.TValue[[]any]
+	AssociatedLoadBalancers  plugin.TValue[[]any]
 }
 
 // createAwsWafAcl creates a new instance of this resource
@@ -79510,6 +79525,22 @@ func (c *mqlAwsWafAcl) GetLoggingConfiguration() *plugin.TValue[*mqlAwsWafAclLog
 func (c *mqlAwsWafAcl) GetAssociatedResources() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.AssociatedResources, func() ([]any, error) {
 		return c.associatedResources()
+	})
+}
+
+func (c *mqlAwsWafAcl) GetAssociatedLoadBalancers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AssociatedLoadBalancers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.waf.acl", c.__id, "associatedLoadBalancers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.associatedLoadBalancers()
 	})
 }
 
@@ -101468,6 +101499,7 @@ type mqlAwsElbLoadbalancer struct {
 	State                plugin.TValue[string]
 	SecurityGroups       plugin.TValue[[]any]
 	Exposure             plugin.TValue[*mqlAwsNetworkExposure]
+	WebAcl               plugin.TValue[*mqlAwsWafAcl]
 	HostedZoneId         plugin.TValue[string]
 	Region               plugin.TValue[string]
 	ElbType              plugin.TValue[string]
@@ -101594,6 +101626,22 @@ func (c *mqlAwsElbLoadbalancer) GetExposure() *plugin.TValue[*mqlAwsNetworkExpos
 		}
 
 		return c.exposure()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetWebAcl() *plugin.TValue[*mqlAwsWafAcl] {
+	return plugin.GetOrCompute[*mqlAwsWafAcl](&c.WebAcl, func() (*mqlAwsWafAcl, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elb.loadbalancer", c.__id, "webAcl")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsWafAcl), nil
+			}
+		}
+
+		return c.webAcl()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4448,6 +4448,7 @@ aws.elb.loadbalancer.subnets 13.39.2
 aws.elb.loadbalancer.tags 11.15.2
 aws.elb.loadbalancer.targetGroups 11.15.2
 aws.elb.loadbalancer.vpc 11.15.2
+aws.elb.loadbalancer.webAcl 13.43.1
 aws.elb.targetgroup 11.15.2
 aws.elb.targetgroup.arn 11.15.2
 aws.elb.targetgroup.attributes 11.15.2
@@ -10155,6 +10156,7 @@ aws.vpcs 11.15.2
 aws.waf 11.15.2
 aws.waf.acl 11.15.2
 aws.waf.acl.arn 11.15.2
+aws.waf.acl.associatedLoadBalancers 13.43.1
 aws.waf.acl.associatedResources 11.16.1
 aws.waf.acl.description 11.15.2
 aws.waf.acl.id 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.43.0",
-  "generated_at": "2026-07-06T12:03:49-07:00",
+  "generated_at": "2026-07-06T13:52:17-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -910,6 +910,7 @@
     "wafv2:GetRegexPatternSet",
     "wafv2:GetRuleGroup",
     "wafv2:GetWebACL",
+    "wafv2:GetWebACLForResource",
     "wafv2:ListIPSets",
     "wafv2:ListRegexPatternSets",
     "wafv2:ListResourcesForWebACL",
@@ -6574,6 +6575,12 @@
       "permission": "wafv2:GetWebACL",
       "service": "wafv2",
       "action": "GetWebACL",
+      "source_file": "aws_waf.go"
+    },
+    {
+      "permission": "wafv2:GetWebACLForResource",
+      "service": "wafv2",
+      "action": "GetWebACLForResource",
       "source_file": "aws_waf.go"
     },
     {

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -1128,3 +1128,105 @@ func (a *mqlAwsWafAcl) associatedResources() ([]any, error) {
 
 	return allArns, nil
 }
+
+// associatedLoadBalancers resolves the Application Load Balancers this regional
+// web ACL protects to typed resources. CloudFront-scoped ACLs attach through
+// distributions rather than this API and so return an empty list.
+func (a *mqlAwsWafAcl) associatedLoadBalancers() ([]any, error) {
+	if a.Scope.Data == "CLOUDFRONT" {
+		return []any{}, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Wafv2(wafRegionForScope(a.Scope.Data))
+	arnVal := a.Arn.Data
+
+	resp, err := svc.ListResourcesForWebACL(context.Background(), &wafv2.ListResourcesForWebACLInput{
+		WebACLArn:    &arnVal,
+		ResourceType: waftypes.ResourceTypeApplicationLoadBalancer,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	res := []any{}
+	for _, lbArn := range resp.ResourceArns {
+		mqlLb, err := NewResource(a.MqlRuntime, ResourceAwsElbLoadbalancer,
+			map[string]*llx.RawData{"arn": llx.StringData(lbArn)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlLb)
+	}
+	return res, nil
+}
+
+// webAcl resolves the WAFv2 web ACL protecting an Application Load Balancer.
+// Only Application Load Balancers can carry a WAFv2 web ACL, so other load
+// balancer types short-circuit to null.
+func (a *mqlAwsElbLoadbalancer) webAcl() (*mqlAwsWafAcl, error) {
+	elbType := a.GetElbType()
+	if elbType.Error != nil {
+		return nil, elbType.Error
+	}
+	if elbType.Data != "application" {
+		a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	arnVal := a.Arn.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Wafv2(a.Region.Data)
+	resp, err := svc.GetWebACLForResource(context.Background(), &wafv2.GetWebACLForResourceInput{
+		ResourceArn: &arnVal,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
+		return nil, err
+	}
+	if resp.WebACL == nil || resp.WebACL.ARN == nil {
+		a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	// Resolve the associated web ACL ARN to the typed resource from the account
+	// web ACL list.
+	obj, err := CreateResource(a.MqlRuntime, ResourceAwsWaf, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	acl, err := obj.(*mqlAwsWaf).wafAclByArn(*resp.WebACL.ARN)
+	if err != nil {
+		return nil, err
+	}
+	if acl == nil {
+		a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return acl, nil
+}
+
+// wafAclByArn returns the web ACL with the given ARN from the account's web ACLs,
+// or nil when none matches.
+func (a *mqlAwsWaf) wafAclByArn(arnVal string) (*mqlAwsWafAcl, error) {
+	acls := a.GetAcls()
+	if acls.Error != nil {
+		return nil, acls.Error
+	}
+	for _, x := range acls.Data {
+		acl, ok := x.(*mqlAwsWafAcl)
+		if !ok {
+			continue
+		}
+		if acl.Arn.Data == arnVal {
+			return acl, nil
+		}
+	}
+	return nil, nil
+}

--- a/providers/aws/resources/aws_waf_test.go
+++ b/providers/aws/resources/aws_waf_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// TestElbWebAclNullForNonApplicationLB verifies that webAcl() short-circuits to a
+// set-null value for every load balancer type that cannot carry a WAFv2 web ACL
+// (Network, Gateway, Classic, or an unset type), without reaching the WAFv2 API.
+func TestElbWebAclNullForNonApplicationLB(t *testing.T) {
+	for _, elbType := range []string{"network", "gateway", "classic", ""} {
+		t.Run("elbType="+elbType, func(t *testing.T) {
+			lb := &mqlAwsElbLoadbalancer{}
+			lb.ElbType = plugin.TValue[string]{Data: elbType, State: plugin.StateIsSet}
+			result, err := lb.webAcl()
+			require.NoError(t, err)
+			require.Nil(t, result)
+			assert.True(t, lb.WebAcl.IsNull())
+			assert.True(t, lb.WebAcl.IsSet())
+		})
+	}
+}
+
+// TestWafAssociatedLoadBalancersEmptyForCloudFront verifies that a
+// CloudFront-scoped web ACL returns an empty association list (CloudFront ACLs
+// attach through distributions, not the regional ListResourcesForWebACL API),
+// without reaching the WAFv2 API.
+func TestWafAssociatedLoadBalancersEmptyForCloudFront(t *testing.T) {
+	acl := &mqlAwsWafAcl{}
+	acl.Scope = plugin.TValue[string]{Data: "CLOUDFRONT", State: plugin.StateIsSet}
+	result, err := acl.associatedLoadBalancers()
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
## What

Closes the WAF ↔ Application Load Balancer blind spot with a typed association in both directions:

| Accessor | Direction | Resolves to |
|---|---|---|
| `aws.elb.loadbalancer.webAcl()` | forward | `aws.waf.acl` (the regional web ACL protecting an ALB) |
| `aws.waf.acl.associatedLoadBalancers()` | reverse | `[]aws.elb.loadbalancer` (the ALBs a regional web ACL protects) |

## Why

The load balancer previously had **no WAF link at all** (only a `wafFailOpenEnabled` bool), and the web ACL exposed its associations only as raw ARN strings — so the WAF↔ALB relationship couldn't be followed in either direction. CloudFront distributions and API Gateway stages already expose a typed `webAcl()`; this brings load balancers in line, so a query can tell whether internet traffic reaching an ALB passes through a web application firewall:

```mql
// internet-facing ALBs and whether a WAF fronts them
aws.elb.loadBalancers.where(scheme == "internet-facing" && elbType == "application") {
  arn
  webAcl { name }   // null == no WAF in front of this ALB
}
```

## Notes

- `webAcl()` short-circuits to null for Network/Gateway/Classic load balancers (only Application Load Balancers can carry a WAFv2 web ACL), calling `GetWebACLForResource` only for ALBs.
- `associatedLoadBalancers()` returns empty for CloudFront-scoped web ACLs (they attach through distributions, not the regional `ListResourcesForWebACL` API).
- Adds the `wafv2:GetWebACLForResource` IAM permission (`permissions.json`).

## Testing

- `TestElbWebAclNullForNonApplicationLB` — webAcl() is set-null for network/gateway/classic/unset LB types (no WAFv2 call).
- `TestWafAssociatedLoadBalancersEmptyForCloudFront` — CloudFront-scoped ACL returns an empty list (no WAFv2 call).
- Full `providers/aws/resources` test package passes.
- Live: verified `associatedLoadBalancers` returns `[]` for a CloudFront-scoped web ACL in the test account. The account has no Application Load Balancers, so the positive `webAcl()` path was not exercised live.
