### PR TITLE
🎉 activedirectory-13.1.4, ansible-13.2.6, arista-13.3.8, atlassian-13.3.8, bicep-13.4.1, claude-13.0.7, cloudflare-13.6.1, cloudformation-13.2.1, datadog-13.0.14, depsdev-13.1.1, equinix-13.0.21, github-13.6.5, gitlab-13.4.1, google-workspace-13.2.4, grafana-13.1.13, helm-13.3.4

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.1.3",
+	Version:         "13.1.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{

--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.5",
+	Version:         "13.2.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "13.3.7",
+	Version:         "13.3.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.3.7",
+	Version:   "13.3.8",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.0",
+	Version:         "13.4.1",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "claude",
 	ID:              "go.mondoo.com/mql/providers/claude",
-	Version:         "13.0.6",
+	Version:         "13.0.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.6.0",
+	Version:         "13.6.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.2.0",
+	Version:         "13.2.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "datadog",
 	ID:              "go.mondoo.com/mql/providers/datadog",
-	Version:         "13.0.13",
+	Version:         "13.0.14",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "depsdev",
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
-	Version:         "13.1.0",
+	Version:         "13.1.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.20",
+	Version:         "13.0.21",
 	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.6.4",
+	Version:         "13.6.5",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.4.0",
+	Version: "13.4.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.2.3",
+	Version:         "13.2.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.12",
+	Version:         "13.1.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.3",
+	Version:         "13.3.4",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### activedirectory (13.1.4)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### ansible (13.2.6)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### arista (13.3.8)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### atlassian (13.3.8)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### bicep (13.4.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)

### claude (13.0.7)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### cloudflare (13.6.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### cloudformation (13.2.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)

### datadog (13.0.14)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### depsdev (13.1.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### equinix (13.0.21)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### github (13.6.5)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 os: migrate off deprecated docker/docker to moby/moby (#8961)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### gitlab (13.4.1)
- 🧹 Update deps for mql and providers 20260706 (#8962)

### google-workspace (13.2.4)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 os: migrate off deprecated docker/docker to moby/moby (#8961)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### grafana (13.1.13)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)

### helm (13.3.4)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)
