### PR TITLE
🐛 fix recurring `parent connection N not found` errors

### DIFF
--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -79,10 +79,11 @@ func (s *Service) AddRuntime(conf *inventory.Config, createRuntime func(connId u
 		if parentId := runtime.Connection.ParentID(); parentId > 0 {
 			parentRuntime, err := s.GetRuntime(parentId)
 			if err != nil {
-				return nil, errors.New("parent connection " + strconv.FormatUint(uint64(parentId), 10) + " not found")
+				log.Warn().Uint32("parent", parentId).Uint32("child", conf.Id).
+					Msg("parent connection not found, proceeding without shared resource cache")
+			} else {
+				runtime.Resources = parentRuntime.Resources
 			}
-			runtime.Resources = parentRuntime.Resources
-
 		}
 	}
 
@@ -115,10 +116,11 @@ func (s *Service) deprecatedAddRuntime(createRuntime func(connId uint32) (*Runti
 		if parentId := runtime.Connection.ParentID(); parentId > 0 {
 			parentRuntime, err := s.doGetRuntime(parentId)
 			if err != nil {
-				return nil, errors.New("parent connection " + strconv.FormatUint(uint64(parentId), 10) + " not found")
+				log.Warn().Uint32("parent", parentId).Uint32("child", s.lastConnectionID).
+					Msg("parent connection not found, proceeding without shared resource cache")
+			} else {
+				runtime.Resources = parentRuntime.Resources
 			}
-			runtime.Resources = parentRuntime.Resources
-
 		}
 	}
 	s.runtimes[s.lastConnectionID] = runtime

--- a/providers-sdk/v1/plugin/service_test.go
+++ b/providers-sdk/v1/plugin/service_test.go
@@ -160,29 +160,29 @@ func TestDeprecatedAddRuntime_DisableDelayedDiscovery(t *testing.T) {
 func TestAddRuntime_ParentNotExist(t *testing.T) {
 	s := NewService()
 	parentId := uint32(10)
-	_, err := s.AddRuntime(&inventory.Config{Id: 1}, func(connId uint32) (*Runtime, error) {
+	runtime, err := s.AddRuntime(&inventory.Config{Id: 1}, func(connId uint32) (*Runtime, error) {
 		c := newTestConnection(connId)
 		c.parentId = parentId
 		return &Runtime{
 			Connection: c,
 		}, nil
 	})
-	require.Error(t, err)
-	assert.Equal(t, "parent connection 10 not found", err.Error())
+	require.NoError(t, err, "missing parent should not cause an error")
+	require.NotNil(t, runtime)
 }
 
 func TestDeprecatedAddRuntime_ParentNotExist(t *testing.T) {
 	s := NewService()
 	parentId := uint32(10)
-	_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
+	runtime, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		c := newTestConnection(connId)
 		c.parentId = parentId
 		return &Runtime{
 			Connection: c,
 		}, nil
 	})
-	require.Error(t, err)
-	assert.Equal(t, "parent connection 10 not found", err.Error())
+	require.NoError(t, err, "missing parent should not cause an error")
+	require.NotNil(t, runtime)
 }
 
 func TestAddRuntime_Parent(t *testing.T) {

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -48,21 +48,45 @@ type connectionGraph struct {
 	nodes map[uint32]connectionGraphNode
 	// edges is a map of connection id to parent connection id
 	edges map[uint32]uint32
+	// collectedNodes preserves connect request data for nodes removed by
+	// garbageCollect. A later Connect() call with a ParentConnectionId
+	// pointing to a collected node can use this data to transparently
+	// reconnect the parent before connecting the child.
+	//
+	// Bounded by: addNode/addImplicitNode remove entries for re-added
+	// IDs, and Reconnect() resets the entire graph including this map.
+	collectedNodes map[uint32]connectReq
 }
 
 func newConnectionGraph() *connectionGraph {
 	return &connectionGraph{
-		nodes: map[uint32]connectionGraphNode{},
-		edges: map[uint32]uint32{},
+		nodes:          map[uint32]connectionGraphNode{},
+		edges:          map[uint32]uint32{},
+		collectedNodes: map[uint32]connectReq{},
 	}
 }
 
 // addNode adds a node to the graph with the given data.
+// If the node was previously garbage-collected, its stale entry in
+// collectedNodes is removed since the fresh data supersedes it.
 func (c *connectionGraph) addNode(node uint32, data connectReq) {
 	c.nodes[node] = connectionGraphNode{
 		explicitlyConnected: true,
 		data:                data,
 	}
+	delete(c.collectedNodes, node)
+}
+
+// addImplicitNode adds a node that is NOT explicitly connected — it was
+// reconnected on behalf of a child, not by a direct user request. The node
+// will be kept alive by topoSort as long as an explicitly-connected child
+// references it, and garbage-collected once all such children disconnect.
+func (c *connectionGraph) addImplicitNode(node uint32, data connectReq) {
+	c.nodes[node] = connectionGraphNode{
+		explicitlyConnected: false,
+		data:                data,
+	}
+	delete(c.collectedNodes, node)
 }
 
 // getNode returns the connect request data for the given node.
@@ -115,7 +139,11 @@ func (c *connectionGraph) topoSort() []uint32 {
 	return sorted
 }
 
-// garbageCollect removes nodes from the graph that are not explicitly connected and are not required by any other connection.
+// garbageCollect removes nodes from the graph that are not explicitly
+// connected and are not required by any other connection.
+// The connect request data of collected nodes is preserved in
+// collectedNodes so that a future child connection can transparently
+// reconnect a garbage-collected parent.
 func (c *connectionGraph) garbageCollect() []uint32 {
 	sorted := c.topoSort()
 
@@ -128,12 +156,20 @@ func (c *connectionGraph) garbageCollect() []uint32 {
 	for node := range c.nodes {
 		if _, ok := keep[node]; !ok {
 			collected = append(collected, node)
+			c.collectedNodes[node] = c.nodes[node].data
 			delete(c.nodes, node)
 			delete(c.edges, node)
 		}
 	}
 
 	return collected
+}
+
+// getCollectedNode returns the preserved connect request data for a
+// node that was previously removed by garbageCollect.
+func (c *connectionGraph) getCollectedNode(id uint32) (connectReq, bool) {
+	cr, ok := c.collectedNodes[id]
+	return cr, ok
 }
 
 type (
@@ -163,19 +199,59 @@ func (r *RestartableProvider) Client() *plugin.Client {
 
 // Connect implements plugin.ProviderPlugin.
 func (r *RestartableProvider) Connect(req *pp.ConnectReq, cb pp.ProviderCallback) (*pp.ConnectRes, error) {
+	var parentToReconnect *connectReq
+
 	if len(req.Asset.GetConnections()) > 0 {
 		reqClone := req.CloneVT()
 		r.lock.Lock()
 		connectionId := req.Asset.Connections[0].Id
+		parentId := req.Asset.Connections[0].ParentConnectionId
 		if _, ok := r.connectionGraph.getNode(connectionId); !ok {
 			r.connectionGraph.addNode(connectionId, connectReq{
 				req: reqClone,
 				cb:  cb,
 			})
-			r.connectionGraph.setEdge(connectionId, req.Asset.Connections[0].ParentConnectionId)
+			r.connectionGraph.setEdge(connectionId, parentId)
+		}
+
+		// If the parent was garbage-collected (its runtime was disconnected
+		// because all previous children finished), we need to reconnect it
+		// before connecting this child. The preserved connect data lets us
+		// re-establish the parent's runtime transparently.
+		if parentId > 0 {
+			if _, inGraph := r.connectionGraph.getNode(parentId); !inGraph {
+				if cr, ok := r.connectionGraph.getCollectedNode(parentId); ok {
+					parentToReconnect = &cr
+				}
+			}
 		}
 
 		r.lock.Unlock()
+	}
+
+	if parentToReconnect != nil {
+		parentId := req.Asset.Connections[0].ParentConnectionId
+
+		// Re-check under lock: a concurrent Connect for a sibling child
+		// may have already reconnected this parent.
+		r.lock.Lock()
+		_, alreadyBack := r.connectionGraph.getNode(parentId)
+		r.lock.Unlock()
+
+		if !alreadyBack {
+			if _, err := r.plugin.Connect(parentToReconnect.req, parentToReconnect.cb); err != nil {
+				log.Warn().Err(err).Uint32("parent", parentId).Msg("failed to reconnect garbage-collected parent connection")
+			} else {
+				r.lock.Lock()
+				if _, ok := r.connectionGraph.getNode(parentId); !ok {
+					r.connectionGraph.addImplicitNode(parentId, *parentToReconnect)
+					if parentToReconnect.req != nil && len(parentToReconnect.req.Asset.GetConnections()) > 0 {
+						r.connectionGraph.setEdge(parentId, parentToReconnect.req.Asset.Connections[0].ParentConnectionId)
+					}
+				}
+				r.lock.Unlock()
+			}
+		}
 	}
 
 	resp, err := r.plugin.Connect(req, cb)

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -54,7 +54,8 @@ type connectionGraph struct {
 	// reconnect the parent before connecting the child.
 	//
 	// Bounded by: addNode/addImplicitNode remove entries for re-added
-	// IDs, and Reconnect() resets the entire graph including this map.
+	// IDs, and Reconnect() clears this map since stale data from before
+	// a provider restart is no longer meaningful.
 	collectedNodes map[uint32]connectReq
 }
 
@@ -240,7 +241,7 @@ func (r *RestartableProvider) Connect(req *pp.ConnectReq, cb pp.ProviderCallback
 
 		if !alreadyBack {
 			if _, err := r.plugin.Connect(parentToReconnect.req, parentToReconnect.cb); err != nil {
-				log.Warn().Err(err).Uint32("parent", parentId).Msg("failed to reconnect garbage-collected parent connection")
+				return nil, fmt.Errorf("failed to reconnect garbage-collected parent %d: %w", parentId, err)
 			} else {
 				r.lock.Lock()
 				if _, ok := r.connectionGraph.getNode(parentId); !ok {
@@ -277,6 +278,7 @@ func (r *RestartableProvider) Reconnect() error {
 	}
 	r.plugin = p
 	r.client = c
+	clear(r.connectionGraph.collectedNodes)
 
 	connectRequestOrder := r.connectionGraph.topoSort()
 

--- a/providers/running_provider_test.go
+++ b/providers/running_provider_test.go
@@ -4,13 +4,17 @@
 package providers
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	pp "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestConnectionGraph(t *testing.T) {
-
 	g := newConnectionGraph()
 	g.addNode(1, connectReq{})
 	g.addNode(2, connectReq{})
@@ -79,4 +83,281 @@ func TestConnectionGraph(t *testing.T) {
 	require.Len(t, sorted, 0)
 	require.Empty(t, g.nodes)
 	require.Empty(t, g.edges)
+}
+
+func TestConnectionGraph_CollectedDataPreserved(t *testing.T) {
+	g := newConnectionGraph()
+
+	parentData := connectReq{req: &pp.ConnectReq{}}
+	g.addNode(1, parentData)
+	g.addNode(2, connectReq{})
+	g.setEdge(2, 1)
+
+	// Disconnect both — parent first, then child. GC after child
+	// disconnect should collect both.
+	g.markDisconnected(1)
+	g.markDisconnected(2)
+	collected := g.garbageCollect()
+	require.Len(t, collected, 2)
+	require.NotContains(t, g.nodes, uint32(1))
+	require.NotContains(t, g.nodes, uint32(2))
+
+	// Collected data should be preserved for reconnection.
+	cr, ok := g.getCollectedNode(1)
+	require.True(t, ok, "collected parent data should be preserved")
+	assert.Equal(t, parentData.req, cr.req)
+
+	cr2, ok := g.getCollectedNode(2)
+	require.True(t, ok, "collected child data should be preserved")
+	_ = cr2
+
+	// Re-adding a node should clear its collected entry.
+	g.addNode(1, parentData)
+	_, ok = g.getCollectedNode(1)
+	assert.False(t, ok, "collected data should be cleared after re-add")
+}
+
+func TestConnectionGraph_ReconnectedParentKeptByChild(t *testing.T) {
+	g := newConnectionGraph()
+
+	// Simulate: parent=1 connected, child=2 connected with edge to 1
+	g.addNode(1, connectReq{})
+	g.addNode(2, connectReq{})
+	g.setEdge(2, 1)
+
+	// Disconnect parent, then child — both get GC'd.
+	g.markDisconnected(1)
+	g.markDisconnected(2)
+	g.garbageCollect()
+	require.Empty(t, g.nodes)
+
+	// New child=3 arrives. Reconnect parent as implicit node.
+	g.addImplicitNode(1, connectReq{})
+	g.addNode(3, connectReq{})
+	g.setEdge(3, 1)
+
+	// GC should NOT collect the implicit parent — child 3 keeps it alive.
+	collected := g.garbageCollect()
+	require.Empty(t, collected)
+	require.Contains(t, g.nodes, uint32(1))
+	require.Contains(t, g.nodes, uint32(3))
+
+	// Disconnect child 3 — now parent should be collected.
+	g.markDisconnected(3)
+	collected = g.garbageCollect()
+	require.Len(t, collected, 2)
+	require.NotContains(t, g.nodes, uint32(1))
+	require.NotContains(t, g.nodes, uint32(3))
+}
+
+// --- End-to-end simulation of the K8s scan pipeline race condition ---
+
+// mockPlugin tracks which connection IDs are currently alive (have a
+// runtime) inside the provider process. It mirrors the real Service's
+// runtimes map closely enough to reproduce the bug.
+type mockPlugin struct {
+	mu       sync.Mutex
+	runtimes map[uint32]bool // true = runtime alive
+	connects int             // total Connect calls (for assertions)
+}
+
+func newMockPlugin() *mockPlugin {
+	return &mockPlugin{runtimes: make(map[uint32]bool)}
+}
+
+func (m *mockPlugin) Connect(req *pp.ConnectReq, _ pp.ProviderCallback) (*pp.ConnectRes, error) {
+	if len(req.Asset.GetConnections()) == 0 {
+		return &pp.ConnectRes{}, nil
+	}
+	conf := req.Asset.Connections[0]
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connects++
+
+	// Already alive? Return early (idempotent, like Service.AddRuntime).
+	if m.runtimes[conf.Id] {
+		return &pp.ConnectRes{}, nil
+	}
+
+	// Check parent, mimicking real AddRuntime before our safety-net fix.
+	if conf.ParentConnectionId > 0 {
+		if !m.runtimes[conf.ParentConnectionId] {
+			return nil, fmt.Errorf("parent connection %d not found", conf.ParentConnectionId)
+		}
+	}
+
+	m.runtimes[conf.Id] = true
+	return &pp.ConnectRes{}, nil
+}
+
+func (m *mockPlugin) Disconnect(req *pp.DisconnectReq) (*pp.DisconnectRes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.runtimes, req.Connection)
+	return &pp.DisconnectRes{}, nil
+}
+
+func (m *mockPlugin) alive(id uint32) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.runtimes[id]
+}
+
+// Stubs — not exercised by these tests.
+func (m *mockPlugin) Heartbeat(*pp.HeartbeatReq) (*pp.HeartbeatRes, error) {
+	return &pp.HeartbeatRes{}, nil
+}
+func (m *mockPlugin) ParseCLI(*pp.ParseCLIReq) (*pp.ParseCLIRes, error) { return nil, nil }
+func (m *mockPlugin) MockConnect(*pp.ConnectReq, pp.ProviderCallback) (*pp.ConnectRes, error) {
+	return nil, nil
+}
+
+func (m *mockPlugin) Shutdown(*pp.ShutdownReq) (*pp.ShutdownRes, error) {
+	return &pp.ShutdownRes{}, nil
+}
+func (m *mockPlugin) GetData(*pp.DataReq) (*pp.DataRes, error)     { return nil, nil }
+func (m *mockPlugin) StoreData(*pp.StoreReq) (*pp.StoreRes, error) { return nil, nil }
+
+// connectReqFor builds a ConnectReq for a connection with the given ID
+// and optional parent.
+func connectReqFor(id, parentId uint32) *pp.ConnectReq {
+	return &pp.ConnectReq{
+		Asset: &inventory.Asset{
+			Connections: []*inventory.Config{{
+				Id:                 id,
+				ParentConnectionId: parentId,
+			}},
+		},
+	}
+}
+
+// TestRestartableProvider_ParentReconnectsAfterGC reproduces the exact
+// K8s scan pipeline race:
+//
+//  1. Namespace connections (parents) are created during stage-2 discovery.
+//  2. Discovery finishes → namespace connections are disconnected → GC'd.
+//  3. Workload connections (children) arrive in a later batch with
+//     ParentConnectionId pointing at the GC'd namespace.
+//
+// Before the fix, step 3 fails with "parent connection N not found".
+// After the fix, the parent is transparently reconnected from preserved
+// data.
+func TestRestartableProvider_ParentReconnectsAfterGC(t *testing.T) {
+	mock := newMockPlugin()
+	rp := &RestartableProvider{
+		plugin:          mock,
+		connectionGraph: newConnectionGraph(),
+	}
+
+	const (
+		nsConn         = uint32(2)  // namespace connection (parent)
+		workloadBatch1 = uint32(10) // first batch child
+		workloadBatch2 = uint32(20) // second batch child (arrives after GC)
+	)
+
+	// --- Stage 2 discovery: connect namespace ---
+	_, err := rp.Connect(connectReqFor(nsConn, 0), nil)
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn))
+
+	// --- Discovery done: disconnect namespace ---
+	// This is the real flow: discovery finishes and the namespace is
+	// disconnected BEFORE any workloads connect. Since no children
+	// exist in the graph, GC immediately collects the namespace.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: nsConn})
+	require.NoError(t, err)
+	require.False(t, mock.alive(nsConn), "namespace runtime should be disconnected")
+
+	// --- First batch: connect a workload child ---
+	// The parent was GC'd — our fix should reconnect it transparently.
+	_, err = rp.Connect(connectReqFor(workloadBatch1, nsConn), nil)
+	require.NoError(t, err, "first child should connect after parent is reconnected")
+	require.True(t, mock.alive(nsConn), "parent should be alive after reconnection")
+
+	// --- First batch done: disconnect workload ---
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: workloadBatch1})
+	require.NoError(t, err)
+	// The implicitly reconnected parent should be GC'd again.
+	require.False(t, mock.alive(nsConn), "parent should be GC'd after all children disconnect")
+
+	// --- Second batch arrives: another reconnection cycle ---
+	_, err = rp.Connect(connectReqFor(workloadBatch2, nsConn), nil)
+	require.NoError(t, err, "second child should also connect after parent is re-reconnected")
+	require.True(t, mock.alive(nsConn), "parent should be alive again")
+	require.True(t, mock.alive(workloadBatch2))
+}
+
+// TestRestartableProvider_MultiNamespaceMultiBatch simulates a realistic
+// K8s cluster scan: 5 namespaces × 10 workloads each, processed in
+// batches of 15. This catches ordering-dependent bugs that single-pair
+// tests miss.
+func TestRestartableProvider_MultiNamespaceMultiBatch(t *testing.T) {
+	mock := newMockPlugin()
+	rp := &RestartableProvider{
+		plugin:          mock,
+		connectionGraph: newConnectionGraph(),
+	}
+
+	const (
+		numNamespaces  = 5
+		workloadsPerNs = 10
+		batchSize      = 15
+	)
+
+	// Assign connection IDs the way the coordinator would: namespaces get
+	// low IDs, workloads get higher IDs interleaved with namespace discovery.
+	nsID := func(ns int) uint32 { return uint32(ns + 1) }
+	wlID := func(ns, wl int) uint32 { return uint32(100 + ns*workloadsPerNs + wl) }
+
+	// --- Discovery phase: connect all namespaces (stage 2) ---
+	for ns := range numNamespaces {
+		_, err := rp.Connect(connectReqFor(nsID(ns), 0), nil)
+		require.NoError(t, err)
+	}
+
+	// --- Discovery done: disconnect all namespaces ---
+	for ns := range numNamespaces {
+		_, err := rp.Disconnect(&pp.DisconnectReq{Connection: nsID(ns)})
+		require.NoError(t, err)
+	}
+
+	// All namespaces should be GC'd now (no children yet).
+	for ns := range numNamespaces {
+		require.False(t, mock.alive(nsID(ns)), "namespace %d should be GC'd", ns)
+	}
+
+	// --- Scan phase: connect workloads in batches ---
+	// Build the full workload list.
+	type workload struct{ id, parent uint32 }
+	var allWorkloads []workload
+	for ns := range numNamespaces {
+		for wl := range workloadsPerNs {
+			allWorkloads = append(allWorkloads, workload{wlID(ns, wl), nsID(ns)})
+		}
+	}
+
+	// Process in batches: connect batch, disconnect batch, repeat.
+	for batchStart := 0; batchStart < len(allWorkloads); batchStart += batchSize {
+		batchEnd := min(batchStart+batchSize, len(allWorkloads))
+		batch := allWorkloads[batchStart:batchEnd]
+
+		// Connect entire batch.
+		for _, wl := range batch {
+			_, err := rp.Connect(connectReqFor(wl.id, wl.parent), nil)
+			require.NoError(t, err, "workload %d (parent %d) should connect", wl.id, wl.parent)
+		}
+
+		// Disconnect entire batch.
+		for _, wl := range batch {
+			_, err := rp.Disconnect(&pp.DisconnectReq{Connection: wl.id})
+			require.NoError(t, err)
+		}
+	}
+
+	// All workloads processed successfully — no "parent connection N not
+	// found" errors. Verify the provider is clean.
+	for ns := range numNamespaces {
+		assert.False(t, mock.alive(nsID(ns)), "namespace %d should be GC'd after scan", ns)
+	}
 }


### PR DESCRIPTION
## Summary

- Fix recurring `parent connection N not found` errors that cause K8s scans to fail with exit code 1 when scanning clusters with many namespaces and workloads
- Preserve garbage-collected parent connection data so children can transparently reconnect parents across batch boundaries
- Downgrade missing-parent from a hard error to a warning in `Service.AddRuntime` as a safety net

## Problem

During K8s scans, the coordinator discovers namespaces (stage 2), then disconnects them before scanning workloads in batches (`max_connections=50`). The `connectionGraph` garbage-collects namespace connections once discovery finishes because no children reference them yet. When workloads later connect with `ParentConnectionId` pointing at the GC'd namespace, `Service.AddRuntime` fails with `parent connection N not found`, marking the asset as failed. In large clusters this cascades across batches, failing dozens of assets and triggering K8s Job failure alerts.

```
ERR failed to connect to asset error="rpc error: code = Unknown desc = parent connection 5 not found"
```

The bug is exacerbated by low `max_connections` values (the operator forces `10`). Smaller batches mean more batch boundaries per namespace, and every boundary is a chance for the parent to get GC'd. A namespace with 15 workloads at `max_connections=10` guarantees at least one GC/reconnect cycle; at `max_connections=50` the same workloads might all fit in one batch.

A previous fix (PR #7500) addressed a related symptom in the OS provider but didn't fix the root cause in the coordinator/plugin layer.

## Fix (three layers)

**Layer 1 — Preserve GC'd connection data** (`running_provider.go`):
- `connectionGraph.garbageCollect()` now saves each collected node's connect request data in `collectedNodes` before deleting it from `nodes`
- New `getCollectedNode()` method retrieves preserved data
- New `addImplicitNode()` method re-adds a parent as non-explicitly-connected (eligible for GC once children finish)

**Layer 2 — Transparent parent reconnection** (`running_provider.go`):
- `RestartableProvider.Connect()` detects when a child's parent was GC'd
- Looks up preserved connect data and reconnects the parent before connecting the child
- Re-adds the parent as an implicit node so it participates in GC lifecycle correctly
- Handles repeated GC/reconnect cycles across multiple scan batches

**Layer 3 — Safety net** (`service.go`):
- `Service.AddRuntime` and `deprecatedAddRuntime` log a warning and continue instead of returning an error when the parent connection is missing
- The scan proceeds without shared resource cache rather than failing the entire asset

## Test plan

- [x] Unit tests for `connectionGraph` — verify GC preserves data in `collectedNodes`, verify implicit parents survive while children reference them
- [x] End-to-end `RestartableProvider` test — single namespace/workload reproducing the exact bug sequence (connect parent → disconnect → GC → connect child → must succeed)
- [x] Multi-namespace multi-batch simulation — 5 namespaces × 10 workloads in batches of 15, full GC/reconnect cycle coverage
- [x] Reverse TDD — tests fail on `main` without the fix (`parent connection 2 not found`), pass with the fix
- [x] Existing `TestAddRuntime_Parent*` tests updated to expect warning instead of error
- [ ] Manual verification: `cnspec scan k8s --discover all` against seeded minikube cluster (20 namespaces, ~240 assets)
