### PR TITLE
🎉 terraform-13.3.4

### DIFF
--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.3",
+	Version:   "13.3.4",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### terraform (13.3.4)
- 🏇 empty ID race condition in terraform.resource (#9002)