### PR TITLE
✨ gitlab: expose GitLab Duo AI indicators on settings and projects

### DIFF
--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -77,6 +77,10 @@ gitlab.settings @defaults("requireTwoFactorAuthentication") {
   sessionExpireDelay int
   // Maximum web-terminal session time, in seconds
   terminalMaxSessionTime int
+  // Whether GitLab Duo AI features are enabled for the instance
+  duoFeaturesEnabled bool
+  // Whether the GitLab Duo features toggle is locked so groups and projects cannot override it
+  lockDuoFeaturesEnabled bool
 }
 
 // GitLab user
@@ -716,6 +720,12 @@ gitlab.project @defaults("fullName visibility webURL") {
   mirrorTriggerBuilds bool
   // Whether mirroring is limited to protected branches
   onlyMirrorProtectedBranches bool
+  // Whether GitLab Duo automatically reviews merge requests
+  autoDuoCodeReviewEnabled bool
+  // Visibility of the machine-learning model experiments feature (disabled, private, enabled)
+  modelExperimentsAccessLevel string
+  // Visibility of the machine-learning model registry feature (disabled, private, enabled)
+  modelRegistryAccessLevel string
   // Approval rules for the project
   approvalRules() []gitlab.project.approvalRule
   // Merge methods for the project

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -78,8 +78,13 @@ gitlab.settings @defaults("requireTwoFactorAuthentication") {
   // Maximum web-terminal session time, in seconds
   terminalMaxSessionTime int
   // Whether GitLab Duo AI features are enabled for the instance
+  //
+  // Reads false when the instance does not support or has not enabled Duo;
+  // older GitLab versions do not report this field.
   duoFeaturesEnabled bool
   // Whether the GitLab Duo features toggle is locked so groups and projects cannot override it
+  //
+  // Reads false on instances that do not report this setting.
   lockDuoFeaturesEnabled bool
 }
 
@@ -721,10 +726,19 @@ gitlab.project @defaults("fullName visibility webURL") {
   // Whether mirroring is limited to protected branches
   onlyMirrorProtectedBranches bool
   // Whether GitLab Duo automatically reviews merge requests
+  //
+  // Reads false when the project's GitLab instance does not support or has not
+  // enabled Duo.
   autoDuoCodeReviewEnabled bool
-  // Visibility of the machine-learning model experiments feature (disabled, private, enabled)
+  // Visibility of the machine-learning model experiments feature
+  //
+  // One of disabled, private, or enabled; empty on instances that do not report
+  // it.
   modelExperimentsAccessLevel string
-  // Visibility of the machine-learning model registry feature (disabled, private, enabled)
+  // Visibility of the machine-learning model registry feature
+  //
+  // One of disabled, private, or enabled; empty on instances that do not report
+  // it.
   modelRegistryAccessLevel string
   // Approval rules for the project
   approvalRules() []gitlab.project.approvalRule

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -461,6 +461,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.settings.terminalMaxSessionTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabSettings).GetTerminalMaxSessionTime()).ToDataRes(types.Int)
 	},
+	"gitlab.settings.duoFeaturesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabSettings).GetDuoFeaturesEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.settings.lockDuoFeaturesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabSettings).GetLockDuoFeaturesEnabled()).ToDataRes(types.Bool)
+	},
 	"gitlab.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabUser).GetId()).ToDataRes(types.Int)
 	},
@@ -1192,6 +1198,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.onlyMirrorProtectedBranches": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetOnlyMirrorProtectedBranches()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.autoDuoCodeReviewEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetAutoDuoCodeReviewEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.modelExperimentsAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetModelExperimentsAccessLevel()).ToDataRes(types.String)
+	},
+	"gitlab.project.modelRegistryAccessLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetModelRegistryAccessLevel()).ToDataRes(types.String)
 	},
 	"gitlab.project.approvalRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetApprovalRules()).ToDataRes(types.Array(types.Resource("gitlab.project.approvalRule")))
@@ -2851,6 +2866,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGitlabSettings).TerminalMaxSessionTime, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"gitlab.settings.duoFeaturesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabSettings).DuoFeaturesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.settings.lockDuoFeaturesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabSettings).LockDuoFeaturesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gitlab.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabUser).__id, ok = v.Value.(string)
 		return
@@ -3877,6 +3900,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.project.onlyMirrorProtectedBranches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).OnlyMirrorProtectedBranches, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.autoDuoCodeReviewEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).AutoDuoCodeReviewEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.modelExperimentsAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ModelExperimentsAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.modelRegistryAccessLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ModelRegistryAccessLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.approvalRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6127,6 +6162,8 @@ type mqlGitlabSettings struct {
 	ImportSources                             plugin.TValue[[]any]
 	SessionExpireDelay                        plugin.TValue[int64]
 	TerminalMaxSessionTime                    plugin.TValue[int64]
+	DuoFeaturesEnabled                        plugin.TValue[bool]
+	LockDuoFeaturesEnabled                    plugin.TValue[bool]
 }
 
 // createGitlabSettings creates a new instance of this resource
@@ -6288,6 +6325,14 @@ func (c *mqlGitlabSettings) GetSessionExpireDelay() *plugin.TValue[int64] {
 
 func (c *mqlGitlabSettings) GetTerminalMaxSessionTime() *plugin.TValue[int64] {
 	return &c.TerminalMaxSessionTime
+}
+
+func (c *mqlGitlabSettings) GetDuoFeaturesEnabled() *plugin.TValue[bool] {
+	return &c.DuoFeaturesEnabled
+}
+
+func (c *mqlGitlabSettings) GetLockDuoFeaturesEnabled() *plugin.TValue[bool] {
+	return &c.LockDuoFeaturesEnabled
 }
 
 // mqlGitlabUser for the gitlab.user resource
@@ -8333,6 +8378,9 @@ type mqlGitlabProject struct {
 	SharedWithGroups                          plugin.TValue[[]any]
 	MirrorTriggerBuilds                       plugin.TValue[bool]
 	OnlyMirrorProtectedBranches               plugin.TValue[bool]
+	AutoDuoCodeReviewEnabled                  plugin.TValue[bool]
+	ModelExperimentsAccessLevel               plugin.TValue[string]
+	ModelRegistryAccessLevel                  plugin.TValue[string]
 	ApprovalRules                             plugin.TValue[[]any]
 	MergeMethod                               plugin.TValue[string]
 	ApprovalSettings                          plugin.TValue[*mqlGitlabProjectApprovalSetting]
@@ -8583,6 +8631,18 @@ func (c *mqlGitlabProject) GetMirrorTriggerBuilds() *plugin.TValue[bool] {
 
 func (c *mqlGitlabProject) GetOnlyMirrorProtectedBranches() *plugin.TValue[bool] {
 	return &c.OnlyMirrorProtectedBranches
+}
+
+func (c *mqlGitlabProject) GetAutoDuoCodeReviewEnabled() *plugin.TValue[bool] {
+	return &c.AutoDuoCodeReviewEnabled
+}
+
+func (c *mqlGitlabProject) GetModelExperimentsAccessLevel() *plugin.TValue[string] {
+	return &c.ModelExperimentsAccessLevel
+}
+
+func (c *mqlGitlabProject) GetModelRegistryAccessLevel() *plugin.TValue[string] {
+	return &c.ModelRegistryAccessLevel
 }
 
 func (c *mqlGitlabProject) GetApprovalRules() *plugin.TValue[[]any] {

--- a/providers/gitlab/resources/gitlab.lr.versions
+++ b/providers/gitlab/resources/gitlab.lr.versions
@@ -290,6 +290,7 @@ gitlab.project.auditEvent.targetDetails 13.3.9
 gitlab.project.auditEvent.targetType 13.3.9
 gitlab.project.auditEvents 13.3.9
 gitlab.project.autoDevopsEnabled 9.0.1
+gitlab.project.autoDuoCodeReviewEnabled 13.4.2
 gitlab.project.autocloseReferencedIssues 11.1.107
 gitlab.project.buildsAccessLevel 13.3.9
 gitlab.project.ciJobTokenScopeEnabled 13.3.9
@@ -502,6 +503,8 @@ gitlab.project.milestone.updatedAt 11.1.129
 gitlab.project.milestones 11.1.129
 gitlab.project.mirror 9.0.1
 gitlab.project.mirrorTriggerBuilds 13.3.9
+gitlab.project.modelExperimentsAccessLevel 13.4.2
+gitlab.project.modelRegistryAccessLevel 13.4.2
 gitlab.project.name 9.0.0
 gitlab.project.onlyAllowMergeIfAllDiscussionsAreResolved 9.0.1
 gitlab.project.onlyAllowMergeIfPipelineSucceeds 9.0.1
@@ -745,12 +748,14 @@ gitlab.settings.disabledOauthSignInSources 13.3.9
 gitlab.settings.domainAllowlist 13.3.9
 gitlab.settings.domainDenylist 13.3.9
 gitlab.settings.domainDenylistEnabled 13.3.9
+gitlab.settings.duoFeaturesEnabled 13.4.2
 gitlab.settings.enforcePatExpiration 13.3.9
 gitlab.settings.enforceSshKeyExpiration 13.3.9
 gitlab.settings.externalAuthorizationServiceEnabled 13.3.9
 gitlab.settings.gitTwoFactorSessionExpiry 13.0.3
 gitlab.settings.id 13.0.3
 gitlab.settings.importSources 13.3.9
+gitlab.settings.lockDuoFeaturesEnabled 13.4.2
 gitlab.settings.minimumPasswordLength 13.3.9
 gitlab.settings.notifyOnUnknownSignIn 13.3.9
 gitlab.settings.passwordAuthenticationEnabledForGit 13.0.3

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -107,6 +107,9 @@ func getGitlabProjectArgs(prj *gitlab.Project) map[string]*llx.RawData {
 		"sharedWithGroups":                          llx.ArrayData(projectSharedGroupsToDicts(prj.SharedWithGroups), types.Dict),
 		"mirrorTriggerBuilds":                       llx.BoolData(prj.MirrorTriggerBuilds),
 		"onlyMirrorProtectedBranches":               llx.BoolData(prj.OnlyMirrorProtectedBranches),
+		"autoDuoCodeReviewEnabled":                  llx.BoolData(prj.AutoDuoCodeReviewEnabled),
+		"modelExperimentsAccessLevel":               llx.StringData(string(prj.ModelExperimentsAccessLevel)),
+		"modelRegistryAccessLevel":                  llx.StringData(string(prj.ModelRegistryAccessLevel)),
 	}
 }
 

--- a/providers/gitlab/resources/gitlab_settings.go
+++ b/providers/gitlab/resources/gitlab_settings.go
@@ -55,6 +55,8 @@ func initGitlabSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	args["importSources"] = llx.ArrayData(convert.SliceAnyToInterface(settings.ImportSources), types.String)
 	args["sessionExpireDelay"] = llx.IntData(settings.SessionExpireDelay)
 	args["terminalMaxSessionTime"] = llx.IntData(settings.TerminalMaxSessionTime)
+	args["duoFeaturesEnabled"] = llx.BoolData(settings.DuoFeaturesEnabled)
+	args["lockDuoFeaturesEnabled"] = llx.BoolData(settings.LockDuoFeaturesEnabled)
 
 	return args, nil, nil
 }


### PR DESCRIPTION
## What

Exposes the GitLab Duo / AI governance indicators that the SDK returns, so audits can assert on AI-feature posture. All additive; new `.lr.versions` entries at `13.4.2`.

**`gitlab.settings` (instance-wide):**
| Field | Meaning |
|---|---|
| `duoFeaturesEnabled` | Whether GitLab Duo AI features are enabled for the instance |
| `lockDuoFeaturesEnabled` | Whether the Duo toggle is locked so groups/projects can't override it |

**`gitlab.project`:**
| Field | Meaning |
|---|---|
| `autoDuoCodeReviewEnabled` | Whether Duo automatically reviews merge requests |
| `modelExperimentsAccessLevel` | Visibility of the ML model-experiments feature (`disabled`/`private`/`enabled`) |
| `modelRegistryAccessLevel` | Visibility of the ML model-registry feature (same enum) |

## Why

AI-feature governance is increasingly audit-relevant (data leaving the org boundary to an LLM, autonomous MR review, ML model hosting). These are the read-side signals for "is Duo/AI on, and is it locked down" at the instance and project tiers.

## Implementation notes

- Every field is read from an existing GET payload (`Settings.GetSettings`, `Projects.GetProject` / project list), so there are **no new API calls** — just extra fields mapped in `initGitlabSettings` and `getGitlabProjectArgs`.
- The model-* access levels use GitLab's uniform `AccessControlValue` enum, mapped to `string` to match how every other `*AccessLevel` field in the provider is already modeled.

## Scope note — group-level Duo

The most-wanted tier for Duo governance is the **group**, but in `client-go` v1.46.0 the group Duo fields (`duo_availability`, `duo_features_enabled`, `lock_duo_features_enabled`, `experiment_features_enabled`) exist **only in `CreateGroupOptions`/`UpdateGroupOptions`** — they are write-only and absent from the `Group` GET response struct, so they can't be read through the typed SDK. There is also no dedicated Duo/AI service in the SDK. Exposing group Duo settings needs either an SDK bump (once the `Group` response carries them) or a supplementary raw GET; tracked as follow-up.

## Follow-up to #9004

Builds on #9004 (now merged); rebased onto `main` so this PR contains only the AI-indicator diff.

## Verification

- `go build ./...` — clean
- `go vet ./resources/` — clean

⚠️ **Live `mql shell gitlab` verification was not run** — no GitLab token in this environment. Suggested smoke test:

```
gitlab.settings { duoFeaturesEnabled lockDuoFeaturesEnabled }
gitlab.project { autoDuoCodeReviewEnabled modelExperimentsAccessLevel modelRegistryAccessLevel }
```
