### PR TITLE
✨ gcp: discover Model Armor templates and Datastream connection profiles as assets

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1182,6 +1182,9 @@ var gcpPermissionOverrides = map[string]map[string]string{
 	},
 	"modelarmor": {
 		"GetFloorSetting": "modelarmor.floorSettings.get",
+		// GetTemplate → singular "template" by default; the real IAM permission
+		// is the plural form (matching modelarmor.templates.list).
+		"GetTemplate": "modelarmor.templates.get",
 	},
 	"cloudbuild": {
 		// Cloud Build triggers use the builds permission, not a separate triggers permission

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -73,6 +73,8 @@ Examples with the GCP project configured:
 				resources.DiscoverSpannerInstances,
 				resources.DiscoverFirestoreDatabases,
 				resources.DiscoverBigtableInstances,
+				resources.DiscoverModelArmorTemplates,
+				resources.DiscoverDatastreamProfiles,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -159,6 +159,10 @@ func GetTitleForPlatformName(name string) string {
 		return "GCP API Key"
 	case "gcp-iam-service-account":
 		return "GCP IAM Service Account"
+	case "gcp-modelarmor-template":
+		return "GCP Model Armor Template"
+	case "gcp-datastream-connectionprofile":
+		return "GCP Datastream Connection Profile"
 	}
 	return "Google Cloud Platform"
 }
@@ -333,6 +337,20 @@ func ResourceTechnologyUrl(service, project, region, objectType, name string) []
 			return []string{"gcp", project, "iam", region, "service-account"}
 		default:
 			return []string{"gcp", project, "iam", region, "other"}
+		}
+	case "modelarmor":
+		switch objectType {
+		case "template":
+			return []string{"gcp", project, "modelarmor", region, "template"}
+		default:
+			return []string{"gcp", project, "modelarmor", region, "other"}
+		}
+	case "datastream":
+		switch objectType {
+		case "connectionprofile":
+			return []string{"gcp", project, "datastream", region, "connectionprofile"}
+		default:
+			return []string{"gcp", project, "datastream", region, "other"}
 		}
 	default:
 		return []string{"gcp", project, "other"}

--- a/providers/gcp/connection/platforms.go
+++ b/providers/gcp/connection/platforms.go
@@ -24,6 +24,7 @@ var gcpPlatformNames = []string{
 	"gcp-dataproc-cluster", "gcp-alloydb-cluster", "gcp-spanner-instance",
 	"gcp-firestore-database", "gcp-bigtable-instance", "gcp-logging-bucket",
 	"gcp-apikey", "gcp-iam-service-account",
+	"gcp-modelarmor-template", "gcp-datastream-connectionprofile",
 }
 
 // Platforms is the static catalog of platforms the GCP provider can emit. Every

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -291,6 +291,20 @@ func initGcpProjectDatastreamServiceConnectionProfile(runtime *plugin.Runtime, a
 	if len(args) > 1 {
 		return args, nil, nil
 	}
+	if args == nil {
+		args = make(map[string]*llx.RawData)
+	}
+
+	// Resolve from the asset identifier when accessed as a discovered
+	// gcp-datastream-connectionprofile asset (no explicit name arg).
+	if len(args) == 0 {
+		ids := getAssetIdentifier(runtime)
+		if ids == nil {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+		args["name"] = llx.StringData(fmt.Sprintf("projects/%s/locations/%s/connectionProfiles/%s", ids.project, ids.region, ids.name))
+	}
+
 	nameRaw := args["name"]
 	if nameRaw == nil {
 		return args, nil, nil

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -67,6 +67,8 @@ const (
 	DiscoverArtifactRegistryRepos   = "artifactregistry-repositories"
 	DiscoverMemcacheInstances       = "memcache-instances"
 	DiscoverVertexAIJobs            = "vertexai-jobs"
+	DiscoverModelArmorTemplates     = "modelarmor-templates"
+	DiscoverDatastreamProfiles      = "datastream-connectionprofiles"
 )
 
 // All includes every discovery target: Auto covers all of them for GCP.
@@ -110,6 +112,8 @@ var Auto = []string{
 	DiscoverArtifactRegistryRepos,
 	DiscoverMemcacheInstances,
 	DiscoverVertexAIJobs,
+	DiscoverModelArmorTemplates,
+	DiscoverDatastreamProfiles,
 }
 
 var AllAPIResources = []string{
@@ -147,6 +151,8 @@ var AllAPIResources = []string{
 	DiscoverArtifactRegistryRepos,
 	DiscoverMemcacheInstances,
 	DiscoverVertexAIJobs,
+	DiscoverModelArmorTemplates,
+	DiscoverDatastreamProfiles,
 }
 
 // List of all CloudSQL types, this will be used during discovery
@@ -1166,6 +1172,80 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 						TechnologyUrlSegments: connection.ResourceTechnologyUrl("secretmanager", gcpProject.Id.Data, "global", "secret", secret.Name.Data),
 					},
 					Labels:      mapStrInterfaceToMapStrStr(secret.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverModelArmorTemplates) {
+		if err := runDiscoveryStep(DiscoverModelArmorTemplates, func() error {
+			modelArmorService := gcpProject.GetModelArmor()
+			if modelArmorService.Error != nil {
+				return modelArmorService.Error
+			}
+			templates := modelArmorService.Data.GetTemplates()
+			if templates.Error != nil {
+				return templates.Error
+			}
+			for i := range templates.Data {
+				template := templates.Data[i].(*mqlGcpProjectModelArmorServiceTemplate)
+				location := parseLocationFromPath(template.Name.Data)
+				shortName := parseResourceName(template.Name.Data)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("modelarmor", gcpProject.Id.Data, location, "template", shortName),
+					},
+					Name: shortName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-modelarmor-template",
+						Title:                 connection.GetTitleForPlatformName("gcp-modelarmor-template"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("modelarmor", gcpProject.Id.Data, location, "template", shortName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(template.GetLabels().Data),
+					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+				})
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverDatastreamProfiles) {
+		if err := runDiscoveryStep(DiscoverDatastreamProfiles, func() error {
+			datastreamService := gcpProject.GetDatastream()
+			if datastreamService.Error != nil {
+				return datastreamService.Error
+			}
+			profiles := datastreamService.Data.GetConnectionProfiles()
+			if profiles.Error != nil {
+				return profiles.Error
+			}
+			for i := range profiles.Data {
+				profile := profiles.Data[i].(*mqlGcpProjectDatastreamServiceConnectionProfile)
+				location := parseLocationFromPath(profile.Name.Data)
+				shortName := parseResourceName(profile.Name.Data)
+				assetList = append(assetList, &inventory.Asset{
+					PlatformIds: []string{
+						connection.NewResourcePlatformID("datastream", gcpProject.Id.Data, location, "connectionprofile", shortName),
+					},
+					Name: shortName,
+					Platform: &inventory.Platform{
+						Name:                  "gcp-datastream-connectionprofile",
+						Title:                 connection.GetTitleForPlatformName("gcp-datastream-connectionprofile"),
+						Runtime:               "gcp",
+						Kind:                  "gcp-object",
+						Family:                []string{"google"},
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("datastream", gcpProject.Id.Data, location, "connectionprofile", shortName),
+					},
+					Labels:      mapStrInterfaceToMapStrStr(profile.GetLabels().Data),
 					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
 				})
 			}

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -57,6 +57,8 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoverArtifactRegistryRepos,
 		DiscoverMemcacheInstances,
 		DiscoverVertexAIJobs,
+		DiscoverModelArmorTemplates,
+		DiscoverDatastreamProfiles,
 	}
 	require.ElementsMatch(t, expected, All)
 }
@@ -100,6 +102,8 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverArtifactRegistryRepos,
 		DiscoverMemcacheInstances,
 		DiscoverVertexAIJobs,
+		DiscoverModelArmorTemplates,
+		DiscoverDatastreamProfiles,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -1944,7 +1944,7 @@ func init() {
 			Create: createGcpProjectModelArmorService,
 		},
 		"gcp.project.modelArmorService.template": {
-			// to override args, implement: initGcpProjectModelArmorServiceTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectModelArmorServiceTemplate,
 			Create: createGcpProjectModelArmorServiceTemplate,
 		},
 		"gcp.project.modelArmorService.floorSetting": {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.29.1",
-  "generated_at": "2026-07-07T12:19:21-07:00",
+  "generated_at": "2026-07-07T23:28:50-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -203,6 +203,7 @@
     "memorystore.instances.get",
     "memorystore.instances.list",
     "modelarmor.floorSettings.get",
+    "modelarmor.templates.get",
     "modelarmor.templates.list",
     "monitoring.alertPolicies.list",
     "monitoring.dashboards.list",
@@ -1517,6 +1518,12 @@
       "permission": "modelarmor.floorSettings.get",
       "service": "modelarmor",
       "action": "GetFloorSetting",
+      "source_file": "modelarmor.go"
+    },
+    {
+      "permission": "modelarmor.templates.get",
+      "service": "modelarmor",
+      "action": "GetTemplate",
       "source_file": "modelarmor.go"
     },
     {

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -109,24 +109,7 @@ func (g *mqlGcpProjectModelArmorService) templates() ([]any, error) {
 			return nil, err
 		}
 
-		filterConfig, err := protoToDict(template.FilterConfig)
-		if err != nil {
-			return nil, err
-		}
-		templateMetadata, err := protoToDict(template.TemplateMetadata)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlTemplate, err := CreateResource(g.MqlRuntime, "gcp.project.modelArmorService.template", map[string]*llx.RawData{
-			"name":             llx.StringData(template.Name),
-			"projectId":        llx.StringData(projectId),
-			"createdAt":        llx.TimeDataPtr(timestampAsTimePtr(template.CreateTime)),
-			"updatedAt":        llx.TimeDataPtr(timestampAsTimePtr(template.UpdateTime)),
-			"labels":           llx.MapData(convert.MapToInterfaceMap(template.Labels), types.String),
-			"filterConfig":     llx.DictData(filterConfig),
-			"templateMetadata": llx.DictData(templateMetadata),
-		})
+		mqlTemplate, err := newMqlModelArmorServiceTemplate(g.MqlRuntime, projectId, template)
 		if err != nil {
 			return nil, err
 		}
@@ -134,6 +117,88 @@ func (g *mqlGcpProjectModelArmorService) templates() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// newMqlModelArmorServiceTemplate maps a Model Armor Template proto into the MQL
+// resource. Shared by templates() and the discovered-asset init.
+func newMqlModelArmorServiceTemplate(runtime *plugin.Runtime, projectId string, template *modelarmorpb.Template) (*mqlGcpProjectModelArmorServiceTemplate, error) {
+	filterConfig, err := protoToDict(template.FilterConfig)
+	if err != nil {
+		return nil, err
+	}
+	templateMetadata, err := protoToDict(template.TemplateMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := CreateResource(runtime, "gcp.project.modelArmorService.template", map[string]*llx.RawData{
+		"name":             llx.StringData(template.Name),
+		"projectId":        llx.StringData(projectId),
+		"createdAt":        llx.TimeDataPtr(timestampAsTimePtr(template.CreateTime)),
+		"updatedAt":        llx.TimeDataPtr(timestampAsTimePtr(template.UpdateTime)),
+		"labels":           llx.MapData(convert.MapToInterfaceMap(template.Labels), types.String),
+		"filterConfig":     llx.DictData(filterConfig),
+		"templateMetadata": llx.DictData(templateMetadata),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectModelArmorServiceTemplate), nil
+}
+
+// initGcpProjectModelArmorServiceTemplate resolves a single Model Armor template.
+// When invoked for a discovered gcp-modelarmor-template asset (no args), it
+// reconstructs the resource name from the asset identifier and fetches it so the
+// asset resolves to exactly one template instead of an empty husk.
+func initGcpProjectModelArmorServiceTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// Fully populated (e.g., from CreateResource in templates()); nothing to do.
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	if args == nil {
+		args = make(map[string]*llx.RawData)
+	}
+
+	// Resolve from the asset identifier when accessed as a discovered asset.
+	if len(args) == 0 {
+		ids := getAssetIdentifier(runtime)
+		if ids == nil {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+		args["name"] = llx.StringData(fmt.Sprintf("projects/%s/locations/%s/templates/%s", ids.project, ids.region, ids.name))
+	}
+
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name := nameRaw.Value.(string)
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	creds, err := conn.Credentials(modelarmor.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx := context.Background()
+	client, err := modelarmor.NewClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	template, err := client.GetTemplate(ctx, &modelarmorpb.GetTemplateRequest{Name: name})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := newMqlModelArmorServiceTemplate(runtime, parseProjectFromPath(name), template)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
 }
 
 func (g *mqlGcpProjectModelArmorServiceTemplate) id() (string, error) {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -242,6 +242,7 @@ var validatedGCPPermissions = []string{
 	"memorystore.instances.get",
 	"memorystore.instances.list",
 	"modelarmor.floorSettings.get",
+	"modelarmor.templates.get",
 	"modelarmor.templates.list",
 	"monitoring.alertPolicies.list",
 	"monitoring.dashboards.list",


### PR DESCRIPTION
## What

Adds two new discoverable GCP asset platforms so that each Model Armor template and each Datastream connection profile can be discovered and scanned as its own asset (rather than only being reachable by iterating `.all()` over a collection under a broad `gcp`/`gcp-project` asset):

- **`gcp-modelarmor-template`** — "GCP Model Armor Template"
- **`gcp-datastream-connectionprofile`** — "GCP Datastream Connection Profile"

This lets cnspec checks that currently filter on `asset.platform == "gcp"` and walk `gcp.project.modelArmorService.templates` / `gcp.project.datastreamService.connectionProfiles` convert to per-resource checks that run against one template / one connection profile per asset.

## Discovery mechanism

Mirrors the existing per-resource discovery pattern (the `gcp-secretmanager-secret` analog was studied end-to-end and copied):

- **Platform catalog** (`connection/platforms.go`, `connection/platform.go`): both platform names registered with titles and `ResourceTechnologyUrl` segments (`modelarmor`/`datastream` services).
- **Discovery targets** (`resources/discovery.go`): new `DiscoverModelArmorTemplates` (`modelarmor-templates`) and `DiscoverDatastreamProfiles` (`datastream-connectionprofiles`) constants, added to `Auto`, `All`, and `AllAPIResources`. Each discovery step enumerates the project's templates / connection profiles and emits one `inventory.Asset` per resource, keyed by `NewResourcePlatformID(service, project, location, objectType, shortName)`, with parent-connection config cloned `WithoutDiscovery()`.
- **Provider config** (`config/config.go`): both targets added to the advertised `Discovery` list.

## Singular-resource init resolution (the key part)

For a discovered asset to render real data instead of an empty husk, the singular resource's `init` must select the one resource named by the discovered platform id:

- `initGcpProjectModelArmorServiceTemplate` — **new**. When called with no args it reconstructs the full resource name from the asset identifier (`projects/{project}/locations/{location}/templates/{name}`) and fetches it via `GetTemplate`. A shared `newMqlModelArmorServiceTemplate` helper was extracted so `templates()` and the init build the resource identically. Codegen was re-run so the generator wires `Init: initGcpProjectModelArmorServiceTemplate`.
- `initGcpProjectDatastreamServiceConnectionProfile` — **extended** with the same discovered-asset fallback (reconstructs `.../connectionProfiles/{name}` and fetches via the existing `GetConnectionProfile` path).

## Permissions

The permission extractor singularized `GetTemplate` to `modelarmor.template.get`; the real IAM permission is the plural `modelarmor.templates.get` (matching `modelarmor.templates.list`). Added a `gcpPermissionOverrides` entry and regenerated `gcp.permissions.json`; the validated-list test was updated to match. Datastream needed no new permission (`GetConnectionProfile` was already used by the existing init).

## Testing

- `go build ./...` in `providers/gcp` and `providers-sdk` — clean.
- `go test ./resources/` discovery + permissions tests pass (`TestAllResolvedResources`, `TestAutoResolvedResources`, `TestGCPPermissionsMatchValidatedList`).
- `go test ./connection/` passes.
- `make providers/build/gcp` succeeds and regenerates the permissions manifest.
