### PR TITLE
🐛 terraform: show module-qualified address in plan check failures

### DIFF
--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -296,7 +296,7 @@ terraform.plan.variable @defaults("name value") {
 // when the change applies to a deposed object), the typed
 // `proposedChange` describing the actions and before / after values,
 // and the human-readable `actionReason`.
-terraform.plan.resourceChange @defaults("type name") {
+terraform.plan.resourceChange @defaults("address") {
   // Resource address
   address string
   // Resource previous address


### PR DESCRIPTION
## What

Make failing Terraform **plan** checks actually actionable by showing the
module-qualified resource address in the output.

`terraform.plan.resourceChange` defaulted to `@defaults("type name")`, so when
a check over `terraform.plan.resourceChanges` failed, the output showed only
the bare `type` and `name` and **dropped the module path**. A reviewer looking
at a failure had no way to tell *which module* the flagged resource lived in.

This switches the resource to `@defaults("address")`. The plan's `address` is
already the fully-qualified, module-prefixed path, so it encodes the module,
type, and name in a single field. The CLI printer renders each failing list
element by its default fields, so failing plan checks now point straight at
the offending resource **and its module**.

One-line schema change; no new field, no `.lr.versions` bump, no Go changes.

Addresses mondoohq/planning#696 — this is **step 1** ("make sure the failing
resource shows, pinpoint the failure in the plan"). Step 2 (linking back to the
`.tf` source line) is a separate, larger effort: the plan JSON carries no source
location, so it needs cross-referencing the plan `configuration` against the
parsed HCL blocks.

## Verification

Built and installed the provider, then ran a failing encryption check against a
plan with resources at three module depths (root, one module deep, two modules
deep):

```
terraform.plan.resourceChanges.all(change.after["storage_encrypted"] == true)
```

**Before — `@defaults("type name")`** (module path lost):

```
0: terraform.plan.resourceChange name="root" type="aws_db_instance" {
1: terraform.plan.resourceChange name="data" type="aws_db_instance" {
2: terraform.plan.resourceChange name="private" type="aws_db_instance" {
```

**After — `@defaults("address")`** (this PR — module shown, no redundancy):

```
0: terraform.plan.resourceChange address="aws_db_instance.root" {
1: terraform.plan.resourceChange address="module.storage.aws_db_instance.data" {
2: terraform.plan.resourceChange address="module.network.module.subnets.aws_db_instance.private" {
```

**Alternative considered — `@defaults("address type name")`** (rejected: `type`
and `name` are already contained in `address`, so they only add noise):

```
0: terraform.plan.resourceChange name="root" address="aws_db_instance.root" type="aws_db_instance" {
1: terraform.plan.resourceChange name="data" address="module.storage.aws_db_instance.data" type="aws_db_instance" {
2: terraform.plan.resourceChange name="private" address="module.network.module.subnets.aws_db_instance.private" type="aws_db_instance" {
```
