### PR TITLE
⭐ azure: expose system-assigned identity on internet-facing app resources

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -696,6 +696,10 @@ func (a *mqlAzureSubscriptionAksServiceCluster) userAssignedIdentities() ([]any,
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionAksServiceCluster) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
+}
+
 func (a *mqlAzureSubscriptionAksServiceCluster) diskEncryptionSet() (*mqlAzureSubscriptionComputeServiceDiskEncryptionSet, error) {
 	if a.cacheDiskEncryptionSetId == "" {
 		a.DiskEncryptionSet.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -33,6 +33,10 @@ func (a *mqlAzureSubscriptionApiManagementServiceService) userAssignedIdentities
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionApiManagementServiceService) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, a.TenantId.Data, &a.SystemAssignedIdentity)
+}
+
 func (a *mqlAzureSubscriptionApiManagementServiceService) privateEndpointConnections() ([]any, error) {
 	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -248,7 +248,7 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) userAssignedIdenti
 }
 
 func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
 }
 
 // managedEnvironment resolves the parent managed environment of the container

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -247,6 +247,10 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) userAssignedIdenti
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
+}
+
 // managedEnvironment resolves the parent managed environment of the container
 // app from its ARM resource ID. The runtime cache short-circuits environments
 // already listed by managedEnvironments(); otherwise the init fetches it on

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -5429,6 +5429,12 @@ azure.subscription.webService.appsite @defaults("id name location") {
   identityType string
   // Principal ID of the app's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
+  // System-assigned managed identity of the app; null when no system-assigned identity is enabled
+  //
+  // Resolves the system-assigned identity so its role assignments, and their
+  // role definitions and permissions, can be traversed, completing the
+  // resource-to-privilege leg of an attack path.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the app
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Whether the app requires HTTPS only
@@ -9066,6 +9072,12 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   identity dict
   // Principal ID of the cluster's system-assigned control-plane managed identity; empty when a user-assigned identity is used
   principalId string
+  // System-assigned control-plane managed identity of the cluster; null when a user-assigned identity is used
+  //
+  // Resolves the system-assigned identity so its role assignments, and their
+  // role definitions and permissions, can be traversed, completing the
+  // resource-to-privilege leg of an attack path.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the cluster control plane
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Disk encryption set used to encrypt cluster OS and data disks with a customer-managed key
@@ -10741,6 +10753,12 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   managedServiceIdentityId @maturity("deprecated") string
   // Principal ID of the function app's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
+  // System-assigned managed identity of the function app; null when no system-assigned identity is enabled
+  //
+  // Resolves the system-assigned identity so its role assignments, and their
+  // role definitions and permissions, can be traversed, completing the
+  // resource-to-privilege leg of an attack path.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the function app
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Identity used to resolve Key Vault references in app settings and connection strings (resource ID of a user-assigned identity, or "SystemAssigned")
@@ -11838,6 +11856,12 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   identity @maturity("deprecated") dict
   // Principal ID of the container app's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
+  // System-assigned managed identity of the container app; null when no system-assigned identity is enabled
+  //
+  // Resolves the system-assigned identity so its role assignments, and their
+  // role definitions and permissions, can be traversed, completing the
+  // resource-to-privilege leg of an attack path.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities attached to the container app
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Container registry references (server, identity, passwordSecretRef)
@@ -12311,6 +12335,12 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   principalId string
   // Tenant ID of the system-assigned managed identity
   tenantId string
+  // System-assigned managed identity of the service; null when no system-assigned identity is enabled
+  //
+  // Resolves the system-assigned identity so its role assignments, and their
+  // role definitions and permissions, can be traversed, completing the
+  // resource-to-privilege leg of an attack path.
+  systemAssignedIdentity() azure.subscription.managedIdentity
   // User-assigned managed identities associated with the service
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Public load-balanced IPv4 addresses of the service in its primary region (Basic / Standard / Premium / Isolated SKUs)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -8141,6 +8141,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.webService.appsite.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.webService.appsite.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
@@ -12434,6 +12437,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.aksService.cluster.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.aksService.cluster.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.aksService.cluster.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
@@ -14330,6 +14336,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.functionsService.functionApp.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.functionsService.functionApp.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.functionsService.functionApp.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
@@ -15497,6 +15506,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.containerApp.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetPrincipalId()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerAppService.containerApp.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
+	},
 	"azure.subscription.containerAppService.containerApp.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
@@ -16036,6 +16048,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.apiManagementService.service.tenantId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.apiManagementService.service.systemAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetSystemAssignedIdentity()).ToDataRes(types.Resource("azure.subscription.managedIdentity"))
 	},
 	"azure.subscription.apiManagementService.service.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
@@ -26049,6 +26064,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsite).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsite.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -32269,6 +32288,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAksServiceCluster).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.aksService.cluster.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAksServiceCluster).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.aksService.cluster.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -35061,6 +35084,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.functionsService.functionApp.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.functionsService.functionApp.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -36777,6 +36804,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerAppService.containerApp.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerAppService.containerApp.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -37539,6 +37570,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.apiManagementService.service.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionApiManagementServiceService).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.apiManagementService.service.systemAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionApiManagementServiceService).SystemAssignedIdentity, ok = plugin.RawToTValue[*mqlAzureSubscriptionManagedIdentity](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.apiManagementService.service.userAssignedIdentities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59801,6 +59836,7 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	Identity                     plugin.TValue[any]
 	IdentityType                 plugin.TValue[string]
 	PrincipalId                  plugin.TValue[string]
+	SystemAssignedIdentity       plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities       plugin.TValue[[]any]
 	HttpsOnly                    plugin.TValue[bool]
 	ClientCertEnabled            plugin.TValue[bool]
@@ -59911,6 +59947,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentityType() *plugin.TValue
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetUserAssignedIdentities() *plugin.TValue[[]any] {
@@ -74494,6 +74546,7 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	IdentityBindings                  plugin.TValue[[]any]
 	Identity                          plugin.TValue[any]
 	PrincipalId                       plugin.TValue[string]
+	SystemAssignedIdentity            plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities            plugin.TValue[[]any]
 	DiskEncryptionSet                 plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
 	KubeletIdentity                   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
@@ -74810,6 +74863,22 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetIdentity() *plugin.TValue[any
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionAksServiceCluster) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.aksService.cluster", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetUserAssignedIdentities() *plugin.TValue[[]any] {
@@ -81852,6 +81921,7 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	ClientCertMode            plugin.TValue[string]
 	ManagedServiceIdentityId  plugin.TValue[string]
 	PrincipalId               plugin.TValue[string]
+	SystemAssignedIdentity    plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities    plugin.TValue[[]any]
 	KeyVaultReferenceIdentity plugin.TValue[string]
 	PublicNetworkAccess       plugin.TValue[string]
@@ -81948,6 +82018,22 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetManagedServiceIdent
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetUserAssignedIdentities() *plugin.TValue[[]any] {
@@ -86279,6 +86365,7 @@ type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	ScaleRules               plugin.TValue[[]any]
 	Identity                 plugin.TValue[any]
 	PrincipalId              plugin.TValue[string]
+	SystemAssignedIdentity   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities   plugin.TValue[[]any]
 	Registries               plugin.TValue[[]any]
 	RegistryAuthUsesIdentity plugin.TValue[bool]
@@ -86454,6 +86541,22 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetIdentity() *plu
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetPrincipalId() *plugin.TValue[string] {
 	return &c.PrincipalId
+}
+
+func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerAppService.containerApp", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetUserAssignedIdentities() *plugin.TValue[[]any] {
@@ -87811,6 +87914,7 @@ type mqlAzureSubscriptionApiManagementServiceService struct {
 	IdentityType                   plugin.TValue[string]
 	PrincipalId                    plugin.TValue[string]
 	TenantId                       plugin.TValue[string]
+	SystemAssignedIdentity         plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities         plugin.TValue[[]any]
 	PublicIpAddresses              plugin.TValue[[]any]
 	PrivateIpAddresses             plugin.TValue[[]any]
@@ -88006,6 +88110,22 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrincipalId() *plug
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetTenantId() *plugin.TValue[string] {
 	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionApiManagementServiceService) GetSystemAssignedIdentity() *plugin.TValue[*mqlAzureSubscriptionManagedIdentity] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionManagedIdentity](&c.SystemAssignedIdentity, func() (*mqlAzureSubscriptionManagedIdentity, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.apiManagementService.service", c.__id, "systemAssignedIdentity")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionManagedIdentity), nil
+			}
+		}
+
+		return c.systemAssignedIdentity()
+	})
 }
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetUserAssignedIdentities() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -163,6 +163,7 @@ azure.subscription.aksService.cluster.servicePrincipalClientId 13.22.1
 azure.subscription.aksService.cluster.skuTier 13.1.8
 azure.subscription.aksService.cluster.storageProfile 9.0.1
 azure.subscription.aksService.cluster.supportPlan 13.1.8
+azure.subscription.aksService.cluster.systemAssignedIdentity 13.26.1
 azure.subscription.aksService.cluster.systemMetadata 13.19.2
 azure.subscription.aksService.cluster.tags 9.0.1
 azure.subscription.aksService.cluster.userAssignedIdentities 13.23.1
@@ -210,6 +211,7 @@ azure.subscription.apiManagementService.service.scmUrl 13.10.2
 azure.subscription.apiManagementService.service.skuCapacity 13.10.2
 azure.subscription.apiManagementService.service.skuName 13.10.2
 azure.subscription.apiManagementService.service.ssl30Enabled 13.24.1
+azure.subscription.apiManagementService.service.systemAssignedIdentity 13.26.1
 azure.subscription.apiManagementService.service.systemMetadata 13.22.1
 azure.subscription.apiManagementService.service.tags 13.10.2
 azure.subscription.apiManagementService.service.targetProvisioningState 13.10.2
@@ -1395,6 +1397,7 @@ azure.subscription.containerAppService.containerApp.runningStatus 13.11.3
 azure.subscription.containerAppService.containerApp.scaleRules 13.10.2
 azure.subscription.containerAppService.containerApp.secretNames 13.10.2
 azure.subscription.containerAppService.containerApp.stickySessions 13.10.2
+azure.subscription.containerAppService.containerApp.systemAssignedIdentity 13.26.1
 azure.subscription.containerAppService.containerApp.systemMetadata 13.22.1
 azure.subscription.containerAppService.containerApp.tags 13.10.2
 azure.subscription.containerAppService.containerApp.targetPort 13.10.2
@@ -2242,6 +2245,7 @@ azure.subscription.functionsService.functionApp.principalId 13.23.1
 azure.subscription.functionsService.functionApp.properties 13.3.3
 azure.subscription.functionsService.functionApp.publicNetworkAccess 13.18.1
 azure.subscription.functionsService.functionApp.state 13.3.3
+azure.subscription.functionsService.functionApp.systemAssignedIdentity 13.26.1
 azure.subscription.functionsService.functionApp.systemMetadata 13.22.1
 azure.subscription.functionsService.functionApp.tags 13.3.3
 azure.subscription.functionsService.functionApp.userAssignedIdentities 13.23.1
@@ -5351,6 +5355,7 @@ azure.subscription.webService.appsite.slots 11.3.85
 azure.subscription.webService.appsite.sshEnabled 13.1.8
 azure.subscription.webService.appsite.stack 9.0.1
 azure.subscription.webService.appsite.state 11.4.28
+azure.subscription.webService.appsite.systemAssignedIdentity 13.26.1
 azure.subscription.webService.appsite.systemMetadata 13.19.2
 azure.subscription.webService.appsite.tags 9.0.1
 azure.subscription.webService.appsite.type 9.0.1

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -307,13 +307,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) userAssignedIdentities() ([]any, 
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	tenantID := ""
-	if id, ok := a.Identity.Data.(map[string]any); ok {
-		if t, ok := id["tenantId"].(string); ok {
-			tenantID = t
-		}
-	}
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantID, &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -242,13 +242,7 @@ func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) userAssignedIdentities() 
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	tenantID := ""
-	if id, ok := a.Identity.Data.(map[string]any); ok {
-		if t, ok := id["tenantId"].(string); ok {
-			tenantID = t
-		}
-	}
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantID, &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) instances() ([]any, error) {

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -238,6 +238,10 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) userAssignedIdentities
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
+}
+
 func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) virtualNetworkSubnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
 	if a.VirtualNetworkSubnetId.Data == "" {
 		a.VirtualNetworkSubnet.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -239,6 +239,10 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) userAssignedIdentities
 }
 
 func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	// Unlike the other resources, the function app has no identity dict (it models
+	// identity as managedServiceIdentityId), so no tenant ID is available here;
+	// tenantID is cosmetic on the synthesized identity anyway, as role assignments
+	// resolve by principal ID.
 	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
 }
 

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -100,6 +100,17 @@ func newSystemAssignedManagedIdentity(runtime *plugin.Runtime, ownerID, principa
 	return r.(*mqlAzureSubscriptionManagedIdentity), nil
 }
 
+// tenantIDFromIdentityDict extracts the tenantId from a resource's identity dict
+// (the managed-identity block Azure returns on a resource), or "" when absent.
+func tenantIDFromIdentityDict(identity plugin.TValue[any]) string {
+	if id, ok := identity.Data.(map[string]any); ok {
+		if t, ok := id["tenantId"].(string); ok {
+			return t
+		}
+	}
+	return ""
+}
+
 func (a *mqlAzureSubscription) iam() (*mqlAzureSubscriptionAuthorizationService, error) {
 	svc, err := NewResource(a.MqlRuntime, "azure.subscription.authorizationService", map[string]*llx.RawData{
 		"subscriptionId": llx.StringData(a.SubscriptionId.Data),

--- a/providers/azure/resources/iam_test.go
+++ b/providers/azure/resources/iam_test.go
@@ -47,3 +47,20 @@ func TestFilterRoleAssignmentsByPrincipal(t *testing.T) {
 		assert.Len(t, filterRoleAssignmentsByPrincipal(mixed, "aaa"), 1)
 	})
 }
+
+func TestTenantIDFromIdentityDict(t *testing.T) {
+	t.Run("reads tenantId from the identity dict", func(t *testing.T) {
+		id := plugin.TValue[any]{Data: map[string]any{"tenantId": "t-123", "principalId": "p-1"}, State: plugin.StateIsSet}
+		assert.Equal(t, "t-123", tenantIDFromIdentityDict(id))
+	})
+	t.Run("empty when tenantId is absent", func(t *testing.T) {
+		id := plugin.TValue[any]{Data: map[string]any{"principalId": "p-1"}, State: plugin.StateIsSet}
+		assert.Equal(t, "", tenantIDFromIdentityDict(id))
+	})
+	t.Run("empty when the value is not a map", func(t *testing.T) {
+		assert.Equal(t, "", tenantIDFromIdentityDict(plugin.TValue[any]{Data: "not-a-map"}))
+	})
+	t.Run("empty when nil", func(t *testing.T) {
+		assert.Equal(t, "", tenantIDFromIdentityDict(plugin.TValue[any]{}))
+	})
+}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -659,7 +659,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) userAssignedIdentities() ([]any,
 }
 
 func (a *mqlAzureSubscriptionWebServiceAppsite) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
 }
 
 // keyVaultReferenceIdentityRef resolves the user-assigned managed identity used

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -658,6 +658,10 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) userAssignedIdentities() ([]any,
 	return resolveUserAssignedIdentities(a.MqlRuntime, a.cacheUserAssignedIdentityIds)
 }
 
+func (a *mqlAzureSubscriptionWebServiceAppsite) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, "", &a.SystemAssignedIdentity)
+}
+
 // keyVaultReferenceIdentityRef resolves the user-assigned managed identity used
 // to fetch Key Vault references in app settings. When the app uses its
 // system-assigned identity the raw value is "SystemAssigned" (not a resource


### PR DESCRIPTION
## What

Extends the resource-to-privilege leg of the Azure attack path (added for VMs and scale sets in #8974) to the other **internet-facing resources that carry a system-assigned managed identity**:

- App Service apps (`webService.appsite`)
- Function apps (`functionsService.functionApp`)
- Container Apps (`containerAppService.containerApp`)
- AKS clusters (`aksService.cluster`)
- API Management services (`apiManagementService.service`)

Each gains a `systemAssignedIdentity()` accessor, so the same `roleAssignments → role → permissions` chain works from these resources. Combined with the exposure work, a single query walks reachable → over-privileged across the common internet-facing compute/app surface:

```mql
azure.subscription.webService.appsites {
  name
  systemAssignedIdentity { roleAssignments { role.name scope } }
  userAssignedIdentities  { roleAssignments { role.name scope } }
}
```

## How

- All five accessors delegate to the shared `newSystemAssignedManagedIdentity` helper (from #8974), which represents the system-assigned identity as a managed identity keyed on its principal ID and sets the field null when no system-assigned identity is enabled.
- Tenant-ID extraction from a resource's identity dict is unified into a `tenantIDFromIdentityDict` helper; the existing VM and scale set accessors are refactored onto it (AKS uses it too; APIM reads its own `tenantId` field; the rest have no tenant field and pass `""` — the value is cosmetic, `roleAssignments` keys off the principal ID).

Schema additions are the five `systemAssignedIdentity` accessors (five `.lr.versions` entries at `13.26.1`). **No new IAM permission** — it reuses the subscription role-assignment list, so `permissions.json` is unchanged.

## Tests

- Unit test `TestTenantIDFromIdentityDict` covers the dict extraction (present / absent / non-map / nil).
- **Live-verified** the AKS accessor on a real subscription: it returns `null` for a cluster using a user-assigned identity (the correct result — its system-assigned `principalId` is empty). App Service / Functions / Container Apps / APIM are not present in the test subscription, so those accessors — structurally identical one-line delegations to the helper that #8974 verified populated on VMs — are covered by the shared helper's existing tests rather than live.

## Series context

Follows the three-PR attack-path sweep (#8968 exposure fidelity, #8974 identity→privilege, #8978 private-link reachability). This broadens the identity→privilege edge to more resource types.
