### PR TITLE
⭐ aws: complete the load balancer listener-to-backend chain

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5538,6 +5538,14 @@ private aws.elb.targetgroup @defaults("name port ec2Targets lambdaTargets") {
   ec2Targets() []aws.ec2.instance
   // Lambda targets for the load balancer target group
   lambdaTargets() []aws.lambda.function
+  // IP addresses registered as targets
+  //
+  // The registered IP targets of an ip-type target group (for example
+  // containers, Kubernetes pods, or on-premises hosts reachable over a
+  // Direct Connect or VPN link). Empty for instance-type and lambda-type
+  // target groups, whose backends are exposed through ec2Targets and
+  // lambdaTargets.
+  ipTargets() []string
   // Region where the target group exists
   region string
 }
@@ -5670,6 +5678,13 @@ private aws.elb.listener @defaults("arn port protocol") {
   sslPolicy string
   // Default actions for the listener
   defaultActions []dict
+  // Target groups this listener forwards to by default
+  //
+  // The target groups named by the listener's default forward action,
+  // resolved to typed resources. This is the internet-to-backend hop for
+  // requests that match no listener rule. Empty for listeners whose default
+  // action does not forward (for example a redirect or fixed-response action).
+  forwardTargetGroups() []aws.elb.targetgroup
   // Server certificates for the listener
   certificates []dict
   // ALPN policy for TLS listeners

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10958,6 +10958,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.targetgroup.lambdaTargets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTargetgroup).GetLambdaTargets()).ToDataRes(types.Array(types.Resource("aws.lambda.function")))
 	},
+	"aws.elb.targetgroup.ipTargets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbTargetgroup).GetIpTargets()).ToDataRes(types.Array(types.String))
+	},
 	"aws.elb.targetgroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTargetgroup).GetRegion()).ToDataRes(types.String)
 	},
@@ -11116,6 +11119,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.listener.defaultActions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListener).GetDefaultActions()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.elb.listener.forwardTargetGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbListener).GetForwardTargetGroups()).ToDataRes(types.Array(types.Resource("aws.elb.targetgroup")))
 	},
 	"aws.elb.listener.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListener).GetCertificates()).ToDataRes(types.Array(types.Dict))
@@ -43141,6 +43147,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElbTargetgroup).LambdaTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elb.targetgroup.ipTargets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbTargetgroup).IpTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.elb.targetgroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbTargetgroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -43367,6 +43377,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.listener.defaultActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbListener).DefaultActions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.elb.listener.forwardTargetGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbListener).ForwardTargetGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.elb.listener.certificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -101164,6 +101178,7 @@ type mqlAwsElbTargetgroup struct {
 	Vpc                        plugin.TValue[*mqlAwsVpc]
 	Ec2Targets                 plugin.TValue[[]any]
 	LambdaTargets              plugin.TValue[[]any]
+	IpTargets                  plugin.TValue[[]any]
 	Region                     plugin.TValue[string]
 }
 
@@ -101325,6 +101340,12 @@ func (c *mqlAwsElbTargetgroup) GetLambdaTargets() *plugin.TValue[[]any] {
 		}
 
 		return c.lambdaTargets()
+	})
+}
+
+func (c *mqlAwsElbTargetgroup) GetIpTargets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IpTargets, func() ([]any, error) {
+		return c.ipTargets()
 	})
 }
 
@@ -101782,16 +101803,17 @@ func (c *mqlAwsNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
 type mqlAwsElbListener struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElbListenerInternal it will be used here
-	Arn             plugin.TValue[string]
-	LoadBalancer    plugin.TValue[*mqlAwsElbLoadbalancer]
-	LoadBalancerArn plugin.TValue[string]
-	Port            plugin.TValue[int64]
-	Protocol        plugin.TValue[string]
-	SslPolicy       plugin.TValue[string]
-	DefaultActions  plugin.TValue[[]any]
-	Certificates    plugin.TValue[[]any]
-	AlpnPolicy      plugin.TValue[[]any]
+	mqlAwsElbListenerInternal
+	Arn                 plugin.TValue[string]
+	LoadBalancer        plugin.TValue[*mqlAwsElbLoadbalancer]
+	LoadBalancerArn     plugin.TValue[string]
+	Port                plugin.TValue[int64]
+	Protocol            plugin.TValue[string]
+	SslPolicy           plugin.TValue[string]
+	DefaultActions      plugin.TValue[[]any]
+	ForwardTargetGroups plugin.TValue[[]any]
+	Certificates        plugin.TValue[[]any]
+	AlpnPolicy          plugin.TValue[[]any]
 }
 
 // createAwsElbListener creates a new instance of this resource
@@ -101869,6 +101891,22 @@ func (c *mqlAwsElbListener) GetSslPolicy() *plugin.TValue[string] {
 
 func (c *mqlAwsElbListener) GetDefaultActions() *plugin.TValue[[]any] {
 	return &c.DefaultActions
+}
+
+func (c *mqlAwsElbListener) GetForwardTargetGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ForwardTargetGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elb.listener", c.__id, "forwardTargetGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.forwardTargetGroups()
+	})
 }
 
 func (c *mqlAwsElbListener) GetCertificates() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4400,6 +4400,7 @@ aws.elb.listener.alpnPolicy 11.15.2
 aws.elb.listener.arn 11.15.2
 aws.elb.listener.certificates 11.15.2
 aws.elb.listener.defaultActions 11.15.2
+aws.elb.listener.forwardTargetGroups 13.43.1
 aws.elb.listener.loadBalancer 13.12.1
 aws.elb.listener.loadBalancerArn 11.15.2
 aws.elb.listener.port 11.15.2
@@ -4475,6 +4476,7 @@ aws.elb.targetgroup.healthCheckProtocol 11.15.2
 aws.elb.targetgroup.healthCheckTimeoutSeconds 11.15.2
 aws.elb.targetgroup.healthyThresholdCount 11.15.2
 aws.elb.targetgroup.ipAddressType 11.15.2
+aws.elb.targetgroup.ipTargets 13.43.1
 aws.elb.targetgroup.lambdaTargets 11.15.2
 aws.elb.targetgroup.name 11.15.2
 aws.elb.targetgroup.port 11.15.2

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -618,7 +618,61 @@ func (a *mqlAwsElbLoadbalancer) listeners() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlListener.(*mqlAwsElbListener).defaultActionsCache = l.DefaultActions
 			res = append(res, mqlListener)
+		}
+	}
+	return res, nil
+}
+
+type mqlAwsElbListenerInternal struct {
+	defaultActionsCache []elbtypes.Action
+}
+
+// forwardTargetGroups resolves the target groups named by the listener's default
+// forward action to typed resources, matched against the parent load balancer's
+// target groups. It completes the internet -> load balancer -> listener ->
+// target group hop of the ingress path.
+func (a *mqlAwsElbListener) forwardTargetGroups() ([]any, error) {
+	// Collect the target group ARNs referenced by forward actions, both the
+	// single-target shorthand and the weighted ForwardConfig form.
+	wanted := map[string]struct{}{}
+	for _, act := range a.defaultActionsCache {
+		if act.TargetGroupArn != nil && *act.TargetGroupArn != "" {
+			wanted[*act.TargetGroupArn] = struct{}{}
+		}
+		if act.ForwardConfig != nil {
+			for _, tg := range act.ForwardConfig.TargetGroups {
+				if tg.TargetGroupArn != nil && *tg.TargetGroupArn != "" {
+					wanted[*tg.TargetGroupArn] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(wanted) == 0 {
+		return []any{}, nil
+	}
+
+	lb := a.GetLoadBalancer()
+	if lb.Error != nil {
+		return nil, lb.Error
+	}
+	if lb.Data == nil {
+		return []any{}, nil
+	}
+	tgs := lb.Data.GetTargetGroups()
+	if tgs.Error != nil {
+		return nil, tgs.Error
+	}
+
+	res := []any{}
+	for _, t := range tgs.Data {
+		tg, ok := t.(*mqlAwsElbTargetgroup)
+		if !ok {
+			continue
+		}
+		if _, found := wanted[tg.Arn.Data]; found {
+			res = append(res, tg)
 		}
 	}
 	return res, nil
@@ -1002,8 +1056,67 @@ func (a *mqlAwsElbTargetgroup) ec2Targets() ([]any, error) {
 }
 
 func (a *mqlAwsElbTargetgroup) lambdaTargets() ([]any, error) {
-	// TODO
-	return nil, nil
+	// Only lambda-type target groups register Lambda functions.
+	if a.targetGroup.TargetType != elbtypes.TargetTypeEnumLambda {
+		return []any{}, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Elbv2(a.region)
+	resp, err := svc.DescribeTargetHealth(context.Background(), &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(a.Arn.Data),
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	res := []any{}
+	for _, desc := range resp.TargetHealthDescriptions {
+		if desc.Target == nil || desc.Target.Id == nil {
+			continue
+		}
+		// lambda-type targets register the function ARN as the target id.
+		mqlFn, err := NewResource(a.MqlRuntime, ResourceAwsLambdaFunction,
+			map[string]*llx.RawData{"arn": llx.StringData(*desc.Target.Id)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlFn)
+	}
+	return res, nil
+}
+
+// ipTargets returns the IP addresses registered with an ip-type target group.
+// These backends (containers, Kubernetes pods, on-premises hosts) are not EC2
+// instances, so they do not appear in ec2Targets.
+func (a *mqlAwsElbTargetgroup) ipTargets() ([]any, error) {
+	if a.targetGroup.TargetType != elbtypes.TargetTypeEnumIp {
+		return []any{}, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Elbv2(a.region)
+	resp, err := svc.DescribeTargetHealth(context.Background(), &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(a.Arn.Data),
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	res := []any{}
+	for _, desc := range resp.TargetHealthDescriptions {
+		if desc.Target == nil || desc.Target.Id == nil {
+			continue
+		}
+		res = append(res, *desc.Target.Id)
+	}
+	return res, nil
 }
 
 // enforcesTls reports whether every listener terminates an encrypted protocol —

--- a/providers/aws/resources/aws_elb_test.go
+++ b/providers/aws/resources/aws_elb_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTargetGroupBackendTypeShortCircuit verifies that lambdaTargets and
+// ipTargets return an empty list (without calling DescribeTargetHealth) for
+// target groups whose target type doesn't match, so an instance-type target
+// group reports no Lambda or IP backends.
+func TestTargetGroupBackendTypeShortCircuit(t *testing.T) {
+	t.Run("lambdaTargets empty for instance-type target group", func(t *testing.T) {
+		tg := &mqlAwsElbTargetgroup{}
+		tg.targetGroup = elbtypes.TargetGroup{TargetType: elbtypes.TargetTypeEnumInstance}
+		result, err := tg.lambdaTargets()
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("ipTargets empty for instance-type target group", func(t *testing.T) {
+		tg := &mqlAwsElbTargetgroup{}
+		tg.targetGroup = elbtypes.TargetGroup{TargetType: elbtypes.TargetTypeEnumInstance}
+		result, err := tg.ipTargets()
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("ipTargets empty for lambda-type target group", func(t *testing.T) {
+		tg := &mqlAwsElbTargetgroup{}
+		tg.targetGroup = elbtypes.TargetGroup{TargetType: elbtypes.TargetTypeEnumLambda}
+		result, err := tg.ipTargets()
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+// TestListenerForwardTargetGroupsNoForwardAction verifies that a listener whose
+// default action does not forward (no target group ARNs) resolves to an empty
+// list without touching the parent load balancer.
+func TestListenerForwardTargetGroupsNoForwardAction(t *testing.T) {
+	listener := &mqlAwsElbListener{}
+	// defaultActionsCache is nil (e.g. a redirect or fixed-response default action)
+	result, err := listener.forwardTargetGroups()
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
## What

Completes the load balancer listener → target group → backend chain so the ingress path is fully traversable in MQL:

| Accessor | Adds |
|---|---|
| `aws.elb.listener.forwardTargetGroups()` → `[]aws.elb.targetgroup` | the target groups the listener's default forward action routes to |
| `aws.elb.targetgroup.lambdaTargets()` | **implemented** (was a `nil` TODO stub) — the Lambda functions behind a lambda-type target group |
| `aws.elb.targetgroup.ipTargets()` → `[]string` | the IP targets of an ip-type target group (containers, pods, on-prem hosts) |

## Why

The audit of the ingress chain found it broken in the middle: a listener's forward action was a raw `[]dict`, so it couldn't be followed to its target group; `lambdaTargets()` returned `nil` from a stub; and ip-type target backends were silently dropped. With these three, a listener resolves to its target groups and each target group resolves to its backends whatever the target type:

```mql
// internet-facing ALBs, their listeners, and the backends behind each
aws.elb.loadBalancers.where(scheme == "internet-facing") {
  listeners {
    port
    forwardTargetGroups {
      name targetType
      ec2Targets { instanceId }
      ipTargets
      lambdaTargets { name }
    }
  }
}
```

## Notes

- `forwardTargetGroups()` resolves target group ARNs (both the single-target shorthand and the weighted `ForwardConfig` form) by matching against the parent load balancer's `targetGroups()`, which the runtime already caches. Empty for non-forward default actions (redirect, fixed-response).
- `lambdaTargets()`/`ipTargets()` short-circuit by `targetType`, calling `DescribeTargetHealth` only for the matching kind. **No new IAM permissions** (`DescribeTargetHealth` was already used by `ec2Targets`).
- Rule-based routing to alternate target groups (listener `rules()` with host/path conditions) is a deliberate follow-up; this PR covers the default forward action.

## Testing

- `TestTargetGroupBackendTypeShortCircuit` — `lambdaTargets`/`ipTargets` return empty for mismatched target types without an API call.
- `TestListenerForwardTargetGroupsNoForwardAction` — a non-forwarding default action resolves to an empty list without touching the load balancer.
- Full `providers/aws/resources` test package passes.
- Note: the test account has no load balancers, so the positive resolution paths were not exercised live; the queries compile and the resolution reuses the live-verified target-group/health enumeration.
