### PR TITLE
⭐ aws: detect Nitro instances via instance-type hypervisor

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -16678,6 +16678,14 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   vpcArn @maturity("deprecated") string
   // Hypervisor type of the instance: ovm or xen
   hypervisor string
+  // Hypervisor of the instance type: nitro or xen
+  //
+  // Reports whether the instance type is built on the AWS Nitro System
+  // (nitro) or the Xen hypervisor (xen). Unlike the instance-level
+  // hypervisor field, which only reports ovm or xen, this reflects the
+  // underlying platform and is how you tell whether an instance is
+  // Nitro-based.
+  instanceTypeHypervisor() string
   // Whether this is a Spot Instance or a Scheduled Instance: spot, scheduled, or capacity-block
   instanceLifecycle string
   // Root device type used by the AMI: ebs or instance-store

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -23066,6 +23066,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.hypervisor": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetHypervisor()).ToDataRes(types.String)
 	},
+	"aws.ec2.instance.instanceTypeHypervisor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetInstanceTypeHypervisor()).ToDataRes(types.String)
+	},
 	"aws.ec2.instance.instanceLifecycle": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetInstanceLifecycle()).ToDataRes(types.String)
 	},
@@ -60829,6 +60832,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.hypervisor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).Hypervisor, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.instanceTypeHypervisor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).InstanceTypeHypervisor, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.instanceLifecycle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -146574,6 +146581,7 @@ type mqlAwsEc2Instance struct {
 	StateTransitionTime     plugin.TValue[*time.Time]
 	VpcArn                  plugin.TValue[string]
 	Hypervisor              plugin.TValue[string]
+	InstanceTypeHypervisor  plugin.TValue[string]
 	InstanceLifecycle       plugin.TValue[string]
 	RootDeviceType          plugin.TValue[string]
 	RootDeviceName          plugin.TValue[string]
@@ -146844,6 +146852,12 @@ func (c *mqlAwsEc2Instance) GetVpcArn() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Instance) GetHypervisor() *plugin.TValue[string] {
 	return &c.Hypervisor
+}
+
+func (c *mqlAwsEc2Instance) GetInstanceTypeHypervisor() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.InstanceTypeHypervisor, func() (string, error) {
+		return c.instanceTypeHypervisor()
+	})
 }
 
 func (c *mqlAwsEc2Instance) GetInstanceLifecycle() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3119,6 +3119,7 @@ aws.ec2.instance.instanceId 11.15.2
 aws.ec2.instance.instanceLifecycle 11.15.2
 aws.ec2.instance.instanceStatus 11.15.2
 aws.ec2.instance.instanceType 11.15.2
+aws.ec2.instance.instanceTypeHypervisor 13.43.1
 aws.ec2.instance.ipv6Address 11.15.2
 aws.ec2.instance.keypair 11.15.2
 aws.ec2.instance.launchTime 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.43.0",
-  "generated_at": "2026-07-06T13:52:17-07:00",
+  "generated_at": "2026-07-06T22:30:03-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -262,6 +262,7 @@
     "ec2:DescribeInstanceAttribute",
     "ec2:DescribeInstanceConnectEndpoints",
     "ec2:DescribeInstanceStatus",
+    "ec2:DescribeInstanceTypes",
     "ec2:DescribeInstances",
     "ec2:DescribeInternetGateways",
     "ec2:DescribeIpamPools",
@@ -2501,6 +2502,12 @@
       "permission": "ec2:DescribeInstanceStatus",
       "service": "ec2",
       "action": "DescribeInstanceStatus",
+      "source_file": "aws_ec2.go"
+    },
+    {
+      "permission": "ec2:DescribeInstanceTypes",
+      "service": "ec2",
+      "action": "DescribeInstanceTypes",
       "source_file": "aws_ec2.go"
     },
     {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1511,6 +1511,50 @@ func (i *mqlAwsEc2Instance) networkInterfaces() ([]any, error) {
 	return res, nil
 }
 
+// instanceTypeHypervisorCache memoizes the mapping from EC2 instance type to its
+// hypervisor (nitro or xen). DescribeInstanceTypes is the only API that reports
+// it, and the value is an immutable, region-independent property of the instance
+// type, so we cache it process-wide to avoid an API call per instance (many
+// instances share a type).
+var instanceTypeHypervisorCache sync.Map // map[string]string
+
+func (i *mqlAwsEc2Instance) instanceTypeHypervisor() (string, error) {
+	instanceType := i.InstanceType.Data
+	if instanceType == "" {
+		return "", nil
+	}
+	if v, ok := instanceTypeHypervisorCache.Load(instanceType); ok {
+		return v.(string), nil
+	}
+
+	conn := i.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(i.Region.Data)
+	resp, err := svc.DescribeInstanceTypes(context.Background(), &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []ec2types.InstanceType{ec2types.InstanceType(instanceType)},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			// Don't mask the missing permission behind an empty "not Nitro"
+			// answer; surface it so it can be granted.
+			log.Warn().Str("instanceType", instanceType).Str("instance", i.InstanceId.Data).
+				Msg("no permission for ec2:DescribeInstanceTypes; cannot determine instance-type hypervisor")
+			return "", nil
+		}
+		return "", err
+	}
+
+	// A running instance's type always exists in its own region, so an empty
+	// result is unexpected. Don't cache it, or we'd poison the process-wide
+	// cache for regions where the type does exist.
+	if len(resp.InstanceTypes) == 0 {
+		return "", nil
+	}
+
+	hypervisor := string(resp.InstanceTypes[0].Hypervisor)
+	instanceTypeHypervisorCache.Store(instanceType, hypervisor)
+	return hypervisor, nil
+}
+
 type mqlAwsEc2NetworkinterfaceInternal struct {
 	networkInterfaceCache   ec2types.NetworkInterface
 	region                  string


### PR DESCRIPTION
## What

Adds an `instanceTypeHypervisor` computed field to `aws.ec2.instance` reporting the instance type's hypervisor (`nitro` or `xen`), so MQL can tell whether an EC2 instance runs on the AWS Nitro System.

## Why

The instance-level `hypervisor` field (from `DescribeInstances`) only ever returns `xen` or `ovm` — it **never** returns `nitro`. So there was no way in MQL to distinguish a Nitro-based instance from a genuine Xen one. Nitro is only exposed on the *instance type's* hypervisor, returned by `DescribeInstanceTypes`.

This is the one unmet goal of the "Support AWS Nitro Enclaves in MQL" work (mondoohq/planning#1079), whose demo flow calls for Mondoo to "surface whether each runs on Nitro or a previous generation hypervisor." The Enclaves/NitroTPM/ENA fields it lists already shipped (`enclaveEnabled`, `tpmSupport`, `enaSupported`); this fills the remaining Nitro-detection gap.

## Implementation

- Lazy computed method on `aws.ec2.instance`, backed by a single `DescribeInstanceTypes` call.
- The instance-type → hypervisor mapping is an immutable, region-independent AWS fact, so it's memoized process-wide to avoid an API call per instance (instances of the same type share one lookup).
- Access-denied is logged rather than silently returning an empty value, and empty API results are not cached (so a type missing from one region can't poison the shared cache).
- Adds `ec2:DescribeInstanceTypes` to the permissions manifest.

## Verification

Ran against live EC2. The instance-level field misreports Nitro instances; the new field gets it right:

```
instanceType: "t3.small"   hypervisor: "xen"   instanceTypeHypervisor: "nitro"
instanceType: "m5.2xlarge" hypervisor: "xen"   instanceTypeHypervisor: "nitro"
instanceType: "t2.large"   hypervisor: "xen"   instanceTypeHypervisor: "xen"
```

Example queries:

```mql
// Flag any instance still on a previous-generation (non-Nitro) type
aws.ec2.instances.where( instanceTypeHypervisor == "xen" )

// Group the fleet by underlying hypervisor
aws.ec2.instances { instanceType instanceTypeHypervisor }
```
