### PR TITLE
⭐ azure: private endpoint network interfaces + fix PE cache collision

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3464,6 +3464,12 @@ private azure.subscription.networkService.privateEndpoint @defaults("id name loc
   // reachable, completing a private-access path from a virtual network to the
   // resource behind the endpoint.
   subnet() azure.subscription.networkService.subnet
+  // Network interfaces automatically created for the private endpoint
+  //
+  // Resolves the interfaces that hold the endpoint's private IPs so their
+  // effective security rules and routes can be examined, connecting the
+  // private-access path to the network filtering applied at the endpoint.
+  networkInterfaces() []azure.subscription.networkService.interface
   // Custom name of the network interface attached to the private endpoint
   customNetworkInterfaceName string
   // Billing SKU of the private endpoint ("Fixed" or "PayAsYouGo")

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -756,7 +756,7 @@ func init() {
 			Create: createAzureSubscriptionNetworkServiceOutboundRule,
 		},
 		"azure.subscription.networkService.interface": {
-			// to override args, implement: initAzureSubscriptionNetworkServiceInterface(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionNetworkServiceInterface,
 			Create: createAzureSubscriptionNetworkServiceInterface,
 		},
 		"azure.subscription.networkService.interface.ipConfiguration": {
@@ -6049,6 +6049,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
+	"azure.subscription.networkService.privateEndpoint.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetNetworkInterfaces()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.interface")))
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetCustomNetworkInterfaceName()).ToDataRes(types.String)
@@ -23026,6 +23029,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.privateEndpoint.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).NetworkInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.privateEndpoint.customNetworkInterfaceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52944,7 +52951,7 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetGateway
 type mqlAzureSubscriptionNetworkServicePrivateEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServicePrivateEndpointInternal it will be used here
+	mqlAzureSubscriptionNetworkServicePrivateEndpointInternal
 	Id                                  plugin.TValue[string]
 	Name                                plugin.TValue[string]
 	Location                            plugin.TValue[string]
@@ -52953,6 +52960,7 @@ type mqlAzureSubscriptionNetworkServicePrivateEndpoint struct {
 	ProvisioningState                   plugin.TValue[string]
 	SubnetId                            plugin.TValue[string]
 	Subnet                              plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
+	NetworkInterfaces                   plugin.TValue[[]any]
 	CustomNetworkInterfaceName          plugin.TValue[string]
 	BillingSku                          plugin.TValue[string]
 	PrivateLinkServiceConnections       plugin.TValue[[]any]
@@ -53033,6 +53041,22 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnet() *plugin.
 		}
 
 		return c.subnet()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetNetworkInterfaces() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.NetworkInterfaces, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.privateEndpoint", c.__id, "networkInterfaces")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.networkInterfaces()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3589,6 +3589,7 @@ azure.subscription.networkService.privateEndpoint.id 11.4.28
 azure.subscription.networkService.privateEndpoint.location 11.4.28
 azure.subscription.networkService.privateEndpoint.manualPrivateLinkServiceConnections 11.4.28
 azure.subscription.networkService.privateEndpoint.name 11.4.28
+azure.subscription.networkService.privateEndpoint.networkInterfaces 13.26.1
 azure.subscription.networkService.privateEndpoint.privateDnsZoneGroups 13.5.1
 azure.subscription.networkService.privateEndpoint.privateLinkServiceConnections 11.4.28
 azure.subscription.networkService.privateEndpoint.provisioningState 11.4.28

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.26.0",
-  "generated_at": "2026-07-06T12:03:49-07:00",
+  "generated_at": "2026-07-06T21:41:00-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -1250,7 +1250,7 @@
     {
       "permission": "Microsoft.Network/networkInterfaces/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1910,6 +1910,7 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 
 	var provisioningState, subnetId, customNicName, billingSku string
 	var plsConns, manualPlsConns []any
+	var nicIDs []string
 
 	if pe.Properties != nil {
 		if pe.Properties.ProvisioningState != nil {
@@ -1921,6 +1922,11 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 		customNicName = convert.ToValue(pe.Properties.CustomNetworkInterfaceName)
 		if pe.Properties.BillingSKU != nil {
 			billingSku = string(*pe.Properties.BillingSKU)
+		}
+		for _, nic := range pe.Properties.NetworkInterfaces {
+			if nic != nil && nic.ID != nil {
+				nicIDs = append(nicIDs, *nic.ID)
+			}
 		}
 
 		for _, c := range pe.Properties.PrivateLinkServiceConnections {
@@ -1941,6 +1947,7 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.privateEndpoint",
 		map[string]*llx.RawData{
+			"__id":                                llx.StringDataPtr(pe.ID),
 			"id":                                  llx.StringDataPtr(pe.ID),
 			"name":                                llx.StringDataPtr(pe.Name),
 			"location":                            llx.StringDataPtr(pe.Location),
@@ -1956,7 +1963,13 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint), nil
+	mqlPe := res.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint)
+	mqlPe.cacheNetworkInterfaceIDs = nicIDs
+	return mqlPe, nil
+}
+
+type mqlAzureSubscriptionNetworkServicePrivateEndpointInternal struct {
+	cacheNetworkInterfaceIDs []string
 }
 
 // subnet resolves the subnet the private endpoint's network interface is
@@ -1973,6 +1986,71 @@ func (a *mqlAzureSubscriptionNetworkServicePrivateEndpoint) subnet() (*mqlAzureS
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
+// networkInterfaces resolves the interfaces holding the private endpoint's
+// private IPs so their effective security rules and routes can be examined.
+func (a *mqlAzureSubscriptionNetworkServicePrivateEndpoint) networkInterfaces() ([]any, error) {
+	res := make([]any, 0, len(a.cacheNetworkInterfaceIDs))
+	for _, id := range a.cacheNetworkInterfaceIDs {
+		if id == "" {
+			continue
+		}
+		nic, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.interface",
+			map[string]*llx.RawData{"id": llx.StringData(id)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, nic)
+	}
+	return res, nil
+}
+
+// initAzureSubscriptionNetworkServiceInterface resolves a network interface
+// referenced only by its resource ID (e.g. from a private endpoint) by fetching
+// it on demand. When the interface was already listed by interfaces() the
+// runtime cache short-circuits this and the init never runs.
+func initAzureSubscriptionNetworkServiceInterface(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return args, nil, nil
+	}
+	name, err := resourceID.Component("networkInterfaces")
+	if err != nil {
+		return args, nil, nil
+	}
+	client, err := network.NewInterfacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, name, nil)
+	if err != nil {
+		// The interface may be inaccessible (deleted, cross-subscription, or
+		// access denied); fall back to the bare reference rather than failing
+		// the surrounding query.
+		return args, nil, nil
+	}
+	mqlIface, err := azureInterfaceToMql(runtime, resp.Interface)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlIface, nil
 }
 
 func initAzureSubscriptionNetworkServicePrivateEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## What

Adds **`privateEndpoint.networkInterfaces()`** so the interfaces holding a private endpoint's private IPs are traversable. Their `effectiveSecurityRules` / `effectiveRouteTable` connect the private-access path (from #8978) to the network filtering applied at the endpoint:

```mql
azure.subscription.networkService.privateEndpoints {
  name
  networkInterfaces { name effectiveSecurityRules { _["access"] _["direction"] } }
}
```

## How

- The `network interface` resource previously had **no `init`**, so an interface referenced only by ID resolved to a bare husk. It now gains `initAzureSubscriptionNetworkServiceInterface`, which fetches the interface on demand and maps it through the existing `azureInterfaceToMql`. Interfaces already listed by `interfaces()` short-circuit via the runtime cache. This is a general enabler — any typed interface reference now populates fully.
- `privateEndpointToMql` caches the endpoint's network-interface IDs (from `pe.Properties.NetworkInterfaces`) on the resource's Internal struct; `networkInterfaces()` resolves each by ID.

## Bug fixed (found during verification)

While checking the new edge against real endpoints, the query returned the *wrong* NIC for a private endpoint. Root cause: `privateEndpointToMql` set **no `__id`**, so every private endpoint shared one empty cache key (`resourceName + "\x00"`) and collapsed to a single cached instance — their `subnet`, connections, and (now) network interfaces were silently **cross-wired** between endpoints. `__id` is now the endpoint's ARM ID.

Verified against three real endpoints (`az network private-endpoint show` as ground truth): before the fix all three collapsed to one and reported another endpoint's NIC; after, each resolves its **own** subnet and network interface.

## Scope / safety

- VM and scale-set NIC building is unaffected: they fetch and map interfaces directly (`Get` + `azureInterfaceToMql`, full data), never via a bare-ID `NewResource`, so the new init adds no calls on that hot path (including exposure from #8968).
- One schema addition (`networkInterfaces`, `.lr.versions` at `13.26.1`). **No new IAM permission** — the interface `Get` requires the same `Microsoft.Network/networkInterfaces/read` the list already used (the manifest's recorded action for that permission flips `NewListAllPager → Get`, same RBAC).

## Tests

The new code is API plumbing + a cache-key fix (no isolated pure logic to unit-test); covered by **live verification** against three real private endpoints as described above.

## Series context

Follow-up to the Azure attack-path sweep (#8968 exposure, #8974 + #8980 identity→privilege, #8978 private-link reachability). This connects private-link endpoints to the interface-level NSG/route analysis.
