### PR TITLE
✨ aws.lambda.function: expose durable-execution encryption settings

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15037,6 +15037,22 @@ private aws.lambda.function @defaults("arn") {
   masterFunction() aws.lambda.function
   // KMS key used to encrypt the function's deployment package, when configured
   sourceKmsKey() aws.kms.key
+  // Maximum time in seconds a durable execution may run before timing out
+  //
+  // Applies to the entire durable execution rather than an individual
+  // invocation. Null when the function is not configured as a durable
+  // function.
+  durableExecutionTimeout int
+  // Number of days durable-execution history is retained after completion
+  //
+  // After this period the history is no longer available through the
+  // execution-history API. Null when the function is not a durable function.
+  durableExecutionRetentionDays int
+  // KMS key encrypting durable-execution payload data, including input, output, and error payloads
+  //
+  // A customer-managed key configured on the durable function. Null when the
+  // function is not a durable function or relies on an AWS-owned key.
+  durableExecutionKmsKey() aws.kms.key
 }
 
 // AWS Lambda function version

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -21128,6 +21128,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.function.sourceKmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetSourceKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
+	"aws.lambda.function.durableExecutionTimeout": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetDurableExecutionTimeout()).ToDataRes(types.Int)
+	},
+	"aws.lambda.function.durableExecutionRetentionDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetDurableExecutionRetentionDays()).ToDataRes(types.Int)
+	},
+	"aws.lambda.function.durableExecutionKmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetDurableExecutionKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.lambda.function.version.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunctionVersion).GetArn()).ToDataRes(types.String)
 	},
@@ -58000,6 +58009,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.sourceKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).SourceKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.durableExecutionTimeout": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).DurableExecutionTimeout, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.durableExecutionRetentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).DurableExecutionRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.durableExecutionKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).DurableExecutionKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.lambda.function.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -139205,6 +139226,9 @@ type mqlAwsLambdaFunction struct {
 	MasterArn                     plugin.TValue[string]
 	MasterFunction                plugin.TValue[*mqlAwsLambdaFunction]
 	SourceKmsKey                  plugin.TValue[*mqlAwsKmsKey]
+	DurableExecutionTimeout       plugin.TValue[int64]
+	DurableExecutionRetentionDays plugin.TValue[int64]
+	DurableExecutionKmsKey        plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsLambdaFunction creates a new instance of this resource
@@ -139693,6 +139717,30 @@ func (c *mqlAwsLambdaFunction) GetSourceKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
 		}
 
 		return c.sourceKmsKey()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetDurableExecutionTimeout() *plugin.TValue[int64] {
+	return &c.DurableExecutionTimeout
+}
+
+func (c *mqlAwsLambdaFunction) GetDurableExecutionRetentionDays() *plugin.TValue[int64] {
+	return &c.DurableExecutionRetentionDays
+}
+
+func (c *mqlAwsLambdaFunction) GetDurableExecutionKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.DurableExecutionKmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "durableExecutionKmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.durableExecutionKmsKey()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6120,6 +6120,9 @@ aws.lambda.function.codeSize 11.15.2
 aws.lambda.function.concurrency 11.15.2
 aws.lambda.function.description 11.15.2
 aws.lambda.function.dlqTargetArn 11.15.2
+aws.lambda.function.durableExecutionKmsKey 13.44.1
+aws.lambda.function.durableExecutionRetentionDays 13.44.1
+aws.lambda.function.durableExecutionTimeout 13.44.1
 aws.lambda.function.environment 11.15.2
 aws.lambda.function.environmentSecretLikeKeys 13.37.1
 aws.lambda.function.ephemeralStorageSize 11.15.2

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -288,6 +288,14 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"masterArn":                   llx.StringDataPtr(function.MasterArn),
 	}
 
+	if function.DurableConfig != nil {
+		args["durableExecutionTimeout"] = llx.IntDataPtr(function.DurableConfig.ExecutionTimeout)
+		args["durableExecutionRetentionDays"] = llx.IntDataPtr(function.DurableConfig.RetentionPeriodInDays)
+	} else {
+		args["durableExecutionTimeout"] = llx.NilData
+		args["durableExecutionRetentionDays"] = llx.NilData
+	}
+
 	if loggingConfigResource != nil {
 		args["loggingConfig"] = llx.ResourceData(loggingConfigResource, "aws.lambda.function.loggingConfig")
 	} else {
@@ -302,6 +310,9 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 	f.cacheRoleArn = function.Role
 	f.region = region
 	f.accountID = accountID
+	if function.DurableConfig != nil {
+		f.cacheDurableExecutionKmsKeyArn = function.DurableConfig.KMSKeyArn
+	}
 	if function.VpcConfig != nil {
 		f.cacheVpcId = function.VpcConfig.VpcId
 		f.cacheSubnetIds = function.VpcConfig.SubnetIds
@@ -424,6 +435,8 @@ type mqlAwsLambdaFunctionInternal struct {
 	cacheImageUri         *string
 	cacheResolvedImageUri *string
 	cacheSourceKmsKeyArn  *string
+
+	cacheDurableExecutionKmsKeyArn *string
 }
 
 // fetchImageData resolves the container image URIs for Image package type
@@ -474,6 +487,22 @@ func (a *mqlAwsLambdaFunction) sourceKmsKey() (*mqlAwsKmsKey, error) {
 	}
 	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
 		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheSourceKmsKeyArn)})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
+}
+
+// durableExecutionKmsKey resolves the customer-managed KMS key that encrypts a
+// durable function's execution payload data, when one is configured. Cached
+// from the durable config at creation time.
+func (a *mqlAwsLambdaFunction) durableExecutionKmsKey() (*mqlAwsKmsKey, error) {
+	if a.cacheDurableExecutionKmsKeyArn == nil || *a.cacheDurableExecutionKmsKeyArn == "" {
+		a.DurableExecutionKmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.cacheDurableExecutionKmsKeyArn)})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Exposes AWS Lambda **Durable Functions** encryption settings on `aws.lambda.function`, using the `DurableConfig` shape introduced in `aws-sdk-go-v2/service/lambda` **v1.96.0** (landed on `main` via the latest deps update):

- `durableExecutionKmsKey() aws.kms.key` — the customer-managed KMS key that encrypts a durable execution's payload data (input, output, and error payloads). Modeled as a typed reference, consistent with the resource's existing `kmsKey()` (env-var key) and `sourceKmsKey()` (deployment-package key) accessors.
- `durableExecutionTimeout int` — maximum seconds a durable execution may run before timing out.
- `durableExecutionRetentionDays int` — days execution history is retained after completion.

## Why

Lets audits verify that durable-execution data is encrypted with a customer-managed key and confirm execution/retention bounds. It rounds out the encryption-posture coverage already present on the function resource.

## Notes

- `DurableConfig` is returned inline on the existing `GetFunction` / `ListFunctions` response, so **no new IAM permission** is required (`aws.permissions.json` is unchanged).
- All three fields report MQL `null` on functions that are not durable functions: the scalars use `IntDataPtr` and the KMS accessor uses the `StateIsSet | StateIsNull` pattern, avoiding a misleading `0`/empty value.
- New `.lr.versions` entries are at `13.44.1` (next patch after the provider's current `13.44.0`).

## Example

```javascript
aws.lambda.functions.where( durableExecutionTimeout != null ) {
  name
  durableExecutionTimeout
  durableExecutionRetentionDays
  durableExecutionKmsKey { arn keyManager }
}
```
