### PR TITLE
✨ aws: expose arn on aws.directoryservice.directory (#9025)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -19782,6 +19782,8 @@ aws.directoryservice @defaults("directories") {
 private aws.directoryservice.directory @defaults("directoryId name type stage region") {
   // Unique identifier of the directory
   directoryId string
+  // Amazon Resource Name (ARN) of the directory
+  arn() string
   // Fully qualified name of the directory (e.g., corp.example.com)
   name string
   // NetBIOS short name of the directory (e.g., CORP)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -26567,6 +26567,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.directoryservice.directory.directoryId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDirectoryserviceDirectory).GetDirectoryId()).ToDataRes(types.String)
 	},
+	"aws.directoryservice.directory.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDirectoryserviceDirectory).GetArn()).ToDataRes(types.String)
+	},
 	"aws.directoryservice.directory.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDirectoryserviceDirectory).GetName()).ToDataRes(types.String)
 	},
@@ -65881,6 +65884,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.directoryservice.directory.directoryId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDirectoryserviceDirectory).DirectoryId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.directoryservice.directory.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDirectoryserviceDirectory).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.directoryservice.directory.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -159265,6 +159272,7 @@ type mqlAwsDirectoryserviceDirectory struct {
 	__id       string
 	mqlAwsDirectoryserviceDirectoryInternal
 	DirectoryId                      plugin.TValue[string]
+	Arn                              plugin.TValue[string]
 	Name                             plugin.TValue[string]
 	ShortName                        plugin.TValue[string]
 	Description                      plugin.TValue[string]
@@ -159332,6 +159340,12 @@ func (c *mqlAwsDirectoryserviceDirectory) MqlID() string {
 
 func (c *mqlAwsDirectoryserviceDirectory) GetDirectoryId() *plugin.TValue[string] {
 	return &c.DirectoryId
+}
+
+func (c *mqlAwsDirectoryserviceDirectory) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsDirectoryserviceDirectory) GetName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2373,6 +2373,7 @@ aws.directoryservice.directories 11.15.6
 aws.directoryservice.directory 11.15.6
 aws.directoryservice.directory.accessUrl 11.15.6
 aws.directoryservice.directory.alias 11.15.6
+aws.directoryservice.directory.arn 13.44.1
 aws.directoryservice.directory.connectSettings 11.15.6
 aws.directoryservice.directory.description 11.15.6
 aws.directoryservice.directory.desiredNumberOfDomainControllers 11.15.6

--- a/providers/aws/resources/aws_directoryservice.go
+++ b/providers/aws/resources/aws_directoryservice.go
@@ -174,6 +174,19 @@ func (a *mqlAwsDirectoryserviceDirectory) id() (string, error) {
 	return "aws.directoryservice.directory/" + a.Region.Data + "/" + a.DirectoryId.Data, nil
 }
 
+// directoryServiceDirectoryArn synthesizes the canonical Directory Service
+// directory ARN. The DescribeDirectories API does not return an ARN, so it is
+// built from the region, account, and directory id. Keep this in sync with the
+// discovered asset's platform id (see discovery.go).
+func directoryServiceDirectoryArn(region, accountID, directoryID string) string {
+	return fmt.Sprintf("arn:aws:ds:%s:%s:directory/%s", region, accountID, directoryID)
+}
+
+func (a *mqlAwsDirectoryserviceDirectory) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return directoryServiceDirectoryArn(a.Region.Data, conn.AccountId(), a.DirectoryId.Data), nil
+}
+
 func (a *mqlAwsDirectoryserviceDirectory) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.DirectoryService(a.Region.Data)

--- a/providers/aws/resources/aws_directoryservice_test.go
+++ b/providers/aws/resources/aws_directoryservice_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirectoryServiceDirectoryArn(t *testing.T) {
+	cases := []struct {
+		name        string
+		region      string
+		accountID   string
+		directoryID string
+		want        string
+	}{
+		{
+			name:        "microsoft ad",
+			region:      "us-east-1",
+			accountID:   "123456789012",
+			directoryID: "d-1234567890",
+			want:        "arn:aws:ds:us-east-1:123456789012:directory/d-1234567890",
+		},
+		{
+			name:        "other region",
+			region:      "eu-central-1",
+			accountID:   "210987654321",
+			directoryID: "d-abcdef0123",
+			want:        "arn:aws:ds:eu-central-1:210987654321:directory/d-abcdef0123",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, directoryServiceDirectoryArn(tc.region, tc.accountID, tc.directoryID))
+		})
+	}
+}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"fmt"
 	"slices"
 	"strconv"
 
@@ -1669,7 +1668,7 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 
 			// Directory Service directories have no ARN in the API response;
 			// synthesize the canonical directory ARN for the platform id.
-			dirArn := fmt.Sprintf("arn:aws:ds:%s:%s:directory/%s", f.Region.Data, accountId, f.DirectoryId.Data)
+			dirArn := directoryServiceDirectoryArn(f.Region.Data, accountId, f.DirectoryId.Data)
 			name := f.Name.Data
 			if name == "" {
 				name = f.DirectoryId.Data


### PR DESCRIPTION
Closes #9025.

## What

`aws.directoryservice.directory` now exposes an `arn` field.

AWS `DescribeDirectories` does not return an ARN, so the resource previously only carried `directoryId`. #9013 already synthesizes the canonical directory ARN for the discovered asset's platform id in `discovery.go`. This surfaces that same value as a queryable MQL field:

```
arn:aws:ds:{region}:{account-id}:directory/{directoryId}
```

The synthesis is factored into a shared `directoryServiceDirectoryArn` helper that both the resource accessor and the discovery code call, so the resource field and the discovered platform id stay consistent by construction.

## Why

Downstream (server), the five sibling asset types from #9013 all have a native `arn`, so their asset-overview groups wire the shared `asset-overview-aws-arn` query that powers the "Open in AWS console" button. Directory assets had to omit it because `aws.directoryservice.directory.arn` didn't compile. Once this lands, the server can wire the ARN query for directory assets.

## Acceptance criteria

- [x] `aws.directoryservice.directory` has an `arn` string field.
- [x] `aws.directoryservice.directory.arn` compiles and returns `arn:aws:ds:{region}:{account}:directory/{directoryId}`.
- [x] The value matches the platform id synthesized in the discovery path (shared helper).

## Verification

- `arn` is a computed accessor (`arn()`), resolving the account id from the connection at access time — the same lazy pattern the resource's `vpc()`/`securityGroup()` accessors already use.
- New unit test `TestDirectoryServiceDirectoryArn` pins the exact canonical format.
- Live: `mql run aws -c "aws.directoryservice.directories { directoryId region arn }"` compiles and runs against a real account (no directories provisioned there, so empty). Negative control confirms the compile check is real — a bogus field errors with `cannot find field`, while `arn` does not.
- `*.permissions.json` unchanged (ARN is synthesized, no new API call).
