### PR TITLE
⭐ azure: traverse private-link reachability (endpoint → subnet → vnet)

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2414,6 +2414,12 @@ azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   privateLinkServiceNetworkPolicies string
   // Whether default outbound access is enabled for VMs in the subnet
   defaultOutboundAccess bool
+  // Virtual network the subnet belongs to; null when the subnet ID has no parent virtual network
+  //
+  // Resolves the parent virtual network so its peerings and address space can
+  // be traversed, extending a reachability path from the subnet to peered
+  // networks that can reach it.
+  virtualNetwork() azure.subscription.networkService.virtualNetwork
   // Network Security Group attached to the subnet; null when no NSG is associated
   networkSecurityGroup() azure.subscription.networkService.securityGroup
   // Route table attached to the subnet; null when no route table is associated
@@ -3447,7 +3453,17 @@ private azure.subscription.networkService.privateEndpoint @defaults("id name loc
   // Provisioning state of the private endpoint
   provisioningState string
   // Subnet ID from which the private IP is allocated
-  subnetId string
+  //
+  // Deprecated in favor of subnet.
+  subnetId @maturity("deprecated") string
+  // Subnet the private endpoint's network interface is allocated in; null when the endpoint has no subnet
+  //
+  // Resolves the subnet hosting the private endpoint so its network security
+  // group, route table, address space, and virtual network can be examined.
+  // This is the network location from which the linked resource is privately
+  // reachable, completing a private-access path from a virtual network to the
+  // resource behind the endpoint.
+  subnet() azure.subscription.networkService.subnet
   // Custom name of the network interface attached to the private endpoint
   customNetworkInterfaceName string
   // Billing SKU of the private endpoint ("Fixed" or "PayAsYouGo")
@@ -5183,7 +5199,15 @@ private azure.subscription.storageService.account.privateEndpointConnection @def
   // Resource type
   type string
   // ARM resource ID of the consumer-side private endpoint, when present
-  privateEndpointId string
+  //
+  // Deprecated in favor of privateEndpoint.
+  privateEndpointId @maturity("deprecated") string
+  // Consumer-side private endpoint, or null when the connection has none
+  //
+  // Resolves the private endpoint connecting to this storage account so the
+  // subnet and virtual network it is reachable from can be traversed, giving
+  // the private-access path into the account.
+  privateEndpoint() azure.subscription.networkService.privateEndpoint
   // Connection status ("Approved", "Pending", "Rejected", "Disconnected")
   status string
   // Reason for the current status

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4976,6 +4976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.subnet.defaultOutboundAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetDefaultOutboundAccess()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.networkService.subnet.virtualNetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetVirtualNetwork()).ToDataRes(types.Resource("azure.subscription.networkService.virtualNetwork"))
+	},
 	"azure.subscription.networkService.subnet.networkSecurityGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetNetworkSecurityGroup()).ToDataRes(types.Resource("azure.subscription.networkService.securityGroup"))
 	},
@@ -6043,6 +6046,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.privateEndpoint.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetSubnetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetCustomNetworkInterfaceName()).ToDataRes(types.String)
@@ -7924,6 +7930,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetPrivateEndpointId()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetPrivateEndpoint()).ToDataRes(types.Resource("azure.subscription.networkService.privateEndpoint"))
 	},
 	"azure.subscription.storageService.account.privateEndpointConnection.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetStatus()).ToDataRes(types.String)
@@ -21440,6 +21449,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSubnet).DefaultOutboundAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.subnet.virtualNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSubnet).VirtualNetwork, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.subnet.networkSecurityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSubnet).NetworkSecurityGroup, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup](v.Value, v.Error)
 		return
@@ -22994,6 +23007,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.privateEndpoint.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25722,6 +25739,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).PrivateEndpointId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).PrivateEndpoint, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.privateEndpointConnection.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49044,6 +49065,7 @@ type mqlAzureSubscriptionNetworkServiceSubnet struct {
 	PrivateEndpointNetworkPolicies    plugin.TValue[string]
 	PrivateLinkServiceNetworkPolicies plugin.TValue[string]
 	DefaultOutboundAccess             plugin.TValue[bool]
+	VirtualNetwork                    plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork]
 	NetworkSecurityGroup              plugin.TValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup]
 	RouteTable                        plugin.TValue[*mqlAzureSubscriptionNetworkServiceRouteTable]
 	ServiceEndpoints                  plugin.TValue[[]any]
@@ -49129,6 +49151,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetPrivateLinkServiceNetworkP
 
 func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetDefaultOutboundAccess() *plugin.TValue[bool] {
 	return &c.DefaultOutboundAccess
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetVirtualNetwork() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](&c.VirtualNetwork, func() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.subnet", c.__id, "virtualNetwork")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+			}
+		}
+
+		return c.virtualNetwork()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetNetworkSecurityGroup() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup] {
@@ -52879,6 +52917,7 @@ type mqlAzureSubscriptionNetworkServicePrivateEndpoint struct {
 	Type                                plugin.TValue[string]
 	ProvisioningState                   plugin.TValue[string]
 	SubnetId                            plugin.TValue[string]
+	Subnet                              plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	CustomNetworkInterfaceName          plugin.TValue[string]
 	BillingSku                          plugin.TValue[string]
 	PrivateLinkServiceConnections       plugin.TValue[[]any]
@@ -52944,6 +52983,22 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetProvisioningState
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnetId() *plugin.TValue[string] {
 	return &c.SubnetId
+}
+
+func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.privateEndpoint", c.__id, "subnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.subnet()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetCustomNetworkInterfaceName() *plugin.TValue[string] {
@@ -59033,6 +59088,7 @@ type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection struct {
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
 	PrivateEndpointId plugin.TValue[string]
+	PrivateEndpoint   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint]
 	Status            plugin.TValue[string]
 	Description       plugin.TValue[string]
 	ActionsRequired   plugin.TValue[string]
@@ -59090,6 +59146,22 @@ func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) Get
 
 func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetPrivateEndpointId() *plugin.TValue[string] {
 	return &c.PrivateEndpointId
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetPrivateEndpoint() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServicePrivateEndpoint](&c.PrivateEndpoint, func() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.privateEndpointConnection", c.__id, "privateEndpoint")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint), nil
+			}
+		}
+
+		return c.privateEndpoint()
+	})
 }
 
 func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetStatus() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3596,6 +3596,7 @@ azure.subscription.networkService.privateEndpoint.serviceconnection.name 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService 13.9.3
 azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.requestMessage 11.4.28
+azure.subscription.networkService.privateEndpoint.subnet 13.26.1
 azure.subscription.networkService.privateEndpoint.subnetId 11.4.28
 azure.subscription.networkService.privateEndpoint.tags 11.4.28
 azure.subscription.networkService.privateEndpoint.type 11.4.28
@@ -3820,6 +3821,7 @@ azure.subscription.networkService.subnet.serviceEndpoint.provisioningState 13.12
 azure.subscription.networkService.subnet.serviceEndpoint.service 13.12.2
 azure.subscription.networkService.subnet.serviceEndpoints 13.12.2
 azure.subscription.networkService.subnet.type 9.0.8
+azure.subscription.networkService.subnet.virtualNetwork 13.26.1
 azure.subscription.networkService.subscriptionId 9.0.1
 azure.subscription.networkService.trafficManagerProfile 13.12.2
 azure.subscription.networkService.trafficManagerProfile.allowedEndpointRecordTypes 13.12.2
@@ -5132,6 +5134,7 @@ azure.subscription.storageService.account.privateEndpointConnection.actionsRequi
 azure.subscription.storageService.account.privateEndpointConnection.description 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.id 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.name 13.10.2
+azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint 13.26.1
 azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.provisioningState 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.status 13.10.2

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1959,6 +1959,22 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 	return res.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint), nil
 }
 
+// subnet resolves the subnet the private endpoint's network interface is
+// allocated in, the network location from which the linked resource is
+// privately reachable.
+func (a *mqlAzureSubscriptionNetworkServicePrivateEndpoint) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.SubnetId.Data == "" {
+		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.SubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
 func initAzureSubscriptionNetworkServicePrivateEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 {
 		return args, nil, nil
@@ -4373,6 +4389,34 @@ func (a *mqlAzureSubscriptionNetworkServiceSubnet) routeTable() (*mqlAzureSubscr
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionNetworkServiceRouteTable), nil
+}
+
+// virtualNetworkIDFromSubnetID derives the parent virtual network's resource ID
+// from a subnet resource ID by trimming the trailing "/subnets/<name>" segment.
+// It returns "" when the ID has no "/subnets/" segment.
+func virtualNetworkIDFromSubnetID(subnetID string) string {
+	idx := strings.Index(strings.ToLower(subnetID), "/subnets/")
+	if idx < 0 {
+		return ""
+	}
+	return subnetID[:idx]
+}
+
+// virtualNetwork resolves the parent virtual network of the subnet so its
+// peerings and address space can be traversed, extending a reachability path to
+// networks peered with the one hosting the subnet.
+func (a *mqlAzureSubscriptionNetworkServiceSubnet) virtualNetwork() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+	vnetID := virtualNetworkIDFromSubnetID(a.Id.Data)
+	if vnetID == "" {
+		a.VirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetwork",
+		map[string]*llx.RawData{"id": llx.StringData(vnetID)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
 }
 
 func azureSubnetServiceEndpointToMql(runtime *plugin.Runtime, subnetID string, idx int, se *network.ServiceEndpointPropertiesFormat) (*mqlAzureSubscriptionNetworkServiceSubnetServiceEndpoint, error) {

--- a/providers/azure/resources/network_test.go
+++ b/providers/azure/resources/network_test.go
@@ -147,3 +147,19 @@ func TestParseAzurePortRange(t *testing.T) {
 	assert.Equal(t, "1024", ranges[2].FromPort)
 	assert.Equal(t, "65535", ranges[2].ToPort)
 }
+
+func TestVirtualNetworkIDFromSubnetID(t *testing.T) {
+	base := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/my-vnet"
+	t.Run("derives the parent virtual network ID", func(t *testing.T) {
+		assert.Equal(t, base, virtualNetworkIDFromSubnetID(base+"/subnets/my-subnet"))
+	})
+	t.Run("case-insensitive on the /subnets/ segment", func(t *testing.T) {
+		assert.Equal(t, base, virtualNetworkIDFromSubnetID(base+"/Subnets/my-subnet"))
+	})
+	t.Run("returns empty when there is no subnets segment", func(t *testing.T) {
+		assert.Equal(t, "", virtualNetworkIDFromSubnetID(base))
+	})
+	t.Run("returns empty for an empty ID", func(t *testing.T) {
+		assert.Equal(t, "", virtualNetworkIDFromSubnetID(""))
+	})
+}

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -30,6 +30,22 @@ func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) id(
 	return a.Id.Data, nil
 }
 
+// privateEndpoint resolves the consumer-side private endpoint of this
+// connection so the subnet and virtual network it is reachable from can be
+// traversed, giving the private-access path into the storage account.
+func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) privateEndpoint() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {
+	if a.PrivateEndpointId.Data == "" {
+		a.PrivateEndpoint.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.privateEndpoint",
+		map[string]*llx.RawData{"id": llx.StringData(a.PrivateEndpointId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint), nil
+}
+
 func (a *mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy) id() (string, error) {
 	return a.Id.Data, nil
 }


### PR DESCRIPTION
## What

Completes the **private-access** leg of an Azure reachability path. PaaS resources already reach their private endpoint (`privateEndpointConnections → privateEndpoint()`), but the chain dead-ended at a raw subnet ID. This makes it fully traversable, so a single query answers *"what network location can privately reach this resource?"*:

```mql
azure.subscription.storageService.accounts {
  name
  privateEndpointConnections {
    status
    privateEndpoint { subnet { name networkSecurityGroup { name } virtualNetwork { name } } }
  }
}
```

## How

Three typed edges (all resolving modeled resources by ID that Azure already returns):

1. **`privateEndpoint.subnet()`** — the subnet the endpoint's interface is allocated in, exposing its NSG, route table, and address space. Deprecates the now-duplicate `subnetId` raw string.
2. **`subnet.virtualNetwork()`** — the parent virtual network (derived from the subnet ID), so its peerings and address space can be traversed to networks peered with the subnet.
3. **`storageService.account.privateEndpointConnection.privateEndpoint()`** — the consumer-side endpoint. The storage account's *own* connection type only carried a raw `privateEndpointId` (unlike the shared `azure.subscription.privateEndpointConnection`, which already has the typed accessor), so the reverse chain broke for storage. Deprecates that duplicate raw string.

Schema-only additions are the three accessors (three `.lr.versions` entries at `13.26.1`); the two `*Id` deprecations keep their versions. **No new IAM permission** — every edge resolves an already-modeled resource by ID, so `permissions.json` is unchanged.

## Scope note

I deliberately left two edges out to keep this focused and fully-populated:
- **`privateEndpoint.networkInterfaces()`** — the `interface` resource has no `init`, so a NIC resolved by ID alone would be a half-populated husk (only `effectiveSecurityRules`/`effectiveRouteTable`, which key off the ID, would work). Deferred rather than ship a partial resource.
- **Private DNS zones as a resource** — a larger add (new client); not required to complete the reachability chain.

## Tests

- Unit test (`TestVirtualNetworkIDFromSubnetID`) covers the subnet→vnet ID derivation: normal, case-insensitive `/subnets/`, no-segment, and empty input.
- **Live-verified** on a real subscription (`--auto-update=false`): the forward chain (`privateEndpoints → subnet → networkSecurityGroup/virtualNetwork`) and the reverse chain (`storage account → privateEndpointConnections (Approved) → privateEndpoint → subnet (10.x/24) → virtualNetwork`) both resolve with real data.

## Series context

Third of a three-PR sweep making Azure attack paths queryable in MQL: #8968 (exposure fidelity — public reachability), #8974 (identity → privilege), and this one (private reachability). Together they let one query walk a resource's public and private reachability plus what its identity is authorized to do.
