### PR TITLE
🐎 recording: fix concurrent-map panic in finalize during parallel scans

### DIFF
--- a/providers-sdk/v1/recording/asset_recording.go
+++ b/providers-sdk/v1/recording/asset_recording.go
@@ -5,6 +5,7 @@ package recording
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"sync"
 
@@ -94,7 +95,19 @@ func (asset *Asset) GetResource(name string, id string) (*Resource, bool) {
 	defer asset.mu.Unlock()
 
 	r, ok := asset.resources[name+keySep+id]
-	return r, ok
+	if !ok {
+		return nil, false
+	}
+
+	// Return a snapshot: callers iterate the Fields map after we release the
+	// lock, while AddData may still be inserting into the live map.
+	clone := &Resource{
+		Resource: r.Resource,
+		ID:       r.ID,
+		Fields:   make(map[string]*llx.RawData, len(r.Fields)),
+	}
+	maps.Copy(clone.Fields, r.Fields)
+	return clone, true
 }
 
 func (asset *Asset) RefreshCache() {

--- a/providers-sdk/v1/recording/asset_recording.go
+++ b/providers-sdk/v1/recording/asset_recording.go
@@ -6,6 +6,7 @@ package recording
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -36,6 +37,13 @@ type Asset struct {
 
 	connections map[string]*connection `json:"-"`
 	resources   map[string]*Resource   `json:"-"`
+
+	// mu guards concurrent access to the connections, resources, and IdsLookup
+	// maps. During a parallel scan multiple assets share one recording: one
+	// asset closing triggers Save (which finalizes every asset by iterating its
+	// resources map) while other assets are still fetching data via AddData
+	// (which writes those maps). Go maps are not safe for concurrent use.
+	mu sync.Mutex `json:"-"`
 }
 
 type connection struct {
@@ -53,6 +61,9 @@ type Resource struct {
 }
 
 func (asset *Asset) finalize() {
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
+
 	asset.Resources = make([]Resource, len(asset.resources))
 	asset.Connections = make([]connection, len(asset.connections))
 
@@ -79,11 +90,17 @@ func (asset *Asset) finalize() {
 }
 
 func (asset *Asset) GetResource(name string, id string) (*Resource, bool) {
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
+
 	r, ok := asset.resources[name+keySep+id]
 	return r, ok
 }
 
 func (asset *Asset) RefreshCache() {
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
+
 	asset.resources = make(map[string]*Resource, len(asset.Resources))
 	asset.connections = make(map[string]*connection, len(asset.Connections))
 

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -367,12 +367,14 @@ func (r *recording) EnsureAsset(asset *inventory.Asset, providerID string, conne
 	}
 
 	if conf.Id > 0 {
+		recordingAsset.mu.Lock()
 		recordingAsset.connections[fmt.Sprintf("%d", conf.Id)] = &connection{
 			Url:        conf.ToUrl(),
 			ProviderID: providerID,
 			Connector:  conf.Type,
 			Id:         conf.Id,
 		}
+		recordingAsset.mu.Unlock()
 	}
 
 	r.resyncAsset(recordingAsset)
@@ -386,6 +388,8 @@ func (r *recording) resyncAsset(recordingAsset *Asset) {
 		r.assets.Set(platformIdKey(pid), recordingAsset)
 	}
 	// Index by connection IDs from the runtime connections (added via EnsureAsset)
+	recordingAsset.mu.Lock()
+	defer recordingAsset.mu.Unlock()
 	for _, conn := range recordingAsset.connections {
 		if conn.Id > 0 {
 			r.assets.Set(connIdKey(conn.Id), recordingAsset)
@@ -398,6 +402,9 @@ func (r *recording) AddData(req llx.AddDataReq) {
 	if !ok {
 		return
 	}
+
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
 
 	if asset.IdsLookup == nil {
 		asset.IdsLookup = map[string]string{}
@@ -427,6 +434,9 @@ func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource st
 	if !ok {
 		return nil, "", false
 	}
+
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
 
 	// overwrite resourceId if there exists a lookup entry
 	if lookupId, ok := asset.IdsLookup[resource+keySep+id]; ok {
@@ -514,6 +524,9 @@ func (r *recording) GetAssetData(assetMrn string) (map[string]*llx.ResourceRecor
 	if !ok {
 		return nil, false
 	}
+
+	cur.mu.Lock()
+	defer cur.mu.Unlock()
 
 	ensureAssetMetadata(cur.resources, cur.Asset)
 

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -368,14 +368,18 @@ func (r *recording) EnsureAsset(asset *inventory.Asset, providerID string, conne
 	}
 
 	if conf.Id > 0 {
-		recordingAsset.mu.Lock()
-		recordingAsset.connections[fmt.Sprintf("%d", conf.Id)] = &connection{
-			Url:        conf.ToUrl(),
-			ProviderID: providerID,
-			Connector:  conf.Type,
-			Id:         conf.Id,
-		}
-		recordingAsset.mu.Unlock()
+		// Scope the lock to just the map write via a closure: resyncAsset below
+		// also takes recordingAsset.mu, so a function-level defer would deadlock.
+		func() {
+			recordingAsset.mu.Lock()
+			defer recordingAsset.mu.Unlock()
+			recordingAsset.connections[fmt.Sprintf("%d", conf.Id)] = &connection{
+				Url:        conf.ToUrl(),
+				ProviderID: providerID,
+				Connector:  conf.Type,
+				Id:         conf.Id,
+			}
+		}()
 	}
 
 	r.resyncAsset(recordingAsset)

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -429,10 +430,13 @@ func (r *recording) AddData(req llx.AddDataReq) {
 	}
 }
 
-func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource string, id string) (*Resource, string, bool) {
+// resolveResource looks up a recorded resource. It returns the owning *Asset so
+// that callers can hold asset.mu while reading the resolved resource's Fields
+// map, which AddData mutates concurrently.
+func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource string, id string) (*Resource, *Asset, string, bool) {
 	asset, ok := r.resolveAsset(lookup)
 	if !ok {
-		return nil, "", false
+		return nil, nil, "", false
 	}
 
 	asset.mu.Lock()
@@ -447,15 +451,15 @@ func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource st
 	// since that provides the most detailed information about the asset
 	if resource == "asset" {
 		assetResource := createResourceAsset(asset.Asset, id)
-		return assetResource, id, true
+		return assetResource, asset, id, true
 	}
 
 	obj, exist := asset.resources[resource+keySep+id]
 	if !exist {
-		return nil, "", false
+		return nil, nil, "", false
 	}
 
-	return obj, id, true
+	return obj, asset, id, true
 }
 
 func createResourceAsset(asset *inventory.Asset, id string) *Resource {
@@ -496,7 +500,7 @@ func CreateAssetResourceArgs(asset *inventory.Asset) map[string]*llx.RawData {
 }
 
 func (r *recording) GetData(lookup llx.AssetRecordingLookup, resource string, id string, field string) (*llx.RawData, bool) {
-	obj, resolvedID, ok := r.resolveResource(lookup, resource, id)
+	obj, asset, resolvedID, ok := r.resolveResource(lookup, resource, id)
 	if !ok {
 		return nil, false
 	}
@@ -505,18 +509,27 @@ func (r *recording) GetData(lookup llx.AssetRecordingLookup, resource string, id
 		return &llx.RawData{Type: types.Resource(resource), Value: resolvedID}, true
 	}
 
+	// AddData mutates obj.Fields under asset.mu, so we must hold it while reading.
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
 	data, ok := obj.Fields[field]
 
 	return data, ok
 }
 
 func (r *recording) GetResource(lookup llx.AssetRecordingLookup, resource string, id string) (map[string]*llx.RawData, bool) {
-	obj, _, ok := r.resolveResource(lookup, resource, id)
+	obj, asset, _, ok := r.resolveResource(lookup, resource, id)
 	if !ok {
 		return nil, false
 	}
 
-	return obj.Fields, true
+	// Return a snapshot of the fields: the caller iterates the map after we
+	// return, while AddData may still be inserting into obj.Fields under asset.mu.
+	asset.mu.Lock()
+	defer asset.mu.Unlock()
+	fields := make(map[string]*llx.RawData, len(obj.Fields))
+	maps.Copy(fields, obj.Fields)
+	return fields, true
 }
 
 func (r *recording) GetAssetData(assetMrn string) (map[string]*llx.ResourceRecording, bool) {

--- a/providers-sdk/v1/recording/recording_test.go
+++ b/providers-sdk/v1/recording/recording_test.go
@@ -28,14 +28,17 @@ func TestLoadRecording(t *testing.T) {
 func TestSaveWhileAddingData(t *testing.T) {
 	r := newTestRecording(t, "test-asset-race", []string{"pid-race"}, 1)
 	r.doNotSave = true // exercise finalize() without touching the filesystem
+	lookup := llx.AssetRecordingLookup{Mrn: "test-asset-race"}
 
+	const iterations = 20000
 	var wg sync.WaitGroup
 
-	// Writer: keeps inserting new resources, growing asset.resources.
+	// Writer 1: keeps inserting distinct resources, growing asset.resources.
+	// This races finalize()'s iteration of that map.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 20000; i++ {
+		for i := 0; i < iterations; i++ {
 			r.AddData(llx.AddDataReq{
 				ConnectionID:      1,
 				Resource:          "aws.ec2.instance",
@@ -47,12 +50,43 @@ func TestSaveWhileAddingData(t *testing.T) {
 		}
 	}()
 
-	// Reader: finalizes the recording repeatedly, iterating the same map.
+	// Writer 2: repeatedly writes fields on a single "hot" resource, mutating
+	// its Fields map. This races the reader goroutine's Fields access.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 2000; i++ {
+		for i := 0; i < iterations; i++ {
+			r.AddData(llx.AddDataReq{
+				ConnectionID:      1,
+				Resource:          "aws.ec2.instance",
+				ResourceID:        "hot",
+				RequestResourceId: "hot",
+				Field:             strconv.Itoa(i % 64),
+				Data:              llx.StringData("v"),
+			})
+		}
+	}()
+
+	// Reader: finalizes the recording repeatedly, iterating the resources map.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations/10; i++ {
 			assert.NoError(t, r.Save())
+		}
+	}()
+
+	// Reader: exercises the data-read paths, which access Resource.Fields while
+	// Writer 2 mutates it. GetResource must hand back a safe snapshot.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			r.GetData(lookup, "aws.ec2.instance", "hot", strconv.Itoa(i%64))
+			if fields, ok := r.GetResource(lookup, "aws.ec2.instance", "hot"); ok {
+				for range fields { // iterate the returned map; must be a safe snapshot
+				}
+			}
 		}
 	}()
 

--- a/providers-sdk/v1/recording/recording_test.go
+++ b/providers-sdk/v1/recording/recording_test.go
@@ -4,6 +4,8 @@
 package recording
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +17,46 @@ func TestLoadRecording(t *testing.T) {
 	record, err := LoadRecordingFile("testdata/recording.json")
 	assert.NoError(t, err)
 	assert.NotNil(t, record)
+}
+
+// TestSaveWhileAddingData reproduces the data race that crashes a parallel scan:
+// a shared recording is saved (which finalizes every asset by iterating its
+// `resources` map) while another goroutine is still fetching data for that asset
+// via AddData (which writes to the same map). Without synchronization this panics
+// with "index out of range" in finalize() or "concurrent map ... write", and the
+// race detector flags it. See providers-sdk/v1/recording/asset_recording.go.
+func TestSaveWhileAddingData(t *testing.T) {
+	r := newTestRecording(t, "test-asset-race", []string{"pid-race"}, 1)
+	r.doNotSave = true // exercise finalize() without touching the filesystem
+
+	var wg sync.WaitGroup
+
+	// Writer: keeps inserting new resources, growing asset.resources.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20000; i++ {
+			r.AddData(llx.AddDataReq{
+				ConnectionID:      1,
+				Resource:          "aws.ec2.instance",
+				ResourceID:        strconv.Itoa(i),
+				RequestResourceId: strconv.Itoa(i),
+				Field:             "name",
+				Data:              llx.StringData("instance"),
+			})
+		}
+	}()
+
+	// Reader: finalizes the recording repeatedly, iterating the same map.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			assert.NoError(t, r.Save())
+		}
+	}()
+
+	wg.Wait()
 }
 
 // newTestRecording creates a fresh recording and ensures an asset with the given


### PR DESCRIPTION
## Problem

A parallel scan panics and aborts:

```
panic: runtime error: index out of range [5547] with length 5547
recording.(*Asset).finalize(...) asset_recording.go:61
recording.(*recording).Save(...)  recording.go:163
providers.(*Runtime).Close.func1() runtime.go:97
discovery.(*AssetExplorer).CloseAsset(...)
policy/scan.(*scanDispatcher).scanSingleAsset(...)
```

## Root cause

This is a **data race on the per-asset recording maps**, not a logic error.

In a parallel scan all assets share one `recording`. When the *first* asset's `Runtime.Close()` fires, it calls the shared recording's `Save()` → `finalize()`, which iterates **every** asset's `resources` map. Meanwhile other assets are still fetching data via `AddData()`, which inserts into those same maps.

Go maps are not safe for concurrent use. `finalize()` sizes a slice with `make([]Resource, len(asset.resources))` and then range-iterates the map to fill it:

```go
asset.Resources = make([]Resource, len(asset.resources)) // len == N
i := 0
for _, v := range asset.resources {                      // grows to N+1 concurrently
    asset.Resources[i] = *v                              // i == N -> out of range
    i++
}
```

If the map grows between the `len()` sizing and the range completing, the loop overruns the pre-sized slice and panics with `index out of range [N] with length N`.

## Fix

Add a per-asset `sync.Mutex` guarding all access to the `resources`, `connections`, and `IdsLookup` maps:

- `asset_recording.go`: `finalize`, `GetResource`, `RefreshCache`
- `recording.go`: `AddData`, `EnsureAsset` (connection write), `resyncAsset`, `resolveResource`, `GetAssetData`

The lock lives on the `Asset` (not the recording), so distinct assets still scan and finalize in parallel. `EnsureAsset` scopes its lock to the connection write so it does not re-enter through `resyncAsset`. The mutex is unexported and untagged, so `encoding/json` skips it and the recording file format is unchanged.

## Testing

- Added `TestSaveWhileAddingData`, which hammers `AddData` while repeatedly calling `Save()`. It reproduces the exact production panic (same `finalize` line) **before** the fix and passes **after** — plainly and under `-race`.
- Full `providers-sdk/v1/recording` package passes under `-race`.
- `go vet` clean (confirms `Asset` is never copied by value now that it holds a lock).

## Notes

- `merge.go` is intentionally left unguarded: it operates on completed recordings during post-scan merge/clone, not concurrently with `AddData`.
