### PR TITLE
🎉 azure-13.28.0, gcp-13.30.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.27.0",
+	Version:   "13.28.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.29.1",
+	Version: "13.30.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Minor version bump for the **azure** and **gcp** providers.

## azure `13.27.0` → `13.28.0`
- ✨ Discover managed HSMs and IoT hubs as per-resource assets (#9011)
- 🧹 Update deps for mql and providers (#8998)

## gcp `13.29.1` → `13.30.0`
- ✨ Discover Model Armor templates and Datastream connection profiles as assets (#9012)
- 🐛 Filter for AWS S3 bucket and Google storage bucket (#9017)
- 🧹 Bump `cloud.google.com/go/pubsub/v2` to v2.6.1 (#9005)
- 🧹 Update deps for mql and providers (#8998)
