### PR TITLE
✨ gcp: propagate project labels to discovered child assets

### DIFF
--- a/providers-sdk/v1/util/filteropts/filteropts.go
+++ b/providers-sdk/v1/util/filteropts/filteropts.go
@@ -5,7 +5,10 @@
 // key/value options that providers use to narrow discovery.
 package filteropts
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // ParseCsvSliceOpt returns the comma-separated values for the given key as a
 // slice. Empty keys or values are skipped, and a non-nil empty slice is
@@ -27,4 +30,21 @@ func ParseCsvSliceOpt(opts map[string]string, key string) []string {
 		}
 	}
 	return res
+}
+
+// ParseBoolOpt returns the boolean value for the given key. If the key is
+// missing or its value cannot be parsed as a boolean, defaultVal is returned.
+//
+// Example:
+//
+//	key        = "propagate-project-labels"
+//	opts       = {"propagate-project-labels": "true"}
+//	returns true
+func ParseBoolOpt(opts map[string]string, key string, defaultVal bool) bool {
+	if v, ok := opts[key]; ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			return parsed
+		}
+	}
+	return defaultVal
 }

--- a/providers-sdk/v1/util/filteropts/filteropts_test.go
+++ b/providers-sdk/v1/util/filteropts/filteropts_test.go
@@ -35,3 +35,31 @@ func TestParseCsvSliceOpt(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 }
+
+func TestParseBoolOpt(t *testing.T) {
+	t.Run("parses true values correctly", func(t *testing.T) {
+		trueValues := []string{"true", "TRUE", "t", "T", "1"}
+		for _, val := range trueValues {
+			result := ParseBoolOpt(map[string]string{"key": val}, "key", false)
+			require.True(t, result)
+		}
+	})
+
+	t.Run("parses false values correctly", func(t *testing.T) {
+		falseValues := []string{"false", "FALSE", "f", "F", "0"}
+		for _, val := range falseValues {
+			result := ParseBoolOpt(map[string]string{"key": val}, "key", true)
+			require.False(t, result)
+		}
+	})
+
+	t.Run("returns default for missing key", func(t *testing.T) {
+		require.True(t, ParseBoolOpt(map[string]string{}, "key", true))
+		require.False(t, ParseBoolOpt(map[string]string{}, "key", false))
+	})
+
+	t.Run("returns default for unparseable value", func(t *testing.T) {
+		require.True(t, ParseBoolOpt(map[string]string{"key": "notabool"}, "key", true))
+		require.False(t, ParseBoolOpt(map[string]string{"key": "notabool"}, "key", false))
+	})
+}

--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -6,7 +6,6 @@ package connection
 import (
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -48,15 +47,15 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 			Scope:                  parseStringOpt(opts, "ecr:scope"),
 		},
 		Ecs: EcsDiscoveryFilters{
-			OnlyRunningContainers: parseBoolOpt(opts, "ecs:only-running-containers", false),
-			DiscoverInstances:     parseBoolOpt(opts, "ecs:discover-instances", false),
-			DiscoverImages:        parseBoolOpt(opts, "ecs:discover-images", false),
+			OnlyRunningContainers: filteropts.ParseBoolOpt(opts, "ecs:only-running-containers", false),
+			DiscoverInstances:     filteropts.ParseBoolOpt(opts, "ecs:discover-instances", false),
+			DiscoverImages:        filteropts.ParseBoolOpt(opts, "ecs:discover-images", false),
 		},
 		S3: S3DiscoveryFilters{
 			BucketNames:        filteropts.ParseCsvSliceOpt(opts, "s3:bucket-names"),
 			ExcludeBucketNames: filteropts.ParseCsvSliceOpt(opts, "s3:exclude:bucket-names"),
 		},
-		PropagateAccountTags: parseBoolOpt(opts, "propagate-account-tags", false),
+		PropagateAccountTags: filteropts.ParseBoolOpt(opts, "propagate-account-tags", false),
 		AccountTags:          parseMapOpt(opts, "account-tag:"),
 	}
 
@@ -238,22 +237,6 @@ func (f EcsDiscoveryFilters) MatchesOnlyRunningContainers(containerState string)
 		return true
 	}
 	return containerState == "RUNNING"
-}
-
-// Given a key-value pair that matches a key, return the boolean value of the key.
-// If the key is not found or the value cannot be parsed as a boolean, return the default value.
-// Example: key = "ecs:only-running-containers", opts = {"ecs:only-running-containers": "true"}
-// Returns: true
-func parseBoolOpt(opts map[string]string, key string, defaultVal bool) bool {
-	for k, v := range opts {
-		if k == key {
-			parsed, err := strconv.ParseBool(v)
-			if err == nil {
-				return parsed
-			}
-		}
-	}
-	return defaultVal
 }
 
 // Given a map of options and a key prefix, return a map of key-value pairs

--- a/providers/aws/connection/filters_test.go
+++ b/providers/aws/connection/filters_test.go
@@ -447,32 +447,6 @@ func TestParseMapOpt(t *testing.T) {
 	})
 }
 
-func TestParseBoolOpt(t *testing.T) {
-	t.Run("parses true values correctly", func(t *testing.T) {
-		trueValues := []string{"true", "TRUE", "t", "T", "1"}
-		for _, val := range trueValues {
-			result := parseBoolOpt(map[string]string{"key": val}, "key", false)
-			require.True(t, result)
-		}
-	})
-
-	t.Run("parses false values correctly", func(t *testing.T) {
-		falseValues := []string{"false", "FALSE", "f", "F", "0"}
-		for _, val := range falseValues {
-			result := parseBoolOpt(map[string]string{"key": val}, "key", true)
-			require.False(t, result)
-		}
-	})
-
-	t.Run("returns default for missing key", func(t *testing.T) {
-		result := parseBoolOpt(map[string]string{}, "key", true)
-		require.True(t, result)
-
-		result = parseBoolOpt(map[string]string{}, "key", false)
-		require.False(t, result)
-	})
-}
-
 func TestBatchRepositoryNames(t *testing.T) {
 	makeNames := func(n int) []string {
 		names := make([]string, n)

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -111,7 +111,7 @@ Examples with the GCP project configured:
 					Long:    "filters",
 					Type:    plugin.FlagType_KeyValue,
 					Default: "",
-					Desc:    "Filter discovered resources, e.g., --filters storage:bucket-names=my-bucket --filters storage:exclude:bucket-names=noisy-bucket",
+					Desc:    "Filter discovered resources, e.g., --filters storage:bucket-names=my-bucket --filters storage:exclude:bucket-names=noisy-bucket --filters propagate-project-labels=true",
 				},
 			},
 		},

--- a/providers/gcp/connection/filters.go
+++ b/providers/gcp/connection/filters.go
@@ -12,6 +12,13 @@ import (
 // DiscoveryFilters holds the per-service filters used to narrow discovery.
 type DiscoveryFilters struct {
 	Storage StorageDiscoveryFilters
+	// PropagateProjectLabels, when enabled, merges each project's labels into
+	// every asset discovered under that project (an asset's own labels win on
+	// collision). GCP resource labels do not inherit from the parent project on
+	// their own, so this mirrors the AWS "propagate-account-tags" behavior.
+	// Note: Resource Manager tags already inherit from project/folder/org
+	// natively and are unaffected by this option.
+	PropagateProjectLabels bool
 }
 
 // DiscoveryFiltersFromOpts builds the discovery filters from the raw --filters
@@ -22,6 +29,7 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 			BucketNames:        filteropts.ParseCsvSliceOpt(opts, "storage:bucket-names"),
 			ExcludeBucketNames: filteropts.ParseCsvSliceOpt(opts, "storage:exclude:bucket-names"),
 		},
+		PropagateProjectLabels: filteropts.ParseBoolOpt(opts, "propagate-project-labels", false),
 	}
 }
 

--- a/providers/gcp/connection/filters_test.go
+++ b/providers/gcp/connection/filters_test.go
@@ -87,4 +87,13 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 		}
 		require.Equal(t, expected, DiscoveryFiltersFromOpts(nil))
 	})
+
+	t.Run("propagate-project-labels defaults to false", func(t *testing.T) {
+		require.False(t, DiscoveryFiltersFromOpts(map[string]string{}).PropagateProjectLabels)
+	})
+
+	t.Run("propagate-project-labels is parsed when enabled", func(t *testing.T) {
+		opts := map[string]string{"propagate-project-labels": "true"}
+		require.True(t, DiscoveryFiltersFromOpts(opts).PropagateProjectLabels)
+	})
 }

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -202,6 +202,8 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 		// storage filters
 		"storage:bucket-names",
 		"storage:exclude:bucket-names",
+		// project-level filters
+		"propagate-project-labels",
 	}
 	for k, v := range x.Map {
 		if slices.Contains(knownKeys, k) {

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1762,11 +1762,38 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 		}
 	}
 
+	if conn.Filters.PropagateProjectLabels {
+		projectLabels := mapStrInterfaceToMapStrStr(gcpProject.GetLabels().Data)
+		propagateProjectLabelsToAssets(assetList, projectLabels)
+	}
+
 	log.Debug().
 		Str("project", gcpProject.Id.Data).
 		Int("assets", len(assetList)).
 		Msg("gcp.discovery> project discovery complete")
 	return assetList, nil
+}
+
+// propagateProjectLabelsToAssets merges the project's labels into every asset
+// discovered under that project. An asset's own labels take precedence, so
+// project labels only fill in keys the asset doesn't already define.
+func propagateProjectLabelsToAssets(assets []*inventory.Asset, projectLabels map[string]string) {
+	if len(projectLabels) == 0 {
+		return
+	}
+	for _, a := range assets {
+		if a == nil {
+			continue
+		}
+		if a.Labels == nil {
+			a.Labels = map[string]string{}
+		}
+		for k, v := range projectLabels {
+			if _, exists := a.Labels[k]; !exists {
+				a.Labels[k] = v
+			}
+		}
+	}
 }
 
 func resolveGcr(ctx context.Context, conf *inventory.Config) ([]*inventory.Asset, error) {

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -296,3 +296,27 @@ func TestGCPAPIServiceRe(t *testing.T) {
 		})
 	}
 }
+
+func TestPropagateProjectLabelsToAssets(t *testing.T) {
+	t.Run("fills missing keys and preserves asset labels on collision", func(t *testing.T) {
+		assets := []*inventoryv1.Asset{
+			{Labels: map[string]string{"env": "prod"}}, // "env" must win over project label
+			{Labels: map[string]string{}},              // empty map gets all project labels
+			nil,                                        // nil asset is skipped safely
+			{Labels: nil},                              // nil map gets initialized + filled
+		}
+		projectLabels := map[string]string{"env": "shared", "team": "platform"}
+
+		propagateProjectLabelsToAssets(assets, projectLabels)
+
+		require.Equal(t, map[string]string{"env": "prod", "team": "platform"}, assets[0].Labels)
+		require.Equal(t, map[string]string{"env": "shared", "team": "platform"}, assets[1].Labels)
+		require.Equal(t, map[string]string{"env": "shared", "team": "platform"}, assets[3].Labels)
+	})
+
+	t.Run("no project labels leaves assets untouched", func(t *testing.T) {
+		assets := []*inventoryv1.Asset{{Labels: map[string]string{"env": "prod"}}}
+		propagateProjectLabelsToAssets(assets, map[string]string{})
+		require.Equal(t, map[string]string{"env": "prod"}, assets[0].Labels)
+	})
+}


### PR DESCRIPTION
## What

Adds a `propagate-project-labels` discovery filter for the GCP provider, mirroring AWS's existing `propagate-account-tags`. When enabled, every asset discovered under a project inherits that project's labels.

```
mql discover gcp project <id> --filters propagate-project-labels=true
```

## Why

GCP resource **labels** do not inherit from the parent project on their own, so tagging/grouping child assets by a project-level label was impossible without this. This closes that gap and matches the AWS behavior users already rely on.

Naming note: the option is `propagate-project-**labels**` (not `-tags`) because in GCP, Resource Manager *tags* already inherit from project/folder/org natively — only *labels* need this. RM tags are unaffected.

## How

- `PropagateProjectLabels` field on the GCP `DiscoveryFilters`, parsed from the `propagate-project-labels` opt (shared `filteropts.ParseBoolOpt` helper).
- Allowlisted in the provider's `--filters` passthrough and documented in the flag description.
- `propagateProjectLabelsToAssets` runs at the end of `discoverProject`, over the child assets it returns. Because that function is scoped to a single project, each child correctly gets **its own** project's labels — even in org/folder discovery that walks many projects. An asset's own labels win on collision.
- No extra API call — project labels are already fetched during discovery.

## Testing

Unit tests for opt parsing and merge behavior (collision precedence, nil-map/nil-asset handling).

Verified live against a real GCP project:

| | Discovered bucket asset labels |
|---|---|
| **without** flag | `null` |
| **with** `--filters propagate-project-labels=true` | `{"goog-terraform-provisioned": "true"}` (the project's label) |

No `.lr` schema changes, so no `.lr.versions` / permissions changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)