### PR TITLE
🏇 terraform.resources intermittenly returns empty

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -26,12 +26,25 @@ import (
 )
 
 type mqlTerraformInternal struct {
-	blocksByName  map[string]*mqlTerraformBlock
-	relatedBlocks map[string][]*mqlTerraformBlock
+	// lock guards every field below. The cache is populated exactly once by
+	// ensureCache and is immutable afterwards; all readers must hold lock.
+	lock sync.Mutex
+	// cached reports whether ensureCache has already populated the fields below.
+	cached bool
+
+	// The parsed HCL blocks, split by type. allBlocks holds every block;
+	// the type-specific slices are views into the same block instances.
+	allBlocks        []any
+	providerBlocks   []any
+	datasourceBlocks []any
+	variableBlocks   []any
+	outputBlocks     []any
+	resources        []*mqlTerraformBlock
 	// these are blocks with the type set to "terraform", used for settings
 	terraformBlocks []*mqlTerraformBlock
-	lock            sync.Mutex
-	resources       []*mqlTerraformBlock
+
+	blocksByName  map[string]*mqlTerraformBlock
+	relatedBlocks map[string][]*mqlTerraformBlock
 }
 
 func (t *mqlTerraform) files() ([]any, error) {
@@ -95,69 +108,73 @@ func (t *mqlTerraform) modules() ([]any, error) {
 }
 
 func (t *mqlTerraform) blocks() ([]any, error) {
-	conn := t.MqlRuntime.Connection.(*connection.Connection)
-	parser := conn.Parser()
-	if parser == nil {
-		return []any{}, nil
+	if err := t.ensureCache(); err != nil {
+		return nil, err
 	}
-
-	files := parser.Files()
-	mqlHclBlocks := make([]any, 0)
-	for k := range files {
-		f := files[k]
-		blocks, err := listHclBlocks(t.MqlRuntime, f.Body, f)
-		if err != nil {
-			return nil, err
-		}
-		mqlHclBlocks = append(mqlHclBlocks, blocks...)
-	}
-
-	return mqlHclBlocks, t.refreshCache(mqlHclBlocks)
-}
-
-func (t *mqlTerraform) refreshCache(blocks []any) error {
-	if blocks == nil {
-		raw := t.GetBlocks()
-		return raw.Error
-	}
-
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	if t.blocksByName != nil {
+	return t.allBlocks, nil
+}
+
+// ensureCache parses the HCL configuration once and populates every cached
+// collection on the terraform singleton. It is safe to call concurrently from
+// any terraform.* field getter or init function: the first caller does the
+// work while holding lock, and every other caller blocks on lock and then
+// observes the fully-populated cache. Populating under a single lock (instead
+// of bouncing through GetBlocks/GetOrCompute, which is not synchronized) is
+// what prevents the intermittently-empty terraform.resources list — several
+// terraform.* fields resolve in parallel during a policy scan and previously
+// raced on this shared state (mondoohq/mql#8966).
+func (t *mqlTerraform) ensureCache() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.cached {
 		return nil
 	}
 
+	var blocks []any
+	// plan and state assets have no HCL parser; there are no blocks to list and
+	// the cache is left empty (but marked populated so we don't re-parse).
+	conn, ok := t.MqlRuntime.Connection.(*connection.Connection)
+	if ok && conn != nil {
+		if parser := conn.Parser(); parser != nil {
+			files := parser.Files()
+			for k := range files {
+				f := files[k]
+				bs, err := listHclBlocks(t.MqlRuntime, f.Body, f)
+				if err != nil {
+					return err
+				}
+				blocks = append(blocks, bs...)
+			}
+		}
+	}
+
+	t.allBlocks = blocks
 	t.blocksByName = map[string]*mqlTerraformBlock{}
 	t.relatedBlocks = map[string][]*mqlTerraformBlock{}
-
-	t.Providers.State = plugin.StateIsSet
-	t.Providers.Data = []any{}
-	t.Datasources.State = plugin.StateIsSet
-	t.Datasources.Data = []any{}
-	t.mqlTerraformInternal.resources = []*mqlTerraformBlock{}
-	t.Variables.State = plugin.StateIsSet
-	t.Variables.Data = []any{}
-	t.Outputs.State = plugin.StateIsSet
-	t.Outputs.Data = []any{}
+	t.providerBlocks = []any{}
+	t.datasourceBlocks = []any{}
+	t.variableBlocks = []any{}
+	t.outputBlocks = []any{}
+	t.resources = []*mqlTerraformBlock{}
 	t.terraformBlocks = []*mqlTerraformBlock{}
 
 	for i := range blocks {
 		block := blocks[i].(*mqlTerraformBlock)
 
 		// type must be pre-initialized
-		typ := block.Type.Data
-
-		switch typ {
+		switch block.Type.Data {
 		case "provider":
-			t.Providers.Data = append(t.Providers.Data, block)
+			t.providerBlocks = append(t.providerBlocks, block)
 		case "data":
-			t.Datasources.Data = append(t.Datasources.Data, block)
+			t.datasourceBlocks = append(t.datasourceBlocks, block)
 		case "resource":
-			t.mqlTerraformInternal.resources = append(t.mqlTerraformInternal.resources, block)
+			t.resources = append(t.resources, block)
 		case "variable":
-			t.Variables.Data = append(t.Variables.Data, block)
+			t.variableBlocks = append(t.variableBlocks, block)
 		case "output":
-			t.Outputs.Data = append(t.Outputs.Data, block)
+			t.outputBlocks = append(t.outputBlocks, block)
 		case "terraform":
 			t.terraformBlocks = append(t.terraformBlocks, block)
 		default:
@@ -192,23 +209,7 @@ func (t *mqlTerraform) refreshCache(blocks []any) error {
 		}
 	}
 
-	for k, v := range t.relatedBlocks {
-		block, ok := t.blocksByName[k]
-		if !ok {
-			return errors.New("cannot find terraform block by name: " + k)
-		}
-
-		vi := make([]any, len(v))
-		for i := range v {
-			vi[i] = v[i]
-		}
-
-		block.Related = plugin.TValue[[]any]{
-			State: plugin.StateIsSet,
-			Data:  vi,
-		}
-	}
-
+	t.cached = true
 	return nil
 }
 
@@ -238,23 +239,39 @@ func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, erro
 }
 
 func (t *mqlTerraform) providers() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	if err := t.ensureCache(); err != nil {
+		return nil, err
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.providerBlocks, nil
 }
 
 func (t *mqlTerraform) datasources() ([]any, error) {
-	return nil, t.refreshCache(nil)
-}
-
-func (t *mqlTerraform) resources() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	if err := t.ensureCache(); err != nil {
+		return nil, err
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.datasourceBlocks, nil
 }
 
 func (t *mqlTerraform) variables() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	if err := t.ensureCache(); err != nil {
+		return nil, err
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.variableBlocks, nil
 }
 
 func (t *mqlTerraform) outputs() ([]any, error) {
-	return nil, t.refreshCache(nil)
+	if err := t.ensureCache(); err != nil {
+		return nil, err
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.outputBlocks, nil
 }
 
 func extractHclCodeSnippet(file *hcl.File, fileRange hcl.Range) string {
@@ -461,10 +478,13 @@ func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	tf := tfraw.(*mqlTerraform)
-	if err := tf.refreshCache(nil); err != nil {
+	if err := tf.ensureCache(); err != nil {
 		return nil, nil, err
 	}
-	resources := tf.mqlTerraformInternal.resources
+	tf.lock.Lock()
+	resources := make([]*mqlTerraformBlock, len(tf.resources))
+	copy(resources, tf.resources)
+	tf.lock.Unlock()
 
 	resourceArg := args["resource"]
 	nameArg := args["name"]
@@ -1036,16 +1056,26 @@ func listHclBlocks(runtime *plugin.Runtime, rawBody any, file *hcl.File) ([]any,
 }
 
 func (g *mqlTerraformBlock) related() ([]any, error) {
-	// This field should be default be set by the Terraform routine that
-	// initializes all blocks. If we land here from a recording or other
-	// path, re-run it.
+	// The related-block graph is built once by the terraform singleton's
+	// ensureCache; look this block up in it.
 	o, err := CreateResource(g.MqlRuntime, "terraform", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}
 
 	terraform := o.(*mqlTerraform)
-	return nil, terraform.refreshCache(nil)
+	if err := terraform.ensureCache(); err != nil {
+		return nil, err
+	}
+
+	terraform.lock.Lock()
+	defer terraform.lock.Unlock()
+	related := terraform.relatedBlocks[g.terraformID()]
+	res := make([]any, len(related))
+	for i := range related {
+		res[i] = related[i]
+	}
+	return res, nil
 }
 
 func newFilePosRange(runtime *plugin.Runtime, r hcl.Range) (plugin.Resource, plugin.Resource, error) {
@@ -1158,11 +1188,14 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	terraform := o.(*mqlTerraform)
-	if err := terraform.refreshCache(nil); err != nil {
+	if err := terraform.ensureCache(); err != nil {
 		return nil, nil, err
 	}
 
-	blocks := terraform.terraformBlocks
+	terraform.lock.Lock()
+	blocks := make([]*mqlTerraformBlock, len(terraform.terraformBlocks))
+	copy(blocks, terraform.terraformBlocks)
+	terraform.lock.Unlock()
 	if len(blocks) == 0 {
 		// no terraform settings block found, this is ok for terraform and not an error
 		// TODO: return modified arguments to load from recording

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -1,0 +1,95 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/terraform/connection"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// newHclRaceRuntime builds a fresh runtime (and therefore a fresh terraform
+// singleton) backed by a real parsed HCL config with several resource blocks.
+func newHclRaceRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "hcl", Options: map[string]string{"path": "../provider/testdata/terraform"}},
+		},
+	}
+	conn, err := connection.NewHclConnection(1, asset)
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+// TestHclCache_ConcurrentAccess is a regression test for the intermittent
+// `terraform.resources` empty-list bug reported in mondoohq/mql#8966. In a real
+// policy scan several terraform.* collection fields (blocks, providers,
+// datasources, ...) and the terraform.resources init all resolve concurrently
+// against the same terraform singleton. Before the fix each funneled into
+// refreshCache -> GetBlocks -> the unsynchronized GetOrCompute, so multiple
+// goroutines parsed and wrote the shared cache at once, and terraform.resources
+// init read the internal slice without holding the lock — a data race whose
+// visible symptom (an empty resources list) surfaced non-deterministically
+// depending on scheduling and memory ordering.
+//
+// Run with -race to surface any regression of the data race; the length
+// assertion catches the user-visible symptom (terraform.resources.length == 0).
+func TestHclCache_ConcurrentAccess(t *testing.T) {
+	const iterations = 300
+
+	for i := 0; i < iterations; i++ {
+		rt := newHclRaceRuntime(t)
+
+		tfraw, err := CreateResource(rt, "terraform", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		tf := tfraw.(*mqlTerraform)
+
+		var wg sync.WaitGroup
+
+		// Writers: concurrent field resolutions that all populate the shared
+		// cache via ensureCache.
+		for _, get := range []func() *plugin.TValue[[]any]{
+			tf.GetBlocks, tf.GetProviders, tf.GetDatasources, tf.GetVariables, tf.GetOutputs,
+		} {
+			get := get
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				get()
+			}()
+		}
+
+		// Readers: terraform.resources init, which reads the internal
+		// `resources` slice.
+		gotLen := make([]int, 3)
+		for r := range gotLen {
+			r := r
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+				if err != nil {
+					return
+				}
+				gotLen[r] = len(args["list"].Value.([]any))
+			}()
+		}
+
+		wg.Wait()
+
+		for r, l := range gotLen {
+			require.Positivef(t, l, "iteration %d reader %d: terraform.resources came back empty", i, r)
+		}
+	}
+}

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -62,7 +62,6 @@ func TestHclCache_ConcurrentAccess(t *testing.T) {
 		for _, get := range []func() *plugin.TValue[[]any]{
 			tf.GetBlocks, tf.GetProviders, tf.GetDatasources, tf.GetVariables, tf.GetOutputs,
 		} {
-			get := get
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -74,7 +73,6 @@ func TestHclCache_ConcurrentAccess(t *testing.T) {
 		// `resources` slice.
 		gotLen := make([]int, 3)
 		for r := range gotLen {
-			r := r
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/providers/terraform/resources/hcl_vars_e2e_test.go
+++ b/providers/terraform/resources/hcl_vars_e2e_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	mql "go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/terraform/connection"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// writeVarFixture writes the reviewer's mondoohq/mql#8966 repro to a temp dir: a
+// security-group-rule whose cidr_blocks reference a variable overridden by
+// terraform.tfvars to 0.0.0.0/0.
+func writeVarFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"main.tf":          "resource \"aws_security_group_rule\" \"example\" {\n  cidr_blocks = [var.ingress_cidr]\n}\n",
+		"variables.tf":     "variable \"ingress_cidr\" { default = \"10.0.0.0/8\" }\n",
+		"terraform.tfvars": "ingress_cidr = \"0.0.0.0/0\"\n",
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	return dir
+}
+
+func newRuntimeForDir(t *testing.T, dir string, features []byte) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "hcl", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewHclConnection(1, asset)
+	require.NoError(t, err)
+	conn.SetFeatures(features)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+// TestTerraformResources_VarResolution exercises the full reported scenario end
+// to end: terraform.resources must return the resource block (the fix for the
+// intermittently-empty list, mondoohq/mql#8966), and with the
+// TerraformResolveVars feature active arguments() must resolve var.ingress_cidr
+// to the .tfvars override 0.0.0.0/0 — so the security check is non-vacuous.
+func TestTerraformResources_VarResolution(t *testing.T) {
+	dir := writeVarFixture(t)
+	rt := newRuntimeForDir(t, dir, []byte{byte(mql.TerraformResolveVars)})
+
+	// terraform.resources init -> the list must contain the resource block.
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list := args["list"].Value.([]any)
+	require.Len(t, list, 1, "terraform.resources must not be empty")
+
+	block := list[0].(*mqlTerraformBlock)
+	name, err := block.nameLabel()
+	require.NoError(t, err)
+	require.Equal(t, "aws_security_group_rule", name)
+
+	// arguments() must resolve the variable to its .tfvars override.
+	arguments, err := block.arguments()
+	require.NoError(t, err)
+	require.Equal(t, []any{"0.0.0.0/0"}, arguments["cidr_blocks"],
+		"var.ingress_cidr must resolve to the .tfvars override")
+}
+
+// TestTerraformResources_VarResolutionDisabled documents the opt-out: with the
+// feature inactive, arguments() surfaces the raw reference string instead of the
+// resolved value, but the resources list is still populated.
+func TestTerraformResources_VarResolutionDisabled(t *testing.T) {
+	dir := writeVarFixture(t)
+	rt := newRuntimeForDir(t, dir, nil)
+
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list := args["list"].Value.([]any)
+	require.Len(t, list, 1, "terraform.resources must not be empty")
+
+	block := list[0].(*mqlTerraformBlock)
+	arguments, err := block.arguments()
+	require.NoError(t, err)
+	require.Equal(t, []any{"var.ingress_cidr"}, arguments["cidr_blocks"],
+		"with the feature off, the reference string is surfaced verbatim")
+}


### PR DESCRIPTION
race condition by writing the shared terraform cache at the same time while reading the internal state without a lock

See this: https://github.com/mondoohq/mql/pull/8966#issuecomment-4895637613