### PR TITLE
🐛 aws: fix elb.loadbalancer.webAcl scopeless ListWebACLs error

### DIFF
--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -1195,38 +1195,22 @@ func (a *mqlAwsElbLoadbalancer) webAcl() (*mqlAwsWafAcl, error) {
 		return nil, nil
 	}
 
-	// Resolve the associated web ACL ARN to the typed resource from the account
-	// web ACL list.
-	obj, err := CreateResource(a.MqlRuntime, ResourceAwsWaf, map[string]*llx.RawData{})
+	// Build the typed web ACL directly from the association response. An ALB's
+	// associated web ACL is always REGIONAL scope; setting scope here (rather
+	// than resolving through the account-wide aws.waf listing) both avoids a
+	// scopeless ListWebACLs call that fails validation and gives the returned
+	// ACL the scope its own accessors (associatedLoadBalancers, rules) need.
+	acl := resp.WebACL
+	mqlAcl, err := CreateResource(a.MqlRuntime, "aws.waf.acl", map[string]*llx.RawData{
+		"__id":        llx.StringDataPtr(acl.ARN),
+		"id":          llx.StringDataPtr(acl.Id),
+		"scope":       llx.StringData(string(waftypes.ScopeRegional)),
+		"arn":         llx.StringDataPtr(acl.ARN),
+		"name":        llx.StringDataPtr(acl.Name),
+		"description": llx.StringDataPtr(acl.Description),
+	})
 	if err != nil {
 		return nil, err
 	}
-	acl, err := obj.(*mqlAwsWaf).wafAclByArn(*resp.WebACL.ARN)
-	if err != nil {
-		return nil, err
-	}
-	if acl == nil {
-		a.WebAcl.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
-	return acl, nil
-}
-
-// wafAclByArn returns the web ACL with the given ARN from the account's web ACLs,
-// or nil when none matches.
-func (a *mqlAwsWaf) wafAclByArn(arnVal string) (*mqlAwsWafAcl, error) {
-	acls := a.GetAcls()
-	if acls.Error != nil {
-		return nil, acls.Error
-	}
-	for _, x := range acls.Data {
-		acl, ok := x.(*mqlAwsWafAcl)
-		if !ok {
-			continue
-		}
-		if acl.Arn.Data == arnVal {
-			return acl, nil
-		}
-	}
-	return nil, nil
+	return mqlAcl.(*mqlAwsWafAcl), nil
 }


### PR DESCRIPTION
## Bug

`aws.elb.loadbalancer.webAcl()` errored on any Application Load Balancer with an associated WAFv2 web ACL:

```
operation error WAFV2: ListWebACLs, 1 validation error(s) found.
- missing required field, ListWebACLsInput.Scope.
```

## Root cause

`webAcl()` fetched the associated ACL ARN via `GetWebACLForResource` (correct), but then resolved it to a typed resource by creating an `aws.waf` resource with **no scope** and calling its `acls()` lister — which issues `ListWebACLs`, an API that **requires** `Scope`. Because `CreateResource` skips `init`, the default-scope fallback in `initAwsWaf` never ran, so `Scope` stayed empty and the call failed validation. This also meant `webAcl.associatedLoadBalancers` could never resolve.

## Fix

Build the typed `aws.waf.acl` directly from the `GetWebACLForResource` response (an ALB's web ACL is always `REGIONAL` scope), mirroring how `aws.waf.acls` constructs each ACL. This drops the `ListWebACLs` round-trip and gives the returned ACL the `scope` its own accessors (`associatedLoadBalancers`, `rules`, …) need. The now-unused `wafAclByArn` helper is removed.

## Verification (live AWS)

Found by the provider-verification sweep of the unreleased AWS delta, against a purpose-built ALB + regional WAFv2 ACL. After the fix:

```
aws.elb.loadBalancers.where(name == /mql/) {
  webAcl { name scope associatedLoadBalancers { name } }
}
=>
webAcl: { name: "mql-verify-web-acl", scope: "REGIONAL",
          associatedLoadBalancers: [ { name: "mql-verify-alb" } ] }
```

Both the `webAcl()` accessor and the reverse `associatedLoadBalancers()` edge now return correct data. No `.lr`/schema change, so no `.lr.versions` bump; permissions manifest unchanged (`GetWebACLForResource` was already used).
