### PR TITLE
🎉 terraform-13.3.2

### DIFF
--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.1",
+	Version:   "13.3.2",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,


### PR DESCRIPTION
Patch version bump for the **terraform** provider (`13.3.1` → `13.3.2`) to release the bugfix that has landed since its last release:

- 🐛 show module-qualified address in plan check failures (#8977)
