### PR TITLE
⭐ hetzner: cross-resource edges for load balancer and region rollups

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -448,6 +448,13 @@ hetzner.loadBalancer @defaults("id name") {
   services() []hetzner.loadBalancer.service
   // Targets behind the load balancer
   targets() []hetzner.loadBalancer.target
+  // Backend servers behind the load balancer
+  //
+  // The servers the load balancer forwards to, combining the direct
+  // server targets with the servers currently matched by any
+  // label_selector targets, deduplicated. The reverse of the load
+  // balancers listed on each server.
+  servers() []hetzner.server
   // Internet-exposure breakdown (public network combined with forwarding services)
   exposure() hetzner.network.exposure
   // Resource protection (delete)
@@ -510,6 +517,12 @@ private hetzner.loadBalancer.target @defaults("type") {
   server() hetzner.server
   // Label selector (only for type=label_selector)
   labelSelector string
+  // Servers resolved from the target's label selector
+  //
+  // The servers a label_selector target currently forwards to. Where
+  // labelSelector holds the selector expression, this lists the servers
+  // it actually matches. Empty for server and ip targets.
+  labelSelectorTargets() []hetzner.server
   // IP address (only for type=ip)
   ip string
 }
@@ -652,6 +665,8 @@ private hetzner.location @defaults("id name city") {
   longitude float
   // Network zone (eu-central, us-east, us-west)
   networkZone string
+  // Servers running in this location
+  servers() []hetzner.server
 }
 
 // Hetzner Cloud datacenter
@@ -671,6 +686,8 @@ private hetzner.datacenter @defaults("id name") {
   availableServerTypes() []hetzner.serverType
   // Server types available for migration into this datacenter
   serverTypesAvailableForMigration() []hetzner.serverType
+  // Servers running in this datacenter
+  servers() []hetzner.server
 }
 
 // Hetzner Cloud Storage Box (managed backup/file storage)

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -750,6 +750,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.loadBalancer.targets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancer).GetTargets()).ToDataRes(types.Array(types.Resource("hetzner.loadBalancer.target")))
 	},
+	"hetzner.loadBalancer.servers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancer).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
+	},
 	"hetzner.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancer).GetExposure()).ToDataRes(types.Resource("hetzner.network.exposure"))
 	},
@@ -824,6 +827,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.loadBalancer.target.labelSelector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerTarget).GetLabelSelector()).ToDataRes(types.String)
+	},
+	"hetzner.loadBalancer.target.labelSelectorTargets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancerTarget).GetLabelSelectorTargets()).ToDataRes(types.Array(types.Resource("hetzner.server")))
 	},
 	"hetzner.loadBalancer.target.ip": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerTarget).GetIp()).ToDataRes(types.String)
@@ -975,6 +981,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.location.networkZone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLocation).GetNetworkZone()).ToDataRes(types.String)
 	},
+	"hetzner.location.servers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLocation).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
+	},
 	"hetzner.datacenter.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerDatacenter).GetId()).ToDataRes(types.Int)
 	},
@@ -995,6 +1004,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.datacenter.serverTypesAvailableForMigration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerDatacenter).GetServerTypesAvailableForMigration()).ToDataRes(types.Array(types.Resource("hetzner.serverType")))
+	},
+	"hetzner.datacenter.servers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerDatacenter).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
 	},
 	"hetzner.storageBox.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBox).GetId()).ToDataRes(types.Int)
@@ -1974,6 +1986,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerLoadBalancer).Targets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"hetzner.loadBalancer.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancer).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"hetzner.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlHetznerNetworkExposure](v.Value, v.Error)
 		return
@@ -2084,6 +2100,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.loadBalancer.target.labelSelector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancerTarget).LabelSelector, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.loadBalancer.target.labelSelectorTargets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancerTarget).LabelSelectorTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"hetzner.loadBalancer.target.ip": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2310,6 +2330,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerLocation).NetworkZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"hetzner.location.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLocation).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"hetzner.datacenter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerDatacenter).__id, ok = v.Value.(string)
 		return
@@ -2340,6 +2364,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.datacenter.serverTypesAvailableForMigration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerDatacenter).ServerTypesAvailableForMigration, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"hetzner.datacenter.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerDatacenter).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"hetzner.storageBox.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4671,6 +4699,7 @@ type mqlHetznerLoadBalancer struct {
 	Algorithm        plugin.TValue[string]
 	Services         plugin.TValue[[]any]
 	Targets          plugin.TValue[[]any]
+	Servers          plugin.TValue[[]any]
 	Exposure         plugin.TValue[*mqlHetznerNetworkExposure]
 	Protection       plugin.TValue[any]
 	Labels           plugin.TValue[map[string]any]
@@ -4810,6 +4839,22 @@ func (c *mqlHetznerLoadBalancer) GetTargets() *plugin.TValue[[]any] {
 		}
 
 		return c.targets()
+	})
+}
+
+func (c *mqlHetznerLoadBalancer) GetServers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Servers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer", c.__id, "servers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.servers()
 	})
 }
 
@@ -5030,13 +5075,14 @@ type mqlHetznerLoadBalancerTarget struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlHetznerLoadBalancerTargetInternal
-	LoadBalancerId plugin.TValue[int64]
-	Type           plugin.TValue[string]
-	HealthStatus   plugin.TValue[[]any]
-	UsePrivateIp   plugin.TValue[bool]
-	Server         plugin.TValue[*mqlHetznerServer]
-	LabelSelector  plugin.TValue[string]
-	Ip             plugin.TValue[string]
+	LoadBalancerId       plugin.TValue[int64]
+	Type                 plugin.TValue[string]
+	HealthStatus         plugin.TValue[[]any]
+	UsePrivateIp         plugin.TValue[bool]
+	Server               plugin.TValue[*mqlHetznerServer]
+	LabelSelector        plugin.TValue[string]
+	LabelSelectorTargets plugin.TValue[[]any]
+	Ip                   plugin.TValue[string]
 }
 
 // createHetznerLoadBalancerTarget creates a new instance of this resource
@@ -5110,6 +5156,22 @@ func (c *mqlHetznerLoadBalancerTarget) GetServer() *plugin.TValue[*mqlHetznerSer
 
 func (c *mqlHetznerLoadBalancerTarget) GetLabelSelector() *plugin.TValue[string] {
 	return &c.LabelSelector
+}
+
+func (c *mqlHetznerLoadBalancerTarget) GetLabelSelectorTargets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LabelSelectorTargets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer.target", c.__id, "labelSelectorTargets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.labelSelectorTargets()
+	})
 }
 
 func (c *mqlHetznerLoadBalancerTarget) GetIp() *plugin.TValue[string] {
@@ -5614,6 +5676,7 @@ type mqlHetznerLocation struct {
 	Latitude    plugin.TValue[float64]
 	Longitude   plugin.TValue[float64]
 	NetworkZone plugin.TValue[string]
+	Servers     plugin.TValue[[]any]
 }
 
 // createHetznerLocation creates a new instance of this resource
@@ -5685,6 +5748,22 @@ func (c *mqlHetznerLocation) GetNetworkZone() *plugin.TValue[string] {
 	return &c.NetworkZone
 }
 
+func (c *mqlHetznerLocation) GetServers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Servers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.location", c.__id, "servers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.servers()
+	})
+}
+
 // mqlHetznerDatacenter for the hetzner.datacenter resource
 type mqlHetznerDatacenter struct {
 	MqlRuntime *plugin.Runtime
@@ -5697,6 +5776,7 @@ type mqlHetznerDatacenter struct {
 	SupportedServerTypes             plugin.TValue[[]any]
 	AvailableServerTypes             plugin.TValue[[]any]
 	ServerTypesAvailableForMigration plugin.TValue[[]any]
+	Servers                          plugin.TValue[[]any]
 }
 
 // createHetznerDatacenter creates a new instance of this resource
@@ -5809,6 +5889,22 @@ func (c *mqlHetznerDatacenter) GetServerTypesAvailableForMigration() *plugin.TVa
 		}
 
 		return c.serverTypesAvailableForMigration()
+	})
+}
+
+func (c *mqlHetznerDatacenter) GetServers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Servers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.datacenter", c.__id, "servers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.servers()
 	})
 }
 

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -2734,7 +2734,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlHetzner struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlHetznerInternal it will be used here
+	mqlHetznerInternal
 	Servers           plugin.TValue[[]any]
 	ServerTypes       plugin.TValue[[]any]
 	Images            plugin.TValue[[]any]

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -24,6 +24,7 @@ hetzner.datacenter.id 13.0.1
 hetzner.datacenter.location 13.0.1
 hetzner.datacenter.name 13.0.1
 hetzner.datacenter.serverTypesAvailableForMigration 13.0.1
+hetzner.datacenter.servers 13.5.2
 hetzner.datacenter.supportedServerTypes 13.0.1
 hetzner.datacenters 13.0.1
 hetzner.firewall 13.0.1
@@ -97,6 +98,7 @@ hetzner.loadBalancer.privateNet.network 13.0.1
 hetzner.loadBalancer.privateNet.networkId 13.0.1
 hetzner.loadBalancer.protection 13.0.1
 hetzner.loadBalancer.publicNet 13.0.1
+hetzner.loadBalancer.servers 13.5.2
 hetzner.loadBalancer.service 13.0.1
 hetzner.loadBalancer.service.certificates 13.0.1
 hetzner.loadBalancer.service.destinationPort 13.0.1
@@ -111,6 +113,7 @@ hetzner.loadBalancer.target 13.0.1
 hetzner.loadBalancer.target.healthStatus 13.0.1
 hetzner.loadBalancer.target.ip 13.0.1
 hetzner.loadBalancer.target.labelSelector 13.0.1
+hetzner.loadBalancer.target.labelSelectorTargets 13.5.2
 hetzner.loadBalancer.target.loadBalancerId 13.0.1
 hetzner.loadBalancer.target.server 13.0.1
 hetzner.loadBalancer.target.type 13.0.1
@@ -136,6 +139,7 @@ hetzner.location.latitude 13.0.1
 hetzner.location.longitude 13.0.1
 hetzner.location.name 13.0.1
 hetzner.location.networkZone 13.0.1
+hetzner.location.servers 13.5.2
 hetzner.locations 13.0.1
 hetzner.network 13.0.1
 hetzner.network.created 13.0.1

--- a/providers/hetzner/resources/hetzner_datacenter.go
+++ b/providers/hetzner/resources/hetzner_datacenter.go
@@ -93,6 +93,13 @@ func (m *mqlHetznerDatacenter) serverTypesAvailableForMigration() ([]any, error)
 	return serverTypeRefs(m.MqlRuntime, m.cacheServerTypesAvailableMigration)
 }
 
+func (m *mqlHetznerDatacenter) servers() ([]any, error) {
+	dcID := m.Id.Data
+	return serversMatching(m.MqlRuntime, func(s *hcloud.Server) bool {
+		return s.Datacenter != nil && s.Datacenter.ID == dcID
+	})
+}
+
 func serverTypeRefs(runtime *plugin.Runtime, types []*hcloud.ServerType) ([]any, error) {
 	out := make([]any, 0, len(types))
 	for _, t := range types {

--- a/providers/hetzner/resources/hetzner_loadbalancer.go
+++ b/providers/hetzner/resources/hetzner_loadbalancer.go
@@ -254,6 +254,11 @@ func (m *mqlHetznerLoadBalancerService) certificates() ([]any, error) {
 
 type mqlHetznerLoadBalancerTargetInternal struct {
 	cacheServerID int64
+	// cacheLabelSelectorServerIDs holds the servers a label_selector target
+	// currently resolves to (from the target's nested Targets), so
+	// labelSelectorTargets() can surface the effective backend set without a
+	// refetch.
+	cacheLabelSelectorServerIDs []int64
 }
 
 func (r *mqlHetznerLoadBalancerTarget) id() (string, error) {
@@ -289,6 +294,7 @@ func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx in
 
 	var keyForId string
 	var serverID int64
+	var labelSelectorServerIDs []int64
 	switch t.Type {
 	case hcloud.LoadBalancerTargetTypeServer:
 		if t.Server != nil && t.Server.Server != nil {
@@ -299,6 +305,7 @@ func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx in
 		}
 	case hcloud.LoadBalancerTargetTypeLabelSelector:
 		keyForId = fmt.Sprintf("label/%s", labelSelector)
+		labelSelectorServerIDs = targetServerIDs(t.Targets)
 	case hcloud.LoadBalancerTargetTypeIP:
 		keyForId = fmt.Sprintf("ip/%s", ip)
 	default:
@@ -319,6 +326,7 @@ func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx in
 	}
 	m := res.(*mqlHetznerLoadBalancerTarget)
 	m.cacheServerID = serverID
+	m.cacheLabelSelectorServerIDs = labelSelectorServerIDs
 	return m, nil
 }
 
@@ -334,4 +342,59 @@ func (m *mqlHetznerLoadBalancerTarget) server() (*mqlHetznerServer, error) {
 		return nil, err
 	}
 	return ref.(*mqlHetznerServer), nil
+}
+
+func (m *mqlHetznerLoadBalancerTarget) labelSelectorTargets() ([]any, error) {
+	return serverRefs(m.MqlRuntime, m.cacheLabelSelectorServerIDs)
+}
+
+// targetServerIDs extracts the deduplicated server IDs a label_selector
+// target resolves to. Hetzner nests the resolved server targets under the
+// label_selector target's Targets field.
+func targetServerIDs(targets []hcloud.LoadBalancerTarget) []int64 {
+	var ids []int64
+	seen := map[int64]struct{}{}
+	for _, t := range targets {
+		if t.Server == nil || t.Server.Server == nil {
+			continue
+		}
+		id := t.Server.Server.ID
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// servers returns the deduplicated backend servers behind the load balancer,
+// combining direct server targets with the servers matched by any
+// label_selector targets.
+func (m *mqlHetznerLoadBalancer) servers() ([]any, error) {
+	var ids []int64
+	seen := map[int64]struct{}{}
+	add := func(id int64) {
+		if id == 0 {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	for _, t := range m.cacheTargets {
+		switch t.Type {
+		case hcloud.LoadBalancerTargetTypeServer:
+			if t.Server != nil && t.Server.Server != nil {
+				add(t.Server.Server.ID)
+			}
+		case hcloud.LoadBalancerTargetTypeLabelSelector:
+			for _, id := range targetServerIDs(t.Targets) {
+				add(id)
+			}
+		}
+	}
+	return serverRefs(m.MqlRuntime, ids)
 }

--- a/providers/hetzner/resources/hetzner_location.go
+++ b/providers/hetzner/resources/hetzner_location.go
@@ -52,6 +52,13 @@ func newMqlHetznerLocation(runtime *plugin.Runtime, loc *hcloud.Location) (*mqlH
 	return res.(*mqlHetznerLocation), nil
 }
 
+func (m *mqlHetznerLocation) servers() ([]any, error) {
+	locID := m.Id.Data
+	return serversMatching(m.MqlRuntime, func(s *hcloud.Server) bool {
+		return s.Location != nil && s.Location.ID == locID
+	})
+}
+
 func initHetznerLocation(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	id, ok := idArg(args, "id")
 	if !ok {

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -5,12 +5,22 @@ package resources
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlHetznerInternal struct {
+	// serversOnce guards a single project-wide Server.List so the servers()
+	// field and the location/datacenter server rollups share one API round-trip
+	// instead of each firing its own list call.
+	serversOnce sync.Once
+	serversList []*hcloud.Server
+	serversErr  error
+}
 
 type mqlHetznerServerInternal struct {
 	cacheServerType     *hcloud.ServerType
@@ -32,11 +42,23 @@ func (r *mqlHetznerServer) id() (string, error) {
 	return fmt.Sprintf("hetzner.server/%d", r.Id.Data), nil
 }
 
-func (h *mqlHetzner) servers() ([]any, error) {
-	c := conn(h.MqlRuntime)
-	items, err := paginate(func(opts hcloud.ListOpts) ([]*hcloud.Server, *hcloud.Response, error) {
-		return c.Client().Server.List(ctx(), hcloud.ServerListOpts{ListOpts: opts})
+// allServers lists every project server exactly once and caches the raw
+// result on the hetzner namespace resource. The servers() field and the
+// location/datacenter server rollups all resolve through here, so a bulk query
+// like `hetzner.locations { servers }` costs a single Server.List rather than
+// one per location.
+func (h *mqlHetzner) allServers() ([]*hcloud.Server, error) {
+	h.serversOnce.Do(func() {
+		c := conn(h.MqlRuntime)
+		h.serversList, h.serversErr = paginate(func(opts hcloud.ListOpts) ([]*hcloud.Server, *hcloud.Response, error) {
+			return c.Client().Server.List(ctx(), hcloud.ServerListOpts{ListOpts: opts})
+		})
 	})
+	return h.serversList, h.serversErr
+}
+
+func (h *mqlHetzner) servers() ([]any, error) {
+	items, err := h.allServers()
 	if err != nil {
 		return nil, err
 	}
@@ -51,15 +73,26 @@ func (h *mqlHetzner) servers() ([]any, error) {
 	return out, nil
 }
 
-// serversMatching lists all project servers once and builds full server
-// resources for the ones the match predicate selects. Reverse edges
-// (location.servers, datacenter.servers) use it so a single list call backs
-// the filter instead of a lazy Get per server.
+// hetznerNamespace resolves the singleton hetzner namespace resource so shared
+// caches (e.g. the server list) can be reached from other resources.
+func hetznerNamespace(runtime *plugin.Runtime) (*mqlHetzner, error) {
+	res, err := NewResource(runtime, "hetzner", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHetzner), nil
+}
+
+// serversMatching returns full server resources for the servers the match
+// predicate selects, filtering the once-cached project server list in memory.
+// Reverse edges (location.servers, datacenter.servers) use it so repeated
+// calls across a bulk query share a single Server.List round-trip.
 func serversMatching(runtime *plugin.Runtime, match func(*hcloud.Server) bool) ([]any, error) {
-	c := conn(runtime)
-	items, err := paginate(func(opts hcloud.ListOpts) ([]*hcloud.Server, *hcloud.Response, error) {
-		return c.Client().Server.List(ctx(), hcloud.ServerListOpts{ListOpts: opts})
-	})
+	h, err := hetznerNamespace(runtime)
+	if err != nil {
+		return nil, err
+	}
+	items, err := h.allServers()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -51,6 +51,32 @@ func (h *mqlHetzner) servers() ([]any, error) {
 	return out, nil
 }
 
+// serversMatching lists all project servers once and builds full server
+// resources for the ones the match predicate selects. Reverse edges
+// (location.servers, datacenter.servers) use it so a single list call backs
+// the filter instead of a lazy Get per server.
+func serversMatching(runtime *plugin.Runtime, match func(*hcloud.Server) bool) ([]any, error) {
+	c := conn(runtime)
+	items, err := paginate(func(opts hcloud.ListOpts) ([]*hcloud.Server, *hcloud.Response, error) {
+		return c.Client().Server.List(ctx(), hcloud.ServerListOpts{ListOpts: opts})
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := []any{}
+	for _, s := range items {
+		if !match(s) {
+			continue
+		}
+		res, err := newMqlHetznerServer(runtime, s)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
 func newMqlHetznerServer(runtime *plugin.Runtime, s *hcloud.Server) (*mqlHetznerServer, error) {
 	// Hetzner assigns a /64 to each server; prefer the network CIDR and fall
 	// back to the bare address when the network is not populated.


### PR DESCRIPTION
Additive cross-resource traversal edges for the Hetzner Cloud provider, all derived from data already in the API responses (no new API calls, no new IAM permissions). Follow-up to #8979.

## Edges

- **`hetzner.loadBalancer.target.labelSelectorTargets`** — resolves a `label_selector` target to the concrete backend servers it currently matches (from the SDK's nested `Targets`), mirroring the existing `hetzner.firewall.labelSelectorTargets`. Previously only the raw selector string was exposed.
- **`hetzner.loadBalancer.servers`** — deduplicated aggregate of all backend servers (direct `server` targets plus label-selector-resolved), the reverse of `hetzner.server.loadBalancers`.
- **`hetzner.location.servers`** / **`hetzner.datacenter.servers`** — the servers running in a region / datacenter, backed by a single `Server.List` and filter.

```mql
hetzner.loadBalancers.where( servers.any(exposure.internetReachable) )
hetzner.locations.where( country == "US" ).servers { name }
```

## Notes

- `loadBalancer.servers` and the region rollups dedupe by server ID; region rollups use one list call rather than a lazy Get per server.
- New `.lr.versions` entries land at `13.5.2`.

## Testing

- `go build ./...`, `go vet`, `gofmt`, and the full provider test suite pass.
- Not yet smoke-tested against a live Hetzner project (no API token in the dev environment) — the edges are straightforward mappings over existing response data.
