### PR TITLE
🎉 gcp-13.29.1, vsphere-13.7.1, vllm-13.0.14, vcd-13.0.20, together-13.0.7, tailscale-13.3.6, stackit-13.4.1, snowflake-13.3.6, slack-13.1.15, shodan-13.2.5, proxmox-0.3.1, portainer-13.1.2, os-13.34.1, openstack-13.7.1, openai-13.0.7, opcua-13.0.20

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.29.0",
+	Version: "13.29.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opcua",
 	ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
-	Version:         "13.0.19",
+	Version:         "13.0.20",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openai",
 	ID:              "go.mondoo.com/mql/providers/openai",
-	Version:         "13.0.6",
+	Version:         "13.0.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.7.0",
+	Version:         "13.7.1",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.34.0",
+	Version: "13.34.1",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
-	Version:         "13.1.1",
+	Version:         "13.1.2",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.3.0",
+	Version:         "0.3.1",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.2.4",
+	Version:         "13.2.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "13.1.14",
+	Version:         "13.1.15",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.3.5",
+	Version:         "13.3.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -16,7 +16,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.4.0",
+	Version:         "13.4.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.3.5",
+	Version:         "13.3.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/together/config/config.go
+++ b/providers/together/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "together",
 	ID:              "go.mondoo.com/mql/providers/together",
-	Version:         "13.0.6",
+	Version:         "13.0.7",
 	Platforms:       provider.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
-	Version:         "13.0.19",
+	Version:         "13.0.20",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vllm/config/config.go
+++ b/providers/vllm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vllm",
 	ID:              "go.mondoo.com/mql/providers/vllm",
-	Version:         "13.0.13",
+	Version:         "13.0.14",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.7.0",
+	Version:         "13.7.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.29.1)
- 🌟 gcp: typed network edges + typed instance NICs for attack-path traversal (#8971)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 os: migrate off deprecated docker/docker to moby/moby (#8961)

### vsphere (13.7.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### vllm (13.0.14)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### vcd (13.0.20)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### together (13.0.7)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### tailscale (13.3.6)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### stackit (13.4.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### snowflake (13.3.6)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### slack (13.1.15)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### shodan (13.2.5)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### proxmox (0.3.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)

### portainer (13.1.2)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### os (13.34.1)
- 🧹 os: migrate off deprecated docker/docker to moby/moby (#8961)

### openstack (13.7.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### openai (13.0.7)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### opcua (13.0.20)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)
