### PR TITLE
🎉 digitalocean-13.11.0, hetzner-13.6.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.10.1",
+	Version:         "13.11.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.5.1",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the **digitalocean** and **hetzner** providers to release the features that have landed since their last release.

### digitalocean `13.10.1` → `13.11.0`
- more typed refs, K8s upgrade/autoscaler fields, Functions access keys (#8985)
- App Platform depth, Functions listing, and typed refs (#8981)

### hetzner `13.5.1` → `13.6.0`
- parse TLS certificate PEM for hygiene audits (#8984)
- cross-resource edges for load balancer and region rollups (#8982)
- server backupsEnabled + SSH key algorithm/bits (#8979)
