### PR TITLE
✨ github: go-github v89 + new repository fields and Copilot coding agent config

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog"

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cockroachdb/errors v1.14.0
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v88 v88.0.0
+	github.com/google/go-github/v89 v89.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.35.1
@@ -106,6 +106,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.21.7 // indirect
+	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -382,6 +382,8 @@ github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnO
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -745,8 +745,14 @@ github.repository @defaults("fullName") {
   hasDownloads bool
   // Whether the repository has discussions
   hasDiscussions bool
+  // Whether the repository has pull requests enabled
+  hasPullRequests bool
   // Whether the repository is an organization repository template
   isTemplate bool
+  // Policy for who can create pull requests
+  //
+  // One of "all" or "collaborators_only".
+  pullRequestCreationPolicy string
   // Repository custom properties
   customProperties dict
   // List of open merge requests for the repository
@@ -847,6 +853,41 @@ github.repository @defaults("fullName") {
   variables() []github.actionsVariable
   // GitHub Pages site configuration (null when the repository does not have Pages enabled)
   pages() github.repository.pages
+  // Copilot coding agent configuration (null when the repository has no coding agent configuration)
+  copilotCloudAgent() github.repository.copilotCloudAgent
+}
+
+// Copilot coding agent configuration for a repository
+//
+// Configuration governing how the Copilot coding agent operates in a repository:
+// whether its network `isFirewallEnabled` and the
+// `isFirewallRecommendedAllowlistEnabled` allowlist are on, any extra hosts in
+// the `customAllowlist`, whether the agent must get approval before running
+// Actions workflows via `requireActionsWorkflowApproval`, and which security
+// tools run during an agent session (`codeqlEnabled`, `copilotCodeReviewEnabled`,
+// `secretScanningEnabled`, and `dependencyVulnerabilityChecksEnabled`). The raw
+// MCP server block is available as `mcpConfiguration`. Selected from a
+// repository as `copilotCloudAgent`, and null when the repository has no coding
+// agent configuration or the token lacks access.
+private github.repository.copilotCloudAgent @defaults("isFirewallEnabled requireActionsWorkflowApproval") {
+  // Whether the coding agent network firewall is enabled
+  isFirewallEnabled bool
+  // Whether the recommended firewall allowlist is enabled
+  isFirewallRecommendedAllowlistEnabled bool
+  // Custom hosts added to the firewall allowlist
+  customAllowlist []string
+  // Whether the agent must get approval before running Actions workflows
+  requireActionsWorkflowApproval bool
+  // Whether CodeQL scanning runs during a coding agent session
+  codeqlEnabled bool
+  // Whether Copilot code review runs during a coding agent session
+  copilotCodeReviewEnabled bool
+  // Whether secret scanning runs during a coding agent session
+  secretScanningEnabled bool
+  // Whether dependency vulnerability checks run during a coding agent session
+  dependencyVulnerabilityChecksEnabled bool
+  // MCP server configuration for the coding agent
+  mcpConfiguration dict
 }
 
 // GitHub Pages site

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -39,6 +39,7 @@ const (
 	ResourceGithubPackageVersion                   string = "github.packageVersion"
 	ResourceGithubPackages                         string = "github.packages"
 	ResourceGithubRepository                       string = "github.repository"
+	ResourceGithubRepositoryCopilotCloudAgent      string = "github.repository.copilotCloudAgent"
 	ResourceGithubRepositoryPages                  string = "github.repository.pages"
 	ResourceGithubDeployKey                        string = "github.deployKey"
 	ResourceGithubPublicKey                        string = "github.publicKey"
@@ -175,6 +176,10 @@ func init() {
 		"github.repository": {
 			Init:   initGithubRepository,
 			Create: createGithubRepository,
+		},
+		"github.repository.copilotCloudAgent": {
+			Init:   initGithubRepositoryCopilotCloudAgent,
+			Create: createGithubRepositoryCopilotCloudAgent,
 		},
 		"github.repository.pages": {
 			Init:   initGithubRepositoryPages,
@@ -1180,8 +1185,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.repository.hasDiscussions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetHasDiscussions()).ToDataRes(types.Bool)
 	},
+	"github.repository.hasPullRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetHasPullRequests()).ToDataRes(types.Bool)
+	},
 	"github.repository.isTemplate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetIsTemplate()).ToDataRes(types.Bool)
+	},
+	"github.repository.pullRequestCreationPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetPullRequestCreationPolicy()).ToDataRes(types.String)
 	},
 	"github.repository.customProperties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetCustomProperties()).ToDataRes(types.Dict)
@@ -1326,6 +1337,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"github.repository.pages": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetPages()).ToDataRes(types.Resource("github.repository.pages"))
+	},
+	"github.repository.copilotCloudAgent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetCopilotCloudAgent()).ToDataRes(types.Resource("github.repository.copilotCloudAgent"))
+	},
+	"github.repository.copilotCloudAgent.isFirewallEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetIsFirewallEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.isFirewallRecommendedAllowlistEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetIsFirewallRecommendedAllowlistEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.customAllowlist": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetCustomAllowlist()).ToDataRes(types.Array(types.String))
+	},
+	"github.repository.copilotCloudAgent.requireActionsWorkflowApproval": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetRequireActionsWorkflowApproval()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.codeqlEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetCodeqlEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.copilotCodeReviewEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetCopilotCodeReviewEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.secretScanningEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetSecretScanningEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.dependencyVulnerabilityChecksEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetDependencyVulnerabilityChecksEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.copilotCloudAgent.mcpConfiguration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepositoryCopilotCloudAgent).GetMcpConfiguration()).ToDataRes(types.Dict)
 	},
 	"github.repository.pages.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepositoryPages).GetUrl()).ToDataRes(types.String)
@@ -3640,8 +3681,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGithubRepository).HasDiscussions, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"github.repository.hasPullRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).HasPullRequests, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"github.repository.isTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).IsTemplate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.pullRequestCreationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).PullRequestCreationPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"github.repository.customProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3834,6 +3883,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.repository.pages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).Pages, ok = plugin.RawToTValue[*mqlGithubRepositoryPages](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).CopilotCloudAgent, ok = plugin.RawToTValue[*mqlGithubRepositoryCopilotCloudAgent](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).__id, ok = v.Value.(string)
+		return
+	},
+	"github.repository.copilotCloudAgent.isFirewallEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).IsFirewallEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.isFirewallRecommendedAllowlistEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).IsFirewallRecommendedAllowlistEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.customAllowlist": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).CustomAllowlist, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.requireActionsWorkflowApproval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).RequireActionsWorkflowApproval, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.codeqlEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).CodeqlEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.copilotCodeReviewEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).CopilotCodeReviewEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.secretScanningEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).SecretScanningEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.dependencyVulnerabilityChecksEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).DependencyVulnerabilityChecksEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.copilotCloudAgent.mcpConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepositoryCopilotCloudAgent).McpConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"github.repository.pages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8161,7 +8254,9 @@ type mqlGithubRepository struct {
 	HasPages                             plugin.TValue[bool]
 	HasDownloads                         plugin.TValue[bool]
 	HasDiscussions                       plugin.TValue[bool]
+	HasPullRequests                      plugin.TValue[bool]
 	IsTemplate                           plugin.TValue[bool]
+	PullRequestCreationPolicy            plugin.TValue[string]
 	CustomProperties                     plugin.TValue[any]
 	OpenMergeRequests                    plugin.TValue[[]any]
 	ClosedMergeRequests                  plugin.TValue[[]any]
@@ -8210,6 +8305,7 @@ type mqlGithubRepository struct {
 	Secrets                              plugin.TValue[[]any]
 	Variables                            plugin.TValue[[]any]
 	Pages                                plugin.TValue[*mqlGithubRepositoryPages]
+	CopilotCloudAgent                    plugin.TValue[*mqlGithubRepositoryCopilotCloudAgent]
 }
 
 // createGithubRepository creates a new instance of this resource
@@ -8377,8 +8473,16 @@ func (c *mqlGithubRepository) GetHasDiscussions() *plugin.TValue[bool] {
 	return &c.HasDiscussions
 }
 
+func (c *mqlGithubRepository) GetHasPullRequests() *plugin.TValue[bool] {
+	return &c.HasPullRequests
+}
+
 func (c *mqlGithubRepository) GetIsTemplate() *plugin.TValue[bool] {
 	return &c.IsTemplate
+}
+
+func (c *mqlGithubRepository) GetPullRequestCreationPolicy() *plugin.TValue[string] {
+	return &c.PullRequestCreationPolicy
 }
 
 func (c *mqlGithubRepository) GetCustomProperties() *plugin.TValue[any] {
@@ -9007,6 +9111,111 @@ func (c *mqlGithubRepository) GetPages() *plugin.TValue[*mqlGithubRepositoryPage
 
 		return c.pages()
 	})
+}
+
+func (c *mqlGithubRepository) GetCopilotCloudAgent() *plugin.TValue[*mqlGithubRepositoryCopilotCloudAgent] {
+	return plugin.GetOrCompute[*mqlGithubRepositoryCopilotCloudAgent](&c.CopilotCloudAgent, func() (*mqlGithubRepositoryCopilotCloudAgent, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.repository", c.__id, "copilotCloudAgent")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGithubRepositoryCopilotCloudAgent), nil
+			}
+		}
+
+		return c.copilotCloudAgent()
+	})
+}
+
+// mqlGithubRepositoryCopilotCloudAgent for the github.repository.copilotCloudAgent resource
+type mqlGithubRepositoryCopilotCloudAgent struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGithubRepositoryCopilotCloudAgentInternal it will be used here
+	IsFirewallEnabled                     plugin.TValue[bool]
+	IsFirewallRecommendedAllowlistEnabled plugin.TValue[bool]
+	CustomAllowlist                       plugin.TValue[[]any]
+	RequireActionsWorkflowApproval        plugin.TValue[bool]
+	CodeqlEnabled                         plugin.TValue[bool]
+	CopilotCodeReviewEnabled              plugin.TValue[bool]
+	SecretScanningEnabled                 plugin.TValue[bool]
+	DependencyVulnerabilityChecksEnabled  plugin.TValue[bool]
+	McpConfiguration                      plugin.TValue[any]
+}
+
+// createGithubRepositoryCopilotCloudAgent creates a new instance of this resource
+func createGithubRepositoryCopilotCloudAgent(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGithubRepositoryCopilotCloudAgent{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("github.repository.copilotCloudAgent", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) MqlName() string {
+	return "github.repository.copilotCloudAgent"
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetIsFirewallEnabled() *plugin.TValue[bool] {
+	return &c.IsFirewallEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetIsFirewallRecommendedAllowlistEnabled() *plugin.TValue[bool] {
+	return &c.IsFirewallRecommendedAllowlistEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetCustomAllowlist() *plugin.TValue[[]any] {
+	return &c.CustomAllowlist
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetRequireActionsWorkflowApproval() *plugin.TValue[bool] {
+	return &c.RequireActionsWorkflowApproval
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetCodeqlEnabled() *plugin.TValue[bool] {
+	return &c.CodeqlEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetCopilotCodeReviewEnabled() *plugin.TValue[bool] {
+	return &c.CopilotCodeReviewEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetSecretScanningEnabled() *plugin.TValue[bool] {
+	return &c.SecretScanningEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetDependencyVulnerabilityChecksEnabled() *plugin.TValue[bool] {
+	return &c.DependencyVulnerabilityChecksEnabled
+}
+
+func (c *mqlGithubRepositoryCopilotCloudAgent) GetMcpConfiguration() *plugin.TValue[any] {
+	return &c.McpConfiguration
 }
 
 // mqlGithubRepositoryPages for the github.repository.pages resource

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -544,6 +544,16 @@ github.repository.codeowners.rules 13.0.8
 github.repository.collaborators 9.0.0
 github.repository.commits 9.0.0
 github.repository.contributors 9.0.0
+github.repository.copilotCloudAgent 13.6.6
+github.repository.copilotCloudAgent.codeqlEnabled 13.6.6
+github.repository.copilotCloudAgent.copilotCodeReviewEnabled 13.6.6
+github.repository.copilotCloudAgent.customAllowlist 13.6.6
+github.repository.copilotCloudAgent.dependencyVulnerabilityChecksEnabled 13.6.6
+github.repository.copilotCloudAgent.isFirewallEnabled 13.6.6
+github.repository.copilotCloudAgent.isFirewallRecommendedAllowlistEnabled 13.6.6
+github.repository.copilotCloudAgent.mcpConfiguration 13.6.6
+github.repository.copilotCloudAgent.requireActionsWorkflowApproval 13.6.6
+github.repository.copilotCloudAgent.secretScanningEnabled 13.6.6
 github.repository.createdAt 9.0.0
 github.repository.customProperties 11.4.47
 github.repository.defaultBranch 11.4.5
@@ -564,6 +574,7 @@ github.repository.hasDownloads 9.0.0
 github.repository.hasIssues 9.0.0
 github.repository.hasPages 9.0.0
 github.repository.hasProjects 9.0.0
+github.repository.hasPullRequests 13.6.6
 github.repository.hasWiki 9.0.0
 github.repository.homepage 9.0.0
 github.repository.id 9.0.0
@@ -594,6 +605,7 @@ github.repository.pages.status 13.3.3
 github.repository.pages.url 13.3.3
 github.repository.private 9.0.0
 github.repository.privateVulnerabilityReportingEnabled 13.2.4
+github.repository.pullRequestCreationPolicy 13.6.6
 github.repository.pushedAt 9.0.0
 github.repository.releases 9.0.0
 github.repository.rulesets 11.4.131

--- a/providers/github/resources/github_actions_secrets.go
+++ b/providers/github/resources/github_actions_secrets.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -269,7 +269,7 @@ func (g *mqlGithubEnvironment) secrets() ([]any, error) {
 	opts := &github.ListOptions{PerPage: paginationPerPage}
 	var all []*github.Secret
 	for {
-		page, resp, err := conn.Client().Actions.ListEnvSecrets(conn.Context(), int(repoID), envName, opts)
+		page, resp, err := conn.Client().Actions.ListEnvSecrets(conn.Context(), owner, repo, envName, opts)
 		if err != nil {
 			return handleActionsListErr(err, "environment secrets")
 		}

--- a/providers/github/resources/github_audit.go
+++ b/providers/github/resources/github_audit.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/github/resources/github_copilot.go
+++ b/providers/github/resources/github_copilot.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/github/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (g *mqlGithubOrganizationCopilot) id() (string, error) {
@@ -223,4 +225,86 @@ func newMqlCopilotSeat(runtime *plugin.Runtime, orgLogin string, seat *github.Co
 		args["user"] = llx.NilData
 	}
 	return CreateResource(runtime, "github.organization.copilot.seat", args)
+}
+
+func (g *mqlGithubRepositoryCopilotCloudAgent) id() (string, error) {
+	if g.__id == "" {
+		return "", errors.New("github.repository.copilotCloudAgent requires __id set by the creator")
+	}
+	return g.__id, nil
+}
+
+func initGithubRepositoryCopilotCloudAgent(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	repo, err := NewResource(runtime, "github.repository", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg := repo.(*mqlGithubRepository).GetCopilotCloudAgent()
+	if cfg.Error != nil {
+		return nil, nil, cfg.Error
+	}
+	if cfg.Data == nil {
+		return nil, nil, errors.New("Copilot coding agent configuration is not available for this repository")
+	}
+	return args, cfg.Data, nil
+}
+
+func (g *mqlGithubRepository) copilotCloudAgent() (*mqlGithubRepositoryCopilotCloudAgent, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	repoName := g.Name.Data
+	if g.Owner.Error != nil {
+		return nil, g.Owner.Error
+	}
+	owner := g.Owner.Data
+	if owner.Login.Error != nil {
+		return nil, owner.Login.Error
+	}
+	ownerLogin := owner.Login.Data
+
+	cfg, _, err := conn.Client().Copilot.GetCloudAgentConfiguration(conn.Context(), ownerLogin, repoName)
+	if err != nil {
+		switch githubResponseStatus(err) {
+		case 404, 403, 401:
+			log.Debug().Err(err).Msg("Copilot coding agent configuration not accessible")
+			g.CopilotCloudAgent.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	if cfg == nil {
+		g.CopilotCloudAgent.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	args := map[string]*llx.RawData{
+		"__id":                                  llx.StringData("github.repository.copilotCloudAgent/" + ownerLogin + "/" + repoName),
+		"isFirewallEnabled":                     llx.BoolData(cfg.IsFirewallEnabled),
+		"isFirewallRecommendedAllowlistEnabled": llx.BoolData(cfg.IsFirewallRecommendedAllowlistEnabled),
+		"customAllowlist":                       llx.ArrayData(convert.SliceAnyToInterface[string](cfg.CustomAllowlist), types.String),
+		"requireActionsWorkflowApproval":        llx.BoolData(cfg.RequireActionsWorkflowApproval),
+		"mcpConfiguration":                      llx.DictData(cfg.MCPConfiguration),
+	}
+	if t := cfg.EnabledTools; t != nil {
+		args["codeqlEnabled"] = llx.BoolData(t.Codeql)
+		args["copilotCodeReviewEnabled"] = llx.BoolData(t.CopilotCodeReview)
+		args["secretScanningEnabled"] = llx.BoolData(t.SecretScanning)
+		args["dependencyVulnerabilityChecksEnabled"] = llx.BoolData(t.DependencyVulnerabilityChecks)
+	} else {
+		args["codeqlEnabled"] = llx.BoolData(false)
+		args["copilotCodeReviewEnabled"] = llx.BoolData(false)
+		args["secretScanningEnabled"] = llx.BoolData(false)
+		args["dependencyVulnerabilityChecksEnabled"] = llx.BoolData(false)
+	}
+
+	res, err := CreateResource(g.MqlRuntime, "github.repository.copilotCloudAgent", args)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGithubRepositoryCopilotCloudAgent), nil
 }

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"
@@ -119,6 +119,8 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 		"hasPages":                            llx.BoolData(repo.GetHasPages()),
 		"hasDownloads":                        llx.BoolData(repo.GetHasDownloads()),
 		"hasDiscussions":                      llx.BoolData(repo.GetHasDiscussions()),
+		"hasPullRequests":                     llx.BoolData(repo.GetHasPullRequests()),
+		"pullRequestCreationPolicy":           llx.StringDataPtr(repo.PullRequestCreationPolicy),
 		"isTemplate":                          llx.BoolData(repo.GetIsTemplate()),
 		"defaultBranchName":                   llx.StringDataPtr(repo.DefaultBranch),
 		"cloneUrl":                            llx.StringData(repo.GetCloneURL()),
@@ -1311,11 +1313,11 @@ func (g *mqlGithubRepository) releases() ([]any, error) {
 		}
 
 		mqlRelease, err := CreateResource(g.MqlRuntime, "github.release", map[string]*llx.RawData{
-			"url":         llx.StringDataPtr(r.HTMLURL),
+			"url":         llx.StringData(r.HTMLURL),
 			"name":        llx.StringDataPtr(r.Name),
-			"tagName":     llx.StringDataPtr(r.TagName),
-			"preRelease":  llx.BoolDataPtr(r.Prerelease),
-			"createdAt":   llx.TimeDataPtr(githubTimestamp(r.CreatedAt)),
+			"tagName":     llx.StringData(r.TagName),
+			"preRelease":  llx.BoolData(r.Prerelease),
+			"createdAt":   llx.TimeDataPtr(githubTimestamp(&r.CreatedAt)),
 			"publishedAt": llx.TimeDataPtr(githubTimestamp(r.PublishedAt)),
 			"author":      llx.AnyData(author),
 		})

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_runners_test.go
+++ b/providers/github/resources/github_runners_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_security_test.go
+++ b/providers/github/resources/github_security_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/github/connection"
 )

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/github/connection"


### PR DESCRIPTION
## What

Updates the github provider's `go-github` dependency **v88 → v89** (latest), handles the breaking changes, and adds the new schema that v89 surfaces.

## Dependency update

Adapted to v89's two breaking changes that touched our code:

- **`ListEnvSecrets`** moved from a `repoID int` addressing scheme to `owner, repo string`, aligning it with every other repo-scoped endpoint.
- **`RepositoryRelease`** flipped its always-present fields (`TagName`, `HTMLURL`, `Prerelease`, `CreatedAt`) from `*T` pointers to bare values; genuinely-optional fields (`Name`, `PublishedAt`) stayed pointers.

I diffed the full v88..v89 deprecated-symbol set (45 → 86 symbols) and confirmed the provider uses **none** of the 51 newly-deprecated ones. The single deprecated symbol we do reference (`PullRequestReview.AuthorAssociation`) is pre-existing and its deprecation only concerns Events-API webhook payloads; we read it via the Pull Request Reviews REST endpoint, which is the documented replacement.

`ghinstallation/v2` (GitHub App JWT auth) still pins go-github v88 internally and has no v89 release yet. It only supplies an `http.RoundTripper`, so the version mismatch is harmless — v88 remains an `// indirect` dep and will collapse to v89-only once ghinstallation catches up.

## New schema

**`github.repository`**

| Field | Type | Notes |
|---|---|---|
| `hasPullRequests` | `bool` | Whether pull requests are enabled |
| `pullRequestCreationPolicy` | `string` | `all` or `collaborators_only`; null when unset |

**`github.repository.copilotCloudAgent`** — new nullable singleton sub-resource modeling the per-repo Copilot coding agent configuration (`GET /repos/{owner}/{repo}/copilot/cloud-agent/configuration`):

- `isFirewallEnabled`, `isFirewallRecommendedAllowlistEnabled`, `customAllowlist`
- `requireActionsWorkflowApproval`
- `codeqlEnabled`, `copilotCodeReviewEnabled`, `secretScanningEnabled`, `dependencyVulnerabilityChecksEnabled` (flattened from the API's `enabled_tools` object — no ID, no typed refs, so no separate sub-resource)
- `mcpConfiguration` (raw MCP block, typed `dict` because the API shape isn't fixed)

Reads as null when a repository has no coding agent configuration or the token lacks access, so it's safe to fan out across an org scan.

```mql
github.repositories.where(hasPullRequests) {
  copilotCloudAgent { isFirewallEnabled secretScanningEnabled requireActionsWorkflowApproval }
}
```

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test ./resources/... ./connection/...` pass
- `mqlr generate` produces no uncommitted drift; new `.lr.versions` entries at `13.6.6`
