### PR TITLE
🎉 oci-13.15.0, digitalocean-13.12.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.11.0",
+	Version:         "13.12.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.14.0",
+	Version:         "13.15.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the `oci` and `digitalocean` providers.

## oci 13.14.0 → 13.15.0
- ✨ oci: discover Generative AI endpoints as `oci-ai-generativeai-endpoint` assets (#9010)
- 🧹 Update deps for mql and providers 20260707 (#8998)

## digitalocean 13.11.0 → 13.12.0
- ✨ digitalocean: discover GradientAI agents as their own assets (#9014)
- 🧹 Update deps for mql and providers 20260707 (#8998)

Each provider gained a new discoverable asset type since its last release, so this is a minor bump rather than a patch.
