### PR TITLE
🐛 azure: give an actionable error when Azure sign-in fails

### DIFF
--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -5,6 +5,7 @@ package azauth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -151,9 +152,10 @@ func GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile string) (az
 func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId string) (azcore.TokenCredential, error) {
 	var azCred azcore.TokenCredential
 	var err error
+	usedDefaultChain := credential == nil
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		log.Debug().Msg("using default azure token chain resolver")
+		log.Info().Msg("no Azure credentials were provided; trying to sign in with your local Azure CLI session, Azure environment variables, or a managed identity")
 		azCred, err = GetDefaultChainedToken(&azidentity.DefaultAzureCredentialOptions{})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating CLI credentials")
@@ -178,5 +180,47 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 			return nil, errors.New("invalid secret configuration for microsoft transport: " + credential.Type.String())
 		}
 	}
-	return azCred, nil
+	return &guidedCredential{inner: azCred, usedDefaultChain: usedDefaultChain}, nil
+}
+
+// guidedCredential decorates an azcore.TokenCredential so that a failed sign-in
+// surfaces a plain-language, actionable message instead of the raw error from
+// deep inside the Azure SDK (for example a JSON decode error when the Azure CLI
+// returns something other than a token). usedDefaultChain records whether we
+// fell back to signing in with whatever Azure login is available on the machine
+// because no credentials were supplied, which changes the guidance we give.
+type guidedCredential struct {
+	inner            azcore.TokenCredential
+	usedDefaultChain bool
+}
+
+func (c *guidedCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	tk, err := c.inner.GetToken(ctx, opts)
+	if err != nil {
+		return azcore.AccessToken{}, enrichTokenError(err, c.usedDefaultChain)
+	}
+	return tk, nil
+}
+
+// enrichTokenError wraps a sign-in failure with guidance tailored to how the
+// credential was configured. The original error is always preserved so no
+// diagnostic detail is lost.
+func enrichTokenError(err error, usedDefaultChain bool) error {
+	if !usedDefaultChain {
+		return errors.Wrap(err, "Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret")
+	}
+
+	msg := "Azure sign-in failed. No credentials were provided, so we tried to sign in using your local Azure CLI session, Azure environment variables, and a managed identity, and none of them worked. " +
+		"Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials directly with --tenant-id and --client-id plus a certificate or client secret"
+
+	// azidentity's Azure CLI credential reports output that isn't a token (for
+	// example a message asking you to sign in again) as a JSON decode error.
+	// Match the typed decode error first, falling back to the message substring
+	// in case the SDK stringifies the error and drops its type.
+	var jsonSyntaxErr *json.SyntaxError
+	if errors.As(err, &jsonSyntaxErr) || strings.Contains(err.Error(), "looking for beginning of value") {
+		msg = "Your Azure CLI returned something other than a sign-in token, which usually means it needs you to sign in again (run `az login`) or is printing a notice. " + msg
+	}
+
+	return errors.Wrap(err, msg)
 }

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -4,8 +4,13 @@
 package azauth
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,4 +18,55 @@ func TestGetWorkloadIdentityToken(t *testing.T) {
 	cred, err := GetWorkloadIdentityToken("tid", "cid", "/tmp/x.jwt")
 	require.NoError(t, err)
 	require.NotNil(t, cred)
+}
+
+type fakeCredential struct {
+	err error
+}
+
+func (f *fakeCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if f.err != nil {
+		return azcore.AccessToken{}, f.err
+	}
+	return azcore.AccessToken{Token: "token"}, nil
+}
+
+func TestGuidedCredential_EnrichesErrors(t *testing.T) {
+	// the raw error azidentity's Azure CLI credential returns when the CLI
+	// hands back something other than a token
+	cliErr := errors.New("invalid character 'N' looking for beginning of value")
+
+	t.Run("default chain with CLI JSON failure", func(t *testing.T) {
+		cred := &guidedCredential{inner: &fakeCredential{err: cliErr}, usedDefaultChain: true}
+		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "az login")
+		assert.Contains(t, err.Error(), "Azure CLI returned something other than a sign-in token")
+		// original error is preserved
+		assert.Contains(t, err.Error(), "invalid character 'N'")
+	})
+
+	t.Run("default chain with generic failure", func(t *testing.T) {
+		cred := &guidedCredential{inner: &fakeCredential{err: errors.New("boom")}, usedDefaultChain: true}
+		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "No credentials were provided")
+		assert.NotContains(t, err.Error(), "Azure CLI returned something other than")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("explicit credentials failure", func(t *testing.T) {
+		cred := &guidedCredential{inner: &fakeCredential{err: errors.New("boom")}, usedDefaultChain: false}
+		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "double-check the tenant ID, client ID")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("success passes through untouched", func(t *testing.T) {
+		cred := &guidedCredential{inner: &fakeCredential{}, usedDefaultChain: true}
+		tk, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "token", tk.Token)
+	})
 }


### PR DESCRIPTION
### Problem

Running an Azure scan with only a Mondoo platform service account (`--config`) and no explicit Azure credentials produces a baffling error:

```
x unable to create runtime for asset error="rpc error: code = Unknown desc = ChainedTokenCredential: failed to acquire a token.
Attempted credentials:
    invalid character 'N' looking for beginning of value"
```

Two things make this hard to act on:

1. **The "what"** — `invalid character 'N' looking for beginning of value` is a raw JSON-decode error from deep inside `azidentity`. It's what the Azure CLI credential returns when `az` hands back something other than a token (e.g. it needs re-authentication or prints a notice).
2. **The "why"** — when no service principal credentials are supplied, the providers fall back to signing in with whatever Azure login is available on the machine. Nothing told the user that fallback was even happening, so passing `--config` looked like it should have provided the credentials.

### Change

In the shared `azauth.GetTokenFromCredential` (used by both the `azure` and `microsoft`/ms365 providers), wrap the resolved credential in a small `guidedCredential`. On a failed `GetToken` it rewrites the error into a plain-language, actionable message:

- **No credentials provided (fallback sign-in):**
  > Azure sign-in failed. No credentials were provided, so we tried to sign in using your local Azure CLI session, Azure environment variables, and a managed identity, and none of them worked. Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials directly with --tenant-id and --client-id plus a certificate or client secret: invalid character 'N' looking for beginning of value

  When the underlying error is the CLI's non-token JSON-decode failure, it prepends: *"Your Azure CLI returned something other than a sign-in token, which usually means it needs you to sign in again (run `az login`) or is printing a notice."*

- **Explicit credentials provided:**
  > Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret: <original error>

The original error is always preserved via wrapping, so no diagnostic detail is lost. A one-line notice is also logged at Info level when the fallback sign-in path is used, so the behavior is visible even on a successful-but-surprising run.

### Notes

- No new API calls: the wrapper only decorates the `GetToken` call that was already going to happen, and lazy authentication is preserved. It covers both discovery and per-asset scans.
- Deliberately keeps the message provider-neutral since `azauth` is shared.

### Testing

- `go test ./providers-sdk/v1/util/azauth/` — added `TestGuidedCredential_EnrichesErrors` covering the CLI-JSON-failure case (the exact error from the report), a generic fallback failure, an explicit-credentials failure, and success pass-through.
- Verified `go build` / `go vet` clean.
