### PR TITLE
✨ digitalocean: discover GradientAI agents as their own assets

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -39,6 +39,7 @@ Notes:
 				connection.DiscoveryLoadBalancers,
 				connection.DiscoveryFirewalls,
 				connection.DiscoverySpacesBuckets,
+				connection.DiscoveryGradientaiAgents,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/digitalocean/connection/platform.go
+++ b/providers/digitalocean/connection/platform.go
@@ -10,13 +10,14 @@ import (
 // Discovery targets. "auto" and "all" both expand to every specific
 // child-asset type the provider knows how to split an account into.
 const (
-	DiscoveryAuto          = "auto"
-	DiscoveryAll           = "all"
-	DiscoveryDatabases     = "databases"
-	DiscoveryKubernetes    = "kubernetes"
-	DiscoveryLoadBalancers = "loadbalancers"
-	DiscoveryFirewalls     = "firewalls"
-	DiscoverySpacesBuckets = "spaces-buckets"
+	DiscoveryAuto             = "auto"
+	DiscoveryAll              = "all"
+	DiscoveryDatabases        = "databases"
+	DiscoveryKubernetes       = "kubernetes"
+	DiscoveryLoadBalancers    = "loadbalancers"
+	DiscoveryFirewalls        = "firewalls"
+	DiscoverySpacesBuckets    = "spaces-buckets"
+	DiscoveryGradientaiAgents = "gradientai-agents"
 )
 
 // Connection options that scope a connection to a single discovered
@@ -36,7 +37,8 @@ const (
 	OptionSpacesBucket = "spaces-bucket"
 	// OptionSpacesRegion is paired with OptionSpacesBucket because a
 	// bucket is addressed by (region, name) on the S3-compatible API.
-	OptionSpacesRegion = "spaces-region"
+	OptionSpacesRegion    = "spaces-region"
+	OptionGradientaiAgent = "gradientai-agent"
 )
 
 const platformIDBase = "//platformid.api.mondoo.app/runtime/digitalocean"
@@ -79,6 +81,11 @@ func SpacesBucketPlatform() *inventory.Platform {
 	return basePlatform("digitalocean-spaces-bucket")
 }
 
+// GradientaiAgentPlatform is a single GradientAI agent.
+func GradientaiAgentPlatform() *inventory.Platform {
+	return basePlatform("digitalocean-gradientai-agent")
+}
+
 // NewAccountIdentifier builds the platform id for the account root. The
 // UUID may be empty when the token isn't permitted to read the account.
 func NewAccountIdentifier(accountUUID string) string {
@@ -112,6 +119,10 @@ func NewSpacesBucketIdentifier(accountUUID, region, name string) string {
 	return childIdentifier(accountUUID, "spaces-bucket", region+"/"+name)
 }
 
+func NewGradientaiAgentIdentifier(accountUUID, uuid string) string {
+	return childIdentifier(accountUUID, "gradientai-agent", uuid)
+}
+
 // SubAssetPlatform reports the specific platform, platform id, and asset
 // name when this connection is scoped to a single discovered sub-asset.
 // It returns (nil, "", "") for a plain account connection. The account
@@ -136,6 +147,9 @@ func (c *DigitaloceanConnection) SubAssetPlatform() (*inventory.Platform, string
 	if name := opts[OptionSpacesBucket]; name != "" {
 		region := opts[OptionSpacesRegion]
 		return SpacesBucketPlatform(), NewSpacesBucketIdentifier(accountUUID, region, name), "DigitalOcean Spaces Bucket " + name
+	}
+	if uuid := opts[OptionGradientaiAgent]; uuid != "" {
+		return GradientaiAgentPlatform(), NewGradientaiAgentIdentifier(accountUUID, uuid), "DigitalOcean GradientAI Agent " + uuid
 	}
 	return nil, "", ""
 }

--- a/providers/digitalocean/connection/platforms.go
+++ b/providers/digitalocean/connection/platforms.go
@@ -51,6 +51,13 @@ var Platforms = []*plugin.PlatformInfo{
 		Kind:    []string{"api"},
 		Runtime: []string{"digitalocean"},
 	},
+	{
+		Name:    "digitalocean-gradientai-agent",
+		Title:   "DigitalOcean GradientAI Agent",
+		Family:  []string{"digitalocean"},
+		Kind:    []string{"api"},
+		Runtime: []string{"digitalocean"},
+	},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)

--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -54,9 +54,10 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	// Discovery expands the account into specific child assets
-	// (databases, Kubernetes clusters, load balancers, firewalls, and
-	// Spaces buckets). Default to "auto" so a plain `digitalocean` scan
-	// surfaces per-resource assets alongside the account.
+	// (databases, Kubernetes clusters, load balancers, firewalls,
+	// Spaces buckets, and GradientAI agents). Default to "auto" so a
+	// plain `digitalocean` scan surfaces per-resource assets alongside
+	// the account.
 	discoverTargets := []string{connection.DiscoveryAuto}
 	if x, ok := flags["discover"]; ok && len(x.Array) != 0 {
 		discoverTargets = discoverTargets[:0]

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -1951,7 +1951,8 @@ digitalocean.gradientai {
 // it uses, and the agent routing graph through `childAgents()` and
 // `parentAgents()`. Select an agent by uuid with
 // `digitalocean.gradientai.agent(uuid: "...")`.
-private digitalocean.gradientai.agent @defaults("uuid name region") {
+digitalocean.gradientai.agent @defaults("uuid name region") {
+  init(uuid? string)
   // Agent UUID
   uuid string
   // Name

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -315,7 +315,7 @@ func init() {
 			Create: createDigitaloceanGradientai,
 		},
 		"digitalocean.gradientai.agent": {
-			// to override args, implement: initDigitaloceanGradientaiAgent(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDigitaloceanGradientaiAgent,
 			Create: createDigitaloceanGradientaiAgent,
 		},
 		"digitalocean.gradientai.agent.guardrail": {

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -263,6 +264,35 @@ func newMqlGradientaiAgent(runtime *plugin.Runtime, a *godo.Agent) (*mqlDigitalo
 		}
 	}
 	return agent, nil
+}
+
+// initDigitaloceanGradientaiAgent resolves a single GradientAI agent. It
+// binds the agent selected by an explicit uuid argument, or - when the
+// connection is scoped to a discovered digitalocean-gradientai-agent
+// asset - the agent whose uuid the discovery step stamped on the
+// connection options. Without either, the resource has nothing to bind
+// to and returns an error.
+func initDigitaloceanGradientaiAgent(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	conn := runtime.Connection.(*connection.DigitaloceanConnection)
+	uuid := stringArg(args, "uuid")
+	if uuid == "" {
+		uuid = conn.Conf.Options[connection.OptionGradientaiAgent]
+	}
+	if uuid == "" {
+		return nil, nil, errors.New("digitalocean.gradientai.agent requires a uuid or a connected digitalocean-gradientai-agent asset")
+	}
+	agent, _, err := conn.Client().GradientAI.GetAgent(context.Background(), uuid)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlGradientaiAgent(runtime, agent)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
 }
 
 func (r *mqlDigitaloceanGradientaiAgent) model() (*mqlDigitaloceanGradientaiModel, error) {

--- a/providers/digitalocean/resources/discovery.go
+++ b/providers/digitalocean/resources/discovery.go
@@ -184,6 +184,35 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 		}
 	}
 
+	if stringx.Contains(targets, connection.DiscoveryGradientaiAgents) {
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			agents, resp, err := client.GradientAI.ListAgents(ctx, opt)
+			if err != nil {
+				return nil, err
+			}
+			for _, a := range agents {
+				if a == nil {
+					continue
+				}
+				assets = append(assets, childAsset(
+					connection.GradientaiAgentPlatform(),
+					connection.NewGradientaiAgentIdentifier(accountUUID, a.Uuid),
+					"DigitalOcean GradientAI Agent "+a.Name,
+					map[string]string{connection.OptionGradientaiAgent: a.Uuid},
+				))
+			}
+			if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				return nil, err
+			}
+			opt.Page = page + 1
+		}
+	}
+
 	return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
 }
 
@@ -197,6 +226,7 @@ func resolveDiscoveryTargets(targets []string) []string {
 			connection.DiscoveryLoadBalancers,
 			connection.DiscoveryFirewalls,
 			connection.DiscoverySpacesBuckets,
+			connection.DiscoveryGradientaiAgents,
 		}
 	}
 	return targets


### PR DESCRIPTION
## Summary

Adds a new discoverable per-resource asset platform to the DigitalOcean provider: **`digitalocean-gradientai-agent`**. Each DigitalOcean GradientAI agent is now surfaced as its own scannable asset, so a policy check can filter `asset.platform == "digitalocean-gradientai-agent"` and query the singular `digitalocean.gradientai.agent` resource directly instead of filtering the broad `digitalocean` platform and iterating `digitalocean.gradientai.agents` with `.all()/.where()`.

This mirrors the provider's existing per-resource discovery for `digitalocean-database`, `digitalocean-kubernetes-cluster`, `digitalocean-loadbalancer`, `digitalocean-firewall`, and `digitalocean-spaces-bucket`.

## New platform

- Registered `digitalocean-gradientai-agent` (title "DigitalOcean GradientAI Agent") in the static platform catalog, plus a `GradientaiAgentPlatform()` helper and a `NewGradientaiAgentIdentifier(accountUUID, uuid)` platform-id builder anchored to the owning account UUID like the other child assets.

## Discovery mechanism

- Added the `gradientai-agents` discovery target and a discover block that paginates `GradientAI.ListAgents` and emits one child asset per agent via the shared `childAsset` helper (cloning the connection without discovery, stamping the account UUID and the agent uuid onto the connection options).
- Wired the target into the `auto`/`all` expansion, the connector's `Discovery` list in `config.go`, and `SubAssetPlatform`, which now reports the agent platform / id / name when a connection is scoped to a discovered agent.

## Singular init resolves discovered assets

- `digitalocean.gradientai.agent` is now directly queryable (no longer `private`) and gained an `init(uuid? string)`. The init resolves the agent by an explicit `uuid` argument, or when the connection is scoped to a discovered `digitalocean-gradientai-agent` asset by the uuid the discovery step stamped on the connection options. It fetches via `GradientAI.GetAgent` and reuses the existing agent builder so all typed refs (model, knowledge bases, guardrails, functions, child/parent agents, vpc, project) populate identically to a listed agent. Without this, a scanned agent asset would render as an empty husk and checks would return null.

## Notes

- No new fields were added, so `.lr.versions` is unchanged and the provider `Version` is not bumped.
- Regenerated `.lr.go` (init hook wiring) via `mqlr generate`.
- `go build ./...` and the provider unit tests pass.
