### PR TITLE
✨ aws: expose arn on 20 more resources with synthesizable ARNs

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -56,6 +56,13 @@ const (
 	efsFilesystemArnPattern       = "arn:aws:elasticfilesystem:%s:%s:file-system/%s"
 	fsxFilesystemArnPattern       = "arn:aws:fsx:%s:%s:file-system/%s"
 	prefixListArnPattern          = "arn:aws:ec2:%s:%s:prefix-list/%s"
+	vpcEndpointArnPattern         = "arn:aws:ec2:%s:%s:vpc-endpoint/%s"
+	vpcFlowLogArnPattern          = "arn:aws:ec2:%s:%s:vpc-flow-log/%s"
+	natGatewayArnPattern          = "arn:aws:ec2:%s:%s:natgateway/%s"
+	networkInterfaceArnPattern    = "arn:aws:ec2:%s:%s:network-interface/%s"
+	dhcpOptionsArnPattern         = "arn:aws:ec2:%s:%s:dhcp-options/%s"
+	tgwAttachmentArnPattern       = "arn:aws:ec2:%s:%s:transit-gateway-attachment/%s"
+	tgwRouteTableArnPattern       = "arn:aws:ec2:%s:%s:transit-gateway-route-table/%s"
 )
 
 func NewSecurityGroupArn(region, accountID, sgID string) string {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -596,6 +596,8 @@ private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAva
 private aws.vpc.endpoint @defaults("id type region") {
   // Unique ID of the endpoint
   id string
+  // Amazon Resource Name (ARN) of the endpoint
+  arn() string
   // Type of the endpoint
   type string
   // VPC in which the endpoint exists
@@ -638,6 +640,8 @@ private aws.vpc.endpoint @defaults("id type region") {
 private aws.vpc.flowlog @defaults("id region status") {
   // Unique ID of the flow log
   id string
+  // Amazon Resource Name (ARN) of the flow log
+  arn() string
   // VPC in which the flow log exists
   vpc string
   // Region in which the VPC flow log exists
@@ -6167,6 +6171,8 @@ aws.guardduty {
 private aws.guardduty.detector @defaults("id region") {
   // Unique ID for the detector
   id string
+  // Amazon Resource Name (ARN) of the detector
+  arn() string
   // Region for the detector
   region string
   // Status of the detector: ENABLED or DISABLED
@@ -10163,6 +10169,8 @@ aws.cloudhsm {
 private aws.cloudhsm.cluster @defaults("clusterId state mode region") {
   // Cluster ID
   clusterId string
+  // Amazon Resource Name (ARN) of the cluster
+  arn() string
   // Region where the cluster is deployed
   region string
   // Cluster lifecycle state
@@ -12964,6 +12972,8 @@ private aws.redshift.snapshot @defaults("arn clusterIdentifier status createdAt"
 private aws.redshift.subnetGroup @defaults("name status") {
   // Subnet group name
   name string
+  // Amazon Resource Name (ARN) of the subnet group
+  arn() string
   // Description of the subnet group
   description string
   // Region where the subnet group exists
@@ -12984,6 +12994,8 @@ private aws.redshift.subnetGroup @defaults("name status") {
 private aws.redshift.eventSubscription @defaults("name status") {
   // Subscription name
   name string
+  // Amazon Resource Name (ARN) of the event subscription
+  arn() string
   // Region where the subscription exists
   region string
   // Whether the subscription is enabled
@@ -15173,6 +15185,8 @@ private aws.lambda.layer.version @defaults("layerVersionArn version") {
 private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   // UUID of the event source mapping
   uuid string
+  // Amazon Resource Name (ARN) of the event source mapping
+  arn() string
   // ARN of the event source
   eventSourceArn string
   // Lambda function for the event source mapping
@@ -15493,6 +15507,8 @@ private aws.vpc.natgateway {
   createdAt time
   // ID of the NAT gateway
   natGatewayId string
+  // Amazon Resource Name (ARN) of the NAT gateway
+  arn() string
   // State of the NAT gateway (pending, failed, available, deleting, or deleted)
   state string
   // Tags for the NAT gateway
@@ -15780,6 +15796,8 @@ private aws.ec2.transitgateway @defaults("arn id state") {
 private aws.ec2.transitgateway.attachment @defaults("id resourceType state") {
   // Transit gateway attachment ID
   id string
+  // Amazon Resource Name (ARN) of the transit gateway attachment
+  arn() string
   // ID of the transit gateway
   transitGatewayId string
   // ID of the attached resource (VPC ID, VPN connection ID, etc.)
@@ -15802,6 +15820,8 @@ private aws.ec2.transitgateway.attachment @defaults("id resourceType state") {
 private aws.ec2.transitgateway.routeTable @defaults("id state") {
   // Transit gateway route table ID
   id string
+  // Amazon Resource Name (ARN) of the transit gateway route table
+  arn() string
   // ID of the transit gateway
   transitGatewayId string
   // State of the route table: pending, available, deleting, deleted
@@ -15822,6 +15842,8 @@ private aws.ec2.transitgateway.routeTable @defaults("id state") {
 private aws.ec2.dhcpOptions @defaults("id region") {
   // ID of the DHCP options set
   id string
+  // Amazon Resource Name (ARN) of the DHCP options set
+  arn() string
   // Region where the DHCP options set exists
   region string
   // Tags on the DHCP options set
@@ -16766,6 +16788,8 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
 private aws.ec2.networkinterface @defaults("id privateIpAddress macAddress") {
   // ID of the network interface
   id string
+  // Amazon Resource Name (ARN) of the network interface
+  arn() string
   // Description of the network interface
   description string
   // Subnet of the network interface
@@ -18173,6 +18197,8 @@ private aws.cognito.userPoolIdentityProvider @defaults("providerName providerTyp
 private aws.cognito.identityPool @defaults("id name") {
   // Identity pool ID (format: REGION:GUID)
   id string
+  // Amazon Resource Name (ARN) of the identity pool
+  arn() string
   // Name of the identity pool
   name string
   // Region of the identity pool
@@ -19731,6 +19757,8 @@ private aws.athena.workgroup @defaults("name state region") {
 private aws.athena.dataCatalog @defaults("name type region") {
   // Name of the data catalog
   name string
+  // Amazon Resource Name (ARN) of the data catalog
+  arn() string
   // Type of data catalog: LAMBDA, GLUE, HIVE, or FEDERATED
   type string
   // Description of the data catalog
@@ -19936,6 +19964,8 @@ aws.workspaces @defaults("directories") {
 private aws.workspaces.directory @defaults("directoryId directoryName state region") {
   // Directory identifier
   directoryId string
+  // Amazon Resource Name (ARN) of the directory
+  arn() string
   // Fully qualified directory name
   directoryName string
   // Directory type: SIMPLE_AD, AD_CONNECTOR, CUSTOMER_MANAGED, AWS_IAM_IDENTITY_CENTER
@@ -20128,6 +20158,8 @@ private aws.workspacesweb.userSetting @defaults("userSettingsArn region") {
 private aws.workspaces.workspace @defaults("workspaceId userName state region") {
   // Workspace identifier
   workspaceId string
+  // Amazon Resource Name (ARN) of the workspace
+  arn() string
   // Associated directory ID
   directoryId string
   // User associated with the workspace
@@ -20224,6 +20256,8 @@ private aws.workspaces.bundle @defaults("bundleId name region") {
 private aws.workspaces.ipGroup @defaults("groupId groupName region") {
   // IP group identifier
   groupId string
+  // Amazon Resource Name (ARN) of the IP group
+  arn() string
   // IP group name
   groupName string
   // IP group description
@@ -21188,6 +21222,8 @@ private aws.glue.securityConfiguration @defaults("name") {
 private aws.glue.database @defaults("name region") {
   // Name of the database
   name string
+  // Amazon Resource Name (ARN) of the database
+  arn() string
   // ID of the Data Catalog in which the database resides
   catalogId string
   // Description of the database
@@ -21493,6 +21529,8 @@ private aws.rds.eventSubscription @defaults("arn name status") {
 private aws.glue.workflow @defaults("name region") {
   // Name of the workflow
   name string
+  // Amazon Resource Name (ARN) of the workflow
+  arn() string
   // Region of the workflow
   region string
   // Description of the workflow
@@ -21524,6 +21562,8 @@ private aws.glue.workflow @defaults("name region") {
 private aws.glue.connection @defaults("name connectionType region") {
   // Name of the connection
   name string
+  // Amazon Resource Name (ARN) of the connection
+  arn() string
   // Region of the connection
   region string
   // Description of the connection

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5201,6 +5201,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetId()).ToDataRes(types.String)
 	},
+	"aws.vpc.endpoint.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcEndpoint).GetArn()).ToDataRes(types.String)
+	},
 	"aws.vpc.endpoint.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetType()).ToDataRes(types.String)
 	},
@@ -5257,6 +5260,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.flowlog.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetId()).ToDataRes(types.String)
+	},
+	"aws.vpc.flowlog.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcFlowlog).GetArn()).ToDataRes(types.String)
 	},
 	"aws.vpc.flowlog.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetVpc()).ToDataRes(types.String)
@@ -11600,6 +11606,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.guardduty.detector.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGuarddutyDetector).GetId()).ToDataRes(types.String)
 	},
+	"aws.guardduty.detector.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyDetector).GetArn()).ToDataRes(types.String)
+	},
 	"aws.guardduty.detector.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGuarddutyDetector).GetRegion()).ToDataRes(types.String)
 	},
@@ -15764,6 +15773,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudhsm.cluster.clusterId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudhsmCluster).GetClusterId()).ToDataRes(types.String)
 	},
+	"aws.cloudhsm.cluster.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudhsmCluster).GetArn()).ToDataRes(types.String)
+	},
 	"aws.cloudhsm.cluster.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudhsmCluster).GetRegion()).ToDataRes(types.String)
 	},
@@ -18950,6 +18962,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.redshift.subnetGroup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftSubnetGroup).GetName()).ToDataRes(types.String)
 	},
+	"aws.redshift.subnetGroup.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftSubnetGroup).GetArn()).ToDataRes(types.String)
+	},
 	"aws.redshift.subnetGroup.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftSubnetGroup).GetDescription()).ToDataRes(types.String)
 	},
@@ -18973,6 +18988,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.redshift.eventSubscription.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftEventSubscription).GetName()).ToDataRes(types.String)
+	},
+	"aws.redshift.eventSubscription.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRedshiftEventSubscription).GetArn()).ToDataRes(types.String)
 	},
 	"aws.redshift.eventSubscription.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshiftEventSubscription).GetRegion()).ToDataRes(types.String)
@@ -21275,6 +21293,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.lambda.eventSourceMapping.uuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaEventSourceMapping).GetUuid()).ToDataRes(types.String)
 	},
+	"aws.lambda.eventSourceMapping.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaEventSourceMapping).GetArn()).ToDataRes(types.String)
+	},
 	"aws.lambda.eventSourceMapping.eventSourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaEventSourceMapping).GetEventSourceArn()).ToDataRes(types.String)
 	},
@@ -21641,6 +21662,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.natgateway.natGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcNatgateway).GetNatGatewayId()).ToDataRes(types.String)
 	},
+	"aws.vpc.natgateway.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcNatgateway).GetArn()).ToDataRes(types.String)
+	},
 	"aws.vpc.natgateway.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcNatgateway).GetState()).ToDataRes(types.String)
 	},
@@ -21977,6 +22001,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.transitgateway.attachment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetId()).ToDataRes(types.String)
 	},
+	"aws.ec2.transitgateway.attachment.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetArn()).ToDataRes(types.String)
+	},
 	"aws.ec2.transitgateway.attachment.transitGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayAttachment).GetTransitGatewayId()).ToDataRes(types.String)
 	},
@@ -22001,6 +22028,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.transitgateway.routeTable.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetId()).ToDataRes(types.String)
 	},
+	"aws.ec2.transitgateway.routeTable.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetArn()).ToDataRes(types.String)
+	},
 	"aws.ec2.transitgateway.routeTable.transitGatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2TransitgatewayRouteTable).GetTransitGatewayId()).ToDataRes(types.String)
 	},
@@ -22024,6 +22054,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.dhcpOptions.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2DhcpOptions).GetId()).ToDataRes(types.String)
+	},
+	"aws.ec2.dhcpOptions.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2DhcpOptions).GetArn()).ToDataRes(types.String)
 	},
 	"aws.ec2.dhcpOptions.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2DhcpOptions).GetRegion()).ToDataRes(types.String)
@@ -23161,6 +23194,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.networkinterface.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetId()).ToDataRes(types.String)
+	},
+	"aws.ec2.networkinterface.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkinterface).GetArn()).ToDataRes(types.String)
 	},
 	"aws.ec2.networkinterface.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetDescription()).ToDataRes(types.String)
@@ -24778,6 +24814,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cognito.identityPool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCognitoIdentityPool).GetId()).ToDataRes(types.String)
+	},
+	"aws.cognito.identityPool.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCognitoIdentityPool).GetArn()).ToDataRes(types.String)
 	},
 	"aws.cognito.identityPool.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCognitoIdentityPool).GetName()).ToDataRes(types.String)
@@ -26519,6 +26558,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.athena.dataCatalog.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAthenaDataCatalog).GetName()).ToDataRes(types.String)
 	},
+	"aws.athena.dataCatalog.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAthenaDataCatalog).GetArn()).ToDataRes(types.String)
+	},
 	"aws.athena.dataCatalog.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAthenaDataCatalog).GetType()).ToDataRes(types.String)
 	},
@@ -26734,6 +26776,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.workspaces.directory.directoryId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesDirectory).GetDirectoryId()).ToDataRes(types.String)
+	},
+	"aws.workspaces.directory.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesDirectory).GetArn()).ToDataRes(types.String)
 	},
 	"aws.workspaces.directory.directoryName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesDirectory).GetDirectoryName()).ToDataRes(types.String)
@@ -26951,6 +26996,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.workspaces.workspace.workspaceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetWorkspaceId()).ToDataRes(types.String)
 	},
+	"aws.workspaces.workspace.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesWorkspace).GetArn()).ToDataRes(types.String)
+	},
 	"aws.workspaces.workspace.directoryId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetDirectoryId()).ToDataRes(types.String)
 	},
@@ -27073,6 +27121,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.workspaces.ipGroup.groupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesIpGroup).GetGroupId()).ToDataRes(types.String)
+	},
+	"aws.workspaces.ipGroup.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesIpGroup).GetArn()).ToDataRes(types.String)
 	},
 	"aws.workspaces.ipGroup.groupName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesIpGroup).GetGroupName()).ToDataRes(types.String)
@@ -28154,6 +28205,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.glue.database.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueDatabase).GetName()).ToDataRes(types.String)
 	},
+	"aws.glue.database.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGlueDatabase).GetArn()).ToDataRes(types.String)
+	},
 	"aws.glue.database.catalogId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueDatabase).GetCatalogId()).ToDataRes(types.String)
 	},
@@ -28517,6 +28571,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.glue.workflow.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueWorkflow).GetName()).ToDataRes(types.String)
 	},
+	"aws.glue.workflow.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGlueWorkflow).GetArn()).ToDataRes(types.String)
+	},
 	"aws.glue.workflow.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueWorkflow).GetRegion()).ToDataRes(types.String)
 	},
@@ -28540,6 +28597,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.glue.connection.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueConnection).GetName()).ToDataRes(types.String)
+	},
+	"aws.glue.connection.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGlueConnection).GetArn()).ToDataRes(types.String)
 	},
 	"aws.glue.connection.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueConnection).GetRegion()).ToDataRes(types.String)
@@ -34754,6 +34814,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcEndpoint).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.endpoint.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcEndpoint).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.endpoint.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcEndpoint).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -34832,6 +34896,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.flowlog.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcFlowlog).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.flowlog.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcFlowlog).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.flowlog.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44094,6 +44162,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsGuarddutyDetector).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.guardduty.detector.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyDetector).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.guardduty.detector.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGuarddutyDetector).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -50302,6 +50374,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudhsmCluster).ClusterId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.cloudhsm.cluster.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudhsmCluster).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.cloudhsm.cluster.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudhsmCluster).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -54874,6 +54950,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRedshiftSubnetGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.redshift.subnetGroup.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftSubnetGroup).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.redshift.subnetGroup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftSubnetGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -54908,6 +54988,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.redshift.eventSubscription.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRedshiftEventSubscription).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.redshift.eventSubscription.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRedshiftEventSubscription).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.eventSubscription.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58238,6 +58322,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsLambdaEventSourceMapping).Uuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.lambda.eventSourceMapping.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaEventSourceMapping).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.lambda.eventSourceMapping.eventSourceArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaEventSourceMapping).EventSourceArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -58762,6 +58850,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcNatgateway).NatGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.natgateway.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcNatgateway).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.natgateway.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcNatgateway).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -59262,6 +59354,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2TransitgatewayAttachment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.transitgateway.attachment.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2TransitgatewayAttachment).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.transitgateway.attachment.transitGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2TransitgatewayAttachment).TransitGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -59298,6 +59394,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2TransitgatewayRouteTable).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.transitgateway.routeTable.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2TransitgatewayRouteTable).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.transitgateway.routeTable.transitGatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2TransitgatewayRouteTable).TransitGatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -59332,6 +59432,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.dhcpOptions.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2DhcpOptions).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.dhcpOptions.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2DhcpOptions).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.dhcpOptions.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60976,6 +61080,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.networkinterface.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Networkinterface).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkinterface.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkinterface).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.networkinterface.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -63304,6 +63412,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cognito.identityPool.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCognitoIdentityPool).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cognito.identityPool.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCognitoIdentityPool).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.cognito.identityPool.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -65810,6 +65922,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsAthenaDataCatalog).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.athena.dataCatalog.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAthenaDataCatalog).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.athena.dataCatalog.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAthenaDataCatalog).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -66130,6 +66246,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWorkspacesDirectory).DirectoryId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.workspaces.directory.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesDirectory).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.workspaces.directory.directoryName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesDirectory).DirectoryName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -66442,6 +66562,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWorkspacesWorkspace).WorkspaceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.workspaces.workspace.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesWorkspace).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.workspaces.workspace.directoryId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesWorkspace).DirectoryId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -66616,6 +66740,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.workspaces.ipGroup.groupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesIpGroup).GroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.workspaces.ipGroup.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesIpGroup).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.workspaces.ipGroup.groupName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -68194,6 +68322,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsGlueDatabase).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.glue.database.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGlueDatabase).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.glue.database.catalogId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGlueDatabase).CatalogId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -68710,6 +68842,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsGlueWorkflow).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.glue.workflow.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGlueWorkflow).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.glue.workflow.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGlueWorkflow).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -68744,6 +68880,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.glue.connection.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGlueConnection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.glue.connection.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGlueConnection).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.glue.connection.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -78919,6 +79059,7 @@ type mqlAwsVpcEndpoint struct {
 	__id       string
 	mqlAwsVpcEndpointInternal
 	Id                plugin.TValue[string]
+	Arn               plugin.TValue[string]
 	Type              plugin.TValue[string]
 	Vpc               plugin.TValue[string]
 	Region            plugin.TValue[string]
@@ -78978,6 +79119,12 @@ func (c *mqlAwsVpcEndpoint) MqlID() string {
 
 func (c *mqlAwsVpcEndpoint) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsVpcEndpoint) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsVpcEndpoint) GetType() *plugin.TValue[string] {
@@ -79106,6 +79253,7 @@ type mqlAwsVpcFlowlog struct {
 	__id       string
 	mqlAwsVpcFlowlogInternal
 	Id                     plugin.TValue[string]
+	Arn                    plugin.TValue[string]
 	Vpc                    plugin.TValue[string]
 	Region                 plugin.TValue[string]
 	Status                 plugin.TValue[string]
@@ -79156,6 +79304,12 @@ func (c *mqlAwsVpcFlowlog) MqlID() string {
 
 func (c *mqlAwsVpcFlowlog) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsVpcFlowlog) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsVpcFlowlog) GetVpc() *plugin.TValue[string] {
@@ -103520,6 +103674,7 @@ type mqlAwsGuarddutyDetector struct {
 	__id       string
 	mqlAwsGuarddutyDetectorInternal
 	Id                         plugin.TValue[string]
+	Arn                        plugin.TValue[string]
 	Region                     plugin.TValue[string]
 	Status                     plugin.TValue[string]
 	Features                   plugin.TValue[[]any]
@@ -103576,6 +103731,12 @@ func (c *mqlAwsGuarddutyDetector) MqlID() string {
 
 func (c *mqlAwsGuarddutyDetector) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsGuarddutyDetector) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsGuarddutyDetector) GetRegion() *plugin.TValue[string] {
@@ -120726,6 +120887,7 @@ type mqlAwsCloudhsmCluster struct {
 	__id       string
 	mqlAwsCloudhsmClusterInternal
 	ClusterId           plugin.TValue[string]
+	Arn                 plugin.TValue[string]
 	Region              plugin.TValue[string]
 	State               plugin.TValue[string]
 	StateMessage        plugin.TValue[string]
@@ -120777,6 +120939,12 @@ func (c *mqlAwsCloudhsmCluster) MqlID() string {
 
 func (c *mqlAwsCloudhsmCluster) GetClusterId() *plugin.TValue[string] {
 	return &c.ClusterId
+}
+
+func (c *mqlAwsCloudhsmCluster) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsCloudhsmCluster) GetRegion() *plugin.TValue[string] {
@@ -131933,6 +132101,7 @@ type mqlAwsRedshiftSubnetGroup struct {
 	__id       string
 	mqlAwsRedshiftSubnetGroupInternal
 	Name                           plugin.TValue[string]
+	Arn                            plugin.TValue[string]
 	Description                    plugin.TValue[string]
 	Region                         plugin.TValue[string]
 	Status                         plugin.TValue[string]
@@ -131983,6 +132152,12 @@ func (c *mqlAwsRedshiftSubnetGroup) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
+func (c *mqlAwsRedshiftSubnetGroup) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
+}
+
 func (c *mqlAwsRedshiftSubnetGroup) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
@@ -132029,6 +132204,7 @@ type mqlAwsRedshiftEventSubscription struct {
 	__id       string
 	// optional: if you define mqlAwsRedshiftEventSubscriptionInternal it will be used here
 	Name            plugin.TValue[string]
+	Arn             plugin.TValue[string]
 	Region          plugin.TValue[string]
 	Enabled         plugin.TValue[bool]
 	EventCategories plugin.TValue[[]any]
@@ -132081,6 +132257,12 @@ func (c *mqlAwsRedshiftEventSubscription) MqlID() string {
 
 func (c *mqlAwsRedshiftEventSubscription) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAwsRedshiftEventSubscription) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsRedshiftEventSubscription) GetRegion() *plugin.TValue[string] {
@@ -140258,6 +140440,7 @@ type mqlAwsLambdaEventSourceMapping struct {
 	__id       string
 	// optional: if you define mqlAwsLambdaEventSourceMappingInternal it will be used here
 	Uuid                           plugin.TValue[string]
+	Arn                            plugin.TValue[string]
 	EventSourceArn                 plugin.TValue[string]
 	Function                       plugin.TValue[*mqlAwsLambdaFunction]
 	FunctionArn                    plugin.TValue[string]
@@ -140320,6 +140503,12 @@ func (c *mqlAwsLambdaEventSourceMapping) MqlID() string {
 
 func (c *mqlAwsLambdaEventSourceMapping) GetUuid() *plugin.TValue[string] {
 	return &c.Uuid
+}
+
+func (c *mqlAwsLambdaEventSourceMapping) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsLambdaEventSourceMapping) GetEventSourceArn() *plugin.TValue[string] {
@@ -141728,6 +141917,7 @@ type mqlAwsVpcNatgateway struct {
 	mqlAwsVpcNatgatewayInternal
 	CreatedAt    plugin.TValue[*time.Time]
 	NatGatewayId plugin.TValue[string]
+	Arn          plugin.TValue[string]
 	State        plugin.TValue[string]
 	Tags         plugin.TValue[map[string]any]
 	Vpc          plugin.TValue[*mqlAwsVpc]
@@ -141778,6 +141968,12 @@ func (c *mqlAwsVpcNatgateway) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsVpcNatgateway) GetNatGatewayId() *plugin.TValue[string] {
 	return &c.NatGatewayId
+}
+
+func (c *mqlAwsVpcNatgateway) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsVpcNatgateway) GetState() *plugin.TValue[string] {
@@ -143067,6 +143263,7 @@ type mqlAwsEc2TransitgatewayAttachment struct {
 	__id       string
 	// optional: if you define mqlAwsEc2TransitgatewayAttachmentInternal it will be used here
 	Id               plugin.TValue[string]
+	Arn              plugin.TValue[string]
 	TransitGatewayId plugin.TValue[string]
 	ResourceId       plugin.TValue[string]
 	ResourceType     plugin.TValue[string]
@@ -143117,6 +143314,12 @@ func (c *mqlAwsEc2TransitgatewayAttachment) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
+func (c *mqlAwsEc2TransitgatewayAttachment) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
+}
+
 func (c *mqlAwsEc2TransitgatewayAttachment) GetTransitGatewayId() *plugin.TValue[string] {
 	return &c.TransitGatewayId
 }
@@ -143151,6 +143354,7 @@ type mqlAwsEc2TransitgatewayRouteTable struct {
 	__id       string
 	// optional: if you define mqlAwsEc2TransitgatewayRouteTableInternal it will be used here
 	Id                           plugin.TValue[string]
+	Arn                          plugin.TValue[string]
 	TransitGatewayId             plugin.TValue[string]
 	State                        plugin.TValue[string]
 	DefaultAssociationRouteTable plugin.TValue[bool]
@@ -143201,6 +143405,12 @@ func (c *mqlAwsEc2TransitgatewayRouteTable) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
+func (c *mqlAwsEc2TransitgatewayRouteTable) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
+}
+
 func (c *mqlAwsEc2TransitgatewayRouteTable) GetTransitGatewayId() *plugin.TValue[string] {
 	return &c.TransitGatewayId
 }
@@ -143235,6 +143445,7 @@ type mqlAwsEc2DhcpOptions struct {
 	__id       string
 	// optional: if you define mqlAwsEc2DhcpOptionsInternal it will be used here
 	Id             plugin.TValue[string]
+	Arn            plugin.TValue[string]
 	Region         plugin.TValue[string]
 	Tags           plugin.TValue[map[string]any]
 	Configurations plugin.TValue[[]any]
@@ -143279,6 +143490,12 @@ func (c *mqlAwsEc2DhcpOptions) MqlID() string {
 
 func (c *mqlAwsEc2DhcpOptions) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsEc2DhcpOptions) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsEc2DhcpOptions) GetRegion() *plugin.TValue[string] {
@@ -147117,6 +147334,7 @@ type mqlAwsEc2Networkinterface struct {
 	__id       string
 	mqlAwsEc2NetworkinterfaceInternal
 	Id                  plugin.TValue[string]
+	Arn                 plugin.TValue[string]
 	Description         plugin.TValue[string]
 	Subnet              plugin.TValue[*mqlAwsVpcSubnet]
 	Vpc                 plugin.TValue[*mqlAwsVpc]
@@ -147180,6 +147398,12 @@ func (c *mqlAwsEc2Networkinterface) MqlID() string {
 
 func (c *mqlAwsEc2Networkinterface) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsEc2Networkinterface) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsEc2Networkinterface) GetDescription() *plugin.TValue[string] {
@@ -152789,6 +153013,7 @@ type mqlAwsCognitoIdentityPool struct {
 	__id       string
 	mqlAwsCognitoIdentityPoolInternal
 	Id                             plugin.TValue[string]
+	Arn                            plugin.TValue[string]
 	Name                           plugin.TValue[string]
 	Region                         plugin.TValue[string]
 	AllowUnauthenticatedIdentities plugin.TValue[bool]
@@ -152836,6 +153061,12 @@ func (c *mqlAwsCognitoIdentityPool) MqlID() string {
 
 func (c *mqlAwsCognitoIdentityPool) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsCognitoIdentityPool) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsCognitoIdentityPool) GetName() *plugin.TValue[string] {
@@ -159054,6 +159285,7 @@ type mqlAwsAthenaDataCatalog struct {
 	__id       string
 	mqlAwsAthenaDataCatalogInternal
 	Name           plugin.TValue[string]
+	Arn            plugin.TValue[string]
 	Type           plugin.TValue[string]
 	Description    plugin.TValue[string]
 	Parameters     plugin.TValue[map[string]any]
@@ -159097,6 +159329,12 @@ func (c *mqlAwsAthenaDataCatalog) MqlID() string {
 
 func (c *mqlAwsAthenaDataCatalog) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAwsAthenaDataCatalog) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsAthenaDataCatalog) GetType() *plugin.TValue[string] {
@@ -159944,6 +160182,7 @@ type mqlAwsWorkspacesDirectory struct {
 	__id       string
 	// optional: if you define mqlAwsWorkspacesDirectoryInternal it will be used here
 	DirectoryId                    plugin.TValue[string]
+	Arn                            plugin.TValue[string]
 	DirectoryName                  plugin.TValue[string]
 	DirectoryType                  plugin.TValue[string]
 	Alias                          plugin.TValue[string]
@@ -160001,6 +160240,12 @@ func (c *mqlAwsWorkspacesDirectory) MqlID() string {
 
 func (c *mqlAwsWorkspacesDirectory) GetDirectoryId() *plugin.TValue[string] {
 	return &c.DirectoryId
+}
+
+func (c *mqlAwsWorkspacesDirectory) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsWorkspacesDirectory) GetDirectoryName() *plugin.TValue[string] {
@@ -160772,6 +161017,7 @@ type mqlAwsWorkspacesWorkspace struct {
 	__id       string
 	mqlAwsWorkspacesWorkspaceInternal
 	WorkspaceId                      plugin.TValue[string]
+	Arn                              plugin.TValue[string]
 	DirectoryId                      plugin.TValue[string]
 	UserName                         plugin.TValue[string]
 	IpAddress                        plugin.TValue[string]
@@ -160832,6 +161078,12 @@ func (c *mqlAwsWorkspacesWorkspace) MqlID() string {
 
 func (c *mqlAwsWorkspacesWorkspace) GetWorkspaceId() *plugin.TValue[string] {
 	return &c.WorkspaceId
+}
+
+func (c *mqlAwsWorkspacesWorkspace) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsWorkspacesWorkspace) GetDirectoryId() *plugin.TValue[string] {
@@ -161141,6 +161393,7 @@ type mqlAwsWorkspacesIpGroup struct {
 	__id       string
 	// optional: if you define mqlAwsWorkspacesIpGroupInternal it will be used here
 	GroupId   plugin.TValue[string]
+	Arn       plugin.TValue[string]
 	GroupName plugin.TValue[string]
 	GroupDesc plugin.TValue[string]
 	UserRules plugin.TValue[[]any]
@@ -161186,6 +161439,12 @@ func (c *mqlAwsWorkspacesIpGroup) MqlID() string {
 
 func (c *mqlAwsWorkspacesIpGroup) GetGroupId() *plugin.TValue[string] {
 	return &c.GroupId
+}
+
+func (c *mqlAwsWorkspacesIpGroup) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsWorkspacesIpGroup) GetGroupName() *plugin.TValue[string] {
@@ -165211,6 +165470,7 @@ type mqlAwsGlueDatabase struct {
 	__id       string
 	// optional: if you define mqlAwsGlueDatabaseInternal it will be used here
 	Name                          plugin.TValue[string]
+	Arn                           plugin.TValue[string]
 	CatalogId                     plugin.TValue[string]
 	Description                   plugin.TValue[string]
 	LocationUri                   plugin.TValue[string]
@@ -165257,6 +165517,12 @@ func (c *mqlAwsGlueDatabase) MqlID() string {
 
 func (c *mqlAwsGlueDatabase) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAwsGlueDatabase) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsGlueDatabase) GetCatalogId() *plugin.TValue[string] {
@@ -166304,6 +166570,7 @@ type mqlAwsGlueWorkflow struct {
 	__id       string
 	// optional: if you define mqlAwsGlueWorkflowInternal it will be used here
 	Name                 plugin.TValue[string]
+	Arn                  plugin.TValue[string]
 	Region               plugin.TValue[string]
 	Description          plugin.TValue[string]
 	DefaultRunProperties plugin.TValue[map[string]any]
@@ -166349,6 +166616,12 @@ func (c *mqlAwsGlueWorkflow) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
+func (c *mqlAwsGlueWorkflow) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
+}
+
 func (c *mqlAwsGlueWorkflow) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -166385,6 +166658,7 @@ type mqlAwsGlueConnection struct {
 	__id       string
 	// optional: if you define mqlAwsGlueConnectionInternal it will be used here
 	Name                           plugin.TValue[string]
+	Arn                            plugin.TValue[string]
 	Region                         plugin.TValue[string]
 	Description                    plugin.TValue[string]
 	ConnectionType                 plugin.TValue[string]
@@ -166429,6 +166703,12 @@ func (c *mqlAwsGlueConnection) MqlID() string {
 
 func (c *mqlAwsGlueConnection) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAwsGlueConnection) GetArn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Arn, func() (string, error) {
+		return c.arn()
+	})
 }
 
 func (c *mqlAwsGlueConnection) GetRegion() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -688,6 +688,7 @@ aws.appsync.graphqlApi.webAcl 13.25.1
 aws.appsync.graphqlApi.xrayEnabled 13.25.1
 aws.athena 11.16.1
 aws.athena.dataCatalog 11.16.1
+aws.athena.dataCatalog.arn 13.44.1
 aws.athena.dataCatalog.connectionType 11.16.1
 aws.athena.dataCatalog.description 11.16.1
 aws.athena.dataCatalog.error 11.16.1
@@ -1645,6 +1646,7 @@ aws.cloudhsm.backup.state 13.28.1
 aws.cloudhsm.backup.tags 13.28.1
 aws.cloudhsm.backups 13.28.1
 aws.cloudhsm.cluster 13.28.1
+aws.cloudhsm.cluster.arn 13.44.1
 aws.cloudhsm.cluster.backupPolicy 13.28.1
 aws.cloudhsm.cluster.backupRetentionDays 13.28.1
 aws.cloudhsm.cluster.certificates 13.28.1
@@ -2114,6 +2116,7 @@ aws.cognito 11.16.1
 aws.cognito.identityPool 11.16.1
 aws.cognito.identityPool.allowClassicFlow 11.16.1
 aws.cognito.identityPool.allowUnauthenticatedIdentities 11.16.1
+aws.cognito.identityPool.arn 13.44.1
 aws.cognito.identityPool.cognitoIdentityProviders 13.26.3
 aws.cognito.identityPool.developerProviderName 11.16.1
 aws.cognito.identityPool.id 11.16.1
@@ -2987,6 +2990,7 @@ aws.ec2.customerGateway.tags 13.6.3
 aws.ec2.customerGateway.type 13.6.3
 aws.ec2.customerGateways 13.6.3
 aws.ec2.dhcpOptions 13.6.3
+aws.ec2.dhcpOptions.arn 13.44.1
 aws.ec2.dhcpOptions.configurations 13.6.3
 aws.ec2.dhcpOptions.id 13.6.3
 aws.ec2.dhcpOptions.region 13.6.3
@@ -3364,6 +3368,7 @@ aws.ec2.networkacl.isDefault 11.15.2
 aws.ec2.networkacl.region 11.15.2
 aws.ec2.networkacl.tags 11.15.2
 aws.ec2.networkinterface 11.15.2
+aws.ec2.networkinterface.arn 13.44.1
 aws.ec2.networkinterface.attachmentStatus 13.15.2
 aws.ec2.networkinterface.attachmentTime 13.15.2
 aws.ec2.networkinterface.availabilityZone 11.15.2
@@ -3469,6 +3474,7 @@ aws.ec2.transitgateway.amazonSideAsn 11.15.2
 aws.ec2.transitgateway.arn 11.15.2
 aws.ec2.transitgateway.associationDefaultRouteTableId 11.15.2
 aws.ec2.transitgateway.attachment 13.6.3
+aws.ec2.transitgateway.attachment.arn 13.44.1
 aws.ec2.transitgateway.attachment.createdAt 13.38.2
 aws.ec2.transitgateway.attachment.id 13.6.3
 aws.ec2.transitgateway.attachment.region 13.6.3
@@ -3501,6 +3507,7 @@ aws.ec2.transitgateway.peeringAttachments 13.6.3
 aws.ec2.transitgateway.propagationDefaultRouteTableId 11.15.2
 aws.ec2.transitgateway.region 11.15.2
 aws.ec2.transitgateway.routeTable 13.6.3
+aws.ec2.transitgateway.routeTable.arn 13.44.1
 aws.ec2.transitgateway.routeTable.createdAt 13.38.2
 aws.ec2.transitgateway.routeTable.defaultAssociationRouteTable 13.6.3
 aws.ec2.transitgateway.routeTable.defaultPropagationRouteTable 13.6.3
@@ -5178,6 +5185,7 @@ aws.fsx.volumes 11.15.2
 aws.glue 11.16.1
 aws.glue.catalogEncryptionSettings 11.16.1
 aws.glue.connection 13.23.2
+aws.glue.connection.arn 13.44.1
 aws.glue.connection.connectionProperties 13.23.2
 aws.glue.connection.connectionType 13.23.2
 aws.glue.connection.createdAt 13.23.2
@@ -5216,6 +5224,7 @@ aws.glue.crawler.updatedAt 11.16.1
 aws.glue.crawler.version 13.26.3
 aws.glue.crawlers 11.16.1
 aws.glue.database 11.16.1
+aws.glue.database.arn 13.44.1
 aws.glue.database.catalogId 11.16.1
 aws.glue.database.createTableDefaultPermissions 13.26.3
 aws.glue.database.createdAt 11.16.1
@@ -5330,6 +5339,7 @@ aws.glue.trigger.type 13.26.3
 aws.glue.trigger.workflowName 13.26.3
 aws.glue.triggers 13.26.3
 aws.glue.workflow 11.16.1
+aws.glue.workflow.arn 13.44.1
 aws.glue.workflow.createdAt 11.16.1
 aws.glue.workflow.defaultRunProperties 11.16.1
 aws.glue.workflow.description 11.16.1
@@ -5341,6 +5351,7 @@ aws.glue.workflow.updatedAt 11.16.1
 aws.glue.workflows 11.16.1
 aws.guardduty 11.15.2
 aws.guardduty.detector 11.15.2
+aws.guardduty.detector.arn 13.44.1
 aws.guardduty.detector.coverageStatistic 13.12.1
 aws.guardduty.detector.coverageStatistic.count 13.12.1
 aws.guardduty.detector.coverageStatistic.resourceType 13.12.1
@@ -6079,6 +6090,7 @@ aws.lambda.codeSigningConfig.id 11.15.2
 aws.lambda.codeSigningConfig.lastModified 11.15.2
 aws.lambda.codeSigningConfig.untrustedArtifactOnDeployment 11.15.2
 aws.lambda.eventSourceMapping 11.15.2
+aws.lambda.eventSourceMapping.arn 13.44.1
 aws.lambda.eventSourceMapping.batchSize 11.15.2
 aws.lambda.eventSourceMapping.bisectBatchOnFunctionError 11.15.2
 aws.lambda.eventSourceMapping.eventSourceArn 11.15.2
@@ -7689,6 +7701,7 @@ aws.redshift.cluster.vpc 11.16.1
 aws.redshift.cluster.vpcId 11.15.2
 aws.redshift.clusters 11.15.2
 aws.redshift.eventSubscription 13.12.1
+aws.redshift.eventSubscription.arn 13.44.1
 aws.redshift.eventSubscription.createdAt 13.12.1
 aws.redshift.eventSubscription.enabled 13.12.1
 aws.redshift.eventSubscription.eventCategories 13.12.1
@@ -7750,6 +7763,7 @@ aws.redshift.snapshotSchedule.scheduleDefinitions 13.12.1
 aws.redshift.snapshotSchedule.tags 13.12.1
 aws.redshift.snapshotSchedules 13.12.1
 aws.redshift.subnetGroup 13.12.1
+aws.redshift.subnetGroup.arn 13.44.1
 aws.redshift.subnetGroup.description 13.12.1
 aws.redshift.subnetGroup.name 13.12.1
 aws.redshift.subnetGroup.region 13.12.1
@@ -9982,6 +9996,7 @@ aws.vpc.encryptionControl.state 13.42.1
 aws.vpc.encryptionControl.stateMessage 13.42.1
 aws.vpc.encryptionControl.tags 13.42.1
 aws.vpc.endpoint 11.15.2
+aws.vpc.endpoint.arn 13.44.1
 aws.vpc.endpoint.createdAt 11.15.2
 aws.vpc.endpoint.dnsEntries 13.6.3
 aws.vpc.endpoint.id 11.15.2
@@ -10004,6 +10019,7 @@ aws.vpc.endpoint.vpc 11.15.2
 aws.vpc.endpoints 11.15.2
 aws.vpc.flowLogs 11.15.2
 aws.vpc.flowlog 11.15.2
+aws.vpc.flowlog.arn 13.44.1
 aws.vpc.flowlog.createdAt 11.15.2
 aws.vpc.flowlog.deliverLogsStatus 11.15.2
 aws.vpc.flowlog.destination 11.15.2
@@ -10037,6 +10053,7 @@ aws.vpc.natgateway.address.networkInterfaceId 11.15.2
 aws.vpc.natgateway.address.privateIp 11.15.2
 aws.vpc.natgateway.address.publicIp 11.15.2
 aws.vpc.natgateway.addresses 11.15.2
+aws.vpc.natgateway.arn 13.44.1
 aws.vpc.natgateway.createdAt 11.15.2
 aws.vpc.natgateway.natGatewayId 11.15.2
 aws.vpc.natgateway.state 11.15.2
@@ -10438,6 +10455,7 @@ aws.workspaces.bundles 11.16.1
 aws.workspaces.directories 11.16.1
 aws.workspaces.directory 11.16.1
 aws.workspaces.directory.alias 11.16.1
+aws.workspaces.directory.arn 13.44.1
 aws.workspaces.directory.certificateBasedAuthProperties 11.16.1
 aws.workspaces.directory.defaultCreationProperties 11.16.1
 aws.workspaces.directory.directoryId 11.16.1
@@ -10466,6 +10484,7 @@ aws.workspaces.image.state 11.16.1
 aws.workspaces.images 11.16.1
 aws.workspaces.instances 11.16.1
 aws.workspaces.ipGroup 11.16.1
+aws.workspaces.ipGroup.arn 13.44.1
 aws.workspaces.ipGroup.groupDesc 11.16.1
 aws.workspaces.ipGroup.groupId 11.16.1
 aws.workspaces.ipGroup.groupName 11.16.1
@@ -10473,6 +10492,7 @@ aws.workspaces.ipGroup.region 11.16.1
 aws.workspaces.ipGroup.userRules 11.16.1
 aws.workspaces.ipGroups 11.16.1
 aws.workspaces.workspace 11.16.1
+aws.workspaces.workspace.arn 13.44.1
 aws.workspaces.workspace.bundleId 11.16.1
 aws.workspaces.workspace.computerName 11.16.1
 aws.workspaces.workspace.connectionState 11.16.1

--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -383,6 +383,13 @@ type mqlAwsAthenaDataCatalogInternal struct {
 	lock          sync.Mutex
 }
 
+const athenaDataCatalogArnPattern = "arn:aws:athena:%s:%s:datacatalog/%s"
+
+func (a *mqlAwsAthenaDataCatalog) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(athenaDataCatalogArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
+}
+
 func (a *mqlAwsAthenaDataCatalog) fetchDetail() error {
 	if a.fetchedDetail {
 		return nil

--- a/providers/aws/resources/aws_cloudhsm.go
+++ b/providers/aws/resources/aws_cloudhsm.go
@@ -178,6 +178,13 @@ type mqlAwsCloudhsmClusterInternal struct {
 	cacheHsms            []cloudhsmv2_types.Hsm
 }
 
+const cloudhsmClusterArnPattern = "arn:aws:cloudhsm:%s:%s:cluster/%s"
+
+func (a *mqlAwsCloudhsmCluster) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(cloudhsmClusterArnPattern, a.Region.Data, conn.AccountId(), a.ClusterId.Data), nil
+}
+
 func (a *mqlAwsCloudhsmCluster) vpc() (*mqlAwsVpc, error) {
 	if a.cacheVpcId == nil || *a.cacheVpcId == "" {
 		a.Vpc.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -469,6 +470,13 @@ type mqlAwsCognitoIdentityPoolInternal struct {
 	descCache *cognitoidentity.DescribeIdentityPoolOutput
 	descDone  bool
 	descLock  sync.Mutex
+}
+
+const cognitoIdentityPoolArnPattern = "arn:aws:cognito-identity:%s:%s:identitypool/%s"
+
+func (a *mqlAwsCognitoIdentityPool) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(cognitoIdentityPoolArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
 }
 
 func (a *mqlAwsCognitoIdentityPool) describe() (*cognitoidentity.DescribeIdentityPoolOutput, error) {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1696,6 +1696,15 @@ func buildNetworkInterfaceResource(runtime *plugin.Runtime, region string, eni e
 	return nil, mqlEni, nil
 }
 
+func (i *mqlAwsEc2Networkinterface) arn() (string, error) {
+	account := i.OwnerId.Data
+	if account == "" {
+		conn := i.MqlRuntime.Connection.(*connection.AwsConnection)
+		account = conn.AccountId()
+	}
+	return fmt.Sprintf(networkInterfaceArnPattern, i.Region.Data, account, i.Id.Data), nil
+}
+
 func (i *mqlAwsEc2Networkinterface) elasticIp() (*mqlAwsEc2Eip, error) {
 	if i.cacheElasticIp == nil || *i.cacheElasticIp == "" {
 		i.ElasticIp.State = plugin.StateIsNull | plugin.StateIsSet
@@ -3347,8 +3356,18 @@ func (a *mqlAwsEc2TransitgatewayAttachment) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+func (a *mqlAwsEc2TransitgatewayAttachment) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(tgwAttachmentArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
+}
+
 func (a *mqlAwsEc2TransitgatewayRouteTable) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAwsEc2TransitgatewayRouteTable) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(tgwRouteTableArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
 }
 
 func (a *mqlAwsEc2Transitgateway) attachments() ([]any, error) {

--- a/providers/aws/resources/aws_glue.go
+++ b/providers/aws/resources/aws_glue.go
@@ -611,6 +611,26 @@ func newMqlAwsGlueDatabase(runtime *plugin.Runtime, region string, db glue_types
 	return resource.(*mqlAwsGlueDatabase), nil
 }
 
+const (
+	glueDatabaseArnPattern   = "arn:aws:glue:%s:%s:database/%s"
+	glueConnectionArnPattern = "arn:aws:glue:%s:%s:connection/%s"
+	glueWorkflowArnPattern   = "arn:aws:glue:%s:%s:workflow/%s"
+)
+
+func (a *mqlAwsGlueDatabase) arn() (string, error) {
+	account := a.CatalogId.Data
+	if account == "" {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		account = conn.AccountId()
+	}
+	return fmt.Sprintf(glueDatabaseArnPattern, a.Region.Data, account, a.Name.Data), nil
+}
+
+func (a *mqlAwsGlueConnection) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(glueConnectionArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
+}
+
 func (a *mqlAwsGlueDatabase) tables() ([]any, error) {
 	dbName := a.Name.Data
 	region := a.Region.Data
@@ -850,6 +870,11 @@ func newMqlAwsGlueWorkflow(runtime *plugin.Runtime, region string, accountID str
 		return nil, err
 	}
 	return resource.(*mqlAwsGlueWorkflow), nil
+}
+
+func (a *mqlAwsGlueWorkflow) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(glueWorkflowArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
 }
 
 func (a *mqlAwsGlueWorkflow) tags() (map[string]any, error) {

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -55,6 +55,13 @@ func (a *mqlAwsGuarddutyDetector) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+const guarddutyDetectorArnPattern = "arn:aws:guardduty:%s:%s:detector/%s"
+
+func (a *mqlAwsGuarddutyDetector) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(guarddutyDetectorArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
+}
+
 func (a *mqlAwsGuardduty) getDetectors(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -1070,6 +1070,13 @@ func (a *mqlAwsLambdaEventSourceMapping) id() (string, error) {
 	return a.Uuid.Data, nil
 }
 
+const lambdaEventSourceMappingArnPattern = "arn:aws:lambda:%s:%s:event-source-mapping:%s"
+
+func (a *mqlAwsLambdaEventSourceMapping) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(lambdaEventSourceMappingArnPattern, a.Region.Data, conn.AccountId(), a.Uuid.Data), nil
+}
+
 func (a *mqlAwsLambdaEventSourceMapping) function() (*mqlAwsLambdaFunction, error) {
 	arnVal := a.FunctionArn.Data
 	if arnVal == "" {

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -653,6 +653,16 @@ func (a *mqlAwsRedshiftSubnetGroup) id() (string, error) {
 	return a.__id, nil
 }
 
+const (
+	redshiftSubnetGroupArnPattern       = "arn:aws:redshift:%s:%s:subnetgroup:%s"
+	redshiftEventSubscriptionArnPattern = "arn:aws:redshift:%s:%s:eventsubscription:%s"
+)
+
+func (a *mqlAwsRedshiftSubnetGroup) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(redshiftSubnetGroupArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
+}
+
 func (a *mqlAwsRedshiftSubnetGroup) vpc() (*mqlAwsVpc, error) {
 	if a.cacheVpcId == nil || *a.cacheVpcId == "" {
 		a.Vpc.State = plugin.StateIsNull | plugin.StateIsSet
@@ -746,6 +756,11 @@ func (a *mqlAwsRedshift) getEventSubscriptions(conn *connection.AwsConnection) [
 
 func (a *mqlAwsRedshiftEventSubscription) id() (string, error) {
 	return a.__id, nil
+}
+
+func (a *mqlAwsRedshiftEventSubscription) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(redshiftEventSubscriptionArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
 }
 
 func (a *mqlAwsRedshiftEventSubscription) snsTopic() (*mqlAwsSnsTopic, error) {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -226,6 +226,11 @@ func (a *mqlAwsVpcNatgateway) id() (string, error) {
 	return a.NatGatewayId.Data, nil
 }
 
+func (a *mqlAwsVpcNatgateway) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(natGatewayArnPattern, a.region, conn.AccountId(), a.NatGatewayId.Data), nil
+}
+
 type mqlAwsVpcNatgatewayInternal struct {
 	natGatewayCache vpctypes.NatGateway
 	region          string
@@ -404,10 +409,20 @@ func (a *mqlAwsVpcEndpoint) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+func (a *mqlAwsVpcEndpoint) arn() (string, error) {
+	account := a.OwnerId.Data
+	if account == "" {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		account = conn.AccountId()
+	}
+	return fmt.Sprintf(vpcEndpointArnPattern, a.Region.Data, account, a.cacheEndpointId), nil
+}
+
 type mqlAwsVpcEndpointInternal struct {
 	securityGroupIdHandler
 	cacheRouteTableIds       []string
 	cacheNetworkInterfaceIds []string
+	cacheEndpointId          string
 	region                   string
 	accountID                string
 }
@@ -475,6 +490,7 @@ func (a *mqlAwsVpc) endpoints() ([]any, error) {
 			ep := mqlEndpoint.(*mqlAwsVpcEndpoint)
 			ep.region = a.Region.Data
 			ep.accountID = conn.AccountId()
+			ep.cacheEndpointId = convert.ToValue(endpoint.VpcEndpointId)
 
 			// Cache security group ARNs
 			sgArns := make([]string, len(endpoint.Groups))
@@ -1983,6 +1999,11 @@ func (a *mqlAwsEc2DhcpOptions) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+func (a *mqlAwsEc2DhcpOptions) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(dhcpOptionsArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
+}
+
 func (a *mqlAwsVpc) dhcpOptions() (*mqlAwsEc2DhcpOptions, error) {
 	dhcpOptionsId := a.DhcpOptionsId.Data
 	if dhcpOptionsId == "" {
@@ -2066,6 +2087,11 @@ type mqlAwsVpcFlowlogInternal struct {
 	cacheLogDestination           *string
 	cacheLogDestinationType       string
 	region                        string
+}
+
+func (a *mqlAwsVpcFlowlog) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(vpcFlowLogArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
 }
 
 func (a *mqlAwsVpcFlowlog) iamRole() (*mqlAwsIamRole, error) {

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -124,6 +124,30 @@ func TestArnPatterns(t *testing.T) {
 		{"route table", routeTableArnPattern, "us-east-1", "123456789012", "rtb-bbb", "arn:aws:ec2:us-east-1:123456789012:route-table/rtb-bbb"},
 		{"network ACL", networkAclArnPattern, "us-east-1", "123456789012", "acl-ccc", "arn:aws:ec2:us-east-1:123456789012:network-acl/acl-ccc"},
 		{"transit gateway", transitGatewayArnPattern, "us-east-1", "123456789012", "tgw-ddd", "arn:aws:ec2:us-east-1:123456789012:transit-gateway/tgw-ddd"},
+		// Synthesized ARNs for resources with no ARN in their describe response.
+		// Expected strings follow the AWS Service Authorization Reference; the
+		// segment/delimiter differences below are deliberate and load-bearing.
+		{"VPC endpoint", vpcEndpointArnPattern, "us-east-1", "123456789012", "vpce-0abc123", "arn:aws:ec2:us-east-1:123456789012:vpc-endpoint/vpce-0abc123"},
+		{"VPC flow log", vpcFlowLogArnPattern, "us-east-1", "123456789012", "fl-0abc123", "arn:aws:ec2:us-east-1:123456789012:vpc-flow-log/fl-0abc123"},
+		{"NAT gateway", natGatewayArnPattern, "us-east-1", "123456789012", "nat-0abc123", "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-0abc123"},
+		{"network interface", networkInterfaceArnPattern, "us-east-1", "123456789012", "eni-0abc123", "arn:aws:ec2:us-east-1:123456789012:network-interface/eni-0abc123"},
+		{"DHCP options", dhcpOptionsArnPattern, "us-east-1", "123456789012", "dopt-0abc123", "arn:aws:ec2:us-east-1:123456789012:dhcp-options/dopt-0abc123"},
+		{"TGW attachment", tgwAttachmentArnPattern, "us-east-1", "123456789012", "tgw-attach-0abc123", "arn:aws:ec2:us-east-1:123456789012:transit-gateway-attachment/tgw-attach-0abc123"},
+		{"TGW route table", tgwRouteTableArnPattern, "us-east-1", "123456789012", "tgw-rtb-0abc123", "arn:aws:ec2:us-east-1:123456789012:transit-gateway-route-table/tgw-rtb-0abc123"},
+		{"CloudHSM cluster", cloudhsmClusterArnPattern, "us-east-1", "123456789012", "cluster-abc", "arn:aws:cloudhsm:us-east-1:123456789012:cluster/cluster-abc"},
+		{"GuardDuty detector", guarddutyDetectorArnPattern, "us-east-1", "123456789012", "det-abc", "arn:aws:guardduty:us-east-1:123456789012:detector/det-abc"},
+		{"Cognito identity pool", cognitoIdentityPoolArnPattern, "us-east-1", "123456789012", "us-east-1:guid", "arn:aws:cognito-identity:us-east-1:123456789012:identitypool/us-east-1:guid"},
+		{"Glue database", glueDatabaseArnPattern, "us-east-1", "123456789012", "mydb", "arn:aws:glue:us-east-1:123456789012:database/mydb"},
+		{"Glue connection", glueConnectionArnPattern, "us-east-1", "123456789012", "myconn", "arn:aws:glue:us-east-1:123456789012:connection/myconn"},
+		{"Glue workflow", glueWorkflowArnPattern, "us-east-1", "123456789012", "mywf", "arn:aws:glue:us-east-1:123456789012:workflow/mywf"},
+		{"Athena data catalog", athenaDataCatalogArnPattern, "us-east-1", "123456789012", "mycatalog", "arn:aws:athena:us-east-1:123456789012:datacatalog/mycatalog"},
+		{"WorkSpaces workspace", workspacesWorkspaceArnPattern, "us-east-1", "123456789012", "ws-abc", "arn:aws:workspaces:us-east-1:123456789012:workspace/ws-abc"},
+		{"WorkSpaces directory", workspacesDirectoryArnPattern, "us-east-1", "123456789012", "d-abc", "arn:aws:workspaces:us-east-1:123456789012:directory/d-abc"},
+		{"WorkSpaces IP group", workspacesIpGroupArnPattern, "us-east-1", "123456789012", "wsipg-abc", "arn:aws:workspaces:us-east-1:123456789012:workspaceipgroup/wsipg-abc"},
+		// colon delimiter before the identifier, not a slash
+		{"Redshift subnet group", redshiftSubnetGroupArnPattern, "us-east-1", "123456789012", "mygroup", "arn:aws:redshift:us-east-1:123456789012:subnetgroup:mygroup"},
+		{"Redshift event subscription", redshiftEventSubscriptionArnPattern, "us-east-1", "123456789012", "mysub", "arn:aws:redshift:us-east-1:123456789012:eventsubscription:mysub"},
+		{"Lambda event source mapping", lambdaEventSourceMappingArnPattern, "us-east-1", "123456789012", "uuid-abc", "arn:aws:lambda:us-east-1:123456789012:event-source-mapping:uuid-abc"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -138,6 +138,17 @@ func (a *mqlAwsWorkspacesDirectory) id() (string, error) {
 	return "aws.workspaces.directory/" + a.Region.Data + "/" + a.DirectoryId.Data, nil
 }
 
+const (
+	workspacesWorkspaceArnPattern = "arn:aws:workspaces:%s:%s:workspace/%s"
+	workspacesDirectoryArnPattern = "arn:aws:workspaces:%s:%s:directory/%s"
+	workspacesIpGroupArnPattern   = "arn:aws:workspaces:%s:%s:workspaceipgroup/%s"
+)
+
+func (a *mqlAwsWorkspacesDirectory) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(workspacesDirectoryArnPattern, a.Region.Data, conn.AccountId(), a.DirectoryId.Data), nil
+}
+
 func (a *mqlAwsWorkspacesDirectory) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Workspaces(a.Region.Data)
@@ -257,6 +268,11 @@ type mqlAwsWorkspacesWorkspaceInternal struct {
 
 func (a *mqlAwsWorkspacesWorkspace) id() (string, error) {
 	return "aws.workspaces.workspace/" + a.Region.Data + "/" + a.WorkspaceId.Data, nil
+}
+
+func (a *mqlAwsWorkspacesWorkspace) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(workspacesWorkspaceArnPattern, a.Region.Data, conn.AccountId(), a.WorkspaceId.Data), nil
 }
 
 func (a *mqlAwsWorkspacesWorkspace) tags() (map[string]any, error) {
@@ -676,6 +692,11 @@ func newMqlAwsWorkspacesIpGroup(runtime *plugin.Runtime, region string, group wo
 
 func (a *mqlAwsWorkspacesIpGroup) id() (string, error) {
 	return "aws.workspaces.ipGroup/" + a.Region.Data + "/" + a.GroupId.Data, nil
+}
+
+func (a *mqlAwsWorkspacesIpGroup) arn() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return fmt.Sprintf(workspacesIpGroupArnPattern, a.Region.Data, conn.AccountId(), a.GroupId.Data), nil
 }
 
 func (a *mqlAwsWorkspacesDirectory) subnets() ([]any, error) {


### PR DESCRIPTION
Follow-up to #9026. During that work you asked me to sweep for other AWS resources missing an `arn`. This adds `arn` to the ones that are genuinely legit.

## Method

A resource qualifies only if **AWS actually defines an ARN for that exact entity** and the ARN's account/region can be attributed to the connection's own account. I verified every candidate against the **AWS Service Authorization Reference** (the `list_*` pages that enumerate each service's ARN resource types) rather than assuming `region + account + id` yields a valid ARN.

## Added (20)

`vpc.endpoint`, `vpc.flowlog`, `vpc.natgateway`, `ec2.networkinterface`, `ec2.dhcpOptions`, `ec2.transitgateway.attachment`, `ec2.transitgateway.routeTable`, `cloudhsm.cluster`, `guardduty.detector`, `cognito.identityPool`, `glue.database`, `glue.connection`, `glue.workflow`, `athena.dataCatalog`, `redshift.subnetGroup`, `redshift.eventSubscription`, `workspaces.workspace`, `workspaces.directory`, `workspaces.ipGroup`, `lambda.eventSourceMapping`.

Each `arn` is a computed accessor resolving the account from the connection at access time (the same lazy pattern the resources' existing typed accessors use).

## Format details that are load-bearing

The verification caught cases a single template would have gotten wrong:

- `network-interface` is hyphenated; `natgateway` is not.
- WorkSpaces ARN segments drop the "id" suffix present in the API resource-type key (`workspace`/`directory`, not `workspaceid`/`directoryid`).
- Redshift `subnetgroup`/`eventsubscription` and Lambda `event-source-mapping` use a **colon** before the identifier, not a slash.
- Where the resource carries the owning account itself (`ownerId` on network interface / VPC endpoint, `catalogId` on Glue database), that is used in preference to the connection account.

Every format is a named `*ArnPattern` constant (matching the existing convention in `aws.go` and elsewhere), and `TestArnPatterns` pins the canonical string for all 20 — so a wrong delimiter or segment fails in CI rather than shipping an ARN AWS won't recognize.

## Deliberately excluded

Real ARN exists, but the account/region can't be reliably attributed to the connection:

- `vpc.peeringConnection` — accepter/requester span accounts/regions.
- `ec2.transitgateway.peeringAttachment` — AWS defines no peering-specific ARN type, and peering is cross-account/region.
- `workspaces.bundle`, `workspaces.image` — public/AMAZON-owned artifacts aren't in your account.

## Verification

- New `arn` fields wired through codegen; whole provider builds.
- `TestArnPatterns` extended with all 20 (28 subtests pass).
- Live against a real account: `aws.vpcs...dhcpOptions.arn` returns the correct `arn:aws:ec2:{region}:{account}:dhcp-options/{id}`; `flowLogs`, `guardduty.detectors`, `cloudhsm.clusters`, `redshift.subnetGroups`, and `endpoints` all compile and run.
- `*.permissions.json` unchanged (all ARNs synthesized from already-fetched fields; no new API calls).
