### PR TITLE
🐛 fix CodeQL allocation-size-overflow bounds

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -6,6 +6,7 @@ package mqlc
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -835,7 +836,12 @@ func (c *compiler) unnamedArgs(callerLabel string, init *resources.Init, args []
 	}
 
 	// add all calls to the chunk stack
-	// collect all their types and call references
+	// collect all their types and call references.
+	// len(args) is bounded by the parsed query, but guard the size computation
+	// explicitly so len(args)*2 can never overflow on pathological input.
+	if len(args) > math.MaxInt/2 {
+		return nil, errors.New("Called " + callerLabel + " with too many arguments")
+	}
 	res := make([]*llx.Primitive, len(args)*2)
 
 	for idx := range args {
@@ -894,6 +900,11 @@ func (c *compiler) resourceArgs(resource *resources.ResourceInfo, args []*parser
 		return c.unnamedResourceArgs(resource, args)
 	}
 
+	// len(args) is bounded by the parsed query, but guard the size computation
+	// explicitly so len(args)*2 can never overflow on pathological input.
+	if len(args) > math.MaxInt/2 {
+		return nil, errors.New("resource " + resource.Name + " called with too many arguments")
+	}
 	res := make([]*llx.Primitive, len(args)*2)
 	for idx := range args {
 		arg := args[idx]

--- a/providers/activedirectory/resources/privileged.go
+++ b/providers/activedirectory/resources/privileged.go
@@ -87,6 +87,13 @@ func sidStringToBytes(sidStr string) ([]byte, error) {
 	}
 
 	subAuthCount := len(parts) - 3
+	// The binary SID encodes SubAuthorityCount in a single byte (buf[1] below),
+	// so a valid SID has at most 255 sub-authorities. Reject anything larger
+	// before sizing the buffer, both to keep the encoding correct and to avoid
+	// computing an allocation size from an unbounded, externally-derived value.
+	if subAuthCount > 255 {
+		return nil, fmt.Errorf("invalid SID string: too many sub-authorities (%d): %s", subAuthCount, sidStr)
+	}
 	buf := make([]byte, 8+4*subAuthCount)
 
 	buf[0] = byte(revision)

--- a/providers/os/resources/shadow.go
+++ b/providers/os/resources/shadow.go
@@ -54,7 +54,7 @@ func (s *mqlShadow) list() ([]any, error) {
 
 	// entries is already materialized in memory, but bound the count explicitly
 	// before sizing the result slice from this file-derived length.
-	if len(entries) > math.MaxInt32 {
+	if len(entries) > math.MaxInt/2 {
 		return nil, errors.New("shadow file has too many entries")
 	}
 	shadowEntryResources := make([]any, len(entries))

--- a/providers/os/resources/shadow.go
+++ b/providers/os/resources/shadow.go
@@ -52,6 +52,11 @@ func (s *mqlShadow) list() ([]any, error) {
 		return nil, err
 	}
 
+	// entries is already materialized in memory, but bound the count explicitly
+	// before sizing the result slice from this file-derived length.
+	if len(entries) > math.MaxInt32 {
+		return nil, errors.New("shadow file has too many entries")
+	}
 	shadowEntryResources := make([]any, len(entries))
 	for i := range entries {
 		entry := entries[i]


### PR DESCRIPTION
## What

Resolves four CodeQL `go-allocation-size-overflow` alerts by adding explicit upper-bound validation before allocations whose size is derived from externally-controlled data.

| Alert | Site | Change |
|---|---|---|
| [#49](https://github.com/mondoohq/mql/security/code-scanning/49) | `providers/activedirectory/resources/privileged.go` | Reject SIDs with more than 255 sub-authorities before sizing the buffer |
| [#40](https://github.com/mondoohq/mql/security/code-scanning/40) | `mqlc/mqlc.go` (`resourceArgs`) | Guard `len(args)` before `make(…, len(args)*2)` |
| [#39](https://github.com/mondoohq/mql/security/code-scanning/39) | `mqlc/mqlc.go` (`unnamedArgs`) | Same guard |
| [#100](https://github.com/mondoohq/mql/security/code-scanning/100) | `providers/os/resources/shadow.go` | Bound the entry count before sizing the result slice |

## Why

The rule fires when a `make([]T, n)` size flows from data an attacker might influence, covering both integer overflow (wrapping to an undersized buffer) and unbounded allocation.

The Active Directory case is the substantive one: `subAuthCount` comes from splitting a SID string returned by the directory server, and it feeds both the allocation size `8+4*subAuthCount` and `buf[1] = byte(subAuthCount)`. That second assignment silently truncates any value over 255, so a malformed SID would have produced an incorrect binary encoding. The binary SID format defines `SubAuthorityCount` as a single byte, so the `<= 255` check is a correct spec bound and fixes that latent encoding bug as well.

The other three take `len()` of an already-materialized in-memory slice, so they cannot realistically overflow, but the size still flows from parsed/file input. An explicit bound in the same function as the allocation clears the alert and doubles as honest input validation.

## Testing

- `go build` passes for `mqlc`, `providers/os`, and `providers/activedirectory`.
- `mqlc` test suite passes.
- `gofmt` clean.
