### PR TITLE
✨ oci: discover Generative AI endpoints as oci-ai-generativeai-endpoint assets

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -40,6 +40,7 @@ Examples:
 				resources.DiscoveryRedisClusters,
 				resources.DiscoveryVaultSecrets,
 				resources.DiscoveryOkeClusters,
+				resources.DiscoveryGenerativeAiEndpoints,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -336,11 +336,10 @@ func discover(runtime *plugin.Runtime, conn *connection.OciConnection, target st
 			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
 				tenantID:    tenantID,
 				compartment: e.CompartmentID.Data,
-				// The endpoint resource doesn't retain the region it was
-				// enumerated in, so fall back to the "unknown" placeholder;
-				// the platform id stays valid and the endpoint id is globally
-				// unique on its own.
-				region:     fallbackRegion(""),
+				// cacheRegion is populated during endpoint enumeration (the
+				// listing runs per subscribed region); empty only when the
+				// enumeration didn't hit a region (defensive fallback).
+				region:     fallbackRegion(e.cacheRegion),
 				id:         e.Id.Data,
 				service:    "generativeai",
 				objectType: "endpoint",

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -32,6 +32,7 @@ const (
 	DiscoveryRedisClusters         = "redis-clusters"
 	DiscoveryVaultSecrets          = "vault-secrets"
 	DiscoveryOkeClusters           = "oke-clusters"
+	DiscoveryGenerativeAiEndpoints = "generativeai-endpoints"
 )
 
 // AllAPIResources lists every fine-grained per-resource discovery target.
@@ -39,6 +40,7 @@ const (
 var AllAPIResources = []string{
 	DiscoveryAPIGatewayDeployments,
 	DiscoveryBuckets,
+	DiscoveryGenerativeAiEndpoints,
 	DiscoveryLoadBalancers,
 	DiscoveryOkeClusters,
 	DiscoveryPolicies,
@@ -319,6 +321,31 @@ func discover(runtime *plugin.Runtime, conn *connection.OciConnection, target st
 				objectType:  "cluster",
 			}, c.Name.Data, tagsToLabels(c.FreeformTags.Data), conn))
 		}
+	case DiscoveryGenerativeAiEndpoints:
+		res, err := NewResource(runtime, "oci.ai.generativeAi", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+		genAi := res.(*mqlOciAiGenerativeAi)
+		endpoints := genAi.GetEndpoints()
+		if endpoints.Error != nil {
+			return nil, endpoints.Error
+		}
+		for i := range endpoints.Data {
+			e := endpoints.Data[i].(*mqlOciAiGenerativeAiEndpoint)
+			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
+				tenantID:    tenantID,
+				compartment: e.CompartmentID.Data,
+				// The endpoint resource doesn't retain the region it was
+				// enumerated in, so fall back to the "unknown" placeholder;
+				// the platform id stays valid and the endpoint id is globally
+				// unique on its own.
+				region:     fallbackRegion(""),
+				id:         e.Id.Data,
+				service:    "generativeai",
+				objectType: "endpoint",
+			}, e.Name.Data, tagsToLabels(e.FreeformTags.Data), conn))
+		}
 	default:
 		log.Warn().Str("target", target).Msg("oci discovery: unknown target; skipping")
 	}
@@ -395,6 +422,10 @@ func getPlatformName(obj ociObject) string {
 	case "oke":
 		if obj.objectType == "cluster" {
 			return "oci-oke-cluster"
+		}
+	case "generativeai":
+		if obj.objectType == "endpoint" {
+			return "oci-ai-generativeai-endpoint"
 		}
 	}
 	return ""

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -306,6 +306,21 @@ type mqlOciAiGenerativeAiEndpointInternal struct {
 }
 
 func initOciAiGenerativeAiEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// When selected as a discovered asset there is no "id" arg; fall back to
+	// the connection's platform id and pull the endpoint OCID from it, matching
+	// the oci-ai-generativeai-endpoint platform emitted during discovery.
+	if ociArgString(args, "id") == "" {
+		conn := runtime.Connection.(*connection.OciConnection)
+		if conn.Conf != nil && conn.Conf.PlatformId != "" {
+			if parsed, ok := parseOciObjectPlatformID(conn.Conf.PlatformId); ok &&
+				parsed.service == "generativeai" && parsed.objectType == "endpoint" {
+				if args == nil {
+					args = map[string]*llx.RawData{}
+				}
+				args["id"] = llx.StringData(parsed.id)
+			}
+		}
+	}
 	return findOciGenerativeAiByID(runtime, args, (*mqlOciAiGenerativeAi).GetEndpoints)
 }
 

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -28,7 +28,7 @@ func (o *mqlOciAiGenerativeAi) compartmentID() string {
 // listRegional runs fetch against the Generative AI API in every subscribed
 // region concurrently and flattens the results. Regions where Generative AI is
 // not available are skipped (see ociRegionServiceUnavailable).
-func (o *mqlOciAiGenerativeAi) listRegional(fetch func(svc *generativeai.GenerativeAiClient) ([]any, error)) ([]any, error) {
+func (o *mqlOciAiGenerativeAi) listRegional(fetch func(svc *generativeai.GenerativeAiClient, region string) ([]any, error)) ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	regions, err := ociAgentRegions(o.MqlRuntime)
 	if err != nil {
@@ -47,7 +47,7 @@ func (o *mqlOciAiGenerativeAi) listRegional(fetch func(svc *generativeai.Generat
 			if err != nil {
 				return nil, err
 			}
-			items, err := fetch(svc)
+			items, err := fetch(svc, regionID)
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
 					return jobpool.JobResult([]any{}), nil
@@ -76,7 +76,7 @@ func (o *mqlOciAiGenerativeAi) dedicatedAiClusters() ([]any, error) {
 	return o.listRegional(o.fetchDedicatedAiClusters)
 }
 
-func (o *mqlOciAiGenerativeAi) fetchDedicatedAiClusters(svc *generativeai.GenerativeAiClient) ([]any, error) {
+func (o *mqlOciAiGenerativeAi) fetchDedicatedAiClusters(svc *generativeai.GenerativeAiClient, _ string) ([]any, error) {
 	ctx := context.Background()
 	var items []generativeai.DedicatedAiClusterSummary
 	var page *string
@@ -144,7 +144,7 @@ func (o *mqlOciAiGenerativeAi) models() ([]any, error) {
 	return o.listRegional(o.fetchModels)
 }
 
-func (o *mqlOciAiGenerativeAi) fetchModels(svc *generativeai.GenerativeAiClient) ([]any, error) {
+func (o *mqlOciAiGenerativeAi) fetchModels(svc *generativeai.GenerativeAiClient, _ string) ([]any, error) {
 	ctx := context.Background()
 	var items []generativeai.ModelSummary
 	var page *string
@@ -230,7 +230,7 @@ func (o *mqlOciAiGenerativeAi) endpoints() ([]any, error) {
 	return o.listRegional(o.fetchEndpoints)
 }
 
-func (o *mqlOciAiGenerativeAi) fetchEndpoints(svc *generativeai.GenerativeAiClient) ([]any, error) {
+func (o *mqlOciAiGenerativeAi) fetchEndpoints(svc *generativeai.GenerativeAiClient, region string) ([]any, error) {
 	ctx := context.Background()
 	var items []generativeai.EndpointSummary
 	var page *string
@@ -295,6 +295,7 @@ func (o *mqlOciAiGenerativeAi) fetchEndpoints(svc *generativeai.GenerativeAiClie
 		mqlEndpointTyped := mqlEndpoint.(*mqlOciAiGenerativeAiEndpoint)
 		mqlEndpointTyped.cacheModelID = stringValue(e.ModelId)
 		mqlEndpointTyped.cacheDedicatedAiClusterID = stringValue(e.DedicatedAiClusterId)
+		mqlEndpointTyped.cacheRegion = region
 		res = append(res, mqlEndpointTyped)
 	}
 	return res, nil
@@ -303,6 +304,7 @@ func (o *mqlOciAiGenerativeAi) fetchEndpoints(svc *generativeai.GenerativeAiClie
 type mqlOciAiGenerativeAiEndpointInternal struct {
 	cacheModelID              string
 	cacheDedicatedAiClusterID string
+	cacheRegion               string
 }
 
 func initOciAiGenerativeAiEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -311,15 +313,17 @@ func initOciAiGenerativeAiEndpoint(runtime *plugin.Runtime, args map[string]*llx
 	// the oci-ai-generativeai-endpoint platform emitted during discovery.
 	if ociArgString(args, "id") == "" {
 		conn := runtime.Connection.(*connection.OciConnection)
-		if conn.Conf != nil && conn.Conf.PlatformId != "" {
-			if parsed, ok := parseOciObjectPlatformID(conn.Conf.PlatformId); ok &&
-				parsed.service == "generativeai" && parsed.objectType == "endpoint" {
-				if args == nil {
-					args = map[string]*llx.RawData{}
-				}
-				args["id"] = llx.StringData(parsed.id)
-			}
+		if conn.Conf == nil || conn.Conf.PlatformId == "" {
+			return args, nil, nil
 		}
+		parsed, ok := parseOciObjectPlatformID(conn.Conf.PlatformId)
+		if !ok || parsed.service != "generativeai" || parsed.objectType != "endpoint" {
+			return args, nil, nil
+		}
+		if args == nil {
+			args = map[string]*llx.RawData{}
+		}
+		args["id"] = llx.StringData(parsed.id)
 	}
 	return findOciGenerativeAiByID(runtime, args, (*mqlOciAiGenerativeAi).GetEndpoints)
 }

--- a/providers/oci/resources/platforms.go
+++ b/providers/oci/resources/platforms.go
@@ -21,6 +21,7 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "oci-redis-cluster", Title: "OCI Redis Cluster", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
 	{Name: "oci-vault-secret", Title: "OCI Vault Secret", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
 	{Name: "oci-oke-cluster", Title: "OCI OKE Cluster", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
+	{Name: "oci-ai-generativeai-endpoint", Title: "OCI Generative AI Endpoint", Family: []string{"oci"}, Kind: []string{"oci-object"}, Runtime: []string{"oci"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)


### PR DESCRIPTION
## What

Adds a new discoverable per-resource asset platform to the OCI provider: **`oci-ai-generativeai-endpoint`**. Each OCI Generative AI *endpoint* now surfaces as its own scannable asset, so cnspec security checks can filter `asset.platform == "oci-ai-generativeai-endpoint"` and query the singular `oci.ai.generativeAi.endpoint` directly, instead of filtering the broad `asset.platform == "oci"` and iterating `oci.ai.generativeAi.endpoints` with `.all()/.where()`.

## How

This mirrors the existing OCI per-resource discovery framework exactly:

- **Platform catalog** (`platforms.go`): registers `oci-ai-generativeai-endpoint` (title "OCI Generative AI Endpoint", family `oci`, kind `oci-object`, runtime `oci`).
- **Discovery** (`discovery.go`): adds the `generativeai-endpoints` target constant, wires it into `AllAPIResources`, and adds a `discover()` case that resolves `oci.ai.generativeAi`, enumerates `endpoints`, and emits one `inventory.Asset` per endpoint (service `generativeai`, objectType `endpoint`, keyed by the endpoint OCID). `getPlatformName()` maps the `(generativeai, endpoint)` pair to the new platform name.
- **Config** (`config/config.go`): registers the target in the provider's default `Discovery` list.
- **Singular init** (`generativeai.go`): `initOciAiGenerativeAiEndpoint` now, when there is no `id` argument, parses `conn.Conf.PlatformId` (matching `service == "generativeai" && objectType == "endpoint"`) and resolves the endpoint by that OCID via the existing `findOciGenerativeAiByID` helper. This lets a discovered endpoint asset resolve back to its concrete resource.

## Notes

- The endpoint resource does not retain the region it was enumerated in, so discovery uses the `"unknown"` region placeholder in the platform id (the endpoint OCID is globally unique on its own, and the singular init matches on OCID, not region). This follows the same `fallbackRegion` convention used elsewhere in discovery.
- No `.lr` change and no codegen were required; the `oci.ai.generativeAi.endpoint` resource already existed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
