### PR TITLE
⭐ hetzner: server backupsEnabled + SSH key algorithm/bits

### DIFF
--- a/providers/hetzner/go.mod
+++ b/providers/hetzner/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.27.4
+	golang.org/x/crypto v0.53.0
 )
 
 require (
@@ -96,7 +97,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/providers/hetzner/go.sum
+++ b/providers/hetzner/go.sum
@@ -107,8 +107,6 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
-github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
-github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/containerd/typeurl/v2 v2.3.0 h1:HZHPhRWo5XMy3QGQoPrUzbW/2ckwjfweHmOwlkIrPAQ=
 github.com/containerd/typeurl/v2 v2.3.0/go.mod h1:Qk+PAdUYArVj41TnGi6rJ+48RF0PkcTc4i/taoBcK0w=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
@@ -124,10 +122,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v29.6.1+incompatible h1:oO7F4nn3Ovr/5TlfTUWFbMwBSS/B7Xs6Epv26gBrUP8=
 github.com/docker/cli v29.6.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
-github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
-github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.8 h1:bIREROb7So6PRlq6KTtdS9MPEjC29OQRkFNlvK2OX8Q=
 github.com/docker/docker-credential-helpers v0.9.8/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
@@ -197,8 +191,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-containerregistry v0.20.7 h1:24VGNpS0IwrOZ2ms2P1QE3Xa5X9p4phx0aUgzYzHW6I=
-github.com/google/go-containerregistry v0.20.7/go.mod h1:Lx5LCZQjLH1QBaMPeGwsME9biPeo1lPx6lbGj/UmzgM=
+github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnOhzei4X2DMW9IU=
+github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v1.20.1 h1:22uLWFvVcxhJ+j3dJ99NNfwGyHynxCmjhYsrcwqbY60=
@@ -421,8 +415,6 @@ github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 h1:2f304B10
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0/go.mod h1:278M4p8WsNh3n4a1eqiFcV2FGk7wE5fwUpUom9mK9lE=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
-github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -113,6 +113,8 @@ private hetzner.server @defaults("id name status") {
   loadBalancers() []hetzner.loadBalancer
   // Backup window (e.g., "22-02"); empty if backups disabled
   backupWindow string
+  // Whether automated backups are enabled (a backup window is set)
+  backupsEnabled bool
   // Whether rescue mode is enabled
   rescueEnabled bool
   // Whether the server is locked (Hetzner-side lock)
@@ -281,6 +283,18 @@ private hetzner.sshKey @defaults("id name fingerprint") {
   fingerprint string
   // Public key content
   publicKey string
+  // Key algorithm parsed from the public key
+  //
+  // The key type as it appears in the public key, for example
+  // ssh-ed25519, ssh-rsa, ecdsa-sha2-nistp256, or ssh-dss. Empty when
+  // the public key cannot be parsed.
+  algorithm string
+  // Key size in bits parsed from the public key
+  //
+  // The modulus size for RSA/DSA keys or the curve size for ECDSA keys.
+  // Ed25519 keys report 256. 0 when the public key cannot be parsed or
+  // the size cannot be determined.
+  bits int
   // Creation timestamp
   created time
   // User-defined labels for organizing the resource

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -375,6 +375,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.backupWindow": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetBackupWindow()).ToDataRes(types.String)
 	},
+	"hetzner.server.backupsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetBackupsEnabled()).ToDataRes(types.Bool)
+	},
 	"hetzner.server.rescueEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetRescueEnabled()).ToDataRes(types.Bool)
 	},
@@ -560,6 +563,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.sshKey.publicKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerSshKey).GetPublicKey()).ToDataRes(types.String)
+	},
+	"hetzner.sshKey.algorithm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerSshKey).GetAlgorithm()).ToDataRes(types.String)
+	},
+	"hetzner.sshKey.bits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerSshKey).GetBits()).ToDataRes(types.Int)
 	},
 	"hetzner.sshKey.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerSshKey).GetCreated()).ToDataRes(types.Time)
@@ -1417,6 +1426,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerServer).BackupWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"hetzner.server.backupsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).BackupsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"hetzner.server.rescueEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServer).RescueEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -1691,6 +1704,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.sshKey.publicKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerSshKey).PublicKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.sshKey.algorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerSshKey).Algorithm, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.sshKey.bits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerSshKey).Bits, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"hetzner.sshKey.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3078,6 +3099,7 @@ type mqlHetznerServer struct {
 	Exposure          plugin.TValue[*mqlHetznerNetworkExposure]
 	LoadBalancers     plugin.TValue[[]any]
 	BackupWindow      plugin.TValue[string]
+	BackupsEnabled    plugin.TValue[bool]
 	RescueEnabled     plugin.TValue[bool]
 	Locked            plugin.TValue[bool]
 	IncludedTraffic   plugin.TValue[int64]
@@ -3380,6 +3402,10 @@ func (c *mqlHetznerServer) GetLoadBalancers() *plugin.TValue[[]any] {
 
 func (c *mqlHetznerServer) GetBackupWindow() *plugin.TValue[string] {
 	return &c.BackupWindow
+}
+
+func (c *mqlHetznerServer) GetBackupsEnabled() *plugin.TValue[bool] {
+	return &c.BackupsEnabled
 }
 
 func (c *mqlHetznerServer) GetRescueEnabled() *plugin.TValue[bool] {
@@ -4027,6 +4053,8 @@ type mqlHetznerSshKey struct {
 	Name        plugin.TValue[string]
 	Fingerprint plugin.TValue[string]
 	PublicKey   plugin.TValue[string]
+	Algorithm   plugin.TValue[string]
+	Bits        plugin.TValue[int64]
 	Created     plugin.TValue[*time.Time]
 	Labels      plugin.TValue[map[string]any]
 }
@@ -4082,6 +4110,14 @@ func (c *mqlHetznerSshKey) GetFingerprint() *plugin.TValue[string] {
 
 func (c *mqlHetznerSshKey) GetPublicKey() *plugin.TValue[string] {
 	return &c.PublicKey
+}
+
+func (c *mqlHetznerSshKey) GetAlgorithm() *plugin.TValue[string] {
+	return &c.Algorithm
+}
+
+func (c *mqlHetznerSshKey) GetBits() *plugin.TValue[int64] {
+	return &c.Bits
 }
 
 func (c *mqlHetznerSshKey) GetCreated() *plugin.TValue[*time.Time] {

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -182,6 +182,7 @@ hetzner.primaryIp.type 13.0.1
 hetzner.primaryIps 13.0.1
 hetzner.server 13.0.1
 hetzner.server.backupWindow 13.0.1
+hetzner.server.backupsEnabled 13.5.2
 hetzner.server.created 13.0.1
 hetzner.server.datacenter 13.0.1
 hetzner.server.exposure 13.3.1
@@ -248,6 +249,8 @@ hetzner.serverType.storageType 13.0.1
 hetzner.serverTypes 13.0.1
 hetzner.servers 13.0.1
 hetzner.sshKey 13.0.1
+hetzner.sshKey.algorithm 13.5.2
+hetzner.sshKey.bits 13.5.2
 hetzner.sshKey.created 13.0.1
 hetzner.sshKey.fingerprint 13.0.1
 hetzner.sshKey.id 13.0.1

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -72,6 +72,7 @@ func newMqlHetznerServer(runtime *plugin.Runtime, s *hcloud.Server) (*mqlHetzner
 		"publicIpv6Blocked": llx.BoolData(s.PublicNet.IPv6.Blocked),
 		"publicIpv6DnsPtr":  dictArrayData(dnsPtrSliceFromMap(s.PublicNet.IPv6.DNSPtr)),
 		"backupWindow":      llx.StringData(s.BackupWindow),
+		"backupsEnabled":    llx.BoolData(s.BackupWindow != ""),
 		"rescueEnabled":     llx.BoolData(s.RescueEnabled),
 		"locked":            llx.BoolData(s.Locked),
 		"includedTraffic":   llx.IntData(int64(s.IncludedTraffic)),

--- a/providers/hetzner/resources/hetzner_sshkey.go
+++ b/providers/hetzner/resources/hetzner_sshkey.go
@@ -4,12 +4,40 @@
 package resources
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"fmt"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"golang.org/x/crypto/ssh"
 )
+
+// parseSSHPublicKey extracts the key algorithm and size in bits from an
+// OpenSSH-format public key. It returns ("", 0) when the key cannot be parsed
+// so weak-key audits can distinguish "unparseable" from a known algorithm.
+func parseSSHPublicKey(publicKey string) (algorithm string, bits int64) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	if err != nil || pub == nil {
+		return "", 0
+	}
+	algorithm = pub.Type()
+	ck, ok := pub.(ssh.CryptoPublicKey)
+	if !ok {
+		return algorithm, 0
+	}
+	switch k := ck.CryptoPublicKey().(type) {
+	case *rsa.PublicKey:
+		bits = int64(k.N.BitLen())
+	case *ecdsa.PublicKey:
+		bits = int64(k.Curve.Params().BitSize)
+	case ed25519.PublicKey:
+		bits = 256
+	}
+	return algorithm, bits
+}
 
 func (r *mqlHetznerSshKey) id() (string, error) {
 	return fmt.Sprintf("hetzner.sshKey/%d", r.Id.Data), nil
@@ -35,12 +63,15 @@ func (h *mqlHetzner) sshKeys() ([]any, error) {
 }
 
 func newMqlHetznerSshKey(runtime *plugin.Runtime, k *hcloud.SSHKey) (*mqlHetznerSshKey, error) {
+	algorithm, bits := parseSSHPublicKey(k.PublicKey)
 	res, err := CreateResource(runtime, "hetzner.sshKey", map[string]*llx.RawData{
 		"__id":        llx.StringData(fmt.Sprintf("hetzner.sshKey/%d", k.ID)),
 		"id":          llx.IntData(k.ID),
 		"name":        llx.StringData(k.Name),
 		"fingerprint": llx.StringData(k.Fingerprint),
 		"publicKey":   llx.StringData(k.PublicKey),
+		"algorithm":   llx.StringData(algorithm),
+		"bits":        llx.IntData(bits),
 		"created":     llx.TimeDataPtr(timePtr(k.Created)),
 		"labels":      labelData(k.Labels),
 	})

--- a/providers/hetzner/resources/hetzner_sshkey_test.go
+++ b/providers/hetzner/resources/hetzner_sshkey_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSSHPublicKey(t *testing.T) {
+	tests := []struct {
+		name          string
+		publicKey     string
+		wantAlgorithm string
+		wantBits      int64
+	}{
+		{
+			name:          "ed25519",
+			publicKey:     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIATxrDDkLHMi0EMdsCES8icnsrbj+2ra3lsm2cjefUA7 test",
+			wantAlgorithm: "ssh-ed25519",
+			wantBits:      256,
+		},
+		{
+			name:          "rsa 2048",
+			publicKey:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCzWUJ5o5nE8AvOzLTV45xJ7b7U3vcH3idgxSQRGumbgXR0JY2O36R6Da6reu+sy1Nio3QjHNX/0prUscJli/N1F8g512wDFwhbFtIUW5J3J4Np2PuGJftxjD119w4uanp47E7kj76IX1TuS86RyZXAAlOJ3BWIrDR/TCoCEdYfCl8yydaIv8Ook5ip1qjZi7JP/RtXagiFOTtvbOmUBeTFz2hDalk6un+l0V4sOE3taULMfaFRwhBi+XeNlnfSmsl1+Bp/T3qJMxLsgRV1AEhwg6hestMGN49TB/YIogiMhAcM8ACF47HIxDMeoNxZJmuRg2tTkDLh4DAG02czba0l test",
+			wantAlgorithm: "ssh-rsa",
+			wantBits:      2048,
+		},
+		{
+			name:          "ecdsa nistp256",
+			publicKey:     "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHoiyNRU8Tk5rBs6ve4wExUzriltXZ/bl8YiuPfd7nF1kC894F306jKgJE0/0JIWSIcMWKeu1o6+e6fa64TwYig= test",
+			wantAlgorithm: "ecdsa-sha2-nistp256",
+			wantBits:      256,
+		},
+		{
+			name:          "unparseable",
+			publicKey:     "not a valid key",
+			wantAlgorithm: "",
+			wantBits:      0,
+		},
+		{
+			name:          "empty",
+			publicKey:     "",
+			wantAlgorithm: "",
+			wantBits:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			algorithm, bits := parseSSHPublicKey(tt.publicKey)
+			assert.Equal(t, tt.wantAlgorithm, algorithm)
+			assert.Equal(t, tt.wantBits, bits)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds three security-context fields to the Hetzner Cloud provider, each derived from data the API already returns (no new API calls, no new IAM permissions):

| Field | Type | Derivation |
|---|---|---|
| `hetzner.server.backupsEnabled` | `bool` | `backupWindow != ""` |
| `hetzner.sshKey.algorithm` | `string` | parsed from `publicKey` (e.g. `ssh-ed25519`, `ssh-rsa`, `ecdsa-sha2-nistp256`, `ssh-dss`) |
| `hetzner.sshKey.bits` | `int` | parsed from `publicKey` (RSA/DSA modulus, ECDSA curve size, Ed25519 → 256) |

## Why

These give policies clean predicates instead of string-matching. Examples:

```mql
hetzner.servers.where( backupsEnabled == false )
hetzner.sshKeys.where( algorithm == "ssh-rsa" && bits < 2048 )
hetzner.sshKeys.where( algorithm == "ssh-dss" )
```

## Testing

- `go build ./...`, `go vet`, `gofmt` clean; full provider test suite passes.
- New table-driven test (`hetzner_sshkey_test.go`) covers ed25519, rsa-2048, ecdsa-nistp256, unparseable, and empty inputs.
