### PR TITLE
⭐ digitalocean: more typed refs, K8s upgrade/autoscaler fields, Functions access keys

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -544,6 +544,7 @@ func (r *mqlDigitalocean) vpcs() ([]interface{}, error) {
 				"region":      llx.StringData(v.RegionSlug),
 				"createdAt":   llx.TimeData(v.CreatedAt),
 				"default":     llx.BoolData(v.Default),
+				"urn":         llx.StringData(v.URN),
 			})
 			if err != nil {
 				return nil, err
@@ -621,6 +622,7 @@ func (r *mqlDigitalocean) projects() ([]interface{}, error) {
 				"createdAt":   llx.TimeDataPtr(parseDoTime(p.CreatedAt)),
 				"updatedAt":   llx.TimeDataPtr(parseDoTime(p.UpdatedAt)),
 				"isDefault":   llx.BoolData(p.IsDefault),
+				"ownerUuid":   llx.StringData(p.OwnerUUID),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -66,6 +66,8 @@ digitalocean {
   sshKeys() []digitalocean.sshKey
   // TLS certificates
   certificates() []digitalocean.certificate
+  // Container registry attached to the account
+  registry() digitalocean.registry
   // Container registry repositories
   registryRepositories() []digitalocean.registry.repository
   // Reserved IPs
@@ -773,6 +775,8 @@ digitalocean.vpc @defaults("id name region") {
   createdAt time
   // Whether this is the default VPC
   default bool
+  // Uniform resource name (URN) identifying the VPC across DigitalOcean APIs
+  urn string
 }
 
 // DigitalOcean VPC peering
@@ -872,6 +876,14 @@ digitalocean.kubernetes.cluster @defaults("id name version") {
   rdmaSharedDevicePluginEnabled bool
   // Whether the CoreDNS cluster-proportional autoscaler add-on is enabled; null when unset
   corednsAutoscalerEnabled bool
+  // UUID of the VPC subnet the cluster's worker nodes are placed in
+  workerSubnetUuid string
+  // Cluster autoscaler tuning
+  //
+  // Keys: scaleDownUtilizationThreshold (fraction), scaleDownUnneededTime (duration string), expanders (list). Empty when the cluster uses platform defaults.
+  clusterAutoscaler dict
+  // Kubernetes versions this cluster can currently upgrade to; empty when the cluster is already on the newest available version
+  availableUpgradeVersions() []string
   // Node pools
   nodePools() []digitalocean.kubernetes.nodePool
 }
@@ -960,6 +972,8 @@ digitalocean.project @defaults("id name environment") {
   updatedAt time
   // Whether this is the default project
   isDefault bool
+  // UUID of the account that owns the project
+  ownerUuid string
 }
 
 // DigitalOcean SSH key
@@ -1017,6 +1031,8 @@ digitalocean.registry @defaults("name region") {
   name string
   // Storage usage in bytes
   storageUsageBytes int
+  // Time storageUsageBytes was last recomputed (DigitalOcean updates it asynchronously); null when never computed
+  storageUsageBytesUpdatedAt time
   // Region slug
   region string
   // Time the resource was created
@@ -1320,6 +1336,12 @@ digitalocean.alertPolicy @defaults("uuid type enabled") {
   entities []string
   // Droplets monitored by this policy, resolved from entity IDs; empty for policies that target non-droplet entities
   droplets() []digitalocean.droplet
+  // Managed databases monitored by this policy, resolved from entity IDs; empty for policies that target other entity types
+  databases() []digitalocean.database
+  // Load balancers monitored by this policy, resolved from entity IDs; empty for policies that target other entity types
+  loadBalancers() []digitalocean.loadBalancer
+  // Kubernetes clusters monitored by this policy, resolved from entity IDs; empty for policies that target other entity types
+  kubernetesClusters() []digitalocean.kubernetes.cluster
   // Tags
   tags []string
   // Email notification targets
@@ -1565,6 +1587,31 @@ digitalocean.function.namespace @defaults("uuid label region") {
   triggers() []digitalocean.function.trigger
   // Functions (actions) deployed in the namespace
   functions() []digitalocean.function.action
+  // Access keys issued for the namespace's Functions API (secret values are never exposed)
+  accessKeys() []digitalocean.function.accessKey
+}
+
+// DigitalOcean Functions access key
+//
+// An access key issued for a Functions namespace's API. The secret value
+// is never exposed; only metadata is surfaced: the key id and name, the
+// creation and last-used times, and the expiry. Use `lastUsedAt` and
+// `expiresAt` to audit for stale or never-expiring namespace credentials.
+private digitalocean.function.accessKey @defaults("name lastUsedAt") {
+  // UUID of the parent namespace
+  namespaceUuid string
+  // Access key ID
+  id string
+  // Key name
+  name string
+  // Time the key was created
+  createdAt time
+  // Time the key was last updated
+  updatedAt time
+  // Time the key was last used; null when the key has never been used
+  lastUsedAt time
+  // Time the key expires; null when the key does not expire
+  expiresAt time
 }
 
 // DigitalOcean Functions action
@@ -2642,8 +2689,12 @@ digitalocean.partnerAttachment @defaults("id name state") {
   bgp dict
   // UUID of the parent attachment, if this is a child
   parentUuid string
+  // Parent attachment, when this attachment is a child; null otherwise
+  parentAttachment() digitalocean.partnerAttachment
   // UUIDs of child attachments, if any
   children []string
+  // Child attachments connected beneath this one
+  childAttachments() []digitalocean.partnerAttachment
   // Time the resource was created
   createdAt time
 }

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -60,6 +60,7 @@ const (
 	ResourceDigitaloceanImage                                           string = "digitalocean.image"
 	ResourceDigitaloceanSnapshot                                        string = "digitalocean.snapshot"
 	ResourceDigitaloceanFunctionNamespace                               string = "digitalocean.function.namespace"
+	ResourceDigitaloceanFunctionAccessKey                               string = "digitalocean.function.accessKey"
 	ResourceDigitaloceanFunctionAction                                  string = "digitalocean.function.action"
 	ResourceDigitaloceanFunctionTrigger                                 string = "digitalocean.function.trigger"
 	ResourceDigitaloceanVpcNatGateway                                   string = "digitalocean.vpcNatGateway"
@@ -272,6 +273,10 @@ func init() {
 		"digitalocean.function.namespace": {
 			// to override args, implement: initDigitaloceanFunctionNamespace(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDigitaloceanFunctionNamespace,
+		},
+		"digitalocean.function.accessKey": {
+			// to override args, implement: initDigitaloceanFunctionAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanFunctionAccessKey,
 		},
 		"digitalocean.function.action": {
 			// to override args, implement: initDigitaloceanFunctionAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -536,6 +541,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitalocean).GetCertificates()).ToDataRes(types.Array(types.Resource("digitalocean.certificate")))
+	},
+	"digitalocean.registry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitalocean).GetRegistry()).ToDataRes(types.Resource("digitalocean.registry"))
 	},
 	"digitalocean.registryRepositories": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitalocean).GetRegistryRepositories()).ToDataRes(types.Array(types.Resource("digitalocean.registry.repository")))
@@ -1245,6 +1253,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.vpc.default": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetDefault()).ToDataRes(types.Bool)
 	},
+	"digitalocean.vpc.urn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetUrn()).ToDataRes(types.String)
+	},
 	"digitalocean.vpcPeering.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcPeering).GetId()).ToDataRes(types.String)
 	},
@@ -1359,6 +1370,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.kubernetes.cluster.corednsAutoscalerEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesCluster).GetCorednsAutoscalerEnabled()).ToDataRes(types.Bool)
 	},
+	"digitalocean.kubernetes.cluster.workerSubnetUuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesCluster).GetWorkerSubnetUuid()).ToDataRes(types.String)
+	},
+	"digitalocean.kubernetes.cluster.clusterAutoscaler": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesCluster).GetClusterAutoscaler()).ToDataRes(types.Dict)
+	},
+	"digitalocean.kubernetes.cluster.availableUpgradeVersions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesCluster).GetAvailableUpgradeVersions()).ToDataRes(types.Array(types.String))
+	},
 	"digitalocean.kubernetes.cluster.nodePools": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesCluster).GetNodePools()).ToDataRes(types.Array(types.Resource("digitalocean.kubernetes.nodePool")))
 	},
@@ -1446,6 +1466,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.project.isDefault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanProject).GetIsDefault()).ToDataRes(types.Bool)
 	},
+	"digitalocean.project.ownerUuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanProject).GetOwnerUuid()).ToDataRes(types.String)
+	},
 	"digitalocean.sshKey.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanSshKey).GetId()).ToDataRes(types.Int)
 	},
@@ -1487,6 +1510,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.registry.storageUsageBytes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanRegistry).GetStorageUsageBytes()).ToDataRes(types.Int)
+	},
+	"digitalocean.registry.storageUsageBytesUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanRegistry).GetStorageUsageBytesUpdatedAt()).ToDataRes(types.Time)
 	},
 	"digitalocean.registry.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanRegistry).GetRegion()).ToDataRes(types.String)
@@ -1794,6 +1820,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.alertPolicy.droplets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAlertPolicy).GetDroplets()).ToDataRes(types.Array(types.Resource("digitalocean.droplet")))
 	},
+	"digitalocean.alertPolicy.databases": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanAlertPolicy).GetDatabases()).ToDataRes(types.Array(types.Resource("digitalocean.database")))
+	},
+	"digitalocean.alertPolicy.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanAlertPolicy).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("digitalocean.loadBalancer")))
+	},
+	"digitalocean.alertPolicy.kubernetesClusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanAlertPolicy).GetKubernetesClusters()).ToDataRes(types.Array(types.Resource("digitalocean.kubernetes.cluster")))
+	},
 	"digitalocean.alertPolicy.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAlertPolicy).GetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -2012,6 +2047,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.function.namespace.functions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFunctionNamespace).GetFunctions()).ToDataRes(types.Array(types.Resource("digitalocean.function.action")))
+	},
+	"digitalocean.function.namespace.accessKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionNamespace).GetAccessKeys()).ToDataRes(types.Array(types.Resource("digitalocean.function.accessKey")))
+	},
+	"digitalocean.function.accessKey.namespaceUuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetNamespaceUuid()).ToDataRes(types.String)
+	},
+	"digitalocean.function.accessKey.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetId()).ToDataRes(types.String)
+	},
+	"digitalocean.function.accessKey.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetName()).ToDataRes(types.String)
+	},
+	"digitalocean.function.accessKey.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.function.accessKey.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.function.accessKey.lastUsedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetLastUsedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.function.accessKey.expiresAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAccessKey).GetExpiresAt()).ToDataRes(types.Time)
 	},
 	"digitalocean.function.action.namespaceUuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFunctionAction).GetNamespaceUuid()).ToDataRes(types.String)
@@ -3105,8 +3164,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.partnerAttachment.parentUuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanPartnerAttachment).GetParentUuid()).ToDataRes(types.String)
 	},
+	"digitalocean.partnerAttachment.parentAttachment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanPartnerAttachment).GetParentAttachment()).ToDataRes(types.Resource("digitalocean.partnerAttachment"))
+	},
 	"digitalocean.partnerAttachment.children": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanPartnerAttachment).GetChildren()).ToDataRes(types.Array(types.String))
+	},
+	"digitalocean.partnerAttachment.childAttachments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanPartnerAttachment).GetChildAttachments()).ToDataRes(types.Array(types.Resource("digitalocean.partnerAttachment")))
 	},
 	"digitalocean.partnerAttachment.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanPartnerAttachment).GetCreatedAt()).ToDataRes(types.Time)
@@ -3229,6 +3294,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.certificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitalocean).Certificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.registry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitalocean).Registry, ok = plugin.RawToTValue[*mqlDigitaloceanRegistry](v.Value, v.Error)
 		return
 	},
 	"digitalocean.registryRepositories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4247,6 +4316,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanVpc).Default, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"digitalocean.vpc.urn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).Urn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"digitalocean.vpcPeering.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVpcPeering).__id, ok = v.Value.(string)
 		return
@@ -4407,6 +4480,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanKubernetesCluster).CorednsAutoscalerEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"digitalocean.kubernetes.cluster.workerSubnetUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesCluster).WorkerSubnetUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.kubernetes.cluster.clusterAutoscaler": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesCluster).ClusterAutoscaler, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.kubernetes.cluster.availableUpgradeVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesCluster).AvailableUpgradeVersions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.kubernetes.cluster.nodePools": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanKubernetesCluster).NodePools, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -4535,6 +4620,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanProject).IsDefault, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"digitalocean.project.ownerUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanProject).OwnerUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"digitalocean.sshKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanSshKey).__id, ok = v.Value.(string)
 		return
@@ -4601,6 +4690,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.registry.storageUsageBytes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanRegistry).StorageUsageBytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.registry.storageUsageBytesUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanRegistry).StorageUsageBytesUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"digitalocean.registry.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5047,6 +5140,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanAlertPolicy).Droplets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.alertPolicy.databases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanAlertPolicy).Databases, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.alertPolicy.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanAlertPolicy).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.alertPolicy.kubernetesClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanAlertPolicy).KubernetesClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.alertPolicy.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanAlertPolicy).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -5369,6 +5474,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.function.namespace.functions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanFunctionNamespace).Functions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.namespace.accessKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionNamespace).AccessKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.function.accessKey.namespaceUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).NamespaceUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.lastUsedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).LastUsedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.accessKey.expiresAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAccessKey).ExpiresAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"digitalocean.function.action.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6947,8 +7088,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanPartnerAttachment).ParentUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"digitalocean.partnerAttachment.parentAttachment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanPartnerAttachment).ParentAttachment, ok = plugin.RawToTValue[*mqlDigitaloceanPartnerAttachment](v.Value, v.Error)
+		return
+	},
 	"digitalocean.partnerAttachment.children": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanPartnerAttachment).Children, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.partnerAttachment.childAttachments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanPartnerAttachment).ChildAttachments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.partnerAttachment.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7027,6 +7176,7 @@ type mqlDigitalocean struct {
 	Projects              plugin.TValue[[]any]
 	SshKeys               plugin.TValue[[]any]
 	Certificates          plugin.TValue[[]any]
+	Registry              plugin.TValue[*mqlDigitaloceanRegistry]
 	RegistryRepositories  plugin.TValue[[]any]
 	ReservedIPs           plugin.TValue[[]any]
 	Apps                  plugin.TValue[[]any]
@@ -7444,6 +7594,22 @@ func (c *mqlDigitalocean) GetCertificates() *plugin.TValue[[]any] {
 		}
 
 		return c.certificates()
+	})
+}
+
+func (c *mqlDigitalocean) GetRegistry() *plugin.TValue[*mqlDigitaloceanRegistry] {
+	return plugin.GetOrCompute[*mqlDigitaloceanRegistry](&c.Registry, func() (*mqlDigitaloceanRegistry, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean", c.__id, "registry")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanRegistry), nil
+			}
+		}
+
+		return c.registry()
 	})
 }
 
@@ -9911,6 +10077,7 @@ type mqlDigitaloceanVpc struct {
 	Region      plugin.TValue[string]
 	CreatedAt   plugin.TValue[*time.Time]
 	Default     plugin.TValue[bool]
+	Urn         plugin.TValue[string]
 }
 
 // createDigitaloceanVpc creates a new instance of this resource
@@ -9976,6 +10143,10 @@ func (c *mqlDigitaloceanVpc) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlDigitaloceanVpc) GetDefault() *plugin.TValue[bool] {
 	return &c.Default
+}
+
+func (c *mqlDigitaloceanVpc) GetUrn() *plugin.TValue[string] {
+	return &c.Urn
 }
 
 // mqlDigitaloceanVpcPeering for the digitalocean.vpcPeering resource
@@ -10101,6 +10272,9 @@ type mqlDigitaloceanKubernetesCluster struct {
 	NvidiaGpuDevicePluginEnabled             plugin.TValue[bool]
 	RdmaSharedDevicePluginEnabled            plugin.TValue[bool]
 	CorednsAutoscalerEnabled                 plugin.TValue[bool]
+	WorkerSubnetUuid                         plugin.TValue[string]
+	ClusterAutoscaler                        plugin.TValue[any]
+	AvailableUpgradeVersions                 plugin.TValue[[]any]
 	NodePools                                plugin.TValue[[]any]
 }
 
@@ -10279,6 +10453,20 @@ func (c *mqlDigitaloceanKubernetesCluster) GetRdmaSharedDevicePluginEnabled() *p
 
 func (c *mqlDigitaloceanKubernetesCluster) GetCorednsAutoscalerEnabled() *plugin.TValue[bool] {
 	return &c.CorednsAutoscalerEnabled
+}
+
+func (c *mqlDigitaloceanKubernetesCluster) GetWorkerSubnetUuid() *plugin.TValue[string] {
+	return &c.WorkerSubnetUuid
+}
+
+func (c *mqlDigitaloceanKubernetesCluster) GetClusterAutoscaler() *plugin.TValue[any] {
+	return &c.ClusterAutoscaler
+}
+
+func (c *mqlDigitaloceanKubernetesCluster) GetAvailableUpgradeVersions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AvailableUpgradeVersions, func() ([]any, error) {
+		return c.availableUpgradeVersions()
+	})
 }
 
 func (c *mqlDigitaloceanKubernetesCluster) GetNodePools() *plugin.TValue[[]any] {
@@ -10534,6 +10722,7 @@ type mqlDigitaloceanProject struct {
 	CreatedAt   plugin.TValue[*time.Time]
 	UpdatedAt   plugin.TValue[*time.Time]
 	IsDefault   plugin.TValue[bool]
+	OwnerUuid   plugin.TValue[string]
 }
 
 // createDigitaloceanProject creates a new instance of this resource
@@ -10603,6 +10792,10 @@ func (c *mqlDigitaloceanProject) GetUpdatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlDigitaloceanProject) GetIsDefault() *plugin.TValue[bool] {
 	return &c.IsDefault
+}
+
+func (c *mqlDigitaloceanProject) GetOwnerUuid() *plugin.TValue[string] {
+	return &c.OwnerUuid
 }
 
 // mqlDigitaloceanSshKey for the digitalocean.sshKey resource
@@ -10758,14 +10951,15 @@ type mqlDigitaloceanRegistry struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanRegistryInternal it will be used here
-	Name               plugin.TValue[string]
-	StorageUsageBytes  plugin.TValue[int64]
-	Region             plugin.TValue[string]
-	CreatedAt          plugin.TValue[*time.Time]
-	SubscriptionTier   plugin.TValue[string]
-	Repositories       plugin.TValue[[]any]
-	GarbageCollections plugin.TValue[[]any]
-	Subscription       plugin.TValue[any]
+	Name                       plugin.TValue[string]
+	StorageUsageBytes          plugin.TValue[int64]
+	StorageUsageBytesUpdatedAt plugin.TValue[*time.Time]
+	Region                     plugin.TValue[string]
+	CreatedAt                  plugin.TValue[*time.Time]
+	SubscriptionTier           plugin.TValue[string]
+	Repositories               plugin.TValue[[]any]
+	GarbageCollections         plugin.TValue[[]any]
+	Subscription               plugin.TValue[any]
 }
 
 // createDigitaloceanRegistry creates a new instance of this resource
@@ -10811,6 +11005,10 @@ func (c *mqlDigitaloceanRegistry) GetName() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanRegistry) GetStorageUsageBytes() *plugin.TValue[int64] {
 	return &c.StorageUsageBytes
+}
+
+func (c *mqlDigitaloceanRegistry) GetStorageUsageBytesUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.StorageUsageBytesUpdatedAt
 }
 
 func (c *mqlDigitaloceanRegistry) GetRegion() *plugin.TValue[string] {
@@ -11777,18 +11975,21 @@ type mqlDigitaloceanAlertPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanAlertPolicyInternal it will be used here
-	Uuid        plugin.TValue[string]
-	Type        plugin.TValue[string]
-	Description plugin.TValue[string]
-	Compare     plugin.TValue[string]
-	Value       plugin.TValue[float64]
-	Window      plugin.TValue[string]
-	Enabled     plugin.TValue[bool]
-	Entities    plugin.TValue[[]any]
-	Droplets    plugin.TValue[[]any]
-	Tags        plugin.TValue[[]any]
-	AlertEmails plugin.TValue[[]any]
-	AlertSlack  plugin.TValue[[]any]
+	Uuid               plugin.TValue[string]
+	Type               plugin.TValue[string]
+	Description        plugin.TValue[string]
+	Compare            plugin.TValue[string]
+	Value              plugin.TValue[float64]
+	Window             plugin.TValue[string]
+	Enabled            plugin.TValue[bool]
+	Entities           plugin.TValue[[]any]
+	Droplets           plugin.TValue[[]any]
+	Databases          plugin.TValue[[]any]
+	LoadBalancers      plugin.TValue[[]any]
+	KubernetesClusters plugin.TValue[[]any]
+	Tags               plugin.TValue[[]any]
+	AlertEmails        plugin.TValue[[]any]
+	AlertSlack         plugin.TValue[[]any]
 }
 
 // createDigitaloceanAlertPolicy creates a new instance of this resource
@@ -11873,6 +12074,54 @@ func (c *mqlDigitaloceanAlertPolicy) GetDroplets() *plugin.TValue[[]any] {
 		}
 
 		return c.droplets()
+	})
+}
+
+func (c *mqlDigitaloceanAlertPolicy) GetDatabases() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Databases, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.alertPolicy", c.__id, "databases")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.databases()
+	})
+}
+
+func (c *mqlDigitaloceanAlertPolicy) GetLoadBalancers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.alertPolicy", c.__id, "loadBalancers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.loadBalancers()
+	})
+}
+
+func (c *mqlDigitaloceanAlertPolicy) GetKubernetesClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.KubernetesClusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.alertPolicy", c.__id, "kubernetesClusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.kubernetesClusters()
 	})
 }
 
@@ -12542,15 +12791,16 @@ type mqlDigitaloceanFunctionNamespace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanFunctionNamespaceInternal it will be used here
-	Uuid      plugin.TValue[string]
-	Namespace plugin.TValue[string]
-	Label     plugin.TValue[string]
-	Region    plugin.TValue[string]
-	ApiHost   plugin.TValue[string]
-	CreatedAt plugin.TValue[*time.Time]
-	UpdatedAt plugin.TValue[*time.Time]
-	Triggers  plugin.TValue[[]any]
-	Functions plugin.TValue[[]any]
+	Uuid       plugin.TValue[string]
+	Namespace  plugin.TValue[string]
+	Label      plugin.TValue[string]
+	Region     plugin.TValue[string]
+	ApiHost    plugin.TValue[string]
+	CreatedAt  plugin.TValue[*time.Time]
+	UpdatedAt  plugin.TValue[*time.Time]
+	Triggers   plugin.TValue[[]any]
+	Functions  plugin.TValue[[]any]
+	AccessKeys plugin.TValue[[]any]
 }
 
 // createDigitaloceanFunctionNamespace creates a new instance of this resource
@@ -12648,6 +12898,96 @@ func (c *mqlDigitaloceanFunctionNamespace) GetFunctions() *plugin.TValue[[]any] 
 
 		return c.functions()
 	})
+}
+
+func (c *mqlDigitaloceanFunctionNamespace) GetAccessKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AccessKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.function.namespace", c.__id, "accessKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.accessKeys()
+	})
+}
+
+// mqlDigitaloceanFunctionAccessKey for the digitalocean.function.accessKey resource
+type mqlDigitaloceanFunctionAccessKey struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDigitaloceanFunctionAccessKeyInternal it will be used here
+	NamespaceUuid plugin.TValue[string]
+	Id            plugin.TValue[string]
+	Name          plugin.TValue[string]
+	CreatedAt     plugin.TValue[*time.Time]
+	UpdatedAt     plugin.TValue[*time.Time]
+	LastUsedAt    plugin.TValue[*time.Time]
+	ExpiresAt     plugin.TValue[*time.Time]
+}
+
+// createDigitaloceanFunctionAccessKey creates a new instance of this resource
+func createDigitaloceanFunctionAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanFunctionAccessKey{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.function.accessKey", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) MqlName() string {
+	return "digitalocean.function.accessKey"
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetNamespaceUuid() *plugin.TValue[string] {
+	return &c.NamespaceUuid
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetLastUsedAt() *plugin.TValue[*time.Time] {
+	return &c.LastUsedAt
+}
+
+func (c *mqlDigitaloceanFunctionAccessKey) GetExpiresAt() *plugin.TValue[*time.Time] {
+	return &c.ExpiresAt
 }
 
 // mqlDigitaloceanFunctionAction for the digitalocean.function.action resource
@@ -16136,7 +16476,9 @@ type mqlDigitaloceanPartnerAttachment struct {
 	Vpcs                      plugin.TValue[[]any]
 	Bgp                       plugin.TValue[any]
 	ParentUuid                plugin.TValue[string]
+	ParentAttachment          plugin.TValue[*mqlDigitaloceanPartnerAttachment]
 	Children                  plugin.TValue[[]any]
+	ChildAttachments          plugin.TValue[[]any]
 	CreatedAt                 plugin.TValue[*time.Time]
 }
 
@@ -16233,8 +16575,40 @@ func (c *mqlDigitaloceanPartnerAttachment) GetParentUuid() *plugin.TValue[string
 	return &c.ParentUuid
 }
 
+func (c *mqlDigitaloceanPartnerAttachment) GetParentAttachment() *plugin.TValue[*mqlDigitaloceanPartnerAttachment] {
+	return plugin.GetOrCompute[*mqlDigitaloceanPartnerAttachment](&c.ParentAttachment, func() (*mqlDigitaloceanPartnerAttachment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.partnerAttachment", c.__id, "parentAttachment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanPartnerAttachment), nil
+			}
+		}
+
+		return c.parentAttachment()
+	})
+}
+
 func (c *mqlDigitaloceanPartnerAttachment) GetChildren() *plugin.TValue[[]any] {
 	return &c.Children
+}
+
+func (c *mqlDigitaloceanPartnerAttachment) GetChildAttachments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ChildAttachments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.partnerAttachment", c.__id, "childAttachments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.childAttachments()
+	})
 }
 
 func (c *mqlDigitaloceanPartnerAttachment) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -18,10 +18,13 @@ digitalocean.alertPolicy 13.0.1
 digitalocean.alertPolicy.alertEmails 13.0.1
 digitalocean.alertPolicy.alertSlack 13.0.1
 digitalocean.alertPolicy.compare 13.0.1
+digitalocean.alertPolicy.databases 13.10.2
 digitalocean.alertPolicy.description 13.0.1
 digitalocean.alertPolicy.droplets 13.10.2
 digitalocean.alertPolicy.enabled 13.0.1
 digitalocean.alertPolicy.entities 13.0.1
+digitalocean.alertPolicy.kubernetesClusters 13.10.2
+digitalocean.alertPolicy.loadBalancers 13.10.2
 digitalocean.alertPolicy.tags 13.0.1
 digitalocean.alertPolicy.type 13.0.1
 digitalocean.alertPolicy.uuid 13.0.1
@@ -295,6 +298,14 @@ digitalocean.firewall.outboundRules 13.0.1
 digitalocean.firewall.status 13.0.1
 digitalocean.firewall.tags 13.0.1
 digitalocean.firewalls 13.0.1
+digitalocean.function.accessKey 13.10.2
+digitalocean.function.accessKey.createdAt 13.10.2
+digitalocean.function.accessKey.expiresAt 13.10.2
+digitalocean.function.accessKey.id 13.10.2
+digitalocean.function.accessKey.lastUsedAt 13.10.2
+digitalocean.function.accessKey.name 13.10.2
+digitalocean.function.accessKey.namespaceUuid 13.10.2
+digitalocean.function.accessKey.updatedAt 13.10.2
 digitalocean.function.action 13.10.2
 digitalocean.function.action.concurrency 13.10.2
 digitalocean.function.action.logSizeMb 13.10.2
@@ -309,6 +320,7 @@ digitalocean.function.action.updatedAt 13.10.2
 digitalocean.function.action.version 13.10.2
 digitalocean.function.action.webExported 13.10.2
 digitalocean.function.namespace 13.1.7
+digitalocean.function.namespace.accessKeys 13.10.2
 digitalocean.function.namespace.apiHost 13.1.7
 digitalocean.function.namespace.createdAt 13.1.7
 digitalocean.function.namespace.functions 13.10.2
@@ -596,6 +608,8 @@ digitalocean.kubernetes.cluster 13.0.1
 digitalocean.kubernetes.cluster.amdGpuDeviceMetricsExporterPluginEnabled 13.6.2
 digitalocean.kubernetes.cluster.amdGpuDevicePluginEnabled 13.6.2
 digitalocean.kubernetes.cluster.autoUpgrade 13.0.1
+digitalocean.kubernetes.cluster.availableUpgradeVersions 13.10.2
+digitalocean.kubernetes.cluster.clusterAutoscaler 13.10.2
 digitalocean.kubernetes.cluster.clusterSubnet 13.0.1
 digitalocean.kubernetes.cluster.controlPlaneFirewallAllowedAddresses 13.6.2
 digitalocean.kubernetes.cluster.controlPlaneFirewallEnabled 13.6.2
@@ -626,6 +640,7 @@ digitalocean.kubernetes.cluster.updatedAt 13.0.1
 digitalocean.kubernetes.cluster.version 13.0.1
 digitalocean.kubernetes.cluster.vpc 13.0.2
 digitalocean.kubernetes.cluster.vpcUuid 13.0.1
+digitalocean.kubernetes.cluster.workerSubnetUuid 13.10.2
 digitalocean.kubernetes.node 13.6.2
 digitalocean.kubernetes.node.createdAt 13.6.2
 digitalocean.kubernetes.node.droplet 13.6.2
@@ -723,12 +738,14 @@ digitalocean.nfs.vpcs 13.4.2
 digitalocean.nfsShares 13.4.2
 digitalocean.partnerAttachment 13.8.2
 digitalocean.partnerAttachment.bgp 13.8.2
+digitalocean.partnerAttachment.childAttachments 13.10.2
 digitalocean.partnerAttachment.children 13.8.2
 digitalocean.partnerAttachment.connectionBandwidthInMbps 13.8.2
 digitalocean.partnerAttachment.createdAt 13.8.2
 digitalocean.partnerAttachment.id 13.8.2
 digitalocean.partnerAttachment.naasProvider 13.8.2
 digitalocean.partnerAttachment.name 13.8.2
+digitalocean.partnerAttachment.parentAttachment 13.10.2
 digitalocean.partnerAttachment.parentUuid 13.8.2
 digitalocean.partnerAttachment.redundancyZone 13.8.2
 digitalocean.partnerAttachment.region 13.8.2
@@ -743,6 +760,7 @@ digitalocean.project.environment 13.0.1
 digitalocean.project.id 13.0.1
 digitalocean.project.isDefault 13.0.1
 digitalocean.project.name 13.0.1
+digitalocean.project.ownerUuid 13.10.2
 digitalocean.project.purpose 13.0.1
 digitalocean.project.updatedAt 13.0.1
 digitalocean.projects 13.0.1
@@ -787,6 +805,7 @@ digitalocean.registry.repository.tag.updatedAt 13.3.1
 digitalocean.registry.repository.tagCount 13.0.1
 digitalocean.registry.repository.tags 13.3.1
 digitalocean.registry.storageUsageBytes 13.0.1
+digitalocean.registry.storageUsageBytesUpdatedAt 13.10.2
 digitalocean.registry.subscription 13.3.1
 digitalocean.registry.subscriptionTier 13.0.1
 digitalocean.registryRepositories 13.0.1
@@ -932,6 +951,7 @@ digitalocean.vpc.id 13.0.1
 digitalocean.vpc.ipRange 13.0.1
 digitalocean.vpc.name 13.0.1
 digitalocean.vpc.region 13.0.1
+digitalocean.vpc.urn 13.10.2
 digitalocean.vpcNatGateway 13.4.2
 digitalocean.vpcNatGateway.createdAt 13.4.2
 digitalocean.vpcNatGateway.egressPublicGatewayIps 13.4.2

--- a/providers/digitalocean/resources/digitalocean_assets.go
+++ b/providers/digitalocean/resources/digitalocean_assets.go
@@ -414,6 +414,20 @@ func kubernetesClusterArgs(c *godo.KubernetesCluster) map[string]*llx.RawData {
 		corednsAutoscalerEnabled = c.CorednsAutoscaler.Enabled
 	}
 
+	autoscaler := map[string]interface{}{}
+	if c.ClusterAutoscalerConfiguration != nil {
+		ca := c.ClusterAutoscalerConfiguration
+		if ca.ScaleDownUtilizationThreshold != nil {
+			autoscaler["scaleDownUtilizationThreshold"] = *ca.ScaleDownUtilizationThreshold
+		}
+		if ca.ScaleDownUnneededTime != nil {
+			autoscaler["scaleDownUnneededTime"] = *ca.ScaleDownUnneededTime
+		}
+		if len(ca.Expanders) > 0 {
+			autoscaler["expanders"] = toStringSlice(ca.Expanders)
+		}
+	}
+
 	return map[string]*llx.RawData{
 		"id":                                   llx.StringData(c.ID),
 		"name":                                 llx.StringData(c.Name),
@@ -446,7 +460,31 @@ func kubernetesClusterArgs(c *godo.KubernetesCluster) map[string]*llx.RawData {
 		"nvidiaGpuDevicePluginEnabled":             llx.BoolDataPtr(nvidiaGpuEnabled),
 		"rdmaSharedDevicePluginEnabled":            llx.BoolDataPtr(rdmaEnabled),
 		"corednsAutoscalerEnabled":                 llx.BoolDataPtr(corednsAutoscalerEnabled),
+		"workerSubnetUuid":                         llx.StringData(c.WorkerSubnetUUID),
+		"clusterAutoscaler":                        llx.DictData(autoscaler),
 	}
+}
+
+// availableUpgradeVersions lists the Kubernetes versions the cluster can
+// currently upgrade to. An empty list means the cluster is already on the
+// newest version DigitalOcean offers for it.
+func (r *mqlDigitaloceanKubernetesCluster) availableUpgradeVersions() ([]interface{}, error) {
+	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+	upgrades, _, err := conn.Client().Kubernetes.GetUpgrades(context.Background(), r.Id.Data)
+	if err != nil {
+		if isDoNotFound(err) {
+			return []interface{}{}, nil
+		}
+		return nil, err
+	}
+	out := make([]interface{}, 0, len(upgrades))
+	for _, u := range upgrades {
+		if u == nil {
+			continue
+		}
+		out = append(out, u.Slug)
+	}
+	return out, nil
 }
 
 func initDigitaloceanKubernetesCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/digitalocean/resources/digitalocean_crossrefs.go
+++ b/providers/digitalocean/resources/digitalocean_crossrefs.go
@@ -7,8 +7,23 @@ import (
 	"strconv"
 	"strings"
 
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// doURNId strips a DigitalOcean URN prefix ("do:<type>:") from s and
+// returns the trailing identifier, or s unchanged when it is not a URN.
+// Monitoring alert entities arrive either as a bare id or as a URN
+// depending on the resource type, so callers normalize before matching.
+func doURNId(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "do:") {
+		if i := strings.LastIndexByte(s, ':'); i >= 0 {
+			return s[i+1:]
+		}
+	}
+	return s
+}
 
 // parseDropletID extracts a droplet id from either a bare numeric id
 // ("12345") or a DigitalOcean droplet URN ("do:droplet:12345"). The
@@ -116,6 +131,129 @@ func (r *mqlDigitaloceanByoipPrefixResource) droplet() (*mqlDigitaloceanDroplet,
 		return nil, nil
 	}
 	return dropletRef(r.MqlRuntime, id, &r.Droplet)
+}
+
+// ----- Alert policy non-droplet targets -----
+//
+// Alert entities carry a resource id (bare or as a do:<type>: URN) whose
+// kind depends on the alert type. Each accessor resolves the entities
+// against one resource index and returns the matches, so a policy that
+// targets a different kind simply resolves to an empty list.
+
+func (r *mqlDigitaloceanAlertPolicy) databases() ([]any, error) {
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	out := []any{}
+	for _, e := range r.Entities.Data {
+		s, ok := e.(string)
+		if !ok {
+			continue
+		}
+		db, err := parent.databaseByID(doURNId(s))
+		if err != nil {
+			return nil, err
+		}
+		if db != nil {
+			out = append(out, db)
+		}
+	}
+	return out, nil
+}
+
+func (r *mqlDigitaloceanAlertPolicy) loadBalancers() ([]any, error) {
+	ids := make([]any, 0, len(r.Entities.Data))
+	for _, e := range r.Entities.Data {
+		if s, ok := e.(string); ok {
+			ids = append(ids, doURNId(s))
+		}
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return parent.loadBalancerByUIDs(ids)
+}
+
+func (r *mqlDigitaloceanAlertPolicy) kubernetesClusters() ([]any, error) {
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	out := []any{}
+	for _, e := range r.Entities.Data {
+		s, ok := e.(string)
+		if !ok {
+			continue
+		}
+		cluster, err := parent.kubernetesClusterByID(doURNId(s))
+		if err != nil {
+			return nil, err
+		}
+		if cluster != nil {
+			out = append(out, cluster)
+		}
+	}
+	return out, nil
+}
+
+// ----- Partner attachment parent / children -----
+
+func (r *mqlDigitaloceanPartnerAttachment) parentAttachment() (*mqlDigitaloceanPartnerAttachment, error) {
+	if r.ParentUuid.Data == "" {
+		r.ParentAttachment.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	pa, err := parent.partnerAttachmentByID(r.ParentUuid.Data)
+	if err != nil {
+		return nil, err
+	}
+	if pa == nil {
+		r.ParentAttachment.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return pa, nil
+}
+
+func (r *mqlDigitaloceanPartnerAttachment) childAttachments() ([]any, error) {
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]any, 0, len(r.Children.Data))
+	for _, c := range r.Children.Data {
+		s, ok := c.(string)
+		if !ok {
+			continue
+		}
+		pa, err := parent.partnerAttachmentByID(s)
+		if err != nil {
+			return nil, err
+		}
+		if pa != nil {
+			out = append(out, pa)
+		}
+	}
+	return out, nil
+}
+
+// ----- Container registry singleton -----
+
+// registry exposes the account's container registry from the namespace so
+// registry-level metadata (usage, subscription, garbage collection) is
+// reachable by walking the digitalocean tree. NewResource runs the
+// registry's init, which returns an empty sentinel when no registry exists.
+func (r *mqlDigitalocean) registry() (*mqlDigitaloceanRegistry, error) {
+	res, err := NewResource(r.MqlRuntime, "digitalocean.registry", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDigitaloceanRegistry), nil
 }
 
 // ----- VPC peering -----

--- a/providers/digitalocean/resources/digitalocean_crossrefs_test.go
+++ b/providers/digitalocean/resources/digitalocean_crossrefs_test.go
@@ -1,0 +1,57 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDropletID(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID int64
+		wantOK bool
+	}{
+		{"bare numeric id", "12345", 12345, true},
+		{"droplet urn", "do:droplet:678", 678, true},
+		{"whitespace trimmed", "  99 ", 99, true},
+		{"non-droplet urn", "do:loadbalancer:abc-123", 0, false},
+		{"dbaas urn", "do:dbaas:uuid", 0, false},
+		{"empty", "", 0, false},
+		{"non-numeric", "abc", 0, false},
+		{"droplet urn missing id", "do:droplet:", 0, false},
+		{"malformed urn extra segment", "do:droplet:12:34", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := parseDropletID(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+func TestDoURNId(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"load balancer urn", "do:loadbalancer:abc-123", "abc-123"},
+		{"dbaas urn", "do:dbaas:cluster-uuid", "cluster-uuid"},
+		{"kubernetes urn", "do:kubernetes:k8s-uuid", "k8s-uuid"},
+		{"bare id passes through", "plain-id", "plain-id"},
+		{"whitespace trimmed", "  x ", "x"},
+		{"empty", "", ""},
+		{"prefix only yields empty tail", "do:", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, doURNId(tt.input))
+		})
+	}
+}

--- a/providers/digitalocean/resources/digitalocean_functions.go
+++ b/providers/digitalocean/resources/digitalocean_functions.go
@@ -122,6 +122,38 @@ func listOpenWhiskActions(ctx context.Context, apiHost, uuid, key string) ([]owA
 	return all, nil
 }
 
+func (r *mqlDigitaloceanFunctionNamespace) accessKeys() ([]interface{}, error) {
+	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+	client := conn.Client()
+
+	keys, _, err := client.Functions.ListAccessKeys(context.Background(), r.Namespace.Data)
+	if err != nil {
+		if isDoNotFound(err) {
+			return []interface{}{}, nil
+		}
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(keys))
+	for _, k := range keys {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.accessKey", map[string]*llx.RawData{
+			"__id":          llx.StringData("digitalocean.function.accessKey/" + r.Uuid.Data + "/" + k.ID),
+			"namespaceUuid": llx.StringData(r.Uuid.Data),
+			"id":            llx.StringData(k.ID),
+			"name":          llx.StringData(k.Name),
+			"createdAt":     llx.TimeDataPtr(timePtr(k.CreatedAt)),
+			"updatedAt":     llx.TimeDataPtr(timePtr(k.UpdatedAt)),
+			"lastUsedAt":    llx.TimeDataPtr(timePtr(k.LastUsedAt)),
+			"expiresAt":     llx.TimeDataPtr(timePtr(k.ExpiresAt)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, res)
+	}
+	return all, nil
+}
+
 func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()

--- a/providers/digitalocean/resources/digitalocean_functions_test.go
+++ b/providers/digitalocean/resources/digitalocean_functions_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwTruthy(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  bool
+	}{
+		{"bool true", true, true},
+		{"bool false", false, false},
+		{"string true", "true", true},
+		{"string false", "false", false},
+		{"string no", "no", false},
+		{"string raw (web action)", "raw", true},
+		{"string auth token", "some-token", true},
+		{"empty string", "", false},
+		{"nil", nil, false},
+		{"other type defaults true", 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, owTruthy(tt.value))
+		})
+	}
+}
+
+func TestOwAnnotation(t *testing.T) {
+	anns := []owKeyValue{
+		{Key: "exec", Value: "nodejs:18"},
+		{Key: "web-export", Value: true},
+	}
+
+	t.Run("found returns value and true", func(t *testing.T) {
+		v, ok := owAnnotation(anns, "exec")
+		assert.True(t, ok)
+		assert.Equal(t, "nodejs:18", v)
+	})
+
+	t.Run("missing returns false", func(t *testing.T) {
+		_, ok := owAnnotation(anns, "require-whisk-auth")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty annotations", func(t *testing.T) {
+		_, ok := owAnnotation(nil, "exec")
+		assert.False(t, ok)
+	})
+}
+
+func TestOwString(t *testing.T) {
+	assert.Equal(t, "nodejs:18", owString("nodejs:18"))
+	assert.Equal(t, "", owString(42))
+	assert.Equal(t, "", owString(nil))
+	assert.Equal(t, "", owString(true))
+}

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -66,6 +66,33 @@ type mqlDigitaloceanInternal struct {
 	firewallByDroplet map[int64][]*mqlDigitaloceanFirewall
 	firewallByTag     map[string][]*mqlDigitaloceanFirewall
 	firewallIndexErr  error
+
+	partnerAttachmentIndexOnce sync.Once
+	partnerAttachmentIndex     map[string]*mqlDigitaloceanPartnerAttachment
+	partnerAttachmentIndexErr  error
+}
+
+// partnerAttachmentByID resolves a partner attachment by its ID from the
+// account-wide list, caching the index. Partner attachments reference
+// their parent and children by UUID, which matches the attachment ID.
+func (r *mqlDigitalocean) partnerAttachmentByID(id string) (*mqlDigitaloceanPartnerAttachment, error) {
+	r.partnerAttachmentIndexOnce.Do(func() {
+		attachments := r.GetPartnerAttachments()
+		if attachments.Error != nil {
+			r.partnerAttachmentIndexErr = attachments.Error
+			return
+		}
+		idx := make(map[string]*mqlDigitaloceanPartnerAttachment, len(attachments.Data))
+		for _, a := range attachments.Data {
+			ma := a.(*mqlDigitaloceanPartnerAttachment)
+			idx[ma.Id.Data] = ma
+		}
+		r.partnerAttachmentIndex = idx
+	})
+	if r.partnerAttachmentIndexErr != nil {
+		return nil, r.partnerAttachmentIndexErr
+	}
+	return r.partnerAttachmentIndex[id], nil
 }
 
 func parentDigitalocean(runtime *plugin.Runtime) (*mqlDigitalocean, error) {

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -316,6 +316,7 @@ func initDigitaloceanRegistry(runtime *plugin.Runtime, args map[string]*llx.RawD
 		}
 		args["name"] = llx.StringData("")
 		args["storageUsageBytes"] = llx.IntData(0)
+		args["storageUsageBytesUpdatedAt"] = llx.TimeDataPtr(nil)
 		args["region"] = llx.StringData("")
 		args["createdAt"] = llx.TimeData(time.Time{})
 		args["subscriptionTier"] = llx.StringData("")
@@ -324,6 +325,7 @@ func initDigitaloceanRegistry(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 	args["name"] = llx.StringData(reg.Name)
 	args["storageUsageBytes"] = llx.IntData(int64(reg.StorageUsageBytes))
+	args["storageUsageBytesUpdatedAt"] = llx.TimeDataPtr(timePtr(reg.StorageUsageBytesUpdatedAt))
 	args["region"] = llx.StringData(reg.Region)
 	args["createdAt"] = llx.TimeData(reg.CreatedAt)
 


### PR DESCRIPTION
## Summary

Follow-up to #8981, continuing to improve the **existing** DigitalOcean resources across three themes: typed cross-references, field completeness, and small self-contained wins. Adds unit tests for the new pure helpers.

### Typed cross-references (correctness)
- `partnerAttachment.parentAttachment()` and `childAttachments()` — resolve `parentUuid` / `children` UUIDs to typed attachments via a cached attachment index.
- `alertPolicy.databases()`, `loadBalancers()`, `kubernetesClusters()` — complements the existing `droplets()`. Alert entities carry a resource id (bare or as a `do:<type>:` URN) whose kind depends on the alert type; each accessor resolves entities against one resource index and returns the matches, so a policy targeting a different kind simply yields an empty list. A shared `doURNId` helper normalizes the URN form.

### Field completeness (depth)
Driven by a godo v1.197.0-vs-schema audit — the schema was already thorough, so this is a small high-value set:
- `kubernetes.cluster.availableUpgradeVersions()` — the versions a cluster can upgrade to (empty = already newest). Answers "is this DOKS cluster on an out-of-date/EOL version?", previously unanswerable. Via `GetUpgrades`.
- `kubernetes.cluster.clusterAutoscaler` (dict: `scaleDownUtilizationThreshold`, `scaleDownUnneededTime`, `expanders`) and `workerSubnetUuid`.
- `project.ownerUuid`, `registry.storageUsageBytesUpdatedAt`, `vpc.urn`.

### Small wins
- `function.namespace.accessKeys()` → `digitalocean.function.accessKey` — audit stale / never-expiring namespace API credentials (`lastUsedAt`, `expiresAt`; secret never exposed). godo-native.
- `registry()` singleton accessor on the namespace, so registry-level metadata (usage, subscription, GC) is reachable by walking the tree.

## Tests
Added table-driven unit tests for the pure helpers: `parseDropletID`, `doURNId`, `owTruthy`, `owAnnotation`, `owString`.

## Versioning
New schema entries at `13.10.2` (unreleased; accumulates with #8981 until the next release). `config.go` `Version` unchanged.

## Testing
- `go test ./resources/`, full `make providers/build/digitalocean`, `gofmt`, `go vet` all pass; codegen drift-free.
- ⚠️ Not verified against a live account (no DigitalOcean token in the dev env). The `accessKeys()` path and `alertPolicy` non-droplet resolvers should be smoke-tested against a real account before relying on them.
