### PR TITLE
🎉 os-13.34.3

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.34.2",
+	Version: "13.34.3",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Patch version bump for the **os** provider.

## os `13.34.2` → `13.34.3`
- 🐛 docker: close the file reader before following a symlink (#8667)
